### PR TITLE
Serde impls for VarULE types (Var tuple types, and make_var)

### DIFF
--- a/utils/zerovec/derive/examples/make_var.rs
+++ b/utils/zerovec/derive/examples/make_var.rs
@@ -149,8 +149,13 @@ where
     if let Some(first) = varzerovec.get(0) {
         let bincode = bincode::serialize(first).unwrap();
         let deserialized: &T = bincode::deserialize(&bincode).unwrap();
+        let deserialized_box: Box<T> = bincode::deserialize(&bincode).unwrap();
         assert_eq!(
             first, deserialized,
+            "Single element roundtrips with bincode"
+        );
+        assert_eq!(
+            first, &*deserialized_box,
             "Single element roundtrips with bincode"
         );
 

--- a/utils/zerovec/derive/src/utils.rs
+++ b/utils/zerovec/derive/src/utils.rs
@@ -270,6 +270,7 @@ pub fn extract_field_attributes(attrs: &mut Vec<Attribute>) -> Result<Option<Ide
 pub struct ZeroVecAttrs {
     pub skip_kv: bool,
     pub skip_ord: bool,
+    pub skip_toowned: bool,
     pub serialize: bool,
     pub deserialize: bool,
     pub debug: bool,
@@ -322,6 +323,8 @@ pub fn extract_attributes_common(
             attrs.skip_kv = true;
         } else if ident == "Ord" {
             attrs.skip_ord = true;
+        } else if ident == "ToOwned" && is_var {
+            attrs.skip_toowned = true;
         } else {
             return Err(Error::new(
                 ident.span(),

--- a/utils/zerovec/src/lib.rs
+++ b/utils/zerovec/src/lib.rs
@@ -241,6 +241,7 @@ pub use crate::zerovec::{ZeroSlice, ZeroVec};
 pub mod __zerovec_internal_reexport {
     pub use zerofrom::ZeroFrom;
 
+    pub use alloc::borrow;
     pub use alloc::boxed;
 
     #[cfg(feature = "serde")]

--- a/utils/zerovec/src/ule/mod.rs
+++ b/utils/zerovec/src/ule/mod.rs
@@ -20,6 +20,8 @@ mod niche;
 mod option;
 mod plain;
 mod slices;
+#[cfg(test)]
+pub mod test_utils;
 
 pub mod tuple;
 pub mod tuplevar;

--- a/utils/zerovec/src/ule/multi.rs
+++ b/utils/zerovec/src/ule/multi.rs
@@ -104,6 +104,11 @@ impl<const LEN: usize, Format: VarZeroVecFormat> MultiFieldsULE<LEN, Format> {
         // &Self is transparent over &VZS<..>
         mem::transmute(<VarZeroLengthlessSlice<[u8]>>::from_bytes_unchecked(bytes))
     }
+
+    /// Get the bytes behind this value
+    pub fn as_bytes(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
 }
 
 impl<const LEN: usize, Format: VarZeroVecFormat> fmt::Debug for MultiFieldsULE<LEN, Format> {

--- a/utils/zerovec/src/ule/test_utils.rs
+++ b/utils/zerovec/src/ule/test_utils.rs
@@ -1,0 +1,30 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+/// Take a VarULE type and serialize it both in human and machine readable contexts,
+/// and ensure it roundtrips correctly
+///
+/// Note that the concrete type may need to be explicitly specified to prevent issues with
+/// https://github.com/rust-lang/rust/issues/130180
+#[cfg(feature = "serde")]
+pub(crate) fn assert_serde_roundtrips<T>(var: &T)
+where
+    T: crate::ule::VarULE + ?Sized + serde::Serialize,
+    for<'a> Box<T>: serde::Deserialize<'a>,
+    for<'a> &'a T: serde::Deserialize<'a>,
+    T: core::fmt::Debug + PartialEq,
+{
+    let bincode = bincode::serialize(var).unwrap();
+    let deserialized: &T = bincode::deserialize(&bincode).unwrap();
+    let deserialized_box: Box<T> = bincode::deserialize(&bincode).unwrap();
+    assert_eq!(var, deserialized, "Single element roundtrips with bincode");
+    assert_eq!(
+        var, &*deserialized_box,
+        "Single element roundtrips with bincode"
+    );
+
+    let json = serde_json::to_string(var).unwrap();
+    let deserialized: Box<T> = serde_json::from_str(&json).unwrap();
+    assert_eq!(var, &*deserialized, "Single element roundtrips with serde");
+}

--- a/utils/zerovec/src/ule/tuplevar.rs
+++ b/utils/zerovec/src/ule/tuplevar.rs
@@ -213,13 +213,13 @@ macro_rules! tuple_varule {
             where
                 'de: 'a {
             fn deserialize<Des>(deserializer: Des) -> Result<Self, Des::Error> where Des: serde::Deserializer<'de> {
-                if !deserializer.is_human_readable() {
-                    let bytes = <&[u8]>::deserialize(deserializer)?;
-                    $name::<$($T),+>::parse_byte_slice(bytes).map_err(serde::de::Error::custom)
-                } else {
+                if deserializer.is_human_readable() {
                     Err(serde::de::Error::custom(
                         concat!("&", stringify!($name), " can only deserialize in zero-copy ways"),
                     ))
+                } else {
+                    let bytes = <&[u8]>::deserialize(deserializer)?;
+                    $name::<$($T),+>::parse_byte_slice(bytes).map_err(serde::de::Error::custom)
                 }
             }
         }

--- a/utils/zerovec/src/ule/tuplevar.rs
+++ b/utils/zerovec/src/ule/tuplevar.rs
@@ -249,6 +249,12 @@ mod tests {
         // Note: ipsum\xFF is not a valid str
         let zerovec3 = VarZeroVec::<Tuple2VarULE<str, str>>::parse_byte_slice(bytes);
         assert!(zerovec3.is_err());
+
+        #[cfg(feature = "serde")]
+        for val in zerovec.iter() {
+            // Can't use inference due to https://github.com/rust-lang/rust/issues/130180
+            crate::ule::test_utils::assert_serde_roundtrips::<Tuple2VarULE<str, [u8]>>(val);
+        }
     }
     #[test]
     fn test_tripleule_validate() {
@@ -270,5 +276,13 @@ mod tests {
         // Note: the str is unlikely to be a valid varzerovec
         let zerovec3 = VarZeroVec::<Tuple3VarULE<VarZeroSlice<str>, [u8], VarZeroSlice<str>>>::parse_byte_slice(bytes);
         assert!(zerovec3.is_err());
+
+        #[cfg(feature = "serde")]
+        for val in zerovec.iter() {
+            // Can't use inference due to https://github.com/rust-lang/rust/issues/130180
+            crate::ule::test_utils::assert_serde_roundtrips::<
+                Tuple3VarULE<str, [u8], VarZeroSlice<str>>,
+            >(val);
+        }
     }
 }

--- a/utils/zerovec/src/ule/vartuple.rs
+++ b/utils/zerovec/src/ule/vartuple.rs
@@ -59,7 +59,7 @@ use super::{AsULE, EncodeAsVarULE, UleError, VarULE, ULE};
 /// A sized type that can be converted to a [`VarTupleULE`].
 ///
 /// See the module for examples.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 #[allow(clippy::exhaustive_structs)] // well-defined type
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VarTuple<A, B> {
@@ -70,7 +70,7 @@ pub struct VarTuple<A, B> {
 /// A dynamically-sized type combining a sized and an unsized type.
 ///
 /// See the module for examples.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[allow(clippy::exhaustive_structs)] // well-defined type
 #[repr(C)]
 pub struct VarTupleULE<A: AsULE, V: VarULE + ?Sized> {
@@ -288,6 +288,10 @@ fn test_simple() {
     let var_tuple_ule = super::encode_varule_to_box(&var_tuple);
     assert_eq!(var_tuple_ule.sized.as_unsigned_int(), 1500);
     assert_eq!(&var_tuple_ule.variable, "hello");
+
+    // Can't use inference due to https://github.com/rust-lang/rust/issues/130180
+    #[cfg(feature = "serde")]
+    crate::ule::test_utils::assert_serde_roundtrips::<VarTupleULE<u16, str>>(&var_tuple_ule);
 }
 
 #[test]
@@ -307,4 +311,9 @@ fn test_nested() {
         &var_tuple_ule.variable.variable,
         ZeroSlice::from_ule_slice(b"ICU")
     );
+    // Can't use inference due to https://github.com/rust-lang/rust/issues/130180
+    #[cfg(feature = "serde")]
+    crate::ule::test_utils::assert_serde_roundtrips::<
+        VarTupleULE<u16, VarTupleULE<char, ZeroSlice<_>>>,
+    >(&var_tuple_ule);
 }

--- a/utils/zerovec/src/varzerovec/serde.rs
+++ b/utils/zerovec/src/varzerovec/serde.rs
@@ -2,7 +2,6 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use super::vec::VarZeroVecInner;
 use super::{VarZeroSlice, VarZeroVec, VarZeroVecFormat};
 use crate::ule::*;
 use alloc::boxed::Box;
@@ -86,7 +85,6 @@ where
 impl<'de, 'a, T, F> Deserialize<'de> for &'a VarZeroSlice<T, F>
 where
     T: VarULE + ?Sized,
-    Box<T>: Deserialize<'de>,
     F: VarZeroVecFormat,
     'de: 'a,
 {
@@ -99,15 +97,8 @@ where
                 "&VarZeroSlice cannot be deserialized from human-readable formats",
             ))
         } else {
-            let deserialized = VarZeroVec::<'a, T, F>::deserialize(deserializer)?;
-            let borrowed = if let VarZeroVec(VarZeroVecInner::Borrowed(b)) = deserialized {
-                b
-            } else {
-                return Err(de::Error::custom(
-                    "&VarZeroSlice can only deserialize in zero-copy ways",
-                ));
-            };
-            Ok(borrowed)
+            let bytes = <&[u8]>::deserialize(deserializer)?;
+            VarZeroSlice::<T, F>::parse_byte_slice(bytes).map_err(de::Error::custom)
         }
     }
 }


### PR DESCRIPTION
We were missing these.

This also gives me a *much* clearer idea of what's needed in https://github.com/unicode-org/icu4x/issues/5561. I might go and implement that, but I may also just use what we have for now for DecimalSymbolsV1.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->