### PR TITLE
Add docs for resolved decimal and datetime prefs

### DIFF
--- a/components/datetime/src/neo.rs
+++ b/components/datetime/src/neo.rs
@@ -59,14 +59,22 @@ define_preferences!(
         /// The user's preferred numbering system.
         ///
         /// Corresponds to the `-u-nu` in Unicode Locale Identifier.
+        ///
+        /// To get the resolved numbering system, you can inspect the data provider.
+        /// See the [`icu_decimal::provider`] module for an example.
         numbering_system: NumberingSystem,
         /// The user's preferred hour cycle.
         ///
         /// Corresponds to the `-u-hc` in Unicode Locale Identifier.
+        ///
+        /// To get the resolved hour cycle, you can inspect the formatting pattern.
+        /// See [`DateTimePattern`](crate::pattern::DateTimePattern) for an example.
         hour_cycle: HourCycle,
         /// The user's preferred calendar system
         ///
         /// Corresponds to the `-u-ca` in Unicode Locale Identifier.
+        ///
+        /// To get the resolved calendar system, use [`DateTimeFormatter::calendar_kind()`].
         calendar_algorithm: CalendarAlgorithm
     }
 );

--- a/components/decimal/README.md
+++ b/components/decimal/README.md
@@ -52,7 +52,7 @@ let fixed_decimal = {
 assert_writeable_eq!(fdf.format(&fixed_decimal), "2,000.50");
 ```
 
-#### Format a number using an alternative numbering system
+### Format a number using an alternative numbering system
 
 Numbering systems specified in the `-u-nu` subtag will be followed.
 
@@ -71,69 +71,6 @@ let fdf = FixedDecimalFormatter::try_new(
 let fixed_decimal = SignedFixedDecimal::from(1000007);
 
 assert_writeable_eq!(fdf.format(&fixed_decimal), "๑,๐๐๐,๐๐๗");
-```
-
-#### Get the resolved numbering system
-
-Inspect the data request to get the resolved numbering system (public but unstable):
-
-```rust
-use icu_provider::prelude::*;
-use icu::decimal::FixedDecimalFormatter;
-use icu::decimal::provider::DecimalDigitsV1Marker;
-use icu::locale::locale;
-use std::any::TypeId;
-use std::cell::RefCell;
-
-struct NumberingSystemInspectionProvider<P> {
-    inner: P,
-    numbering_system: RefCell<Option<Box<DataMarkerAttributes>>>,
-}
-
-impl<M, P> DataProvider<M> for NumberingSystemInspectionProvider<P>
-where
-    M: DataMarker,
-    P: DataProvider<M>,
-{
-    fn load(&self, req: DataRequest) -> Result<DataResponse<M>, DataError> {
-        if TypeId::of::<M>() == TypeId::of::<DecimalDigitsV1Marker>() {
-            *self.numbering_system.try_borrow_mut().unwrap() = Some(req.id.marker_attributes.to_owned());
-        }
-        self.inner.load(req)
-    }
-}
-
-let provider = NumberingSystemInspectionProvider {
-    inner: icu::decimal::provider::Baked,
-    numbering_system: RefCell::new(None),
-};
-
-let fdf = FixedDecimalFormatter::try_new_unstable(
-    &provider,
-    locale!("th").into(),
-    Default::default(),
-)
-.unwrap();
-
-assert_eq!(provider.numbering_system.borrow().as_ref().map(|x| x.as_str()), Some("latn"));
-
-let fdf = FixedDecimalFormatter::try_new_unstable(
-    &provider,
-    locale!("th-u-nu-thai").into(),
-    Default::default(),
-)
-.unwrap();
-
-assert_eq!(provider.numbering_system.borrow().as_ref().map(|x| x.as_str()), Some("thai"));
-
-let fdf = FixedDecimalFormatter::try_new_unstable(
-    &provider,
-    locale!("th-u-nu-adlm").into(),
-    Default::default(),
-)
-.unwrap();
-
-assert_eq!(provider.numbering_system.borrow().as_ref().map(|x| x.as_str()), Some("adlm"));
 ```
 
 [`FixedDecimalFormatter`]: FixedDecimalFormatter

--- a/components/decimal/src/lib.rs
+++ b/components/decimal/src/lib.rs
@@ -52,7 +52,7 @@
 //! assert_writeable_eq!(fdf.format(&fixed_decimal), "2,000.50");
 //! ```
 //!
-//! ### Format a number using an alternative numbering system
+//! ## Format a number using an alternative numbering system
 //!
 //! Numbering systems specified in the `-u-nu` subtag will be followed.
 //!
@@ -71,69 +71,6 @@
 //! let fixed_decimal = SignedFixedDecimal::from(1000007);
 //!
 //! assert_writeable_eq!(fdf.format(&fixed_decimal), "๑,๐๐๐,๐๐๗");
-//! ```
-//!
-//! ### Get the resolved numbering system
-//!
-//! Inspect the data request to get the resolved numbering system (public but unstable):
-//!
-//! ```
-//! use icu_provider::prelude::*;
-//! use icu::decimal::FixedDecimalFormatter;
-//! use icu::decimal::provider::DecimalDigitsV1Marker;
-//! use icu::locale::locale;
-//! use std::any::TypeId;
-//! use std::cell::RefCell;
-//!
-//! struct NumberingSystemInspectionProvider<P> {
-//!     inner: P,
-//!     numbering_system: RefCell<Option<Box<DataMarkerAttributes>>>,
-//! }
-//!
-//! impl<M, P> DataProvider<M> for NumberingSystemInspectionProvider<P>
-//! where
-//!     M: DataMarker,
-//!     P: DataProvider<M>,
-//! {
-//!     fn load(&self, req: DataRequest) -> Result<DataResponse<M>, DataError> {
-//!         if TypeId::of::<M>() == TypeId::of::<DecimalDigitsV1Marker>() {
-//!             *self.numbering_system.try_borrow_mut().unwrap() = Some(req.id.marker_attributes.to_owned());
-//!         }
-//!         self.inner.load(req)
-//!     }
-//! }
-//!
-//! let provider = NumberingSystemInspectionProvider {
-//!     inner: icu::decimal::provider::Baked,
-//!     numbering_system: RefCell::new(None),
-//! };
-//!
-//! let fdf = FixedDecimalFormatter::try_new_unstable(
-//!     &provider,
-//!     locale!("th").into(),
-//!     Default::default(),
-//! )
-//! .unwrap();
-//!
-//! assert_eq!(provider.numbering_system.borrow().as_ref().map(|x| x.as_str()), Some("latn"));
-//!
-//! let fdf = FixedDecimalFormatter::try_new_unstable(
-//!     &provider,
-//!     locale!("th-u-nu-thai").into(),
-//!     Default::default(),
-//! )
-//! .unwrap();
-//!
-//! assert_eq!(provider.numbering_system.borrow().as_ref().map(|x| x.as_str()), Some("thai"));
-//!
-//! let fdf = FixedDecimalFormatter::try_new_unstable(
-//!     &provider,
-//!     locale!("th-u-nu-adlm").into(),
-//!     Default::default(),
-//! )
-//! .unwrap();
-//!
-//! assert_eq!(provider.numbering_system.borrow().as_ref().map(|x| x.as_str()), Some("adlm"));
 //! ```
 //!
 //! [`FixedDecimalFormatter`]: FixedDecimalFormatter
@@ -185,6 +122,9 @@ define_preferences!(
         /// The user's preferred numbering system.
         ///
         /// Corresponds to the `-u-nu` in Unicode Locale Identifier.
+        ///
+        /// To get the resolved numbering system, you can inspect the data provider.
+        /// See the [`provider`] module for an example.
         numbering_system: NumberingSystem
     }
 );
@@ -197,7 +137,7 @@ define_preferences!(
 /// 2. Locale-sensitive grouping separator positions
 /// 3. Locale-sensitive plus and minus signs
 ///
-/// Read more about the options in the [`options`] module.
+/// To get the resolved numbering system, see [`provider`].
 ///
 /// See the crate-level documentation for examples.
 #[doc = fixed_decimal_formatter_size!()]


### PR DESCRIPTION
Fixes #5900

I moved the decimal numbering system example into the `provider` module since it is unstable and since it refers to multiple types from that module (`DecimalDigitsV1Marker` and `Baked`).