### PR TITLE
Add Default and Copy to Preferences and add Collator kn and kf

### DIFF
--- a/components/collator/src/comparison.rs
+++ b/components/collator/src/comparison.rs
@@ -72,14 +72,13 @@ struct LocaleSpecificDataHolder {
 
 icu_locale_core::preferences::define_preferences!(
     /// The preferences for collation.
+    [Copy]
     CollatorPreferences,
     {
         /// The collation type. This corresponds to the `-u-co` BCP-47 tag.
         collation_type: icu_locale_core::preferences::extensions::unicode::keywords::CollationType
     }
 );
-
-impl Copy for CollatorPreferences {}
 
 impl LocaleSpecificDataHolder {
     /// The constructor code reused between owned and borrowed cases.

--- a/components/decimal/src/lib.rs
+++ b/components/decimal/src/lib.rs
@@ -112,6 +112,7 @@ size_test!(FixedDecimalFormatter, fixed_decimal_formatter_size, 96);
 
 define_preferences!(
     /// The preferences for fixed decimal formatting.
+    [Copy]
     FixedDecimalFormatterPreferences,
     {
         /// Numbering System. Corresponds to the `-u-nu` in Unicode Locale Identifier.

--- a/components/experimental/src/compactdecimal/formatter.rs
+++ b/components/experimental/src/compactdecimal/formatter.rs
@@ -25,6 +25,7 @@ use zerovec::maps::ZeroMap2dCursor;
 
 define_preferences!(
     /// The preferences for compact decimal formatting.
+    [Copy]
     CompactDecimalFormatterPreferences,
     {
         numbering_system: NumberingSystem

--- a/components/experimental/src/dimension/currency/formatter.rs
+++ b/components/experimental/src/dimension/currency/formatter.rs
@@ -23,6 +23,7 @@ extern crate alloc;
 
 define_preferences!(
     /// The preferences for currency formatting.
+    [Copy]
     CurrencyFormatterPreferences,
     {
         numbering_system: NumberingSystem

--- a/components/experimental/src/dimension/percent/formatter.rs
+++ b/components/experimental/src/dimension/percent/formatter.rs
@@ -22,6 +22,7 @@ extern crate alloc;
 
 define_preferences!(
     /// The preferences for percent formatting.
+    [Copy]
     PercentFormatterPreferences,
     {
         numbering_system: NumberingSystem

--- a/components/experimental/src/dimension/units/formatter.rs
+++ b/components/experimental/src/dimension/units/formatter.rs
@@ -23,6 +23,7 @@ extern crate alloc;
 
 define_preferences!(
     /// The preferences for units formatting.
+    [Copy]
     UnitsFormatterPreferences,
     {
         numbering_system: NumberingSystem

--- a/components/experimental/src/duration/formatter.rs
+++ b/components/experimental/src/duration/formatter.rs
@@ -23,13 +23,12 @@ use icu_provider::prelude::*;
 
 define_preferences!(
     /// The preferences for duration formatting.
+    [Copy]
     DurationFormatterPreferences,
     {
         numbering_system: NumberingSystem
     }
 );
-
-impl Copy for DurationFormatterPreferences {}
 
 prefs_convert!(DurationFormatterPreferences, UnitsFormatterPreferences, {
     numbering_system

--- a/components/experimental/src/relativetime/relativetime.rs
+++ b/components/experimental/src/relativetime/relativetime.rs
@@ -19,6 +19,7 @@ use crate::relativetime::provider::*;
 
 define_preferences!(
     /// The preferences for relative time formatting.
+    [Copy]
     RelativeTimeFormatterPreferences,
     {}
 );

--- a/components/list/src/list_formatter.rs
+++ b/components/list/src/list_formatter.rs
@@ -15,6 +15,7 @@ extern crate writeable;
 
 define_preferences!(
     /// The preferences for list formatting.
+    [Copy]
     ListFormatterPreferences,
     {}
 );

--- a/components/locale_core/src/extensions/unicode/subdivision.rs
+++ b/components/locale_core/src/extensions/unicode/subdivision.rs
@@ -73,7 +73,7 @@ impl_tinystr_subtag!(
 ///
 /// assert_eq!(si.to_string(), "gbzzzz");
 /// ```
-#[derive(Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord, Copy)]
 #[non_exhaustive]
 pub struct SubdivisionId {
     /// A region field of a Subdivision Id.

--- a/components/locale_core/src/preferences/extensions/unicode/keywords/collation.rs
+++ b/components/locale_core/src/preferences/extensions/unicode/keywords/collation.rs
@@ -40,3 +40,36 @@ enum_keyword!(
         /// Pinyin ordering for Latin, zhuyin order for Bopomofo and CJK characters (used in Chinese)
         ("zhuyin" => Zhuyin),
 }, "co");
+
+enum_keyword!(
+    /// Collation parameter key for ordering by case.
+    ///
+    /// If set to upper, causes upper case to sort before lower case. If set to lower, causes lower case to sort before upper case.
+    /// Useful for locales that have already supported ordering but require different order of cases. Affects case and tertiary levels.
+    ///
+    /// The defails see [LDML](https://unicode.org/reports/tr35/tr35-collation.html#Case_Parameters).
+    [Default]
+    CollationCaseFirst {
+        /// Upper case to be sorted before lower case
+        ("upper" => Upper),
+        /// Lower case to be sorted before upper case
+        ("lower" => Lower),
+        /// No special case ordering
+        [default]
+        ("false" => False),
+}, "kf");
+
+enum_keyword!(
+    /// Collation parameter key for numeric handling.
+    ///
+    /// If set to on, any sequence of Decimal Digits (General_Category = Nd in the [UAX44]) is sorted at a primary level with
+    /// its numeric value. For example, "1" < "2" < "10". The computed primary weights are all at the start of the digit
+    /// reordering group.
+    [Default]
+    CollationNumericOrdering {
+        /// A sequence of decimal digits is sorted at primary level with its numeric value
+        ("true" => True),
+        /// No special handling for numeric ordering
+        [default]
+        ("false" => False),
+}, "kn");

--- a/components/locale_core/src/preferences/extensions/unicode/keywords/currency_format.rs
+++ b/components/locale_core/src/preferences/extensions/unicode/keywords/currency_format.rs
@@ -8,8 +8,10 @@ enum_keyword!(
     /// A Unicode Currency Format Identifier defines a style for currency formatting.
     ///
     /// The valid values are listed in [LDML](https://unicode.org/reports/tr35/#UnicodeCurrencyFormatIdentifier).
+    [Default]
     CurrencyFormatStyle {
         /// Negative numbers use the minusSign symbol (the default)
+        [default]
         ("standard" => Standard),
         /// Negative numbers use parentheses or equivalent
         ("account" => Account)

--- a/components/locale_core/src/preferences/extensions/unicode/keywords/emoji.rs
+++ b/components/locale_core/src/preferences/extensions/unicode/keywords/emoji.rs
@@ -11,11 +11,13 @@ enum_keyword!(
     /// presentation style. This can be used as part of the value for an HTML lang attribute,
     /// for example `<html lang="sr-Latn-u-em-emoji">`.
     /// The valid values are listed in [LDML](https://unicode.org/reports/tr35/#UnicodeEmojiPresentationStyleIdentifier).
+    [Default]
     EmojiPresentationStyle {
         /// Use an emoji presentation for emoji characters if possible
         ("emoji" => Emoji),
         /// Use a text presentation for emoji characters if possible
         ("text" => Text),
         /// Use the default presentation for emoji characters as specified in UTR #51 Presentation Style
+        [default]
         ("default" => Default)
 }, "em");

--- a/components/locale_core/src/preferences/extensions/unicode/keywords/mod.rs
+++ b/components/locale_core/src/preferences/extensions/unicode/keywords/mod.rs
@@ -25,7 +25,7 @@ mod variant;
 
 pub use calendar::CalendarAlgorithm;
 pub use calendar::IslamicCalendarAlgorithm;
-pub use collation::CollationType;
+pub use collation::{CollationCaseFirst, CollationNumericOrdering, CollationType};
 pub use currency::CurrencyType;
 pub use currency_format::CurrencyFormatStyle;
 pub use dictionary_break::DictionaryBreakScriptExclusions;

--- a/components/locale_core/src/preferences/extensions/unicode/keywords/numbering_system.rs
+++ b/components/locale_core/src/preferences/extensions/unicode/keywords/numbering_system.rs
@@ -10,6 +10,7 @@ struct_keyword!(
     /// A Unicode Number System Identifier defines a type of number system.
     ///
     /// The valid values are listed in [LDML](https://unicode.org/reports/tr35/#UnicodeNumberSystemIdentifier).
+    [Copy]
     NumberingSystem,
     "nu",
     Subtag,
@@ -23,5 +24,3 @@ struct_keyword!(
         crate::extensions::unicode::Value::from_subtag(Some(input.0))
     }
 );
-
-impl Copy for NumberingSystem {}

--- a/components/locale_core/src/preferences/extensions/unicode/keywords/region_override.rs
+++ b/components/locale_core/src/preferences/extensions/unicode/keywords/region_override.rs
@@ -10,6 +10,7 @@ struct_keyword!(
     /// A Region Override specifies an alternate region to use for obtaining certain region-specific default values.
     ///
     /// The valid values are listed in [LDML](https://unicode.org/reports/tr35/#RegionOverride).
+    [Copy]
     RegionOverride,
     "rg",
     SubdivisionId,

--- a/components/locale_core/src/preferences/extensions/unicode/keywords/regional_subdivision.rs
+++ b/components/locale_core/src/preferences/extensions/unicode/keywords/regional_subdivision.rs
@@ -13,6 +13,7 @@ struct_keyword!(
     /// A Unicode Subdivision Identifier defines a regional subdivision used for locales.
     ///
     /// The valid values are listed in [LDML](https://unicode.org/reports/tr35/#UnicodeSubdivisionIdentifier).
+    [Copy]
     RegionalSubdivision,
     "sd",
     SubdivisionId,

--- a/components/locale_core/src/preferences/extensions/unicode/keywords/sentence_supression.rs
+++ b/components/locale_core/src/preferences/extensions/unicode/keywords/sentence_supression.rs
@@ -9,8 +9,10 @@ enum_keyword!(
     /// sentence breaks that would otherwise be found by UAX #14 rules.
     ///
     /// The valid values are listed in [LDML](https://unicode.org/reports/tr35/#UnicodeSentenceBreakSuppressionsIdentifier).
+    [Default]
     SentenceBreakSupressions {
         /// Don’t use sentence break suppressions data (the default)
+        [default]
         ("none" => None),
         /// Use sentence break suppressions data of type "standard"
         ("standard" => Standard),

--- a/components/locale_core/src/preferences/extensions/unicode/keywords/timezone.rs
+++ b/components/locale_core/src/preferences/extensions/unicode/keywords/timezone.rs
@@ -10,6 +10,7 @@ struct_keyword!(
     /// A Unicode Timezone Identifier defines a timezone.
     ///
     /// The valid values are listed in [LDML](https://unicode.org/reports/tr35/#UnicodeTimezoneIdentifier).
+    [Copy]
     TimeZoneShortId,
     "tz",
     Subtag,

--- a/components/locale_core/src/preferences/extensions/unicode/macros/enum_keyword.rs
+++ b/components/locale_core/src/preferences/extensions/unicode/macros/enum_keyword.rs
@@ -53,26 +53,31 @@ macro_rules! __enum_keyword_inner {
 macro_rules! __enum_keyword {
     (
         $(#[$doc:meta])*
+        $([$derive_attrs:ty])?
         $name:ident {
             $(
                 $(#[$variant_doc:meta])*
+                $([$variant_attr:ty])?
                 $variant:ident $($v2:ident)?
             ),*
         }
     ) => {
         #[non_exhaustive]
         #[derive(Debug, Clone, Eq, PartialEq, Copy, Hash)]
+        $(#[derive($derive_attrs)])?
         $(#[$doc])*
         pub enum $name {
             $(
                 $(#[$variant_doc])*
+                $(#[$variant_attr])?
                 $variant $((Option<$v2>))?
             ),*
         }
     };
-    ($(#[$doc:meta])* $name:ident {
+    ($(#[$doc:meta])* $([$derive_attrs:ty])? $name:ident {
         $(
             $(#[$variant_doc:meta])*
+            $([$variant_attr:ty])?
             ($key:expr => $variant:ident $(($v2:ident) {
                 $(
                     ($subk:expr => $subv:ident)
@@ -82,9 +87,11 @@ macro_rules! __enum_keyword {
     }, $ext_key:literal) => {
         $crate::__enum_keyword!(
             $(#[$doc])*
+            $([$derive_attrs])?
             $name {
                 $(
                     $(#[$variant_doc])*
+                    $([$variant_attr])?
                     $variant $($v2)?
                 ),*
             }

--- a/components/locale_core/src/preferences/extensions/unicode/macros/struct_keyword.rs
+++ b/components/locale_core/src/preferences/extensions/unicode/macros/struct_keyword.rs
@@ -27,10 +27,11 @@
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __struct_keyword {
-    ($(#[$doc:meta])* $name:ident, $ext_key:literal, $value:ty, $try_from:expr, $into:expr) => {
-        #[derive(Debug, Clone, Eq, PartialEq)]
-        #[allow(clippy::exhaustive_structs)] // TODO
+    ($(#[$doc:meta])* $([$derive_attrs:ty])? $name:ident, $ext_key:literal, $value:ty, $try_from:expr, $into:expr) => {
         $(#[$doc])*
+        #[derive(Debug, Clone, Eq, PartialEq, Hash)]
+        $(#[derive($derive_attrs)])?
+        #[allow(clippy::exhaustive_structs)] // TODO
         pub struct $name($value);
 
         impl TryFrom<$crate::extensions::unicode::Value> for $name {

--- a/components/locale_core/src/preferences/locale.rs
+++ b/components/locale_core/src/preferences/locale.rs
@@ -6,7 +6,7 @@ use crate::subtags::{Language, Region, Script, Subtag, Variant, Variants};
 
 /// The structure storing locale subtags used in preferences.
 #[allow(clippy::exhaustive_structs)] // this type is stable
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct LocalePreferences {
     /// Preference of Language
     pub language: Language,

--- a/components/locale_core/src/preferences/mod.rs
+++ b/components/locale_core/src/preferences/mod.rs
@@ -95,10 +95,11 @@
 //! # fn load_data(locale: ()) -> MyData { MyData {} }
 //! # struct MyData {}
 //! define_preferences!(
-//!     // Name of the preferences struct
+//!     /// Name of the preferences struct
+//!     [Copy]
 //!     ExampleComponentPreferences,
 //!     {
-//!         // A preference relevant to the component
+//!         /// A preference relevant to the component
 //!         hour_cycle: HourCycle
 //!     }
 //! );
@@ -130,10 +131,11 @@
 //! # fn load_data(locale: ()) -> MyData { MyData {} }
 //! # struct MyData {}
 //! # define_preferences!(
-//! #     // Name of the preferences struct
+//! #     /// Name of the preferences struct
+//! #     [Copy]
 //! #     ExampleComponentPreferences,
 //! #     {
-//! #         // A preference relevant to the component
+//! #         /// A preference relevant to the component
 //! #         hour_cycle: HourCycle
 //! #     }
 //! # );
@@ -164,10 +166,11 @@
 //! # fn load_data(locale: ()) -> MyData { MyData {} }
 //! # struct MyData {}
 //! # define_preferences!(
-//! #     // Name of the preferences struct
+//! #     /// Name of the preferences struct
+//! #     [Copy]
 //! #     ExampleComponentPreferences,
 //! #     {
-//! #         // A preference relevant to the component
+//! #         /// A preference relevant to the component
 //! #         hour_cycle: HourCycle
 //! #     }
 //! # );
@@ -209,10 +212,11 @@
 //! # fn load_data(locale: ()) -> MyData { MyData {} }
 //! # struct MyData {}
 //! # define_preferences!(
-//! #     // Name of the preferences struct
+//! #     /// Name of the preferences struct
+//! #     [Copy]
 //! #     ExampleComponentPreferences,
 //! #     {
-//! #         // A preference relevant to the component
+//! #         /// A preference relevant to the component
 //! #         hour_cycle: HourCycle
 //! #     }
 //! # );
@@ -263,10 +267,11 @@
 //! # fn load_data(locale: ()) -> MyData { MyData {} }
 //! # struct MyData {}
 //! # define_preferences!(
-//! #     // Name of the preferences struct
+//! #     /// Name of the preferences struct
+//! #     [Copy]
 //! #     ExampleComponentPreferences,
 //! #     {
-//! #         // A preference relevant to the component
+//! #         /// A preference relevant to the component
 //! #         hour_cycle: HourCycle
 //! #     }
 //! # );
@@ -331,10 +336,11 @@ pub use locale::*;
 /// };
 ///
 /// #[non_exhaustive]
-/// #[derive(Debug, Clone, Eq, PartialEq, Copy)]
+/// #[derive(Debug, Clone, Eq, PartialEq, Copy, Hash, Default)]
 /// pub enum EmojiPresentationStyle {
 ///     Emoji,
 ///     Text,
+///     [default]
 ///     Default,
 /// }
 ///
@@ -371,7 +377,7 @@ pub use locale::*;
 /// }
 ///
 /// #[non_exhaustive]
-/// #[derive(Debug, Clone, Eq, PartialEq)]
+/// #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 /// pub struct CustomFormat {
 ///     value: String
 /// }
@@ -379,6 +385,7 @@ pub use locale::*;
 /// impl PreferenceKey for CustomFormat {}
 ///
 /// define_preferences!(
+///     [Copy]
 ///     MyFormatterPreferences,
 ///     {
 ///         emoji: EmojiPresentationStyle,
@@ -431,6 +438,7 @@ pub trait PreferenceKey: Sized {
 /// };
 ///
 /// define_preferences!(
+///     [Copy]
 ///     TimeFormatterPreferences,
 ///     {
 ///         hour_cycle: HourCycle
@@ -457,6 +465,7 @@ pub trait PreferenceKey: Sized {
 macro_rules! __define_preferences {
     (
         $(#[$doc:meta])*
+        $([$derive_attrs:ty])?
         $name:ident,
         {
             $(
@@ -466,7 +475,8 @@ macro_rules! __define_preferences {
         }
      ) => (
         $(#[$doc])*
-        #[derive(Default, Debug, Clone)]
+        #[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+        $(#[derive($derive_attrs)])?
         #[non_exhaustive]
         pub struct $name {
             /// Locale Preferences for the Preferences structure.

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -264,6 +264,7 @@ impl PluralCategory {
 
 define_preferences!(
     /// The preferences for plural rules.
+    [Copy]
     PluralRulesPreferences,
     {}
 );

--- a/provider/core/src/hello_world.rs
+++ b/provider/core/src/hello_world.rs
@@ -252,9 +252,9 @@ icu_provider::export::make_exportable_provider!(HelloWorldProvider, [HelloWorldV
 
 define_preferences!(
     /// Hello World Preferences.
-    HelloWorldFormatterPreferences, {});
-
-impl Copy for HelloWorldFormatterPreferences {}
+    [Copy]
+    HelloWorldFormatterPreferences, {}
+);
 
 /// A type that formats localized "hello world" strings.
 ///


### PR DESCRIPTION
I cleaned up how you propagate Default and Copy to prefs and keywords and added the last two missing keywords used in Collator (kn and kf) in ECMA-402.

I didn't add other Collator ones and I didn't propagate it to Collator yet.