### PR TITLE
build: improve building with -Zminimal-versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -249,7 +249,7 @@ memchr = { version = "2.6.0", default-features = false }
 num-bigint = { version = "0.4.3", default-features = false }
 num-rational = { version = "0.4.0", default-features = false }
 num-traits = { version = "0.2.0", default-features = false }
-postcard = { version = "1.0.1", default-features = false }
+postcard = { version = "1.0.3", default-features = false }
 regex-automata = { version = "0.4.7", default-features = false }
 ryu = { version = "1.0.5", default-features = false }
 serde = { version = "1.0.110", default-features = false }


### PR DESCRIPTION
This improves building with `-Zminimal-versions` by increasing the minimum allowed version of postcard to the first one that can be used to successfully compile this project.