### PR TITLE
Add `BTreeMap` like apis to `LiteMap`

### DIFF
--- a/components/experimental/src/personnames/provided_struct.rs
+++ b/components/experimental/src/personnames/provided_struct.rs
@@ -35,7 +35,7 @@ impl PersonName for DefaultPersonName {
     }
 
     fn available_name_fields(&self) -> Vec<&NameField> {
-        self.person_data.iter_keys().collect()
+        self.person_data.keys().collect()
     }
 
     fn has_name_field_kind(&self, lookup_name_field: &NameFieldKind) -> bool {

--- a/components/experimental/src/units/converter_factory.rs
+++ b/components/experimental/src/units/converter_factory.rs
@@ -232,7 +232,7 @@ impl ConverterFactory {
         insert_non_basic_units(self, unit2, -1, &mut map)?;
 
         let (power_sums_are_zero, power_diffs_are_zero) =
-            map.iter_values()
+            map.values()
                 .fold((true, true), |(sums, diffs), powers_info| {
                     (
                         sums && powers_info.sums == 0,

--- a/utils/litemap/src/map.rs
+++ b/utils/litemap/src/map.rs
@@ -878,12 +878,24 @@ where
     }
 
     /// Produce an ordered iterator over keys
+    #[deprecated = "use keys() instead"]
     pub fn iter_keys(&'a self) -> impl DoubleEndedIterator<Item = &'a K> {
         self.values.lm_iter().map(|val| val.0)
     }
 
     /// Produce an iterator over values, ordered by their keys
+    #[deprecated = "use values() instead"]
     pub fn iter_values(&'a self) -> impl DoubleEndedIterator<Item = &'a V> {
+        self.values.lm_iter().map(|val| val.1)
+    }
+
+    /// Produce an ordered iterator over keys
+    pub fn keys(&'a self) -> impl DoubleEndedIterator<Item = &'a K> {
+        self.values.lm_iter().map(|val| val.0)
+    }
+
+    /// Produce an iterator over values, ordered by their keys
+    pub fn values(&'a self) -> impl DoubleEndedIterator<Item = &'a V> {
         self.values.lm_iter().map(|val| val.1)
     }
 }
@@ -907,6 +919,30 @@ where
 
     fn into_iter(self) -> Self::IntoIter {
         self.values.lm_into_iter()
+    }
+}
+
+impl<'a, K, V, S> IntoIterator for &'a LiteMap<K, V, S>
+where
+    S: StoreIterable<'a, K, V>,
+{
+    type Item = (&'a K, &'a V);
+    type IntoIter = S::KeyValueIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.values.lm_iter()
+    }
+}
+
+impl<'a, K, V, S> IntoIterator for &'a mut LiteMap<K, V, S>
+where
+    S: StoreIterableMut<'a, K, V>,
+{
+    type Item = (&'a K, &'a mut V);
+    type IntoIter = S::KeyValueIterMut;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.values.lm_iter_mut()
     }
 }
 

--- a/utils/zerotrie/tests/locale_aux_test.rs
+++ b/utils/zerotrie/tests/locale_aux_test.rs
@@ -55,7 +55,7 @@ fn test_combined() {
         8445
     );
 
-    let total_str_len = litemap.iter_keys().map(|k| k.len()).sum::<usize>();
+    let total_str_len = litemap.keys().map(|k| k.len()).sum::<usize>();
     assert_eq!(total_str_len, 8115);
 
     // Lookup table size:
@@ -118,7 +118,7 @@ fn test_aux_split() {
         let trie = ZeroTriePerfectHash::try_from(&litemap).unwrap();
         total_perfecthash_len += trie.byte_len();
 
-        for k in litemap.iter_keys() {
+        for k in litemap.keys() {
             unique_locales.insert(k.clone());
         }
 


### PR DESCRIPTION
Add BTreeMap-like APIs to LiteMap to get closer to the std lib BTreeMap, which has familiarity benefits and allows easier integration of LiteMap into existing projects.

* implement `IntoIter` for `&LiteMap` and `&mut LiteMap`
* Deprecate `iter_keys` and `iter_values` in favor of `keys` and `values`