### PR TITLE
Clarify `iana_to_bcp47` return type in docs

### DIFF
--- a/components/timezone/src/ids.rs
+++ b/components/timezone/src/ids.rs
@@ -194,7 +194,7 @@ impl TimeZoneIdMapperBorrowed<'_> {
     /// Gets the BCP-47 time zone ID from an IANA time zone ID
     /// with a case-insensitive lookup.
     ///
-    /// Returns `None` if the IANA ID is not found.
+    /// Returns [`TimeZoneBcp47Id::unknown()`] if the IANA ID is not found.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->

`TimeZoneIdMapperBorrowed::iana_to_bcp47` returns the unknown BCP-47 ID, not `None` (like most other methods on `TimeZoneIdMapperBorrowed`). This PR specifies that in the doc-comment for the method.
