### PR TITLE
Expose `CompactDecimalFormatterOptions` in the compactdecimal module

### DIFF
--- a/components/experimental/src/compactdecimal/mod.rs
+++ b/components/experimental/src/compactdecimal/mod.rs
@@ -27,3 +27,4 @@ pub mod provider;
 
 pub use error::ExponentError;
 pub use formatter::CompactDecimalFormatter;
+pub use options::CompactDecimalFormatterOptions;


### PR DESCRIPTION
As in `LongCompactCurrencyFormatter` and `CompactCurrencyFormatter`, we need to create a compact decimal formatter. The `CompactDecimalFormatterOptions` should be exposed.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->