### PR TITLE
Make FFI DataProvider only support BufferProvider

### DIFF
--- a/components/datetime/src/error.rs
+++ b/components/datetime/src/error.rs
@@ -30,6 +30,12 @@ pub enum DateTimeFormatterLoadError {
     Data(DataError),
 }
 
+impl From<DataError> for DateTimeFormatterLoadError {
+    fn from(error: DataError) -> Self {
+        Self::Data(error)
+    }
+}
+
 /// An error from mixing calendar types in a formatter.
 #[derive(Display, Debug, Copy, Clone, PartialEq)]
 #[displaydoc("DateTimeFormatter for {this_kind} calendar was given a {date_kind:?} calendar")]

--- a/ffi/capi/bindings/c/DataProvider.h
+++ b/ffi/capi/bindings/c/DataProvider.h
@@ -17,15 +17,11 @@
 
 
 
-DataProvider* icu4x_DataProvider_compiled_mv1(void);
-
 typedef struct icu4x_DataProvider_from_fs_mv1_result {union {DataProvider* ok; DataError err;}; bool is_ok;} icu4x_DataProvider_from_fs_mv1_result;
 icu4x_DataProvider_from_fs_mv1_result icu4x_DataProvider_from_fs_mv1(DiplomatStringView path);
 
 typedef struct icu4x_DataProvider_from_byte_slice_mv1_result {union {DataProvider* ok; DataError err;}; bool is_ok;} icu4x_DataProvider_from_byte_slice_mv1_result;
 icu4x_DataProvider_from_byte_slice_mv1_result icu4x_DataProvider_from_byte_slice_mv1(DiplomatU8View blob);
-
-DataProvider* icu4x_DataProvider_empty_mv1(void);
 
 typedef struct icu4x_DataProvider_fork_by_key_mv1_result {union { DataError err;}; bool is_ok;} icu4x_DataProvider_fork_by_key_mv1_result;
 icu4x_DataProvider_fork_by_key_mv1_result icu4x_DataProvider_fork_by_key_mv1(DataProvider* self, DataProvider* other);

--- a/ffi/capi/bindings/cpp/icu4x/DataProvider.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/DataProvider.d.hpp
@@ -28,13 +28,9 @@ namespace icu4x {
 class DataProvider {
 public:
 
-  inline static std::unique_ptr<icu4x::DataProvider> compiled();
-
   inline static diplomat::result<std::unique_ptr<icu4x::DataProvider>, icu4x::DataError> from_fs(std::string_view path);
 
   inline static diplomat::result<std::unique_ptr<icu4x::DataProvider>, icu4x::DataError> from_byte_slice(diplomat::span<const uint8_t> blob);
-
-  inline static std::unique_ptr<icu4x::DataProvider> empty();
 
   inline diplomat::result<std::monostate, icu4x::DataError> fork_by_key(icu4x::DataProvider& other);
 

--- a/ffi/capi/bindings/cpp/icu4x/DataProvider.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/DataProvider.hpp
@@ -18,15 +18,11 @@ namespace icu4x {
 namespace capi {
     extern "C" {
     
-    icu4x::capi::DataProvider* icu4x_DataProvider_compiled_mv1(void);
-    
     typedef struct icu4x_DataProvider_from_fs_mv1_result {union {icu4x::capi::DataProvider* ok; icu4x::capi::DataError err;}; bool is_ok;} icu4x_DataProvider_from_fs_mv1_result;
     icu4x_DataProvider_from_fs_mv1_result icu4x_DataProvider_from_fs_mv1(diplomat::capi::DiplomatStringView path);
     
     typedef struct icu4x_DataProvider_from_byte_slice_mv1_result {union {icu4x::capi::DataProvider* ok; icu4x::capi::DataError err;}; bool is_ok;} icu4x_DataProvider_from_byte_slice_mv1_result;
     icu4x_DataProvider_from_byte_slice_mv1_result icu4x_DataProvider_from_byte_slice_mv1(diplomat::capi::DiplomatU8View blob);
-    
-    icu4x::capi::DataProvider* icu4x_DataProvider_empty_mv1(void);
     
     typedef struct icu4x_DataProvider_fork_by_key_mv1_result {union { icu4x::capi::DataError err;}; bool is_ok;} icu4x_DataProvider_fork_by_key_mv1_result;
     icu4x_DataProvider_fork_by_key_mv1_result icu4x_DataProvider_fork_by_key_mv1(icu4x::capi::DataProvider* self, icu4x::capi::DataProvider* other);
@@ -44,11 +40,6 @@ namespace capi {
 } // namespace capi
 } // namespace
 
-inline std::unique_ptr<icu4x::DataProvider> icu4x::DataProvider::compiled() {
-  auto result = icu4x::capi::icu4x_DataProvider_compiled_mv1();
-  return std::unique_ptr<icu4x::DataProvider>(icu4x::DataProvider::FromFFI(result));
-}
-
 inline diplomat::result<std::unique_ptr<icu4x::DataProvider>, icu4x::DataError> icu4x::DataProvider::from_fs(std::string_view path) {
   auto result = icu4x::capi::icu4x_DataProvider_from_fs_mv1({path.data(), path.size()});
   return result.is_ok ? diplomat::result<std::unique_ptr<icu4x::DataProvider>, icu4x::DataError>(diplomat::Ok<std::unique_ptr<icu4x::DataProvider>>(std::unique_ptr<icu4x::DataProvider>(icu4x::DataProvider::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<icu4x::DataProvider>, icu4x::DataError>(diplomat::Err<icu4x::DataError>(icu4x::DataError::FromFFI(result.err)));
@@ -57,11 +48,6 @@ inline diplomat::result<std::unique_ptr<icu4x::DataProvider>, icu4x::DataError> 
 inline diplomat::result<std::unique_ptr<icu4x::DataProvider>, icu4x::DataError> icu4x::DataProvider::from_byte_slice(diplomat::span<const uint8_t> blob) {
   auto result = icu4x::capi::icu4x_DataProvider_from_byte_slice_mv1({blob.data(), blob.size()});
   return result.is_ok ? diplomat::result<std::unique_ptr<icu4x::DataProvider>, icu4x::DataError>(diplomat::Ok<std::unique_ptr<icu4x::DataProvider>>(std::unique_ptr<icu4x::DataProvider>(icu4x::DataProvider::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<icu4x::DataProvider>, icu4x::DataError>(diplomat::Err<icu4x::DataError>(icu4x::DataError::FromFFI(result.err)));
-}
-
-inline std::unique_ptr<icu4x::DataProvider> icu4x::DataProvider::empty() {
-  auto result = icu4x::capi::icu4x_DataProvider_empty_mv1();
-  return std::unique_ptr<icu4x::DataProvider>(icu4x::DataProvider::FromFFI(result));
 }
 
 inline diplomat::result<std::monostate, icu4x::DataError> icu4x::DataProvider::fork_by_key(icu4x::DataProvider& other) {

--- a/ffi/capi/bindings/dart/DataProvider.g.dart
+++ b/ffi/capi/bindings/dart/DataProvider.g.dart
@@ -24,25 +24,6 @@ final class DataProvider implements ffi.Finalizable {
 
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_DataProvider_destroy_mv1));
 
-  /// Constructs an [`DataProvider`] that uses compiled data.
-  ///
-  /// Requires the `compiled_data` feature.
-  ///
-  /// This provider cannot be modified or combined with other providers, so `enable_fallback`,
-  /// `enabled_fallback_with`, `fork_by_locale`, and `fork_by_key` will return `Err`s.
-  factory DataProvider.compiled() {
-    final result = _icu4x_DataProvider_compiled_mv1();
-    return DataProvider._fromFfi(result, []);
-  }
-
-  /// Constructs an empty [`DataProvider`].
-  ///
-  /// See the [Rust documentation for `EmptyDataProvider`](https://docs.rs/icu_provider_adapters/latest/icu_provider_adapters/empty/struct.EmptyDataProvider.html) for more information.
-  factory DataProvider.empty() {
-    final result = _icu4x_DataProvider_empty_mv1();
-    return DataProvider._fromFfi(result, []);
-  }
-
   /// Creates a provider that tries the current provider and then, if the current provider
   /// doesn't support the data key, another provider `other`.
   ///
@@ -94,16 +75,6 @@ final class DataProvider implements ffi.Finalizable {
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_DataProvider_destroy_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_DataProvider_destroy_mv1(ffi.Pointer<ffi.Void> self);
-
-@meta.RecordUse()
-@ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_DataProvider_compiled_mv1')
-// ignore: non_constant_identifier_names
-external ffi.Pointer<ffi.Opaque> _icu4x_DataProvider_compiled_mv1();
-
-@meta.RecordUse()
-@ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_DataProvider_empty_mv1')
-// ignore: non_constant_identifier_names
-external ffi.Pointer<ffi.Opaque> _icu4x_DataProvider_empty_mv1();
 
 @meta.RecordUse()
 @ffi.Native<_ResultVoidInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_DataProvider_fork_by_key_mv1')

--- a/ffi/capi/bindings/js/DataProvider.d.ts
+++ b/ffi/capi/bindings/js/DataProvider.d.ts
@@ -13,10 +13,6 @@ export class DataProvider {
 
     get ffiValue(): pointer;
 
-    static compiled(): DataProvider;
-
-    static empty(): DataProvider;
-
     forkByKey(other: DataProvider): void;
 
     forkByLocale(other: DataProvider): void;

--- a/ffi/capi/bindings/js/DataProvider.mjs
+++ b/ffi/capi/bindings/js/DataProvider.mjs
@@ -40,26 +40,6 @@ export class DataProvider {
         return this.#ptr;
     }
 
-    static compiled() {
-        const result = wasm.icu4x_DataProvider_compiled_mv1();
-    
-        try {
-            return new DataProvider(diplomatRuntime.internalConstructor, result, []);
-        }
-        
-        finally {}
-    }
-
-    static empty() {
-        const result = wasm.icu4x_DataProvider_empty_mv1();
-    
-        try {
-            return new DataProvider(diplomatRuntime.internalConstructor, result, []);
-        }
-        
-        finally {}
-    }
-
     forkByKey(other) {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
         

--- a/ffi/capi/src/bidi.rs
+++ b/ffi/capi/src/bidi.rs
@@ -10,8 +10,8 @@ pub mod ffi {
     use alloc::vec::Vec;
     use core::fmt::Write;
 
-    use crate::errors::ffi::DataError;
-    use crate::provider::ffi::DataProvider;
+    #[cfg(feature = "buffer_provider")]
+    use crate::{errors::ffi::DataError, provider::ffi::DataProvider};
 
     pub enum BidiDirection {
         Ltr,
@@ -39,6 +39,7 @@ pub mod ffi {
         /// Creates a new [`Bidi`] from locale data, and a particular data source.
         #[diplomat::rust_link(icu::properties::bidi::BidiClassAdapter::new, FnInStruct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_with_provider(provider: &DataProvider) -> Result<Box<Bidi>, DataError> {
             Ok(Box::new(Bidi(call_constructor_unstable!(
                 icu_properties::CodePointMapData::try_new_unstable,

--- a/ffi/capi/src/bidi.rs
+++ b/ffi/capi/src/bidi.rs
@@ -40,8 +40,7 @@ pub mod ffi {
         #[diplomat::rust_link(icu::properties::bidi::BidiClassAdapter::new, FnInStruct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "with_provider")]
         pub fn create_with_provider(provider: &DataProvider) -> Result<Box<Bidi>, DataError> {
-            Ok(Box::new(Bidi(call_constructor_unstable!(
-                icu_properties::CodePointMapData::new [m => Ok(m.static_to_owned())],
+            Ok(Box::new(Bidi(call_constructor_unstable2!(
                 icu_properties::CodePointMapData::try_new_unstable,
                 provider,
             )?)))

--- a/ffi/capi/src/bidi.rs
+++ b/ffi/capi/src/bidi.rs
@@ -40,7 +40,7 @@ pub mod ffi {
         #[diplomat::rust_link(icu::properties::bidi::BidiClassAdapter::new, FnInStruct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "with_provider")]
         pub fn create_with_provider(provider: &DataProvider) -> Result<Box<Bidi>, DataError> {
-            Ok(Box::new(Bidi(call_constructor_unstable2!(
+            Ok(Box::new(Bidi(call_constructor_unstable!(
                 icu_properties::CodePointMapData::try_new_unstable,
                 provider,
             )?)))

--- a/ffi/capi/src/calendar.rs
+++ b/ffi/capi/src/calendar.rs
@@ -135,10 +135,8 @@ pub mod ffi {
         ) -> Result<Box<Calendar>, DataError> {
             let prefs = (&locale.0).into();
 
-            Ok(Box::new(Calendar(Arc::new(call_constructor!(
-                icu_calendar::AnyCalendar::try_new_with_buffer_provider,
-                provider,
-                prefs
+            Ok(Box::new(Calendar(Arc::new(provider.call_constructor(
+                |provider| icu_calendar::AnyCalendar::try_new_with_buffer_provider(provider, prefs),
             )?))))
         }
 
@@ -150,10 +148,13 @@ pub mod ffi {
             provider: &DataProvider,
             kind: AnyCalendarKind,
         ) -> Result<Box<Calendar>, DataError> {
-            Ok(Box::new(Calendar(Arc::new(call_constructor!(
-                icu_calendar::AnyCalendar::try_new_for_kind_with_buffer_provider,
-                provider,
-                kind.into()
+            Ok(Box::new(Calendar(Arc::new(provider.call_constructor(
+                |provider| {
+                    icu_calendar::AnyCalendar::try_new_for_kind_with_buffer_provider(
+                        provider,
+                        kind.into(),
+                    )
+                },
             )?))))
         }
 

--- a/ffi/capi/src/calendar.rs
+++ b/ffi/capi/src/calendar.rs
@@ -132,9 +132,7 @@ pub mod ffi {
         ) -> Result<Box<Calendar>, DataError> {
             let prefs = (&locale.0).into();
 
-            Ok(Box::new(Calendar(Arc::new(call_constructor!(
-                icu_calendar::AnyCalendar::try_new,
-                icu_calendar::AnyCalendar::try_new_with_any_provider,
+            Ok(Box::new(Calendar(Arc::new(call_constructor2!(
                 icu_calendar::AnyCalendar::try_new_with_buffer_provider,
                 provider,
                 prefs
@@ -148,9 +146,7 @@ pub mod ffi {
             provider: &DataProvider,
             kind: AnyCalendarKind,
         ) -> Result<Box<Calendar>, DataError> {
-            Ok(Box::new(Calendar(Arc::new(call_constructor!(
-                icu_calendar::AnyCalendar::new_for_kind [r => Ok(r)],
-                icu_calendar::AnyCalendar::try_new_for_kind_with_any_provider,
+            Ok(Box::new(Calendar(Arc::new(call_constructor2!(
                 icu_calendar::AnyCalendar::try_new_for_kind_with_buffer_provider,
                 provider,
                 kind.into()

--- a/ffi/capi/src/calendar.rs
+++ b/ffi/capi/src/calendar.rs
@@ -132,7 +132,7 @@ pub mod ffi {
         ) -> Result<Box<Calendar>, DataError> {
             let prefs = (&locale.0).into();
 
-            Ok(Box::new(Calendar(Arc::new(call_constructor2!(
+            Ok(Box::new(Calendar(Arc::new(call_constructor!(
                 icu_calendar::AnyCalendar::try_new_with_buffer_provider,
                 provider,
                 prefs
@@ -146,7 +146,7 @@ pub mod ffi {
             provider: &DataProvider,
             kind: AnyCalendarKind,
         ) -> Result<Box<Calendar>, DataError> {
-            Ok(Box::new(Calendar(Arc::new(call_constructor2!(
+            Ok(Box::new(Calendar(Arc::new(call_constructor!(
                 icu_calendar::AnyCalendar::try_new_for_kind_with_buffer_provider,
                 provider,
                 kind.into()

--- a/ffi/capi/src/calendar.rs
+++ b/ffi/capi/src/calendar.rs
@@ -10,8 +10,10 @@ pub mod ffi {
     use alloc::sync::Arc;
     use core::fmt::Write;
 
+    #[cfg(any(feature = "compiled_data", feature = "buffer_provider"))]
     use crate::errors::ffi::DataError;
     use crate::locale_core::ffi::Locale;
+    #[cfg(feature = "buffer_provider")]
     use crate::provider::ffi::DataProvider;
 
     /// The various calendar types currently supported by [`Calendar`]
@@ -126,6 +128,7 @@ pub mod ffi {
         #[diplomat::rust_link(icu::calendar::AnyCalendar::try_new, FnInEnum)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "for_locale_with_provider")]
         #[diplomat::demo(default_constructor)]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_for_locale_with_provider(
             provider: &DataProvider,
             locale: &Locale,
@@ -142,6 +145,7 @@ pub mod ffi {
         /// Creates a new [`Calendar`] from the specified date and time, using a particular data source.
         #[diplomat::rust_link(icu::calendar::AnyCalendar::new_for_kind, FnInEnum)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "for_kind_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_for_kind_with_provider(
             provider: &DataProvider,
             kind: AnyCalendarKind,

--- a/ffi/capi/src/casemap.rs
+++ b/ffi/capi/src/casemap.rs
@@ -10,7 +10,11 @@ use icu_casemap::titlecase::TitlecaseOptions;
 pub mod ffi {
     use alloc::boxed::Box;
 
-    use crate::{errors::ffi::DataError, locale_core::ffi::Locale, provider::ffi::DataProvider};
+    #[cfg(any(feature = "compiled_data", feature = "buffer_provider"))]
+    use crate::errors::ffi::DataError;
+    use crate::locale_core::ffi::Locale;
+    #[cfg(feature = "buffer_provider")]
+    use crate::provider::ffi::DataProvider;
     use diplomat_runtime::DiplomatOption;
 
     use writeable::Writeable;
@@ -65,6 +69,7 @@ pub mod ffi {
         /// Construct a new CaseMapper instance using a particular data source.
         #[diplomat::rust_link(icu::casemap::CaseMapper::new, FnInStruct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_with_provider(provider: &DataProvider) -> Result<Box<CaseMapper>, DataError> {
             Ok(Box::new(CaseMapper(call_constructor!(
                 icu_casemap::CaseMapper::try_new_with_buffer_provider,
@@ -228,6 +233,7 @@ pub mod ffi {
         #[diplomat::rust_link(icu::casemap::CaseMapCloser::new, FnInStruct)]
         #[diplomat::rust_link(icu::casemap::CaseMapCloser::new_with_mapper, FnInStruct, hidden)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CaseMapCloser>, DataError> {
@@ -285,6 +291,7 @@ pub mod ffi {
         #[diplomat::rust_link(icu::casemap::TitlecaseMapper::new, FnInStruct)]
         #[diplomat::rust_link(icu::casemap::TitlecaseMapper::new_with_mapper, FnInStruct, hidden)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<TitlecaseMapper>, DataError> {

--- a/ffi/capi/src/casemap.rs
+++ b/ffi/capi/src/casemap.rs
@@ -72,7 +72,7 @@ pub mod ffi {
         #[cfg(feature = "buffer_provider")]
         pub fn create_with_provider(provider: &DataProvider) -> Result<Box<CaseMapper>, DataError> {
             Ok(Box::new(CaseMapper(provider.call_constructor(
-                |provider| icu_casemap::CaseMapper::try_new_with_buffer_provider(provider),
+                icu_casemap::CaseMapper::try_new_with_buffer_provider,
             )?)))
         }
         /// Returns the full lowercase mapping of the given string
@@ -237,7 +237,7 @@ pub mod ffi {
             provider: &DataProvider,
         ) -> Result<Box<CaseMapCloser>, DataError> {
             Ok(Box::new(CaseMapCloser(provider.call_constructor(
-                |provider| icu_casemap::CaseMapCloser::try_new_with_buffer_provider(provider),
+                icu_casemap::CaseMapCloser::try_new_with_buffer_provider,
             )?)))
         }
         /// Adds all simple case mappings and the full case folding for `c` to `builder`.
@@ -294,7 +294,7 @@ pub mod ffi {
             provider: &DataProvider,
         ) -> Result<Box<TitlecaseMapper>, DataError> {
             Ok(Box::new(TitlecaseMapper(provider.call_constructor(
-                |provider| icu_casemap::TitlecaseMapper::try_new_with_buffer_provider(provider),
+                icu_casemap::TitlecaseMapper::try_new_with_buffer_provider,
             )?)))
         }
         /// Returns the full titlecase mapping of the given string

--- a/ffi/capi/src/casemap.rs
+++ b/ffi/capi/src/casemap.rs
@@ -66,9 +66,7 @@ pub mod ffi {
         #[diplomat::rust_link(icu::casemap::CaseMapper::new, FnInStruct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "with_provider")]
         pub fn create_with_provider(provider: &DataProvider) -> Result<Box<CaseMapper>, DataError> {
-            Ok(Box::new(CaseMapper(call_constructor!(
-                icu_casemap::CaseMapper::new [r => Ok(r)],
-                icu_casemap::CaseMapper::try_new_with_any_provider,
+            Ok(Box::new(CaseMapper(call_constructor2!(
                 icu_casemap::CaseMapper::try_new_with_buffer_provider,
                 provider,
             )?)))
@@ -233,9 +231,7 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CaseMapCloser>, DataError> {
-            Ok(Box::new(CaseMapCloser(call_constructor!(
-                icu_casemap::CaseMapCloser::new [r => Ok(r)],
-                icu_casemap::CaseMapCloser::try_new_with_any_provider,
+            Ok(Box::new(CaseMapCloser(call_constructor2!(
                 icu_casemap::CaseMapCloser::try_new_with_buffer_provider,
                 provider,
             )?)))
@@ -292,9 +288,7 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<TitlecaseMapper>, DataError> {
-            Ok(Box::new(TitlecaseMapper(call_constructor!(
-                icu_casemap::TitlecaseMapper::new [r => Ok(r)],
-                icu_casemap::TitlecaseMapper::try_new_with_any_provider,
+            Ok(Box::new(TitlecaseMapper(call_constructor2!(
                 icu_casemap::TitlecaseMapper::try_new_with_buffer_provider,
                 provider,
             )?)))

--- a/ffi/capi/src/casemap.rs
+++ b/ffi/capi/src/casemap.rs
@@ -66,7 +66,7 @@ pub mod ffi {
         #[diplomat::rust_link(icu::casemap::CaseMapper::new, FnInStruct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "with_provider")]
         pub fn create_with_provider(provider: &DataProvider) -> Result<Box<CaseMapper>, DataError> {
-            Ok(Box::new(CaseMapper(call_constructor2!(
+            Ok(Box::new(CaseMapper(call_constructor!(
                 icu_casemap::CaseMapper::try_new_with_buffer_provider,
                 provider,
             )?)))
@@ -231,7 +231,7 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CaseMapCloser>, DataError> {
-            Ok(Box::new(CaseMapCloser(call_constructor2!(
+            Ok(Box::new(CaseMapCloser(call_constructor!(
                 icu_casemap::CaseMapCloser::try_new_with_buffer_provider,
                 provider,
             )?)))
@@ -288,7 +288,7 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<TitlecaseMapper>, DataError> {
-            Ok(Box::new(TitlecaseMapper(call_constructor2!(
+            Ok(Box::new(TitlecaseMapper(call_constructor!(
                 icu_casemap::TitlecaseMapper::try_new_with_buffer_provider,
                 provider,
             )?)))

--- a/ffi/capi/src/casemap.rs
+++ b/ffi/capi/src/casemap.rs
@@ -71,9 +71,8 @@ pub mod ffi {
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "with_provider")]
         #[cfg(feature = "buffer_provider")]
         pub fn create_with_provider(provider: &DataProvider) -> Result<Box<CaseMapper>, DataError> {
-            Ok(Box::new(CaseMapper(call_constructor!(
-                icu_casemap::CaseMapper::try_new_with_buffer_provider,
-                provider,
+            Ok(Box::new(CaseMapper(provider.call_constructor(
+                |provider| icu_casemap::CaseMapper::try_new_with_buffer_provider(provider),
             )?)))
         }
         /// Returns the full lowercase mapping of the given string
@@ -237,9 +236,8 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CaseMapCloser>, DataError> {
-            Ok(Box::new(CaseMapCloser(call_constructor!(
-                icu_casemap::CaseMapCloser::try_new_with_buffer_provider,
-                provider,
+            Ok(Box::new(CaseMapCloser(provider.call_constructor(
+                |provider| icu_casemap::CaseMapCloser::try_new_with_buffer_provider(provider),
             )?)))
         }
         /// Adds all simple case mappings and the full case folding for `c` to `builder`.
@@ -295,9 +293,8 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<TitlecaseMapper>, DataError> {
-            Ok(Box::new(TitlecaseMapper(call_constructor!(
-                icu_casemap::TitlecaseMapper::try_new_with_buffer_provider,
-                provider,
+            Ok(Box::new(TitlecaseMapper(provider.call_constructor(
+                |provider| icu_casemap::TitlecaseMapper::try_new_with_buffer_provider(provider),
             )?)))
         }
         /// Returns the full titlecase mapping of the given string

--- a/ffi/capi/src/collator.rs
+++ b/ffi/capi/src/collator.rs
@@ -8,7 +8,10 @@
 pub mod ffi {
     use alloc::boxed::Box;
 
-    use crate::{errors::ffi::DataError, locale_core::ffi::Locale, provider::ffi::DataProvider};
+    #[cfg(feature = "buffer_provider")]
+    use crate::provider::ffi::DataProvider;
+    #[cfg(any(feature = "compiled_data", feature = "buffer_provider"))]
+    use crate::{errors::ffi::DataError, locale_core::ffi::Locale};
     use diplomat_runtime::DiplomatOption;
 
     #[diplomat::opaque]
@@ -131,6 +134,7 @@ pub mod ffi {
         #[diplomat::rust_link(icu::collator::CollatorPreferences, Struct, hidden)]
         #[diplomat::attr(supports = fallible_constructors, constructor)]
         #[diplomat::attr(supports = non_exhaustive_structs, rename = "create_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_v1_with_provider(
             provider: &DataProvider,
             locale: &Locale,

--- a/ffi/capi/src/collator.rs
+++ b/ffi/capi/src/collator.rs
@@ -140,11 +140,15 @@ pub mod ffi {
             locale: &Locale,
             options: CollatorOptionsV1,
         ) -> Result<Box<Collator>, DataError> {
-            Ok(Box::new(Collator(call_constructor!(
-                icu_collator::Collator::try_new_with_buffer_provider,
-                provider,
-                icu_collator::CollatorPreferences::from(&locale.0),
-                icu_collator::CollatorOptions::from(options),
+            let options = options.into();
+            Ok(Box::new(Collator(provider.call_constructor(
+                |provider| {
+                    icu_collator::Collator::try_new_with_buffer_provider(
+                        provider,
+                        (&locale.0).into(),
+                        options,
+                    )
+                },
             )?)))
         }
         /// Compare two strings.

--- a/ffi/capi/src/collator.rs
+++ b/ffi/capi/src/collator.rs
@@ -136,7 +136,7 @@ pub mod ffi {
             locale: &Locale,
             options: CollatorOptionsV1,
         ) -> Result<Box<Collator>, DataError> {
-            Ok(Box::new(Collator(call_constructor2!(
+            Ok(Box::new(Collator(call_constructor!(
                 icu_collator::Collator::try_new_with_buffer_provider,
                 provider,
                 icu_collator::CollatorPreferences::from(&locale.0),

--- a/ffi/capi/src/collator.rs
+++ b/ffi/capi/src/collator.rs
@@ -136,9 +136,7 @@ pub mod ffi {
             locale: &Locale,
             options: CollatorOptionsV1,
         ) -> Result<Box<Collator>, DataError> {
-            Ok(Box::new(Collator(call_constructor!(
-                icu_collator::Collator::try_new [r => Ok(r?.static_to_owned())],
-                icu_collator::Collator::try_new_with_any_provider,
+            Ok(Box::new(Collator(call_constructor2!(
                 icu_collator::Collator::try_new_with_buffer_provider,
                 provider,
                 icu_collator::CollatorPreferences::from(&locale.0),

--- a/ffi/capi/src/datetime_formatter.rs
+++ b/ffi/capi/src/datetime_formatter.rs
@@ -67,12 +67,13 @@ pub mod ffi {
             let prefs = (&locale.0).into();
             let options = T::with_length(Length::from(length)).hm();
 
-            Ok(Box::new(TimeFormatter(call_constructor!(
-                icu_datetime::FixedCalendarDateTimeFormatter::try_new_with_buffer_provider,
-                provider,
-                prefs,
-                options
-            )?)))
+            Ok(Box::new(TimeFormatter(
+                provider.call_constructor_custom_err(move |provider| {
+                    icu_datetime::FixedCalendarDateTimeFormatter::try_new_with_buffer_provider(
+                        provider, prefs, options,
+                    )
+                })?,
+            )))
         }
 
         /// Formats a [`Time`] to a string.
@@ -135,12 +136,13 @@ pub mod ffi {
             let prefs = (&locale.0).into();
             let options = YMD::with_length(Length::from(length));
 
-            Ok(Box::new(GregorianDateFormatter(call_constructor!(
-                icu_datetime::FixedCalendarDateTimeFormatter::try_new_with_buffer_provider,
-                provider,
-                prefs,
-                options
-            )?)))
+            Ok(Box::new(GregorianDateFormatter(
+                provider.call_constructor_custom_err(move |provider| {
+                    icu_datetime::FixedCalendarDateTimeFormatter::try_new_with_buffer_provider(
+                        provider, prefs, options,
+                    )
+                })?,
+            )))
         }
 
         /// Formats a [`IsoDate`] to a string.
@@ -199,12 +201,13 @@ pub mod ffi {
             let prefs = (&locale.0).into();
             let options = YMDT::with_length(Length::from(length)).hm();
 
-            Ok(Box::new(GregorianDateTimeFormatter(call_constructor!(
-                icu_datetime::FixedCalendarDateTimeFormatter::try_new_with_buffer_provider,
-                provider,
-                prefs,
-                options
-            )?)))
+            Ok(Box::new(GregorianDateTimeFormatter(
+                provider.call_constructor_custom_err(move |provider| {
+                    icu_datetime::FixedCalendarDateTimeFormatter::try_new_with_buffer_provider(
+                        provider, prefs, options,
+                    )
+                })?,
+            )))
         }
 
         /// Formats a [`IsoDateTime`] to a string.
@@ -252,12 +255,13 @@ pub mod ffi {
             let prefs = (&locale.0).into();
             let options = YMD::with_length(Length::from(length));
 
-            Ok(Box::new(DateFormatter(call_constructor!(
-                icu_datetime::DateTimeFormatter::try_new_with_buffer_provider,
-                provider,
-                prefs,
-                options
-            )?)))
+            Ok(Box::new(DateFormatter(
+                provider.call_constructor_custom_err(move |provider| {
+                    icu_datetime::DateTimeFormatter::try_new_with_buffer_provider(
+                        provider, prefs, options,
+                    )
+                })?,
+            )))
         }
 
         /// Formats a [`Date`] to a string.
@@ -341,12 +345,13 @@ pub mod ffi {
             let prefs = (&locale.0).into();
             let options = YMDT::with_length(Length::from(length)).hm();
 
-            Ok(Box::new(DateTimeFormatter(call_constructor!(
-                icu_datetime::DateTimeFormatter::try_new_with_buffer_provider,
-                provider,
-                prefs,
-                options
-            )?)))
+            Ok(Box::new(DateTimeFormatter(
+                provider.call_constructor_custom_err(move |provider| {
+                    icu_datetime::DateTimeFormatter::try_new_with_buffer_provider(
+                        provider, prefs, options,
+                    )
+                })?,
+            )))
         }
         /// Formats a [`DateTime`] to a string.
         pub fn format_datetime(

--- a/ffi/capi/src/datetime_formatter.rs
+++ b/ffi/capi/src/datetime_formatter.rs
@@ -63,9 +63,7 @@ pub mod ffi {
             let prefs = (&locale.0).into();
             let options = T::with_length(Length::from(length)).hm();
 
-            Ok(Box::new(TimeFormatter(call_constructor!(
-                icu_datetime::FixedCalendarDateTimeFormatter::try_new,
-                icu_datetime::FixedCalendarDateTimeFormatter::try_new_with_any_provider,
+            Ok(Box::new(TimeFormatter(call_constructor2!(
                 icu_datetime::FixedCalendarDateTimeFormatter::try_new_with_buffer_provider,
                 provider,
                 prefs,
@@ -132,9 +130,7 @@ pub mod ffi {
             let prefs = (&locale.0).into();
             let options = YMD::with_length(Length::from(length));
 
-            Ok(Box::new(GregorianDateFormatter(call_constructor!(
-                icu_datetime::FixedCalendarDateTimeFormatter::try_new,
-                icu_datetime::FixedCalendarDateTimeFormatter::try_new_with_any_provider,
+            Ok(Box::new(GregorianDateFormatter(call_constructor2!(
                 icu_datetime::FixedCalendarDateTimeFormatter::try_new_with_buffer_provider,
                 provider,
                 prefs,
@@ -197,9 +193,7 @@ pub mod ffi {
             let prefs = (&locale.0).into();
             let options = YMDT::with_length(Length::from(length)).hm();
 
-            Ok(Box::new(GregorianDateTimeFormatter(call_constructor!(
-                icu_datetime::FixedCalendarDateTimeFormatter::try_new,
-                icu_datetime::FixedCalendarDateTimeFormatter::try_new_with_any_provider,
+            Ok(Box::new(GregorianDateTimeFormatter(call_constructor2!(
                 icu_datetime::FixedCalendarDateTimeFormatter::try_new_with_buffer_provider,
                 provider,
                 prefs,
@@ -251,9 +245,7 @@ pub mod ffi {
             let prefs = (&locale.0).into();
             let options = YMD::with_length(Length::from(length));
 
-            Ok(Box::new(DateFormatter(call_constructor!(
-                icu_datetime::DateTimeFormatter::try_new,
-                icu_datetime::DateTimeFormatter::try_new_with_any_provider,
+            Ok(Box::new(DateFormatter(call_constructor2!(
                 icu_datetime::DateTimeFormatter::try_new_with_buffer_provider,
                 provider,
                 prefs,
@@ -341,9 +333,7 @@ pub mod ffi {
             let prefs = (&locale.0).into();
             let options = YMDT::with_length(Length::from(length)).hm();
 
-            Ok(Box::new(DateTimeFormatter(call_constructor!(
-                icu_datetime::DateTimeFormatter::try_new,
-                icu_datetime::DateTimeFormatter::try_new_with_any_provider,
+            Ok(Box::new(DateTimeFormatter(call_constructor2!(
                 icu_datetime::DateTimeFormatter::try_new_with_buffer_provider,
                 provider,
                 prefs,

--- a/ffi/capi/src/datetime_formatter.rs
+++ b/ffi/capi/src/datetime_formatter.rs
@@ -7,17 +7,20 @@
 #[diplomat::attr(auto, namespace = "icu4x")]
 pub mod ffi {
     use alloc::boxed::Box;
-    use icu_datetime::{
-        fieldsets::{T, YMD, YMDT},
-        options::Length,
-    };
+    use icu_datetime::fieldsets::{T, YMD, YMDT};
+    #[cfg(any(feature = "compiled_data", feature = "buffer_provider"))]
+    use icu_datetime::options::Length;
 
+    #[cfg(any(feature = "compiled_data", feature = "buffer_provider"))]
+    use crate::errors::ffi::DateTimeFormatterLoadError;
+    #[cfg(any(feature = "compiled_data", feature = "buffer_provider"))]
+    use crate::locale_core::ffi::Locale;
+    #[cfg(feature = "buffer_provider")]
+    use crate::provider::ffi::DataProvider;
     use crate::{
         date::ffi::{Date, IsoDate},
         datetime::ffi::{DateTime, IsoDateTime},
-        errors::ffi::{DateTimeFormatError, DateTimeFormatterLoadError},
-        locale_core::ffi::Locale,
-        provider::ffi::DataProvider,
+        errors::ffi::DateTimeFormatError,
         time::ffi::Time,
     };
 
@@ -55,6 +58,7 @@ pub mod ffi {
 
         /// Creates a new [`TimeFormatter`] using a particular data source.
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "with_length_and_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_with_length_and_provider(
             provider: &DataProvider,
             locale: &Locale,
@@ -122,6 +126,7 @@ pub mod ffi {
 
         /// Creates a new [`GregorianDateFormatter`] using a particular data source.
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "with_length_and_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_with_length_and_provider(
             provider: &DataProvider,
             locale: &Locale,
@@ -185,6 +190,7 @@ pub mod ffi {
 
         /// Creates a new [`GregorianDateTimeFormatter`] using a particular data source.
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "with_length_and_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_with_length_and_provider(
             provider: &DataProvider,
             locale: &Locale,
@@ -237,6 +243,7 @@ pub mod ffi {
 
         /// Creates a new [`DateFormatter`] using a particular data source.
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "with_length_and_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_with_length_and_provider(
             provider: &DataProvider,
             locale: &Locale,
@@ -325,6 +332,7 @@ pub mod ffi {
 
         /// Creates a new [`DateTimeFormatter`] using a particular data source.
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "with_length_and_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_with_length_and_provider(
             provider: &DataProvider,
             locale: &Locale,

--- a/ffi/capi/src/datetime_formatter.rs
+++ b/ffi/capi/src/datetime_formatter.rs
@@ -63,7 +63,7 @@ pub mod ffi {
             let prefs = (&locale.0).into();
             let options = T::with_length(Length::from(length)).hm();
 
-            Ok(Box::new(TimeFormatter(call_constructor2!(
+            Ok(Box::new(TimeFormatter(call_constructor!(
                 icu_datetime::FixedCalendarDateTimeFormatter::try_new_with_buffer_provider,
                 provider,
                 prefs,
@@ -130,7 +130,7 @@ pub mod ffi {
             let prefs = (&locale.0).into();
             let options = YMD::with_length(Length::from(length));
 
-            Ok(Box::new(GregorianDateFormatter(call_constructor2!(
+            Ok(Box::new(GregorianDateFormatter(call_constructor!(
                 icu_datetime::FixedCalendarDateTimeFormatter::try_new_with_buffer_provider,
                 provider,
                 prefs,
@@ -193,7 +193,7 @@ pub mod ffi {
             let prefs = (&locale.0).into();
             let options = YMDT::with_length(Length::from(length)).hm();
 
-            Ok(Box::new(GregorianDateTimeFormatter(call_constructor2!(
+            Ok(Box::new(GregorianDateTimeFormatter(call_constructor!(
                 icu_datetime::FixedCalendarDateTimeFormatter::try_new_with_buffer_provider,
                 provider,
                 prefs,
@@ -245,7 +245,7 @@ pub mod ffi {
             let prefs = (&locale.0).into();
             let options = YMD::with_length(Length::from(length));
 
-            Ok(Box::new(DateFormatter(call_constructor2!(
+            Ok(Box::new(DateFormatter(call_constructor!(
                 icu_datetime::DateTimeFormatter::try_new_with_buffer_provider,
                 provider,
                 prefs,
@@ -333,7 +333,7 @@ pub mod ffi {
             let prefs = (&locale.0).into();
             let options = YMDT::with_length(Length::from(length)).hm();
 
-            Ok(Box::new(DateTimeFormatter(call_constructor2!(
+            Ok(Box::new(DateTimeFormatter(call_constructor!(
                 icu_datetime::DateTimeFormatter::try_new_with_buffer_provider,
                 provider,
                 prefs,

--- a/ffi/capi/src/decimal.rs
+++ b/ffi/capi/src/decimal.rs
@@ -67,7 +67,7 @@ pub mod ffi {
             options.grouping_strategy = grouping_strategy
                 .map(Into::into)
                 .unwrap_or(options.grouping_strategy);
-            Ok(Box::new(FixedDecimalFormatter(call_constructor2!(
+            Ok(Box::new(FixedDecimalFormatter(call_constructor!(
                 icu_decimal::FixedDecimalFormatter::try_new_with_buffer_provider,
                 provider,
                 prefs,

--- a/ffi/capi/src/decimal.rs
+++ b/ffi/capi/src/decimal.rs
@@ -8,11 +8,14 @@
 pub mod ffi {
     use alloc::boxed::Box;
 
-    use crate::{
-        errors::ffi::DataError, fixed_decimal::ffi::SignedFixedDecimal, locale_core::ffi::Locale,
-        provider::ffi::DataProvider,
-    };
-    use icu_decimal::{options::FixedDecimalFormatterOptions, FixedDecimalFormatterPreferences};
+    #[cfg(any(feature = "compiled_data", feature = "buffer_provider"))]
+    use crate::locale_core::ffi::Locale;
+    #[cfg(feature = "buffer_provider")]
+    use crate::provider::ffi::DataProvider;
+    use crate::{errors::ffi::DataError, fixed_decimal::ffi::SignedFixedDecimal};
+    use icu_decimal::options::FixedDecimalFormatterOptions;
+    #[cfg(any(feature = "compiled_data", feature = "buffer_provider"))]
+    use icu_decimal::FixedDecimalFormatterPreferences;
 
     use writeable::Writeable;
 
@@ -56,6 +59,7 @@ pub mod ffi {
         #[diplomat::rust_link(icu::decimal::FixedDecimalFormatter::try_new, FnInStruct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "with_grouping_strategy_and_provider")]
         #[diplomat::demo(default_constructor)]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_with_grouping_strategy_and_provider(
             provider: &DataProvider,
             locale: &Locale,

--- a/ffi/capi/src/decimal.rs
+++ b/ffi/capi/src/decimal.rs
@@ -67,9 +67,7 @@ pub mod ffi {
             options.grouping_strategy = grouping_strategy
                 .map(Into::into)
                 .unwrap_or(options.grouping_strategy);
-            Ok(Box::new(FixedDecimalFormatter(call_constructor!(
-                icu_decimal::FixedDecimalFormatter::try_new,
-                icu_decimal::FixedDecimalFormatter::try_new_with_any_provider,
+            Ok(Box::new(FixedDecimalFormatter(call_constructor2!(
                 icu_decimal::FixedDecimalFormatter::try_new_with_buffer_provider,
                 provider,
                 prefs,

--- a/ffi/capi/src/decimal.rs
+++ b/ffi/capi/src/decimal.rs
@@ -71,12 +71,13 @@ pub mod ffi {
             options.grouping_strategy = grouping_strategy
                 .map(Into::into)
                 .unwrap_or(options.grouping_strategy);
-            Ok(Box::new(FixedDecimalFormatter(call_constructor!(
-                icu_decimal::FixedDecimalFormatter::try_new_with_buffer_provider,
-                provider,
-                prefs,
-                options,
-            )?)))
+            Ok(Box::new(FixedDecimalFormatter(
+                provider.call_constructor_custom_err(move |provider| {
+                    icu_decimal::FixedDecimalFormatter::try_new_with_buffer_provider(
+                        provider, prefs, options,
+                    )
+                })?,
+            )))
         }
 
         /// Creates a new [`FixedDecimalFormatter`] from preconstructed locale data.

--- a/ffi/capi/src/displaynames.rs
+++ b/ffi/capi/src/displaynames.rs
@@ -95,9 +95,7 @@ pub mod ffi {
             let options = icu_experimental::displaynames::DisplayNamesOptions::from(options);
 
             Ok(Box::new(LocaleDisplayNamesFormatter(
-                call_constructor!(
-                    icu_experimental::displaynames::LocaleDisplayNamesFormatter::try_new,
-                    icu_experimental::displaynames::LocaleDisplayNamesFormatter::try_new_with_any_provider,
+                call_constructor2!(
                     icu_experimental::displaynames::LocaleDisplayNamesFormatter::try_new_with_buffer_provider,
                     provider,
                     prefs,
@@ -145,9 +143,7 @@ pub mod ffi {
         ) -> Result<Box<RegionDisplayNames>, DataError> {
             let prefs = (&locale.0).into();
             let options = icu_experimental::displaynames::DisplayNamesOptions::from(options);
-            Ok(Box::new(RegionDisplayNames(call_constructor!(
-                icu_experimental::displaynames::RegionDisplayNames::try_new,
-                icu_experimental::displaynames::RegionDisplayNames::try_new_with_any_provider,
+            Ok(Box::new(RegionDisplayNames(call_constructor2!(
                 icu_experimental::displaynames::RegionDisplayNames::try_new_with_buffer_provider,
                 provider,
                 prefs,

--- a/ffi/capi/src/displaynames.rs
+++ b/ffi/capi/src/displaynames.rs
@@ -99,12 +99,9 @@ pub mod ffi {
             let options = icu_experimental::displaynames::DisplayNamesOptions::from(options);
 
             Ok(Box::new(LocaleDisplayNamesFormatter(
-                call_constructor!(
-                    icu_experimental::displaynames::LocaleDisplayNamesFormatter::try_new_with_buffer_provider,
-                    provider,
-                    prefs,
+                provider.call_constructor_custom_err(move |provider| icu_experimental::displaynames::LocaleDisplayNamesFormatter::try_new_with_buffer_provider(provider, prefs,
                     options,
-                )?,
+                ))?,
             )))
         }
 
@@ -148,12 +145,9 @@ pub mod ffi {
         ) -> Result<Box<RegionDisplayNames>, DataError> {
             let prefs = (&locale.0).into();
             let options = icu_experimental::displaynames::DisplayNamesOptions::from(options);
-            Ok(Box::new(RegionDisplayNames(call_constructor!(
-                icu_experimental::displaynames::RegionDisplayNames::try_new_with_buffer_provider,
-                provider,
-                prefs,
+            Ok(Box::new(RegionDisplayNames(provider.call_constructor_custom_err(move |provider| icu_experimental::displaynames::RegionDisplayNames::try_new_with_buffer_provider(provider, prefs,
                 options
-            )?)))
+            ))?)))
         }
 
         /// Returns the locale specific display name of a region.

--- a/ffi/capi/src/displaynames.rs
+++ b/ffi/capi/src/displaynames.rs
@@ -95,7 +95,7 @@ pub mod ffi {
             let options = icu_experimental::displaynames::DisplayNamesOptions::from(options);
 
             Ok(Box::new(LocaleDisplayNamesFormatter(
-                call_constructor2!(
+                call_constructor!(
                     icu_experimental::displaynames::LocaleDisplayNamesFormatter::try_new_with_buffer_provider,
                     provider,
                     prefs,
@@ -143,7 +143,7 @@ pub mod ffi {
         ) -> Result<Box<RegionDisplayNames>, DataError> {
             let prefs = (&locale.0).into();
             let options = icu_experimental::displaynames::DisplayNamesOptions::from(options);
-            Ok(Box::new(RegionDisplayNames(call_constructor2!(
+            Ok(Box::new(RegionDisplayNames(call_constructor!(
                 icu_experimental::displaynames::RegionDisplayNames::try_new_with_buffer_provider,
                 provider,
                 prefs,

--- a/ffi/capi/src/displaynames.rs
+++ b/ffi/capi/src/displaynames.rs
@@ -8,8 +8,11 @@
 pub mod ffi {
     use alloc::boxed::Box;
 
-    use crate::errors::ffi::{DataError, LocaleParseError};
+    #[cfg(any(feature = "compiled_data", feature = "buffer_provider"))]
+    use crate::errors::ffi::DataError;
+    use crate::errors::ffi::LocaleParseError;
     use crate::locale_core::ffi::Locale;
+    #[cfg(feature = "buffer_provider")]
     use crate::provider::ffi::DataProvider;
     use diplomat_runtime::DiplomatOption;
 
@@ -86,6 +89,7 @@ pub mod ffi {
         #[diplomat::attr(supports = non_exhaustive_structs, rename = "create_with_provider")]
         #[diplomat::attr(all(supports = fallible_constructors, supports = non_exhaustive_structs), named_constructor = "with_provider")]
         #[diplomat::attr(all(supports = fallible_constructors, not(supports = non_exhaustive_structs)), named_constructor = "v1_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_v1_with_provider(
             provider: &DataProvider,
             locale: &Locale,
@@ -136,6 +140,7 @@ pub mod ffi {
         #[diplomat::attr(supports = non_exhaustive_structs, rename = "create_with_provider")]
         #[diplomat::attr(all(supports = fallible_constructors, supports = non_exhaustive_structs), named_constructor = "with_provider")]
         #[diplomat::attr(all(supports = fallible_constructors, not(supports = non_exhaustive_structs)), named_constructor = "v1_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_v1_with_provider(
             provider: &DataProvider,
             locale: &Locale,

--- a/ffi/capi/src/exemplar_chars.rs
+++ b/ffi/capi/src/exemplar_chars.rs
@@ -72,7 +72,7 @@ pub mod ffi {
             locale: &Locale,
         ) -> Result<Box<ExemplarCharacters>, DataError> {
             let locale = locale.to_datalocale();
-            Ok(Box::new(ExemplarCharacters(call_constructor_unstable2!(
+            Ok(Box::new(ExemplarCharacters(call_constructor_unstable!(
                 icu_locale::exemplar_chars::ExemplarCharacters::try_new_main_unstable,
                 provider,
                 &locale
@@ -104,7 +104,7 @@ pub mod ffi {
             locale: &Locale,
         ) -> Result<Box<ExemplarCharacters>, DataError> {
             let locale = locale.to_datalocale();
-            Ok(Box::new(ExemplarCharacters(call_constructor_unstable2!(
+            Ok(Box::new(ExemplarCharacters(call_constructor_unstable!(
                 icu_locale::exemplar_chars::ExemplarCharacters::try_new_auxiliary_unstable,
                 provider,
                 &locale
@@ -136,7 +136,7 @@ pub mod ffi {
             locale: &Locale,
         ) -> Result<Box<ExemplarCharacters>, DataError> {
             let locale = locale.to_datalocale();
-            Ok(Box::new(ExemplarCharacters(call_constructor_unstable2!(
+            Ok(Box::new(ExemplarCharacters(call_constructor_unstable!(
                 icu_locale::exemplar_chars::ExemplarCharacters::try_new_punctuation_unstable,
                 provider,
                 &locale
@@ -169,7 +169,7 @@ pub mod ffi {
             locale: &Locale,
         ) -> Result<Box<ExemplarCharacters>, DataError> {
             let locale = locale.to_datalocale();
-            Ok(Box::new(ExemplarCharacters(call_constructor_unstable2!(
+            Ok(Box::new(ExemplarCharacters(call_constructor_unstable!(
                 icu_locale::exemplar_chars::ExemplarCharacters::try_new_numbers_unstable,
                 provider,
                 &locale
@@ -202,7 +202,7 @@ pub mod ffi {
             locale: &Locale,
         ) -> Result<Box<ExemplarCharacters>, DataError> {
             let locale = locale.to_datalocale();
-            Ok(Box::new(ExemplarCharacters(call_constructor_unstable2!(
+            Ok(Box::new(ExemplarCharacters(call_constructor_unstable!(
                 icu_locale::exemplar_chars::ExemplarCharacters::try_new_index_unstable,
                 provider,
                 &locale

--- a/ffi/capi/src/exemplar_chars.rs
+++ b/ffi/capi/src/exemplar_chars.rs
@@ -8,9 +8,10 @@
 pub mod ffi {
     use alloc::boxed::Box;
 
-    use crate::errors::ffi::DataError;
-    use crate::locale_core::ffi::Locale;
+    #[cfg(feature = "buffer_provider")]
     use crate::provider::ffi::DataProvider;
+    #[cfg(any(feature = "compiled_data", feature = "buffer_provider"))]
+    use crate::{errors::ffi::DataError, locale_core::ffi::Locale};
 
     #[diplomat::opaque]
     /// A set of "exemplar characters" for a given locale.
@@ -67,6 +68,7 @@ pub mod ffi {
             FnInStruct
         )]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "main_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_main_with_provider(
             provider: &DataProvider,
             locale: &Locale,
@@ -99,6 +101,7 @@ pub mod ffi {
             FnInStruct
         )]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "auxiliary_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_auxiliary_with_provider(
             provider: &DataProvider,
             locale: &Locale,
@@ -131,6 +134,7 @@ pub mod ffi {
             FnInStruct
         )]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "punctuation_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_punctuation_with_provider(
             provider: &DataProvider,
             locale: &Locale,
@@ -164,6 +168,7 @@ pub mod ffi {
             FnInStruct
         )]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "numbers_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_numbers_with_provider(
             provider: &DataProvider,
             locale: &Locale,
@@ -197,6 +202,7 @@ pub mod ffi {
             FnInStruct
         )]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "index_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_index_with_provider(
             provider: &DataProvider,
             locale: &Locale,

--- a/ffi/capi/src/exemplar_chars.rs
+++ b/ffi/capi/src/exemplar_chars.rs
@@ -72,8 +72,7 @@ pub mod ffi {
             locale: &Locale,
         ) -> Result<Box<ExemplarCharacters>, DataError> {
             let locale = locale.to_datalocale();
-            Ok(Box::new(ExemplarCharacters(call_constructor_unstable!(
-                icu_locale::exemplar_chars::ExemplarCharacters::try_new_main [r => r.map(|r| r.static_to_owned())],
+            Ok(Box::new(ExemplarCharacters(call_constructor_unstable2!(
                 icu_locale::exemplar_chars::ExemplarCharacters::try_new_main_unstable,
                 provider,
                 &locale
@@ -105,8 +104,7 @@ pub mod ffi {
             locale: &Locale,
         ) -> Result<Box<ExemplarCharacters>, DataError> {
             let locale = locale.to_datalocale();
-            Ok(Box::new(ExemplarCharacters(call_constructor_unstable!(
-                icu_locale::exemplar_chars::ExemplarCharacters::try_new_auxiliary [r => r.map(|r| r.static_to_owned())],
+            Ok(Box::new(ExemplarCharacters(call_constructor_unstable2!(
                 icu_locale::exemplar_chars::ExemplarCharacters::try_new_auxiliary_unstable,
                 provider,
                 &locale
@@ -138,8 +136,7 @@ pub mod ffi {
             locale: &Locale,
         ) -> Result<Box<ExemplarCharacters>, DataError> {
             let locale = locale.to_datalocale();
-            Ok(Box::new(ExemplarCharacters(call_constructor_unstable!(
-                icu_locale::exemplar_chars::ExemplarCharacters::try_new_punctuation [r => r.map(|r| r.static_to_owned())],
+            Ok(Box::new(ExemplarCharacters(call_constructor_unstable2!(
                 icu_locale::exemplar_chars::ExemplarCharacters::try_new_punctuation_unstable,
                 provider,
                 &locale
@@ -172,8 +169,7 @@ pub mod ffi {
             locale: &Locale,
         ) -> Result<Box<ExemplarCharacters>, DataError> {
             let locale = locale.to_datalocale();
-            Ok(Box::new(ExemplarCharacters(call_constructor_unstable!(
-                icu_locale::exemplar_chars::ExemplarCharacters::try_new_numbers [r => r.map(|r| r.static_to_owned())],
+            Ok(Box::new(ExemplarCharacters(call_constructor_unstable2!(
                 icu_locale::exemplar_chars::ExemplarCharacters::try_new_numbers_unstable,
                 provider,
                 &locale
@@ -206,8 +202,7 @@ pub mod ffi {
             locale: &Locale,
         ) -> Result<Box<ExemplarCharacters>, DataError> {
             let locale = locale.to_datalocale();
-            Ok(Box::new(ExemplarCharacters(call_constructor_unstable!(
-                icu_locale::exemplar_chars::ExemplarCharacters::try_new_index [r => r.map(|r| r.static_to_owned())],
+            Ok(Box::new(ExemplarCharacters(call_constructor_unstable2!(
                 icu_locale::exemplar_chars::ExemplarCharacters::try_new_index_unstable,
                 provider,
                 &locale

--- a/ffi/capi/src/fallbacker.rs
+++ b/ffi/capi/src/fallbacker.rs
@@ -81,7 +81,7 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<LocaleFallbacker>, DataError> {
-            Ok(Box::new(LocaleFallbacker(call_constructor2!(
+            Ok(Box::new(LocaleFallbacker(call_constructor!(
                 icu_locale::LocaleFallbacker::try_new_with_buffer_provider,
                 provider,
             )?)))

--- a/ffi/capi/src/fallbacker.rs
+++ b/ffi/capi/src/fallbacker.rs
@@ -81,9 +81,7 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<LocaleFallbacker>, DataError> {
-            Ok(Box::new(LocaleFallbacker(call_constructor!(
-                icu_locale::LocaleFallbacker::new [r => Ok(r.static_to_owned())],
-                icu_locale::LocaleFallbacker::try_new_with_any_provider,
+            Ok(Box::new(LocaleFallbacker(call_constructor2!(
                 icu_locale::LocaleFallbacker::try_new_with_buffer_provider,
                 provider,
             )?)))

--- a/ffi/capi/src/fallbacker.rs
+++ b/ffi/capi/src/fallbacker.rs
@@ -8,7 +8,9 @@
 pub mod ffi {
     use alloc::boxed::Box;
 
-    use crate::{errors::ffi::DataError, locale_core::ffi::Locale, provider::ffi::DataProvider};
+    use crate::locale_core::ffi::Locale;
+    #[cfg(feature = "buffer_provider")]
+    use crate::{errors::ffi::DataError, provider::ffi::DataProvider};
 
     /// An object that runs the ICU4X locale fallback algorithm.
     #[diplomat::opaque]
@@ -78,6 +80,7 @@ pub mod ffi {
             hidden
         )]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<LocaleFallbacker>, DataError> {

--- a/ffi/capi/src/fallbacker.rs
+++ b/ffi/capi/src/fallbacker.rs
@@ -84,9 +84,8 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<LocaleFallbacker>, DataError> {
-            Ok(Box::new(LocaleFallbacker(call_constructor!(
-                icu_locale::LocaleFallbacker::try_new_with_buffer_provider,
-                provider,
+            Ok(Box::new(LocaleFallbacker(provider.call_constructor(
+                |provider| icu_locale::LocaleFallbacker::try_new_with_buffer_provider(provider),
             )?)))
         }
 

--- a/ffi/capi/src/fallbacker.rs
+++ b/ffi/capi/src/fallbacker.rs
@@ -85,7 +85,7 @@ pub mod ffi {
             provider: &DataProvider,
         ) -> Result<Box<LocaleFallbacker>, DataError> {
             Ok(Box::new(LocaleFallbacker(provider.call_constructor(
-                |provider| icu_locale::LocaleFallbacker::try_new_with_buffer_provider(provider),
+                icu_locale::LocaleFallbacker::try_new_with_buffer_provider,
             )?)))
         }
 

--- a/ffi/capi/src/list.rs
+++ b/ffi/capi/src/list.rs
@@ -52,9 +52,7 @@ pub mod ffi {
         ) -> Result<Box<ListFormatter>, DataError> {
             let prefs = ListFormatterPreferences::from(&locale.0);
             let options = ListFormatterOptions::default().with_length(length.into());
-            Ok(Box::new(ListFormatter(call_constructor!(
-                icu_list::ListFormatter::try_new_and,
-                icu_list::ListFormatter::try_new_and_with_any_provider,
+            Ok(Box::new(ListFormatter(call_constructor2!(
                 icu_list::ListFormatter::try_new_and_with_buffer_provider,
                 provider,
                 prefs,
@@ -87,9 +85,7 @@ pub mod ffi {
         ) -> Result<Box<ListFormatter>, DataError> {
             let prefs = ListFormatterPreferences::from(&locale.0);
             let options = ListFormatterOptions::default().with_length(length.into());
-            Ok(Box::new(ListFormatter(call_constructor!(
-                icu_list::ListFormatter::try_new_or,
-                icu_list::ListFormatter::try_new_or_with_any_provider,
+            Ok(Box::new(ListFormatter(call_constructor2!(
                 icu_list::ListFormatter::try_new_or_with_buffer_provider,
                 provider,
                 prefs,
@@ -122,9 +118,7 @@ pub mod ffi {
         ) -> Result<Box<ListFormatter>, DataError> {
             let prefs = ListFormatterPreferences::from(&locale.0);
             let options = ListFormatterOptions::default().with_length(length.into());
-            Ok(Box::new(ListFormatter(call_constructor!(
-                icu_list::ListFormatter::try_new_unit,
-                icu_list::ListFormatter::try_new_unit_with_any_provider,
+            Ok(Box::new(ListFormatter(call_constructor2!(
                 icu_list::ListFormatter::try_new_unit_with_buffer_provider,
                 provider,
                 prefs,

--- a/ffi/capi/src/list.rs
+++ b/ffi/capi/src/list.rs
@@ -8,9 +8,13 @@
 pub mod ffi {
     use alloc::boxed::Box;
     use diplomat_runtime::{DiplomatStr16Slice, DiplomatStrSlice};
+    #[cfg(any(feature = "compiled_data", feature = "buffer_provider"))]
     use icu_list::{ListFormatterOptions, ListFormatterPreferences};
 
-    use crate::{errors::ffi::DataError, locale_core::ffi::Locale, provider::ffi::DataProvider};
+    #[cfg(feature = "buffer_provider")]
+    use crate::provider::ffi::DataProvider;
+    #[cfg(any(feature = "compiled_data", feature = "buffer_provider"))]
+    use crate::{errors::ffi::DataError, locale_core::ffi::Locale};
 
     use writeable::Writeable;
 
@@ -45,6 +49,7 @@ pub mod ffi {
         /// Construct a new ListFormatter instance for And patterns
         #[diplomat::rust_link(icu::list::ListFormatter::try_new_and, FnInStruct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "and_with_length_and_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_and_with_length_and_provider(
             provider: &DataProvider,
             locale: &Locale,
@@ -78,6 +83,7 @@ pub mod ffi {
         /// Construct a new ListFormatter instance for And patterns
         #[diplomat::rust_link(icu::list::ListFormatter::try_new_or, FnInStruct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "or_with_length_and_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_or_with_length_and_provider(
             provider: &DataProvider,
             locale: &Locale,
@@ -111,6 +117,7 @@ pub mod ffi {
         /// Construct a new ListFormatter instance for And patterns
         #[diplomat::rust_link(icu::list::ListFormatter::try_new_unit, FnInStruct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "unit_with_length_and_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_unit_with_length_and_provider(
             provider: &DataProvider,
             locale: &Locale,

--- a/ffi/capi/src/list.rs
+++ b/ffi/capi/src/list.rs
@@ -57,11 +57,12 @@ pub mod ffi {
         ) -> Result<Box<ListFormatter>, DataError> {
             let prefs = ListFormatterPreferences::from(&locale.0);
             let options = ListFormatterOptions::default().with_length(length.into());
-            Ok(Box::new(ListFormatter(call_constructor!(
-                icu_list::ListFormatter::try_new_and_with_buffer_provider,
-                provider,
-                prefs,
-                options,
+            Ok(Box::new(ListFormatter(provider.call_constructor(
+                move |provider| {
+                    icu_list::ListFormatter::try_new_and_with_buffer_provider(
+                        provider, prefs, options,
+                    )
+                },
             )?)))
         }
 
@@ -91,11 +92,12 @@ pub mod ffi {
         ) -> Result<Box<ListFormatter>, DataError> {
             let prefs = ListFormatterPreferences::from(&locale.0);
             let options = ListFormatterOptions::default().with_length(length.into());
-            Ok(Box::new(ListFormatter(call_constructor!(
-                icu_list::ListFormatter::try_new_or_with_buffer_provider,
-                provider,
-                prefs,
-                options
+            Ok(Box::new(ListFormatter(provider.call_constructor(
+                move |provider| {
+                    icu_list::ListFormatter::try_new_or_with_buffer_provider(
+                        provider, prefs, options,
+                    )
+                },
             )?)))
         }
 
@@ -125,11 +127,12 @@ pub mod ffi {
         ) -> Result<Box<ListFormatter>, DataError> {
             let prefs = ListFormatterPreferences::from(&locale.0);
             let options = ListFormatterOptions::default().with_length(length.into());
-            Ok(Box::new(ListFormatter(call_constructor!(
-                icu_list::ListFormatter::try_new_unit_with_buffer_provider,
-                provider,
-                prefs,
-                options
+            Ok(Box::new(ListFormatter(provider.call_constructor(
+                move |provider| {
+                    icu_list::ListFormatter::try_new_unit_with_buffer_provider(
+                        provider, prefs, options,
+                    )
+                },
             )?)))
         }
 

--- a/ffi/capi/src/list.rs
+++ b/ffi/capi/src/list.rs
@@ -52,7 +52,7 @@ pub mod ffi {
         ) -> Result<Box<ListFormatter>, DataError> {
             let prefs = ListFormatterPreferences::from(&locale.0);
             let options = ListFormatterOptions::default().with_length(length.into());
-            Ok(Box::new(ListFormatter(call_constructor2!(
+            Ok(Box::new(ListFormatter(call_constructor!(
                 icu_list::ListFormatter::try_new_and_with_buffer_provider,
                 provider,
                 prefs,
@@ -85,7 +85,7 @@ pub mod ffi {
         ) -> Result<Box<ListFormatter>, DataError> {
             let prefs = ListFormatterPreferences::from(&locale.0);
             let options = ListFormatterOptions::default().with_length(length.into());
-            Ok(Box::new(ListFormatter(call_constructor2!(
+            Ok(Box::new(ListFormatter(call_constructor!(
                 icu_list::ListFormatter::try_new_or_with_buffer_provider,
                 provider,
                 prefs,
@@ -118,7 +118,7 @@ pub mod ffi {
         ) -> Result<Box<ListFormatter>, DataError> {
             let prefs = ListFormatterPreferences::from(&locale.0);
             let options = ListFormatterOptions::default().with_length(length.into());
-            Ok(Box::new(ListFormatter(call_constructor2!(
+            Ok(Box::new(ListFormatter(call_constructor!(
                 icu_list::ListFormatter::try_new_unit_with_buffer_provider,
                 provider,
                 prefs,

--- a/ffi/capi/src/locale.rs
+++ b/ffi/capi/src/locale.rs
@@ -40,7 +40,7 @@ pub mod ffi {
             provider: &DataProvider,
         ) -> Result<Box<LocaleCanonicalizer>, DataError> {
             Ok(Box::new(LocaleCanonicalizer(provider.call_constructor(
-                |provider| icu_locale::LocaleCanonicalizer::try_new_with_buffer_provider(provider),
+                icu_locale::LocaleCanonicalizer::try_new_with_buffer_provider,
             )?)))
         }
         /// Create a new [`LocaleCanonicalizer`] with extended data using compiled data.
@@ -99,7 +99,7 @@ pub mod ffi {
             provider: &DataProvider,
         ) -> Result<Box<LocaleExpander>, DataError> {
             Ok(Box::new(LocaleExpander(provider.call_constructor(
-                |provider| icu_locale::LocaleExpander::try_new_with_buffer_provider(provider),
+                icu_locale::LocaleExpander::try_new_with_buffer_provider,
             )?)))
         }
         /// Create a new [`LocaleExpander`] with extended data using compiled data.
@@ -117,7 +117,7 @@ pub mod ffi {
             provider: &DataProvider,
         ) -> Result<Box<LocaleExpander>, DataError> {
             Ok(Box::new(LocaleExpander(provider.call_constructor(
-                |provider| icu_locale::LocaleExpander::try_new_with_buffer_provider(provider),
+                icu_locale::LocaleExpander::try_new_with_buffer_provider,
             )?)))
         }
         #[diplomat::rust_link(icu::locale::LocaleExpander::maximize, FnInStruct)]

--- a/ffi/capi/src/locale.rs
+++ b/ffi/capi/src/locale.rs
@@ -39,9 +39,8 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<LocaleCanonicalizer>, DataError> {
-            Ok(Box::new(LocaleCanonicalizer(call_constructor!(
-                icu_locale::LocaleCanonicalizer::try_new_with_buffer_provider,
-                provider,
+            Ok(Box::new(LocaleCanonicalizer(provider.call_constructor(
+                |provider| icu_locale::LocaleCanonicalizer::try_new_with_buffer_provider(provider),
             )?)))
         }
         /// Create a new [`LocaleCanonicalizer`] with extended data using compiled data.
@@ -62,14 +61,15 @@ pub mod ffi {
         pub fn create_extended_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<LocaleCanonicalizer>, DataError> {
-            let expander = call_constructor!(
-                icu_locale::LocaleExpander::try_new_with_buffer_provider,
-                provider,
-            )?;
-            Ok(Box::new(LocaleCanonicalizer(call_constructor!(
-                icu_locale::LocaleCanonicalizer::try_new_with_expander_with_buffer_provider,
-                provider,
-                expander
+            let expander = provider.call_constructor(|provider| {
+                icu_locale::LocaleExpander::try_new_with_buffer_provider(provider)
+            })?;
+            Ok(Box::new(LocaleCanonicalizer(provider.call_constructor(
+                move |provider| {
+                    icu_locale::LocaleCanonicalizer::try_new_with_expander_with_buffer_provider(
+                        provider, expander,
+                    )
+                },
             )?)))
         }
         #[diplomat::rust_link(icu::locale::LocaleCanonicalizer::canonicalize, FnInStruct)]
@@ -98,9 +98,8 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<LocaleExpander>, DataError> {
-            Ok(Box::new(LocaleExpander(call_constructor!(
-                icu_locale::LocaleExpander::try_new_with_buffer_provider,
-                provider,
+            Ok(Box::new(LocaleExpander(provider.call_constructor(
+                |provider| icu_locale::LocaleExpander::try_new_with_buffer_provider(provider),
             )?)))
         }
         /// Create a new [`LocaleExpander`] with extended data using compiled data.
@@ -117,9 +116,8 @@ pub mod ffi {
         pub fn create_extended_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<LocaleExpander>, DataError> {
-            Ok(Box::new(LocaleExpander(call_constructor!(
-                icu_locale::LocaleExpander::try_new_with_buffer_provider,
-                provider,
+            Ok(Box::new(LocaleExpander(provider.call_constructor(
+                |provider| icu_locale::LocaleExpander::try_new_with_buffer_provider(provider),
             )?)))
         }
         #[diplomat::rust_link(icu::locale::LocaleExpander::maximize, FnInStruct)]

--- a/ffi/capi/src/locale.rs
+++ b/ffi/capi/src/locale.rs
@@ -8,9 +8,9 @@
 pub mod ffi {
     use alloc::boxed::Box;
 
-    use crate::errors::ffi::DataError;
     use crate::locale_core::ffi::Locale;
-    use crate::provider::ffi::DataProvider;
+    #[cfg(feature = "buffer_provider")]
+    use crate::{errors::ffi::DataError, provider::ffi::DataProvider};
 
     #[diplomat::rust_link(icu::locale::TransformResult, Enum)]
     #[diplomat::enum_convert(icu_locale::TransformResult)]
@@ -35,6 +35,7 @@ pub mod ffi {
         /// Create a new [`LocaleCanonicalizer`].
         #[diplomat::rust_link(icu::locale::LocaleCanonicalizer::new, FnInStruct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<LocaleCanonicalizer>, DataError> {
@@ -57,6 +58,7 @@ pub mod ffi {
         /// Create a new [`LocaleCanonicalizer`] with extended data.
         #[diplomat::rust_link(icu::locale::LocaleCanonicalizer::new_with_expander, FnInStruct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "extended_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_extended_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<LocaleCanonicalizer>, DataError> {
@@ -92,6 +94,7 @@ pub mod ffi {
         /// Create a new [`LocaleExpander`] using a particular data source.
         #[diplomat::rust_link(icu::locale::LocaleExpander::new, FnInStruct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<LocaleExpander>, DataError> {
@@ -110,6 +113,7 @@ pub mod ffi {
         /// Create a new [`LocaleExpander`] with extended data using a particular data source.
         #[diplomat::rust_link(icu::locale::LocaleExpander::new_extended, FnInStruct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "extended_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_extended_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<LocaleExpander>, DataError> {

--- a/ffi/capi/src/locale.rs
+++ b/ffi/capi/src/locale.rs
@@ -38,7 +38,7 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<LocaleCanonicalizer>, DataError> {
-            Ok(Box::new(LocaleCanonicalizer(call_constructor2!(
+            Ok(Box::new(LocaleCanonicalizer(call_constructor!(
                 icu_locale::LocaleCanonicalizer::try_new_with_buffer_provider,
                 provider,
             )?)))
@@ -60,11 +60,11 @@ pub mod ffi {
         pub fn create_extended_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<LocaleCanonicalizer>, DataError> {
-            let expander = call_constructor2!(
+            let expander = call_constructor!(
                 icu_locale::LocaleExpander::try_new_with_buffer_provider,
                 provider,
             )?;
-            Ok(Box::new(LocaleCanonicalizer(call_constructor2!(
+            Ok(Box::new(LocaleCanonicalizer(call_constructor!(
                 icu_locale::LocaleCanonicalizer::try_new_with_expander_with_buffer_provider,
                 provider,
                 expander
@@ -95,7 +95,7 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<LocaleExpander>, DataError> {
-            Ok(Box::new(LocaleExpander(call_constructor2!(
+            Ok(Box::new(LocaleExpander(call_constructor!(
                 icu_locale::LocaleExpander::try_new_with_buffer_provider,
                 provider,
             )?)))
@@ -113,7 +113,7 @@ pub mod ffi {
         pub fn create_extended_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<LocaleExpander>, DataError> {
-            Ok(Box::new(LocaleExpander(call_constructor2!(
+            Ok(Box::new(LocaleExpander(call_constructor!(
                 icu_locale::LocaleExpander::try_new_with_buffer_provider,
                 provider,
             )?)))

--- a/ffi/capi/src/locale.rs
+++ b/ffi/capi/src/locale.rs
@@ -38,9 +38,7 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<LocaleCanonicalizer>, DataError> {
-            Ok(Box::new(LocaleCanonicalizer(call_constructor!(
-                icu_locale::LocaleCanonicalizer::new [r => Ok(r)],
-                icu_locale::LocaleCanonicalizer::try_new_with_any_provider,
+            Ok(Box::new(LocaleCanonicalizer(call_constructor2!(
                 icu_locale::LocaleCanonicalizer::try_new_with_buffer_provider,
                 provider,
             )?)))
@@ -62,15 +60,11 @@ pub mod ffi {
         pub fn create_extended_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<LocaleCanonicalizer>, DataError> {
-            let expander = call_constructor!(
-                icu_locale::LocaleExpander::new_extended [r => Ok(r)],
-                icu_locale::LocaleExpander::try_new_with_any_provider,
+            let expander = call_constructor2!(
                 icu_locale::LocaleExpander::try_new_with_buffer_provider,
                 provider,
             )?;
-            Ok(Box::new(LocaleCanonicalizer(call_constructor!(
-                icu_locale::LocaleCanonicalizer::new_with_expander [r => Ok(r)],
-                icu_locale::LocaleCanonicalizer::try_new_with_expander_with_any_provider,
+            Ok(Box::new(LocaleCanonicalizer(call_constructor2!(
                 icu_locale::LocaleCanonicalizer::try_new_with_expander_with_buffer_provider,
                 provider,
                 expander
@@ -101,9 +95,7 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<LocaleExpander>, DataError> {
-            Ok(Box::new(LocaleExpander(call_constructor!(
-                icu_locale::LocaleExpander::new [r => Ok(r)],
-                icu_locale::LocaleExpander::try_new_with_any_provider,
+            Ok(Box::new(LocaleExpander(call_constructor2!(
                 icu_locale::LocaleExpander::try_new_with_buffer_provider,
                 provider,
             )?)))
@@ -121,9 +113,7 @@ pub mod ffi {
         pub fn create_extended_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<LocaleExpander>, DataError> {
-            Ok(Box::new(LocaleExpander(call_constructor!(
-                icu_locale::LocaleExpander::new_extended [r => Ok(r)],
-                icu_locale::LocaleExpander::try_new_with_any_provider,
+            Ok(Box::new(LocaleExpander(call_constructor2!(
                 icu_locale::LocaleExpander::try_new_with_buffer_provider,
                 provider,
             )?)))

--- a/ffi/capi/src/locale_directionality.rs
+++ b/ffi/capi/src/locale_directionality.rs
@@ -45,7 +45,7 @@ pub mod ffi {
             provider: &DataProvider,
         ) -> Result<Box<LocaleDirectionality>, DataError> {
             Ok(Box::new(LocaleDirectionality(provider.call_constructor(
-                |provider| icu_locale::LocaleDirectionality::try_new_with_buffer_provider(provider),
+                icu_locale::LocaleDirectionality::try_new_with_buffer_provider,
             )?)))
         }
 

--- a/ffi/capi/src/locale_directionality.rs
+++ b/ffi/capi/src/locale_directionality.rs
@@ -41,7 +41,7 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<LocaleDirectionality>, DataError> {
-            Ok(Box::new(LocaleDirectionality(call_constructor2!(
+            Ok(Box::new(LocaleDirectionality(call_constructor!(
                 icu_locale::LocaleDirectionality::try_new_with_buffer_provider,
                 provider,
             )?)))

--- a/ffi/capi/src/locale_directionality.rs
+++ b/ffi/capi/src/locale_directionality.rs
@@ -8,12 +8,14 @@
 pub mod ffi {
     use alloc::boxed::Box;
 
-    use crate::{
-        errors::ffi::DataError,
-        locale::ffi::LocaleExpander,
-        locale_core::ffi::Locale,
-        provider::{ffi::DataProvider, DataProviderInner},
-    };
+    #[cfg(feature = "buffer_provider")]
+    use crate::errors::ffi::DataError;
+    #[cfg(feature = "buffer_provider")]
+    use crate::provider::{ffi::DataProvider, DataProviderInner};
+
+    #[cfg(any(feature = "compiled_data", feature = "buffer_provider"))]
+    use crate::locale::ffi::LocaleExpander;
+    use crate::locale_core::ffi::Locale;
 
     #[diplomat::rust_link(icu::locale::Direction, Enum)]
     pub enum LocaleDirection {
@@ -38,6 +40,7 @@ pub mod ffi {
         /// Construct a new LocaleDirectionality instance using a particular data source.
         #[diplomat::rust_link(icu::locale::LocaleDirectionality::new, FnInStruct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<LocaleDirectionality>, DataError> {
@@ -60,6 +63,7 @@ pub mod ffi {
         /// Construct a new LocaleDirectionality instance with a custom expander and a particular data source.
         #[diplomat::rust_link(icu::locale::LocaleDirectionality::new_with_expander, FnInStruct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "with_expander_and_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_with_expander_and_provider(
             provider: &DataProvider,
             expander: &LocaleExpander,

--- a/ffi/capi/src/locale_directionality.rs
+++ b/ffi/capi/src/locale_directionality.rs
@@ -44,9 +44,8 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<LocaleDirectionality>, DataError> {
-            Ok(Box::new(LocaleDirectionality(call_constructor!(
-                icu_locale::LocaleDirectionality::try_new_with_buffer_provider,
-                provider,
+            Ok(Box::new(LocaleDirectionality(provider.call_constructor(
+                |provider| icu_locale::LocaleDirectionality::try_new_with_buffer_provider(provider),
             )?)))
         }
 

--- a/ffi/capi/src/locale_directionality.rs
+++ b/ffi/capi/src/locale_directionality.rs
@@ -74,22 +74,12 @@ pub mod ffi {
                 DataProviderInner::Destroyed => Err(icu_provider::DataError::custom(
                     "This provider has been destroyed",
                 ))?,
-                DataProviderInner::Empty => {
-                    icu_locale::LocaleDirectionality::try_new_with_expander_unstable(
-                        &icu_provider_adapters::empty::EmptyDataProvider::new(),
-                        expander.0.clone(),
-                    )?
-                }
-                #[cfg(feature = "buffer_provider")]
+
                 DataProviderInner::Buffer(buffer_provider) => {
                     icu_locale::LocaleDirectionality::try_new_with_expander_unstable(
                         &buffer_provider.as_deserializing(),
                         expander.0.clone(),
                     )?
-                }
-                #[cfg(feature = "compiled_data")]
-                DataProviderInner::Compiled => {
-                    icu_locale::LocaleDirectionality::new_with_expander(expander.0.clone())
                 }
             })))
         }

--- a/ffi/capi/src/locale_directionality.rs
+++ b/ffi/capi/src/locale_directionality.rs
@@ -41,9 +41,7 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<LocaleDirectionality>, DataError> {
-            Ok(Box::new(LocaleDirectionality(call_constructor!(
-                icu_locale::LocaleDirectionality::new [r => Ok(r)],
-                icu_locale::LocaleDirectionality::try_new_with_any_provider,
+            Ok(Box::new(LocaleDirectionality(call_constructor2!(
                 icu_locale::LocaleDirectionality::try_new_with_buffer_provider,
                 provider,
             )?)))

--- a/ffi/capi/src/normalizer.rs
+++ b/ffi/capi/src/normalizer.rs
@@ -8,6 +8,7 @@
 pub mod ffi {
     use alloc::boxed::Box;
 
+    #[cfg(feature = "buffer_provider")]
     use crate::{errors::ffi::DataError, provider::ffi::DataProvider};
 
     #[diplomat::opaque]
@@ -39,6 +40,7 @@ pub mod ffi {
             hidden
         )]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "nfc_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_nfc_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<ComposingNormalizer>, DataError> {
@@ -69,6 +71,7 @@ pub mod ffi {
             hidden
         )]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "nfkc_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_nfkc_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<ComposingNormalizer>, DataError> {
@@ -195,6 +198,7 @@ pub mod ffi {
             hidden
         )]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "nfd_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_nfd_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<DecomposingNormalizer>, DataError> {
@@ -227,6 +231,7 @@ pub mod ffi {
             hidden
         )]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "nfkd_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_nfkd_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<DecomposingNormalizer>, DataError> {

--- a/ffi/capi/src/normalizer.rs
+++ b/ffi/capi/src/normalizer.rs
@@ -44,9 +44,10 @@ pub mod ffi {
         pub fn create_nfc_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<ComposingNormalizer>, DataError> {
-            Ok(Box::new(ComposingNormalizer(call_constructor!(
-                icu_normalizer::ComposingNormalizer::try_new_nfc_with_buffer_provider,
-                provider,
+            Ok(Box::new(ComposingNormalizer(provider.call_constructor(
+                |provider| {
+                    icu_normalizer::ComposingNormalizer::try_new_nfc_with_buffer_provider(provider)
+                },
             )?)))
         }
         /// Construct a new ComposingNormalizer instance for NFKC using compiled data.
@@ -75,9 +76,10 @@ pub mod ffi {
         pub fn create_nfkc_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<ComposingNormalizer>, DataError> {
-            Ok(Box::new(ComposingNormalizer(call_constructor!(
-                icu_normalizer::ComposingNormalizer::try_new_nfkc_with_buffer_provider,
-                provider,
+            Ok(Box::new(ComposingNormalizer(provider.call_constructor(
+                |provider| {
+                    icu_normalizer::ComposingNormalizer::try_new_nfkc_with_buffer_provider(provider)
+                },
             )?)))
         }
         /// Normalize a string
@@ -202,9 +204,12 @@ pub mod ffi {
         pub fn create_nfd_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<DecomposingNormalizer>, DataError> {
-            Ok(Box::new(DecomposingNormalizer(call_constructor!(
-                icu_normalizer::DecomposingNormalizer::try_new_nfd_with_buffer_provider,
-                provider,
+            Ok(Box::new(DecomposingNormalizer(provider.call_constructor(
+                |provider| {
+                    icu_normalizer::DecomposingNormalizer::try_new_nfd_with_buffer_provider(
+                        provider,
+                    )
+                },
             )?)))
         }
 
@@ -235,9 +240,12 @@ pub mod ffi {
         pub fn create_nfkd_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<DecomposingNormalizer>, DataError> {
-            Ok(Box::new(DecomposingNormalizer(call_constructor!(
-                icu_normalizer::DecomposingNormalizer::try_new_nfkd_with_buffer_provider,
-                provider,
+            Ok(Box::new(DecomposingNormalizer(provider.call_constructor(
+                |provider| {
+                    icu_normalizer::DecomposingNormalizer::try_new_nfkd_with_buffer_provider(
+                        provider,
+                    )
+                },
             )?)))
         }
 

--- a/ffi/capi/src/normalizer.rs
+++ b/ffi/capi/src/normalizer.rs
@@ -42,7 +42,7 @@ pub mod ffi {
         pub fn create_nfc_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<ComposingNormalizer>, DataError> {
-            Ok(Box::new(ComposingNormalizer(call_constructor2!(
+            Ok(Box::new(ComposingNormalizer(call_constructor!(
                 icu_normalizer::ComposingNormalizer::try_new_nfc_with_buffer_provider,
                 provider,
             )?)))
@@ -72,7 +72,7 @@ pub mod ffi {
         pub fn create_nfkc_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<ComposingNormalizer>, DataError> {
-            Ok(Box::new(ComposingNormalizer(call_constructor2!(
+            Ok(Box::new(ComposingNormalizer(call_constructor!(
                 icu_normalizer::ComposingNormalizer::try_new_nfkc_with_buffer_provider,
                 provider,
             )?)))
@@ -198,7 +198,7 @@ pub mod ffi {
         pub fn create_nfd_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<DecomposingNormalizer>, DataError> {
-            Ok(Box::new(DecomposingNormalizer(call_constructor2!(
+            Ok(Box::new(DecomposingNormalizer(call_constructor!(
                 icu_normalizer::DecomposingNormalizer::try_new_nfd_with_buffer_provider,
                 provider,
             )?)))
@@ -230,7 +230,7 @@ pub mod ffi {
         pub fn create_nfkd_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<DecomposingNormalizer>, DataError> {
-            Ok(Box::new(DecomposingNormalizer(call_constructor2!(
+            Ok(Box::new(DecomposingNormalizer(call_constructor!(
                 icu_normalizer::DecomposingNormalizer::try_new_nfkd_with_buffer_provider,
                 provider,
             )?)))

--- a/ffi/capi/src/normalizer.rs
+++ b/ffi/capi/src/normalizer.rs
@@ -42,9 +42,7 @@ pub mod ffi {
         pub fn create_nfc_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<ComposingNormalizer>, DataError> {
-            Ok(Box::new(ComposingNormalizer(call_constructor!(
-                icu_normalizer::ComposingNormalizer::new_nfc [r => Ok(r.static_to_owned())],
-                icu_normalizer::ComposingNormalizer::try_new_nfc_with_any_provider,
+            Ok(Box::new(ComposingNormalizer(call_constructor2!(
                 icu_normalizer::ComposingNormalizer::try_new_nfc_with_buffer_provider,
                 provider,
             )?)))
@@ -74,9 +72,7 @@ pub mod ffi {
         pub fn create_nfkc_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<ComposingNormalizer>, DataError> {
-            Ok(Box::new(ComposingNormalizer(call_constructor!(
-                icu_normalizer::ComposingNormalizer::new_nfkc [r => Ok(r.static_to_owned())],
-                icu_normalizer::ComposingNormalizer::try_new_nfkc_with_any_provider,
+            Ok(Box::new(ComposingNormalizer(call_constructor2!(
                 icu_normalizer::ComposingNormalizer::try_new_nfkc_with_buffer_provider,
                 provider,
             )?)))
@@ -202,9 +198,7 @@ pub mod ffi {
         pub fn create_nfd_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<DecomposingNormalizer>, DataError> {
-            Ok(Box::new(DecomposingNormalizer(call_constructor!(
-                icu_normalizer::DecomposingNormalizer::new_nfd [r => Ok(r.static_to_owned())],
-                icu_normalizer::DecomposingNormalizer::try_new_nfd_with_any_provider,
+            Ok(Box::new(DecomposingNormalizer(call_constructor2!(
                 icu_normalizer::DecomposingNormalizer::try_new_nfd_with_buffer_provider,
                 provider,
             )?)))
@@ -236,9 +230,7 @@ pub mod ffi {
         pub fn create_nfkd_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<DecomposingNormalizer>, DataError> {
-            Ok(Box::new(DecomposingNormalizer(call_constructor!(
-                icu_normalizer::DecomposingNormalizer::new_nfkd [r => Ok(r.static_to_owned())],
-                icu_normalizer::DecomposingNormalizer::try_new_nfkd_with_any_provider,
+            Ok(Box::new(DecomposingNormalizer(call_constructor2!(
                 icu_normalizer::DecomposingNormalizer::try_new_nfkd_with_buffer_provider,
                 provider,
             )?)))

--- a/ffi/capi/src/normalizer_properties.rs
+++ b/ffi/capi/src/normalizer_properties.rs
@@ -57,7 +57,7 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CanonicalCombiningClassMap>, DataError> {
-            Ok(Box::new(CanonicalCombiningClassMap(provider.call_constructor(|provider| icu_normalizer::properties::CanonicalCombiningClassMap::try_new_with_buffer_provider(provider))?)))
+            Ok(Box::new(CanonicalCombiningClassMap(provider.call_constructor(icu_normalizer::properties::CanonicalCombiningClassMap::try_new_with_buffer_provider)?)))
         }
 
         #[diplomat::rust_link(
@@ -204,7 +204,7 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CanonicalDecomposition>, DataError> {
-            Ok(Box::new(CanonicalDecomposition(provider.call_constructor(|provider| icu_normalizer::properties::CanonicalDecomposition::try_new_with_buffer_provider(provider))?)))
+            Ok(Box::new(CanonicalDecomposition(provider.call_constructor(icu_normalizer::properties::CanonicalDecomposition::try_new_with_buffer_provider)?)))
         }
 
         /// Performs non-recursive canonical decomposition (including for Hangul).

--- a/ffi/capi/src/normalizer_properties.rs
+++ b/ffi/capi/src/normalizer_properties.rs
@@ -8,6 +8,7 @@
 pub mod ffi {
     use alloc::boxed::Box;
 
+    #[cfg(feature = "buffer_provider")]
     use crate::{errors::ffi::DataError, provider::ffi::DataProvider};
 
     /// Lookup of the Canonical_Combining_Class Unicode property
@@ -52,6 +53,7 @@ pub mod ffi {
             hidden
         )]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CanonicalCombiningClassMap>, DataError> {
@@ -127,6 +129,7 @@ pub mod ffi {
             hidden
         )]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CanonicalComposition>, DataError> {
@@ -197,6 +200,7 @@ pub mod ffi {
             hidden
         )]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CanonicalDecomposition>, DataError> {

--- a/ffi/capi/src/normalizer_properties.rs
+++ b/ffi/capi/src/normalizer_properties.rs
@@ -55,7 +55,7 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CanonicalCombiningClassMap>, DataError> {
-            Ok(Box::new(CanonicalCombiningClassMap(call_constructor2!(
+            Ok(Box::new(CanonicalCombiningClassMap(call_constructor!(
                 icu_normalizer::properties::CanonicalCombiningClassMap::try_new_with_buffer_provider,
                 provider
             )?)))
@@ -130,7 +130,7 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CanonicalComposition>, DataError> {
-            Ok(Box::new(CanonicalComposition(call_constructor2!(
+            Ok(Box::new(CanonicalComposition(call_constructor!(
                 icu_normalizer::properties::CanonicalComposition::try_new_with_buffer_provider,
                 provider,
             )?)))
@@ -200,7 +200,7 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CanonicalDecomposition>, DataError> {
-            Ok(Box::new(CanonicalDecomposition(call_constructor2!(
+            Ok(Box::new(CanonicalDecomposition(call_constructor!(
                 icu_normalizer::properties::CanonicalDecomposition::try_new_with_buffer_provider,
                 provider,
             )?)))

--- a/ffi/capi/src/normalizer_properties.rs
+++ b/ffi/capi/src/normalizer_properties.rs
@@ -55,9 +55,7 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CanonicalCombiningClassMap>, DataError> {
-            Ok(Box::new(CanonicalCombiningClassMap(call_constructor!(
-                icu_normalizer::properties::CanonicalCombiningClassMap::new [r => Ok(r.static_to_owned())],
-                icu_normalizer::properties::CanonicalCombiningClassMap::try_new_with_any_provider,
+            Ok(Box::new(CanonicalCombiningClassMap(call_constructor2!(
                 icu_normalizer::properties::CanonicalCombiningClassMap::try_new_with_buffer_provider,
                 provider
             )?)))
@@ -132,9 +130,7 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CanonicalComposition>, DataError> {
-            Ok(Box::new(CanonicalComposition(call_constructor!(
-                icu_normalizer::properties::CanonicalComposition::new [r => Ok(r.static_to_owned())],
-                icu_normalizer::properties::CanonicalComposition::try_new_with_any_provider,
+            Ok(Box::new(CanonicalComposition(call_constructor2!(
                 icu_normalizer::properties::CanonicalComposition::try_new_with_buffer_provider,
                 provider,
             )?)))
@@ -204,9 +200,7 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CanonicalDecomposition>, DataError> {
-            Ok(Box::new(CanonicalDecomposition(call_constructor!(
-                icu_normalizer::properties::CanonicalDecomposition::new [r => Ok(r.static_to_owned())],
-                icu_normalizer::properties::CanonicalDecomposition::try_new_with_any_provider,
+            Ok(Box::new(CanonicalDecomposition(call_constructor2!(
                 icu_normalizer::properties::CanonicalDecomposition::try_new_with_buffer_provider,
                 provider,
             )?)))

--- a/ffi/capi/src/normalizer_properties.rs
+++ b/ffi/capi/src/normalizer_properties.rs
@@ -57,10 +57,7 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CanonicalCombiningClassMap>, DataError> {
-            Ok(Box::new(CanonicalCombiningClassMap(call_constructor!(
-                icu_normalizer::properties::CanonicalCombiningClassMap::try_new_with_buffer_provider,
-                provider
-            )?)))
+            Ok(Box::new(CanonicalCombiningClassMap(provider.call_constructor(|provider| icu_normalizer::properties::CanonicalCombiningClassMap::try_new_with_buffer_provider(provider))?)))
         }
 
         #[diplomat::rust_link(
@@ -133,9 +130,12 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CanonicalComposition>, DataError> {
-            Ok(Box::new(CanonicalComposition(call_constructor!(
-                icu_normalizer::properties::CanonicalComposition::try_new_with_buffer_provider,
-                provider,
+            Ok(Box::new(CanonicalComposition(provider.call_constructor(
+                |provider| {
+                    icu_normalizer::properties::CanonicalComposition::try_new_with_buffer_provider(
+                        provider,
+                    )
+                },
             )?)))
         }
 
@@ -204,10 +204,7 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CanonicalDecomposition>, DataError> {
-            Ok(Box::new(CanonicalDecomposition(call_constructor!(
-                icu_normalizer::properties::CanonicalDecomposition::try_new_with_buffer_provider,
-                provider,
-            )?)))
+            Ok(Box::new(CanonicalDecomposition(provider.call_constructor(|provider| icu_normalizer::properties::CanonicalDecomposition::try_new_with_buffer_provider(provider))?)))
         }
 
         /// Performs non-recursive canonical decomposition (including for Hangul).

--- a/ffi/capi/src/pluralrules.rs
+++ b/ffi/capi/src/pluralrules.rs
@@ -65,10 +65,10 @@ pub mod ffi {
             locale: &Locale,
         ) -> Result<Box<PluralRules>, DataError> {
             let prefs = icu_plurals::PluralRulesPreferences::from(&locale.0);
-            Ok(Box::new(PluralRules(call_constructor!(
-                icu_plurals::PluralRules::try_new_cardinal_with_buffer_provider,
-                provider,
-                prefs
+            Ok(Box::new(PluralRules(provider.call_constructor(
+                |provider| {
+                    icu_plurals::PluralRules::try_new_cardinal_with_buffer_provider(provider, prefs)
+                },
             )?)))
         }
         /// Construct an [`PluralRules`] for the given locale, for ordinal numbers, using compiled data.
@@ -94,10 +94,10 @@ pub mod ffi {
             locale: &Locale,
         ) -> Result<Box<PluralRules>, DataError> {
             let prefs = icu_plurals::PluralRulesPreferences::from(&locale.0);
-            Ok(Box::new(PluralRules(call_constructor!(
-                icu_plurals::PluralRules::try_new_ordinal_with_buffer_provider,
-                provider,
-                prefs
+            Ok(Box::new(PluralRules(provider.call_constructor(
+                |provider| {
+                    icu_plurals::PluralRules::try_new_ordinal_with_buffer_provider(provider, prefs)
+                },
             )?)))
         }
         /// Get the category for a given number represented as operands

--- a/ffi/capi/src/pluralrules.rs
+++ b/ffi/capi/src/pluralrules.rs
@@ -61,9 +61,7 @@ pub mod ffi {
             locale: &Locale,
         ) -> Result<Box<PluralRules>, DataError> {
             let prefs = icu_plurals::PluralRulesPreferences::from(&locale.0);
-            Ok(Box::new(PluralRules(call_constructor!(
-                icu_plurals::PluralRules::try_new_cardinal,
-                icu_plurals::PluralRules::try_new_cardinal_with_any_provider,
+            Ok(Box::new(PluralRules(call_constructor2!(
                 icu_plurals::PluralRules::try_new_cardinal_with_buffer_provider,
                 provider,
                 prefs
@@ -91,9 +89,7 @@ pub mod ffi {
             locale: &Locale,
         ) -> Result<Box<PluralRules>, DataError> {
             let prefs = icu_plurals::PluralRulesPreferences::from(&locale.0);
-            Ok(Box::new(PluralRules(call_constructor!(
-                icu_plurals::PluralRules::try_new_ordinal,
-                icu_plurals::PluralRules::try_new_ordinal_with_any_provider,
+            Ok(Box::new(PluralRules(call_constructor2!(
                 icu_plurals::PluralRules::try_new_ordinal_with_buffer_provider,
                 provider,
                 prefs

--- a/ffi/capi/src/pluralrules.rs
+++ b/ffi/capi/src/pluralrules.rs
@@ -61,7 +61,7 @@ pub mod ffi {
             locale: &Locale,
         ) -> Result<Box<PluralRules>, DataError> {
             let prefs = icu_plurals::PluralRulesPreferences::from(&locale.0);
-            Ok(Box::new(PluralRules(call_constructor2!(
+            Ok(Box::new(PluralRules(call_constructor!(
                 icu_plurals::PluralRules::try_new_cardinal_with_buffer_provider,
                 provider,
                 prefs
@@ -89,7 +89,7 @@ pub mod ffi {
             locale: &Locale,
         ) -> Result<Box<PluralRules>, DataError> {
             let prefs = icu_plurals::PluralRulesPreferences::from(&locale.0);
-            Ok(Box::new(PluralRules(call_constructor2!(
+            Ok(Box::new(PluralRules(call_constructor!(
                 icu_plurals::PluralRules::try_new_ordinal_with_buffer_provider,
                 provider,
                 prefs

--- a/ffi/capi/src/pluralrules.rs
+++ b/ffi/capi/src/pluralrules.rs
@@ -8,9 +8,12 @@
 pub mod ffi {
     use alloc::boxed::Box;
 
+    #[cfg(any(feature = "compiled_data", feature = "buffer_provider"))]
     use crate::errors::ffi::DataError;
     use crate::errors::ffi::FixedDecimalParseError;
+    #[cfg(any(feature = "compiled_data", feature = "buffer_provider"))]
     use crate::locale_core::ffi::Locale;
+    #[cfg(feature = "buffer_provider")]
     use crate::provider::ffi::DataProvider;
 
     #[diplomat::rust_link(icu::plurals::PluralCategory, Enum)]
@@ -56,6 +59,7 @@ pub mod ffi {
         #[diplomat::rust_link(icu::plurals::PluralRules::try_new, FnInStruct, hidden)]
         #[diplomat::rust_link(icu::plurals::PluralRuleType, Enum, hidden)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "cardinal_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_cardinal_with_provider(
             provider: &DataProvider,
             locale: &Locale,
@@ -84,6 +88,7 @@ pub mod ffi {
         #[diplomat::rust_link(icu::plurals::PluralRules::try_new, FnInStruct, hidden)]
         #[diplomat::rust_link(icu::plurals::PluralRuleType, Enum, hidden)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "ordinal_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_ordinal_with_provider(
             provider: &DataProvider,
             locale: &Locale,

--- a/ffi/capi/src/properties_maps.rs
+++ b/ffi/capi/src/properties_maps.rs
@@ -142,8 +142,7 @@ pub mod ffi {
         pub fn create_general_category_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointMapData8>, DataError> {
-            Ok(convert_8(call_constructor_unstable!(
-                icu_properties::CodePointMapData::<GeneralCategory>::new [r => Ok(r.static_to_owned())],
+            Ok(convert_8(call_constructor_unstable2!(
                 icu_properties::CodePointMapData::<GeneralCategory>::try_new_unstable,
                 provider,
             )?))
@@ -163,8 +162,7 @@ pub mod ffi {
         pub fn create_bidi_class_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointMapData8>, DataError> {
-            Ok(convert_8(call_constructor_unstable!(
-                icu_properties::CodePointMapData::<BidiClass>::new [r => Ok(r.static_to_owned())],
+            Ok(convert_8(call_constructor_unstable2!(
                 icu_properties::CodePointMapData::<BidiClass>::try_new_unstable,
                 provider,
             )?))
@@ -183,8 +181,7 @@ pub mod ffi {
         pub fn create_east_asian_width_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointMapData8>, DataError> {
-            Ok(convert_8(call_constructor_unstable!(
-                icu_properties::CodePointMapData::<EastAsianWidth>::new [r => Ok(r.static_to_owned())],
+            Ok(convert_8(call_constructor_unstable2!(
                 icu_properties::CodePointMapData::<EastAsianWidth>::try_new_unstable,
                 provider,
             )?))
@@ -204,8 +201,7 @@ pub mod ffi {
         pub fn create_hangul_syllable_type_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointMapData8>, DataError> {
-            Ok(convert_8(call_constructor_unstable!(
-                icu_properties::CodePointMapData::<HangulSyllableType>::new [r => Ok(r.static_to_owned())],
+            Ok(convert_8(call_constructor_unstable2!(
                 icu_properties::CodePointMapData::<HangulSyllableType>::try_new_unstable,
                 provider,
             )?))
@@ -225,8 +221,7 @@ pub mod ffi {
         pub fn create_indic_syllabic_category_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointMapData8>, DataError> {
-            Ok(convert_8(call_constructor_unstable!(
-                icu_properties::CodePointMapData::<IndicSyllabicCategory>::new [r => Ok(r.static_to_owned())],
+            Ok(convert_8(call_constructor_unstable2!(
                 icu_properties::CodePointMapData::<IndicSyllabicCategory>::try_new_unstable,
                 provider,
             )?))
@@ -244,8 +239,7 @@ pub mod ffi {
         pub fn create_line_break_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointMapData8>, DataError> {
-            Ok(convert_8(call_constructor_unstable!(
-                icu_properties::CodePointMapData::<LineBreak>::new [r => Ok(r.static_to_owned())],
+            Ok(convert_8(call_constructor_unstable2!(
                 icu_properties::CodePointMapData::<LineBreak>::try_new_unstable,
                 provider,
             )?))
@@ -265,8 +259,7 @@ pub mod ffi {
         pub fn create_grapheme_cluster_break_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointMapData8>, DataError> {
-            Ok(convert_8(call_constructor_unstable!(
-                icu_properties::CodePointMapData::<GraphemeClusterBreak>::new [r => Ok(r.static_to_owned())],
+            Ok(convert_8(call_constructor_unstable2!(
                 icu_properties::CodePointMapData::<GraphemeClusterBreak>::try_new_unstable,
                 provider,
             )?))
@@ -284,8 +277,7 @@ pub mod ffi {
         pub fn create_word_break_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointMapData8>, DataError> {
-            Ok(convert_8(call_constructor_unstable!(
-                icu_properties::CodePointMapData::<WordBreak>::new [r => Ok(r.static_to_owned())],
+            Ok(convert_8(call_constructor_unstable2!(
                 icu_properties::CodePointMapData::<WordBreak>::try_new_unstable,
                 provider,
             )?))
@@ -303,8 +295,7 @@ pub mod ffi {
         pub fn create_sentence_break_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointMapData8>, DataError> {
-            Ok(convert_8(call_constructor_unstable!(
-                icu_properties::CodePointMapData::<SentenceBreak>::new [r => Ok(r.static_to_owned())],
+            Ok(convert_8(call_constructor_unstable2!(
                 icu_properties::CodePointMapData::<SentenceBreak>::try_new_unstable,
                 provider,
             )?))
@@ -323,8 +314,7 @@ pub mod ffi {
         pub fn create_joining_type_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointMapData8>, DataError> {
-            Ok(convert_8(call_constructor_unstable!(
-                icu_properties::CodePointMapData::<JoiningType>::new [r => Ok(r.static_to_owned())],
+            Ok(convert_8(call_constructor_unstable2!(
                 icu_properties::CodePointMapData::<JoiningType>::try_new_unstable,
                 provider,
             )?))
@@ -345,8 +335,7 @@ pub mod ffi {
         pub fn create_canonical_combining_class_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointMapData8>, DataError> {
-            Ok(convert_8(call_constructor_unstable!(
-                icu_properties::CodePointMapData::<CanonicalCombiningClass>::new [r => Ok(r.static_to_owned())],
+            Ok(convert_8(call_constructor_unstable2!(
                 icu_properties::CodePointMapData::<CanonicalCombiningClass>::try_new_unstable,
                 provider,
             )?))
@@ -431,8 +420,7 @@ pub mod ffi {
         ) -> Result<Box<CodePointMapData16>, DataError> {
             #[allow(clippy::unwrap_used)] // script is a 16-bit property
             Ok(Box::new(CodePointMapData16(
-                call_constructor_unstable!(
-                    icu_properties::CodePointMapData::<Script>::new [r => Ok(r.static_to_owned())],
+                call_constructor_unstable2!(
                     icu_properties::CodePointMapData::<Script>::try_new_unstable,
                     provider,
                 )?

--- a/ffi/capi/src/properties_maps.rs
+++ b/ffi/capi/src/properties_maps.rs
@@ -142,7 +142,7 @@ pub mod ffi {
         pub fn create_general_category_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointMapData8>, DataError> {
-            Ok(convert_8(call_constructor_unstable2!(
+            Ok(convert_8(call_constructor_unstable!(
                 icu_properties::CodePointMapData::<GeneralCategory>::try_new_unstable,
                 provider,
             )?))
@@ -162,7 +162,7 @@ pub mod ffi {
         pub fn create_bidi_class_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointMapData8>, DataError> {
-            Ok(convert_8(call_constructor_unstable2!(
+            Ok(convert_8(call_constructor_unstable!(
                 icu_properties::CodePointMapData::<BidiClass>::try_new_unstable,
                 provider,
             )?))
@@ -181,7 +181,7 @@ pub mod ffi {
         pub fn create_east_asian_width_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointMapData8>, DataError> {
-            Ok(convert_8(call_constructor_unstable2!(
+            Ok(convert_8(call_constructor_unstable!(
                 icu_properties::CodePointMapData::<EastAsianWidth>::try_new_unstable,
                 provider,
             )?))
@@ -201,7 +201,7 @@ pub mod ffi {
         pub fn create_hangul_syllable_type_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointMapData8>, DataError> {
-            Ok(convert_8(call_constructor_unstable2!(
+            Ok(convert_8(call_constructor_unstable!(
                 icu_properties::CodePointMapData::<HangulSyllableType>::try_new_unstable,
                 provider,
             )?))
@@ -221,7 +221,7 @@ pub mod ffi {
         pub fn create_indic_syllabic_category_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointMapData8>, DataError> {
-            Ok(convert_8(call_constructor_unstable2!(
+            Ok(convert_8(call_constructor_unstable!(
                 icu_properties::CodePointMapData::<IndicSyllabicCategory>::try_new_unstable,
                 provider,
             )?))
@@ -239,7 +239,7 @@ pub mod ffi {
         pub fn create_line_break_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointMapData8>, DataError> {
-            Ok(convert_8(call_constructor_unstable2!(
+            Ok(convert_8(call_constructor_unstable!(
                 icu_properties::CodePointMapData::<LineBreak>::try_new_unstable,
                 provider,
             )?))
@@ -259,7 +259,7 @@ pub mod ffi {
         pub fn create_grapheme_cluster_break_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointMapData8>, DataError> {
-            Ok(convert_8(call_constructor_unstable2!(
+            Ok(convert_8(call_constructor_unstable!(
                 icu_properties::CodePointMapData::<GraphemeClusterBreak>::try_new_unstable,
                 provider,
             )?))
@@ -277,7 +277,7 @@ pub mod ffi {
         pub fn create_word_break_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointMapData8>, DataError> {
-            Ok(convert_8(call_constructor_unstable2!(
+            Ok(convert_8(call_constructor_unstable!(
                 icu_properties::CodePointMapData::<WordBreak>::try_new_unstable,
                 provider,
             )?))
@@ -295,7 +295,7 @@ pub mod ffi {
         pub fn create_sentence_break_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointMapData8>, DataError> {
-            Ok(convert_8(call_constructor_unstable2!(
+            Ok(convert_8(call_constructor_unstable!(
                 icu_properties::CodePointMapData::<SentenceBreak>::try_new_unstable,
                 provider,
             )?))
@@ -314,7 +314,7 @@ pub mod ffi {
         pub fn create_joining_type_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointMapData8>, DataError> {
-            Ok(convert_8(call_constructor_unstable2!(
+            Ok(convert_8(call_constructor_unstable!(
                 icu_properties::CodePointMapData::<JoiningType>::try_new_unstable,
                 provider,
             )?))
@@ -335,7 +335,7 @@ pub mod ffi {
         pub fn create_canonical_combining_class_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointMapData8>, DataError> {
-            Ok(convert_8(call_constructor_unstable2!(
+            Ok(convert_8(call_constructor_unstable!(
                 icu_properties::CodePointMapData::<CanonicalCombiningClass>::try_new_unstable,
                 provider,
             )?))
@@ -420,7 +420,7 @@ pub mod ffi {
         ) -> Result<Box<CodePointMapData16>, DataError> {
             #[allow(clippy::unwrap_used)] // script is a 16-bit property
             Ok(Box::new(CodePointMapData16(
-                call_constructor_unstable2!(
+                call_constructor_unstable!(
                     icu_properties::CodePointMapData::<Script>::try_new_unstable,
                     provider,
                 )?

--- a/ffi/capi/src/properties_maps.rs
+++ b/ffi/capi/src/properties_maps.rs
@@ -7,16 +7,17 @@
 #[diplomat::attr(auto, namespace = "icu4x")]
 pub mod ffi {
     use alloc::boxed::Box;
+    #[cfg(any(feature = "compiled_data", feature = "buffer_provider"))]
     use icu_properties::props::{
         BidiClass, CanonicalCombiningClass, EastAsianWidth, GeneralCategory, GraphemeClusterBreak,
         HangulSyllableType, IndicSyllabicCategory, JoiningType, LineBreak, Script, SentenceBreak,
         WordBreak,
     };
 
-    use crate::errors::ffi::DataError;
     use crate::properties_iter::ffi::CodePointRangeIterator;
     use crate::properties_sets::ffi::CodePointSetData;
-    use crate::provider::ffi::DataProvider;
+    #[cfg(feature = "buffer_provider")]
+    use crate::{errors::ffi::DataError, provider::ffi::DataProvider};
 
     #[diplomat::opaque]
     /// An ICU4X Unicode Map Property object, capable of querying whether a code point (key) to obtain the Unicode property value, for a specific Unicode property.
@@ -34,6 +35,7 @@ pub mod ffi {
     )]
     pub struct CodePointMapData8(icu_properties::CodePointMapData<u8>);
 
+    #[cfg(any(feature = "compiled_data", feature = "buffer_provider"))]
     fn convert_8<P: icu_collections::codepointtrie::TrieValue>(
         data: icu_properties::CodePointMapData<P>,
     ) -> Box<CodePointMapData8> {
@@ -139,6 +141,7 @@ pub mod ffi {
         /// Create a map for the `General_Category` property, using a particular data source
         #[diplomat::rust_link(icu::properties::props::GeneralCategory, Enum)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "general_category_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_general_category_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointMapData8>, DataError> {
@@ -159,6 +162,7 @@ pub mod ffi {
         /// Create a map for the `Bidi_Class` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::BidiClass, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "bidi_class_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_bidi_class_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointMapData8>, DataError> {
@@ -178,6 +182,7 @@ pub mod ffi {
         /// Create a map for the `East_Asian_Width` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::EastAsianWidth, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "east_asian_width_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_east_asian_width_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointMapData8>, DataError> {
@@ -198,6 +203,7 @@ pub mod ffi {
         /// Create a map for the `Hangul_Syllable_Type` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::HangulSyllableType, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "hangul_syllable_type_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_hangul_syllable_type_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointMapData8>, DataError> {
@@ -218,6 +224,7 @@ pub mod ffi {
         /// Create a map for the `Indic_Syllabic_Property` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::IndicSyllabicCategory, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "indic_syllabic_category_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_indic_syllabic_category_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointMapData8>, DataError> {
@@ -236,6 +243,7 @@ pub mod ffi {
         /// Create a map for the `Line_Break` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::LineBreak, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "line_break_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_line_break_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointMapData8>, DataError> {
@@ -256,6 +264,7 @@ pub mod ffi {
         /// Create a map for the `Grapheme_Cluster_Break` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::GraphemeClusterBreak, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "grapheme_cluster_break_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_grapheme_cluster_break_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointMapData8>, DataError> {
@@ -274,6 +283,7 @@ pub mod ffi {
         /// Create a map for the `Word_Break` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::WordBreak, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "word_break_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_word_break_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointMapData8>, DataError> {
@@ -292,6 +302,7 @@ pub mod ffi {
         /// Create a map for the `Sentence_Break` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::SentenceBreak, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "sentence_break_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_sentence_break_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointMapData8>, DataError> {
@@ -311,6 +322,7 @@ pub mod ffi {
         /// Create a map for the `Joining_Type` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::JoiningType, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "joining_type_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_joining_type_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointMapData8>, DataError> {
@@ -332,6 +344,7 @@ pub mod ffi {
         /// Create a map for the `Canonical_Combining_Class` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::CanonicalCombiningClass, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "canonical_combining_class_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_canonical_combining_class_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointMapData8>, DataError> {
@@ -415,6 +428,7 @@ pub mod ffi {
         /// Create a map for the `Script` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::Script, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "script_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_script_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointMapData16>, DataError> {

--- a/ffi/capi/src/properties_names.rs
+++ b/ffi/capi/src/properties_names.rs
@@ -77,8 +77,7 @@ pub mod ffi {
             provider: &DataProvider,
         ) -> Result<Box<PropertyValueNameToEnumMapper>, DataError> {
             Ok(Box::new(PropertyValueNameToEnumMapper(
-                call_constructor_unstable!(
-                    icu_properties::PropertyParser::<icu_properties::props::GeneralCategory>::new [r => Ok(r.static_to_owned())],
+                call_constructor_unstable2!(
                     icu_properties::PropertyParser::<icu_properties::props::GeneralCategory>::try_new_unstable,
                     provider,
                 )?
@@ -103,11 +102,12 @@ pub mod ffi {
             provider: &DataProvider,
         ) -> Result<Box<PropertyValueNameToEnumMapper>, DataError> {
             Ok(Box::new(PropertyValueNameToEnumMapper(
-                call_constructor_unstable!(
-                    icu_properties::PropertyParser::<icu_properties::props::HangulSyllableType>::new [r => Ok(r.static_to_owned())],
-                    icu_properties::PropertyParser::<icu_properties::props::HangulSyllableType>::try_new_unstable,
-                    provider,
-                )?
+                call_constructor_unstable2!(
+                            icu_properties::PropertyParser::<
+                                icu_properties::props::HangulSyllableType,
+                            >::try_new_unstable,
+                            provider,
+                        )?
                 .erase(),
             )))
         }
@@ -129,8 +129,7 @@ pub mod ffi {
             provider: &DataProvider,
         ) -> Result<Box<PropertyValueNameToEnumMapper>, DataError> {
             Ok(Box::new(PropertyValueNameToEnumMapper(
-                call_constructor_unstable!(
-                    icu_properties::PropertyParser::<icu_properties::props::EastAsianWidth>::new [r => Ok(r.static_to_owned())],
+                call_constructor_unstable2!(
                     icu_properties::PropertyParser::<icu_properties::props::EastAsianWidth>::try_new_unstable,
                     provider,
                 )?
@@ -155,8 +154,7 @@ pub mod ffi {
             provider: &DataProvider,
         ) -> Result<Box<PropertyValueNameToEnumMapper>, DataError> {
             Ok(Box::new(PropertyValueNameToEnumMapper(
-                call_constructor_unstable!(
-                    icu_properties::PropertyParser::<icu_properties::props::BidiClass>::new [r => Ok(r.static_to_owned())],
+                call_constructor_unstable2!(
                     icu_properties::PropertyParser::<icu_properties::props::BidiClass>::try_new_unstable,
                     provider,
                 )?
@@ -177,11 +175,12 @@ pub mod ffi {
             provider: &DataProvider,
         ) -> Result<Box<PropertyValueNameToEnumMapper>, DataError> {
             Ok(Box::new(PropertyValueNameToEnumMapper(
-                call_constructor_unstable!(
-                    icu_properties::PropertyParser::<icu_properties::props::IndicSyllabicCategory>::new [r => Ok(r.static_to_owned())],
-                    icu_properties::PropertyParser::<icu_properties::props::IndicSyllabicCategory>::try_new_unstable,
-                    provider,
-                )?
+                call_constructor_unstable2!(
+                        icu_properties::PropertyParser::<
+                            icu_properties::props::IndicSyllabicCategory,
+                        >::try_new_unstable,
+                        provider,
+                    )?
                 .erase(),
             )))
         }
@@ -203,8 +202,7 @@ pub mod ffi {
             provider: &DataProvider,
         ) -> Result<Box<PropertyValueNameToEnumMapper>, DataError> {
             Ok(Box::new(PropertyValueNameToEnumMapper(
-                call_constructor_unstable!(
-                    icu_properties::PropertyParser::<icu_properties::props::LineBreak>::new [r => Ok(r.static_to_owned())],
+                call_constructor_unstable2!(
                     icu_properties::PropertyParser::<icu_properties::props::LineBreak>::try_new_unstable,
                     provider,
                 )?
@@ -230,11 +228,12 @@ pub mod ffi {
             provider: &DataProvider,
         ) -> Result<Box<PropertyValueNameToEnumMapper>, DataError> {
             Ok(Box::new(PropertyValueNameToEnumMapper(
-                call_constructor_unstable!(
-                    icu_properties::PropertyParser::<icu_properties::props::GraphemeClusterBreak>::new [r => Ok(r.static_to_owned())],
-                    icu_properties::PropertyParser::<icu_properties::props::GraphemeClusterBreak>::try_new_unstable,
-                    provider,
-                )?
+                call_constructor_unstable2!(
+                            icu_properties::PropertyParser::<
+                                icu_properties::props::GraphemeClusterBreak,
+                            >::try_new_unstable,
+                            provider,
+                        )?
                 .erase(),
             )))
         }
@@ -256,8 +255,7 @@ pub mod ffi {
             provider: &DataProvider,
         ) -> Result<Box<PropertyValueNameToEnumMapper>, DataError> {
             Ok(Box::new(PropertyValueNameToEnumMapper(
-                call_constructor_unstable!(
-                    icu_properties::PropertyParser::<icu_properties::props::WordBreak>::new [r => Ok(r.static_to_owned())],
+                call_constructor_unstable2!(
                     icu_properties::PropertyParser::<icu_properties::props::WordBreak>::try_new_unstable,
                     provider,
                 )?
@@ -282,8 +280,7 @@ pub mod ffi {
             provider: &DataProvider,
         ) -> Result<Box<PropertyValueNameToEnumMapper>, DataError> {
             Ok(Box::new(PropertyValueNameToEnumMapper(
-                call_constructor_unstable!(
-                    icu_properties::PropertyParser::<icu_properties::props::SentenceBreak>::new [r => Ok(r.static_to_owned())],
+                call_constructor_unstable2!(
                     icu_properties::PropertyParser::<icu_properties::props::SentenceBreak>::try_new_unstable,
                     provider,
                 )?
@@ -308,8 +305,7 @@ pub mod ffi {
             provider: &DataProvider,
         ) -> Result<Box<PropertyValueNameToEnumMapper>, DataError> {
             Ok(Box::new(PropertyValueNameToEnumMapper(
-                call_constructor_unstable!(
-                    icu_properties::PropertyParser::<icu_properties::props::Script>::new [r => Ok(r.static_to_owned())],
+                call_constructor_unstable2!(
                     icu_properties::PropertyParser::<icu_properties::props::Script>::try_new_unstable,
                     provider,
                 )?
@@ -382,11 +378,12 @@ pub mod ffi {
             provider: &DataProvider,
         ) -> Result<Box<GeneralCategoryNameToMaskMapper>, DataError> {
             Ok(Box::new(GeneralCategoryNameToMaskMapper(
-                call_constructor_unstable!(
-                    icu_properties::PropertyParser::<icu_properties::props::GeneralCategoryGroup>::new [r => Ok(r.static_to_owned())],
-                    icu_properties::PropertyParser::<icu_properties::props::GeneralCategoryGroup>::try_new_unstable,
-                    provider,
-                )?,
+                call_constructor_unstable2!(
+                            icu_properties::PropertyParser::<
+                                icu_properties::props::GeneralCategoryGroup,
+                            >::try_new_unstable,
+                            provider,
+                        )?,
             )))
         }
     }

--- a/ffi/capi/src/properties_names.rs
+++ b/ffi/capi/src/properties_names.rs
@@ -77,7 +77,7 @@ pub mod ffi {
             provider: &DataProvider,
         ) -> Result<Box<PropertyValueNameToEnumMapper>, DataError> {
             Ok(Box::new(PropertyValueNameToEnumMapper(
-                call_constructor_unstable2!(
+                call_constructor_unstable!(
                     icu_properties::PropertyParser::<icu_properties::props::GeneralCategory>::try_new_unstable,
                     provider,
                 )?
@@ -102,7 +102,7 @@ pub mod ffi {
             provider: &DataProvider,
         ) -> Result<Box<PropertyValueNameToEnumMapper>, DataError> {
             Ok(Box::new(PropertyValueNameToEnumMapper(
-                call_constructor_unstable2!(
+                call_constructor_unstable!(
                             icu_properties::PropertyParser::<
                                 icu_properties::props::HangulSyllableType,
                             >::try_new_unstable,
@@ -129,7 +129,7 @@ pub mod ffi {
             provider: &DataProvider,
         ) -> Result<Box<PropertyValueNameToEnumMapper>, DataError> {
             Ok(Box::new(PropertyValueNameToEnumMapper(
-                call_constructor_unstable2!(
+                call_constructor_unstable!(
                     icu_properties::PropertyParser::<icu_properties::props::EastAsianWidth>::try_new_unstable,
                     provider,
                 )?
@@ -154,7 +154,7 @@ pub mod ffi {
             provider: &DataProvider,
         ) -> Result<Box<PropertyValueNameToEnumMapper>, DataError> {
             Ok(Box::new(PropertyValueNameToEnumMapper(
-                call_constructor_unstable2!(
+                call_constructor_unstable!(
                     icu_properties::PropertyParser::<icu_properties::props::BidiClass>::try_new_unstable,
                     provider,
                 )?
@@ -175,7 +175,7 @@ pub mod ffi {
             provider: &DataProvider,
         ) -> Result<Box<PropertyValueNameToEnumMapper>, DataError> {
             Ok(Box::new(PropertyValueNameToEnumMapper(
-                call_constructor_unstable2!(
+                call_constructor_unstable!(
                         icu_properties::PropertyParser::<
                             icu_properties::props::IndicSyllabicCategory,
                         >::try_new_unstable,
@@ -202,7 +202,7 @@ pub mod ffi {
             provider: &DataProvider,
         ) -> Result<Box<PropertyValueNameToEnumMapper>, DataError> {
             Ok(Box::new(PropertyValueNameToEnumMapper(
-                call_constructor_unstable2!(
+                call_constructor_unstable!(
                     icu_properties::PropertyParser::<icu_properties::props::LineBreak>::try_new_unstable,
                     provider,
                 )?
@@ -228,7 +228,7 @@ pub mod ffi {
             provider: &DataProvider,
         ) -> Result<Box<PropertyValueNameToEnumMapper>, DataError> {
             Ok(Box::new(PropertyValueNameToEnumMapper(
-                call_constructor_unstable2!(
+                call_constructor_unstable!(
                             icu_properties::PropertyParser::<
                                 icu_properties::props::GraphemeClusterBreak,
                             >::try_new_unstable,
@@ -255,7 +255,7 @@ pub mod ffi {
             provider: &DataProvider,
         ) -> Result<Box<PropertyValueNameToEnumMapper>, DataError> {
             Ok(Box::new(PropertyValueNameToEnumMapper(
-                call_constructor_unstable2!(
+                call_constructor_unstable!(
                     icu_properties::PropertyParser::<icu_properties::props::WordBreak>::try_new_unstable,
                     provider,
                 )?
@@ -280,7 +280,7 @@ pub mod ffi {
             provider: &DataProvider,
         ) -> Result<Box<PropertyValueNameToEnumMapper>, DataError> {
             Ok(Box::new(PropertyValueNameToEnumMapper(
-                call_constructor_unstable2!(
+                call_constructor_unstable!(
                     icu_properties::PropertyParser::<icu_properties::props::SentenceBreak>::try_new_unstable,
                     provider,
                 )?
@@ -305,7 +305,7 @@ pub mod ffi {
             provider: &DataProvider,
         ) -> Result<Box<PropertyValueNameToEnumMapper>, DataError> {
             Ok(Box::new(PropertyValueNameToEnumMapper(
-                call_constructor_unstable2!(
+                call_constructor_unstable!(
                     icu_properties::PropertyParser::<icu_properties::props::Script>::try_new_unstable,
                     provider,
                 )?
@@ -378,7 +378,7 @@ pub mod ffi {
             provider: &DataProvider,
         ) -> Result<Box<GeneralCategoryNameToMaskMapper>, DataError> {
             Ok(Box::new(GeneralCategoryNameToMaskMapper(
-                call_constructor_unstable2!(
+                call_constructor_unstable!(
                             icu_properties::PropertyParser::<
                                 icu_properties::props::GeneralCategoryGroup,
                             >::try_new_unstable,

--- a/ffi/capi/src/properties_names.rs
+++ b/ffi/capi/src/properties_names.rs
@@ -8,8 +8,8 @@
 pub mod ffi {
     use alloc::boxed::Box;
 
-    use crate::errors::ffi::DataError;
-    use crate::provider::ffi::DataProvider;
+    #[cfg(feature = "buffer_provider")]
+    use crate::{errors::ffi::DataError, provider::ffi::DataProvider};
 
     /// A type capable of looking up a property value from a string name.
     #[diplomat::opaque]
@@ -73,6 +73,7 @@ pub mod ffi {
         /// Create a name-to-enum mapper for the `General_Category` property, using a particular data source.
         #[diplomat::rust_link(icu_properties::props::GeneralCategory, Enum)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "general_category_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_general_category_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<PropertyValueNameToEnumMapper>, DataError> {
@@ -98,6 +99,7 @@ pub mod ffi {
         /// Create a name-to-enum mapper for the `Hangul_Syllable_Type` property, using a particular data source.
         #[diplomat::rust_link(icu_properties::props::HangulSyllableType, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "hangul_syllable_type_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_hangul_syllable_type_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<PropertyValueNameToEnumMapper>, DataError> {
@@ -125,6 +127,7 @@ pub mod ffi {
         /// Create a name-to-enum mapper for the `East_Asian_Width` property, using a particular data source.
         #[diplomat::rust_link(icu_properties::props::EastAsianWidth, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "east_asian_width_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_east_asian_width_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<PropertyValueNameToEnumMapper>, DataError> {
@@ -150,6 +153,7 @@ pub mod ffi {
         /// Create a name-to-enum mapper for the `Bidi_Class` property, using a particular data source.
         #[diplomat::rust_link(icu_properties::props::BidiClass, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "bidi_class_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_bidi_class_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<PropertyValueNameToEnumMapper>, DataError> {
@@ -171,6 +175,7 @@ pub mod ffi {
         /// Create a name-to-enum mapper for the `Indic_Syllabic_Category` property, using a particular data source.
         #[diplomat::rust_link(icu_properties::props::IndicSyllabicCategory, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "indic_syllabic_category_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_indic_syllabic_category_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<PropertyValueNameToEnumMapper>, DataError> {
@@ -198,6 +203,7 @@ pub mod ffi {
         /// Create a name-to-enum mapper for the `Line_Break` property, using a particular data source.
         #[diplomat::rust_link(icu_properties::props::LineBreak, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "line_break_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_line_break_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<PropertyValueNameToEnumMapper>, DataError> {
@@ -224,6 +230,7 @@ pub mod ffi {
         /// Create a name-to-enum mapper for the `Grapheme_Cluster_Break` property, using a particular data source.
         #[diplomat::rust_link(icu_properties::props::GraphemeClusterBreak, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "grapheme_cluster_break_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_grapheme_cluster_break_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<PropertyValueNameToEnumMapper>, DataError> {
@@ -251,6 +258,7 @@ pub mod ffi {
         /// Create a name-to-enum mapper for the `Word_Break` property, using a particular data source.
         #[diplomat::rust_link(icu_properties::props::WordBreak, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "word_break_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_word_break_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<PropertyValueNameToEnumMapper>, DataError> {
@@ -276,6 +284,7 @@ pub mod ffi {
         /// Create a name-to-enum mapper for the `Sentence_Break` property, using a particular data source.
         #[diplomat::rust_link(icu_properties::props::SentenceBreak, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "sentence_break_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_sentence_break_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<PropertyValueNameToEnumMapper>, DataError> {
@@ -301,6 +310,7 @@ pub mod ffi {
         /// Create a name-to-enum mapper for the `Script` property, using a particular data source.
         #[diplomat::rust_link(icu_properties::props::Script, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "script_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_script_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<PropertyValueNameToEnumMapper>, DataError> {
@@ -374,6 +384,7 @@ pub mod ffi {
         /// Create a name-to-mask mapper for the `General_Category` property, using a particular data source.
         #[diplomat::rust_link(icu_properties::props::GeneralCategoryGroup, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<GeneralCategoryNameToMaskMapper>, DataError> {

--- a/ffi/capi/src/properties_sets.rs
+++ b/ffi/capi/src/properties_sets.rs
@@ -96,8 +96,7 @@ pub mod ffi {
             group: u32,
         ) -> Result<Box<CodePointSetData>, DataError> {
             Ok(Box::new(CodePointSetData(
-                call_constructor_unstable!(
-                    icu_properties::CodePointMapData::<GeneralCategory>::new [r => Ok(r.static_to_owned())],
+                call_constructor_unstable2!(
                     icu_properties::CodePointMapData::<GeneralCategory>::try_new_unstable,
                     provider,
                 )?
@@ -122,8 +121,7 @@ pub mod ffi {
         pub fn create_ascii_hex_digit_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<AsciiHexDigit> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<AsciiHexDigit>,
                 provider
             )?)))
@@ -145,8 +143,7 @@ pub mod ffi {
         pub fn create_alnum_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<Alnum> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<Alnum>,
                 provider
             )?)))
@@ -168,8 +165,7 @@ pub mod ffi {
         pub fn create_alphabetic_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<Alphabetic> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<Alphabetic>,
                 provider
             )?)))
@@ -191,8 +187,7 @@ pub mod ffi {
         pub fn create_bidi_control_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<BidiControl> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<BidiControl>,
                 provider
             )?)))
@@ -214,8 +209,7 @@ pub mod ffi {
         pub fn create_bidi_mirrored_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<BidiMirrored> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<BidiMirrored>,
                 provider
             )?)))
@@ -237,8 +231,7 @@ pub mod ffi {
         pub fn create_blank_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<Blank> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<Blank>,
                 provider
             )?)))
@@ -260,8 +253,7 @@ pub mod ffi {
         pub fn create_cased_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<Cased> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<Cased>,
                 provider
             )?)))
@@ -283,8 +275,7 @@ pub mod ffi {
         pub fn create_case_ignorable_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<CaseIgnorable> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<CaseIgnorable>,
                 provider
             )?)))
@@ -307,8 +298,7 @@ pub mod ffi {
         pub fn create_full_composition_exclusion_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<FullCompositionExclusion> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<FullCompositionExclusion>,
                 provider
             )?)))
@@ -330,8 +320,7 @@ pub mod ffi {
         pub fn create_changes_when_casefolded_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<ChangesWhenCasefolded> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<ChangesWhenCasefolded>,
                 provider
             )?)))
@@ -353,8 +342,7 @@ pub mod ffi {
         pub fn create_changes_when_casemapped_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<ChangesWhenCasemapped> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<ChangesWhenCasemapped>,
                 provider
             )?)))
@@ -377,8 +365,7 @@ pub mod ffi {
         pub fn create_changes_when_nfkc_casefolded_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<ChangesWhenNfkcCasefolded> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<ChangesWhenNfkcCasefolded>,
                 provider
             )?)))
@@ -400,8 +387,7 @@ pub mod ffi {
         pub fn create_changes_when_lowercased_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<ChangesWhenLowercased> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<ChangesWhenLowercased>,
                 provider
             )?)))
@@ -423,8 +409,7 @@ pub mod ffi {
         pub fn create_changes_when_titlecased_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<ChangesWhenTitlecased> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<ChangesWhenTitlecased>,
                 provider
             )?)))
@@ -446,8 +431,7 @@ pub mod ffi {
         pub fn create_changes_when_uppercased_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<ChangesWhenUppercased> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<ChangesWhenUppercased>,
                 provider
             )?)))
@@ -469,8 +453,7 @@ pub mod ffi {
         pub fn create_dash_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<Dash> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<Dash>,
                 provider
             )?)))
@@ -492,8 +475,7 @@ pub mod ffi {
         pub fn create_deprecated_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<Deprecated> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<Deprecated>,
                 provider
             )?)))
@@ -516,8 +498,7 @@ pub mod ffi {
         pub fn create_default_ignorable_code_point_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<DefaultIgnorableCodePoint> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<DefaultIgnorableCodePoint>,
                 provider
             )?)))
@@ -539,8 +520,7 @@ pub mod ffi {
         pub fn create_diacritic_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<Diacritic> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<Diacritic>,
                 provider
             )?)))
@@ -562,8 +542,7 @@ pub mod ffi {
         pub fn create_emoji_modifier_base_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<EmojiModifierBase> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<EmojiModifierBase>,
                 provider
             )?)))
@@ -585,8 +564,7 @@ pub mod ffi {
         pub fn create_emoji_component_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<EmojiComponent> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<EmojiComponent>,
                 provider
             )?)))
@@ -608,8 +586,7 @@ pub mod ffi {
         pub fn create_emoji_modifier_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<EmojiModifier> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<EmojiModifier>,
                 provider
             )?)))
@@ -631,8 +608,7 @@ pub mod ffi {
         pub fn create_emoji_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<Emoji> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<Emoji>,
                 provider
             )?)))
@@ -654,8 +630,7 @@ pub mod ffi {
         pub fn create_emoji_presentation_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<EmojiPresentation> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<EmojiPresentation>,
                 provider
             )?)))
@@ -677,8 +652,7 @@ pub mod ffi {
         pub fn create_extender_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<Extender> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<Extender>,
                 provider
             )?)))
@@ -700,8 +674,7 @@ pub mod ffi {
         pub fn create_extended_pictographic_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<ExtendedPictographic> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<ExtendedPictographic>,
                 provider
             )?)))
@@ -723,8 +696,7 @@ pub mod ffi {
         pub fn create_graph_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<Graph> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<Graph>,
                 provider
             )?)))
@@ -746,8 +718,7 @@ pub mod ffi {
         pub fn create_grapheme_base_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<GraphemeBase> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<GraphemeBase>,
                 provider
             )?)))
@@ -769,8 +740,7 @@ pub mod ffi {
         pub fn create_grapheme_extend_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<GraphemeExtend> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<GraphemeExtend>,
                 provider
             )?)))
@@ -792,8 +762,7 @@ pub mod ffi {
         pub fn create_grapheme_link_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<GraphemeLink> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<GraphemeLink>,
                 provider
             )?)))
@@ -815,8 +784,7 @@ pub mod ffi {
         pub fn create_hex_digit_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<HexDigit> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<HexDigit>,
                 provider
             )?)))
@@ -838,8 +806,7 @@ pub mod ffi {
         pub fn create_hyphen_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<Hyphen> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<Hyphen>,
                 provider
             )?)))
@@ -861,8 +828,7 @@ pub mod ffi {
         pub fn create_id_continue_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<IdContinue> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<IdContinue>,
                 provider
             )?)))
@@ -884,8 +850,7 @@ pub mod ffi {
         pub fn create_ideographic_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<Ideographic> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<Ideographic>,
                 provider
             )?)))
@@ -907,8 +872,7 @@ pub mod ffi {
         pub fn create_id_start_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<IdStart> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<IdStart>,
                 provider
             )?)))
@@ -930,8 +894,7 @@ pub mod ffi {
         pub fn create_ids_binary_operator_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<IdsBinaryOperator> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<IdsBinaryOperator>,
                 provider
             )?)))
@@ -953,8 +916,7 @@ pub mod ffi {
         pub fn create_ids_trinary_operator_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<IdsTrinaryOperator> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<IdsTrinaryOperator>,
                 provider
             )?)))
@@ -976,8 +938,7 @@ pub mod ffi {
         pub fn create_join_control_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<JoinControl> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<JoinControl>,
                 provider
             )?)))
@@ -999,8 +960,7 @@ pub mod ffi {
         pub fn create_logical_order_exception_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<LogicalOrderException> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<LogicalOrderException>,
                 provider
             )?)))
@@ -1022,8 +982,7 @@ pub mod ffi {
         pub fn create_lowercase_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<Lowercase> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<Lowercase>,
                 provider
             )?)))
@@ -1045,8 +1004,7 @@ pub mod ffi {
         pub fn create_math_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<Math> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<Math>,
                 provider
             )?)))
@@ -1068,8 +1026,7 @@ pub mod ffi {
         pub fn create_noncharacter_code_point_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<NoncharacterCodePoint> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<NoncharacterCodePoint>,
                 provider
             )?)))
@@ -1091,8 +1048,7 @@ pub mod ffi {
         pub fn create_nfc_inert_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<NfcInert> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<NfcInert>,
                 provider
             )?)))
@@ -1114,8 +1070,7 @@ pub mod ffi {
         pub fn create_nfd_inert_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<NfdInert> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<NfdInert>,
                 provider
             )?)))
@@ -1137,8 +1092,7 @@ pub mod ffi {
         pub fn create_nfkc_inert_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<NfkcInert> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<NfkcInert>,
                 provider
             )?)))
@@ -1160,8 +1114,7 @@ pub mod ffi {
         pub fn create_nfkd_inert_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<NfkdInert> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<NfkdInert>,
                 provider
             )?)))
@@ -1183,8 +1136,7 @@ pub mod ffi {
         pub fn create_pattern_syntax_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<PatternSyntax> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<PatternSyntax>,
                 provider
             )?)))
@@ -1206,8 +1158,7 @@ pub mod ffi {
         pub fn create_pattern_white_space_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<PatternWhiteSpace> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<PatternWhiteSpace>,
                 provider
             )?)))
@@ -1230,8 +1181,7 @@ pub mod ffi {
         pub fn create_prepended_concatenation_mark_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<PrependedConcatenationMark> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<PrependedConcatenationMark>,
                 provider
             )?)))
@@ -1253,8 +1203,7 @@ pub mod ffi {
         pub fn create_print_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<Print> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<Print>,
                 provider
             )?)))
@@ -1276,8 +1225,7 @@ pub mod ffi {
         pub fn create_quotation_mark_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<QuotationMark> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<QuotationMark>,
                 provider
             )?)))
@@ -1299,8 +1247,7 @@ pub mod ffi {
         pub fn create_radical_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<Radical> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<Radical>,
                 provider
             )?)))
@@ -1322,8 +1269,7 @@ pub mod ffi {
         pub fn create_regional_indicator_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<RegionalIndicator> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<RegionalIndicator>,
                 provider
             )?)))
@@ -1345,8 +1291,7 @@ pub mod ffi {
         pub fn create_soft_dotted_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<SoftDotted> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<SoftDotted>,
                 provider
             )?)))
@@ -1368,8 +1313,7 @@ pub mod ffi {
         pub fn create_segment_starter_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<SegmentStarter> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<SegmentStarter>,
                 provider
             )?)))
@@ -1391,8 +1335,7 @@ pub mod ffi {
         pub fn create_case_sensitive_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<CaseSensitive> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<CaseSensitive>,
                 provider
             )?)))
@@ -1414,8 +1357,7 @@ pub mod ffi {
         pub fn create_sentence_terminal_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<SentenceTerminal> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<SentenceTerminal>,
                 provider
             )?)))
@@ -1437,8 +1379,7 @@ pub mod ffi {
         pub fn create_terminal_punctuation_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<TerminalPunctuation> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<TerminalPunctuation>,
                 provider
             )?)))
@@ -1460,8 +1401,7 @@ pub mod ffi {
         pub fn create_unified_ideograph_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<UnifiedIdeograph> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<UnifiedIdeograph>,
                 provider
             )?)))
@@ -1483,8 +1423,7 @@ pub mod ffi {
         pub fn create_uppercase_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<Uppercase> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<Uppercase>,
                 provider
             )?)))
@@ -1506,8 +1445,7 @@ pub mod ffi {
         pub fn create_variation_selector_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<VariationSelector> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<VariationSelector>,
                 provider
             )?)))
@@ -1529,8 +1467,7 @@ pub mod ffi {
         pub fn create_white_space_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<WhiteSpace> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<WhiteSpace>,
                 provider
             )?)))
@@ -1552,8 +1489,7 @@ pub mod ffi {
         pub fn create_xdigit_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<Xdigit> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<Xdigit>,
                 provider
             )?)))
@@ -1575,8 +1511,7 @@ pub mod ffi {
         pub fn create_xid_continue_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<XidContinue> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<XidContinue>,
                 provider
             )?)))
@@ -1598,8 +1533,7 @@ pub mod ffi {
         pub fn create_xid_start_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new::<XidStart> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
                 icu_properties::CodePointSetData::try_new_unstable::<XidStart>,
                 provider
             )?)))
@@ -1625,12 +1559,14 @@ pub mod ffi {
             provider: &DataProvider,
             property_name: &DiplomatStr,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
-                icu_properties::CodePointSetData::new_for_ecma262 [r => r.map(|d| Ok(d.static_to_owned()))],
-                icu_properties::CodePointSetData::try_new_for_ecma262_unstable,
-                provider,
-                property_name
-            ).ok_or(DataError::Custom)??)))
+            Ok(Box::new(CodePointSetData(
+                call_constructor_unstable2!(
+                    icu_properties::CodePointSetData::try_new_for_ecma262_unstable,
+                    provider,
+                    property_name
+                )
+                .ok_or(DataError::Custom)??,
+            )))
         }
     }
 }

--- a/ffi/capi/src/properties_sets.rs
+++ b/ffi/capi/src/properties_sets.rs
@@ -7,7 +7,9 @@
 #[diplomat::attr(auto, namespace = "icu4x")]
 pub mod ffi {
     use alloc::boxed::Box;
+    #[cfg(any(feature = "compiled_data", feature = "buffer_provider"))]
     use icu_properties::props::GeneralCategory;
+    #[cfg(any(feature = "compiled_data", feature = "buffer_provider"))]
     use icu_properties::props::{
         Alnum, Alphabetic, AsciiHexDigit, BidiControl, BidiMirrored, Blank, CaseIgnorable,
         CaseSensitive, Cased, ChangesWhenCasefolded, ChangesWhenCasemapped, ChangesWhenLowercased,
@@ -23,8 +25,10 @@ pub mod ffi {
         Uppercase, VariationSelector, WhiteSpace, Xdigit, XidContinue, XidStart,
     };
 
+    #[cfg(any(feature = "compiled_data", feature = "buffer_provider"))]
     use crate::errors::ffi::DataError;
     use crate::properties_iter::ffi::CodePointRangeIterator;
+    #[cfg(feature = "buffer_provider")]
     use crate::provider::ffi::DataProvider;
 
     #[diplomat::opaque]
@@ -91,6 +95,7 @@ pub mod ffi {
             FnInStruct
         )]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "general_category_group_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_general_category_group_with_provider(
             provider: &DataProvider,
             group: u32,
@@ -118,6 +123,7 @@ pub mod ffi {
         /// Create a set for the `Ascii_Hex_Digit` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::AsciiHexDigit, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "ascii_hex_digit_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_ascii_hex_digit_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -140,6 +146,7 @@ pub mod ffi {
         /// Create a set for the `Alnum` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::Alnum, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "alnum_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_alnum_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -162,6 +169,7 @@ pub mod ffi {
         /// Create a set for the `Alphabetic` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::Alphabetic, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "alphabetic_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_alphabetic_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -184,6 +192,7 @@ pub mod ffi {
         /// Create a set for the `Bidi_Control` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::BidiControl, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "bidi_control_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_bidi_control_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -206,6 +215,7 @@ pub mod ffi {
         /// Create a set for the `Bidi_Mirrored` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::BidiMirrored, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "bidi_mirrored_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_bidi_mirrored_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -228,6 +238,7 @@ pub mod ffi {
         /// Create a set for the `Blank` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::Blank, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "blank_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_blank_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -250,6 +261,7 @@ pub mod ffi {
         /// Create a set for the `Cased` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::Cased, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "cased_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_cased_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -272,6 +284,7 @@ pub mod ffi {
         /// Create a set for the `Case_Ignorable` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::CaseIgnorable, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "case_ignorable_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_case_ignorable_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -295,6 +308,7 @@ pub mod ffi {
         /// Create a set for the `Full_Composition_Exclusion` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::FullCompositionExclusion, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "full_composition_exclusion_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_full_composition_exclusion_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -317,6 +331,7 @@ pub mod ffi {
         /// Create a set for the `Changes_When_Casefolded` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::ChangesWhenCasefolded, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "changes_when_casefolded_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_changes_when_casefolded_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -339,6 +354,7 @@ pub mod ffi {
         /// Create a set for the `Changes_When_Casemapped` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::ChangesWhenCasemapped, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "changes_when_casemapped_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_changes_when_casemapped_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -362,6 +378,7 @@ pub mod ffi {
         /// Create a set for the `Changes_When_Nfkc_Casefolded` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::ChangesWhenNfkcCasefolded, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "changes_when_nfkc_casefolded_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_changes_when_nfkc_casefolded_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -384,6 +401,7 @@ pub mod ffi {
         /// Create a set for the `Changes_When_Lowercased` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::ChangesWhenLowercased, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "changes_when_lowercased_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_changes_when_lowercased_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -406,6 +424,7 @@ pub mod ffi {
         /// Create a set for the `Changes_When_Titlecased` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::ChangesWhenTitlecased, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "changes_when_titlecased_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_changes_when_titlecased_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -428,6 +447,7 @@ pub mod ffi {
         /// Create a set for the `Changes_When_Uppercased` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::ChangesWhenUppercased, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "changes_when_uppercased_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_changes_when_uppercased_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -450,6 +470,7 @@ pub mod ffi {
         /// Create a set for the `Dash` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::Dash, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "dash_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_dash_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -472,6 +493,7 @@ pub mod ffi {
         /// Create a set for the `Deprecated` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::Deprecated, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "deprecated_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_deprecated_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -495,6 +517,7 @@ pub mod ffi {
         /// Create a set for the `Default_Ignorable_Code_Point` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::DefaultIgnorableCodePoint, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "default_ignorable_code_point_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_default_ignorable_code_point_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -517,6 +540,7 @@ pub mod ffi {
         /// Create a set for the `Diacritic` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::Diacritic, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "diacritic_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_diacritic_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -539,6 +563,7 @@ pub mod ffi {
         /// Create a set for the `Emoji_Modifier_Base` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::EmojiModifierBase, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "emoji_modifier_base_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_emoji_modifier_base_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -561,6 +586,7 @@ pub mod ffi {
         /// Create a set for the `Emoji_Component` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::EmojiComponent, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "emoji_component_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_emoji_component_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -583,6 +609,7 @@ pub mod ffi {
         /// Create a set for the `Emoji_Modifier` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::EmojiModifier, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "emoji_modifier_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_emoji_modifier_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -605,6 +632,7 @@ pub mod ffi {
         /// Create a set for the `Emoji` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::Emoji, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "emoji_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_emoji_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -627,6 +655,7 @@ pub mod ffi {
         /// Create a set for the `Emoji_Presentation` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::EmojiPresentation, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "emoji_presentation_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_emoji_presentation_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -649,6 +678,7 @@ pub mod ffi {
         /// Create a set for the `Extender` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::Extender, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "extender_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_extender_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -671,6 +701,7 @@ pub mod ffi {
         /// Create a set for the `Extended_Pictographic` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::ExtendedPictographic, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "extended_pictographic_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_extended_pictographic_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -693,6 +724,7 @@ pub mod ffi {
         /// Create a set for the `Graph` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::Graph, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "graph_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_graph_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -715,6 +747,7 @@ pub mod ffi {
         /// Create a set for the `Grapheme_Base` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::GraphemeBase, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "grapheme_base_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_grapheme_base_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -737,6 +770,7 @@ pub mod ffi {
         /// Create a set for the `Grapheme_Extend` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::GraphemeExtend, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "grapheme_extend_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_grapheme_extend_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -759,6 +793,7 @@ pub mod ffi {
         /// Create a set for the `Grapheme_Link` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::GraphemeLink, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "grapheme_link_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_grapheme_link_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -781,6 +816,7 @@ pub mod ffi {
         /// Create a set for the `Hex_Digit` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::HexDigit, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "hex_digit_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_hex_digit_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -803,6 +839,7 @@ pub mod ffi {
         /// Create a set for the `Hyphen` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::Hyphen, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "hyphen_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_hyphen_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -825,6 +862,7 @@ pub mod ffi {
         /// Create a set for the `Id_Continue` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::IdContinue, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "id_continue_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_id_continue_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -847,6 +885,7 @@ pub mod ffi {
         /// Create a set for the `Ideographic` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::Ideographic, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "ideographic_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_ideographic_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -869,6 +908,7 @@ pub mod ffi {
         /// Create a set for the `Id_Start` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::IdStart, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "id_start_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_id_start_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -891,6 +931,7 @@ pub mod ffi {
         /// Create a set for the `Ids_Binary_Operator` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::IdsBinaryOperator, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "ids_binary_operator_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_ids_binary_operator_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -913,6 +954,7 @@ pub mod ffi {
         /// Create a set for the `Ids_Trinary_Operator` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::IdsTrinaryOperator, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "ids_trinary_operator_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_ids_trinary_operator_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -935,6 +977,7 @@ pub mod ffi {
         /// Create a set for the `Join_Control` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::JoinControl, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "join_control_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_join_control_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -957,6 +1000,7 @@ pub mod ffi {
         /// Create a set for the `Logical_Order_Exception` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::LogicalOrderException, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "logical_order_exception_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_logical_order_exception_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -979,6 +1023,7 @@ pub mod ffi {
         /// Create a set for the `Lowercase` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::Lowercase, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "lowercase_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_lowercase_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -1001,6 +1046,7 @@ pub mod ffi {
         /// Create a set for the `Math` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::Math, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "math_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_math_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -1023,6 +1069,7 @@ pub mod ffi {
         /// Create a set for the `Noncharacter_Code_Point` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::NoncharacterCodePoint, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "noncharacter_code_point_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_noncharacter_code_point_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -1045,6 +1092,7 @@ pub mod ffi {
         /// Create a set for the `Nfc_Inert` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::NfcInert, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "nfc_inert_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_nfc_inert_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -1067,6 +1115,7 @@ pub mod ffi {
         /// Create a set for the `Nfd_Inert` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::NfdInert, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "nfd_inert_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_nfd_inert_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -1089,6 +1138,7 @@ pub mod ffi {
         /// Create a set for the `Nfkc_Inert` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::NfkcInert, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "nfkc_inert_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_nfkc_inert_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -1111,6 +1161,7 @@ pub mod ffi {
         /// Create a set for the `Nfkd_Inert` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::NfkdInert, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "nfkd_inert_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_nfkd_inert_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -1133,6 +1184,7 @@ pub mod ffi {
         /// Create a set for the `Pattern_Syntax` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::PatternSyntax, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "pattern_syntax_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_pattern_syntax_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -1155,6 +1207,7 @@ pub mod ffi {
         /// Create a set for the `Pattern_White_Space` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::PatternWhiteSpace, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "pattern_white_space_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_pattern_white_space_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -1178,6 +1231,7 @@ pub mod ffi {
         /// Create a set for the `Prepended_Concatenation_Mark` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::PrependedConcatenationMark, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "prepended_concatenation_mark_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_prepended_concatenation_mark_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -1200,6 +1254,7 @@ pub mod ffi {
         /// Create a set for the `Print` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::Print, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "print_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_print_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -1222,6 +1277,7 @@ pub mod ffi {
         /// Create a set for the `Quotation_Mark` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::QuotationMark, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "quotation_mark_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_quotation_mark_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -1244,6 +1300,7 @@ pub mod ffi {
         /// Create a set for the `Radical` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::Radical, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "radical_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_radical_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -1266,6 +1323,7 @@ pub mod ffi {
         /// Create a set for the `Regional_Indicator` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::RegionalIndicator, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "regional_indicator_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_regional_indicator_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -1288,6 +1346,7 @@ pub mod ffi {
         /// Create a set for the `Soft_Dotted` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::SoftDotted, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "soft_dotted_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_soft_dotted_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -1310,6 +1369,7 @@ pub mod ffi {
         /// Create a set for the `Segment_Starter` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::SegmentStarter, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "segment_starter_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_segment_starter_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -1332,6 +1392,7 @@ pub mod ffi {
         /// Create a set for the `Case_Sensitive` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::CaseSensitive, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "case_sensitive_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_case_sensitive_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -1354,6 +1415,7 @@ pub mod ffi {
         /// Create a set for the `Sentence_Terminal` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::SentenceTerminal, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "sentence_terminal_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_sentence_terminal_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -1376,6 +1438,7 @@ pub mod ffi {
         /// Create a set for the `Terminal_Punctuation` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::TerminalPunctuation, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "terminal_punctuation_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_terminal_punctuation_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -1398,6 +1461,7 @@ pub mod ffi {
         /// Create a set for the `Unified_Ideograph` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::UnifiedIdeograph, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "unified_ideograph_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_unified_ideograph_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -1420,6 +1484,7 @@ pub mod ffi {
         /// Create a set for the `Uppercase` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::Uppercase, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "uppercase_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_uppercase_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -1442,6 +1507,7 @@ pub mod ffi {
         /// Create a set for the `Variation_Selector` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::VariationSelector, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "variation_selector_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_variation_selector_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -1464,6 +1530,7 @@ pub mod ffi {
         /// Create a set for the `White_Space` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::WhiteSpace, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "white_space_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_white_space_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -1486,6 +1553,7 @@ pub mod ffi {
         /// Create a set for the `Xdigit` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::Xdigit, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "xdigit_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_xdigit_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -1508,6 +1576,7 @@ pub mod ffi {
         /// Create a set for the `Xid_Continue` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::XidContinue, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "xid_continue_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_xid_continue_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -1530,6 +1599,7 @@ pub mod ffi {
         /// Create a set for the `Xid_Start` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::XidStart, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "xid_start_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_xid_start_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -1555,6 +1625,7 @@ pub mod ffi {
         /// [ecma]: https://tc39.es/ecma262/#table-binary-unicode-properties
         #[diplomat::rust_link(icu::properties::CodePointSetData::new_for_ecma262, FnInStruct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "for_ecma262_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_for_ecma262_with_provider(
             provider: &DataProvider,
             property_name: &DiplomatStr,

--- a/ffi/capi/src/properties_sets.rs
+++ b/ffi/capi/src/properties_sets.rs
@@ -96,7 +96,7 @@ pub mod ffi {
             group: u32,
         ) -> Result<Box<CodePointSetData>, DataError> {
             Ok(Box::new(CodePointSetData(
-                call_constructor_unstable2!(
+                call_constructor_unstable!(
                     icu_properties::CodePointMapData::<GeneralCategory>::try_new_unstable,
                     provider,
                 )?
@@ -121,7 +121,7 @@ pub mod ffi {
         pub fn create_ascii_hex_digit_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<AsciiHexDigit>,
                 provider
             )?)))
@@ -143,7 +143,7 @@ pub mod ffi {
         pub fn create_alnum_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<Alnum>,
                 provider
             )?)))
@@ -165,7 +165,7 @@ pub mod ffi {
         pub fn create_alphabetic_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<Alphabetic>,
                 provider
             )?)))
@@ -187,7 +187,7 @@ pub mod ffi {
         pub fn create_bidi_control_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<BidiControl>,
                 provider
             )?)))
@@ -209,7 +209,7 @@ pub mod ffi {
         pub fn create_bidi_mirrored_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<BidiMirrored>,
                 provider
             )?)))
@@ -231,7 +231,7 @@ pub mod ffi {
         pub fn create_blank_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<Blank>,
                 provider
             )?)))
@@ -253,7 +253,7 @@ pub mod ffi {
         pub fn create_cased_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<Cased>,
                 provider
             )?)))
@@ -275,7 +275,7 @@ pub mod ffi {
         pub fn create_case_ignorable_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<CaseIgnorable>,
                 provider
             )?)))
@@ -298,7 +298,7 @@ pub mod ffi {
         pub fn create_full_composition_exclusion_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<FullCompositionExclusion>,
                 provider
             )?)))
@@ -320,7 +320,7 @@ pub mod ffi {
         pub fn create_changes_when_casefolded_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<ChangesWhenCasefolded>,
                 provider
             )?)))
@@ -342,7 +342,7 @@ pub mod ffi {
         pub fn create_changes_when_casemapped_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<ChangesWhenCasemapped>,
                 provider
             )?)))
@@ -365,7 +365,7 @@ pub mod ffi {
         pub fn create_changes_when_nfkc_casefolded_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<ChangesWhenNfkcCasefolded>,
                 provider
             )?)))
@@ -387,7 +387,7 @@ pub mod ffi {
         pub fn create_changes_when_lowercased_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<ChangesWhenLowercased>,
                 provider
             )?)))
@@ -409,7 +409,7 @@ pub mod ffi {
         pub fn create_changes_when_titlecased_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<ChangesWhenTitlecased>,
                 provider
             )?)))
@@ -431,7 +431,7 @@ pub mod ffi {
         pub fn create_changes_when_uppercased_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<ChangesWhenUppercased>,
                 provider
             )?)))
@@ -453,7 +453,7 @@ pub mod ffi {
         pub fn create_dash_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<Dash>,
                 provider
             )?)))
@@ -475,7 +475,7 @@ pub mod ffi {
         pub fn create_deprecated_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<Deprecated>,
                 provider
             )?)))
@@ -498,7 +498,7 @@ pub mod ffi {
         pub fn create_default_ignorable_code_point_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<DefaultIgnorableCodePoint>,
                 provider
             )?)))
@@ -520,7 +520,7 @@ pub mod ffi {
         pub fn create_diacritic_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<Diacritic>,
                 provider
             )?)))
@@ -542,7 +542,7 @@ pub mod ffi {
         pub fn create_emoji_modifier_base_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<EmojiModifierBase>,
                 provider
             )?)))
@@ -564,7 +564,7 @@ pub mod ffi {
         pub fn create_emoji_component_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<EmojiComponent>,
                 provider
             )?)))
@@ -586,7 +586,7 @@ pub mod ffi {
         pub fn create_emoji_modifier_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<EmojiModifier>,
                 provider
             )?)))
@@ -608,7 +608,7 @@ pub mod ffi {
         pub fn create_emoji_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<Emoji>,
                 provider
             )?)))
@@ -630,7 +630,7 @@ pub mod ffi {
         pub fn create_emoji_presentation_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<EmojiPresentation>,
                 provider
             )?)))
@@ -652,7 +652,7 @@ pub mod ffi {
         pub fn create_extender_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<Extender>,
                 provider
             )?)))
@@ -674,7 +674,7 @@ pub mod ffi {
         pub fn create_extended_pictographic_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<ExtendedPictographic>,
                 provider
             )?)))
@@ -696,7 +696,7 @@ pub mod ffi {
         pub fn create_graph_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<Graph>,
                 provider
             )?)))
@@ -718,7 +718,7 @@ pub mod ffi {
         pub fn create_grapheme_base_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<GraphemeBase>,
                 provider
             )?)))
@@ -740,7 +740,7 @@ pub mod ffi {
         pub fn create_grapheme_extend_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<GraphemeExtend>,
                 provider
             )?)))
@@ -762,7 +762,7 @@ pub mod ffi {
         pub fn create_grapheme_link_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<GraphemeLink>,
                 provider
             )?)))
@@ -784,7 +784,7 @@ pub mod ffi {
         pub fn create_hex_digit_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<HexDigit>,
                 provider
             )?)))
@@ -806,7 +806,7 @@ pub mod ffi {
         pub fn create_hyphen_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<Hyphen>,
                 provider
             )?)))
@@ -828,7 +828,7 @@ pub mod ffi {
         pub fn create_id_continue_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<IdContinue>,
                 provider
             )?)))
@@ -850,7 +850,7 @@ pub mod ffi {
         pub fn create_ideographic_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<Ideographic>,
                 provider
             )?)))
@@ -872,7 +872,7 @@ pub mod ffi {
         pub fn create_id_start_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<IdStart>,
                 provider
             )?)))
@@ -894,7 +894,7 @@ pub mod ffi {
         pub fn create_ids_binary_operator_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<IdsBinaryOperator>,
                 provider
             )?)))
@@ -916,7 +916,7 @@ pub mod ffi {
         pub fn create_ids_trinary_operator_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<IdsTrinaryOperator>,
                 provider
             )?)))
@@ -938,7 +938,7 @@ pub mod ffi {
         pub fn create_join_control_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<JoinControl>,
                 provider
             )?)))
@@ -960,7 +960,7 @@ pub mod ffi {
         pub fn create_logical_order_exception_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<LogicalOrderException>,
                 provider
             )?)))
@@ -982,7 +982,7 @@ pub mod ffi {
         pub fn create_lowercase_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<Lowercase>,
                 provider
             )?)))
@@ -1004,7 +1004,7 @@ pub mod ffi {
         pub fn create_math_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<Math>,
                 provider
             )?)))
@@ -1026,7 +1026,7 @@ pub mod ffi {
         pub fn create_noncharacter_code_point_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<NoncharacterCodePoint>,
                 provider
             )?)))
@@ -1048,7 +1048,7 @@ pub mod ffi {
         pub fn create_nfc_inert_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<NfcInert>,
                 provider
             )?)))
@@ -1070,7 +1070,7 @@ pub mod ffi {
         pub fn create_nfd_inert_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<NfdInert>,
                 provider
             )?)))
@@ -1092,7 +1092,7 @@ pub mod ffi {
         pub fn create_nfkc_inert_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<NfkcInert>,
                 provider
             )?)))
@@ -1114,7 +1114,7 @@ pub mod ffi {
         pub fn create_nfkd_inert_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<NfkdInert>,
                 provider
             )?)))
@@ -1136,7 +1136,7 @@ pub mod ffi {
         pub fn create_pattern_syntax_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<PatternSyntax>,
                 provider
             )?)))
@@ -1158,7 +1158,7 @@ pub mod ffi {
         pub fn create_pattern_white_space_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<PatternWhiteSpace>,
                 provider
             )?)))
@@ -1181,7 +1181,7 @@ pub mod ffi {
         pub fn create_prepended_concatenation_mark_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<PrependedConcatenationMark>,
                 provider
             )?)))
@@ -1203,7 +1203,7 @@ pub mod ffi {
         pub fn create_print_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<Print>,
                 provider
             )?)))
@@ -1225,7 +1225,7 @@ pub mod ffi {
         pub fn create_quotation_mark_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<QuotationMark>,
                 provider
             )?)))
@@ -1247,7 +1247,7 @@ pub mod ffi {
         pub fn create_radical_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<Radical>,
                 provider
             )?)))
@@ -1269,7 +1269,7 @@ pub mod ffi {
         pub fn create_regional_indicator_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<RegionalIndicator>,
                 provider
             )?)))
@@ -1291,7 +1291,7 @@ pub mod ffi {
         pub fn create_soft_dotted_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<SoftDotted>,
                 provider
             )?)))
@@ -1313,7 +1313,7 @@ pub mod ffi {
         pub fn create_segment_starter_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<SegmentStarter>,
                 provider
             )?)))
@@ -1335,7 +1335,7 @@ pub mod ffi {
         pub fn create_case_sensitive_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<CaseSensitive>,
                 provider
             )?)))
@@ -1357,7 +1357,7 @@ pub mod ffi {
         pub fn create_sentence_terminal_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<SentenceTerminal>,
                 provider
             )?)))
@@ -1379,7 +1379,7 @@ pub mod ffi {
         pub fn create_terminal_punctuation_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<TerminalPunctuation>,
                 provider
             )?)))
@@ -1401,7 +1401,7 @@ pub mod ffi {
         pub fn create_unified_ideograph_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<UnifiedIdeograph>,
                 provider
             )?)))
@@ -1423,7 +1423,7 @@ pub mod ffi {
         pub fn create_uppercase_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<Uppercase>,
                 provider
             )?)))
@@ -1445,7 +1445,7 @@ pub mod ffi {
         pub fn create_variation_selector_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<VariationSelector>,
                 provider
             )?)))
@@ -1467,7 +1467,7 @@ pub mod ffi {
         pub fn create_white_space_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<WhiteSpace>,
                 provider
             )?)))
@@ -1489,7 +1489,7 @@ pub mod ffi {
         pub fn create_xdigit_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<Xdigit>,
                 provider
             )?)))
@@ -1511,7 +1511,7 @@ pub mod ffi {
         pub fn create_xid_continue_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<XidContinue>,
                 provider
             )?)))
@@ -1533,7 +1533,7 @@ pub mod ffi {
         pub fn create_xid_start_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
-            Ok(Box::new(CodePointSetData(call_constructor_unstable2!(
+            Ok(Box::new(CodePointSetData(call_constructor_unstable!(
                 icu_properties::CodePointSetData::try_new_unstable::<XidStart>,
                 provider
             )?)))
@@ -1560,7 +1560,7 @@ pub mod ffi {
             property_name: &DiplomatStr,
         ) -> Result<Box<CodePointSetData>, DataError> {
             Ok(Box::new(CodePointSetData(
-                call_constructor_unstable2!(
+                call_constructor_unstable!(
                     icu_properties::CodePointSetData::try_new_for_ecma262_unstable,
                     provider,
                     property_name

--- a/ffi/capi/src/properties_unisets.rs
+++ b/ffi/capi/src/properties_unisets.rs
@@ -56,8 +56,7 @@ pub mod ffi {
         pub fn create_basic_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<EmojiSetData>, DataError> {
-            Ok(Box::new(EmojiSetData(call_constructor_unstable!(
-                icu_properties::EmojiSetData::new::<BasicEmoji> [r => Ok(r.static_to_owned())],
+            Ok(Box::new(EmojiSetData(call_constructor_unstable2!(
                 icu_properties::EmojiSetData::try_new_unstable::<BasicEmoji>,
                 provider,
             )?)))

--- a/ffi/capi/src/properties_unisets.rs
+++ b/ffi/capi/src/properties_unisets.rs
@@ -7,10 +7,11 @@
 #[diplomat::attr(auto, namespace = "icu4x")]
 pub mod ffi {
     use alloc::boxed::Box;
+    #[cfg(any(feature = "compiled_data", feature = "buffer_provider"))]
     use icu_properties::props::BasicEmoji;
 
-    use crate::errors::ffi::DataError;
-    use crate::provider::ffi::DataProvider;
+    #[cfg(feature = "buffer_provider")]
+    use crate::{errors::ffi::DataError, provider::ffi::DataProvider};
 
     #[diplomat::opaque]
     /// An ICU4X Unicode Set Property object, capable of querying whether a code point is contained in a set based on a Unicode property.
@@ -53,6 +54,7 @@ pub mod ffi {
         /// Create a map for the `Basic_Emoji` property, using a particular data source.
         #[diplomat::rust_link(icu::properties::props::BasicEmoji, Struct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "basic_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_basic_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<EmojiSetData>, DataError> {

--- a/ffi/capi/src/properties_unisets.rs
+++ b/ffi/capi/src/properties_unisets.rs
@@ -56,7 +56,7 @@ pub mod ffi {
         pub fn create_basic_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<EmojiSetData>, DataError> {
-            Ok(Box::new(EmojiSetData(call_constructor_unstable2!(
+            Ok(Box::new(EmojiSetData(call_constructor_unstable!(
                 icu_properties::EmojiSetData::try_new_unstable::<BasicEmoji>,
                 provider,
             )?)))

--- a/ffi/capi/src/provider.rs
+++ b/ffi/capi/src/provider.rs
@@ -277,11 +277,8 @@ macro_rules! call_constructor2 {
             $crate::provider::DataProviderInner::Destroyed => Err(icu_provider::DataError::custom(
                 "This provider has been destroyed",
             ))?,
-            $crate::provider::DataProviderInner::Empty => unreachable!(),
-            #[cfg(feature = "buffer_provider")]
             $crate::provider::DataProviderInner::Buffer(buffer_provider) => $buffer(buffer_provider, $($args,)*),
-            #[cfg(feature = "compiled_data")]
-            $crate::provider::DataProviderInner::Compiled => unreachable!(),
+            _ => unreachable!()
         }
     };
     ($buffer:path, $provider:expr $(, $args:expr)* $(,)?) => {
@@ -289,11 +286,8 @@ macro_rules! call_constructor2 {
             $crate::provider::DataProviderInner::Destroyed => Err(icu_provider::DataError::custom(
                 "This provider has been destroyed",
             ))?,
-            $crate::provider::DataProviderInner::Empty => unreachable!(),
-            #[cfg(feature = "buffer_provider")]
             $crate::provider::DataProviderInner::Buffer(buffer_provider) => $buffer(buffer_provider, $($args,)*),
-            #[cfg(feature = "compiled_data")]
-            $crate::provider::DataProviderInner::Compiled => unreachable!(),
+            _ => unreachable!()
         }
     };
 }

--- a/ffi/capi/src/provider.rs
+++ b/ffi/capi/src/provider.rs
@@ -244,34 +244,6 @@ where
 
 #[macro_export]
 macro_rules! call_constructor {
-    ($compiled:path [$pre_transform:ident => $transform:expr], $any:path, $buffer:path, $provider:expr $(, $args:expr)* $(,)?) => {
-        match &$provider.0 {
-            $crate::provider::DataProviderInner::Destroyed => Err(icu_provider::DataError::custom(
-                "This provider has been destroyed",
-            ))?,
-            $crate::provider::DataProviderInner::Empty => $any(&icu_provider_adapters::empty::EmptyDataProvider::new(), $($args,)*),
-            #[cfg(feature = "buffer_provider")]
-            $crate::provider::DataProviderInner::Buffer(buffer_provider) => $buffer(buffer_provider, $($args,)*),
-            #[cfg(feature = "compiled_data")]
-            $crate::provider::DataProviderInner::Compiled => { let $pre_transform = $compiled($($args,)*); $transform },
-        }
-    };
-    ($compiled:path, $any:path, $buffer:path, $provider:expr $(, $args:expr)* $(,)?) => {
-        match &$provider.0 {
-            $crate::provider::DataProviderInner::Destroyed => Err(icu_provider::DataError::custom(
-                "This provider has been destroyed",
-            ))?,
-            $crate::provider::DataProviderInner::Empty => $any(&icu_provider_adapters::empty::EmptyDataProvider::new(), $($args,)*),
-            #[cfg(feature = "buffer_provider")]
-            $crate::provider::DataProviderInner::Buffer(buffer_provider) => $buffer(buffer_provider, $($args,)*),
-            #[cfg(feature = "compiled_data")]
-            $crate::provider::DataProviderInner::Compiled => $compiled($($args,)*),
-        }
-    };
-}
-
-#[macro_export]
-macro_rules! call_constructor2 {
     ($buffer:path, $provider:expr $(, $args:expr)* $(,)?) => {
         match &$provider.0 {
             $crate::provider::DataProviderInner::Destroyed => Err(icu_provider::DataError::custom(
@@ -294,34 +266,6 @@ macro_rules! call_constructor2 {
 
 #[macro_export]
 macro_rules! call_constructor_unstable {
-    ($compiled:path [$pre_transform:ident => $transform:expr], $unstable:path, $provider:expr $(, $args:expr)* $(,)?) => {
-        match &$provider.0 {
-            $crate::provider::DataProviderInner::Destroyed => Err(icu_provider::DataError::custom(
-                "This provider has been destroyed",
-            ))?,
-            $crate::provider::DataProviderInner::Empty => $unstable(&icu_provider_adapters::empty::EmptyDataProvider::new(), $($args,)*),
-            #[cfg(feature = "buffer_provider")]
-            $crate::provider::DataProviderInner::Buffer(buffer_provider) => $unstable(&icu_provider::buf::AsDeserializingBufferProvider::as_deserializing(buffer_provider), $($args,)*),
-            #[cfg(feature = "compiled_data")]
-            $crate::provider::DataProviderInner::Compiled => { let $pre_transform = $compiled($($args,)*); $transform },
-        }
-    };
-    ($compiled:path, $unstable:path, $provider:expr $(, $args:expr)* $(,)?) => {
-        match &$provider.0 {
-            $crate::provider::DataProviderInner::Destroyed => Err(icu_provider::DataError::custom(
-                "This provider has been destroyed",
-            ))?,
-            $crate::provider::DataProviderInner::Empty => $unstable(&icu_provider_adapters::empty::EmptyDataProvider::new(), $($args,)*),
-            #[cfg(feature = "buffer_provider")]
-            $crate::provider::DataProviderInner::Buffer(buffer_provider) => $unstable(&icu_provider::buf::AsDeserializingBufferProvider::as_deserializing(buffer_provider), $($args,)*),
-            #[cfg(feature = "compiled_data")]
-            $crate::provider::DataProviderInner::Compiled => $compiled($($args,)*),
-        }
-    };
-}
-
-#[macro_export]
-macro_rules! call_constructor_unstable2 {
     ($unstable:path, $provider:expr $(, $args:expr)* $(,)?) => {
         match &$provider.0 {
             $crate::provider::DataProviderInner::Destroyed => Err(icu_provider::DataError::custom(

--- a/ffi/capi/src/provider.rs
+++ b/ffi/capi/src/provider.rs
@@ -217,18 +217,6 @@ where
 }
 
 #[macro_export]
-macro_rules! call_constructor {
-    ($buffer:path, $provider:expr $(, $args:expr)* $(,)?) => {
-        match &$provider.0 {
-            $crate::provider::DataProviderInner::Destroyed => Err(icu_provider::DataError::custom(
-                "This provider has been destroyed",
-            ))?,
-            $crate::provider::DataProviderInner::Buffer(buffer_provider) => $buffer(buffer_provider, $($args,)*),
-        }
-    };
-}
-
-#[macro_export]
 macro_rules! call_constructor_unstable {
     ($unstable:path, $provider:expr $(, $args:expr)* $(,)?) => {
         match &$provider.0 {

--- a/ffi/capi/src/provider.rs
+++ b/ffi/capi/src/provider.rs
@@ -33,6 +33,23 @@ pub mod ffi {
     }
 
     impl DataProvider {
+        pub(crate) fn call_constructor<F, Ret>(
+            &self,
+            ctor: F,
+        ) -> Result<Ret, icu_provider::DataError>
+        where
+            F: FnOnce(
+                &(dyn icu_provider::buf::BufferProvider + 'static),
+            ) -> Result<Ret, icu_provider::DataError>,
+        {
+            match &self.0 {
+                DataProviderInner::Destroyed => Err(icu_provider::DataError::custom(
+                    "This provider has been destroyed",
+                ))?,
+                DataProviderInner::Buffer(ref buffer_provider) => ctor(buffer_provider),
+            }
+        }
+
         /// Constructs an `FsDataProvider` and returns it as an [`DataProvider`].
         /// Requires the `provider_fs` Cargo feature.
         /// Not supported in WASM.

--- a/ffi/capi/src/provider.rs
+++ b/ffi/capi/src/provider.rs
@@ -319,3 +319,25 @@ macro_rules! call_constructor_unstable {
         }
     };
 }
+
+#[macro_export]
+macro_rules! call_constructor_unstable2 {
+    ($unstable:path, $provider:expr $(, $args:expr)* $(,)?) => {
+        match &$provider.0 {
+            $crate::provider::DataProviderInner::Destroyed => Err(icu_provider::DataError::custom(
+                "This provider has been destroyed",
+            ))?,
+            $crate::provider::DataProviderInner::Buffer(buffer_provider) => $unstable(&icu_provider::buf::AsDeserializingBufferProvider::as_deserializing(buffer_provider), $($args,)*),
+            _ => unreachable!()
+        }
+    };
+    ($unstable:path, $provider:expr $(, $args:expr)* $(,)?) => {
+        match &$provider.0 {
+            $crate::provider::DataProviderInner::Destroyed => Err(icu_provider::DataError::custom(
+                "This provider has been destroyed",
+            ))?,
+            $crate::provider::DataProviderInner::Buffer(buffer_provider) => $unstable(&icu_provider::buf::AsDeserializingBufferProvider::as_deserializing(buffer_provider), $($args,)*),
+            _ => unreachable!()
+        }
+    };
+}

--- a/ffi/capi/src/script.rs
+++ b/ffi/capi/src/script.rs
@@ -8,10 +8,10 @@
 pub mod ffi {
     use alloc::boxed::Box;
 
-    use crate::errors::ffi::DataError;
     use crate::properties_iter::ffi::CodePointRangeIterator;
     use crate::properties_sets::ffi::CodePointSetData;
-    use crate::provider::ffi::DataProvider;
+    #[cfg(feature = "buffer_provider")]
+    use crate::{errors::ffi::DataError, provider::ffi::DataProvider};
 
     #[diplomat::opaque]
     /// An ICU4X ScriptWithExtensions map object, capable of holding a map of codepoints to scriptextensions values
@@ -53,6 +53,7 @@ pub mod ffi {
             hidden
         )]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<ScriptWithExtensions>, DataError> {

--- a/ffi/capi/src/script.rs
+++ b/ffi/capi/src/script.rs
@@ -56,7 +56,7 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<ScriptWithExtensions>, DataError> {
-            Ok(Box::new(ScriptWithExtensions(call_constructor2!(
+            Ok(Box::new(ScriptWithExtensions(call_constructor!(
                 icu_properties::script::ScriptWithExtensions::try_new_with_buffer_provider,
                 provider
             )?)))

--- a/ffi/capi/src/script.rs
+++ b/ffi/capi/src/script.rs
@@ -56,9 +56,7 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<ScriptWithExtensions>, DataError> {
-            Ok(Box::new(ScriptWithExtensions(call_constructor!(
-                icu_properties::script::ScriptWithExtensions::new [r => Ok(r.static_to_owned())],
-                icu_properties::script::ScriptWithExtensions::try_new_with_any_provider,
+            Ok(Box::new(ScriptWithExtensions(call_constructor2!(
                 icu_properties::script::ScriptWithExtensions::try_new_with_buffer_provider,
                 provider
             )?)))

--- a/ffi/capi/src/script.rs
+++ b/ffi/capi/src/script.rs
@@ -57,9 +57,12 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<ScriptWithExtensions>, DataError> {
-            Ok(Box::new(ScriptWithExtensions(call_constructor!(
-                icu_properties::script::ScriptWithExtensions::try_new_with_buffer_provider,
-                provider
+            Ok(Box::new(ScriptWithExtensions(provider.call_constructor(
+                |provider| {
+                    icu_properties::script::ScriptWithExtensions::try_new_with_buffer_provider(
+                        provider,
+                    )
+                },
             )?)))
         }
 

--- a/ffi/capi/src/segmenter_grapheme.rs
+++ b/ffi/capi/src/segmenter_grapheme.rs
@@ -60,10 +60,11 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<GraphemeClusterSegmenter>, DataError> {
-            Ok(Box::new(GraphemeClusterSegmenter(call_constructor!(
-                icu_segmenter::GraphemeClusterSegmenter::try_new_with_buffer_provider,
-                provider,
-            )?)))
+            Ok(Box::new(GraphemeClusterSegmenter(
+                provider.call_constructor(|provider| {
+                    icu_segmenter::GraphemeClusterSegmenter::try_new_with_buffer_provider(provider)
+                })?,
+            )))
         }
         /// Segments a string.
         ///

--- a/ffi/capi/src/segmenter_grapheme.rs
+++ b/ffi/capi/src/segmenter_grapheme.rs
@@ -59,7 +59,7 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<GraphemeClusterSegmenter>, DataError> {
-            Ok(Box::new(GraphemeClusterSegmenter(call_constructor2!(
+            Ok(Box::new(GraphemeClusterSegmenter(call_constructor!(
                 icu_segmenter::GraphemeClusterSegmenter::try_new_with_buffer_provider,
                 provider,
             )?)))

--- a/ffi/capi/src/segmenter_grapheme.rs
+++ b/ffi/capi/src/segmenter_grapheme.rs
@@ -8,8 +8,8 @@
 pub mod ffi {
     use alloc::boxed::Box;
 
-    use crate::errors::ffi::DataError;
-    use crate::provider::ffi::DataProvider;
+    #[cfg(feature = "buffer_provider")]
+    use crate::{errors::ffi::DataError, provider::ffi::DataProvider};
 
     #[diplomat::opaque]
     /// An ICU4X grapheme-cluster-break segmenter, capable of finding grapheme cluster breakpoints
@@ -56,6 +56,7 @@ pub mod ffi {
         /// Construct an [`GraphemeClusterSegmenter`].
         #[diplomat::rust_link(icu::segmenter::GraphemeClusterSegmenter::new, FnInStruct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<GraphemeClusterSegmenter>, DataError> {

--- a/ffi/capi/src/segmenter_grapheme.rs
+++ b/ffi/capi/src/segmenter_grapheme.rs
@@ -59,9 +59,7 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<GraphemeClusterSegmenter>, DataError> {
-            Ok(Box::new(GraphemeClusterSegmenter(call_constructor!(
-                icu_segmenter::GraphemeClusterSegmenter::new [r => Ok(r)],
-                icu_segmenter::GraphemeClusterSegmenter::try_new_with_any_provider,
+            Ok(Box::new(GraphemeClusterSegmenter(call_constructor2!(
                 icu_segmenter::GraphemeClusterSegmenter::try_new_with_buffer_provider,
                 provider,
             )?)))

--- a/ffi/capi/src/segmenter_line.rs
+++ b/ffi/capi/src/segmenter_line.rs
@@ -8,9 +8,10 @@
 pub mod ffi {
     use alloc::boxed::Box;
 
-    use crate::errors::ffi::DataError;
+    #[cfg(any(feature = "compiled_data", feature = "buffer_provider"))]
     use crate::locale_core::ffi::Locale;
-    use crate::provider::ffi::DataProvider;
+    #[cfg(feature = "buffer_provider")]
+    use crate::{errors::ffi::DataError, provider::ffi::DataProvider};
     use diplomat_runtime::DiplomatOption;
 
     #[diplomat::opaque]
@@ -77,6 +78,7 @@ pub mod ffi {
         /// available payload data for Burmese, Khmer, Lao, and Thai.
         #[diplomat::rust_link(icu::segmenter::LineSegmenter::new_auto, FnInStruct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "auto_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_auto_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<LineSegmenter>, DataError> {
@@ -97,6 +99,7 @@ pub mod ffi {
         /// Burmese, Khmer, Lao, and Thai,  using a particular data source.
         #[diplomat::rust_link(icu::segmenter::LineSegmenter::new_lstm, FnInStruct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "lstm_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_lstm_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<LineSegmenter>, DataError> {
@@ -117,6 +120,7 @@ pub mod ffi {
         /// Burmese, Khmer, Lao, and Thai, using a particular data source.
         #[diplomat::rust_link(icu::segmenter::LineSegmenter::new_dictionary, FnInStruct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "dictionary_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_dictionary_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<LineSegmenter>, DataError> {
@@ -149,6 +153,7 @@ pub mod ffi {
         #[diplomat::attr(supports = non_exhaustive_structs, rename = "auto_with_options_and_provider")]
         #[diplomat::attr(all(supports = non_exhaustive_structs, supports = fallible_constructors), named_constructor = "auto_with_options_and_provider")]
         #[diplomat::attr(all(not(supports = non_exhaustive_structs), supports = fallible_constructors), named_constructor = "auto_with_options_v2_and_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_auto_with_options_v2_and_provider(
             provider: &DataProvider,
             content_locale: &Locale,
@@ -187,6 +192,7 @@ pub mod ffi {
         #[diplomat::attr(supports = non_exhaustive_structs, rename = "lstm_with_options_and_provider")]
         #[diplomat::attr(all(supports = non_exhaustive_structs, supports = fallible_constructors), named_constructor = "lstm_with_options_and_provider")]
         #[diplomat::attr(all(not(supports = non_exhaustive_structs), supports = fallible_constructors), named_constructor = "lstm_with_options_v2_and_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_lstm_with_options_v2_and_provider(
             provider: &DataProvider,
             content_locale: &Locale,
@@ -231,6 +237,7 @@ pub mod ffi {
         #[diplomat::attr(supports = non_exhaustive_structs, rename = "dictionary_with_options_and_provider")]
         #[diplomat::attr(all(supports = non_exhaustive_structs, supports = fallible_constructors), named_constructor = "dictionary_with_options_and_provider")]
         #[diplomat::attr(all(not(supports = non_exhaustive_structs), supports = fallible_constructors), named_constructor = "dictionary_with_options_v2_and_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_dictionary_with_options_v2_and_provider(
             provider: &DataProvider,
             content_locale: &Locale,

--- a/ffi/capi/src/segmenter_line.rs
+++ b/ffi/capi/src/segmenter_line.rs
@@ -82,9 +82,10 @@ pub mod ffi {
         pub fn create_auto_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<LineSegmenter>, DataError> {
-            Ok(Box::new(LineSegmenter(call_constructor!(
-                icu_segmenter::LineSegmenter::try_new_auto_with_buffer_provider,
-                provider
+            Ok(Box::new(LineSegmenter(provider.call_constructor(
+                |provider| {
+                    icu_segmenter::LineSegmenter::try_new_auto_with_buffer_provider(provider)
+                },
             )?)))
         }
         /// Construct a [`LineSegmenter`] with default options and LSTM payload data for
@@ -103,9 +104,10 @@ pub mod ffi {
         pub fn create_lstm_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<LineSegmenter>, DataError> {
-            Ok(Box::new(LineSegmenter(call_constructor!(
-                icu_segmenter::LineSegmenter::try_new_lstm_with_buffer_provider,
-                provider,
+            Ok(Box::new(LineSegmenter(provider.call_constructor(
+                |provider| {
+                    icu_segmenter::LineSegmenter::try_new_lstm_with_buffer_provider(provider)
+                },
             )?)))
         }
         /// Construct a [`LineSegmenter`] with default options and dictionary payload data for
@@ -124,9 +126,10 @@ pub mod ffi {
         pub fn create_dictionary_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<LineSegmenter>, DataError> {
-            Ok(Box::new(LineSegmenter(call_constructor!(
-                icu_segmenter::LineSegmenter::try_new_dictionary_with_buffer_provider,
-                provider,
+            Ok(Box::new(LineSegmenter(provider.call_constructor(
+                |provider| {
+                    icu_segmenter::LineSegmenter::try_new_dictionary_with_buffer_provider(provider)
+                },
             )?)))
         }
         /// Construct a [`LineSegmenter`] with custom options using compiled data. It automatically loads the best
@@ -162,10 +165,12 @@ pub mod ffi {
             let mut options: icu_segmenter::LineBreakOptions = options.into();
             options.content_locale = Some(&content_locale.0.id);
 
-            Ok(Box::new(LineSegmenter(call_constructor!(
-                icu_segmenter::LineSegmenter::try_new_auto_with_options_with_buffer_provider,
-                provider,
-                options,
+            Ok(Box::new(LineSegmenter(provider.call_constructor(
+                |provider| {
+                    icu_segmenter::LineSegmenter::try_new_auto_with_options_with_buffer_provider(
+                        provider, options,
+                    )
+                },
             )?)))
         }
         /// Construct a [`LineSegmenter`] with custom options and LSTM payload data for
@@ -201,10 +206,12 @@ pub mod ffi {
             let mut options: icu_segmenter::LineBreakOptions = options.into();
             options.content_locale = Some(&content_locale.0.id);
 
-            Ok(Box::new(LineSegmenter(call_constructor!(
-                icu_segmenter::LineSegmenter::try_new_lstm_with_options_with_buffer_provider,
-                provider,
-                options,
+            Ok(Box::new(LineSegmenter(provider.call_constructor(
+                |provider| {
+                    icu_segmenter::LineSegmenter::try_new_lstm_with_options_with_buffer_provider(
+                        provider, options,
+                    )
+                },
             )?)))
         }
         /// Construct a [`LineSegmenter`] with custom options and dictionary payload data for
@@ -246,11 +253,7 @@ pub mod ffi {
             let mut options: icu_segmenter::LineBreakOptions = options.into();
             options.content_locale = Some(&content_locale.0.id);
 
-            Ok(Box::new(LineSegmenter(call_constructor!(
-                icu_segmenter::LineSegmenter::try_new_dictionary_with_options_with_buffer_provider,
-                provider,
-                options,
-            )?)))
+            Ok(Box::new(LineSegmenter(provider.call_constructor(|provider| icu_segmenter::LineSegmenter::try_new_dictionary_with_options_with_buffer_provider(provider, options))?)))
         }
         /// Segments a string.
         ///

--- a/ffi/capi/src/segmenter_line.rs
+++ b/ffi/capi/src/segmenter_line.rs
@@ -80,7 +80,7 @@ pub mod ffi {
         pub fn create_auto_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<LineSegmenter>, DataError> {
-            Ok(Box::new(LineSegmenter(call_constructor2!(
+            Ok(Box::new(LineSegmenter(call_constructor!(
                 icu_segmenter::LineSegmenter::try_new_auto_with_buffer_provider,
                 provider
             )?)))
@@ -100,7 +100,7 @@ pub mod ffi {
         pub fn create_lstm_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<LineSegmenter>, DataError> {
-            Ok(Box::new(LineSegmenter(call_constructor2!(
+            Ok(Box::new(LineSegmenter(call_constructor!(
                 icu_segmenter::LineSegmenter::try_new_lstm_with_buffer_provider,
                 provider,
             )?)))
@@ -120,7 +120,7 @@ pub mod ffi {
         pub fn create_dictionary_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<LineSegmenter>, DataError> {
-            Ok(Box::new(LineSegmenter(call_constructor2!(
+            Ok(Box::new(LineSegmenter(call_constructor!(
                 icu_segmenter::LineSegmenter::try_new_dictionary_with_buffer_provider,
                 provider,
             )?)))
@@ -157,7 +157,7 @@ pub mod ffi {
             let mut options: icu_segmenter::LineBreakOptions = options.into();
             options.content_locale = Some(&content_locale.0.id);
 
-            Ok(Box::new(LineSegmenter(call_constructor2!(
+            Ok(Box::new(LineSegmenter(call_constructor!(
                 icu_segmenter::LineSegmenter::try_new_auto_with_options_with_buffer_provider,
                 provider,
                 options,
@@ -195,7 +195,7 @@ pub mod ffi {
             let mut options: icu_segmenter::LineBreakOptions = options.into();
             options.content_locale = Some(&content_locale.0.id);
 
-            Ok(Box::new(LineSegmenter(call_constructor2!(
+            Ok(Box::new(LineSegmenter(call_constructor!(
                 icu_segmenter::LineSegmenter::try_new_lstm_with_options_with_buffer_provider,
                 provider,
                 options,
@@ -239,7 +239,7 @@ pub mod ffi {
             let mut options: icu_segmenter::LineBreakOptions = options.into();
             options.content_locale = Some(&content_locale.0.id);
 
-            Ok(Box::new(LineSegmenter(call_constructor2!(
+            Ok(Box::new(LineSegmenter(call_constructor!(
                 icu_segmenter::LineSegmenter::try_new_dictionary_with_options_with_buffer_provider,
                 provider,
                 options,

--- a/ffi/capi/src/segmenter_line.rs
+++ b/ffi/capi/src/segmenter_line.rs
@@ -80,9 +80,7 @@ pub mod ffi {
         pub fn create_auto_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<LineSegmenter>, DataError> {
-            Ok(Box::new(LineSegmenter(call_constructor!(
-                icu_segmenter::LineSegmenter::new_auto [r => Ok(r)],
-                icu_segmenter::LineSegmenter::try_new_auto_with_any_provider,
+            Ok(Box::new(LineSegmenter(call_constructor2!(
                 icu_segmenter::LineSegmenter::try_new_auto_with_buffer_provider,
                 provider
             )?)))
@@ -102,9 +100,7 @@ pub mod ffi {
         pub fn create_lstm_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<LineSegmenter>, DataError> {
-            Ok(Box::new(LineSegmenter(call_constructor!(
-                icu_segmenter::LineSegmenter::new_lstm [r => Ok(r)],
-                icu_segmenter::LineSegmenter::try_new_lstm_with_any_provider,
+            Ok(Box::new(LineSegmenter(call_constructor2!(
                 icu_segmenter::LineSegmenter::try_new_lstm_with_buffer_provider,
                 provider,
             )?)))
@@ -124,9 +120,7 @@ pub mod ffi {
         pub fn create_dictionary_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<LineSegmenter>, DataError> {
-            Ok(Box::new(LineSegmenter(call_constructor!(
-                icu_segmenter::LineSegmenter::new_dictionary [r => Ok(r)],
-                icu_segmenter::LineSegmenter::try_new_dictionary_with_any_provider,
+            Ok(Box::new(LineSegmenter(call_constructor2!(
                 icu_segmenter::LineSegmenter::try_new_dictionary_with_buffer_provider,
                 provider,
             )?)))
@@ -163,9 +157,7 @@ pub mod ffi {
             let mut options: icu_segmenter::LineBreakOptions = options.into();
             options.content_locale = Some(&content_locale.0.id);
 
-            Ok(Box::new(LineSegmenter(call_constructor!(
-                icu_segmenter::LineSegmenter::new_auto_with_options [r => Ok(r)],
-                icu_segmenter::LineSegmenter::try_new_auto_with_options_with_any_provider,
+            Ok(Box::new(LineSegmenter(call_constructor2!(
                 icu_segmenter::LineSegmenter::try_new_auto_with_options_with_buffer_provider,
                 provider,
                 options,
@@ -203,9 +195,7 @@ pub mod ffi {
             let mut options: icu_segmenter::LineBreakOptions = options.into();
             options.content_locale = Some(&content_locale.0.id);
 
-            Ok(Box::new(LineSegmenter(call_constructor!(
-                icu_segmenter::LineSegmenter::new_lstm_with_options [r => Ok(r)],
-                icu_segmenter::LineSegmenter::try_new_lstm_with_options_with_any_provider,
+            Ok(Box::new(LineSegmenter(call_constructor2!(
                 icu_segmenter::LineSegmenter::try_new_lstm_with_options_with_buffer_provider,
                 provider,
                 options,
@@ -249,9 +239,7 @@ pub mod ffi {
             let mut options: icu_segmenter::LineBreakOptions = options.into();
             options.content_locale = Some(&content_locale.0.id);
 
-            Ok(Box::new(LineSegmenter(call_constructor!(
-                icu_segmenter::LineSegmenter::new_dictionary_with_options [r => Ok(r)],
-                icu_segmenter::LineSegmenter::try_new_dictionary_with_options_with_any_provider,
+            Ok(Box::new(LineSegmenter(call_constructor2!(
                 icu_segmenter::LineSegmenter::try_new_dictionary_with_options_with_buffer_provider,
                 provider,
                 options,

--- a/ffi/capi/src/segmenter_sentence.rs
+++ b/ffi/capi/src/segmenter_sentence.rs
@@ -56,7 +56,7 @@ pub mod ffi {
             provider: &DataProvider,
         ) -> Result<Box<SentenceSegmenter>, DataError> {
             Ok(Box::new(SentenceSegmenter(provider.call_constructor(
-                |provider| icu_segmenter::SentenceSegmenter::try_new_with_buffer_provider(provider),
+                icu_segmenter::SentenceSegmenter::try_new_with_buffer_provider,
             )?)))
         }
 

--- a/ffi/capi/src/segmenter_sentence.rs
+++ b/ffi/capi/src/segmenter_sentence.rs
@@ -53,9 +53,7 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<SentenceSegmenter>, DataError> {
-            Ok(Box::new(SentenceSegmenter(call_constructor!(
-                icu_segmenter::SentenceSegmenter::new [r => Ok(r)],
-                icu_segmenter::SentenceSegmenter::try_new_with_any_provider,
+            Ok(Box::new(SentenceSegmenter(call_constructor2!(
                 icu_segmenter::SentenceSegmenter::try_new_with_buffer_provider,
                 provider,
             )?)))
@@ -88,9 +86,7 @@ pub mod ffi {
             provider: &DataProvider,
             locale: &Locale,
         ) -> Result<Box<SentenceSegmenter>, DataError> {
-            Ok(Box::new(SentenceSegmenter(call_constructor!(
-                icu_segmenter::SentenceSegmenter::try_new_with_options,
-                icu_segmenter::SentenceSegmenter::try_new_with_options_with_any_provider,
+            Ok(Box::new(SentenceSegmenter(call_constructor2!(
                 icu_segmenter::SentenceSegmenter::try_new_with_options_with_buffer_provider,
                 provider,
                 locale.into(),

--- a/ffi/capi/src/segmenter_sentence.rs
+++ b/ffi/capi/src/segmenter_sentence.rs
@@ -8,9 +8,10 @@
 pub mod ffi {
     use alloc::boxed::Box;
 
-    use crate::errors::ffi::DataError;
-    use crate::locale_core::ffi::Locale;
+    #[cfg(feature = "buffer_provider")]
     use crate::provider::ffi::DataProvider;
+    #[cfg(any(feature = "compiled_data", feature = "buffer_provider"))]
+    use crate::{errors::ffi::DataError, locale_core::ffi::Locale};
 
     #[diplomat::opaque]
     /// An ICU4X sentence-break segmenter, capable of finding sentence breakpoints in strings.
@@ -50,6 +51,7 @@ pub mod ffi {
         /// Construct a [`SentenceSegmenter`], using a particular data source.
         #[diplomat::rust_link(icu::segmenter::SentenceSegmenter::new, FnInStruct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<SentenceSegmenter>, DataError> {
@@ -82,6 +84,7 @@ pub mod ffi {
             hidden
         )]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "with_content_locale_and_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_with_content_locale_and_provider(
             provider: &DataProvider,
             locale: &Locale,

--- a/ffi/capi/src/segmenter_sentence.rs
+++ b/ffi/capi/src/segmenter_sentence.rs
@@ -55,9 +55,8 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<SentenceSegmenter>, DataError> {
-            Ok(Box::new(SentenceSegmenter(call_constructor!(
-                icu_segmenter::SentenceSegmenter::try_new_with_buffer_provider,
-                provider,
+            Ok(Box::new(SentenceSegmenter(provider.call_constructor(
+                |provider| icu_segmenter::SentenceSegmenter::try_new_with_buffer_provider(provider),
             )?)))
         }
 
@@ -89,10 +88,13 @@ pub mod ffi {
             provider: &DataProvider,
             locale: &Locale,
         ) -> Result<Box<SentenceSegmenter>, DataError> {
-            Ok(Box::new(SentenceSegmenter(call_constructor!(
-                icu_segmenter::SentenceSegmenter::try_new_with_options_with_buffer_provider,
-                provider,
-                locale.into(),
+            Ok(Box::new(SentenceSegmenter(provider.call_constructor(
+                |provider| {
+                    icu_segmenter::SentenceSegmenter::try_new_with_options_with_buffer_provider(
+                        provider,
+                        locale.into(),
+                    )
+                },
             )?)))
         }
 

--- a/ffi/capi/src/segmenter_sentence.rs
+++ b/ffi/capi/src/segmenter_sentence.rs
@@ -53,7 +53,7 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<SentenceSegmenter>, DataError> {
-            Ok(Box::new(SentenceSegmenter(call_constructor2!(
+            Ok(Box::new(SentenceSegmenter(call_constructor!(
                 icu_segmenter::SentenceSegmenter::try_new_with_buffer_provider,
                 provider,
             )?)))
@@ -86,7 +86,7 @@ pub mod ffi {
             provider: &DataProvider,
             locale: &Locale,
         ) -> Result<Box<SentenceSegmenter>, DataError> {
-            Ok(Box::new(SentenceSegmenter(call_constructor2!(
+            Ok(Box::new(SentenceSegmenter(call_constructor!(
                 icu_segmenter::SentenceSegmenter::try_new_with_options_with_buffer_provider,
                 provider,
                 locale.into(),

--- a/ffi/capi/src/segmenter_word.rs
+++ b/ffi/capi/src/segmenter_word.rs
@@ -79,7 +79,7 @@ pub mod ffi {
         pub fn create_auto_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<WordSegmenter>, DataError> {
-            Ok(Box::new(WordSegmenter(call_constructor2!(
+            Ok(Box::new(WordSegmenter(call_constructor!(
                 icu_segmenter::WordSegmenter::try_new_auto_with_buffer_provider,
                 provider
             )?)))
@@ -112,7 +112,7 @@ pub mod ffi {
             provider: &DataProvider,
             locale: &Locale,
         ) -> Result<Box<WordSegmenter>, DataError> {
-            Ok(Box::new(WordSegmenter(call_constructor2!(
+            Ok(Box::new(WordSegmenter(call_constructor!(
                 icu_segmenter::WordSegmenter::try_new_auto_with_options_with_buffer_provider,
                 provider,
                 locale.into(),
@@ -141,7 +141,7 @@ pub mod ffi {
         pub fn create_lstm_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<WordSegmenter>, DataError> {
-            Ok(Box::new(WordSegmenter(call_constructor2!(
+            Ok(Box::new(WordSegmenter(call_constructor!(
                 icu_segmenter::WordSegmenter::try_new_lstm_with_buffer_provider,
                 provider
             )?)))
@@ -174,7 +174,7 @@ pub mod ffi {
             provider: &DataProvider,
             locale: &Locale,
         ) -> Result<Box<WordSegmenter>, DataError> {
-            Ok(Box::new(WordSegmenter(call_constructor2!(
+            Ok(Box::new(WordSegmenter(call_constructor!(
                 icu_segmenter::WordSegmenter::try_new_lstm_with_options_with_buffer_provider,
                 provider,
                 locale.into(),
@@ -203,7 +203,7 @@ pub mod ffi {
         pub fn create_dictionary_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<WordSegmenter>, DataError> {
-            Ok(Box::new(WordSegmenter(call_constructor2!(
+            Ok(Box::new(WordSegmenter(call_constructor!(
                 icu_segmenter::WordSegmenter::try_new_dictionary_with_buffer_provider,
                 provider
             )?)))
@@ -242,7 +242,7 @@ pub mod ffi {
             provider: &DataProvider,
             locale: &Locale,
         ) -> Result<Box<WordSegmenter>, DataError> {
-            Ok(Box::new(WordSegmenter(call_constructor2!(
+            Ok(Box::new(WordSegmenter(call_constructor!(
                 icu_segmenter::WordSegmenter::try_new_dictionary_with_options_with_buffer_provider,
                 provider,
                 locale.into(),

--- a/ffi/capi/src/segmenter_word.rs
+++ b/ffi/capi/src/segmenter_word.rs
@@ -79,9 +79,7 @@ pub mod ffi {
         pub fn create_auto_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<WordSegmenter>, DataError> {
-            Ok(Box::new(WordSegmenter(call_constructor!(
-                icu_segmenter::WordSegmenter::new_auto [r => Ok(r)],
-                icu_segmenter::WordSegmenter::try_new_auto_with_any_provider,
+            Ok(Box::new(WordSegmenter(call_constructor2!(
                 icu_segmenter::WordSegmenter::try_new_auto_with_buffer_provider,
                 provider
             )?)))
@@ -114,9 +112,7 @@ pub mod ffi {
             provider: &DataProvider,
             locale: &Locale,
         ) -> Result<Box<WordSegmenter>, DataError> {
-            Ok(Box::new(WordSegmenter(call_constructor!(
-                icu_segmenter::WordSegmenter::try_new_auto_with_options,
-                icu_segmenter::WordSegmenter::try_new_auto_with_options_with_any_provider,
+            Ok(Box::new(WordSegmenter(call_constructor2!(
                 icu_segmenter::WordSegmenter::try_new_auto_with_options_with_buffer_provider,
                 provider,
                 locale.into(),
@@ -145,9 +141,7 @@ pub mod ffi {
         pub fn create_lstm_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<WordSegmenter>, DataError> {
-            Ok(Box::new(WordSegmenter(call_constructor!(
-                icu_segmenter::WordSegmenter::new_lstm [r => Ok(r)],
-                icu_segmenter::WordSegmenter::try_new_lstm_with_any_provider,
+            Ok(Box::new(WordSegmenter(call_constructor2!(
                 icu_segmenter::WordSegmenter::try_new_lstm_with_buffer_provider,
                 provider
             )?)))
@@ -180,9 +174,7 @@ pub mod ffi {
             provider: &DataProvider,
             locale: &Locale,
         ) -> Result<Box<WordSegmenter>, DataError> {
-            Ok(Box::new(WordSegmenter(call_constructor!(
-                icu_segmenter::WordSegmenter::try_new_lstm_with_options,
-                icu_segmenter::WordSegmenter::try_new_lstm_with_options_with_any_provider,
+            Ok(Box::new(WordSegmenter(call_constructor2!(
                 icu_segmenter::WordSegmenter::try_new_lstm_with_options_with_buffer_provider,
                 provider,
                 locale.into(),
@@ -211,9 +203,7 @@ pub mod ffi {
         pub fn create_dictionary_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<WordSegmenter>, DataError> {
-            Ok(Box::new(WordSegmenter(call_constructor!(
-                icu_segmenter::WordSegmenter::new_dictionary [r => Ok(r)],
-                icu_segmenter::WordSegmenter::try_new_dictionary_with_any_provider,
+            Ok(Box::new(WordSegmenter(call_constructor2!(
                 icu_segmenter::WordSegmenter::try_new_dictionary_with_buffer_provider,
                 provider
             )?)))
@@ -252,9 +242,7 @@ pub mod ffi {
             provider: &DataProvider,
             locale: &Locale,
         ) -> Result<Box<WordSegmenter>, DataError> {
-            Ok(Box::new(WordSegmenter(call_constructor!(
-                icu_segmenter::WordSegmenter::try_new_dictionary_with_options,
-                icu_segmenter::WordSegmenter::try_new_dictionary_with_options_with_any_provider,
+            Ok(Box::new(WordSegmenter(call_constructor2!(
                 icu_segmenter::WordSegmenter::try_new_dictionary_with_options_with_buffer_provider,
                 provider,
                 locale.into(),

--- a/ffi/capi/src/segmenter_word.rs
+++ b/ffi/capi/src/segmenter_word.rs
@@ -8,9 +8,10 @@
 pub mod ffi {
     use alloc::boxed::Box;
 
-    use crate::errors::ffi::DataError;
-    use crate::locale_core::ffi::Locale;
+    #[cfg(feature = "buffer_provider")]
     use crate::provider::ffi::DataProvider;
+    #[cfg(any(feature = "compiled_data", feature = "buffer_provider"))]
+    use crate::{errors::ffi::DataError, locale_core::ffi::Locale};
 
     #[diplomat::enum_convert(icu_segmenter::WordType, needs_wildcard)]
     #[diplomat::rust_link(icu::segmenter::WordType, Enum)]
@@ -76,6 +77,7 @@ pub mod ffi {
         /// Khmer, Lao, and Thai.
         #[diplomat::rust_link(icu::segmenter::WordSegmenter::new_auto, FnInStruct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "auto_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_auto_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<WordSegmenter>, DataError> {
@@ -108,6 +110,7 @@ pub mod ffi {
         /// Khmer, Lao, and Thai.
         #[diplomat::rust_link(icu::segmenter::WordSegmenter::try_new_auto_with_options, FnInStruct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "auto_with_content_locale_and_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_auto_with_content_locale_and_provider(
             provider: &DataProvider,
             locale: &Locale,
@@ -138,6 +141,7 @@ pub mod ffi {
         /// Khmer, Lao, and Thai.
         #[diplomat::rust_link(icu::segmenter::WordSegmenter::new_lstm, FnInStruct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "lstm_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_lstm_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<WordSegmenter>, DataError> {
@@ -170,6 +174,7 @@ pub mod ffi {
         /// Khmer, Lao, and Thai.
         #[diplomat::rust_link(icu::segmenter::WordSegmenter::try_new_lstm_with_options, FnInStruct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "lstm_with_content_locale_and_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_lstm_with_content_locale_and_provider(
             provider: &DataProvider,
             locale: &Locale,
@@ -200,6 +205,7 @@ pub mod ffi {
         /// Khmer, Lao, and Thai.
         #[diplomat::rust_link(icu::segmenter::WordSegmenter::new_dictionary, FnInStruct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "dictionary_with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_dictionary_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<WordSegmenter>, DataError> {
@@ -238,6 +244,7 @@ pub mod ffi {
             FnInStruct
         )]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "dictionary_with_content_locale_and_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_dictionary_with_content_locale_and_provider(
             provider: &DataProvider,
             locale: &Locale,

--- a/ffi/capi/src/segmenter_word.rs
+++ b/ffi/capi/src/segmenter_word.rs
@@ -81,9 +81,10 @@ pub mod ffi {
         pub fn create_auto_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<WordSegmenter>, DataError> {
-            Ok(Box::new(WordSegmenter(call_constructor!(
-                icu_segmenter::WordSegmenter::try_new_auto_with_buffer_provider,
-                provider
+            Ok(Box::new(WordSegmenter(provider.call_constructor(
+                |provider| {
+                    icu_segmenter::WordSegmenter::try_new_auto_with_buffer_provider(provider)
+                },
             )?)))
         }
 
@@ -115,10 +116,13 @@ pub mod ffi {
             provider: &DataProvider,
             locale: &Locale,
         ) -> Result<Box<WordSegmenter>, DataError> {
-            Ok(Box::new(WordSegmenter(call_constructor!(
-                icu_segmenter::WordSegmenter::try_new_auto_with_options_with_buffer_provider,
-                provider,
-                locale.into(),
+            Ok(Box::new(WordSegmenter(provider.call_constructor(
+                |provider| {
+                    icu_segmenter::WordSegmenter::try_new_auto_with_options_with_buffer_provider(
+                        provider,
+                        locale.into(),
+                    )
+                },
             )?)))
         }
 
@@ -145,9 +149,10 @@ pub mod ffi {
         pub fn create_lstm_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<WordSegmenter>, DataError> {
-            Ok(Box::new(WordSegmenter(call_constructor!(
-                icu_segmenter::WordSegmenter::try_new_lstm_with_buffer_provider,
-                provider
+            Ok(Box::new(WordSegmenter(provider.call_constructor(
+                |provider| {
+                    icu_segmenter::WordSegmenter::try_new_lstm_with_buffer_provider(provider)
+                },
             )?)))
         }
 
@@ -179,10 +184,13 @@ pub mod ffi {
             provider: &DataProvider,
             locale: &Locale,
         ) -> Result<Box<WordSegmenter>, DataError> {
-            Ok(Box::new(WordSegmenter(call_constructor!(
-                icu_segmenter::WordSegmenter::try_new_lstm_with_options_with_buffer_provider,
-                provider,
-                locale.into(),
+            Ok(Box::new(WordSegmenter(provider.call_constructor(
+                |provider| {
+                    icu_segmenter::WordSegmenter::try_new_lstm_with_options_with_buffer_provider(
+                        provider,
+                        locale.into(),
+                    )
+                },
             )?)))
         }
 
@@ -209,9 +217,10 @@ pub mod ffi {
         pub fn create_dictionary_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<WordSegmenter>, DataError> {
-            Ok(Box::new(WordSegmenter(call_constructor!(
-                icu_segmenter::WordSegmenter::try_new_dictionary_with_buffer_provider,
-                provider
+            Ok(Box::new(WordSegmenter(provider.call_constructor(
+                |provider| {
+                    icu_segmenter::WordSegmenter::try_new_dictionary_with_buffer_provider(provider)
+                },
             )?)))
         }
 
@@ -249,11 +258,7 @@ pub mod ffi {
             provider: &DataProvider,
             locale: &Locale,
         ) -> Result<Box<WordSegmenter>, DataError> {
-            Ok(Box::new(WordSegmenter(call_constructor!(
-                icu_segmenter::WordSegmenter::try_new_dictionary_with_options_with_buffer_provider,
-                provider,
-                locale.into(),
-            )?)))
+            Ok(Box::new(WordSegmenter(provider.call_constructor(|provider| icu_segmenter::WordSegmenter::try_new_dictionary_with_options_with_buffer_provider(provider, locale.into()))?)))
         }
         /// Segments a string.
         ///

--- a/ffi/capi/src/timezone_mapper.rs
+++ b/ffi/capi/src/timezone_mapper.rs
@@ -9,8 +9,8 @@ pub mod ffi {
     use alloc::boxed::Box;
     use writeable::Writeable;
 
-    use crate::errors::ffi::DataError;
-    use crate::provider::ffi::DataProvider;
+    #[cfg(feature = "buffer_provider")]
+    use crate::{errors::ffi::DataError, provider::ffi::DataProvider};
 
     use tinystr::TinyAsciiStr;
 
@@ -40,6 +40,7 @@ pub mod ffi {
         /// Create a new [`TimeZoneIdMapper`] using a particular data source
         #[diplomat::rust_link(icu::timezone::TimeZoneIdMapper::new, FnInStruct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<TimeZoneIdMapper>, DataError> {
@@ -167,6 +168,7 @@ pub mod ffi {
             FnInStruct
         )]
         #[diplomat::attr(auto, named_constructor = "with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<TimeZoneIdMapperWithFastCanonicalization>, DataError> {

--- a/ffi/capi/src/timezone_mapper.rs
+++ b/ffi/capi/src/timezone_mapper.rs
@@ -43,9 +43,7 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<TimeZoneIdMapper>, DataError> {
-            Ok(Box::new(TimeZoneIdMapper(call_constructor!(
-                icu_timezone::TimeZoneIdMapper::new [r => Ok(r.static_to_owned())],
-                icu_timezone::TimeZoneIdMapper::try_new_with_any_provider,
+            Ok(Box::new(TimeZoneIdMapper(call_constructor2!(
                 icu_timezone::TimeZoneIdMapper::try_new_with_buffer_provider,
                 provider,
             )?)))
@@ -173,9 +171,7 @@ pub mod ffi {
             provider: &DataProvider,
         ) -> Result<Box<TimeZoneIdMapperWithFastCanonicalization>, DataError> {
             Ok(Box::new(TimeZoneIdMapperWithFastCanonicalization(
-                call_constructor!(
-                    icu_timezone::TimeZoneIdMapperWithFastCanonicalization::new [r => Ok(r.static_to_owned())],
-                    icu_timezone::TimeZoneIdMapperWithFastCanonicalization::try_new_with_any_provider,
+                call_constructor2!(
                     icu_timezone::TimeZoneIdMapperWithFastCanonicalization::try_new_with_buffer_provider,
                     provider,
                 )?,

--- a/ffi/capi/src/timezone_mapper.rs
+++ b/ffi/capi/src/timezone_mapper.rs
@@ -43,7 +43,7 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<TimeZoneIdMapper>, DataError> {
-            Ok(Box::new(TimeZoneIdMapper(call_constructor2!(
+            Ok(Box::new(TimeZoneIdMapper(call_constructor!(
                 icu_timezone::TimeZoneIdMapper::try_new_with_buffer_provider,
                 provider,
             )?)))
@@ -171,7 +171,7 @@ pub mod ffi {
             provider: &DataProvider,
         ) -> Result<Box<TimeZoneIdMapperWithFastCanonicalization>, DataError> {
             Ok(Box::new(TimeZoneIdMapperWithFastCanonicalization(
-                call_constructor2!(
+                call_constructor!(
                     icu_timezone::TimeZoneIdMapperWithFastCanonicalization::try_new_with_buffer_provider,
                     provider,
                 )?,

--- a/ffi/capi/src/timezone_mapper.rs
+++ b/ffi/capi/src/timezone_mapper.rs
@@ -45,7 +45,7 @@ pub mod ffi {
             provider: &DataProvider,
         ) -> Result<Box<TimeZoneIdMapper>, DataError> {
             Ok(Box::new(TimeZoneIdMapper(provider.call_constructor(
-                |provider| icu_timezone::TimeZoneIdMapper::try_new_with_buffer_provider(provider),
+                icu_timezone::TimeZoneIdMapper::try_new_with_buffer_provider,
             )?)))
         }
 
@@ -172,7 +172,7 @@ pub mod ffi {
             provider: &DataProvider,
         ) -> Result<Box<TimeZoneIdMapperWithFastCanonicalization>, DataError> {
             Ok(Box::new(TimeZoneIdMapperWithFastCanonicalization(
-                provider.call_constructor(|provider| icu_timezone::TimeZoneIdMapperWithFastCanonicalization::try_new_with_buffer_provider(provider))?,
+                provider.call_constructor(icu_timezone::TimeZoneIdMapperWithFastCanonicalization::try_new_with_buffer_provider)?,
             )))
         }
 

--- a/ffi/capi/src/timezone_mapper.rs
+++ b/ffi/capi/src/timezone_mapper.rs
@@ -44,9 +44,8 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<TimeZoneIdMapper>, DataError> {
-            Ok(Box::new(TimeZoneIdMapper(call_constructor!(
-                icu_timezone::TimeZoneIdMapper::try_new_with_buffer_provider,
-                provider,
+            Ok(Box::new(TimeZoneIdMapper(provider.call_constructor(
+                |provider| icu_timezone::TimeZoneIdMapper::try_new_with_buffer_provider(provider),
             )?)))
         }
 
@@ -173,10 +172,7 @@ pub mod ffi {
             provider: &DataProvider,
         ) -> Result<Box<TimeZoneIdMapperWithFastCanonicalization>, DataError> {
             Ok(Box::new(TimeZoneIdMapperWithFastCanonicalization(
-                call_constructor!(
-                    icu_timezone::TimeZoneIdMapperWithFastCanonicalization::try_new_with_buffer_provider,
-                    provider,
-                )?,
+                provider.call_constructor(|provider| icu_timezone::TimeZoneIdMapperWithFastCanonicalization::try_new_with_buffer_provider(provider))?,
             )))
         }
 

--- a/ffi/capi/src/units_converter.rs
+++ b/ffi/capi/src/units_converter.rs
@@ -46,7 +46,7 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<UnitsConverterFactory>, DataError> {
-            Ok(Box::new(UnitsConverterFactory(provider.call_constructor(|provider| icu_experimental::units::converter_factory::ConverterFactory::try_new_with_buffer_provider(provider))?)))
+            Ok(Box::new(UnitsConverterFactory(provider.call_constructor(icu_experimental::units::converter_factory::ConverterFactory::try_new_with_buffer_provider)?)))
         }
         /// Creates a new [`UnitsConverter`] from the input and output [`MeasureUnit`]s.
         /// Returns nothing if the conversion between the two units is not possible.

--- a/ffi/capi/src/units_converter.rs
+++ b/ffi/capi/src/units_converter.rs
@@ -46,10 +46,7 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<UnitsConverterFactory>, DataError> {
-            Ok(Box::new(UnitsConverterFactory(call_constructor!(
-                icu_experimental::units::converter_factory::ConverterFactory::try_new_with_buffer_provider,
-                provider,
-            )?)))
+            Ok(Box::new(UnitsConverterFactory(provider.call_constructor(|provider| icu_experimental::units::converter_factory::ConverterFactory::try_new_with_buffer_provider(provider))?)))
         }
         /// Creates a new [`UnitsConverter`] from the input and output [`MeasureUnit`]s.
         /// Returns nothing if the conversion between the two units is not possible.

--- a/ffi/capi/src/units_converter.rs
+++ b/ffi/capi/src/units_converter.rs
@@ -42,9 +42,7 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<UnitsConverterFactory>, DataError> {
-            Ok(Box::new(UnitsConverterFactory(call_constructor!(
-                icu_experimental::units::converter_factory::ConverterFactory::new [r => Ok(r)],
-                icu_experimental::units::converter_factory::ConverterFactory::try_new_with_any_provider,
+            Ok(Box::new(UnitsConverterFactory(call_constructor2!(
                 icu_experimental::units::converter_factory::ConverterFactory::try_new_with_buffer_provider,
                 provider,
             )?)))

--- a/ffi/capi/src/units_converter.rs
+++ b/ffi/capi/src/units_converter.rs
@@ -42,7 +42,7 @@ pub mod ffi {
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<UnitsConverterFactory>, DataError> {
-            Ok(Box::new(UnitsConverterFactory(call_constructor2!(
+            Ok(Box::new(UnitsConverterFactory(call_constructor!(
                 icu_experimental::units::converter_factory::ConverterFactory::try_new_with_buffer_provider,
                 provider,
             )?)))

--- a/ffi/capi/src/units_converter.rs
+++ b/ffi/capi/src/units_converter.rs
@@ -8,7 +8,10 @@
 pub mod ffi {
     use alloc::boxed::Box;
 
-    use crate::{errors::ffi::DataError, provider::ffi::DataProvider};
+    #[cfg(feature = "buffer_provider")]
+    use crate::errors::ffi::DataError;
+    #[cfg(feature = "buffer_provider")]
+    use crate::provider::ffi::DataProvider;
 
     #[diplomat::opaque]
     /// An ICU4X Units Converter Factory object, capable of creating converters a [`UnitsConverter`]
@@ -39,6 +42,7 @@ pub mod ffi {
             FnInStruct
         )]
         #[diplomat::attr(auto, named_constructor = "with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<UnitsConverterFactory>, DataError> {

--- a/ffi/capi/src/week.rs
+++ b/ffi/capi/src/week.rs
@@ -9,9 +9,10 @@ pub mod ffi {
     use alloc::boxed::Box;
 
     use crate::date::ffi::IsoWeekday;
-    use crate::errors::ffi::DataError;
-    use crate::locale_core::ffi::Locale;
+    #[cfg(feature = "buffer_provider")]
     use crate::provider::ffi::DataProvider;
+    #[cfg(any(feature = "compiled_data", feature = "buffer_provider"))]
+    use crate::{errors::ffi::DataError, locale_core::ffi::Locale};
 
     #[diplomat::rust_link(icu::calendar::week::RelativeUnit, Enum)]
     #[diplomat::enum_convert(icu_calendar::week::RelativeUnit)]
@@ -47,6 +48,7 @@ pub mod ffi {
         /// Creates a new [`WeekCalculator`] from locale data using a particular data source.
         #[diplomat::rust_link(icu::calendar::week::WeekCalculator::try_new, FnInStruct)]
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "with_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_with_provider(
             provider: &DataProvider,
             locale: &Locale,

--- a/ffi/capi/src/week.rs
+++ b/ffi/capi/src/week.rs
@@ -53,7 +53,7 @@ pub mod ffi {
         ) -> Result<Box<WeekCalculator>, DataError> {
             let prefs = (&locale.0).into();
 
-            Ok(Box::new(WeekCalculator(call_constructor2!(
+            Ok(Box::new(WeekCalculator(call_constructor!(
                 icu_calendar::week::WeekCalculator::try_new_with_buffer_provider,
                 provider,
                 prefs,

--- a/ffi/capi/src/week.rs
+++ b/ffi/capi/src/week.rs
@@ -53,9 +53,7 @@ pub mod ffi {
         ) -> Result<Box<WeekCalculator>, DataError> {
             let prefs = (&locale.0).into();
 
-            Ok(Box::new(WeekCalculator(call_constructor!(
-                icu_calendar::week::WeekCalculator::try_new,
-                icu_calendar::week::WeekCalculator::try_new_with_any_provider,
+            Ok(Box::new(WeekCalculator(call_constructor2!(
                 icu_calendar::week::WeekCalculator::try_new_with_buffer_provider,
                 provider,
                 prefs,

--- a/ffi/capi/src/week.rs
+++ b/ffi/capi/src/week.rs
@@ -55,10 +55,12 @@ pub mod ffi {
         ) -> Result<Box<WeekCalculator>, DataError> {
             let prefs = (&locale.0).into();
 
-            Ok(Box::new(WeekCalculator(call_constructor!(
-                icu_calendar::week::WeekCalculator::try_new_with_buffer_provider,
-                provider,
-                prefs,
+            Ok(Box::new(WeekCalculator(provider.call_constructor(
+                |provider| {
+                    icu_calendar::week::WeekCalculator::try_new_with_buffer_provider(
+                        provider, prefs,
+                    )
+                },
             )?)))
         }
         #[diplomat::rust_link(

--- a/ffi/capi/src/zoned_formatter.rs
+++ b/ffi/capi/src/zoned_formatter.rs
@@ -61,9 +61,7 @@ pub mod ffi {
             let options = YMDTV::with_length(Length::from(length));
 
             Ok(Box::new(GregorianZonedDateTimeFormatter(
-                call_constructor!(
-                    icu_datetime::FixedCalendarDateTimeFormatter::try_new,
-                    icu_datetime::FixedCalendarDateTimeFormatter::try_new_with_any_provider,
+                call_constructor2!(
                     icu_datetime::FixedCalendarDateTimeFormatter::try_new_with_buffer_provider,
                     provider,
                     prefs,
@@ -130,9 +128,7 @@ pub mod ffi {
             let prefs = (&locale.0).into();
             let options = YMDTV::with_length(Length::from(length));
 
-            Ok(Box::new(ZonedDateTimeFormatter(call_constructor!(
-                icu_datetime::DateTimeFormatter::try_new,
-                icu_datetime::DateTimeFormatter::try_new_with_any_provider,
+            Ok(Box::new(ZonedDateTimeFormatter(call_constructor2!(
                 icu_datetime::DateTimeFormatter::try_new_with_buffer_provider,
                 provider,
                 prefs,

--- a/ffi/capi/src/zoned_formatter.rs
+++ b/ffi/capi/src/zoned_formatter.rs
@@ -69,12 +69,11 @@ pub mod ffi {
             let options = YMDTV::with_length(Length::from(length));
 
             Ok(Box::new(GregorianZonedDateTimeFormatter(
-                call_constructor!(
-                    icu_datetime::FixedCalendarDateTimeFormatter::try_new_with_buffer_provider,
-                    provider,
-                    prefs,
-                    options
-                )?,
+                provider.call_constructor_custom_err(move |provider| {
+                    icu_datetime::FixedCalendarDateTimeFormatter::try_new_with_buffer_provider(
+                        provider, prefs, options,
+                    )
+                })?,
             )))
         }
         /// Formats a [`IsoDateTime`] and [`TimeZoneInfo`] to a string.
@@ -137,12 +136,13 @@ pub mod ffi {
             let prefs = (&locale.0).into();
             let options = YMDTV::with_length(Length::from(length));
 
-            Ok(Box::new(ZonedDateTimeFormatter(call_constructor!(
-                icu_datetime::DateTimeFormatter::try_new_with_buffer_provider,
-                provider,
-                prefs,
-                options,
-            )?)))
+            Ok(Box::new(ZonedDateTimeFormatter(
+                provider.call_constructor_custom_err(move |provider| {
+                    icu_datetime::DateTimeFormatter::try_new_with_buffer_provider(
+                        provider, prefs, options,
+                    )
+                })?,
+            )))
         }
         /// Formats a [`DateTime`] and [`TimeZoneInfo`] to a string.
         pub fn format_datetime_with_custom_time_zone(

--- a/ffi/capi/src/zoned_formatter.rs
+++ b/ffi/capi/src/zoned_formatter.rs
@@ -7,16 +7,23 @@
 #[diplomat::attr(auto, namespace = "icu4x")]
 pub mod ffi {
     use alloc::boxed::Box;
-    use icu_datetime::{fieldsets::YMDTV, options::Length};
+    use icu_datetime::fieldsets::YMDTV;
+    #[cfg(any(feature = "compiled_data", feature = "buffer_provider"))]
+    use icu_datetime::options::Length;
     use icu_timezone::ZoneVariant;
 
+    #[cfg(feature = "buffer_provider")]
+    use crate::provider::ffi::DataProvider;
     use crate::{
         datetime::ffi::{DateTime, IsoDateTime},
-        datetime_formatter::ffi::DateTimeLength,
-        errors::ffi::{DateTimeFormatError, DateTimeFormatterLoadError},
-        locale_core::ffi::Locale,
-        provider::ffi::DataProvider,
+        errors::ffi::DateTimeFormatError,
         timezone::ffi::TimeZoneInfo,
+    };
+
+    #[cfg(any(feature = "compiled_data", feature = "buffer_provider"))]
+    use crate::{
+        datetime_formatter::ffi::DateTimeLength, errors::ffi::DateTimeFormatterLoadError,
+        locale_core::ffi::Locale,
     };
 
     use writeable::Writeable;
@@ -52,6 +59,7 @@ pub mod ffi {
         /// This function has `date_length` and `time_length` arguments and uses default options
         /// for the time zone.
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "with_length_and_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_with_length_and_provider(
             provider: &DataProvider,
             locale: &Locale,
@@ -120,6 +128,7 @@ pub mod ffi {
         /// This function has `date_length` and `time_length` arguments and uses default options
         /// for the time zone.
         #[diplomat::attr(supports = fallible_constructors, named_constructor = "with_length_and_provider")]
+        #[cfg(feature = "buffer_provider")]
         pub fn create_with_length_and_provider(
             provider: &DataProvider,
             locale: &Locale,

--- a/ffi/capi/src/zoned_formatter.rs
+++ b/ffi/capi/src/zoned_formatter.rs
@@ -61,7 +61,7 @@ pub mod ffi {
             let options = YMDTV::with_length(Length::from(length));
 
             Ok(Box::new(GregorianZonedDateTimeFormatter(
-                call_constructor2!(
+                call_constructor!(
                     icu_datetime::FixedCalendarDateTimeFormatter::try_new_with_buffer_provider,
                     provider,
                     prefs,
@@ -128,7 +128,7 @@ pub mod ffi {
             let prefs = (&locale.0).into();
             let options = YMDTV::with_length(Length::from(length));
 
-            Ok(Box::new(ZonedDateTimeFormatter(call_constructor2!(
+            Ok(Box::new(ZonedDateTimeFormatter(call_constructor!(
                 icu_datetime::DateTimeFormatter::try_new_with_buffer_provider,
                 provider,
                 prefs,

--- a/tutorials/cpp/segmenter.cpp
+++ b/tutorials/cpp/segmenter.cpp
@@ -144,7 +144,6 @@ void test_word_with_options(const std::string_view& str) {
 }
 
 void test_sentence(const std::string_view& str) {
-    const auto provider = DataProvider::compiled();
     const auto segmenter = SentenceSegmenter::create();
     cout << "Finding sentence breakpoints in string:" << endl
          << str << endl;


### PR DESCRIPTION
Fixes #4639

I still plan to do docs for this, please review the actual changes first.


"refactor" and "move usages to closures" are commits that are largely mechanical.

In the last two commits I attempt to get rid of the macro in favor of a closure based situation. Datetime uses a custom error so it's weird.


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->