### PR TITLE
Refactor: rename variable from `locale` to `currency_preferences` for clarity.

### DIFF
--- a/components/experimental/src/dimension/currency/long_format.rs
+++ b/components/experimental/src/dimension/currency/long_format.rs
@@ -50,9 +50,9 @@ mod tests {
 
     #[test]
     pub fn test_en_us() {
-        let locale = locale!("en-US").into();
+        let currency_preferences = locale!("en-US").into();
         let currency_code = CurrencyCode(tinystr!(3, "USD"));
-        let fmt = LongCurrencyFormatter::try_new(locale, &currency_code).unwrap();
+        let fmt = LongCurrencyFormatter::try_new(currency_preferences, &currency_code).unwrap();
 
         // Positive case
         let positive_value = "12345.67".parse().unwrap();
@@ -67,9 +67,9 @@ mod tests {
 
     #[test]
     pub fn test_fr_fr() {
-        let locale = locale!("fr-FR").into();
+        let currency_preferences = locale!("fr-FR").into();
         let currency_code = CurrencyCode(tinystr!(3, "EUR"));
-        let fmt = LongCurrencyFormatter::try_new(locale, &currency_code).unwrap();
+        let fmt = LongCurrencyFormatter::try_new(currency_preferences, &currency_code).unwrap();
 
         // Positive case
         let positive_value = "12345.67".parse().unwrap();
@@ -84,9 +84,9 @@ mod tests {
 
     #[test]
     pub fn test_ar_eg() {
-        let locale = locale!("ar-EG").into();
+        let currency_preferences = locale!("ar-EG").into();
         let currency_code = CurrencyCode(tinystr!(3, "EGP"));
-        let fmt = LongCurrencyFormatter::try_new(locale, &currency_code).unwrap();
+        let fmt = LongCurrencyFormatter::try_new(currency_preferences, &currency_code).unwrap();
 
         // Positive case
         let positive_value = "12345.67".parse().unwrap();

--- a/components/experimental/src/dimension/currency/long_formatter.rs
+++ b/components/experimental/src/dimension/currency/long_formatter.rs
@@ -159,9 +159,9 @@ impl LongCurrencyFormatter {
     /// use tinystr::*;
     /// use writeable::Writeable;
     ///
-    /// let locale = locale!("en-US").into();
+    /// let currency_preferences = locale!("en-US").into();
     /// let currency_code = CurrencyCode(tinystr!(3, "USD"));
-    /// let fmt = LongCurrencyFormatter::try_new(locale, &currency_code).unwrap();
+    /// let fmt = LongCurrencyFormatter::try_new(currency_preferences, &currency_code).unwrap();
     /// let value = "12345.67".parse().unwrap();
     /// let formatted_currency = fmt.format_fixed_decimal(&value, currency_code);
     /// let mut sink = String::new();


### PR DESCRIPTION

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->