### PR TITLE
Generate to_string concrete fn in impl_display_with_writeable

### DIFF
--- a/components/locale_core/src/databake.rs
+++ b/components/locale_core/src/databake.rs
@@ -3,7 +3,6 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::LanguageIdentifier;
-use alloc::string::ToString;
 use databake::*;
 
 impl Bake for LanguageIdentifier {

--- a/components/locale_core/src/preferences/extensions/unicode/keywords/regional_subdivision.rs
+++ b/components/locale_core/src/preferences/extensions/unicode/keywords/regional_subdivision.rs
@@ -10,7 +10,6 @@ use crate::{
     extensions::unicode::{SubdivisionId, Value},
     subtags::Subtag,
 };
-use alloc::string::ToString;
 
 struct_keyword!(
     /// A Unicode Subdivision Identifier defines a regional subdivision used for locales.

--- a/components/locale_core/src/serde.rs
+++ b/components/locale_core/src/serde.rs
@@ -3,7 +3,6 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::LanguageIdentifier;
-use alloc::string::ToString;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 impl Serialize for LanguageIdentifier {

--- a/ffi/capi/src/decimal.rs
+++ b/ffi/capi/src/decimal.rs
@@ -138,6 +138,7 @@ pub mod ffi {
         )]
         #[diplomat::rust_link(icu::decimal::FormattedFixedDecimal, Struct, hidden)]
         #[diplomat::rust_link(icu::decimal::FormattedFixedDecimal::write_to, FnInStruct, hidden)]
+        #[diplomat::rust_link(icu::decimal::FormattedFixedDecimal::to_string, FnInStruct, hidden)]
         pub fn format(&self, value: &FixedDecimal, write: &mut diplomat_runtime::DiplomatWrite) {
             let _infallible = self.0.format(&value.0).write_to(write);
         }

--- a/ffi/capi/src/fixed_decimal.rs
+++ b/ffi/capi/src/fixed_decimal.rs
@@ -350,6 +350,7 @@ pub mod ffi {
 
         /// Format the [`FixedDecimal`] as a string.
         #[diplomat::rust_link(fixed_decimal::FixedDecimal::write_to, FnInStruct)]
+        #[diplomat::rust_link(fixed_decimal::FixedDecimal::to_string, FnInStruct, hidden)]
         #[diplomat::attr(auto, stringifier)]
         pub fn to_string(&self, to: &mut diplomat_runtime::DiplomatWrite) {
             let _ = self.0.write_to(to);

--- a/ffi/capi/src/locale_core.rs
+++ b/ffi/capi/src/locale_core.rs
@@ -146,6 +146,7 @@ pub mod ffi {
         }
         /// Returns a string representation of [`Locale`].
         #[diplomat::rust_link(icu::locale::Locale::write_to, FnInStruct)]
+        #[diplomat::rust_link(icu::locale::Locale::to_string, FnInStruct, hidden)]
         #[diplomat::attr(auto, stringifier)]
         pub fn to_string(&self, write: &mut diplomat_runtime::DiplomatWrite) {
             let _infallible = self.0.write_to(write);

--- a/utils/writeable/README.md
+++ b/utils/writeable/README.md
@@ -45,6 +45,7 @@ assert_writeable_eq!(&message, "Hello, Alice!");
 // Types implementing `Writeable` are recommended to also implement `fmt::Display`.
 // This can be simply done by redirecting to the `Writeable` implementation:
 writeable::impl_display_with_writeable!(WelcomeMessage<'_>);
+assert_eq!(message.to_string(), "Hello, Alice!");
 ```
 
 [`ICU4X`]: ../icu/index.html

--- a/utils/writeable/src/lib.rs
+++ b/utils/writeable/src/lib.rs
@@ -60,6 +60,7 @@
 //! // Types implementing `Writeable` are recommended to also implement `fmt::Display`.
 //! // This can be simply done by redirecting to the `Writeable` implementation:
 //! writeable::impl_display_with_writeable!(WelcomeMessage<'_>);
+//! assert_eq!(message.to_string(), "Hello, Alice!");
 //! ```
 //!
 //! [`ICU4X`]: ../icu/index.html
@@ -116,10 +117,11 @@ pub mod adapters {
     }
 }
 
-#[doc(hidden)] // for testing
+#[doc(hidden)] // for testing and macros
 pub mod _internal {
     pub use super::testing::try_writeable_to_parts_for_test;
     pub use super::testing::writeable_to_parts_for_test;
+    pub use alloc::string::String;
 }
 
 /// A hint to help consumers of `Writeable` pre-allocate bytes before they call
@@ -314,15 +316,32 @@ pub trait Writeable {
 /// It's recommended to do this for every [`Writeable`] type, as it will add
 /// support for `core::fmt` features like [`fmt!`](std::fmt),
 /// [`print!`](std::print), [`write!`](std::write), etc.
+///
+/// This macro also adds a concrete `to_string` function. This function will shadow the
+/// standard library `ToString`, using the more efficient writeable-based code path.
+/// To add only `Display`, use the `@display` macro variant.
 #[macro_export]
 macro_rules! impl_display_with_writeable {
-    ($type:ty) => {
+    (@display, $type:ty) => {
         /// This trait is implemented for compatibility with [`fmt!`](alloc::fmt).
         /// To create a string, [`Writeable::write_to_string`] is usually more efficient.
         impl core::fmt::Display for $type {
             #[inline]
             fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
                 $crate::Writeable::write_to(&self, f)
+            }
+        }
+    };
+    ($type:ty) => {
+        $crate::impl_display_with_writeable!(@display, $type);
+        impl $type {
+            /// Converts the given value to a `String`.
+            ///
+            /// Under the hood, this uses an efficient [`Writeable`] implementation.
+            /// However, in order to avoid allocating a string, it is more efficient
+            /// to use [`Writeable`] directly.
+            pub fn to_string(&self) -> $crate::_internal::String {
+                $crate::Writeable::write_to_string(self).into_owned()
             }
         }
     };


### PR DESCRIPTION
Fixes #4590

I made it the default behavior.