### PR TITLE
Breaking: change format_fixed_decimal to accept a reference to `SignedFixedDecimal`

### DIFF
--- a/components/experimental/src/compactdecimal/formatter.rs
+++ b/components/experimental/src/compactdecimal/formatter.rs
@@ -315,7 +315,7 @@ impl CompactDecimalFormatter {
     /// ```
     pub fn format_i64(&self, value: i64) -> FormattedCompactDecimal<'_> {
         let unrounded = SignedFixedDecimal::from(value);
-        self.format_fixed_decimal(unrounded)
+        self.format_fixed_decimal(&unrounded)
     }
 
     /// Formats a floating-point number in compact decimal notation using the default
@@ -380,7 +380,7 @@ impl CompactDecimalFormatter {
         // NOTE: This first gets the shortest representation of the f64, which
         // manifests as double rounding.
         let partly_rounded = SignedFixedDecimal::try_from_f64(value, RoundTrip)?;
-        Ok(self.format_fixed_decimal(partly_rounded))
+        Ok(self.format_fixed_decimal(&partly_rounded))
     }
 
     /// Formats a [`SignedFixedDecimal`] by automatically scaling and rounding it.
@@ -481,7 +481,7 @@ impl CompactDecimalFormatter {
     ///     "-1.2M"
     /// );
     /// ```
-    pub fn format_fixed_decimal(&self, value: SignedFixedDecimal) -> FormattedCompactDecimal<'_> {
+    pub fn format_fixed_decimal(&self, value: &SignedFixedDecimal) -> FormattedCompactDecimal<'_> {
         let log10_type = value.absolute.nonzero_magnitude_start();
         let (mut plural_map, mut exponent) = self.plural_map_and_exponent_for_magnitude(log10_type);
         let mut significand = value.clone();

--- a/components/experimental/src/compactdecimal/formatter.rs
+++ b/components/experimental/src/compactdecimal/formatter.rs
@@ -406,38 +406,38 @@ impl CompactDecimalFormatter {
     /// .unwrap();
     ///
     /// assert_writeable_eq!(
-    ///     short_english.format_fixed_decimal(SignedFixedDecimal::from(0)),
+    ///     short_english.format_fixed_decimal(&SignedFixedDecimal::from(0)),
     ///     "0"
     /// );
     /// assert_writeable_eq!(
-    ///     short_english.format_fixed_decimal(SignedFixedDecimal::from(2)),
+    ///     short_english.format_fixed_decimal(&SignedFixedDecimal::from(2)),
     ///     "2"
     /// );
     /// assert_writeable_eq!(
-    ///     short_english.format_fixed_decimal(SignedFixedDecimal::from(843)),
+    ///     short_english.format_fixed_decimal(&SignedFixedDecimal::from(843)),
     ///     "843"
     /// );
     /// assert_writeable_eq!(
-    ///     short_english.format_fixed_decimal(SignedFixedDecimal::from(2207)),
+    ///     short_english.format_fixed_decimal(&SignedFixedDecimal::from(2207)),
     ///     "2.2K"
     /// );
     /// assert_writeable_eq!(
-    ///     short_english.format_fixed_decimal(SignedFixedDecimal::from(15127)),
+    ///     short_english.format_fixed_decimal(&SignedFixedDecimal::from(15127)),
     ///     "15K"
     /// );
     /// assert_writeable_eq!(
-    ///     short_english.format_fixed_decimal(SignedFixedDecimal::from(3010349)),
+    ///     short_english.format_fixed_decimal(&SignedFixedDecimal::from(3010349)),
     ///     "3M"
     /// );
     /// assert_writeable_eq!(
-    ///     short_english.format_fixed_decimal(SignedFixedDecimal::from(-13132)),
+    ///     short_english.format_fixed_decimal(&SignedFixedDecimal::from(-13132)),
     ///     "-13K"
     /// );
     ///
     /// // The sign display on the FixedDecimal is respected:
     /// assert_writeable_eq!(
     ///     short_english.format_fixed_decimal(
-    ///         SignedFixedDecimal::from(2500)
+    ///         &SignedFixedDecimal::from(2500)
     ///             .with_sign_display(fixed_decimal::SignDisplay::ExceptZero)
     ///     ),
     ///     "+2.5K"
@@ -457,27 +457,27 @@ impl CompactDecimalFormatter {
     /// #    Default::default(),
     /// # ).unwrap();
     /// assert_writeable_eq!(
-    ///     short_english.format_fixed_decimal("999499.99".parse().unwrap()),
+    ///     short_english.format_fixed_decimal(&"999499.99".parse().unwrap()),
     ///     "999K"
     /// );
     /// assert_writeable_eq!(
-    ///     short_english.format_fixed_decimal("999500.00".parse().unwrap()),
+    ///     short_english.format_fixed_decimal(&"999500.00".parse().unwrap()),
     ///     "1M"
     /// );
     /// assert_writeable_eq!(
-    ///     short_english.format_fixed_decimal("1650".parse().unwrap()),
+    ///     short_english.format_fixed_decimal(&"1650".parse().unwrap()),
     ///     "1.6K"
     /// );
     /// assert_writeable_eq!(
-    ///     short_english.format_fixed_decimal("1750".parse().unwrap()),
+    ///     short_english.format_fixed_decimal(&"1750".parse().unwrap()),
     ///     "1.8K"
     /// );
     /// assert_writeable_eq!(
-    ///     short_english.format_fixed_decimal("1950".parse().unwrap()),
+    ///     short_english.format_fixed_decimal(&"1950".parse().unwrap()),
     ///     "2K"
     /// );
     /// assert_writeable_eq!(
-    ///     short_english.format_fixed_decimal("-1172700".parse().unwrap()),
+    ///     short_english.format_fixed_decimal(&"-1172700".parse().unwrap()),
     ///     "-1.2M"
     /// );
     /// ```


### PR DESCRIPTION
Fix: #5881 


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->