### PR TITLE
Relax trait bound for `EitherCart` in `Yoke` crate

### DIFF
--- a/utils/yoke/src/either.rs
+++ b/utils/yoke/src/either.rs
@@ -56,6 +56,7 @@ impl<C0, C1, T> Deref for EitherCart<C0, C1>
 where
     C0: Deref<Target = T>,
     C1: Deref<Target = T>,
+    T:?Sized,
 {
     type Target = T;
     fn deref(&self) -> &T {
@@ -74,6 +75,7 @@ where
     C1: StableDeref,
     C0: Deref<Target = T>,
     C1: Deref<Target = T>,
+    T:?Sized,
 {
 }
 

--- a/utils/yoke/src/either.rs
+++ b/utils/yoke/src/either.rs
@@ -56,7 +56,7 @@ impl<C0, C1, T> Deref for EitherCart<C0, C1>
 where
     C0: Deref<Target = T>,
     C1: Deref<Target = T>,
-    T:?Sized,
+    T: ?Sized,
 {
     type Target = T;
     fn deref(&self) -> &T {
@@ -75,7 +75,7 @@ where
     C1: StableDeref,
     C0: Deref<Target = T>,
     C1: Deref<Target = T>,
-    T:?Sized,
+    T: ?Sized,
 {
 }
 


### PR DESCRIPTION
The enum `EitherCart` in `Yoke` crate theoretically implements `Deref` and `StableDeref` traits. However, it does not support the dereferenced type `T` being Unsized (like `[u8]`). As a result, types like `EitherCart<Arc<[u8]>, Box<[u8]>>` cause compiler errors, making this enum less useful.

In this pull request, I have relaxed the trait bound of `T` to support unsized types. This change should be safe as the origin `Deref` already allows Unsized `T`.