### PR TITLE
Make writeable_cmp_bytes a free function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@
         - Optimize `MultiFieldsULE` to not store a length anymore. This breaks data layout for any `#[make_varule]`-using struct with multiple variable-sized fields. (https://github.com/unicode-org/icu4x/pull/5593)
       - Remove `FlexZeroVec` (https://github.com/unicode-org/icu4x/pull/5604)
     - `writeable`
-      - Make `Writeable::writeable_cmp_bytes` a free function `writeable::cmp_bytes`
+      - Make `Writeable::writeable_cmp_bytes` a free function `writeable::cmp_bytes` (https://github.com/unicode-org/icu4x/pull/5737)
 
 
 ## icu4x 1.5.x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
         - Optimize `MultiFieldsULE` to not store a length anymore. This breaks data layout for any `#[make_varule]`-using struct with multiple variable-sized fields. (https://github.com/unicode-org/icu4x/pull/5593)
       - Remove `FlexZeroVec` (https://github.com/unicode-org/icu4x/pull/5604)
     - `writeable`
+      - Make `Writeable::writeable_cmp_bytes` a free function `writeable::cmp_bytes`
 
 
 ## icu4x 1.5.x

--- a/components/locale_core/src/extensions/unicode/keywords.rs
+++ b/components/locale_core/src/extensions/unicode/keywords.rs
@@ -7,7 +7,6 @@ use core::cmp::Ordering;
 use core::iter::FromIterator;
 use core::str::FromStr;
 use litemap::LiteMap;
-use writeable::Writeable;
 
 use super::Key;
 use super::Value;
@@ -312,7 +311,7 @@ impl Keywords {
     /// }
     /// ```
     pub fn strict_cmp(&self, other: &[u8]) -> Ordering {
-        self.writeable_cmp_bytes(other)
+        writeable::cmp_bytes(self, other)
     }
 
     pub(crate) fn try_from_iter(iter: &mut SubtagIterator) -> Result<Self, ParseError> {

--- a/components/locale_core/src/extensions/unicode/value.rs
+++ b/components/locale_core/src/extensions/unicode/value.rs
@@ -7,7 +7,6 @@ use crate::shortvec::{ShortBoxSlice, ShortBoxSliceIntoIter};
 use crate::subtags::{subtag, Subtag};
 use alloc::vec::Vec;
 use core::str::FromStr;
-use writeable::Writeable;
 
 /// A value used in a list of [`Keywords`](super::Keywords).
 ///
@@ -306,7 +305,7 @@ impl FromStr for Value {
 
 impl PartialEq<&str> for Value {
     fn eq(&self, other: &&str) -> bool {
-        self.writeable_cmp_bytes(other.as_bytes()).is_eq()
+        writeable::cmp_bytes(self, other.as_bytes()).is_eq()
     }
 }
 

--- a/components/locale_core/src/langid.rs
+++ b/components/locale_core/src/langid.rs
@@ -260,7 +260,7 @@ impl LanguageIdentifier {
     /// }
     /// ```
     pub fn strict_cmp(&self, other: &[u8]) -> Ordering {
-        self.writeable_cmp_bytes(other)
+        writeable::cmp_bytes(self, other)
     }
 
     pub(crate) fn as_tuple(

--- a/components/locale_core/src/locale.rs
+++ b/components/locale_core/src/locale.rs
@@ -241,7 +241,7 @@ impl Locale {
     /// }
     /// ```
     pub fn strict_cmp(&self, other: &[u8]) -> Ordering {
-        self.writeable_cmp_bytes(other)
+        writeable::cmp_bytes(self, other)
     }
 
     #[allow(clippy::type_complexity)]

--- a/provider/core/src/request.rs
+++ b/provider/core/src/request.rs
@@ -18,7 +18,6 @@ use icu_locale_core::subtags::Subtag;
 use icu_locale_core::subtags::Variant;
 use icu_locale_core::subtags::{Language, Region, Script};
 use icu_locale_core::{LanguageIdentifier, Locale, ParseError};
-use writeable::Writeable;
 use zerovec::ule::VarULE;
 
 /// The request type passed into all data provider implementations.
@@ -527,7 +526,7 @@ impl DataLocale {
     /// }
     /// ```
     pub fn strict_cmp(&self, other: &[u8]) -> Ordering {
-        self.writeable_cmp_bytes(other)
+        writeable::cmp_bytes(self, other)
     }
 
     /// Returns whether this [`DataLocale`] is `und` in the locale and extensions portion.

--- a/utils/writeable/benches/writeable.rs
+++ b/utils/writeable/benches/writeable.rs
@@ -131,6 +131,19 @@ fn writeable_benches(c: &mut Criterion) {
             .into_owned()
         });
     });
+    c.bench_function("writeable/writeable_cmp_bytes", |b| {
+        b.iter(|| {
+            let short = black_box(SHORT_STR);
+            let medium = black_box(MEDIUM_STR);
+            let long = black_box(LONG_STR);
+            [short, medium, long].map(|s1| {
+                [short, medium, long].map(|s2| {
+                    let message = WriteableMessage { message: s1 };
+                    message.writeable_cmp_bytes(s2.as_bytes())
+                })
+            })
+        });
+    });
 }
 
 #[cfg(feature = "bench")]
@@ -212,6 +225,20 @@ fn complex_benches(c: &mut Criterion) {
     });
     c.bench_function("complex/display_to_string/medium", |b| {
         b.iter(|| black_box(COMPLEX_WRITEABLE_MEDIUM).to_string());
+    });
+    const REFERENCE_STRS: [&str; 6] = [
+        "There are 55 apples and 8124 oranges",
+        "There are 55 apples and 0 oranges",
+        "There are no apples",
+        SHORT_STR,
+        MEDIUM_STR,
+        LONG_STR,
+    ];
+    c.bench_function("complex/writeable_cmp_bytes", |b| {
+        b.iter(|| {
+            black_box(REFERENCE_STRS)
+                .map(|s| black_box(COMPLEX_WRITEABLE_MEDIUM).writeable_cmp_bytes(s.as_bytes()))
+        });
     });
 }
 

--- a/utils/writeable/benches/writeable.rs
+++ b/utils/writeable/benches/writeable.rs
@@ -72,7 +72,7 @@ writeable::impl_display_with_writeable!(ComplexWriteable<'_>);
 
 const SHORT_STR: &str = "short";
 const MEDIUM_STR: &str = "this is a medium-length string";
-const LONG_STR: &str = "this is a very very very very very very very very very very very very very very very very very very very very very very very very long string";
+const LONG_STR: &str = "this is a very very very very very very very very very very very very very very very very very very very very very very verrrry long string";
 
 fn overview_bench(c: &mut Criterion) {
     c.bench_function("writeable/overview", |b| {

--- a/utils/writeable/benches/writeable.rs
+++ b/utils/writeable/benches/writeable.rs
@@ -72,7 +72,7 @@ writeable::impl_display_with_writeable!(ComplexWriteable<'_>);
 
 const SHORT_STR: &str = "short";
 const MEDIUM_STR: &str = "this is a medium-length string";
-const LONG_STR: &str = "this is a very very very very very very very very very very very very very very very very very very very very very very verrrry long string";
+const LONG_STR: &str = "this string is very very very very very very very very very very very very very very very very very very very very very very very very long";
 
 fn overview_bench(c: &mut Criterion) {
     c.bench_function("writeable/overview", |b| {

--- a/utils/writeable/benches/writeable.rs
+++ b/utils/writeable/benches/writeable.rs
@@ -131,7 +131,7 @@ fn writeable_benches(c: &mut Criterion) {
             .into_owned()
         });
     });
-    c.bench_function("writeable/writeable_cmp_bytes", |b| {
+    c.bench_function("writeable/cmp_bytes", |b| {
         b.iter(|| {
             let short = black_box(SHORT_STR);
             let medium = black_box(MEDIUM_STR);
@@ -139,7 +139,7 @@ fn writeable_benches(c: &mut Criterion) {
             [short, medium, long].map(|s1| {
                 [short, medium, long].map(|s2| {
                     let message = WriteableMessage { message: s1 };
-                    message.writeable_cmp_bytes(s2.as_bytes())
+                    writeable::cmp_bytes(&message, s2.as_bytes())
                 })
             })
         });
@@ -234,10 +234,10 @@ fn complex_benches(c: &mut Criterion) {
         MEDIUM_STR,
         LONG_STR,
     ];
-    c.bench_function("complex/writeable_cmp_bytes", |b| {
+    c.bench_function("complex/cmp_bytes", |b| {
         b.iter(|| {
             black_box(REFERENCE_STRS)
-                .map(|s| black_box(COMPLEX_WRITEABLE_MEDIUM).writeable_cmp_bytes(s.as_bytes()))
+                .map(|s| writeable::cmp_bytes(black_box(&COMPLEX_WRITEABLE_MEDIUM), s.as_bytes()))
         });
     });
 }

--- a/utils/writeable/benches/writeable.rs
+++ b/utils/writeable/benches/writeable.rs
@@ -73,6 +73,9 @@ writeable::impl_display_with_writeable!(ComplexWriteable<'_>);
 const SHORT_STR: &str = "short";
 const MEDIUM_STR: &str = "this is a medium-length string";
 const LONG_STR: &str = "this string is very very very very very very very very very very very very very very very very very very very very very very very very long";
+#[cfg(feature = "bench")]
+const LONG_OVERLAP_STR: &str =
+    "this string is very very very very very very very long but different";
 
 fn overview_bench(c: &mut Criterion) {
     c.bench_function("writeable/overview", |b| {
@@ -136,8 +139,9 @@ fn writeable_benches(c: &mut Criterion) {
             let short = black_box(SHORT_STR);
             let medium = black_box(MEDIUM_STR);
             let long = black_box(LONG_STR);
-            [short, medium, long].map(|s1| {
-                [short, medium, long].map(|s2| {
+            let long_overlap = black_box(LONG_OVERLAP_STR);
+            [short, medium, long, long_overlap].map(|s1| {
+                [short, medium, long, long_overlap].map(|s2| {
                     let message = WriteableMessage { message: s1 };
                     writeable::cmp_bytes(&message, s2.as_bytes())
                 })

--- a/utils/writeable/benches/writeable.rs
+++ b/utils/writeable/benches/writeable.rs
@@ -72,7 +72,7 @@ writeable::impl_display_with_writeable!(ComplexWriteable<'_>);
 
 const SHORT_STR: &str = "short";
 const MEDIUM_STR: &str = "this is a medium-length string";
-const LONG_STR: &str = "this string is very very very very very very very very very very very very very very very very very very very very very very very very long";
+const LONG_STR: &str = "this is a very very very very very very very very very very very very very very very very very very very very very very very very long string";
 
 fn overview_bench(c: &mut Criterion) {
     c.bench_function("writeable/overview", |b| {

--- a/utils/writeable/src/cmp.rs
+++ b/utils/writeable/src/cmp.rs
@@ -51,7 +51,8 @@ impl<'a> WriteComparator<'a> {
 ///
 /// This returns a lexicographical comparison, the same as if the Writeable
 /// were first converted to a String and then compared with `Ord`. For a
-/// locale-sensitive string ordering, use an ICU4X Collator.
+/// string ordering suitable for display to end users, use a localized
+/// collation crate, such as `icu_collator`.
 ///
 /// # Examples
 ///

--- a/utils/writeable/src/cmp.rs
+++ b/utils/writeable/src/cmp.rs
@@ -6,7 +6,7 @@ use crate::Writeable;
 use core::cmp::Ordering;
 use core::fmt;
 
-pub(crate) struct WriteComparator<'a> {
+struct WriteComparator<'a> {
     code_units: &'a [u8],
     result: Ordering,
 }
@@ -28,7 +28,7 @@ impl fmt::Write for WriteComparator<'_> {
 
 impl<'a> WriteComparator<'a> {
     #[inline]
-    pub fn new(code_units: &'a [u8]) -> Self {
+    fn new(code_units: &'a [u8]) -> Self {
         Self {
             code_units,
             result: Ordering::Equal,
@@ -36,7 +36,7 @@ impl<'a> WriteComparator<'a> {
     }
 
     #[inline]
-    pub fn finish(self) -> Ordering {
+    fn finish(self) -> Ordering {
         if matches!(self.result, Ordering::Equal) && !self.code_units.is_empty() {
             // Self is longer than Other
             Ordering::Greater

--- a/utils/writeable/src/cmp.rs
+++ b/utils/writeable/src/cmp.rs
@@ -77,12 +77,12 @@ impl<'a> WriteComparator<'a> {
 /// let message = WelcomeMessage { name: "Alice" };
 /// let message_str = message.write_to_string();
 ///
-/// assert_eq!(Ordering::Equal, writeable::cmp_bytes(message, b"Hello, Alice!"));
+/// assert_eq!(Ordering::Equal, writeable::cmp_bytes(&message, b"Hello, Alice!"));
 ///
-/// assert_eq!(Ordering::Greater, writeable::cmp_bytes(message, b"Alice!"));
+/// assert_eq!(Ordering::Greater, writeable::cmp_bytes(&message, b"Alice!"));
 /// assert_eq!(Ordering::Greater, (*message_str).cmp("Alice!"));
 ///
-/// assert_eq!(Ordering::Less, writeable::cmp_bytes(message, b"Hello, Bob!"));
+/// assert_eq!(Ordering::Less, writeable::cmp_bytes(&message, b"Hello, Bob!"));
 /// assert_eq!(Ordering::Less, (*message_str).cmp("Hello, Bob!"));
 /// ```
 pub fn cmp_bytes(writeable: &impl Writeable, other: &[u8]) -> Ordering {

--- a/utils/writeable/src/cmp.rs
+++ b/utils/writeable/src/cmp.rs
@@ -2,6 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use crate::Writeable;
 use core::cmp::Ordering;
 use core::fmt;
 
@@ -43,6 +44,51 @@ impl<'a> WriteComparator<'a> {
             self.result
         }
     }
+}
+
+/// Compares the contents of a `Writeable` to the given bytes
+/// without allocating a String to hold the `Writeable` contents.
+///
+/// This returns a lexicographical comparison, the same as if the Writeable
+/// were first converted to a String and then compared with `Ord`. For a
+/// locale-sensitive string ordering, use an ICU4X Collator.
+///
+/// # Examples
+///
+/// ```
+/// use core::cmp::Ordering;
+/// use core::fmt;
+/// use writeable::Writeable;
+///
+/// struct WelcomeMessage<'s> {
+///     pub name: &'s str,
+/// }
+///
+/// impl<'s> Writeable for WelcomeMessage<'s> {
+///     // see impl in Writeable docs
+/// #    fn write_to<W: fmt::Write + ?Sized>(&self, sink: &mut W) -> fmt::Result {
+/// #        sink.write_str("Hello, ")?;
+/// #        sink.write_str(self.name)?;
+/// #        sink.write_char('!')?;
+/// #        Ok(())
+/// #    }
+/// }
+///
+/// let message = WelcomeMessage { name: "Alice" };
+/// let message_str = message.write_to_string();
+///
+/// assert_eq!(Ordering::Equal, writeable::cmp_bytes(message, b"Hello, Alice!"));
+///
+/// assert_eq!(Ordering::Greater, writeable::cmp_bytes(message, b"Alice!"));
+/// assert_eq!(Ordering::Greater, (*message_str).cmp("Alice!"));
+///
+/// assert_eq!(Ordering::Less, writeable::cmp_bytes(message, b"Hello, Bob!"));
+/// assert_eq!(Ordering::Less, (*message_str).cmp("Hello, Bob!"));
+/// ```
+pub fn cmp_bytes(writeable: &impl Writeable, other: &[u8]) -> Ordering {
+    let mut wc = WriteComparator::new(other);
+    let _ = writeable.write_to(&mut wc);
+    wc.finish().reverse()
 }
 
 #[cfg(test)]

--- a/utils/writeable/src/either.rs
+++ b/utils/writeable/src/either.rs
@@ -38,11 +38,4 @@ where
             Either::Right(w) => w.write_to_string(),
         }
     }
-
-    fn writeable_cmp_bytes(&self, other: &[u8]) -> core::cmp::Ordering {
-        match self {
-            Either::Left(w) => w.writeable_cmp_bytes(other),
-            Either::Right(w) => w.writeable_cmp_bytes(other),
-        }
-    }
 }

--- a/utils/writeable/src/impls.rs
+++ b/utils/writeable/src/impls.rs
@@ -231,7 +231,7 @@ fn test_string_impls() {
         assert_writeable_eq!(&chars[i], s);
         for j in 0..chars.len() {
             assert_eq!(
-                chars[j].writeable_cmp_bytes(s.as_bytes()),
+                crate::cmp_bytes(&chars[j], s.as_bytes()),
                 chars[j].cmp(&chars[i]),
                 "{:?} vs {:?}",
                 chars[j],

--- a/utils/writeable/src/impls.rs
+++ b/utils/writeable/src/impls.rs
@@ -115,11 +115,6 @@ impl Writeable for str {
     fn write_to_string(&self) -> Cow<str> {
         Cow::Borrowed(self)
     }
-
-    #[inline]
-    fn writeable_cmp_bytes(&self, other: &[u8]) -> core::cmp::Ordering {
-        self.as_bytes().cmp(other)
-    }
 }
 
 impl Writeable for String {
@@ -136,11 +131,6 @@ impl Writeable for String {
     #[inline]
     fn write_to_string(&self) -> Cow<str> {
         Cow::Borrowed(self)
-    }
-
-    #[inline]
-    fn writeable_cmp_bytes(&self, other: &[u8]) -> core::cmp::Ordering {
-        self.as_bytes().cmp(other)
     }
 }
 
@@ -160,11 +150,6 @@ impl Writeable for char {
         let mut s = String::with_capacity(self.len_utf8());
         s.push(*self);
         Cow::Owned(s)
-    }
-
-    #[inline]
-    fn writeable_cmp_bytes(&self, other: &[u8]) -> core::cmp::Ordering {
-        self.encode_utf8(&mut [0u8; 4]).as_bytes().cmp(other)
     }
 }
 
@@ -188,11 +173,6 @@ impl<T: Writeable + ?Sized> Writeable for &T {
     fn write_to_string(&self) -> Cow<str> {
         (*self).write_to_string()
     }
-
-    #[inline]
-    fn writeable_cmp_bytes(&self, other: &[u8]) -> core::cmp::Ordering {
-        (*self).writeable_cmp_bytes(other)
-    }
 }
 
 macro_rules! impl_write_smart_pointer {
@@ -213,10 +193,6 @@ macro_rules! impl_write_smart_pointer {
             #[inline]
             fn write_to_string(&self) -> Cow<str> {
                 core::borrow::Borrow::<T>::borrow(self).write_to_string()
-            }
-            #[inline]
-            fn writeable_cmp_bytes(&self, other: &[u8]) -> core::cmp::Ordering {
-                core::borrow::Borrow::<T>::borrow(self).writeable_cmp_bytes(other)
             }
         }
     };

--- a/utils/writeable/src/lib.rs
+++ b/utils/writeable/src/lib.rs
@@ -79,6 +79,7 @@ use alloc::borrow::Cow;
 use alloc::string::String;
 use core::fmt;
 
+pub use cmp::cmp_bytes;
 pub use try_writeable::TryWriteable;
 
 /// Helper types for trait impls.
@@ -304,51 +305,6 @@ pub trait Writeable {
         let _ = self.write_to(&mut output);
         Cow::Owned(output)
     }
-
-    /// Compares the contents of this `Writeable` to the given bytes
-    /// without allocating a String to hold the `Writeable` contents.
-    ///
-    /// This returns a lexicographical comparison, the same as if the Writeable
-    /// were first converted to a String and then compared with `Ord`. For a
-    /// locale-sensitive string ordering, use an ICU4X Collator.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use core::cmp::Ordering;
-    /// use core::fmt;
-    /// use writeable::Writeable;
-    ///
-    /// struct WelcomeMessage<'s> {
-    ///     pub name: &'s str,
-    /// }
-    ///
-    /// impl<'s> Writeable for WelcomeMessage<'s> {
-    ///     // see impl in Writeable docs
-    /// #    fn write_to<W: fmt::Write + ?Sized>(&self, sink: &mut W) -> fmt::Result {
-    /// #        sink.write_str("Hello, ")?;
-    /// #        sink.write_str(self.name)?;
-    /// #        sink.write_char('!')?;
-    /// #        Ok(())
-    /// #    }
-    /// }
-    ///
-    /// let message = WelcomeMessage { name: "Alice" };
-    /// let message_str = message.write_to_string();
-    ///
-    /// assert_eq!(Ordering::Equal, message.writeable_cmp_bytes(b"Hello, Alice!"));
-    ///
-    /// assert_eq!(Ordering::Greater, message.writeable_cmp_bytes(b"Alice!"));
-    /// assert_eq!(Ordering::Greater, (*message_str).cmp("Alice!"));
-    ///
-    /// assert_eq!(Ordering::Less, message.writeable_cmp_bytes(b"Hello, Bob!"));
-    /// assert_eq!(Ordering::Less, (*message_str).cmp("Hello, Bob!"));
-    /// ```
-    fn writeable_cmp_bytes(&self, other: &[u8]) -> core::cmp::Ordering {
-        let mut wc = cmp::WriteComparator::new(other);
-        let _ = self.write_to(&mut wc);
-        wc.finish().reverse()
-    }
 }
 
 /// Implements [`Display`](core::fmt::Display) for types that implement [`Writeable`].
@@ -460,14 +416,6 @@ macro_rules! assert_writeable_eq {
             );
         }
         assert_eq!(actual_writeable.to_string(), $expected_str);
-        let ordering = $crate::Writeable::writeable_cmp_bytes(actual_writeable, $expected_str.as_bytes());
-        assert_eq!(ordering, core::cmp::Ordering::Equal, $($arg)*);
-        let ordering = $crate::Writeable::writeable_cmp_bytes(actual_writeable, "\u{10FFFF}".as_bytes());
-        assert_eq!(ordering, core::cmp::Ordering::Less, $($arg)*);
-        if $expected_str != "" {
-            let ordering = $crate::Writeable::writeable_cmp_bytes(actual_writeable, "".as_bytes());
-            assert_eq!(ordering, core::cmp::Ordering::Greater, $($arg)*);
-        }
         actual_parts // return for assert_writeable_parts_eq
     }};
 }

--- a/utils/writeable/src/parts_write_adapter.rs
+++ b/utils/writeable/src/parts_write_adapter.rs
@@ -105,11 +105,6 @@ impl<T: Writeable + ?Sized> Writeable for WithPart<T> {
     fn write_to_string(&self) -> Cow<str> {
         self.writeable.write_to_string()
     }
-
-    #[inline]
-    fn writeable_cmp_bytes(&self, other: &[u8]) -> core::cmp::Ordering {
-        self.writeable.writeable_cmp_bytes(other)
-    }
 }
 
 impl<T: Writeable + ?Sized> fmt::Display for WithPart<T> {

--- a/utils/writeable/src/try_writeable.rs
+++ b/utils/writeable/src/try_writeable.rs
@@ -4,7 +4,7 @@
 
 use super::*;
 use crate::parts_write_adapter::CoreWriteAsPartsWrite;
-use core::{cmp::Ordering, convert::Infallible};
+use core::convert::Infallible;
 
 /// A writeable object that can fail while writing.
 ///
@@ -206,87 +206,6 @@ pub trait TryWriteable {
             Err(e) => Err((e, Cow::Owned(output))),
         }
     }
-
-    /// Compares the content of this writeable to a byte slice.
-    ///
-    /// This function compares the "lossy mode" string; for more information,
-    /// see [`TryWriteable::try_write_to()`].
-    ///
-    /// For more information, see [`Writeable::writeable_cmp_bytes()`].
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use core::cmp::Ordering;
-    /// use core::fmt;
-    /// use writeable::TryWriteable;
-    /// # use writeable::PartsWrite;
-    /// # use writeable::LengthHint;
-    ///
-    /// #[derive(Debug, PartialEq, Eq)]
-    /// enum HelloWorldWriteableError {
-    ///     MissingName
-    /// }
-    ///
-    /// #[derive(Debug, PartialEq, Eq)]
-    /// struct HelloWorldWriteable {
-    ///     pub name: Option<&'static str>
-    /// }
-    ///
-    /// impl TryWriteable for HelloWorldWriteable {
-    ///     type Error = HelloWorldWriteableError;
-    ///     // see impl in TryWriteable docs
-    /// #    fn try_write_to_parts<S: PartsWrite + ?Sized>(
-    /// #        &self,
-    /// #        sink: &mut S,
-    /// #    ) -> Result<Result<(), Self::Error>, fmt::Error> {
-    /// #        sink.write_str("Hello, ")?;
-    /// #        // Use `impl TryWriteable for Result` to generate the error part:
-    /// #        let _ = self.name.ok_or("nobody").try_write_to_parts(sink)?;
-    /// #        sink.write_char('!')?;
-    /// #        // Return a doubly-wrapped Result.
-    /// #        // The outer Result is for fmt::Error, handled by the `?`s above.
-    /// #        // The inner Result is for our own Self::Error.
-    /// #        if self.name.is_some() {
-    /// #            Ok(Ok(()))
-    /// #        } else {
-    /// #            Ok(Err(HelloWorldWriteableError::MissingName))
-    /// #        }
-    /// #    }
-    /// }
-    ///
-    /// // Success case:
-    /// let writeable = HelloWorldWriteable { name: Some("Alice") };
-    /// let writeable_str = writeable.try_write_to_string().expect("name is Some");
-    ///
-    /// assert_eq!(Ordering::Equal, writeable.writeable_cmp_bytes(b"Hello, Alice!"));
-    ///
-    /// assert_eq!(Ordering::Greater, writeable.writeable_cmp_bytes(b"Alice!"));
-    /// assert_eq!(Ordering::Greater, (*writeable_str).cmp("Alice!"));
-    ///
-    /// assert_eq!(Ordering::Less, writeable.writeable_cmp_bytes(b"Hello, Bob!"));
-    /// assert_eq!(Ordering::Less, (*writeable_str).cmp("Hello, Bob!"));
-    ///
-    /// // Failure case:
-    /// let writeable = HelloWorldWriteable { name: None };
-    /// let mut writeable_str = String::new();
-    /// let _ = writeable.try_write_to(&mut writeable_str).expect("write to String is infallible");
-    ///
-    /// assert_eq!(Ordering::Equal, writeable.writeable_cmp_bytes(b"Hello, nobody!"));
-    ///
-    /// assert_eq!(Ordering::Greater, writeable.writeable_cmp_bytes(b"Hello, alice!"));
-    /// assert_eq!(Ordering::Greater, (*writeable_str).cmp("Hello, alice!"));
-    ///
-    /// assert_eq!(Ordering::Less, writeable.writeable_cmp_bytes(b"Hello, zero!"));
-    /// assert_eq!(Ordering::Less, (*writeable_str).cmp("Hello, zero!"));
-    /// ```
-    fn writeable_cmp_bytes(&self, other: &[u8]) -> Ordering {
-        let mut wc = cmp::WriteComparator::new(other);
-        let _ = self
-            .try_write_to(&mut wc)
-            .unwrap_or_else(|fmt::Error| Ok(()));
-        wc.finish().reverse()
-    }
 }
 
 impl<T, E> TryWriteable for Result<T, E>
@@ -335,14 +254,6 @@ where
             Err(e) => Err((e.clone(), e.write_to_string())),
         }
     }
-
-    #[inline]
-    fn writeable_cmp_bytes(&self, other: &[u8]) -> Ordering {
-        match self {
-            Ok(t) => t.writeable_cmp_bytes(other),
-            Err(e) => e.writeable_cmp_bytes(other),
-        }
-    }
 }
 
 /// A wrapper around [`TryWriteable`] that implements [`Writeable`]
@@ -385,11 +296,6 @@ where
             Ok(s) => s,
             Err((infallible, _)) => match infallible {},
         }
-    }
-
-    #[inline]
-    fn writeable_cmp_bytes(&self, other: &[u8]) -> core::cmp::Ordering {
-        self.0.writeable_cmp_bytes(other)
     }
 }
 
@@ -440,11 +346,6 @@ where
     #[inline]
     fn try_write_to_string(&self) -> Result<Cow<str>, (Infallible, Cow<str>)> {
         Ok(self.0.write_to_string())
-    }
-
-    #[inline]
-    fn writeable_cmp_bytes(&self, other: &[u8]) -> core::cmp::Ordering {
-        self.0.writeable_cmp_bytes(other)
     }
 }
 
@@ -509,14 +410,6 @@ macro_rules! assert_try_writeable_eq {
                 "hint upper bound {} smaller than actual length {}: {}",
                 length_hint.0, actual_str.len(), format!($($arg)*),
             );
-        }
-        let ordering = actual_writeable.writeable_cmp_bytes($expected_str.as_bytes());
-        assert_eq!(ordering, core::cmp::Ordering::Equal, $($arg)*);
-        let ordering = actual_writeable.writeable_cmp_bytes("\u{10FFFF}".as_bytes());
-        assert_eq!(ordering, core::cmp::Ordering::Less, $($arg)*);
-        if $expected_str != "" {
-            let ordering = actual_writeable.writeable_cmp_bytes("".as_bytes());
-            assert_eq!(ordering, core::cmp::Ordering::Greater, $($arg)*);
         }
         actual_parts // return for assert_try_writeable_parts_eq
     }};


### PR DESCRIPTION
It simplifies writeable impls. There is no impact on benchmarks, either the new microbenchmark I added or the higher-level `strict_cmp` benchmark in the icu_locale_core crate:

```
     Running benches/langid.rs
langid/compare/strict_cmp/langid
                        time:   [271.42 ns 272.76 ns 274.20 ns]
                        change: [-0.2857% +0.0019% +0.3042%] (p = 0.99 > 0.05)
                        No change in performance detected.
Found 12 outliers among 100 measurements (12.00%)
  4 (4.00%) high mild
  8 (8.00%) high severe

     Running benches/locale.rs
locale/compare/strict_cmp/locale
                        time:   [370.74 ns 371.09 ns 371.44 ns]
                        change: [-0.4829% -0.1979% +0.0605%] (p = 0.16 > 0.05)
                        No change in performance detected.
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) high mild
  6 (6.00%) high severe
```