### PR TITLE
Change AnyCalendar constructors

### DIFF
--- a/components/calendar/src/any_calendar.rs
+++ b/components/calendar/src/any_calendar.rs
@@ -774,7 +774,7 @@ impl AnyCalendar {
     icu_provider::gen_any_buffer_data_constructors!(
         (prefs: AnyCalendarPreferences) -> error: DataError,
         functions: [
-            new: skip,
+            try_new: skip,
             try_new_with_any_provider,
             try_new_with_buffer_provider,
             try_new_unstable,
@@ -782,7 +782,7 @@ impl AnyCalendar {
         ]
     );
 
-    #[doc = icu_provider::gen_any_buffer_unstable_docs!(UNSTABLE, Self::new)]
+    #[doc = icu_provider::gen_any_buffer_unstable_docs!(UNSTABLE, Self::try_new)]
     pub fn try_new_unstable<P>(
         provider: &P,
         prefs: AnyCalendarPreferences,

--- a/components/calendar/src/any_calendar.rs
+++ b/components/calendar/src/any_calendar.rs
@@ -60,7 +60,7 @@ define_preferences!(
 ///
 /// let locale = locale!("en-u-ca-japanese"); // English with the Japanese calendar
 ///
-/// let calendar = AnyCalendar::new_for_locale(locale.into());
+/// let calendar = AnyCalendar::try_new(locale.into()).unwrap();
 /// let calendar = Rc::new(calendar); // Avoid cloning it each time
 ///                                   // If everything is a local reference, you may use icu::calendar::Ref instead.
 ///
@@ -576,13 +576,13 @@ impl AnyCalendar {
     /// Constructs an AnyCalendar for a given calendar kind from compiled data.
     ///
     /// As this requires a valid [`AnyCalendarKind`] to work, it does not do any kind of locale-based
-    /// fallbacking. If this is desired, use [`Self::new_for_locale()`].
+    /// fallbacking. If this is desired, use [`Self::try_new()`].
     ///
     /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
-    pub const fn new(kind: AnyCalendarKind) -> Self {
+    pub const fn new_for_kind(kind: AnyCalendarKind) -> Self {
         match kind {
             AnyCalendarKind::Buddhist => AnyCalendar::Buddhist(Buddhist),
             AnyCalendarKind::Chinese => AnyCalendar::Chinese(Chinese::new()),
@@ -615,8 +615,8 @@ impl AnyCalendar {
         }
     }
 
-    #[doc = icu_provider::gen_any_buffer_unstable_docs!(ANY, Self::new)]
-    pub fn try_new_with_any_provider<P>(
+    #[doc = icu_provider::gen_any_buffer_unstable_docs!(ANY, Self::new_for_kind)]
+    pub fn try_new_for_kind_with_any_provider<P>(
         provider: &P,
         kind: AnyCalendarKind,
     ) -> Result<Self, DataError>
@@ -662,8 +662,8 @@ impl AnyCalendar {
     }
 
     #[cfg(feature = "serde")]
-    #[doc = icu_provider::gen_any_buffer_unstable_docs!(BUFFER, Self::new)]
-    pub fn try_new_with_buffer_provider<P>(
+    #[doc = icu_provider::gen_any_buffer_unstable_docs!(BUFFER, Self::new_for_kind)]
+    pub fn try_new_for_kind_with_buffer_provider<P>(
         provider: &P,
         kind: AnyCalendarKind,
     ) -> Result<Self, DataError>
@@ -708,8 +708,8 @@ impl AnyCalendar {
         })
     }
 
-    #[doc = icu_provider::gen_any_buffer_unstable_docs!(UNSTABLE, Self::new)]
-    pub fn try_new_unstable<P>(provider: &P, kind: AnyCalendarKind) -> Result<Self, DataError>
+    #[doc = icu_provider::gen_any_buffer_unstable_docs!(UNSTABLE, Self::new_for_kind)]
+    pub fn try_new_for_kind_unstable<P>(provider: &P, kind: AnyCalendarKind) -> Result<Self, DataError>
     where
         P: DataProvider<crate::provider::JapaneseErasV1Marker>
             + DataProvider<crate::provider::JapaneseExtendedErasV1Marker>
@@ -753,7 +753,7 @@ impl AnyCalendar {
         })
     }
 
-    /// Constructs an AnyCalendar for a given calendar kind from compiled data.
+    /// Constructs an AnyCalendar for a given preference bag from compiled data.
     ///
     /// In case the locale's calendar is unknown or unspecified, it will attempt to load the default
     /// calendar for the locale, falling back to gregorian.
@@ -762,24 +762,25 @@ impl AnyCalendar {
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
-    pub fn new_for_locale(prefs: AnyCalendarPreferences) -> Self {
+    pub fn try_new(prefs: AnyCalendarPreferences) -> Result<Self, DataError> {
+        // NOTE: This returns DataError because this operation should become data-driven
         let kind = AnyCalendarKind::from_prefs_with_fallback(prefs);
-        Self::new(kind)
+        Ok(Self::new_for_kind(kind))
     }
 
     icu_provider::gen_any_buffer_data_constructors!(
         (prefs: AnyCalendarPreferences) -> error: DataError,
         functions: [
-            new_for_locale: skip,
-            try_new_for_locale_with_any_provider,
-            try_new_for_locale_with_buffer_provider,
-            try_new_for_locale_unstable,
+            new: skip,
+            try_new_with_any_provider,
+            try_new_with_buffer_provider,
+            try_new_unstable,
             Self,
         ]
     );
 
-    #[doc = icu_provider::gen_any_buffer_unstable_docs!(UNSTABLE, Self::new_for_locale)]
-    pub fn try_new_for_locale_unstable<P>(
+    #[doc = icu_provider::gen_any_buffer_unstable_docs!(UNSTABLE, Self::new)]
+    pub fn try_new_unstable<P>(
         provider: &P,
         prefs: AnyCalendarPreferences,
     ) -> Result<Self, DataError>
@@ -793,7 +794,7 @@ impl AnyCalendar {
             + ?Sized,
     {
         let kind = AnyCalendarKind::from_prefs_with_fallback(prefs);
-        Self::try_new_unstable(provider, kind)
+        Self::try_new_for_kind_unstable(provider, kind)
     }
 
     /// The [`AnyCalendarKind`] corresponding to the calendar this contains
@@ -1974,24 +1975,24 @@ mod tests {
 
     #[test]
     fn test_any_construction() {
-        let buddhist = AnyCalendar::new(AnyCalendarKind::Buddhist);
-        let chinese = AnyCalendar::new(AnyCalendarKind::Chinese);
-        let coptic = AnyCalendar::new(AnyCalendarKind::Coptic);
-        let dangi = AnyCalendar::new(AnyCalendarKind::Dangi);
-        let ethioaa = AnyCalendar::new(AnyCalendarKind::EthiopianAmeteAlem);
-        let ethiopian = AnyCalendar::new(AnyCalendarKind::Ethiopian);
-        let gregorian = AnyCalendar::new(AnyCalendarKind::Gregorian);
-        let hebrew = AnyCalendar::new(AnyCalendarKind::Hebrew);
-        let indian = AnyCalendar::new(AnyCalendarKind::Indian);
-        let islamic_civil: AnyCalendar = AnyCalendar::new(AnyCalendarKind::IslamicCivil);
+        let buddhist = AnyCalendar::new_for_kind(AnyCalendarKind::Buddhist);
+        let chinese = AnyCalendar::new_for_kind(AnyCalendarKind::Chinese);
+        let coptic = AnyCalendar::new_for_kind(AnyCalendarKind::Coptic);
+        let dangi = AnyCalendar::new_for_kind(AnyCalendarKind::Dangi);
+        let ethioaa = AnyCalendar::new_for_kind(AnyCalendarKind::EthiopianAmeteAlem);
+        let ethiopian = AnyCalendar::new_for_kind(AnyCalendarKind::Ethiopian);
+        let gregorian = AnyCalendar::new_for_kind(AnyCalendarKind::Gregorian);
+        let hebrew = AnyCalendar::new_for_kind(AnyCalendarKind::Hebrew);
+        let indian = AnyCalendar::new_for_kind(AnyCalendarKind::Indian);
+        let islamic_civil: AnyCalendar = AnyCalendar::new_for_kind(AnyCalendarKind::IslamicCivil);
         let islamic_observational: AnyCalendar =
-            AnyCalendar::new(AnyCalendarKind::IslamicObservational);
-        let islamic_tabular: AnyCalendar = AnyCalendar::new(AnyCalendarKind::IslamicTabular);
-        let islamic_umm_al_qura: AnyCalendar = AnyCalendar::new(AnyCalendarKind::IslamicUmmAlQura);
-        let japanese = AnyCalendar::new(AnyCalendarKind::Japanese);
-        let japanext = AnyCalendar::new(AnyCalendarKind::JapaneseExtended);
-        let persian = AnyCalendar::new(AnyCalendarKind::Persian);
-        let roc = AnyCalendar::new(AnyCalendarKind::Roc);
+            AnyCalendar::new_for_kind(AnyCalendarKind::IslamicObservational);
+        let islamic_tabular: AnyCalendar = AnyCalendar::new_for_kind(AnyCalendarKind::IslamicTabular);
+        let islamic_umm_al_qura: AnyCalendar = AnyCalendar::new_for_kind(AnyCalendarKind::IslamicUmmAlQura);
+        let japanese = AnyCalendar::new_for_kind(AnyCalendarKind::Japanese);
+        let japanext = AnyCalendar::new_for_kind(AnyCalendarKind::JapaneseExtended);
+        let persian = AnyCalendar::new_for_kind(AnyCalendarKind::Persian);
+        let roc = AnyCalendar::new_for_kind(AnyCalendarKind::Roc);
         let buddhist = Ref(&buddhist);
         let chinese = Ref(&chinese);
         let coptic = Ref(&coptic);

--- a/components/calendar/src/any_calendar.rs
+++ b/components/calendar/src/any_calendar.rs
@@ -46,7 +46,7 @@ define_preferences!(
 /// This allows for the construction of [`Date`] objects that have their calendar known at runtime.
 ///
 /// This can be constructed by calling `.into()` on a concrete calendar type if the calendar type is known at
-/// compile time. When the type is known at runtime, the [`AnyCalendar::new()`] and sibling methods may be used.
+/// compile time. When the type is known at runtime, the [`AnyCalendar::new_for_kind()`] and sibling methods may be used.
 ///
 /// [`Date`] can also be converted to [`AnyCalendar`]-compatible ones
 /// via [`Date::to_any()`](crate::Date::to_any()).
@@ -709,7 +709,10 @@ impl AnyCalendar {
     }
 
     #[doc = icu_provider::gen_any_buffer_unstable_docs!(UNSTABLE, Self::new_for_kind)]
-    pub fn try_new_for_kind_unstable<P>(provider: &P, kind: AnyCalendarKind) -> Result<Self, DataError>
+    pub fn try_new_for_kind_unstable<P>(
+        provider: &P,
+        kind: AnyCalendarKind,
+    ) -> Result<Self, DataError>
     where
         P: DataProvider<crate::provider::JapaneseErasV1Marker>
             + DataProvider<crate::provider::JapaneseExtendedErasV1Marker>
@@ -1987,8 +1990,10 @@ mod tests {
         let islamic_civil: AnyCalendar = AnyCalendar::new_for_kind(AnyCalendarKind::IslamicCivil);
         let islamic_observational: AnyCalendar =
             AnyCalendar::new_for_kind(AnyCalendarKind::IslamicObservational);
-        let islamic_tabular: AnyCalendar = AnyCalendar::new_for_kind(AnyCalendarKind::IslamicTabular);
-        let islamic_umm_al_qura: AnyCalendar = AnyCalendar::new_for_kind(AnyCalendarKind::IslamicUmmAlQura);
+        let islamic_tabular: AnyCalendar =
+            AnyCalendar::new_for_kind(AnyCalendarKind::IslamicTabular);
+        let islamic_umm_al_qura: AnyCalendar =
+            AnyCalendar::new_for_kind(AnyCalendarKind::IslamicUmmAlQura);
         let japanese = AnyCalendar::new_for_kind(AnyCalendarKind::Japanese);
         let japanext = AnyCalendar::new_for_kind(AnyCalendarKind::JapaneseExtended);
         let persian = AnyCalendar::new_for_kind(AnyCalendarKind::Persian);

--- a/components/calendar/src/ixdtf.rs
+++ b/components/calendar/src/ixdtf.rs
@@ -41,7 +41,7 @@ impl AnyCalendar {
         let calendar_id = ixdtf_record.calendar.unwrap_or(b"iso");
         let calendar_kind = crate::AnyCalendarKind::get_for_bcp47_bytes(calendar_id)
             .ok_or(ParseError::UnknownCalendar)?;
-        let calendar = AnyCalendar::new(calendar_kind);
+        let calendar = AnyCalendar::new_for_kind(calendar_kind);
         Ok(calendar)
     }
 }

--- a/components/datetime/src/external_loaders.rs
+++ b/components/datetime/src/external_loaders.rs
@@ -47,7 +47,7 @@ impl FixedDecimalFormatterLoader for ExternalLoaderCompiledData {
 impl AnyCalendarLoader for ExternalLoaderCompiledData {
     #[inline]
     fn load(&self, prefs: AnyCalendarPreferences) -> Result<AnyCalendar, DataError> {
-        Ok(AnyCalendar::new_for_locale(prefs))
+        AnyCalendar::try_new(prefs)
     }
 }
 
@@ -74,7 +74,7 @@ where
 {
     #[inline]
     fn load(&self, prefs: AnyCalendarPreferences) -> Result<AnyCalendar, DataError> {
-        AnyCalendar::try_new_for_locale_with_any_provider(self.0, prefs)
+        AnyCalendar::try_new_with_any_provider(self.0, prefs)
     }
 }
 
@@ -104,7 +104,7 @@ where
 {
     #[inline]
     fn load(&self, prefs: AnyCalendarPreferences) -> Result<AnyCalendar, DataError> {
-        AnyCalendar::try_new_for_locale_with_buffer_provider(self.0, prefs)
+        AnyCalendar::try_new_with_buffer_provider(self.0, prefs)
     }
 }
 
@@ -139,6 +139,6 @@ where
 {
     #[inline]
     fn load(&self, prefs: AnyCalendarPreferences) -> Result<AnyCalendar, DataError> {
-        AnyCalendar::try_new_for_locale_unstable(self.0, prefs)
+        AnyCalendar::try_new_unstable(self.0, prefs)
     }
 }

--- a/components/timezone/src/ixdtf.rs
+++ b/components/timezone/src/ixdtf.rs
@@ -758,7 +758,7 @@ impl IxdtfParser {
         let calendar_id = ixdtf_record.calendar.unwrap_or(b"iso");
         let calendar_kind = icu_calendar::AnyCalendarKind::get_for_bcp47_bytes(calendar_id)
             .ok_or(ParseError::UnknownCalendar)?;
-        let calendar = AnyCalendar::new(calendar_kind);
+        let calendar = AnyCalendar::new_for_kind(calendar_kind);
 
         Ok(CustomZonedDateTime {
             date: iso_zdt.date.to_any().to_calendar(calendar),

--- a/ffi/capi/bindings/dart/Calendar.g.dart
+++ b/ffi/capi/bindings/dart/Calendar.g.dart
@@ -24,7 +24,7 @@ final class Calendar implements ffi.Finalizable {
 
   /// Creates a new [`Calendar`] from the specified date and time.
   ///
-  /// See the [Rust documentation for `new_for_locale`](https://docs.rs/icu/latest/icu/calendar/enum.AnyCalendar.html#method.new_for_locale) for more information.
+  /// See the [Rust documentation for `try_new`](https://docs.rs/icu/latest/icu/calendar/enum.AnyCalendar.html#method.try_new) for more information.
   ///
   /// Throws [DataError] on failure.
   factory Calendar.forLocale(DataProvider provider, Locale locale) {
@@ -37,7 +37,7 @@ final class Calendar implements ffi.Finalizable {
 
   /// Creates a new [`Calendar`] from the specified date and time.
   ///
-  /// See the [Rust documentation for `new`](https://docs.rs/icu/latest/icu/calendar/enum.AnyCalendar.html#method.new) for more information.
+  /// See the [Rust documentation for `new_for_kind`](https://docs.rs/icu/latest/icu/calendar/enum.AnyCalendar.html#method.new_for_kind) for more information.
   ///
   /// Throws [DataError] on failure.
   factory Calendar.forKind(DataProvider provider, AnyCalendarKind kind) {

--- a/ffi/capi/src/calendar.rs
+++ b/ffi/capi/src/calendar.rs
@@ -101,7 +101,7 @@ pub mod ffi {
 
     impl Calendar {
         /// Creates a new [`Calendar`] from the specified date and time.
-        #[diplomat::rust_link(icu::calendar::AnyCalendar::new_for_locale, FnInEnum)]
+        #[diplomat::rust_link(icu::calendar::AnyCalendar::try_new, FnInEnum)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "for_locale")]
         #[diplomat::demo(default_constructor)]
         pub fn create_for_locale(
@@ -111,25 +111,25 @@ pub mod ffi {
             let prefs = (&locale.0).into();
 
             Ok(Box::new(Calendar(Arc::new(call_constructor!(
-                icu_calendar::AnyCalendar::new_for_locale [r => Ok(r)],
-                icu_calendar::AnyCalendar::try_new_for_locale_with_any_provider,
-                icu_calendar::AnyCalendar::try_new_for_locale_with_buffer_provider,
+                icu_calendar::AnyCalendar::try_new,
+                icu_calendar::AnyCalendar::try_new_with_any_provider,
+                icu_calendar::AnyCalendar::try_new_with_buffer_provider,
                 provider,
                 prefs
             )?))))
         }
 
         /// Creates a new [`Calendar`] from the specified date and time.
-        #[diplomat::rust_link(icu::calendar::AnyCalendar::new, FnInEnum)]
+        #[diplomat::rust_link(icu::calendar::AnyCalendar::new_for_kind, FnInEnum)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "for_kind")]
         pub fn create_for_kind(
             provider: &DataProvider,
             kind: AnyCalendarKind,
         ) -> Result<Box<Calendar>, DataError> {
             Ok(Box::new(Calendar(Arc::new(call_constructor!(
-                icu_calendar::AnyCalendar::new [r => Ok(r)],
-                icu_calendar::AnyCalendar::try_new_with_any_provider,
-                icu_calendar::AnyCalendar::try_new_with_buffer_provider,
+                icu_calendar::AnyCalendar::new_for_kind [r => Ok(r)],
+                icu_calendar::AnyCalendar::try_new_for_kind_with_any_provider,
+                icu_calendar::AnyCalendar::try_new_for_kind_with_buffer_provider,
                 provider,
                 kind.into()
             )?))))


### PR DESCRIPTION
Fixes #5843

I think this is better because it is more uniform, and most of the time you have a locale, not an AnyCalendarKind.