### PR TITLE
Special-case `Z`, `Z[Etc/UTC]` and `Z[Etc/GMT]` in IXDTF parser

### DIFF
--- a/components/datetime/src/time_zone.rs
+++ b/components/datetime/src/time_zone.rs
@@ -385,11 +385,10 @@ impl FormatTimeZone for GenericNonLocationFormat {
             return Ok(Err(FormatTimeZoneError::MissingZoneSymbols));
         };
 
-        let Some(name) = metazone(time_zone_id, local_time, metazone_period).and_then(|mz| {
+        let Some(name) = names.overrides.get(&time_zone_id).or_else(|| {
             names
-                .overrides
-                .get(&time_zone_id)
-                .or_else(|| names.defaults.get(&mz))
+                .defaults
+                .get(&metazone(time_zone_id, local_time, metazone_period)?)
         }) else {
             return Ok(Err(FormatTimeZoneError::Fallback));
         };
@@ -433,12 +432,16 @@ impl FormatTimeZone for SpecificNonLocationFormat {
             return Ok(Err(FormatTimeZoneError::MissingZoneSymbols));
         };
 
-        let Some(name) = metazone(time_zone_id, local_time, metazone_period).and_then(|mz| {
-            names
-                .overrides
-                .get(&(time_zone_id, zone_variant))
-                .or_else(|| names.defaults.get(&(mz, zone_variant)))
-        }) else {
+        let Some(name) = names
+            .overrides
+            .get(&(time_zone_id, zone_variant))
+            .or_else(|| {
+                names.defaults.get(&(
+                    metazone(time_zone_id, local_time, metazone_period)?,
+                    zone_variant,
+                ))
+            })
+        else {
             return Ok(Err(FormatTimeZoneError::Fallback));
         };
 
@@ -651,14 +654,11 @@ impl FormatTimeZone for GenericPartialLocationFormat {
         let Some(location) = locations.locations.get(&time_zone_id) else {
             return Ok(Err(FormatTimeZoneError::Fallback));
         };
-        let Some(non_location) =
-            metazone(time_zone_id, local_time, metazone_period).and_then(|mz| {
-                non_locations
-                    .overrides
-                    .get(&time_zone_id)
-                    .or_else(|| non_locations.defaults.get(&mz))
-            })
-        else {
+        let Some(non_location) = non_locations.overrides.get(&time_zone_id).or_else(|| {
+            non_locations
+                .defaults
+                .get(&metazone(time_zone_id, local_time, metazone_period)?)
+        }) else {
             return Ok(Err(FormatTimeZoneError::Fallback));
         };
 

--- a/components/datetime/tests/patterns/tests/time_zones.json
+++ b/components/datetime/tests/patterns/tests/time_zones.json
@@ -204,5 +204,45 @@
       "Z": "+?",
       "ZZZZZ": "+?"
     }
+  },
+  {
+    "locale": "en",
+    "datetime": "2021-07-11T12:00:00.000Z",
+    "expectations": {
+      "z": "UTC",
+      "zzzz": "Coordinated Universal Time",
+
+      "v": "UTC",
+      "vvvv": "Coordinated Universal Time",
+
+      "VVV": "Unknown City",
+      "VVVV": "GMT",
+
+      "O": "GMT",
+      "OOOO": "GMT",
+
+      "Z": "+0000",
+      "ZZZZZ": "Z"
+    }
+  },
+  {
+    "locale": "en",
+    "datetime": "2021-07-11T12:00:00.000[Etc/GMT]",
+    "expectations": {
+      "z": "GMT",
+      "zzzz": "Greenwich Mean Time",
+
+      "v": "GMT",
+      "vvvv": "Greenwich Mean Time",
+
+      "VVV": "Unknown City",
+      "VVVV": "GMT",
+
+      "O": "GMT",
+      "OOOO": "GMT",
+
+      "Z": "+0000",
+      "ZZZZZ": "Z"
+    }
   }
 ]

--- a/components/timezone/src/ixdtf.rs
+++ b/components/timezone/src/ixdtf.rs
@@ -213,7 +213,6 @@ impl<'a> Intermediate<'a> {
                     }),
                 ..
             } => (Some(*offset), true, None),
-            // Z[-0800]
             // Z[America/Los_Angeles]
             IxdtfParseRecord {
                 offset: Some(UtcOffsetRecordOrZ::Z),

--- a/components/timezone/src/ixdtf.rs
+++ b/components/timezone/src/ixdtf.rs
@@ -286,6 +286,9 @@ impl<'a> Intermediate<'a> {
             return Err(ParseError::MismatchedTimeZoneFields);
         };
         let Some(iana_identifier) = self.iana_identifier else {
+            if self.is_z {
+                return Err(ParseError::RequiresCalculation);
+            }
             return Err(ParseError::MismatchedTimeZoneFields);
         };
         let time_zone_id = mapper.iana_bytes_to_bcp47(iana_identifier);

--- a/utils/ixdtf/src/parsers/records.rs
+++ b/utils/ixdtf/src/parsers/records.rs
@@ -114,8 +114,21 @@ pub struct UtcOffsetRecord {
     pub nanosecond: u32,
 }
 
-#[non_exhaustive]
+impl UtcOffsetRecord {
+    /// +0000
+    pub const fn zero() -> Self {
+        Self {
+            sign: Sign::Positive,
+            hour: 0,
+            minute: 0,
+            second: 0,
+            nanosecond: 0,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[allow(clippy::exhaustive_enums)] // explicitly A or B
 pub enum UtcOffsetRecordOrZ {
     Offset(UtcOffsetRecord),
     Z,


### PR DESCRIPTION
These are the only `Z`s that don't require any calculation.