### PR TITLE
Add `experimental` to datetime's `bench` features

### DIFF
--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -97,7 +97,7 @@ datagen = [
 ]
 logging = ["icu_calendar/logging"]
 experimental = ["dep:litemap"]
-bench = ["serde", "datagen"]
+bench = ["serde", "datagen", "experimental"]
 compiled_data = ["dep:icu_datetime_data", "icu_calendar/compiled_data", "icu_decimal/compiled_data", "icu_plurals/compiled_data", "icu_timezone/compiled_data"]
 
 [lib]


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->

Both benchmark suites in the `datetime` component use the `CompositeFieldSetSerde` which is under the `experimental` feature. As a result, running `cargo bench -F bench --manifest-path components/datetime/Cargo.toml` will not run any benchmark. This currently causes CI to fail on the main branch (e.g. https://github.com/unicode-org/icu4x/actions/runs/12279258426/job/34262931118).

This PR adds the `experimental` feature to the `bench` feature. Alternatively, the workflow could specify additional features to pass to a component's benchmarks. However, when running the benchmarks locally, one would always need to specify the `experimental` feature.