### PR TITLE
The directory is still called /usr/include/wasm32-wasi

### DIFF
--- a/components/collections/codepointtrie_builder/cpp/Makefile
+++ b/components/collections/codepointtrie_builder/cpp/Makefile
@@ -30,7 +30,7 @@ wasm_obj/icu4c/%.o: $(ICU4C_SOURCE)/%.cpp
 wasm_obj/ucptrie_wrap.o: ucptrie_wrap.cpp
 	mkdir -p wasm_obj
 	$(CXX) --target=wasm32-unknown-wasi \
-		-I/usr/include/wasm32-wasip1 \
+		-I/usr/include/wasm32-wasi \
 		--compile \
 		-flto \
 		-I$(ICU4C_SOURCE)/common \


### PR DESCRIPTION
```
$ sudo apt install libc++-dev-wasm32
libc++-dev-wasm32 is already the newest version (1:16.0-58.1).
$ ls /usr/include | grep wasi
wasm32-wasi
```