### PR TITLE
Bump versions of semver-broken crates to `{N+1}-dev`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,7 +548,7 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "databake"
-version = "0.1.8"
+version = "0.1.9-dev"
 dependencies = [
  "databake-derive",
  "proc-macro2",
@@ -772,7 +772,7 @@ checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "env_preferences"
-version = "1.5.0"
+version = "0.0.0"
 dependencies = [
  "core-foundation-sys",
  "icu_locale",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "fixed_decimal"
-version = "0.5.6"
+version = "0.6.0-dev"
 dependencies = [
  "criterion",
  "displaydoc",
@@ -943,7 +943,7 @@ checksum = "71a816c97c42258aa5834d07590b718b4c9a598944cd39a52dc25b351185d678"
 
 [[package]]
 name = "icu"
-version = "1.5.0"
+version = "2.0.0-dev"
 dependencies = [
  "icu_calendar",
  "icu_casemap",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "icu4x-datagen"
-version = "1.5.0"
+version = "2.0.0-dev"
 dependencies = [
  "clap",
  "eyre",
@@ -986,7 +986,7 @@ dependencies = [
 
 [[package]]
 name = "icu4x_ecma402"
-version = "0.8.2"
+version = "0.9.0-dev"
 dependencies = [
  "ecma402_traits",
  "fixed_decimal",
@@ -1018,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "icu_calendar"
-version = "1.5.0"
+version = "2.0.0-dev"
 dependencies = [
  "calendrical_calculations",
  "criterion",
@@ -1040,7 +1040,7 @@ dependencies = [
 
 [[package]]
 name = "icu_calendar_data"
-version = "1.5.0"
+version = "2.0.0-dev"
 dependencies = [
  "icu_locale",
  "icu_provider_baked",
@@ -1048,7 +1048,7 @@ dependencies = [
 
 [[package]]
 name = "icu_capi"
-version = "1.5.0"
+version = "2.0.0-dev"
 dependencies = [
  "diplomat",
  "diplomat-runtime",
@@ -1084,7 +1084,7 @@ dependencies = [
 
 [[package]]
 name = "icu_casemap"
-version = "1.5.0"
+version = "2.0.0-dev"
 dependencies = [
  "criterion",
  "databake",
@@ -1105,14 +1105,14 @@ dependencies = [
 
 [[package]]
 name = "icu_casemap_data"
-version = "1.5.0"
+version = "2.0.0-dev"
 dependencies = [
  "icu_provider_baked",
 ]
 
 [[package]]
 name = "icu_codepointtrie_builder"
-version = "0.3.8"
+version = "0.4.0-dev"
 dependencies = [
  "icu",
  "icu_collections",
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "icu_collator"
-version = "1.5.0"
+version = "2.0.0-dev"
 dependencies = [
  "arraystring",
  "atoi",
@@ -1148,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "icu_collator_data"
-version = "1.5.0"
+version = "2.0.0-dev"
 dependencies = [
  "icu_locale",
  "icu_provider_baked",
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.0.0-dev"
 dependencies = [
  "criterion",
  "databake",
@@ -1177,7 +1177,7 @@ dependencies = [
 
 [[package]]
 name = "icu_datetime"
-version = "1.5.0"
+version = "2.0.0-dev"
 dependencies = [
  "bincode",
  "criterion",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "icu_datetime_data"
-version = "1.5.0"
+version = "2.0.0-dev"
 dependencies = [
  "icu_locale",
  "icu_provider_baked",
@@ -1217,7 +1217,7 @@ dependencies = [
 
 [[package]]
 name = "icu_decimal"
-version = "1.5.0"
+version = "2.0.0-dev"
 dependencies = [
  "criterion",
  "databake",
@@ -1239,7 +1239,7 @@ dependencies = [
 
 [[package]]
 name = "icu_decimal_data"
-version = "1.5.0"
+version = "2.0.0-dev"
 dependencies = [
  "icu_locale",
  "icu_provider_baked",
@@ -1247,7 +1247,7 @@ dependencies = [
 
 [[package]]
 name = "icu_experimental"
-version = "0.1.0"
+version = "0.2.0-dev"
 dependencies = [
  "criterion",
  "databake",
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "icu_experimental_data"
-version = "0.1.0"
+version = "0.2.0-dev"
 dependencies = [
  "icu_locale",
  "icu_provider_baked",
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "icu_freertos"
-version = "1.5.0"
+version = "2.0.0-dev"
 dependencies = [
  "cortex-m",
  "freertos-rust",
@@ -1315,7 +1315,7 @@ dependencies = [
 
 [[package]]
 name = "icu_list"
-version = "1.5.0"
+version = "2.0.0-dev"
 dependencies = [
  "databake",
  "displaydoc",
@@ -1333,7 +1333,7 @@ dependencies = [
 
 [[package]]
 name = "icu_list_data"
-version = "1.5.0"
+version = "2.0.0-dev"
 dependencies = [
  "icu_locale",
  "icu_provider_baked",
@@ -1341,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "icu_locale"
-version = "1.5.0"
+version = "2.0.0-dev"
 dependencies = [
  "criterion",
  "databake",
@@ -1361,7 +1361,7 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "1.5.0"
+version = "2.0.0-dev"
 dependencies = [
  "criterion",
  "databake",
@@ -1381,14 +1381,14 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_data"
-version = "1.5.0"
+version = "2.0.0-dev"
 dependencies = [
  "icu_provider_baked",
 ]
 
 [[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.0.0-dev"
 dependencies = [
  "arraystring",
  "arrayvec",
@@ -1412,14 +1412,14 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.0"
+version = "2.0.0-dev"
 dependencies = [
  "icu_provider_baked",
 ]
 
 [[package]]
 name = "icu_pattern"
-version = "0.2.0"
+version = "0.3.0-dev"
 dependencies = [
  "databake",
  "displaydoc",
@@ -1437,7 +1437,7 @@ dependencies = [
 
 [[package]]
 name = "icu_plurals"
-version = "1.5.0"
+version = "2.0.0-dev"
 dependencies = [
  "criterion",
  "databake",
@@ -1456,7 +1456,7 @@ dependencies = [
 
 [[package]]
 name = "icu_plurals_data"
-version = "1.5.0"
+version = "2.0.0-dev"
 dependencies = [
  "icu_locale",
  "icu_provider_baked",
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "icu_properties"
-version = "1.5.0"
+version = "2.0.0-dev"
 dependencies = [
  "databake",
  "displaydoc",
@@ -1482,14 +1482,14 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.0"
+version = "2.0.0-dev"
 dependencies = [
  "icu_provider_baked",
 ]
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
+version = "2.0.0-dev"
 dependencies = [
  "bincode",
  "criterion",
@@ -1515,7 +1515,7 @@ dependencies = [
 
 [[package]]
 name = "icu_provider_adapters"
-version = "1.5.0"
+version = "2.0.0-dev"
 dependencies = [
  "databake",
  "icu_locale",
@@ -1528,7 +1528,7 @@ dependencies = [
 
 [[package]]
 name = "icu_provider_baked"
-version = "1.5.0"
+version = "2.0.0-dev"
 dependencies = [
  "crlify",
  "databake",
@@ -1544,7 +1544,7 @@ dependencies = [
 
 [[package]]
 name = "icu_provider_blob"
-version = "1.5.0"
+version = "2.0.0-dev"
 dependencies = [
  "criterion",
  "databake",
@@ -1564,7 +1564,7 @@ dependencies = [
 
 [[package]]
 name = "icu_provider_export"
-version = "1.5.0"
+version = "2.0.0-dev"
 dependencies = [
  "displaydoc",
  "elsa",
@@ -1584,7 +1584,7 @@ dependencies = [
 
 [[package]]
 name = "icu_provider_fs"
-version = "1.5.0"
+version = "2.0.0-dev"
 dependencies = [
  "bincode",
  "criterion",
@@ -1604,7 +1604,7 @@ dependencies = [
 
 [[package]]
 name = "icu_provider_macros"
-version = "1.5.0"
+version = "2.0.0-dev"
 dependencies = [
  "icu_provider",
  "proc-macro2",
@@ -1614,7 +1614,7 @@ dependencies = [
 
 [[package]]
 name = "icu_provider_registry"
-version = "1.5.0"
+version = "2.0.0-dev"
 dependencies = [
  "icu",
  "icu_provider",
@@ -1622,7 +1622,7 @@ dependencies = [
 
 [[package]]
 name = "icu_provider_source"
-version = "1.5.0"
+version = "2.0.0-dev"
 dependencies = [
  "calendrical_calculations",
  "displaydoc",
@@ -1664,7 +1664,7 @@ dependencies = [
 
 [[package]]
 name = "icu_segmenter"
-version = "1.5.0"
+version = "2.0.0-dev"
 dependencies = [
  "core_maths",
  "criterion",
@@ -1686,7 +1686,7 @@ dependencies = [
 
 [[package]]
 name = "icu_segmenter_data"
-version = "1.5.0"
+version = "2.0.0-dev"
 dependencies = [
  "icu_locale",
  "icu_provider_baked",
@@ -1694,7 +1694,7 @@ dependencies = [
 
 [[package]]
 name = "icu_timezone"
-version = "1.5.0"
+version = "2.0.0-dev"
 dependencies = [
  "calendrical_calculations",
  "databake",
@@ -1712,7 +1712,7 @@ dependencies = [
 
 [[package]]
 name = "icu_timezone_data"
-version = "1.5.0"
+version = "2.0.0-dev"
 dependencies = [
  "icu_provider_baked",
 ]
@@ -1783,7 +1783,7 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "ixdtf"
-version = "0.2.0"
+version = "0.3.0-dev"
 dependencies = [
  "criterion",
  "displaydoc",
@@ -2171,7 +2171,7 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.0.0"
+version = "0.1.0-dev"
 dependencies = [
  "bincode",
  "databake",
@@ -2812,7 +2812,7 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
+version = "0.8.0-dev"
 dependencies = [
  "bincode",
  "criterion",
@@ -2877,7 +2877,7 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "tzif"
-version = "0.2.3"
+version = "0.3.0-dev"
 dependencies = [
  "combine",
  "walkdir",
@@ -3391,7 +3391,7 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.5.5"
+version = "0.5.6-dev"
 dependencies = [
  "criterion",
  "either",
@@ -3410,7 +3410,7 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.7.4"
+version = "0.7.5-dev"
 dependencies = [
  "bincode",
  "postcard",
@@ -3480,7 +3480,7 @@ checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zerotrie"
-version = "0.1.3"
+version = "0.2.0-dev"
 dependencies = [
  "bincode",
  "criterion",
@@ -3503,7 +3503,7 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.10.4"
+version = "0.11.0-dev"
 dependencies = [
  "bincode",
  "criterion",
@@ -3527,7 +3527,7 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.11.0-dev"
 dependencies = [
  "bincode",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.5.0"
+version = "2.0.0-dev"
 rust-version = "1.71.1"
 authors = ["The ICU4X Project Developers"]
 edition = "2021"
@@ -130,80 +130,80 @@ include = [
 
 # ICU4X core
 # These use non-tilde deps, see https://github.com/unicode-org/icu4x/issues/4343
-icu_locale_core = { version = "1.5.0", path = "components/locale_core", default-features = false }
-icu_provider = { version = "1.5.0", path = "provider/core", default-features = false }
+icu_locale_core = { version = "2.0.0-dev", path = "components/locale_core", default-features = false }
+icu_provider = { version = "2.0.0-dev", path = "provider/core", default-features = false }
+icu_pattern = { version = "0.3.0-dev", path = "components/pattern", default-features = false }
 
 # Components
-icu = { version = "~1.5.0", path = "components/icu", default-features = false }
-icu_calendar = { version = "~1.5.0", path = "components/calendar", default-features = false }
-icu_casemap = { version = "~1.5.0", path = "components/casemap", default-features = false }
-icu_collator = { version = "~1.5.0", path = "components/collator", default-features = false }
-icu_collections = { version = "~1.5.0", path = "components/collections", default-features = false }
-icu_codepointtrie_builder = { version = "0.3.8", path = "components/collections/codepointtrie_builder", default-features = false }
-icu_datetime = { version = "~1.5.0", path = "components/datetime", default-features = false }
-icu_decimal = { version = "~1.5.0", path = "components/decimal", default-features = false }
-icu_experimental = { version = "~0.1.0", path = "components/experimental", default-features = false }
-icu_list = { version = "~1.5.0", path = "components/list", default-features = false }
-icu_locale = { version = "~1.5.0", path = "components/locale", default-features = false }
-icu_normalizer = { version = "~1.5.0", path = "components/normalizer", default-features = false }
-icu_pattern = { version = "0.2.0", path = "components/pattern", default-features = false }
-icu_plurals = { version = "~1.5.0", path = "components/plurals", default-features = false }
-icu_properties = { version = "~1.5.0", path = "components/properties", default-features = false }
-icu_segmenter = { version = "~1.5.0", path = "components/segmenter", default-features = false }
-icu_timezone = { version = "~1.5.0", path = "components/timezone", default-features = false }
+icu = { version = "~2.0.0-dev", path = "components/icu", default-features = false }
+icu_calendar = { version = "~2.0.0-dev", path = "components/calendar", default-features = false }
+icu_casemap = { version = "~2.0.0-dev", path = "components/casemap", default-features = false }
+icu_collator = { version = "~2.0.0-dev", path = "components/collator", default-features = false }
+icu_collections = { version = "~2.0.0-dev", path = "components/collections", default-features = false }
+icu_codepointtrie_builder = { version = "~0.4.0-dev", path = "components/collections/codepointtrie_builder", default-features = false }
+icu_datetime = { version = "~2.0.0-dev", path = "components/datetime", default-features = false }
+icu_decimal = { version = "~2.0.0-dev", path = "components/decimal", default-features = false }
+icu_experimental = { version = "~0.2.0-dev", path = "components/experimental", default-features = false }
+icu_list = { version = "~2.0.0-dev", path = "components/list", default-features = false }
+icu_locale = { version = "~2.0.0-dev", path = "components/locale", default-features = false }
+icu_normalizer = { version = "~2.0.0-dev", path = "components/normalizer", default-features = false }
+icu_plurals = { version = "~2.0.0-dev", path = "components/plurals", default-features = false }
+icu_properties = { version = "~2.0.0-dev", path = "components/properties", default-features = false }
+icu_segmenter = { version = "~2.0.0-dev", path = "components/segmenter", default-features = false }
+icu_timezone = { version = "~2.0.0-dev", path = "components/timezone", default-features = false }
 
 # FFI
-icu_capi = { version = "~1.5.0", path = "ffi/capi", default-features = false }
-icu4x_ecma402 = { version = "0.8.2", path = "ffi/ecma402", default-features = false }
-icu_freertos = { version = "~1.5.0", path = "ffi/freertos", default-features = false }
-icu_harfbuzz = { version = "~0.2.0", path = "ffi/harfbuzz", default-features = false }
+icu_capi = { version = "~2.0.0-dev", path = "ffi/capi", default-features = false }
+# icu4x_ecma402 never used as a dep
+# icu_freertos never used as a dep
+# icu_harfbuzz never used as a dep
 
 # Provider
-icu_provider_export = { version = "~1.5.0", path = "provider/export", default-features = false }
-icu_provider_source = { version = "~1.5.0", path = "provider/source", default-features = false }
-icu_provider_macros = { version = "~1.5.0", path = "provider/core/macros", default-features = false }
-icu_provider_adapters = { version = "~1.5.0", path = "provider/adapters", default-features = false }
-icu_provider_baked = { version = "~1.5.0", path = "provider/baked", default-features = false }
-icu_provider_blob = { version = "~1.5.0", path = "provider/blob", default-features = false }
-icu_provider_fs = { version = "~1.5.0", path = "provider/fs", default-features = false }
-icu_provider_registry = { version = "~1.5.0", path = "provider/registry", default-features = false }
+icu_provider_export = { version = "~2.0.0-dev", path = "provider/export", default-features = false }
+icu_provider_source = { version = "~2.0.0-dev", path = "provider/source", default-features = false }
+icu_provider_macros = { version = "~2.0.0-dev", path = "provider/core/macros", default-features = false }
+icu_provider_adapters = { version = "~2.0.0-dev", path = "provider/adapters", default-features = false }
+icu_provider_baked = { version = "~2.0.0-dev", path = "provider/baked", default-features = false }
+icu_provider_blob = { version = "~2.0.0-dev", path = "provider/blob", default-features = false }
+icu_provider_fs = { version = "~2.0.0-dev", path = "provider/fs", default-features = false }
+icu_provider_registry = { version = "~2.0.0-dev", path = "provider/registry", default-features = false }
 
 # Baked data
-icu_calendar_data = { version = "~1.5.0", path = "provider/data/calendar", default-features = false }
-icu_casemap_data = { version = "~1.5.0", path = "provider/data/casemap", default-features = false }
-icu_collator_data = { version = "~1.5.0", path = "provider/data/collator", default-features = false }
-icu_datetime_data = { version = "~1.5.0", path = "provider/data/datetime", default-features = false }
-icu_decimal_data = { version = "~1.5.0", path = "provider/data/decimal", default-features = false }
-icu_list_data = { version = "~1.5.0", path = "provider/data/list", default-features = false }
-icu_locale_data = { version = "~1.5.0", path = "provider/data/locale", default-features = false }
-icu_normalizer_data = { version = "~1.5.0", path = "provider/data/normalizer", default-features = false }
-icu_plurals_data = { version = "~1.5.0", path = "provider/data/plurals", default-features = false }
-icu_properties_data = { version = "~1.5.0", path = "provider/data/properties", default-features = false }
-icu_segmenter_data = { version = "~1.5.0", path = "provider/data/segmenter", default-features = false }
-icu_timezone_data = { version = "~1.5.0", path = "provider/data/timezone", default-features = false }
-icu_experimental_data = { version = "~0.1.0", path = "provider/data/experimental", default-features = false }
+icu_calendar_data = { version = "~2.0.0-dev", path = "provider/data/calendar", default-features = false }
+icu_casemap_data = { version = "~2.0.0-dev", path = "provider/data/casemap", default-features = false }
+icu_collator_data = { version = "~2.0.0-dev", path = "provider/data/collator", default-features = false }
+icu_datetime_data = { version = "~2.0.0-dev", path = "provider/data/datetime", default-features = false }
+icu_decimal_data = { version = "~2.0.0-dev", path = "provider/data/decimal", default-features = false }
+icu_list_data = { version = "~2.0.0-dev", path = "provider/data/list", default-features = false }
+icu_locale_data = { version = "~2.0.0-dev", path = "provider/data/locale", default-features = false }
+icu_normalizer_data = { version = "~2.0.0-dev", path = "provider/data/normalizer", default-features = false }
+icu_plurals_data = { version = "~2.0.0-dev", path = "provider/data/plurals", default-features = false }
+icu_properties_data = { version = "~2.0.0-dev", path = "provider/data/properties", default-features = false }
+icu_segmenter_data = { version = "~2.0.0-dev", path = "provider/data/segmenter", default-features = false }
+icu_timezone_data = { version = "~2.0.0-dev", path = "provider/data/timezone", default-features = false }
+icu_experimental_data = { version = "~0.2.0-dev", path = "provider/data/experimental", default-features = false }
 
 # Utils
 bies = { version = "0.2.2", path = "utils/bies", default-features = false }
 calendrical_calculations = { version = "0.1.1", path = "utils/calendrical_calculations", default-features = false }
 crlify = { version = "1.0.4", path = "utils/crlify", default-features = false }
-databake = { version = "0.1.8", path = "utils/databake", default-features = false }
+databake = { version = "0.1.9-dev", path = "utils/databake", default-features = false }
 databake-derive = { version = "0.1.8", path = "utils/databake/derive", default-features = false }
 deduplicating_array = { version = "0.1.6", path = "utils/deduplicating_array", default-features = false }
-fixed_decimal = { version = "0.5.6", path = "utils/fixed_decimal", default-features = false }
-ixdtf = { version = "0.2.0", path = "utils/ixdtf", default-features = false }
+fixed_decimal = { version = "0.6.0-dev", path = "utils/fixed_decimal", default-features = false }
+ixdtf = { version = "0.3.0-dev", path = "utils/ixdtf", default-features = false }
 litemap = { version = "0.7.3", path = "utils/litemap", default-features = false }
-tinystr = { version = "0.7.5", path = "utils/tinystr", default-features = false }
-tzif = { version = "0.2.3", path = "utils/tzif", default-features = false }
-potential_utf = { version = "0.0.0", path = "utils/potential_utf", default-features = false }
-writeable = { version = "0.5.5", path = "utils/writeable", default-features = false }
-yoke = { version = "0.7.4", path = "utils/yoke", default-features = false }
+tinystr = { version = "0.8.0-dev", path = "utils/tinystr", default-features = false }
+tzif = { version = "0.3.0-dev", path = "utils/tzif", default-features = false }
+potential_utf = { version = "0.1.0-dev", path = "utils/potential_utf", default-features = false }
+writeable = { version = "0.5.6-dev", path = "utils/writeable", default-features = false }
+yoke = { version = "0.7.5-dev", path = "utils/yoke", default-features = false }
 yoke-derive = { version = "0.7.4", path = "utils/yoke/derive", default-features = false }
 zerofrom = { version = "0.1.3", path = "utils/zerofrom", default-features = false }
 zerofrom-derive = { version = "0.1.3", path = "utils/zerofrom/derive", default-features = false }
-zerotrie = { version = "0.1.3", path = "utils/zerotrie", default-features = false }
-zerovec = { version = "0.10.2", path = "utils/zerovec", default-features = false }
-zerovec-derive = { version = "0.10.2", path = "utils/zerovec/derive", default-features = false }
+zerotrie = { version = "0.2.0-dev", path = "utils/zerotrie", default-features = false }
+zerovec = { version = "0.11.0-dev", path = "utils/zerovec", default-features = false }
+zerovec-derive = { version = "0.11.0-dev", path = "utils/zerovec/derive", default-features = false }
 
 # Tools
 icu_benchmark_macros = { path = "tools/benchmark/macros" }

--- a/components/collections/codepointtrie_builder/Cargo.toml
+++ b/components/collections/codepointtrie_builder/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_codepointtrie_builder"
 description = "Runtime builder for CodePointTrie"
-version = "0.3.8"
+version = "0.4.0-dev"
 license = "Unicode-3.0"
 include = [
     "src/**/*",

--- a/components/experimental/Cargo.toml
+++ b/components/experimental/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_experimental"
 description = "ICU4X pre-release components under active development; all code in this crate is unstable."
-version = "0.1.0"
+version = "0.2.0-dev"
 
 authors.workspace = true
 categories.workspace = true

--- a/components/pattern/Cargo.toml
+++ b/components/pattern/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_pattern"
 description = "ICU pattern utilities"
-version = "0.2.0"
+version = "0.3.0-dev"
 
 authors.workspace = true
 edition.workspace = true

--- a/documents/process/release.md
+++ b/documents/process/release.md
@@ -38,6 +38,7 @@ Once the release checklist is complete, the assigned release driver will perform
 
 * Land the changelog (see below)
   * Note: Do this _before_ tagging the release so that it is included in the tag
+* Remove all `-dev` prelease tags from `Cargo.toml`s
 * Go through the prerelease checklist again, ensuring that no problems were reintroduced in the PRs that landed since the opening of the checklist. (Things like doc prettification will likely need to be rerun!)
 * Release utils (see section below). Get the version bumps reviewed and checked in before releasing.
 * Update ICU4X package versions as needed. Most of this can be done by updating `workspace.package` in the root `Cargo.toml` and the `workspace.dependencies` entries there. Some `icu_*` crates do not follow the ICU4X versioning scheme like `icu_codepointtrie_builder` or experimental crates.

--- a/ffi/ecma402/Cargo.toml
+++ b/ffi/ecma402/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu4x_ecma402"
 description = "ECMA-402 API functionality backed by the ICU4X library"
-version = "0.8.2"
+version = "0.9.0-dev"
 
 authors.workspace = true
 categories.workspace = true

--- a/provider/data/experimental/Cargo.toml
+++ b/provider/data/experimental/Cargo.toml
@@ -6,7 +6,7 @@
 name = "icu_experimental_data"
 description = "Data for the icu_experimental crate"
 license = "Unicode-3.0"
-version = "0.1.0"
+version = "0.2.0-dev"
 
 authors.workspace = true
 categories.workspace = true

--- a/tools/make/bakeddata/src/main.rs
+++ b/tools/make/bakeddata/src/main.rs
@@ -41,7 +41,7 @@ const COMPONENTS: &[(&str, &[DataMarkerInfo], &str)] = &[
     (
         "experimental",
         icu::experimental::provider::MARKERS,
-        r#"version = "0.1.0""#,
+        r#"version = "0.2.0-dev""#,
     ),
 ];
 

--- a/tutorials/.cargo/config.toml
+++ b/tutorials/.cargo/config.toml
@@ -7,9 +7,6 @@
 # by cargo for any invocation inside tutorials/.
 
 [patch.crates-io]
-# Workaround for broken semver in repo
-idna_adapter = { git = "https://github.com/hsivonen/idna_adapter", rev = "v1.1.0" }
-
 # KEEP IN SYNC WITH TOP-LEVEL Cargo.toml
 
 # ICU4X core

--- a/tutorials/c-tiny/fixeddecimal/Cargo.toml
+++ b/tutorials/c-tiny/fixeddecimal/Cargo.toml
@@ -12,4 +12,4 @@ rust-version = "1.71.1"
 path = "unused"
 
 [dependencies]
-icu_capi = { version = "1.5", default-features = false }
+icu_capi = { version = "2.0.0-dev", default-features = false }

--- a/tutorials/c-tiny/segmenter/Cargo.toml
+++ b/tutorials/c-tiny/segmenter/Cargo.toml
@@ -13,4 +13,4 @@ rust-version = "1.71.1"
 path = "unused"
 
 [dependencies]
-icu_capi = { version = "1.5", default-features = false }
+icu_capi = { version = "2.0.0-dev", default-features = false }

--- a/tutorials/c/Cargo.toml
+++ b/tutorials/c/Cargo.toml
@@ -9,4 +9,4 @@ name = "unused"
 path = "unused"
 
 [dependencies]
-icu_capi = "1.5"
+icu_capi = "2.0.0-dev"

--- a/tutorials/cpp.md
+++ b/tutorials/cpp.md
@@ -26,7 +26,7 @@ resolver = "2"
 path = "unused"
 
 [dependencies]
-icu_capi = { version = "1.4", default-features = false, features = [] }
+icu_capi = { version = "2.0.0-dev", default-features = false, features = [] }
 ```
 
 Some of the keys are required by the parser, but won't be used by us. 
@@ -43,7 +43,7 @@ Some of the keys are required by the parser, but won't be used by us.
 You can now set features by updating the `features` key in `Cargo.toml`:
 
 ```toml
-icu_capi = { version = "1.4", default-features = false, features = ["default", "buffer_provider"] }
+icu_capi = { version = "2.0.0-dev", default-features = false, features = ["default", "buffer_provider"] }
 
 ```
 
@@ -120,7 +120,7 @@ C++ versions beyond C++17 are supported, as are other C++ compilers.
 Users wishing to use ICU4X on a `no_std` platform will need to provide an allocator and a panic hook in order to build a linkable library. The `icu_capi` crate can provide a looping panic handler, and a `malloc`-backed allocator, under the `looping_panic_handler` and `libc_alloc` features, respectively.
 
 ```toml
-icu_capi = { version = "1.4", default-features = false, features = ["default_components", "buffer_provider", "looping_panic_handler", "libc_alloc"] }
+icu_capi = { version = "2.0.0-dev", default-features = false, features = ["default_components", "buffer_provider", "looping_panic_handler", "libc_alloc"] }
 
 ```
 

--- a/tutorials/cpp/Cargo.toml
+++ b/tutorials/cpp/Cargo.toml
@@ -9,5 +9,5 @@ name = "unused"
 path = "unused"
 
 [dependencies]
-icu_capi = { version = "1.5", features = ["provider_fs", "experimental"] }
-icu_provider = { version = "1.5", features = ["deserialize_json"] }
+icu_capi = { version = "2.0.0-dev", features = ["provider_fs", "experimental"] }
+icu_provider = { version = "2.0.0-dev", features = ["deserialize_json"] }

--- a/tutorials/gn/Cargo.toml
+++ b/tutorials/gn/Cargo.toml
@@ -10,9 +10,9 @@ edition = "2021"
 
 [dependencies]
 # Note: Only dependencies that are explicitly listed here are given public GN build targets.
-icu_capi = { version = "1.0", default-features = false, features = ["default_components"] }
-icu = { version = "1.0", default-features = false }
-icu_provider = { version = "1.0" }
+icu_capi = { version = "2.0.0-dev", default-features = false, features = ["default_components"] }
+icu = { version = "2.0.0-dev", default-features = false }
+icu_provider = { version = "2.0.0-dev" }
 
 [gn.package.proc-macro2."1.0.83"]
 rustflags = ["--cfg=use_proc_macro", "--cfg=wrap_proc_macro", "--cfg=proc_macro_span"]

--- a/tutorials/js-tiny/Cargo.toml
+++ b/tutorials/js-tiny/Cargo.toml
@@ -13,4 +13,4 @@ rust-version = "1.71.1"
 path = "unused"
 
 [dependencies]
-icu_capi = "1.5"
+icu_capi = "2.0.0-dev"

--- a/tutorials/rust.md
+++ b/tutorials/rust.md
@@ -8,7 +8,7 @@ The most basic Cargo.toml to get you off the ground is the following:
 
 ```toml
 [dependencies]
-icu = "1.5"
+icu = "2.0.0-dev"
 ```
 
 In your main.rs, you can use all stable ICU4X components for the recommended set of locales, which get compiled into the library.
@@ -33,7 +33,7 @@ Experimental modules are published in a separate `icu_experimental` crate:
 
 ```toml
 [dependencies]
-icu = { version = "1.5", features = ["experimental"] }
+icu = { version = "2.0.0-dev", features = ["experimental"] }
 ```
 
 In your main.rs, you can now use e.g. the `icu_experimental::displaynames` module.
@@ -46,8 +46,8 @@ If you wish to generate your own data in blob format and pass it into ICU4X, ena
 
 ```toml
 [dependencies]
-icu = { version = "1.5", features = ["serde"] }
-icu_provider_blob = "1.5"
+icu = { version = "2.0.0-dev", features = ["serde"] }
+icu_provider_blob = "2.0.0-dev"
 ```
 
 To learn about building ICU4X data, including whether to check in the data blob file to your repository, see [data_management.md](./data_management.md).
@@ -60,7 +60,7 @@ If you wish to share ICU4X objects between threads, you must enable the `"sync"`
 
 ```toml
 [dependencies]
-icu = { version = "1.5", features = ["sync"] }
+icu = { version = "2.0.0-dev", features = ["sync"] }
 ```
 
 You can now use most ICU4X types when `Send + Sync` are required, such as when sharing across threads.
@@ -73,16 +73,16 @@ If you wish to use data generation in a `build.rs` script, you need to manually 
 
 ```toml
 [dependencies]
-icu = { version = "1.5", default-features = false } # turn off compiled_data
-icu_provider = "1.5" # for databake
-icu_provider_baked = "1.5" # for databake
+icu = { version = "2.0.0-dev", default-features = false } # turn off compiled_data
+icu_provider = "2.0.0-dev" # for databake
+icu_provider_baked = "2.0.0-dev" # for databake
 zerovec = "0.9" # for databake
 
 # for build.rs:
 [build-dependencies]
-icu = "1.5"
-icu_provider_export = "1.5"
-icu_provider_source = "1.5"
+icu = "2.0.0-dev"
+icu_provider_export = "2.0.0-dev"
+icu_provider_source = "2.0.0-dev"
 ```
 
 This example has an additional section for auto-generating the data in build.rs. In your build.rs, invoke the ICU4X Datagen API with the set of markers you require. Don't worry; if using databake, you will get a compiler error if you don't specify enough markers.

--- a/tutorials/rust/baked/Cargo.toml
+++ b/tutorials/rust/baked/Cargo.toml
@@ -12,12 +12,12 @@ edition = "2021"
 publish = false
 
 [dependencies]
-icu = { version = "1.5", default-features = false } # turn off compiled_data
-icu_provider = "1.5" # for databake
-icu_provider_baked = "1.5" # for databake
-zerovec = "0.10" # for databake
+icu = { version = "2.0.0-dev", default-features = false } # turn off compiled_data
+icu_provider = "2.0.0-dev" # for databake
+icu_provider_baked = "2.0.0-dev" # for databake
+zerovec = "0.11.0-dev" # for databake
 
 [build-dependencies]
-icu = "1.5"
-icu_provider_export = "1.5"
-icu_provider_source = "1.5"
+icu = "2.0.0-dev"
+icu_provider_export = "2.0.0-dev"
+icu_provider_source = "2.0.0-dev"

--- a/tutorials/rust/buffer/Cargo.toml
+++ b/tutorials/rust/buffer/Cargo.toml
@@ -12,5 +12,5 @@ edition = "2021"
 publish = false
 
 [dependencies]
-icu = { version = "1.5", features = ["serde"] }
-icu_provider_blob = "1.5"
+icu = { version = "2.0.0-dev", features = ["serde"] }
+icu_provider_blob = "2.0.0-dev"

--- a/tutorials/rust/custom_compiled/Cargo.toml
+++ b/tutorials/rust/custom_compiled/Cargo.toml
@@ -12,4 +12,4 @@ edition = "2021"
 publish = false
 
 [dependencies]
-icu = "1.5"
+icu = "2.0.0-dev"

--- a/tutorials/rust/default/Cargo.toml
+++ b/tutorials/rust/default/Cargo.toml
@@ -12,4 +12,4 @@ edition = "2021"
 publish = false
 
 [dependencies]
-icu = "1.5"
+icu = "2.0.0-dev"

--- a/tutorials/rust/experimental/Cargo.toml
+++ b/tutorials/rust/experimental/Cargo.toml
@@ -12,4 +12,4 @@ edition = "2021"
 publish = false
 
 [dependencies]
-icu = { version = "1.5", features = ["experimental"] }
+icu = { version = "2.0.0-dev", features = ["experimental"] }

--- a/tutorials/rust/sync/Cargo.toml
+++ b/tutorials/rust/sync/Cargo.toml
@@ -12,4 +12,4 @@ edition = "2021"
 publish = false
 
 [dependencies]
-icu = { version = "1.5", features = ["sync"] }
+icu = { version = "2.0.0-dev", features = ["sync"] }

--- a/utils/databake/Cargo.toml
+++ b/utils/databake/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "databake"
 description = "Trait that lets structs represent themselves as (const) Rust expressions"
-version = "0.1.8"
+version = "0.1.9-dev"
 categories = ["rust-patterns", "memory-management", "development-tools::procedural-macro-helpers", "development-tools::build-utils"]
 keywords = ["zerocopy", "serialization", "const", "proc"]
 

--- a/utils/env_preferences/Cargo.toml
+++ b/utils/env_preferences/Cargo.toml
@@ -4,7 +4,9 @@
 
 [package]
 name = "env_preferences"
-version.workspace = true
+version = "0.0.0"
+publish = false
+
 rust-version.workspace = true
 authors.workspace = true
 edition.workspace = true

--- a/utils/fixed_decimal/Cargo.toml
+++ b/utils/fixed_decimal/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "fixed_decimal"
 description = "An API for representing numbers in a human-readable form"
-version = "0.5.6"
+version = "0.6.0-dev"
 
 authors.workspace = true
 categories.workspace = true

--- a/utils/ixdtf/Cargo.toml
+++ b/utils/ixdtf/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "ixdtf"
 description = "Parser for Internet eXtended DateTime Format"
-version = "0.2.0"
+version = "0.3.0-dev"
 
 authors.workspace = true
 categories.workspace = true

--- a/utils/potential_utf/Cargo.toml
+++ b/utils/potential_utf/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "potential_utf"
-version = "0.0.0"
+version = "0.1.0-dev"
 rust-version.workspace = true
 authors.workspace = true
 edition.workspace = true

--- a/utils/tinystr/Cargo.toml
+++ b/utils/tinystr/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "tinystr"
 description = "A small ASCII-only bounded length string representation."
-version = "0.7.6"
+version = "0.8.0-dev"
 keywords = ["string", "str", "small", "tiny", "no_std"]
 categories = ["data-structures"]
 

--- a/utils/tzif/Cargo.toml
+++ b/utils/tzif/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "tzif"
 description = "A parser for TZif files"
-version = "0.2.3"
+version = "0.3.0-dev"
 keywords = ["time-zone", "posix", "iana", "parse", "data"]
 categories = ["date-and-time", "parser-implementations"]
 

--- a/utils/writeable/Cargo.toml
+++ b/utils/writeable/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "writeable"
 description = "A more efficient alternative to fmt::Display"
-version = "0.5.5"
+version = "0.5.6-dev"
 
 authors.workspace = true
 edition.workspace = true

--- a/utils/yoke/Cargo.toml
+++ b/utils/yoke/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "yoke"
 description = "Abstraction allowing borrowed data to be carried along with the backing data it borrows from"
-version = "0.7.4"
+version = "0.7.5-dev"
 authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
 categories = ["data-structures", "memory-management", "caching", "no-std"]
 keywords = ["zerocopy", "serialization", "lifetime", "borrow", "self-referential"]

--- a/utils/zerotrie/Cargo.toml
+++ b/utils/zerotrie/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "zerotrie"
 description = "A data structure that efficiently maps strings to integers"
-version = "0.1.3"
+version = "0.2.0-dev"
 
 authors.workspace = true
 categories.workspace = true

--- a/utils/zerovec/Cargo.toml
+++ b/utils/zerovec/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "zerovec"
 description = "Zero-copy vector backed by a byte array"
-version = "0.10.4"
+version = "0.11.0-dev"
 categories = ["rust-patterns", "memory-management", "caching", "no-std", "data-structures"]
 keywords = ["zerocopy", "serialization", "zero-copy", "serde"]
 
@@ -30,12 +30,7 @@ zerovec-derive = { workspace = true, optional = true}
 databake = { workspace = true, features = ["derive"], optional = true }
 serde = { workspace = true, features = ["alloc", "derive"], optional = true }
 
-# Special dep for yoke: avoid non-breaking zerovec bumps requiring breaking yoke bumps
-# Can be reset on next zerovec breaking if necessary
-#
-# This effectively stands for the range `~0.6 OR ~0.7`, i.e. it supports all 0.6 versions
-# and all 0.7 versions, but not further.
-yoke = { version = ">=0.6.0, <0.8.0", path = "../yoke", optional = true }
+yoke = { workspace = true, optional = true }
 twox-hash = { workspace = true, optional = true }
 
 [dev-dependencies]
@@ -51,7 +46,7 @@ rmp-serde = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 potential_utf = { workspace = true, features = ["zerovec"] }
-yoke = { version = ">=0.6.0, <0.8.0", path = "../../utils/yoke", features = ["derive"] }
+yoke = { workspace = true, features = ["derive"] }
 zerofrom = { path = "../../utils/zerofrom", features = ["derive"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/utils/zerovec/derive/Cargo.toml
+++ b/utils/zerovec/derive/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "zerovec-derive"
 description = "Custom derive for the zerovec crate"
-version = "0.10.3"
+version = "0.11.0-dev"
 authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
 categories = ["rust-patterns", "memory-management", "caching", "no-std", "data-structures"]
 keywords = ["zerocopy", "serialization", "zero-copy", "serde"]


### PR DESCRIPTION
I think we should in the future do this as soon as we make a semver-breaking change anywhere, as it's much harder to do this after the fact. We can use the `-dev` tag to avoid bumping a crate twice, and it's easy to remove the tag before a release (or replace with `beta`).