### PR TITLE
Сalculation speed up for the Gregorian calendar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,6 +315,7 @@ name = "calendrical_calculations"
 version = "0.1.1"
 dependencies = [
  "core_maths",
+ "criterion",
  "displaydoc",
  "log",
 ]

--- a/components/calendar/src/iso.rs
+++ b/components/calendar/src/iso.rs
@@ -33,7 +33,7 @@ use crate::calendar_arithmetic::{ArithmeticDate, CalendarArithmetic};
 use crate::error::DateError;
 use crate::{types, Calendar, Date, DateDuration, DateDurationUnit, DateTime, RangeError, Time};
 use calendrical_calculations::helpers::I32CastError;
-use calendrical_calculations::iso::{is_leap_year, iso_from_year_day};
+use calendrical_calculations::iso::{day_of_year, is_leap_year, iso_from_year_day};
 use calendrical_calculations::rata_die::RataDie;
 use tinystr::tinystr;
 
@@ -312,18 +312,7 @@ impl Iso {
     }
 
     pub(crate) fn day_of_year(date: IsoDateInner) -> u16 {
-        // Cumulatively how much are dates in each month
-        // offset from "30 days in each month" (in non leap years)
-        let month_offset = [0, 1, -1, 0, 0, 1, 1, 2, 3, 3, 4, 4];
-        #[allow(clippy::indexing_slicing)] // date.0.month in 1..=12
-        let mut offset = month_offset[date.0.month as usize - 1];
-        if Self::is_leap_year(date.0.year, ()) && date.0.month > 2 {
-            // Months after February in a leap year are offset by one less
-            offset += 1;
-        }
-        let prev_month_days = (30 * (date.0.month as i32 - 1) + offset) as u16;
-
-        prev_month_days + date.0.day as u16
+        day_of_year(date.0.year, date.0.month, date.0.day)
     }
 
     /// Wrap the year in the appropriate era code

--- a/components/calendar/src/julian.rs
+++ b/components/calendar/src/julian.rs
@@ -67,12 +67,11 @@ pub struct JulianDateInner(pub(crate) ArithmeticDate<Julian>);
 impl CalendarArithmetic for Julian {
     type YearInfo = ();
 
-    fn month_days(year: i32, month: u8, _data: ()) -> u8 {
+    fn month_days(year: i32, month: u8, data: ()) -> u8 {
+        // See `Iso::month_days`
         match month {
-            4 | 6 | 9 | 11 => 30,
-            2 if Self::is_leap_year(year, ()) => 29,
-            2 => 28,
-            1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+            2 => 28 | (Self::is_leap_year(year, data) as u8),
+            1..=12 => 30 | (month ^ (month >> 3)),
             _ => 0,
         }
     }

--- a/utils/calendrical_calculations/Cargo.toml
+++ b/utils/calendrical_calculations/Cargo.toml
@@ -23,7 +23,7 @@ rust-version.workspace = true
 
 # This is a special exception: The algorithms in this crate are based on "Calendrical Calculations" by Reingold and Dershowitz
 # which has its lisp code published at https://github.com/EdReingold/calendar-code2/
-license = "Apache-2.0"
+license = "Apache-2.0" # TODO: Need to add `MIT`/`GNU`?
 
 [package.metadata.workspaces]
 independent = true

--- a/utils/calendrical_calculations/Cargo.toml
+++ b/utils/calendrical_calculations/Cargo.toml
@@ -37,9 +37,20 @@ displaydoc = { workspace = true }
 log = { workspace = true, optional = true }
 
 [features]
+bench = []
 logging = ["dep:log"]
 std = []
 
-[package.metadata.cargo-all-features]
-# Bench feature gets tested separately and is only relevant for CI
-denylist = ["bench"]
+# [package.metadata.cargo-all-features]
+# # Bench feature gets tested separately and is only relevant for CI
+# denylist = ["bench"]
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+criterion = { workspace = true }
+
+[[bench]]
+name = "iso"
+harness = false
+
+# [profile.bench]
+# lto = false

--- a/utils/calendrical_calculations/benches/iso.rs
+++ b/utils/calendrical_calculations/benches/iso.rs
@@ -7,6 +7,10 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use calendrical_calculations::bench_support::iso_old as old;
 use calendrical_calculations::iso as new;
 
+#[cfg(feature = "bench")]
+use calendrical_calculations::bench_support::julian_old as j_old;
+use calendrical_calculations::julian as j_new;
+
 const MONTH_DAYS: [u8; 12] = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
 type IsoFromFixedFn = fn(RataDie) -> Result<(i32, u8, u8), I32CastError>;
 
@@ -38,7 +42,7 @@ fn prep_gen_rata_die_vec(n: i64) -> Vec<RataDie> {
     bb(ret)
 }
 
-fn from_iso(f: fn(i32, u8, u8) -> RataDie, ymd_vec: &Vec<(i32, u8, u8)>) -> i64 {
+fn fixed_from(f: fn(i32, u8, u8) -> RataDie, ymd_vec: &Vec<(i32, u8, u8)>) -> i64 {
     // The problem here is that LTO(it is turned on for benches in the workspace)
     // is very good at cyclic optimization when we goes year by year:
     // ```
@@ -107,7 +111,7 @@ fn day_of_year(f: fn(i32, u8, u8) -> u16, ymd_vec: &Vec<(i32, u8, u8)>) -> i32 {
     sum
 }
 
-fn iso_from_fixed(f: IsoFromFixedFn, rd_vec: &Vec<RataDie>) -> i64 {
+fn from_fixed(f: IsoFromFixedFn, rd_vec: &Vec<RataDie>) -> i64 {
     let map = |r: Result<(i32, u8, u8), I32CastError>| {
         let x = r.unwrap();
         x.0 as i64 + (x.1 + x.2) as i64
@@ -143,19 +147,34 @@ fn iso_from_year_day(f: fn(i32, u16) -> (u8, u8), rd_vec: &Vec<(i32, u16)>) -> i
 }
 
 #[no_mangle]
-fn bench_fixed_from_iso(c: &mut Criterion) {
+fn bench_fixed_from(c: &mut Criterion) {
     const Y: i32 = 1_000;
     const DELTA: i32 = 2_000;
     let ymd_vec = prep_gen_ymd_vec(Y, DELTA);
 
-    #[cfg(feature = "bench")]
-    c.bench_function("OLD/fixed_from_iso", |b| {
-        b.iter(|| from_iso(old::fixed_from_iso, bb(&ymd_vec)))
-    });
+    {
+        let mut group = c.benchmark_group("fixed_from_iso");
 
-    c.bench_function("NEW/fixed_from_iso", |b| {
-        b.iter(|| from_iso(new::fixed_from_iso, bb(&ymd_vec)))
-    });
+        #[cfg(feature = "bench")]
+        group.bench_function("OLD", |b| {
+            b.iter(|| fixed_from(old::fixed_from_iso, bb(&ymd_vec)))
+        });
+        group.bench_function("NEW", |b| {
+            b.iter(|| fixed_from(new::fixed_from_iso, bb(&ymd_vec)))
+        });
+    }
+
+    {
+        let mut group = c.benchmark_group("fixed_from_julian");
+
+        #[cfg(feature = "bench")]
+        group.bench_function("OLD", |b| {
+            b.iter(|| fixed_from(j_old::fixed_from_julian, bb(&ymd_vec)))
+        });
+        group.bench_function("NEW", |b| {
+            b.iter(|| fixed_from(j_new::fixed_from_julian, bb(&ymd_vec)))
+        });
+    }
 }
 
 fn bench_day_of_week(c: &mut Criterion) {
@@ -163,11 +182,13 @@ fn bench_day_of_week(c: &mut Criterion) {
     const DELTA: i32 = 2_000;
     let ymd_vec = prep_gen_ymd_vec(Y, DELTA);
 
+    let mut group = c.benchmark_group("day_of_week");
+
     #[cfg(feature = "bench")]
-    c.bench_function("OLD/day_of_week", |b| {
+    group.bench_function("iso/OLD", |b| {
         b.iter(|| day_of_week(old::day_of_week, bb(&ymd_vec)))
     });
-    c.bench_function("NEW/day_of_week", |b| {
+    group.bench_function("iso/NEW", |b| {
         b.iter(|| day_of_week(new::day_of_week, bb(&ymd_vec)))
     });
 }
@@ -177,25 +198,45 @@ fn bench_day_of_year(c: &mut Criterion) {
     const DELTA: i32 = 2_000;
     let ymd_vec = prep_gen_ymd_vec(Y, DELTA);
 
+    let mut group = c.benchmark_group("day_of_year");
+
     #[cfg(feature = "bench")]
-    c.bench_function("OLD/day_of_year", |b| {
+    group.bench_function("iso/OLD", |b| {
         b.iter(|| day_of_year(old::day_of_year, bb(&ymd_vec)))
     });
-    c.bench_function("NEW/day_of_year", |b| {
+    group.bench_function("iso/NEW", |b| {
         b.iter(|| day_of_year(new::day_of_year, bb(&ymd_vec)))
+    });
+
+    #[cfg(feature = "bench")]
+    group.bench_function("julian/OLD", |b| {
+        b.iter(|| day_of_year(j_old::day_of_year, bb(&ymd_vec)))
+    });
+    group.bench_function("julian/NEW", |b| {
+        b.iter(|| day_of_year(j_new::day_of_year, bb(&ymd_vec)))
     });
 }
 
-fn bench_iso_from_fixed(c: &mut Criterion) {
+fn bench_from_fixed(c: &mut Criterion) {
     const N: i64 = 10_000;
     let rd_vec = prep_gen_rata_die_vec(N);
 
+    let mut group = c.benchmark_group("from_fixed");
+
     #[cfg(feature = "bench")]
-    c.bench_function("OLD/iso_from_fixed", |b| {
-        b.iter(|| iso_from_fixed(old::iso_from_fixed, bb(&rd_vec)))
+    group.bench_function("iso/OLD", |b| {
+        b.iter(|| from_fixed(old::iso_from_fixed, bb(&rd_vec)))
     });
-    c.bench_function("NEW/iso_from_fixed", |b| {
-        b.iter(|| iso_from_fixed(new::iso_from_fixed, bb(&rd_vec)))
+    group.bench_function("iso/NEW", |b| {
+        b.iter(|| from_fixed(new::iso_from_fixed, bb(&rd_vec)))
+    });
+
+    #[cfg(feature = "bench")]
+    group.bench_function("julian/OLD", |b| {
+        b.iter(|| from_fixed(j_old::julian_from_fixed, bb(&rd_vec)))
+    });
+    group.bench_function("julian/NEW", |b| {
+        b.iter(|| from_fixed(j_new::julian_from_fixed, bb(&rd_vec)))
     });
 }
 
@@ -203,12 +244,14 @@ fn bench_iso_from_year_day(c: &mut Criterion) {
     const Y: i32 = 1_000;
     const DELTA: i32 = 2_000;
 
+    let mut group = c.benchmark_group("from_year_day");
+
     let yd_vec = prep_gen_yd_vec(Y, DELTA, 1, 365);
     #[cfg(feature = "bench")]
-    c.bench_function("OLD/iso_from_year_day/AVG", |b| {
+    group.bench_function("iso/OLD/AVG", |b| {
         b.iter(|| iso_from_year_day(old::iso_from_year_day, bb(&yd_vec)))
     });
-    c.bench_function("NEW/iso_from_year_day/AVG", |b| {
+    group.bench_function("iso/NEW/AVG", |b| {
         b.iter(|| iso_from_year_day(new::iso_from_year_day, bb(&yd_vec)))
     });
 
@@ -216,33 +259,33 @@ fn bench_iso_from_year_day(c: &mut Criterion) {
     // And they ~ the same perf in 3rd/4th months
     let yd_vec = prep_gen_yd_vec(Y, DELTA, 3, 57);
     #[cfg(feature = "bench")]
-    c.bench_function("OLD/iso_from_year_day/START", |b| {
+    group.bench_function("iso/OLD/START", |b| {
         b.iter(|| iso_from_year_day(old::iso_from_year_day, bb(&yd_vec)))
     });
-    c.bench_function("NEW/iso_from_year_day/START", |b| {
+    group.bench_function("iso/NEW/START", |b| {
         b.iter(|| iso_from_year_day(new::iso_from_year_day, bb(&yd_vec)))
     });
 
     let yd_vec = prep_gen_yd_vec(Y, DELTA, 300, 360);
     #[cfg(feature = "bench")]
-    c.bench_function("OLD/iso_from_year_day/END", |b| {
+    group.bench_function("iso/OLD/END", |b| {
         b.iter(|| iso_from_year_day(old::iso_from_year_day, bb(&yd_vec)))
     });
-    c.bench_function("NEW/iso_from_year_day/END", |b| {
+    group.bench_function("iso/NEW/END", |b| {
         b.iter(|| iso_from_year_day(new::iso_from_year_day, bb(&yd_vec)))
     });
 }
 
-criterion_group!(benchmark_fixed_from_iso, bench_fixed_from_iso);
+criterion_group!(benchmark_fixed_from, bench_fixed_from);
 criterion_group!(benchmark_year_from_fixed, bench_day_of_week);
 criterion_group!(benchmark_day_of_year, bench_day_of_year);
-criterion_group!(benchmark_iso_from_fixed, bench_iso_from_fixed);
+criterion_group!(benchmark_from_fixed, bench_from_fixed);
 criterion_group!(benchmark_iso_from_year_day, bench_iso_from_year_day);
 
 criterion_main!(
-    benchmark_fixed_from_iso,
+    benchmark_fixed_from,
     benchmark_year_from_fixed,
     benchmark_day_of_year,
-    benchmark_iso_from_fixed,
+    benchmark_from_fixed,
     benchmark_iso_from_year_day
 );

--- a/utils/calendrical_calculations/benches/iso.rs
+++ b/utils/calendrical_calculations/benches/iso.rs
@@ -1,0 +1,248 @@
+use core::hint::black_box as bb;
+
+use calendrical_calculations::{helpers::I32CastError, rata_die::RataDie};
+use criterion::{criterion_group, criterion_main, Criterion};
+
+#[cfg(feature = "bench")]
+use calendrical_calculations::bench_support::iso_old as old;
+use calendrical_calculations::iso as new;
+
+const MONTH_DAYS: [u8; 12] = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+type IsoFromFixedFn = fn(RataDie) -> Result<(i32, u8, u8), I32CastError>;
+
+fn prep_gen_ymd_vec(y: i32, delta: i32) -> Vec<(i32, u8, u8)> {
+    let mut ret = Vec::with_capacity(delta as usize * 2 * 366);
+    for year in y - delta..=y + delta {
+        for month in 1..=12u8 {
+            for day in 1..=MONTH_DAYS[(month as usize) - 1] {
+                ret.push((year, month, day));
+            }
+        }
+    }
+    bb(ret)
+}
+
+fn prep_gen_yd_vec(y: i32, delta: i32, from: u16, to: u16) -> Vec<(i32, u16)> {
+    let mut ret = Vec::with_capacity(delta as usize * 2 * 365);
+    for year in y - delta..=y + delta {
+        for day in from..=to {
+            ret.push((year, day))
+        }
+    }
+    bb(ret)
+}
+
+fn prep_gen_rata_die_vec(n: i64) -> Vec<RataDie> {
+    let mut ret = Vec::with_capacity(n as usize);
+    (1..=n).for_each(|n| ret.push(RataDie::new(n)));
+    bb(ret)
+}
+
+fn from_iso(f: fn(i32, u8, u8) -> RataDie, ymd_vec: &Vec<(i32, u8, u8)>) -> i64 {
+    // The problem here is that LTO(it is turned on for benches in the workspace)
+    // is very good at cyclic optimization when we goes year by year:
+    // ```
+    //  for year in (y - delta)..=(y + delta) {
+    //      for month in 1..=12u8 {
+    //          for day in 1..=MONTH_DAYS[(month as usize) - 1] {
+    //              ...
+    // ```
+    // and seems like the optimizer find out that in such cycles
+    // result will be differ a little, and loop unroling stage
+    // transforms it in something very optimized
+    // (like incrimenting by one. It seems really so, because for new algo
+    //       mentioned cycle was optimized to perf of empty cycle with `black_box`'es)
+    //
+    // And we want to test perf of the algos, not how good the optimizer work with
+    // cases when the dates goes one by one.
+    //
+    // And there we get another problem: the algo(at least the new one) is +- as fast
+    // as {cycle + `black_box`} overheads ://
+    // So we should to call the function multiple times to at least reduce
+    // the influence of perf measurements of the cycle ¯\_(ツ)_/¯
+
+    let mut sum = 0;
+    for (year, month, day) in ymd_vec {
+        let (year, month, day) = (bb(*year), bb(*month), bb(*day));
+
+        // If you comment next lines
+        // Then you will get ~10% of NEW algo (lets say this ~10% is `X ms`)
+        // So real perf ratio is:
+        // `(OLD - X)/(NEW - X)`
+        // And in my case this is +- about the asm instr len differ
+        sum += f(year, month, day).to_i64_date();
+        sum += f(year + 7, month, (day + 2) >> 1).to_i64_date();
+        sum += f(year + 37, (month + 3) >> 1, (day + 3) >> 1).to_i64_date();
+        sum += f(year + 137, (month + 7) >> 1, (day + 19) >> 1).to_i64_date();
+    }
+
+    bb(sum)
+}
+
+fn day_of_week(f: fn(i32, u8, u8) -> u8, ymd_vec: &Vec<(i32, u8, u8)>) -> i32 {
+    let mut sum = 0;
+    for (year, month, day) in ymd_vec {
+        let (year, month, day) = (bb(*year), bb(*month), bb(*day));
+
+        sum += f(year, month, day) as i32;
+        sum += f(year + 31, month, (day + 7) >> 1) as i32;
+        sum += f(year + 141, (month + 5) >> 1, day) as i32;
+        sum += f(year + 243, (month + 2) >> 1, (day + 17) >> 1) as i32;
+    }
+
+    sum
+}
+
+fn day_of_year(f: fn(i32, u8, u8) -> u16, ymd_vec: &Vec<(i32, u8, u8)>) -> i32 {
+    let mut sum = 0;
+    for (year, month, day) in ymd_vec {
+        let (year, month, day) = (bb(*year), bb(*month), bb(*day));
+
+        sum += f(year, month, day) as i32;
+        sum += f(year + 31, month, (day + 7) >> 1) as i32;
+        sum += f(year + 141, (month + 5) >> 1, day) as i32;
+        sum += f(year + 243, (month + 2) >> 1, (day + 17) >> 1) as i32;
+    }
+
+    sum
+}
+
+fn iso_from_fixed(f: IsoFromFixedFn, rd_vec: &Vec<RataDie>) -> i64 {
+    let map = |r: Result<(i32, u8, u8), I32CastError>| {
+        let x = r.unwrap();
+        x.0 as i64 + (x.1 + x.2) as i64
+    };
+
+    let mut sum = 0;
+    for rd in rd_vec {
+        let rd = bb(*rd).to_i64_date();
+
+        sum += map(f(RataDie::new(rd)));
+        sum += map(f(RataDie::new(rd + 1313)));
+        sum += map(f(RataDie::new(rd + 7429)));
+        sum += map(f(RataDie::new(rd - 5621)));
+    }
+
+    sum
+}
+
+fn iso_from_year_day(f: fn(i32, u16) -> (u8, u8), rd_vec: &Vec<(i32, u16)>) -> i64 {
+    let map = |x: (u8, u8)| (x.0 + x.1) as i64;
+    let mut sum = 0;
+
+    for (year, day_of_year) in rd_vec {
+        let (year, day_of_year) = (bb(*year), bb(*day_of_year));
+
+        sum += map(f(year, day_of_year));
+        sum += map(f(year + 21, day_of_year));
+        sum += map(f(year + 97, (day_of_year + 127) >> 1));
+        sum += map(f(year + 137, (day_of_year + 12) >> 1));
+    }
+
+    sum
+}
+
+#[no_mangle]
+fn bench_fixed_from_iso(c: &mut Criterion) {
+    const Y: i32 = 1_000;
+    const DELTA: i32 = 2_000;
+    let ymd_vec = prep_gen_ymd_vec(Y, DELTA);
+
+    #[cfg(feature = "bench")]
+    c.bench_function("OLD/fixed_from_iso", |b| {
+        b.iter(|| from_iso(old::fixed_from_iso, bb(&ymd_vec)))
+    });
+
+    c.bench_function("NEW/fixed_from_iso", |b| {
+        b.iter(|| from_iso(new::fixed_from_iso, bb(&ymd_vec)))
+    });
+}
+
+fn bench_day_of_week(c: &mut Criterion) {
+    const Y: i32 = 1_000;
+    const DELTA: i32 = 2_000;
+    let ymd_vec = prep_gen_ymd_vec(Y, DELTA);
+
+    #[cfg(feature = "bench")]
+    c.bench_function("OLD/day_of_week", |b| {
+        b.iter(|| day_of_week(old::day_of_week, bb(&ymd_vec)))
+    });
+    c.bench_function("NEW/day_of_week", |b| {
+        b.iter(|| day_of_week(new::day_of_week, bb(&ymd_vec)))
+    });
+}
+
+fn bench_day_of_year(c: &mut Criterion) {
+    const Y: i32 = 1_000;
+    const DELTA: i32 = 2_000;
+    let ymd_vec = prep_gen_ymd_vec(Y, DELTA);
+
+    #[cfg(feature = "bench")]
+    c.bench_function("OLD/day_of_year", |b| {
+        b.iter(|| day_of_year(old::day_of_year, bb(&ymd_vec)))
+    });
+    c.bench_function("NEW/day_of_year", |b| {
+        b.iter(|| day_of_year(new::day_of_year, bb(&ymd_vec)))
+    });
+}
+
+fn bench_iso_from_fixed(c: &mut Criterion) {
+    const N: i64 = 10_000;
+    let rd_vec = prep_gen_rata_die_vec(N);
+
+    #[cfg(feature = "bench")]
+    c.bench_function("OLD/iso_from_fixed", |b| {
+        b.iter(|| iso_from_fixed(old::iso_from_fixed, bb(&rd_vec)))
+    });
+    c.bench_function("NEW/iso_from_fixed", |b| {
+        b.iter(|| iso_from_fixed(new::iso_from_fixed, bb(&rd_vec)))
+    });
+}
+
+fn bench_iso_from_year_day(c: &mut Criterion) {
+    const Y: i32 = 1_000;
+    const DELTA: i32 = 2_000;
+
+    let yd_vec = prep_gen_yd_vec(Y, DELTA, 1, 365);
+    #[cfg(feature = "bench")]
+    c.bench_function("OLD/iso_from_year_day/AVG", |b| {
+        b.iter(|| iso_from_year_day(old::iso_from_year_day, bb(&yd_vec)))
+    });
+    c.bench_function("NEW/iso_from_year_day/AVG", |b| {
+        b.iter(|| iso_from_year_day(new::iso_from_year_day, bb(&yd_vec)))
+    });
+
+    // In range of first two months old algo is faster
+    // And they ~ the same perf in 3rd/4th months
+    let yd_vec = prep_gen_yd_vec(Y, DELTA, 3, 57);
+    #[cfg(feature = "bench")]
+    c.bench_function("OLD/iso_from_year_day/START", |b| {
+        b.iter(|| iso_from_year_day(old::iso_from_year_day, bb(&yd_vec)))
+    });
+    c.bench_function("NEW/iso_from_year_day/START", |b| {
+        b.iter(|| iso_from_year_day(new::iso_from_year_day, bb(&yd_vec)))
+    });
+
+    let yd_vec = prep_gen_yd_vec(Y, DELTA, 300, 360);
+    #[cfg(feature = "bench")]
+    c.bench_function("OLD/iso_from_year_day/END", |b| {
+        b.iter(|| iso_from_year_day(old::iso_from_year_day, bb(&yd_vec)))
+    });
+    c.bench_function("NEW/iso_from_year_day/END", |b| {
+        b.iter(|| iso_from_year_day(new::iso_from_year_day, bb(&yd_vec)))
+    });
+}
+
+criterion_group!(benchmark_fixed_from_iso, bench_fixed_from_iso);
+criterion_group!(benchmark_year_from_fixed, bench_day_of_week);
+criterion_group!(benchmark_day_of_year, bench_day_of_year);
+criterion_group!(benchmark_iso_from_fixed, bench_iso_from_fixed);
+criterion_group!(benchmark_iso_from_year_day, bench_iso_from_year_day);
+
+criterion_main!(
+    benchmark_fixed_from_iso,
+    benchmark_year_from_fixed,
+    benchmark_day_of_year,
+    benchmark_iso_from_fixed,
+    benchmark_iso_from_year_day
+);

--- a/utils/calendrical_calculations/src/helpers.rs
+++ b/utils/calendrical_calculations/src/helpers.rs
@@ -282,7 +282,7 @@ fn test_invert_angular() {
 }
 
 /// Error returned when casting from an i32
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 #[allow(clippy::exhaustive_enums)] // enum is specific to function and has a closed set of possible values
 pub enum I32CastError {
     /// Less than i32::MIN

--- a/utils/calendrical_calculations/src/iso.rs
+++ b/utils/calendrical_calculations/src/iso.rs
@@ -1,93 +1,343 @@
 // This file is part of ICU4X.
-//
-// The contents of this file implement algorithms from Calendrical Calculations
-// by Reingold & Dershowitz, Cambridge University Press, 4th edition (2018),
-// which have been released as Lisp code at <https://github.com/EdReingold/calendar-code2/>
-// under the Apache-2.0 license. Accordingly, this file is released under
+//  
+// The contents of this file implement algorithms from
+// "Euclidean Affine Functions and Applications to Calendar Algorithms" 
+// by Cassio Neri, Lorenz Schneider (Feb. 2021), DOI: 10.48550/arXiv.2102.06959
+// which have been released as C/C++ code at 
+// <https://github.com/cassioneri/eaf/blob/main/algorithms/neri_schneider.hpp>
+// under the MIT license. Accordingly, this file is released under
 // the Apache License, Version 2.0 which can be found at the calendrical_calculations
 // package root or at http://www.apache.org/licenses/LICENSE-2.0.
 
-use crate::helpers::{i64_to_i32, I32CastError};
+use crate::helpers::I32CastError;
 use crate::rata_die::RataDie;
 
-// The Gregorian epoch is equivalent to first day in fixed day measurement
-const EPOCH: RataDie = RataDie::new(1);
+/// Days in 4 years (there is 1 leap day):
+const FOUR_YEARS_TO_D: u64 = 365 * 4 + 1;
+
+/// In Gregorian calendar each 400 years sequence of leap days repeated.\
+/// In Gregorian calendar 400 years have 146097 days.
+const ONE_PERIOD_TO_DAYS: i64 = 365 * 400 + 1 * 100 - 4 + 1; // 146097
+
+/// In plain language, this is a reference point (in 4 centuries).
+/// 
+/// Amount of periods is calculated in way that `year + SHIFT_TO_YEARS > 0`,
+/// otherwise we will have inaccuracy of 1 day around of leap days.
+///
+/// Minimal input for `fixed_from_iso` is `-2**31`(`i32::MIN`) and the condition 
+/// above start to be always true from `(1 << 31) / 400 + 1` (`5_368_710`)
+/// 
+/// But for `iso_year_from_fixed` output is `i64` and input is RataData
+/// that allow to have input from `-i64::MIN / 256`(`2**55`) to `i64::MAX / 256`(`2**55`);
+/// corresponding years will be in `-98643495811588..246608739529`;
+/// `AMOUNT_OF_PERIODS` from which the condition always true more than `(1 << 50) / 400 + 1`
+/// so this value is correct for `iso_year_from_fixed`;
+/// 
+/// We should choose max(correct_val(iso_year_from_fixed), correct_val(fixed_from_iso))
+const AMOUNT_OF_PERIODS: i64 = (1 << 50) / 400 + 1;
+
+/// In plain language, this is a reference point (in days).
+///
+/// Amount of days by which two calendars(Gregorian & pseudo calendar) differ.
+const SHIFT: i64 = 305 + ONE_PERIOD_TO_DAYS * AMOUNT_OF_PERIODS;
+
+/// In plain language, this is a reference point (in years).
+///
+/// How many years in `AMOUNT_OF_PERIODS` periods.
+const SHIFT_TO_YEARS: i64 = 400 * AMOUNT_OF_PERIODS;
 
 /// Whether or not `year` is a leap year
-pub fn is_leap_year(year: i32) -> bool {
-    year % 4 == 0 && (year % 400 == 0 || year % 100 != 0)
+#[inline] // real call will be more complex operation than inner code 
+pub const fn is_leap_year(year: i32) -> bool {
+    // ```
+    // if year % 100 != 0 { year % 4 == 0 }
+    // else { year % 400 == 0 }
+    // ```
+    // here we can change 400 to 16 because:
+    // 1.  `x % 100 == 0`  =  `x % (25 *  4) == 0`  =   `(x % 25 == 0) && (x %  4 == 0)`
+    // 2.  `x % 400 == 0`  =  `x % (25 * 16) == 0`  =   `(x % 25 == 0) && (x % 16 == 0)`
+    // so if 1. is true then we already know that `(x % 25 == 0)` is true
+    // 
+    // so it becomes:
+    // ```
+    // if year % 100 != 0 { year % 4 == 0 }
+    // else { year % 16 == 0 }
+    // ```
+    // then we see `year % X == 0` and make transformation:
+    // ```
+    // divisor = year % 100 != 0 { 4 } else { 16 };
+    // year % divisor == 0
+    // ```
+    // and for divisor that is equal to 2^N 
+    // `year % divisor == 0` is the same as `(year & (divisor - 1)) == 0`
+    // so it becomes:
+    // ```
+    // divisor = year % 100 != 0 { 4 } else { 16 };
+    // (year & (divisor - 1)) == 0
+    // ```
+    //
+    // Also the compiler could potentially use CMOVcc (conditional move instr)
+    // for `if ... { VAL_A } else { VAL_B }` stmt
+    // in such case there will be no branching.
+    // Otherwise branch predictor will mostly right.
+    
+    let divisor_sub_1 = if year % 100 != 0 { 0b11 } else { 0b1111 };
+    (year & divisor_sub_1) == 0
 }
 
-// Fixed is day count representation of calendars starting from Jan 1st of year 1.
-// The fixed calculations algorithms are from the Calendrical Calculations book.
+// Returns years passed from Jan 1st of year 1.
 //
-/// Lisp code reference: <https://github.com/EdReingold/calendar-code2/blob/1ee51ecfaae6f856b0d7de3e36e9042100b4f424/calendar.l#L1167-L1189>
-pub fn fixed_from_iso(year: i32, month: u8, day: u8) -> RataDie {
-    let prev_year = (year as i64) - 1;
-    // Calculate days per year
-    let mut fixed: i64 = (EPOCH.to_i64_date() - 1) + 365 * prev_year;
-    // Calculate leap year offset
-    let offset = prev_year.div_euclid(4) - prev_year.div_euclid(100) + prev_year.div_euclid(400);
-    // Adjust for leap year logic
-    fixed += offset;
-    // Days of current year
-    fixed += (367 * (month as i64) - 362).div_euclid(12);
-    // Leap year adjustment for the current year
-    fixed += if month <= 2 {
-        0
-    } else if is_leap_year(year) {
-        -1
-    } else {
-        -2
-    };
-    // Days passed in current month
-    fixed += day as i64;
-    RataDie::new(fixed)
+// Fixed is day count representation of calendars starting from Jan 1st of year 1.
+// The calculation algorithm is from Cassio Neri & Lorenz Schneider article.
+//
+/// C/C++ code reference: <https://github.com/cassioneri/eaf/blob/main/algorithms/neri_schneider.hpp#L71-L101>
+pub const fn fixed_from_iso(year: i32, month: u8, day: u8) -> RataDie {
+    // There no branching.
+    
+
+    // [[SECTION]]  Map to the pseudo calendar:
+    let need_to_shift_months = month <= 2;
+    let day = day - 1;
+    
+    // Always more than 0:
+    // `SHIFT_TO_YEARS` > any `i32` (see comment to `AMOUNT_OF_PERIODS`).
+    let year = (((year as i64) + SHIFT_TO_YEARS) - (need_to_shift_months as i64)) as u64;
+    
+    // We move the leap month (February) to the end of our pseud year.
+    // And we start our month from 3rd month. So:
+    //
+    // Gregorian:  .. | 11 | 12 \  1 |  2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 \  1 |  2 | 3 | 4 | ..
+    // Pseudo:     .. | 11 | 12 | 13 | 14 \ 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 \ 3 | 4 | ..
+    // 
+    // So mappping will be next:
+    // `let month = if need_to_shift_months { month + 12 } else { month };`
+    // Minimal value is 3.
+    // `month + 12` is equal to `month | 12` when month is `1` or `2` (our case). 
+    let month = if need_to_shift_months { month | 12 } else { month };
+    
+    // always more than 0. (see comment to `AMOUNT_OF_PERIODS` & `year`).
+    let century = year / 100;
+
+
+    // [[SECTION]]  Calc shifted `RataDie`:
+    // Leap years every 4 year: `365 * year + year / 4` = `1461 * year / 4`
+    // Except for each century: `- century`
+    // But not for each 4th: `+ (century / 4)`
+    let days_before_year = ((FOUR_YEARS_TO_D * year) >> 2) - century + (century >> 2);
+    
+    // Our months in `3..=14` with next days amount in it:
+    // month: |  3 |  4 |  5 |  6 |  7 |  8 |  9 | 10 | 11 | 12 | 13 | 14 |
+    // days:  | 31 | 30 | 31 | 30 | 31 | 31 | 30 | 31 | 30 | 31 | 31 | 28 |
+    // days before a month will be:
+    //        |  0 | 31 | 61 | 92 | 122| 153| 184| 214| 245| 275| 306| 337|
+    // it's the same as `(979 * (month as i64) - 2919) / 32`
+    //
+    // See `test_days_before_month`.
+    // 
+    // See [formulas 1]:
+    // [X = months] [N = days]  :  a = 5, b = 461, d = 153; 
+    // It's aprox for `(153 * (month as i64) -457) / 5` within month in `3..=14`.
+    //
+    // Instead of `2919` there can be any number in `2918..=2922`;
+    // `2919` choosed because of `month * 9X9 - X9X9` (＾▽＾)
+    let days_before_month = (979 * (month as i64) - 2919) >> 5;
+    
+    let shifted_rata_die = (days_before_year as i64) + days_before_month + (day as i64);
+
+
+    // [[SECTION]]  Shift `RataDie`:
+    RataDie::new(shifted_rata_die - SHIFT)
 }
 
-/// Lisp code reference: <https://github.com/EdReingold/calendar-code2/blob/1ee51ecfaae6f856b0d7de3e36e9042100b4f424/calendar.l#L1191-L1217>
+// Returns (years, months, days) passed from Jan 1st of year 1.
+//
+// Fixed is day count representation of calendars starting from Jan 1st of year 1.
+// The calculation algorithm is from Cassio Neri & Lorenz Schneider article.
+//
+/// C/C++ code reference: <https://github.com/cassioneri/eaf/blob/main/algorithms/neri_schneider.hpp#L40-L69>
+pub fn iso_from_fixed(date: RataDie) -> Result<(i32, u8, u8), I32CastError> {
+    if let Some(err) = check_rata_die_have_i32_year(date) {
+        return Err(err)
+    }
+
+    let shifted_rata_die = (date.to_i64_date() + SHIFT) as u64;
+
+    // Let say that X & N can be any period of time that
+    // can be represented in the form `X = (a * N + b) / d`.
+    // 
+    // For example:
+    // * X can be centuries & N can be days; 
+    // * X can be years & N can be weeks; 
+    // * X can be months & N can be days; 
+    //
+    //  
+    //
+    //                       [←----x_from_n(N)-----→]                       
+    //                         /                  \
+    //                        /                    \
+    //                       |               N      |
+    //                       ↓               ↓      ↓
+    // ----------------------[←--------------|-----→]--------------  ← the time
+    //           ↑                   ↑
+    //           |                   |
+    //           |           [←-n_of_the_x-→]
+    //           |
+    // [←----n_before_x----→]   
+    //
+    //
+    // Then:                                                  [formulas 1]:
+    //
+    // n_before_x(X) = (d * X + a - b - 1) / a;
+    // x_from_n(N)   = (a * N + b) / d     = X;
+    // n_of_the_x(N) = (a * N + b) % d / a = Nx; where Nx within of the X
+    // 
+    // `(a * N + b)` will call `prepared_n_to_x` 
+
+
+    // [[SECTION]]  Century:
+    // [X = centries] [N = days]  :  a = 4, b = 3, d = ONE_PERIOD_TO_DAYS;
+    let prepared_days_to_cent = shifted_rata_die * 4 + 3;
+    let century = prepared_days_to_cent / (ONE_PERIOD_TO_DAYS as u64);
+    // We have 4 centuries in each period
+    // `let day_of_century = (prepared_days_to_cent % (ONE_PERIOD_TO_DAYS as u64)) / 4;`
+    let day_of_4_century = prepared_days_to_cent % (ONE_PERIOD_TO_DAYS as u64);
+
+
+    // [[Section]]  Year:
+    // [X = year] [N = days]  :  a = 4, b = 3, d = FOUR_YEARS_TO_D;
+
+    // prepared_days_to_year = day_of_century * 4 + 3 = day_of_4_century / 4 * 4 + 3 = day_of_4_century | 3;
+    let prepared_days_to_year = day_of_4_century | 3;
+    
+    // [approx comment 1]:
+    // ```
+    // let day_of_year = (prepared_days_to_year % FOUR_YEARS_TO_D) / 4;
+    // let year_of_century = prepared_days_to_year / FOUR_YEARS_TO_D;
+    // ```
+    // And
+    // `prepared_days_to_year` in `0..((ONE_PERIOD_TO_DAYS - 1) | 3)`
+    //
+    // For such `prepared_days_to_year` initial values the same as nexts
+    // ```
+    // let approx_prepared = 2939745 * prepared_days_to_year;
+    // let day_of_year = (approx_prepared % (1 << 32)) / 2939745 / 4;
+    // let year_of_century = approx_prepared >> 32;
+    // ```
+    //
+    // See `test_approx_1`.
+    const APPROX_NUM_C: u64 = 2939745;
+    let approx_prepared = APPROX_NUM_C * prepared_days_to_year;
+    let year_of_century = approx_prepared >> 32;
+    // `(approx_prepared % (1 << 32)) / 2939745 / 4` :
+    //      `approx_prepared % (1 << 32)` is equal to `approx_prepared as u32`
+    let day_of_year = (approx_prepared as u32) / (APPROX_NUM_C as u32) / 4;
+    let year = (100 * century + year_of_century) as i64;
+
+
+    // [[Section]]  Month & Day:
+    // [X = months] [N = days]  :  a = 5, b = 461, d = 153;
+    // [approx comment 2]:
+    // for any `day_of_year` in `0..734`:
+    // prep_a = (5 * day_of_year + 461)
+    // prep_b = (2141 * day_of_year + 197913)
+    // `prep_a / 153     == prep_b >> 16` 
+    // `prep_a % 153 / 5 == prep_b % (1 << 16) / 2141`
+    const APPROX_NUM_A: u32 = 2141;
+    const APPROX_NUM_B: u32 = 197913;
+    const DIV_MASK_02: u32 = (1 << 16) - 1;
+    let approx_day = APPROX_NUM_A * day_of_year + APPROX_NUM_B;
+    // Month from days: see [formulas 1] & [approx comment 2].
+    let month = (approx_day >> 16) as u8;
+    // Day of the month: see [formulas 1] & [approx comment 2].
+    let day = ((approx_day & DIV_MASK_02) as u16 / APPROX_NUM_A as u16) as u8;
+
+
+    // [[Section]]  Map from the pseudo calendar to the Gregorian:
+    let need_to_shift_months = day_of_year >= 306;
+    let year = (year - SHIFT_TO_YEARS) + (need_to_shift_months as i64);
+    let month = if need_to_shift_months { month & 0b11 } else { month };
+    let day = day + 1;
+
+    Ok((year as i32, month, day))
+}
+
+// Returns years passed from Jan 1st of year 1.
+//
+// Fixed is day count representation of calendars starting from Jan 1st of year 1.
+// The calculation algorithm is from Cassio Neri & Lorenz Schneider article.
+//
+/// C/C++ code reference: <https://github.com/cassioneri/eaf/blob/main/algorithms/neri_schneider.hpp#L40-L64>
 pub(crate) fn iso_year_from_fixed(date: RataDie) -> i64 {
-    // Shouldn't overflow because it's not possbile to construct extreme values of RataDie
-    let date = date - EPOCH;
+    // ⚠️ To understand this code please see `iso_from_fixed`. 
+    
+    let shifted_rata_die = (date.to_i64_date() + SHIFT) as u64;
 
-    // 400 year cycles have 146097 days
-    let (n_400, date) = (date.div_euclid(146097), date.rem_euclid(146097));
+    // [[SECTION]]  Century:
+    let prepared_days_to_cent = shifted_rata_die * 4 + 3;
+    let century = prepared_days_to_cent / (ONE_PERIOD_TO_DAYS as u64);
+    let day_of_4_century = prepared_days_to_cent % (ONE_PERIOD_TO_DAYS as u64);
 
-    // 100 year cycles have 36524 days
-    let (n_100, date) = (date.div_euclid(36524), date.rem_euclid(36524));
+    // [[Section]]  Year:
+    let prepared_days_to_year = day_of_4_century | 3;
+    const APPROX_NUM_C: u64 = 2939745;
+    let approx_prepared = APPROX_NUM_C * prepared_days_to_year;
+    let year_of_century = approx_prepared >> 32;
+    let day_of_year = (approx_prepared as u32) / (APPROX_NUM_C as u32) / 4;
+    let year = (100 * century + year_of_century) as i64;
 
-    // 4 year cycles have 1461 days
-    let (n_4, date) = (date.div_euclid(1461), date.rem_euclid(1461));
+    // [[Section]]  Map year from the pseudo calendar to the Gregorian:
+    let need_to_shift_months = day_of_year >= 306;
+    let year = (year - SHIFT_TO_YEARS) + (need_to_shift_months as i64);
 
-    let n_1 = date.div_euclid(365);
+    year
+}
 
-    let year = 400 * n_400 + 100 * n_100 + 4 * n_4 + n_1;
+#[inline(always)]
+const fn check_rata_die_have_i32_year(input: RataDie) -> Option<I32CastError> {
+    const MIN: i64 = fixed_from_iso(i32::MIN, 1, 1).to_i64_date();
+    const MAX: i64 = fixed_from_iso(i32::MAX, 12, 31).to_i64_date();
 
-    if n_100 == 4 || n_1 == 4 {
-        year
+    let input = input.to_i64_date();
+    if input < MIN {
+        Some(I32CastError::BelowMin)
+    } else if input > MAX {
+        Some(I32CastError::AboveMax)
     } else {
-        year + 1
+        None
     }
 }
 
-fn iso_new_year(year: i32) -> RataDie {
-    fixed_from_iso(year, 1, 1)
-}
 
-/// Lisp code reference: <https://github.com/EdReingold/calendar-code2/blob/1ee51ecfaae6f856b0d7de3e36e9042100b4f424/calendar.l#L1525-L1540>
-pub fn iso_from_fixed(date: RataDie) -> Result<(i32, u8, u8), I32CastError> {
-    let year = iso_year_from_fixed(date);
-    let year = i64_to_i32(year)?;
-    // Calculates the prior days of the adjusted year, then applies a correction based on leap year conditions for the correct ISO date conversion.
-    let prior_days = date - iso_new_year(year);
-    let correction = if date < fixed_from_iso(year, 3, 1) {
-        0
-    } else if is_leap_year(year) {
-        1
-    } else {
-        2
-    };
-    let month = (12 * (prior_days + correction) + 373).div_euclid(367) as u8; // in 1..12 < u8::MAX
-    let day = (date - fixed_from_iso(year, month, 1) + 1) as u8; // <= days_in_month < u8::MAX
-    Ok((year, month, day))
+#[cfg(test)]
+mod tests {
+    use super::FOUR_YEARS_TO_D;
+    use super::ONE_PERIOD_TO_DAYS;
+
+    #[test]
+    fn test_days_before_month() {
+        pub const DAYS: [i64; 12] = [31, 30, 31, 30, 31, 31, 30, 31, 30, 31, 31, 28];
+        const SHIFT: usize = 2;
+        
+        let mut sum = 0;
+        for month in (1 + SHIFT)..=(12 + SHIFT) {
+            let days_before_month = (979 * (month as i64) - 2919) >> 5;
+            assert_eq!(days_before_month, sum);
+            sum += DAYS[month - SHIFT - 1];
+        }
+    }
+    
+    #[test]
+    fn test_approx_1() {
+        for prepared_days_to_year in 0..=((ONE_PERIOD_TO_DAYS - 1) | 3) as u64 {
+            let day_of_year_a = ((prepared_days_to_year % FOUR_YEARS_TO_D) / 4) as u32;
+            let year_of_century_a = prepared_days_to_year / FOUR_YEARS_TO_D;
+            
+            let x = prepared_days_to_year * 2939745;
+            let day_of_year_b = x as u32 / 2939745 / 4;
+            let year_of_century_b = x >> 32;
+            
+            assert_eq!(day_of_year_a, day_of_year_b);
+            assert_eq!(year_of_century_a, year_of_century_b);
+        }
+    }
 }

--- a/utils/calendrical_calculations/src/iso.rs
+++ b/utils/calendrical_calculations/src/iso.rs
@@ -1,8 +1,8 @@
 // This file is part of ICU4X.
 //
 // The contents of this file implement algorithms from the article:
-// "Euclidean Affine Functions and Applications to Calendar Algorithms"
-// by Cassio Neri & Lorenz Schneider (Feb. 2021), DOI: 10.48550/arXiv.2102.06959
+// "Euclidean affine functions and their application to calendar algorithms"
+// by Cassio Neri & Lorenz Schneider (Dec. 2022), DOI: 10.1002/spe.3172
 // which have been released as C/C++ code at
 // <https://github.com/cassioneri/eaf/blob/main/algorithms/neri_schneider.hpp>
 // under the MIT/GNU license. Accordingly, this file is released under
@@ -87,8 +87,8 @@ pub const fn is_leap_year(year: i32) -> bool {
     // in such case there will be no branching.
     // Otherwise branch predictor will mostly right.
 
-    let divisor_sub_1 = if year % 100 != 0 { 0b11 } else { 0b1111 };
-    (year & divisor_sub_1) == 0
+    let divisor = if year % 100 != 0 { 4 } else { 16 };
+    (year & (divisor - 1)) == 0
 }
 
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -196,7 +196,7 @@ pub const fn day_of_week(year: i32, month: u8, day: u8) -> u8 {
 }
 
 /// # Returns
-/// day of the year in the Grigorian calendar:
+/// day of the year in the Gregorian calendar:
 /// + `1..=365` for a non leap year
 /// + `1..=366` for a leap year
 pub const fn day_of_year(year: i32, month: u8, day: u8) -> u16 {

--- a/utils/calendrical_calculations/src/iso.rs
+++ b/utils/calendrical_calculations/src/iso.rs
@@ -17,7 +17,7 @@ const FOUR_YEARS_TO_D: u64 = 365 * 4 + 1;
 
 /// In Gregorian calendar each 400 years sequence of leap days repeated.\
 /// In Gregorian calendar 400 years have 146097 days.
-const ONE_PERIOD_TO_DAYS: i64 = 365 * 400 + 1 * 100 - 4 + 1; // 146097
+const ONE_PERIOD_TO_DAYS: i64 = 365 * 400 + 400 / 4 - 4 + 1; // 146097
 
 /// In plain language, this is a reference point (in 4 centuries).
 ///
@@ -297,9 +297,8 @@ pub(crate) fn iso_year_from_fixed(date: RataDie) -> i64 {
 
     // [[Section]]  Map year from the pseudo calendar to the Gregorian:
     let need_to_shift_months = day_of_year >= 306;
-    let year = (year - SHIFT_TO_YEARS) + (need_to_shift_months as i64);
 
-    year
+    (year - SHIFT_TO_YEARS) + (need_to_shift_months as i64)
 }
 
 #[inline(always)]

--- a/utils/calendrical_calculations/src/iso.rs
+++ b/utils/calendrical_calculations/src/iso.rs
@@ -1,9 +1,9 @@
 // This file is part of ICU4X.
-//  
+//
 // The contents of this file implement algorithms from
-// "Euclidean Affine Functions and Applications to Calendar Algorithms" 
+// "Euclidean Affine Functions and Applications to Calendar Algorithms"
 // by Cassio Neri, Lorenz Schneider (Feb. 2021), DOI: 10.48550/arXiv.2102.06959
-// which have been released as C/C++ code at 
+// which have been released as C/C++ code at
 // <https://github.com/cassioneri/eaf/blob/main/algorithms/neri_schneider.hpp>
 // under the MIT license. Accordingly, this file is released under
 // the Apache License, Version 2.0 which can be found at the calendrical_calculations
@@ -20,19 +20,19 @@ const FOUR_YEARS_TO_D: u64 = 365 * 4 + 1;
 const ONE_PERIOD_TO_DAYS: i64 = 365 * 400 + 1 * 100 - 4 + 1; // 146097
 
 /// In plain language, this is a reference point (in 4 centuries).
-/// 
+///
 /// Amount of periods is calculated in way that `year + SHIFT_TO_YEARS > 0`,
 /// otherwise we will have inaccuracy of 1 day around of leap days.
 ///
-/// Minimal input for `fixed_from_iso` is `-2**31`(`i32::MIN`) and the condition 
+/// Minimal input for `fixed_from_iso` is `-2**31`(`i32::MIN`) and the condition
 /// above start to be always true from `(1 << 31) / 400 + 1` (`5_368_710`)
-/// 
+///
 /// But for `iso_year_from_fixed` output is `i64` and input is RataData
 /// that allow to have input from `-i64::MIN / 256`(`2**55`) to `i64::MAX / 256`(`2**55`);
 /// corresponding years will be in `-98643495811588..246608739529`;
 /// `AMOUNT_OF_PERIODS` from which the condition always true more than `(1 << 50) / 400 + 1`
 /// so this value is correct for `iso_year_from_fixed`;
-/// 
+///
 /// We should choose max(correct_val(iso_year_from_fixed), correct_val(fixed_from_iso))
 const AMOUNT_OF_PERIODS: i64 = (1 << 50) / 400 + 1;
 
@@ -47,7 +47,7 @@ const SHIFT: i64 = 305 + ONE_PERIOD_TO_DAYS * AMOUNT_OF_PERIODS;
 const SHIFT_TO_YEARS: i64 = 400 * AMOUNT_OF_PERIODS;
 
 /// Whether or not `year` is a leap year
-#[inline] // real call will be more complex operation than inner code 
+#[inline] // real call will be more complex operation than inner code
 pub const fn is_leap_year(year: i32) -> bool {
     // ```
     // if year % 100 != 0 { year % 4 == 0 }
@@ -57,7 +57,7 @@ pub const fn is_leap_year(year: i32) -> bool {
     // 1.  `x % 100 == 0`  =  `x % (25 *  4) == 0`  =   `(x % 25 == 0) && (x %  4 == 0)`
     // 2.  `x % 400 == 0`  =  `x % (25 * 16) == 0`  =   `(x % 25 == 0) && (x % 16 == 0)`
     // so if 1. is true then we already know that `(x % 25 == 0)` is true
-    // 
+    //
     // so it becomes:
     // ```
     // if year % 100 != 0 { year % 4 == 0 }
@@ -68,7 +68,7 @@ pub const fn is_leap_year(year: i32) -> bool {
     // divisor = year % 100 != 0 { 4 } else { 16 };
     // year % divisor == 0
     // ```
-    // and for divisor that is equal to 2^N 
+    // and for divisor that is equal to 2^N
     // `year % divisor == 0` is the same as `(year & (divisor - 1)) == 0`
     // so it becomes:
     // ```
@@ -80,7 +80,7 @@ pub const fn is_leap_year(year: i32) -> bool {
     // for `if ... { VAL_A } else { VAL_B }` stmt
     // in such case there will be no branching.
     // Otherwise branch predictor will mostly right.
-    
+
     let divisor_sub_1 = if year % 100 != 0 { 0b11 } else { 0b1111 };
     (year & divisor_sub_1) == 0
 }
@@ -92,39 +92,44 @@ pub const fn is_leap_year(year: i32) -> bool {
 //
 /// C/C++ code reference: <https://github.com/cassioneri/eaf/blob/main/algorithms/neri_schneider.hpp#L71-L101>
 pub const fn fixed_from_iso(year: i32, month: u8, day: u8) -> RataDie {
-    // There no branching.
-    
+    // There is no branching.
 
+    // ↴
     // [[SECTION]]  Map to the pseudo calendar:
     let need_to_shift_months = month <= 2;
     let day = day - 1;
-    
+
     // Always more than 0:
     // `SHIFT_TO_YEARS` > any `i32` (see comment to `AMOUNT_OF_PERIODS`).
     let year = (((year as i64) + SHIFT_TO_YEARS) - (need_to_shift_months as i64)) as u64;
-    
+
     // We move the leap month (February) to the end of our pseud year.
     // And we start our month from 3rd month. So:
     //
     // Gregorian:  .. | 11 | 12 \  1 |  2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 \  1 |  2 | 3 | 4 | ..
     // Pseudo:     .. | 11 | 12 | 13 | 14 \ 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 \ 3 | 4 | ..
-    // 
+    //
     // So mappping will be next:
     // `let month = if need_to_shift_months { month + 12 } else { month };`
     // Minimal value is 3.
-    // `month + 12` is equal to `month | 12` when month is `1` or `2` (our case). 
-    let month = if need_to_shift_months { month | 12 } else { month };
-    
+    // `month + 12` is equal to `month | 12` when month is `1` or `2` (our case).
+    // So we will have:
+    // `let month = if need_to_shift_months { month | 12 } else { month };`
+    // `mask` = `-(need_to_shift_months as i8)` = `if need_to_shift_months { 0xFF } else { 0x00 }`
+    // `12 & (mask as u8)` = `if need_to_shift_months { 12 } else { 0 }`
+    let mask = -(need_to_shift_months as i8);
+    let month = month | ((mask as u8) & 12);
+
     // always more than 0. (see comment to `AMOUNT_OF_PERIODS` & `year`).
     let century = year / 100;
 
-
+    // ↴
     // [[SECTION]]  Calc shifted `RataDie`:
     // Leap years every 4 year: `365 * year + year / 4` = `1461 * year / 4`
     // Except for each century: `- century`
     // But not for each 4th: `+ (century / 4)`
     let days_before_year = ((FOUR_YEARS_TO_D * year) >> 2) - century + (century >> 2);
-    
+
     // Our months in `3..=14` with next days amount in it:
     // month: |  3 |  4 |  5 |  6 |  7 |  8 |  9 | 10 | 11 | 12 | 13 | 14 |
     // days:  | 31 | 30 | 31 | 30 | 31 | 31 | 30 | 31 | 30 | 31 | 31 | 28 |
@@ -133,18 +138,18 @@ pub const fn fixed_from_iso(year: i32, month: u8, day: u8) -> RataDie {
     // it's the same as `(979 * (month as i64) - 2919) / 32`
     //
     // See `test_days_before_month`.
-    // 
+    //
     // See [formulas 1]:
-    // [X = months] [N = days]  :  a = 5, b = 461, d = 153; 
+    // [X = months] [N = days]  :  a = 5, b = 461, d = 153;
     // It's aprox for `(153 * (month as i64) -457) / 5` within month in `3..=14`.
     //
     // Instead of `2919` there can be any number in `2918..=2922`;
     // `2919` choosed because of `month * 9X9 - X9X9` (＾▽＾)
     let days_before_month = (979 * (month as i64) - 2919) >> 5;
-    
+
     let shifted_rata_die = (days_before_year as i64) + days_before_month + (day as i64);
 
-
+    // ↴
     // [[SECTION]]  Shift `RataDie`:
     RataDie::new(shifted_rata_die - SHIFT)
 }
@@ -157,22 +162,24 @@ pub const fn fixed_from_iso(year: i32, month: u8, day: u8) -> RataDie {
 /// C/C++ code reference: <https://github.com/cassioneri/eaf/blob/main/algorithms/neri_schneider.hpp#L40-L69>
 pub fn iso_from_fixed(date: RataDie) -> Result<(i32, u8, u8), I32CastError> {
     if let Some(err) = check_rata_die_have_i32_year(date) {
-        return Err(err)
+        return Err(err);
     }
+
+    // There is no branching after:
 
     let shifted_rata_die = (date.to_i64_date() + SHIFT) as u64;
 
     // Let say that X & N can be any period of time that
     // can be represented in the form `X = (a * N + b) / d`.
-    // 
+    //
     // For example:
-    // * X can be centuries & N can be days; 
-    // * X can be years & N can be weeks; 
-    // * X can be months & N can be days; 
+    // * X can be centuries & N can be days;
+    // * X can be years & N can be weeks;
+    // * X can be months & N can be days;
     //
-    //  
     //
-    //                       [←----x_from_n(N)-----→]                       
+    //
+    //                       [←----x_from_n(N)-----→]
     //                         /                  \
     //                        /                    \
     //                       |               N      |
@@ -182,7 +189,7 @@ pub fn iso_from_fixed(date: RataDie) -> Result<(i32, u8, u8), I32CastError> {
     //           |                   |
     //           |           [←-n_of_the_x-→]
     //           |
-    // [←----n_before_x----→]   
+    // [←----n_before_x----→]
     //
     //
     // Then:                                                  [formulas 1]:
@@ -190,10 +197,10 @@ pub fn iso_from_fixed(date: RataDie) -> Result<(i32, u8, u8), I32CastError> {
     // n_before_x(X) = (d * X + a - b - 1) / a;
     // x_from_n(N)   = (a * N + b) / d     = X;
     // n_of_the_x(N) = (a * N + b) % d / a = Nx; where Nx within of the X
-    // 
-    // `(a * N + b)` will call `prepared_n_to_x` 
+    //
+    // `(a * N + b)` will call `prepared_n_to_x`
 
-
+    // ↴
     // [[SECTION]]  Century:
     // [X = centries] [N = days]  :  a = 4, b = 3, d = ONE_PERIOD_TO_DAYS;
     let prepared_days_to_cent = shifted_rata_die * 4 + 3;
@@ -202,13 +209,13 @@ pub fn iso_from_fixed(date: RataDie) -> Result<(i32, u8, u8), I32CastError> {
     // `let day_of_century = (prepared_days_to_cent % (ONE_PERIOD_TO_DAYS as u64)) / 4;`
     let day_of_4_century = prepared_days_to_cent % (ONE_PERIOD_TO_DAYS as u64);
 
-
+    // ↴
     // [[Section]]  Year:
     // [X = year] [N = days]  :  a = 4, b = 3, d = FOUR_YEARS_TO_D;
 
     // prepared_days_to_year = day_of_century * 4 + 3 = day_of_4_century / 4 * 4 + 3 = day_of_4_century | 3;
     let prepared_days_to_year = day_of_4_century | 3;
-    
+
     // [approx comment 1]:
     // ```
     // let day_of_year = (prepared_days_to_year % FOUR_YEARS_TO_D) / 4;
@@ -233,14 +240,14 @@ pub fn iso_from_fixed(date: RataDie) -> Result<(i32, u8, u8), I32CastError> {
     let day_of_year = (approx_prepared as u32) / (APPROX_NUM_C as u32) / 4;
     let year = (100 * century + year_of_century) as i64;
 
-
+    // ↴
     // [[Section]]  Month & Day:
     // [X = months] [N = days]  :  a = 5, b = 461, d = 153;
     // [approx comment 2]:
     // for any `day_of_year` in `0..734`:
     // prep_a = (5 * day_of_year + 461)
     // prep_b = (2141 * day_of_year + 197913)
-    // `prep_a / 153     == prep_b >> 16` 
+    // `prep_a / 153     == prep_b >> 16`
     // `prep_a % 153 / 5 == prep_b % (1 << 16) / 2141`
     const APPROX_NUM_A: u32 = 2141;
     const APPROX_NUM_B: u32 = 197913;
@@ -251,12 +258,15 @@ pub fn iso_from_fixed(date: RataDie) -> Result<(i32, u8, u8), I32CastError> {
     // Day of the month: see [formulas 1] & [approx comment 2].
     let day = ((approx_day & DIV_MASK_02) as u16 / APPROX_NUM_A as u16) as u8;
 
-
+    // ↴
     // [[Section]]  Map from the pseudo calendar to the Gregorian:
     let need_to_shift_months = day_of_year >= 306;
     let year = (year - SHIFT_TO_YEARS) + (need_to_shift_months as i64);
-    let month = if need_to_shift_months { month & 0b11 } else { month };
     let day = day + 1;
+    // `let month = if need_to_shift_months { month & 0b11 } else { month };`
+    // mask = if need_to_shift_months { 0x03 } else { 0xFF }:
+    let mask = (!(-(need_to_shift_months as i8) as u8)) | 0b11;
+    let month = month & mask;
 
     Ok((year as i32, month, day))
 }
@@ -268,8 +278,8 @@ pub fn iso_from_fixed(date: RataDie) -> Result<(i32, u8, u8), I32CastError> {
 //
 /// C/C++ code reference: <https://github.com/cassioneri/eaf/blob/main/algorithms/neri_schneider.hpp#L40-L64>
 pub(crate) fn iso_year_from_fixed(date: RataDie) -> i64 {
-    // ⚠️ To understand this code please see `iso_from_fixed`. 
-    
+    // ⚠️ To understand this code please see `iso_from_fixed`.
+
     let shifted_rata_die = (date.to_i64_date() + SHIFT) as u64;
 
     // [[SECTION]]  Century:
@@ -307,7 +317,6 @@ const fn check_rata_die_have_i32_year(input: RataDie) -> Option<I32CastError> {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::FOUR_YEARS_TO_D;
@@ -317,7 +326,7 @@ mod tests {
     fn test_days_before_month() {
         pub const DAYS: [i64; 12] = [31, 30, 31, 30, 31, 31, 30, 31, 30, 31, 31, 28];
         const SHIFT: usize = 2;
-        
+
         let mut sum = 0;
         for month in (1 + SHIFT)..=(12 + SHIFT) {
             let days_before_month = (979 * (month as i64) - 2919) >> 5;
@@ -325,17 +334,17 @@ mod tests {
             sum += DAYS[month - SHIFT - 1];
         }
     }
-    
+
     #[test]
     fn test_approx_1() {
         for prepared_days_to_year in 0..=((ONE_PERIOD_TO_DAYS - 1) | 3) as u64 {
             let day_of_year_a = ((prepared_days_to_year % FOUR_YEARS_TO_D) / 4) as u32;
             let year_of_century_a = prepared_days_to_year / FOUR_YEARS_TO_D;
-            
+
             let x = prepared_days_to_year * 2939745;
             let day_of_year_b = x as u32 / 2939745 / 4;
             let year_of_century_b = x >> 32;
-            
+
             assert_eq!(day_of_year_a, day_of_year_b);
             assert_eq!(year_of_century_a, year_of_century_b);
         }

--- a/utils/calendrical_calculations/src/iso.rs
+++ b/utils/calendrical_calculations/src/iso.rs
@@ -470,7 +470,7 @@ const fn check_rata_die_have_i32_year(input: RataDie) -> Option<I32CastError> {
 }
 
 #[cfg(test)]
-mod tests {
+mod bruteforce_proofs {
     use super::FOUR_YEARS_TO_D;
     use super::ONE_PERIOD_TO_DAYS;
 

--- a/utils/calendrical_calculations/src/julian.rs
+++ b/utils/calendrical_calculations/src/julian.rs
@@ -1,8 +1,8 @@
 // This file is part of ICU4X.
 //
 // The contents of this file implement algorithms from the article:
-// "Euclidean Affine Functions and Applications to Calendar Algorithms"
-// by Cassio Neri & Lorenz Schneider (Feb. 2021), DOI: 10.48550/arXiv.2102.06959
+// "Euclidean affine functions and their application to calendar algorithms"
+// by Cassio Neri & Lorenz Schneider (Dec. 2022), DOI: 10.1002/spe.3172
 
 use crate::helpers::I32CastError;
 use crate::rata_die::RataDie;
@@ -17,7 +17,7 @@ pub const fn is_leap_year(year: i32) -> bool {
 }
 
 /// # Returns
-/// day of the year in the Grigorian calendar:
+/// day of the year in the Gregorian calendar:
 /// + `1..=365` for a non leap year
 /// + `1..=366` for a leap year
 pub const fn day_of_year(year: i32, month: u8, day: u8) -> u16 {

--- a/utils/calendrical_calculations/src/lib.rs
+++ b/utils/calendrical_calculations/src/lib.rs
@@ -60,5 +60,21 @@ pub mod persian;
 /// represented as the number of days since ISO date 0001-01-01.
 pub mod rata_die;
 
-#[cfg(test)]
+#[cfg(any(test, feature = "bench"))]
+#[doc(hidden)]
 mod tests;
+
+#[cfg(feature = "bench")]
+#[doc(hidden)]
+/// Old implementations for bench comparing
+pub mod bench_support {
+    /// Old Julian implementation
+    pub mod julian_old {
+        pub use crate::tests::julian_old_file::*;
+    }
+    /// Old Greorgian implementation
+    pub mod iso_old {
+        pub use crate::tests::iso_old_algos::*;
+        pub use crate::tests::iso_old_file::*;
+    }
+}

--- a/utils/calendrical_calculations/src/lib.rs
+++ b/utils/calendrical_calculations/src/lib.rs
@@ -59,3 +59,6 @@ pub mod persian;
 /// Representation of Rata Die (R.D.) dates, which are
 /// represented as the number of days since ISO date 0001-01-01.
 pub mod rata_die;
+
+#[cfg(test)]
+mod tests;

--- a/utils/calendrical_calculations/src/tests/iso.rs
+++ b/utils/calendrical_calculations/src/tests/iso.rs
@@ -191,3 +191,25 @@ fn test_from_year_day_the_same() {
     MIN_YEAR_BOUND_RANGE.for_each(the_same_in_year);
     MAX_YEAR_BOUND_RANGE.for_each(the_same_in_year);
 }
+
+#[test]
+fn test_day_of_year_the_same() {
+    const N_YEAR: i32 = 2_999;
+    const N_RANGE: RangeInclusive<i32> = (-N_YEAR)..=N_YEAR;
+
+    fn the_same_in_year(year: i32) {
+        for month in 1..=12u8 {
+            for day in 1..=calc_last_month_day(year, month) {
+                assert_eq!(
+                    alg_old::day_of_year(year, month, day),
+                    iso_new::day_of_year(year, month, day),
+                    "YMD: {year} {month} {day}"
+                );
+            }
+        }
+    }
+
+    N_RANGE.for_each(the_same_in_year);
+    MIN_YEAR_BOUND_RANGE.for_each(the_same_in_year);
+    MAX_YEAR_BOUND_RANGE.for_each(the_same_in_year);
+}

--- a/utils/calendrical_calculations/src/tests/iso.rs
+++ b/utils/calendrical_calculations/src/tests/iso.rs
@@ -1,0 +1,146 @@
+use super::iso_old_file as iso_old;
+use crate::{iso as iso_new, rata_die::RataDie};
+use core::ops::{Range, RangeInclusive};
+
+const N_YEAR_BOUND: i32 = 1234; // more than one one cycle (400 years)
+const MIN_YEAR_BOUND_RANGE: Range<i32> = i32::MIN..(i32::MIN + N_YEAR_BOUND);
+const MAX_YEAR_BOUND_RANGE: RangeInclusive<i32> = (i32::MAX - N_YEAR_BOUND)..=i32::MAX;
+
+const MONTH_DAYS: [u8; 12] = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+fn calc_last_month_day(year: i32, month: u8) -> u8 {
+    let to = MONTH_DAYS[(month as usize) - 1];
+    if iso_old::is_leap_year(year) && (month == 2) {
+        to + 1
+    } else {
+        to
+    }
+}
+
+#[test]
+fn test_is_leap_year_the_same() {
+    const N_YEAR: i32 = 99_999;
+    const N_RANGE: RangeInclusive<i32> = (-N_YEAR)..=N_YEAR; // i32::MIN..=i32::MAX
+
+    fn the_same_in_year(year: i32) {
+        assert_eq!(
+            iso_old::is_leap_year(year),
+            iso_new::is_leap_year(year),
+            "year = {year}"
+        );
+    }
+
+    N_RANGE.for_each(the_same_in_year);
+    MIN_YEAR_BOUND_RANGE.for_each(the_same_in_year);
+    MAX_YEAR_BOUND_RANGE.for_each(the_same_in_year);
+}
+
+#[test]
+fn test_fixed_from_iso_the_same() {
+    const N_YEAR: i32 = 9_999;
+    const N_RANGE: RangeInclusive<i32> = (-N_YEAR)..=N_YEAR;
+
+    fn the_same_in_year(year: i32) {
+        for month in 1..=12u8 {
+            for day in 1..=calc_last_month_day(year, month) {
+                assert_eq!(
+                    iso_old::fixed_from_iso(year, month, day),
+                    iso_new::fixed_from_iso(year, month, day),
+                    "YMD: {year} {month} {day}"
+                );
+            }
+        }
+    }
+
+    N_RANGE.for_each(the_same_in_year);
+    MIN_YEAR_BOUND_RANGE.for_each(the_same_in_year);
+    MAX_YEAR_BOUND_RANGE.for_each(the_same_in_year);
+}
+
+#[test]
+fn test_year_from_fixed_the_same() {
+    const N_YEAR: i32 = 9_999;
+    const N_RANGE: RangeInclusive<i32> = (-N_YEAR)..=N_YEAR;
+
+    fn the_same_in_year(year: i32) {
+        for month in 1..=12u8 {
+            for day in 1..=calc_last_month_day(year, month) {
+                let rata_die = iso_old::fixed_from_iso(year, month, day);
+                assert_eq!(
+                    year as i64,
+                    iso_new::iso_year_from_fixed(rata_die),
+                    "{year} {month} {day} | {rata_die:?}"
+                );
+            }
+        }
+    }
+
+    N_RANGE.for_each(the_same_in_year);
+    MIN_YEAR_BOUND_RANGE.for_each(the_same_in_year);
+    MAX_YEAR_BOUND_RANGE.for_each(the_same_in_year);
+
+    const RATA_MIN: i64 = i64::MIN / 256;
+    const RATA_MAX: i64 = i64::MAX / 256;
+    const N_DAYS: i64 = 9_999;
+
+    for rata_die in RATA_MIN..(RATA_MIN + N_DAYS) {
+        let rata_die = RataDie::new(rata_die);
+        assert_eq!(
+            iso_old::iso_year_from_fixed(rata_die),
+            iso_new::iso_year_from_fixed(rata_die),
+            "{rata_die:?}"
+        );
+    }
+    for rata_die in (RATA_MAX - N_DAYS)..=RATA_MAX {
+        let rata_die = RataDie::new(rata_die);
+        assert_eq!(
+            iso_old::iso_year_from_fixed(rata_die),
+            iso_new::iso_year_from_fixed(rata_die),
+            "{rata_die:?}"
+        );
+    }
+}
+
+#[test]
+fn test_from_fixed_eq() {
+    const N_YEAR: i32 = 1_999; // `iso_old::iso_from_fixed` is slow
+    const N_RANGE: RangeInclusive<i32> = (-N_YEAR)..=N_YEAR;
+
+    fn the_same_in_year(year: i32) {
+        for month in 1..=12u8 {
+            for day in 1..=calc_last_month_day(year, month) {
+                let rata_die = iso_old::fixed_from_iso(year, month, day);
+                assert_eq!(
+                    iso_old::iso_from_fixed(rata_die),
+                    iso_new::iso_from_fixed(rata_die),
+                    "{year} {month} {day}"
+                );
+            }
+        }
+    }
+
+    N_RANGE.for_each(the_same_in_year);
+    MIN_YEAR_BOUND_RANGE.for_each(the_same_in_year);
+    MAX_YEAR_BOUND_RANGE.for_each(the_same_in_year);
+
+    const RATA_MIN: i64 = i64::MIN / 256;
+    const RATA_MAX: i64 = i64::MAX / 256;
+    const N_DAYS: i64 = 99_999;
+
+    for rata_die in RATA_MIN..(RATA_MIN + N_DAYS) {
+        let rata_die = RataDie::new(rata_die);
+        assert_eq!(
+            iso_old::iso_from_fixed(rata_die),
+            iso_new::iso_from_fixed(rata_die),
+            "{rata_die:?}"
+        );
+    }
+    for rata_die in (RATA_MAX - N_DAYS)..=RATA_MAX {
+        let rata_die = RataDie::new(rata_die);
+        assert_eq!(
+            iso_old::iso_from_fixed(rata_die),
+            iso_new::iso_from_fixed(rata_die),
+            "{rata_die:?}"
+        );
+    }
+}

--- a/utils/calendrical_calculations/src/tests/iso.rs
+++ b/utils/calendrical_calculations/src/tests/iso.rs
@@ -5,6 +5,9 @@ use crate::iso as iso_new;
 use crate::rata_die::RataDie;
 use core::ops::RangeInclusive;
 
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// [+] helpful fns
+
 fn calc_last_month_day(year: i32, month: u8) -> u8 {
     let to = MONTH_DAYS[(month as usize) - 1];
     if iso_old::is_leap_year(year) && (month == 2) {
@@ -13,6 +16,97 @@ fn calc_last_month_day(year: i32, month: u8) -> u8 {
         to
     }
 }
+
+pub(crate) fn assert_year(year: i32, mut assert_f: impl FnMut(i32, u8, u8)) {
+    for month in 1..=12u8 {
+        for day in 1..=calc_last_month_day(year, month) {
+            assert_f(year, month, day)
+        }
+    }
+}
+
+fn assert_year_rata_die(year: i32, mut assert_f: impl FnMut(i32, u8, u8, RataDie)) {
+    for month in 1..=12u8 {
+        for day in 1..=calc_last_month_day(year, month) {
+            let rata_die = iso_old::fixed_from_iso(year, month, day);
+            assert_f(year, month, day, rata_die)
+        }
+    }
+}
+
+// [-] helpful fns
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// [+] test correctness
+
+#[test]
+fn test_algo_correctness() {
+    // 1st Jan of 1 year:
+    let rata_die_initial = RataDie::new(1);
+
+    // Now we know that `iso_new::iso_from_fixed` is correct for YMD(1, 1, 1):
+    assert_eq!(iso_new::iso_from_fixed(rata_die_initial), Ok((1, 1, 1)));
+    // Now we know that `iso_new::day_of_week` is correct for YMD(2024, 11, 25):
+    assert_eq!(iso_new::day_of_week(2024, 11, 25), 1);
+
+    let delta = 9_999; // 3_999_999;
+
+    // This can be incorrect, but if it so, then on YMD(1, 1, 1) we will figured that out,
+    // because if it is incorrect we get incorrect value for `rata_die_i64` for the YMD(1, 1, 1)
+    // and `assert_eq!(iso_new::iso_from_fixed(rata_die), Ok((year, month, day)))` will panic
+    let mut rata_die_i64 = iso_new::fixed_from_iso(-delta, 1, 1).to_i64_date();
+
+    // This can be incorrect, but if it so, then on YMD(2024, 11, 25) we will figured that out
+    // (days of weeks goes cyclic on each other)
+    let mut day_of_week = iso_new::day_of_week(2024, 11, 25);
+
+    let mut year_day = 1;
+    // Because rata die's stay each after each we can verify that in a range
+    // all of `iso_new::iso_from_fixed` is correct, if that range contains the YMD(1, 1, 1):
+    for year in -delta..=delta {
+        assert_year(year, |year, month, day| {
+            if (month == 1) && (day == 1) {
+                year_day = 1;
+            }
+
+            let rata_die = RataDie::new(rata_die_i64);
+            assert_eq!(iso_new::iso_from_fixed(rata_die), Ok((year, month, day)));
+            assert_eq!(iso_new::iso_year_from_fixed(rata_die), year as i64);
+            assert_eq!(iso_new::fixed_from_iso(year, month, day), rata_die);
+            assert_eq!(iso_new::day_of_week(year, month, day), day_of_week);
+
+            assert_eq!(iso_new::iso_from_year_day(year, year_day), (month, day));
+            assert_eq!(iso_new::day_of_year(year, month, day), year_day);
+
+            if (month == 12) && (day == 31) {
+                assert_eq!(
+                    year_day,
+                    365 + iso_old::is_leap_year(year) as u16,
+                    "YMD: {year} {month} {day}"
+                );
+            }
+
+            rata_die_i64 += 1;
+
+            day_of_week += 1;
+            if day_of_week == 8 {
+                day_of_week = 1;
+            }
+
+            year_day += 1;
+        });
+    }
+
+    // FNS: {iso_from_fixed, iso_year_from_fixed, fixed_from_iso, day_of_week, iso_from_year_day, day_of_year};
+    // So now we sure that all fns from FNS is correct (at least in range -delta..=delta)
+}
+
+// [-] test correctness
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// [+] test the same result as prev algo
 
 #[test]
 fn test_is_leap_year_the_same() {
@@ -37,17 +131,15 @@ fn test_fixed_from_iso_the_same() {
     const N_YEAR: i32 = 9_999;
     const N_RANGE: RangeInclusive<i32> = (-N_YEAR)..=N_YEAR;
 
-    fn the_same_in_year(year: i32) {
-        for month in 1..=12u8 {
-            for day in 1..=calc_last_month_day(year, month) {
-                assert_eq!(
-                    iso_old::fixed_from_iso(year, month, day),
-                    iso_new::fixed_from_iso(year, month, day),
-                    "YMD: {year} {month} {day}"
-                );
-            }
-        }
-    }
+    let the_same_in_year = |year| {
+        assert_year(year, |year, month, day| {
+            assert_eq!(
+                iso_old::fixed_from_iso(year, month, day),
+                iso_new::fixed_from_iso(year, month, day),
+                "YMD: {year} {month} {day}"
+            );
+        })
+    };
 
     N_RANGE.for_each(the_same_in_year);
     MIN_YEAR_BOUND_RANGE.for_each(the_same_in_year);
@@ -59,18 +151,15 @@ fn test_year_from_fixed_the_same() {
     const N_YEAR: i32 = 9_999;
     const N_RANGE: RangeInclusive<i32> = (-N_YEAR)..=N_YEAR;
 
-    fn the_same_in_year(year: i32) {
-        for month in 1..=12u8 {
-            for day in 1..=calc_last_month_day(year, month) {
-                let rata_die = iso_old::fixed_from_iso(year, month, day);
-                assert_eq!(
-                    year as i64,
-                    iso_new::iso_year_from_fixed(rata_die),
-                    "{year} {month} {day} | {rata_die:?}"
-                );
-            }
-        }
-    }
+    let the_same_in_year = |year| {
+        assert_year_rata_die(year, |year, month, day, rata_die| {
+            assert_eq!(
+                year as i64,
+                iso_new::iso_year_from_fixed(rata_die),
+                "{year} {month} {day} | {rata_die:?}"
+            );
+        })
+    };
 
     N_RANGE.for_each(the_same_in_year);
     MIN_YEAR_BOUND_RANGE.for_each(the_same_in_year);
@@ -103,18 +192,15 @@ fn test_from_fixed_eq() {
     const N_YEAR: i32 = 1_999; // `iso_old::iso_from_fixed` is slow
     const N_RANGE: RangeInclusive<i32> = (-N_YEAR)..=N_YEAR;
 
-    fn the_same_in_year(year: i32) {
-        for month in 1..=12u8 {
-            for day in 1..=calc_last_month_day(year, month) {
-                let rata_die = iso_old::fixed_from_iso(year, month, day);
-                assert_eq!(
-                    iso_old::iso_from_fixed(rata_die),
-                    iso_new::iso_from_fixed(rata_die),
-                    "{year} {month} {day}"
-                );
-            }
-        }
-    }
+    let the_same_in_year = |year| {
+        assert_year_rata_die(year, |year, month, day, rata_die| {
+            assert_eq!(
+                iso_old::iso_from_fixed(rata_die),
+                iso_new::iso_from_fixed(rata_die),
+                "{year} {month} {day}"
+            );
+        })
+    };
 
     N_RANGE.for_each(the_same_in_year);
     MIN_YEAR_BOUND_RANGE.for_each(the_same_in_year);
@@ -192,19 +278,20 @@ fn test_day_of_year_the_same() {
     const N_YEAR: i32 = 2_999;
     const N_RANGE: RangeInclusive<i32> = (-N_YEAR)..=N_YEAR;
 
-    fn the_same_in_year(year: i32) {
-        for month in 1..=12u8 {
-            for day in 1..=calc_last_month_day(year, month) {
-                assert_eq!(
-                    alg_old::day_of_year(year, month, day),
-                    iso_new::day_of_year(year, month, day),
-                    "YMD: {year} {month} {day}"
-                );
-            }
-        }
-    }
+    let the_same_in_year = |year| {
+        assert_year(year, |year, month, day| {
+            assert_eq!(
+                alg_old::day_of_year(year, month, day),
+                iso_new::day_of_year(year, month, day),
+                "YMD: {year} {month} {day}"
+            );
+        })
+    };
 
     N_RANGE.for_each(the_same_in_year);
     MIN_YEAR_BOUND_RANGE.for_each(the_same_in_year);
     MAX_YEAR_BOUND_RANGE.for_each(the_same_in_year);
 }
+
+// [-] test the same result as prev algo
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/utils/calendrical_calculations/src/tests/iso.rs
+++ b/utils/calendrical_calculations/src/tests/iso.rs
@@ -2,10 +2,10 @@ use super::iso_old_algos as alg_old;
 use super::iso_old_file as iso_old;
 use crate::iso as iso_new;
 use crate::rata_die::RataDie;
-use core::ops::{Range, RangeInclusive};
+use core::ops::RangeInclusive;
 
 const N_YEAR_BOUND: i32 = 1234; // more than one cycle (400 years)
-const MIN_YEAR_BOUND_RANGE: Range<i32> = i32::MIN..(i32::MIN + N_YEAR_BOUND);
+const MIN_YEAR_BOUND_RANGE: RangeInclusive<i32> = i32::MIN..=(i32::MIN + N_YEAR_BOUND);
 const MAX_YEAR_BOUND_RANGE: RangeInclusive<i32> = (i32::MAX - N_YEAR_BOUND)..=i32::MAX;
 
 const MONTH_DAYS: [u8; 12] = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
@@ -163,6 +163,27 @@ fn test_day_of_week_the_same() {
                     "YMD: {year} {month} {day}"
                 );
             }
+        }
+    }
+
+    N_RANGE.for_each(the_same_in_year);
+    MIN_YEAR_BOUND_RANGE.for_each(the_same_in_year);
+    MAX_YEAR_BOUND_RANGE.for_each(the_same_in_year);
+}
+
+#[test]
+fn test_from_year_day_the_same() {
+    const N_YEAR: i32 = 2_999;
+    const N_RANGE: RangeInclusive<i32> = (-N_YEAR)..=N_YEAR;
+
+    fn the_same_in_year(year: i32) {
+        let days = 365 + iso_new::is_leap_year(year) as u16;
+        for day_of_year in 1..=days {
+            assert_eq!(
+                alg_old::iso_from_year_day(year, day_of_year),
+                iso_new::iso_from_year_day(year, day_of_year),
+                "Y & DofY: {year} {day_of_year}"
+            );
         }
     }
 

--- a/utils/calendrical_calculations/src/tests/iso.rs
+++ b/utils/calendrical_calculations/src/tests/iso.rs
@@ -1,14 +1,9 @@
+use super::helpful_consts::*;
 use super::iso_old_algos as alg_old;
 use super::iso_old_file as iso_old;
 use crate::iso as iso_new;
 use crate::rata_die::RataDie;
 use core::ops::RangeInclusive;
-
-const N_YEAR_BOUND: i32 = 1234; // more than one cycle (400 years)
-const MIN_YEAR_BOUND_RANGE: RangeInclusive<i32> = i32::MIN..=(i32::MIN + N_YEAR_BOUND);
-const MAX_YEAR_BOUND_RANGE: RangeInclusive<i32> = (i32::MAX - N_YEAR_BOUND)..=i32::MAX;
-
-const MONTH_DAYS: [u8; 12] = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
 
 fn calc_last_month_day(year: i32, month: u8) -> u8 {
     let to = MONTH_DAYS[(month as usize) - 1];

--- a/utils/calendrical_calculations/src/tests/iso.rs
+++ b/utils/calendrical_calculations/src/tests/iso.rs
@@ -2,7 +2,7 @@ use super::iso_old_file as iso_old;
 use crate::{iso as iso_new, rata_die::RataDie};
 use core::ops::{Range, RangeInclusive};
 
-const N_YEAR_BOUND: i32 = 1234; // more than one one cycle (400 years)
+const N_YEAR_BOUND: i32 = 1234; // more than one cycle (400 years)
 const MIN_YEAR_BOUND_RANGE: Range<i32> = i32::MIN..(i32::MIN + N_YEAR_BOUND);
 const MAX_YEAR_BOUND_RANGE: RangeInclusive<i32> = (i32::MAX - N_YEAR_BOUND)..=i32::MAX;
 

--- a/utils/calendrical_calculations/src/tests/iso.rs
+++ b/utils/calendrical_calculations/src/tests/iso.rs
@@ -1,5 +1,7 @@
+use super::iso_old_algos as alg_old;
 use super::iso_old_file as iso_old;
-use crate::{iso as iso_new, rata_die::RataDie};
+use crate::iso as iso_new;
+use crate::rata_die::RataDie;
 use core::ops::{Range, RangeInclusive};
 
 const N_YEAR_BOUND: i32 = 1234; // more than one cycle (400 years)
@@ -143,4 +145,28 @@ fn test_from_fixed_eq() {
             "{rata_die:?}"
         );
     }
+}
+
+// New algos in the `iso` and prev. algos from others files:
+
+#[test]
+fn test_day_of_week_the_same() {
+    const N_YEAR: i32 = 2_999;
+    const N_RANGE: RangeInclusive<i32> = (-N_YEAR)..=N_YEAR;
+
+    fn the_same_in_year(year: i32) {
+        for month in 1..=12u8 {
+            for day in 1..=calc_last_month_day(year, month) {
+                assert_eq!(
+                    alg_old::day_of_week(year, month, day),
+                    iso_new::day_of_week(year, month, day),
+                    "YMD: {year} {month} {day}"
+                );
+            }
+        }
+    }
+
+    N_RANGE.for_each(the_same_in_year);
+    MIN_YEAR_BOUND_RANGE.for_each(the_same_in_year);
+    MAX_YEAR_BOUND_RANGE.for_each(the_same_in_year);
 }

--- a/utils/calendrical_calculations/src/tests/iso_old_algos.rs
+++ b/utils/calendrical_calculations/src/tests/iso_old_algos.rs
@@ -82,3 +82,21 @@ pub fn iso_from_year_day(year: i32, year_day: u16) -> (u8, u8) {
 
     (month, day)
 }
+
+/// Prev algo from: `components\calendar\src\iso.rs::Iso`
+///
+/// Return `day_of_the_year` (`1..=365`/`1..=366`)
+pub fn day_of_year(year: i32, month: u8, day: u8) -> u16 {
+    // Cumulatively how much are dates in each month
+    // offset from "30 days in each month" (in non leap years)
+    let month_offset = [0, 1, -1, 0, 0, 1, 1, 2, 3, 3, 4, 4];
+    #[allow(clippy::indexing_slicing)] // date.0.month in 1..=12
+    let mut offset = month_offset[month as usize - 1];
+    if is_leap_year(year) && month > 2 {
+        // Months after February in a leap year are offset by one less
+        offset += 1;
+    }
+    let prev_month_days = (30 * (month as i32 - 1) + offset) as u16;
+
+    prev_month_days + day as u16
+}

--- a/utils/calendrical_calculations/src/tests/iso_old_algos.rs
+++ b/utils/calendrical_calculations/src/tests/iso_old_algos.rs
@@ -1,0 +1,54 @@
+use crate::iso::is_leap_year;
+
+type IsoWeekday = u8;
+
+// Prev algo from: `components\calendar\src\iso.rs`
+// In the code removed: `date.0.`
+// Next line WAS: `fn day_of_week(&self, date: &Self::DateInner) -> types::IsoWeekday {`
+pub fn day_of_week(year: i32, month: u8, day: u8) -> IsoWeekday {
+    // For the purposes of the calculation here, Monday is 0, Sunday is 6
+    // ISO has Monday=1, Sunday=7, which we transform in the last step
+
+    // The days of the week are the same every 400 years
+    // so we normalize to the nearest multiple of 400
+    let years_since_400 = year.rem_euclid(400);
+    debug_assert!(years_since_400 >= 0); // rem_euclid returns positive numbers
+    let years_since_400 = years_since_400 as u32;
+    let leap_years_since_400 = years_since_400 / 4 - years_since_400 / 100;
+    // The number of days to the current year
+    // Can never cause an overflow because years_since_400 has a maximum value of 399.
+    let days_to_current_year = 365 * years_since_400 + leap_years_since_400;
+    // The weekday offset from January 1 this year and January 1 2000
+    let year_offset = days_to_current_year % 7;
+
+    // Corresponding months from
+    // https://en.wikipedia.org/wiki/Determination_of_the_day_of_the_week#Corresponding_months
+    let month_offset = if is_leap_year(year) {
+        match month {
+            10 => 0,
+            5 => 1,
+            2 | 8 => 2,
+            3 | 11 => 3,
+            6 => 4,
+            9 | 12 => 5,
+            1 | 4 | 7 => 6,
+            _ => unreachable!(),
+        }
+    } else {
+        match month {
+            1 | 10 => 0,
+            5 => 1,
+            8 => 2,
+            2 | 3 | 11 => 3,
+            6 => 4,
+            9 | 12 => 5,
+            4 | 7 => 6,
+            _ => unreachable!(),
+        }
+    };
+    let january_1_2000 = 5; // Saturday
+    let day_offset = (january_1_2000 + year_offset + month_offset + day as u32) % 7;
+
+    // We calculated in a zero-indexed fashion, but ISO specifies one-indexed
+    (day_offset + 1) as u8
+}

--- a/utils/calendrical_calculations/src/tests/iso_old_algos.rs
+++ b/utils/calendrical_calculations/src/tests/iso_old_algos.rs
@@ -2,7 +2,7 @@ use crate::iso::is_leap_year;
 
 type IsoWeekday = u8;
 
-// Prev algo from: `components\calendar\src\iso.rs`
+/// Prev algo from: `components\calendar\src\iso.rs`
 // In the code removed: `date.0.`
 // Next line WAS: `fn day_of_week(&self, date: &Self::DateInner) -> types::IsoWeekday {`
 pub fn day_of_week(year: i32, month: u8, day: u8) -> IsoWeekday {
@@ -51,4 +51,34 @@ pub fn day_of_week(year: i32, month: u8, day: u8) -> IsoWeekday {
 
     // We calculated in a zero-indexed fashion, but ISO specifies one-indexed
     (day_offset + 1) as u8
+}
+
+/// Count the number of days in a given month/year combo
+const fn days_in_month(year: i32, month: u8) -> u8 {
+    // see comment to `<impl CalendarArithmetic for Iso>::month_days`
+    match month {
+        2 => 28 | (is_leap_year(year) as u8),
+        _ => 30 | (month ^ (month >> 3)),
+    }
+}
+
+/// Prev algo from: `components\calendar\src\iso.rs::Iso`
+///
+/// Return `(day, month)` for the given `year & `day_of_year`
+pub fn iso_from_year_day(year: i32, year_day: u16) -> (u8, u8) {
+    let mut month = 1;
+    let mut day = year_day as i32;
+    while month <= 12 {
+        let month_days = days_in_month(year, month) as i32;
+        if day <= month_days {
+            break;
+        } else {
+            debug_assert!(month < 12); // don't try going to month 13
+            day -= month_days;
+            month += 1;
+        }
+    }
+    let day = day as u8; // day <= month_days < u8::MAX
+
+    (month, day)
 }

--- a/utils/calendrical_calculations/src/tests/iso_old_file.rs
+++ b/utils/calendrical_calculations/src/tests/iso_old_file.rs
@@ -1,0 +1,94 @@
+// This file is part of ICU4X.
+//
+// The contents of this file implement algorithms from Calendrical Calculations
+// by Reingold & Dershowitz, Cambridge University Press, 4th edition (2018),
+// which have been released as Lisp code at <https://github.com/EdReingold/calendar-code2/>
+// under the Apache-2.0 license. Accordingly, this file is released under
+// the Apache License, Version 2.0 which can be found at the calendrical_calculations
+// package root or at http://www.apache.org/licenses/LICENSE-2.0.
+
+use crate::helpers::{i64_to_i32, I32CastError};
+use crate::rata_die::RataDie;
+
+// The Gregorian epoch is equivalent to first day in fixed day measurement
+const EPOCH: RataDie = RataDie::new(1);
+
+/// Whether or not `year` is a leap year
+#[inline] // real call will be more complex operation than inner code
+pub fn is_leap_year(year: i32) -> bool {
+    year % 4 == 0 && (year % 400 == 0 || year % 100 != 0)
+}
+
+// Fixed is day count representation of calendars starting from Jan 1st of year 1.
+// The fixed calculations algorithms are from the Calendrical Calculations book.
+//
+/// Lisp code reference: <https://github.com/EdReingold/calendar-code2/blob/1ee51ecfaae6f856b0d7de3e36e9042100b4f424/calendar.l#L1167-L1189>
+pub fn fixed_from_iso(year: i32, month: u8, day: u8) -> RataDie {
+    let prev_year = (year as i64) - 1;
+    // Calculate days per year
+    let mut fixed: i64 = (EPOCH.to_i64_date() - 1) + 365 * prev_year;
+    // Calculate leap year offset
+    let offset = prev_year.div_euclid(4) - prev_year.div_euclid(100) + prev_year.div_euclid(400);
+    // Adjust for leap year logic
+    fixed += offset;
+    // Days of current year
+    fixed += (367 * (month as i64) - 362).div_euclid(12);
+    // Leap year adjustment for the current year
+    fixed += if month <= 2 {
+        0
+    } else if is_leap_year(year) {
+        -1
+    } else {
+        -2
+    };
+    // Days passed in current month
+    fixed += day as i64;
+    RataDie::new(fixed)
+}
+
+/// Lisp code reference: <https://github.com/EdReingold/calendar-code2/blob/1ee51ecfaae6f856b0d7de3e36e9042100b4f424/calendar.l#L1191-L1217>
+pub(crate) fn iso_year_from_fixed(date: RataDie) -> i64 {
+    // Shouldn't overflow because it's not possbile to construct extreme values of RataDie
+    let date = date - EPOCH;
+
+    // 400 year cycles have 146097 days
+    let (n_400, date) = (date.div_euclid(146097), date.rem_euclid(146097));
+
+    // 100 year cycles have 36524 days
+    let (n_100, date) = (date.div_euclid(36524), date.rem_euclid(36524));
+
+    // 4 year cycles have 1461 days
+    let (n_4, date) = (date.div_euclid(1461), date.rem_euclid(1461));
+
+    let n_1 = date.div_euclid(365);
+
+    let year = 400 * n_400 + 100 * n_100 + 4 * n_4 + n_1;
+
+    if n_100 == 4 || n_1 == 4 {
+        year
+    } else {
+        year + 1
+    }
+}
+
+fn iso_new_year(year: i32) -> RataDie {
+    fixed_from_iso(year, 1, 1)
+}
+
+/// Lisp code reference: <https://github.com/EdReingold/calendar-code2/blob/1ee51ecfaae6f856b0d7de3e36e9042100b4f424/calendar.l#L1525-L1540>
+pub fn iso_from_fixed(date: RataDie) -> Result<(i32, u8, u8), I32CastError> {
+    let year = iso_year_from_fixed(date);
+    let year = i64_to_i32(year)?;
+    // Calculates the prior days of the adjusted year, then applies a correction based on leap year conditions for the correct ISO date conversion.
+    let prior_days = date - iso_new_year(year);
+    let correction = if date < fixed_from_iso(year, 3, 1) {
+        0
+    } else if is_leap_year(year) {
+        1
+    } else {
+        2
+    };
+    let month = (12 * (prior_days + correction) + 373).div_euclid(367) as u8; // in 1..12 < u8::MAX
+    let day = (date - fixed_from_iso(year, month, 1) + 1) as u8; // <= days_in_month < u8::MAX
+    Ok((year, month, day))
+}

--- a/utils/calendrical_calculations/src/tests/julian.rs
+++ b/utils/calendrical_calculations/src/tests/julian.rs
@@ -1,0 +1,105 @@
+use super::helpful_consts::*;
+use super::julian_old_file as old;
+use crate::{helpers::I32CastError, julian as new, rata_die::RataDie};
+use core::ops::RangeInclusive;
+
+fn calc_last_month_day(year: i32, month: u8) -> u8 {
+    let to = MONTH_DAYS[(month as usize) - 1];
+    if new::is_leap_year(year) && (month == 2) {
+        to + 1
+    } else {
+        to
+    }
+}
+
+#[test]
+fn day_of_year_the_same() {
+    const N_YEAR: i32 = 9_999;
+    const N_RANGE: RangeInclusive<i32> = (-N_YEAR)..=N_YEAR;
+
+    fn the_same_in_year(year: i32) {
+        for month in 1..=12u8 {
+            for day in 1..=calc_last_month_day(year, month) {
+                assert_eq!(
+                    old::day_of_year(year, month, day),
+                    new::day_of_year(year, month, day),
+                    "YMD: {year} {month} {day}"
+                );
+            }
+        }
+    }
+
+    N_RANGE.for_each(the_same_in_year);
+    MIN_YEAR_BOUND_RANGE.for_each(the_same_in_year);
+    MAX_YEAR_BOUND_RANGE.for_each(the_same_in_year);
+}
+
+#[test]
+fn fixed_from_julian_the_same() {
+    const N_YEAR: i32 = 9_999;
+    const N_RANGE: RangeInclusive<i32> = (-N_YEAR)..=N_YEAR;
+
+    fn the_same_in_year(year: i32) {
+        for month in 1..=12u8 {
+            for day in 1..=calc_last_month_day(year, month) {
+                assert_eq!(
+                    old::fixed_from_julian(year, month, day),
+                    new::fixed_from_julian(year, month, day),
+                    "YMD: {year} {month} {day}"
+                );
+            }
+        }
+    }
+
+    N_RANGE.for_each(the_same_in_year);
+    MIN_YEAR_BOUND_RANGE.for_each(the_same_in_year);
+    MAX_YEAR_BOUND_RANGE.for_each(the_same_in_year);
+}
+
+#[test]
+fn julian_from_fixed_the_same() {
+    const N_YEAR: i32 = 9_999;
+    const N_RANGE: RangeInclusive<i32> = (-N_YEAR)..=N_YEAR;
+
+    fn the_same_in_year(year: i32) {
+        for month in 1..=12u8 {
+            for day in 1..=calc_last_month_day(year, month) {
+                let date = new::fixed_from_julian(year, month, day);
+                assert_eq!(
+                    old::julian_from_fixed(date),
+                    new::julian_from_fixed(date),
+                    "YMD: {year} {month} {day}"
+                );
+            }
+        }
+    }
+
+    N_RANGE.for_each(the_same_in_year);
+    MAX_YEAR_BOUND_RANGE.for_each(the_same_in_year);
+
+    // There was a mistake in the prev algo for the date (i32::MIN, 1, 1):
+    ((i32::MIN + 1)..=(i32::MIN + N_YEAR_BOUND)).for_each(the_same_in_year);
+    let rata_die = new::fixed_from_julian(i32::MIN, 1, 1);
+    let date = rata_die.to_i64_date();
+    for date in (date + 1)..=(date + 366) {
+        let date = RataDie::new(date);
+        assert_eq!(old::julian_from_fixed(date), new::julian_from_fixed(date),);
+    }
+
+    // The mistake:
+    assert_eq!(
+        old::julian_from_fixed(rata_die),
+        Err(I32CastError::BelowMin)
+    );
+    assert_eq!(new::julian_from_fixed(rata_die), Ok((i32::MIN, 1, 1)));
+
+    // Ok (should be BelowMin):
+    assert_eq!(
+        old::julian_from_fixed(RataDie::new(date - 1)),
+        Err(I32CastError::BelowMin)
+    );
+    assert_eq!(
+        new::julian_from_fixed(RataDie::new(date - 1)),
+        Err(I32CastError::BelowMin)
+    );
+}

--- a/utils/calendrical_calculations/src/tests/julian.rs
+++ b/utils/calendrical_calculations/src/tests/julian.rs
@@ -3,6 +3,9 @@ use super::julian_old_file as old;
 use crate::{helpers::I32CastError, julian as new, rata_die::RataDie};
 use core::ops::RangeInclusive;
 
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// [+] helpful fns
+
 fn calc_last_month_day(year: i32, month: u8) -> u8 {
     let to = MONTH_DAYS[(month as usize) - 1];
     if new::is_leap_year(year) && (month == 2) {
@@ -12,22 +15,106 @@ fn calc_last_month_day(year: i32, month: u8) -> u8 {
     }
 }
 
+pub(crate) fn assert_year(year: i32, mut assert_f: impl FnMut(i32, u8, u8)) {
+    for month in 1..=12u8 {
+        for day in 1..=calc_last_month_day(year, month) {
+            assert_f(year, month, day)
+        }
+    }
+}
+
+fn assert_year_rata_die(year: i32, mut assert_f: impl FnMut(i32, u8, u8, RataDie)) {
+    for month in 1..=12u8 {
+        for day in 1..=calc_last_month_day(year, month) {
+            let rata_die = old::fixed_from_julian(year, month, day);
+            assert_f(year, month, day, rata_die)
+        }
+    }
+}
+
+// [-] helpful fns
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// [+] test correctness
+
+#[test]
+fn test_algo_correctness() {
+    // In old algo there was a comment:
+    // ```
+    // Julian epoch is equivalent to fixed_from_iso of December 30th of 0 year
+    // 1st Jan of 1st year Julian is equivalent to December 30th of 0th year of ISO year
+    // ```
+    // ⚠️ IS IT TRUE? ⚠️
+
+    // firstly we must be sure that `crate::iso::fixed_from_iso` is correct
+    // (see `super::iso::test_algo_correctness`)
+    //
+    // 1st Jan of 1 year:
+    let rata_die_initial = crate::iso::fixed_from_iso(0, 12, 30);
+
+    // Now we know that `iso_new::julian_from_fixed` is correct for jYMD(1, 1, 1):
+    assert_eq!(new::julian_from_fixed(rata_die_initial), Ok((1, 1, 1)));
+
+    let delta = 9_999; // 3_999_999;
+
+    // This can be incorrect, but if it so, then on jYMD(1, 1, 1) we will figured that out,
+    // because if it is incorrect we get incorrect value for `rata_die_i64` for the jYMD(1, 1, 1)
+    // and `assert_eq!(iso_new::julian_from_fixed(rata_die), Ok((year, month, day)))` will panic
+    let mut rata_die_i64 = new::fixed_from_julian(-delta, 1, 1).to_i64_date();
+
+    let mut year_day = 1;
+    // Because rata die's stay each after each we can verify that in a range
+    // all of `iso_new::julian_from_fixed` is correct, if that range contains the jYMD(1, 1, 1):
+    for year in -delta..=delta {
+        assert_year(year, |year, month, day| {
+            if (month == 1) && (day == 1) {
+                year_day = 1;
+            }
+
+            let rata_die = RataDie::new(rata_die_i64);
+            assert_eq!(new::julian_from_fixed(rata_die), Ok((year, month, day)));
+            assert_eq!(new::fixed_from_julian(year, month, day), rata_die);
+
+            assert_eq!(new::day_of_year(year, month, day), year_day);
+
+            if (month == 12) && (day == 31) {
+                assert_eq!(
+                    year_day,
+                    365 + old::is_leap_year(year) as u16,
+                    "YMD: {year} {month} {day}"
+                );
+            }
+
+            rata_die_i64 += 1;
+            year_day += 1;
+        });
+    }
+
+    // FNS: {julian_from_fixed, fixed_from_julian, day_of_year};
+    // So now we sure that all fns from FNS is correct (at least in range -delta..=delta)
+}
+
+// [-] test correctness
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// [+] test the same result as prev algo
+
 #[test]
 fn day_of_year_the_same() {
     const N_YEAR: i32 = 9_999;
     const N_RANGE: RangeInclusive<i32> = (-N_YEAR)..=N_YEAR;
 
-    fn the_same_in_year(year: i32) {
-        for month in 1..=12u8 {
-            for day in 1..=calc_last_month_day(year, month) {
-                assert_eq!(
-                    old::day_of_year(year, month, day),
-                    new::day_of_year(year, month, day),
-                    "YMD: {year} {month} {day}"
-                );
-            }
-        }
-    }
+    let the_same_in_year = |year| {
+        assert_year(year, |year, month, day| {
+            assert_eq!(
+                old::day_of_year(year, month, day),
+                new::day_of_year(year, month, day),
+                "YMD: {year} {month} {day}"
+            );
+        })
+    };
 
     N_RANGE.for_each(the_same_in_year);
     MIN_YEAR_BOUND_RANGE.for_each(the_same_in_year);
@@ -39,17 +126,15 @@ fn fixed_from_julian_the_same() {
     const N_YEAR: i32 = 9_999;
     const N_RANGE: RangeInclusive<i32> = (-N_YEAR)..=N_YEAR;
 
-    fn the_same_in_year(year: i32) {
-        for month in 1..=12u8 {
-            for day in 1..=calc_last_month_day(year, month) {
-                assert_eq!(
-                    old::fixed_from_julian(year, month, day),
-                    new::fixed_from_julian(year, month, day),
-                    "YMD: {year} {month} {day}"
-                );
-            }
-        }
-    }
+    let the_same_in_year = |year| {
+        assert_year(year, |year, month, day| {
+            assert_eq!(
+                old::fixed_from_julian(year, month, day),
+                new::fixed_from_julian(year, month, day),
+                "YMD: {year} {month} {day}"
+            );
+        })
+    };
 
     N_RANGE.for_each(the_same_in_year);
     MIN_YEAR_BOUND_RANGE.for_each(the_same_in_year);
@@ -61,18 +146,15 @@ fn julian_from_fixed_the_same() {
     const N_YEAR: i32 = 9_999;
     const N_RANGE: RangeInclusive<i32> = (-N_YEAR)..=N_YEAR;
 
-    fn the_same_in_year(year: i32) {
-        for month in 1..=12u8 {
-            for day in 1..=calc_last_month_day(year, month) {
-                let date = new::fixed_from_julian(year, month, day);
-                assert_eq!(
-                    old::julian_from_fixed(date),
-                    new::julian_from_fixed(date),
-                    "YMD: {year} {month} {day}"
-                );
-            }
-        }
-    }
+    let the_same_in_year = |year| {
+        assert_year_rata_die(year, |year, month, day, date| {
+            assert_eq!(
+                old::julian_from_fixed(date),
+                new::julian_from_fixed(date),
+                "YMD: {year} {month} {day}"
+            );
+        })
+    };
 
     N_RANGE.for_each(the_same_in_year);
     MAX_YEAR_BOUND_RANGE.for_each(the_same_in_year);
@@ -103,3 +185,6 @@ fn julian_from_fixed_the_same() {
         Err(I32CastError::BelowMin)
     );
 }
+
+// [-] test the same result as prev algo
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/utils/calendrical_calculations/src/tests/julian_old_file.rs
+++ b/utils/calendrical_calculations/src/tests/julian_old_file.rs
@@ -1,0 +1,106 @@
+// This file is part of ICU4X.
+//
+// The contents of this file implement algorithms from Calendrical Calculations
+// by Reingold & Dershowitz, Cambridge University Press, 4th edition (2018),
+// which have been released as Lisp code at <https://github.com/EdReingold/calendar-code2/>
+// under the Apache-2.0 license. Accordingly, this file is released under
+// the Apache License, Version 2.0 which can be found at the calendrical_calculations
+// package root or at http://www.apache.org/licenses/LICENSE-2.0.
+
+use crate::helpers::{i64_to_i32, I32CastError};
+use crate::rata_die::RataDie;
+
+// Julian epoch is equivalent to fixed_from_iso of December 30th of 0 year
+// 1st Jan of 1st year Julian is equivalent to December 30th of 0th year of ISO year
+const JULIAN_EPOCH: RataDie = RataDie::new(-1);
+
+/// Lisp code reference: <https://github.com/EdReingold/calendar-code2/blob/1ee51ecfaae6f856b0d7de3e36e9042100b4f424/calendar.l#L1684-L1687>
+#[inline(always)]
+pub const fn is_leap_year(year: i32) -> bool {
+    year % 4 == 0
+}
+
+/// Lisp code reference: <https://github.com/EdReingold/calendar-code2/blob/1ee51ecfaae6f856b0d7de3e36e9042100b4f424/calendar.l#L1689-L1709>
+pub const fn fixed_from_julian(year: i32, month: u8, day: u8) -> RataDie {
+    let mut fixed =
+        JULIAN_EPOCH.to_i64_date() - 1 + 365 * (year as i64 - 1) + (year as i64 - 1).div_euclid(4);
+    debug_assert!(month > 0 && month < 13, "Month should be in range 1..=12.");
+    fixed += day_of_year(year, month, day) as i64;
+    RataDie::new(fixed)
+}
+
+/// Lisp code reference: <https://github.com/EdReingold/calendar-code2/blob/1ee51ecfaae6f856b0d7de3e36e9042100b4f424/calendar.l#L1711-L1738>
+pub fn julian_from_fixed(date: RataDie) -> Result<(i32, u8, u8), I32CastError> {
+    // incorrect for rata_data(i32::MIN, 1, 1)
+    let approx = (4 * date.to_i64_date() + 1464).div_euclid(1461);
+    let year = i64_to_i32(approx)?;
+
+    let prior_days = date
+        - fixed_from_julian(year, 1, 1)
+        - if is_leap_year(year) && date > fixed_from_julian(year, 2, 28) {
+            1
+        } else {
+            0
+        };
+    let adjusted_year = if prior_days >= 365 {
+        year.saturating_add(1)
+    } else {
+        year
+    };
+    let adjusted_prior_days = prior_days.rem_euclid(365);
+    debug_assert!((0..365).contains(&adjusted_prior_days));
+    let month = if adjusted_prior_days < 31 {
+        1
+    } else if adjusted_prior_days < 59 {
+        2
+    } else if adjusted_prior_days < 90 {
+        3
+    } else if adjusted_prior_days < 120 {
+        4
+    } else if adjusted_prior_days < 151 {
+        5
+    } else if adjusted_prior_days < 181 {
+        6
+    } else if adjusted_prior_days < 212 {
+        7
+    } else if adjusted_prior_days < 243 {
+        8
+    } else if adjusted_prior_days < 273 {
+        9
+    } else if adjusted_prior_days < 304 {
+        10
+    } else if adjusted_prior_days < 334 {
+        11
+    } else {
+        12
+    };
+    let day = (date - fixed_from_julian(adjusted_year, month, 1) + 1) as u8; // as days_in_month is < u8::MAX
+    debug_assert!(day <= 31, "Day assertion failed; date: {date:?}, adjusted_year: {adjusted_year}, prior_days: {prior_days}, month: {month}, day: {day}");
+
+    Ok((adjusted_year, month, day))
+}
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+pub const fn day_of_year(year: i32, month: u8, day: u8) -> u16 {
+    let mut day_before_month = match month {
+        1 => 0,
+        2 => 31,
+        3 => 59,
+        4 => 90,
+        5 => 120,
+        6 => 151,
+        7 => 181,
+        8 => 212,
+        9 => 243,
+        10 => 273,
+        11 => 304,
+        12 => 334,
+        _ => 0,
+    };
+    // Only add one if the month is after February (month > 2), since leap days are added to the end of February
+    if month > 2 && is_leap_year(year) {
+        day_before_month += 1;
+    }
+    day_before_month + day as u16
+}

--- a/utils/calendrical_calculations/src/tests/mod.rs
+++ b/utils/calendrical_calculations/src/tests/mod.rs
@@ -2,6 +2,9 @@ mod iso;
 mod iso_old_algos;
 mod iso_old_file;
 
+mod julian;
+mod julian_old_file;
+
 mod helpful_consts {
     use core::ops::RangeInclusive;
 

--- a/utils/calendrical_calculations/src/tests/mod.rs
+++ b/utils/calendrical_calculations/src/tests/mod.rs
@@ -1,3 +1,13 @@
 mod iso;
 mod iso_old_algos;
 mod iso_old_file;
+
+mod helpful_consts {
+    use core::ops::RangeInclusive;
+
+    pub const N_YEAR_BOUND: i32 = 1234; // more than one cycle (400 years)
+    pub const MIN_YEAR_BOUND_RANGE: RangeInclusive<i32> = i32::MIN..=(i32::MIN + N_YEAR_BOUND);
+    pub const MAX_YEAR_BOUND_RANGE: RangeInclusive<i32> = (i32::MAX - N_YEAR_BOUND)..=i32::MAX;
+
+    pub const MONTH_DAYS: [u8; 12] = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+}

--- a/utils/calendrical_calculations/src/tests/mod.rs
+++ b/utils/calendrical_calculations/src/tests/mod.rs
@@ -1,2 +1,3 @@
 mod iso;
+mod iso_old_algos;
 mod iso_old_file;

--- a/utils/calendrical_calculations/src/tests/mod.rs
+++ b/utils/calendrical_calculations/src/tests/mod.rs
@@ -1,0 +1,2 @@
+mod iso;
+mod iso_old_file;

--- a/utils/calendrical_calculations/src/tests/mod.rs
+++ b/utils/calendrical_calculations/src/tests/mod.rs
@@ -1,11 +1,16 @@
+// We also can compile parts of this file for bench purpose (to cmp algo perfs) => `#[cfg(test)]`
+
+#[cfg(test)]
 mod iso;
-mod iso_old_algos;
-mod iso_old_file;
+pub mod iso_old_algos;
+pub mod iso_old_file;
 
+#[cfg(test)]
 mod julian;
-mod julian_old_file;
+pub mod julian_old_file;
 
-mod helpful_consts {
+#[cfg(test)]
+pub mod helpful_consts {
     use core::ops::RangeInclusive;
 
     pub const N_YEAR_BOUND: i32 = 1234; // more than one cycle (400 years)


### PR DESCRIPTION
Solving #5562 by implementing algo from the article for the Gregorian calendar.
The article: "Euclidean Affine Functions and Applications to Calendar Algorithms" by Cassio Neri & Lorenz Schneider (Feb. 2021).

~~Draft PR:~~
* ~~As I understand there is many places where parts of the logic is used and I only change the main file.~~
* ~~Also need to run/writes benchmarks in the repo (by now, I run benches only in local pseudo repo where I test the algo).~~
* ~~Also with the same logic can be speeded up the Julian calendar.~~
* ~~Tests: not only test the same value as prev algos~~
