### PR TITLE
Improved c-tiny benchmark

### DIFF
--- a/tutorials/c-tiny/README.md
+++ b/tutorials/c-tiny/README.md
@@ -1,0 +1,123 @@
+# Size-optimized C++ builds
+
+This folder contains benchmarks for various tactics for reducing the codesize of an ICU4X build when linked with C++.
+
+The results of the benchmarks (Rust `nightly-2024-01-01`, Clang/LLD 17`) are:
+
+```
+# Fixed Decimal Formatting
+-rwxr-x--- 1 manishearth primarygroup 5273536 Dec 27 14:25 1-release.elf
+-rwxr-x--- 1 manishearth primarygroup  387664 Dec 27 14:25 2-release-gcc-stripped.elf
+-rwxr-x--- 1 manishearth primarygroup 1178184 Dec 27 14:25 3-panic-abort-clang.elf
+-rwxr-x--- 1 manishearth primarygroup  133520 Dec 27 14:25 4-panic-abort-lto-clang.elf
+-rwxr-x--- 1 manishearth primarygroup   47416 Dec 27 14:25 5-panic-abort-clang-stripped.elf
+-rwxr-x--- 1 manishearth primarygroup   34040 Dec 27 14:25 6-panic-abort-lto-clang-stripped.elf
+-rwxr-x--- 1 manishearth primarygroup   33296 Dec 27 14:25 7-panic-abort-linker-plugin-lto-clang-stripped.elf
+
+
+# Segmenter
+-rwxr-x--- 1 manishearth primarygroup 9601072 Dec 27 14:25 1-release.elf
+-rwxr-x--- 1 manishearth primarygroup  719432 Dec 27 14:25 2-release-gcc-stripped.elf
+-rwxr-x--- 1 manishearth primarygroup 5681200 Dec 27 14:25 3-panic-abort-clang.elf
+-rwxr-x--- 1 manishearth primarygroup 4318128 Dec 27 14:25 4-panic-abort-lto-clang.elf
+-rwxr-x--- 1 manishearth primarygroup  383280 Dec 27 14:25 5-panic-abort-clang-stripped.elf
+-rwxr-x--- 1 manishearth primarygroup  372744 Dec 27 14:25 6-panic-abort-lto-clang-stripped.elf
+-rwxr-x--- 1 manishearth primarygroup  372136 Dec 27 14:25 7-panic-abort-linker-plugin-lto-clang-stripped.elf
+```
+
+The maximally low-size build documented here involves using LTO with `-Clinker-plugin-lto`, `-Os` Rust, `panic=abort`, `panic-immediate-abort` std, `gc-sections`, and `--strip-all`, as seen in the `7-panic-abort-linker-plugin-lto-clang-stripped.elf`. Furthermore, the Fixed Decimal Format test works by baking in a minimal set of locales (in this case, English and Bengali).
+
+
+```bash
+# Pick a toolchain where Rust and Clang use the same underlying LLVM version
+CLANG := clang-17
+LLD := lld-17
+LLVM_COMPATIBLE_NIGHTLY = "nightly-2024-01-01"
+
+# Rust build
+# ============
+
+
+# Enable LTO, -Os, and panic=abort
+RUSTFLAGS="-Clto -Cembed-bitcode -Clinker-plugin-lto -Clinker=$(CLANG) -Ccodegen-units=1 -Clink-arg=-flto -Cpanic=abort -Copt-level=s" \
+`# Use the optimal baked data including the locales we care about` \
+ICU4X_DATA_DIR=$(shell pwd)/baked_data \
+`# Build ICU4X with the optimized looping panic handler` \
+cargo +${LLVM_COMPATIBLE_NIGHTLY} rustc -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/${CAPI_COMPONENT},icu_capi/looping_panic_handler,icu_capi/libc_alloc \
+`# Build the standard library in panic-abort mode with panic-immediate-abort.` \
+-Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target x86_64-unknown-linux-gnu --release  --target-dir target-panic-abort-linker-plugin-lto 
+
+
+# Clang build
+# ===========
+
+$(CLANG) \
+`# Use ThinLTO with LLD` \
+-flto=thin -fuse-ld=$(LLD) --target=x86_64-unknown-linux-gnu test.c -I${HEADERS} -o 7-panic-abort-linker-plugin-lto-clang-stripped.elf target-panic-abort-linker-plugin-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a\
+`# Dead-code eliminate unused sections and strip all symbols` \
+ -Wl,--gc-sections -Wl,--strip-all
+```
+
+
+There is a lot of documentation on these strategies in [this guide](https://github.com/johnthagen/min-sized-rust?tab=readme-ov-file), but to give a gist of the different facets and their tradeoffs (tradeoffs impacting compile time are not listed), we have a list here. Note that in the benchmarks above, panic-abort builds always set `-Os`, and "stripped" builds are running both `gc-sections` and stripping.
+
+
+# Size opt level
+
+`RUSTFLAGS=-Os` or Cargo profile `opt-level=s`
+
+This tunes the optimizer for producing lower codesize.
+
+Tradeoff: This may impact runtime performance.
+
+# panic-abort
+
+`RUSTFLAGS=-Cpanic=abort` or Cargo profile `panic=abort`
+
+`panic=abort` turns all panics into aborts after printing an error message. This is configurable in your Cargo profile with `panic=abort`.
+
+Tradeoff: Unwinding will no longer work in this scenario.
+
+
+# panic-immediate-abort
+
+`cargo rustc ... -- -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort`
+
+This requires Rust nightly, using `-Zbuild-std`, and setting `RUSTFLAGS`, but will make errors _immediately_ abort instead of attempting to format the panic message. This gets rid of a lot of formatting code in the final binary, which tends to take up a fair amount of space.
+
+Tradeoff: This requires Rust nightly, and removes all panic error messages.
+
+# gc-sections
+
+`clang -fdata-sections -ffunction-sections .... -Wl,--gc-sections`
+
+This performs dead code elimination on the binary at link time. This is a coarser form of link time optimization that is quick and dirty and gets rid of a lot of low hanging fruit.
+
+It's not really necessary to use this when using LTO.
+
+Tradeoff: None
+
+# strip
+
+`clang .... -Wl,--strip`
+
+This removes all symbols, which severely impacts debuggability but greatly reduces codesize. Debuggability can be regained by setting up split debuginfo, which is not documented here but is possible.
+
+Tradeoff: Debugging can be harder
+
+# LTO
+
+`clang ... -flto -fuse-ld=$(LLD)`, `RUSTFLAGS=-Clto -Cembed-bitcode` (or Cargo profile `lto = true` / `lto = thin`)
+
+This performs additional link time optimization based on LLVM IR. LTO can be performed by Rust, Clang, or both. Explicitly setting the linker to LLD helps as well.
+
+Tradeoff: None
+
+## Cross-language LTO
+
+`RUSTFLAGS=-Clinker-plugin-lto`
+
+This is paired with the regular LTO setttings and enables Clang's LTO to optimize within the Rust binary.
+
+Tradeoff: Requires pairing Rust and Clang versions such that they have compatible LLVM bitcode.
+

--- a/tutorials/c-tiny/fixeddecimal/Makefile
+++ b/tutorials/c-tiny/fixeddecimal/Makefile
@@ -65,30 +65,30 @@ target-panic-abort-linker-plugin-lto/x86_64-unknown-linux-gnu/release/libicu_cap
 
 # Naive target: basic release mode, full std
 1-release.elf: target-normal/release/libicu_capi.a $(ALL_HEADERS) test.c
-	$(GCC) test.c -I${HEADERS} target-normal/release/libicu_capi.a -ldl -lm -g -o 1-release.elf
+	$(GCC) test.c -I${HEADERS} target-normal/release/libicu_capi.a -ldl -lm -o 1-release.elf
 
 # gcc with maximum link-time code stripping (gc-sections and strip-all)
 2-release-gcc-stripped.elf: target-normal/release/libicu_capi.a $(ALL_HEADERS) test.c
-	$(GCC) -fdata-sections -ffunction-sections test.c -I${HEADERS} target-normal/release/libicu_capi.a -ldl -lm -g -o 2-release-gcc-stripped.elf -Wl,--gc-sections -Wl,--strip-all
+	$(GCC) -fdata-sections -ffunction-sections test.c -I${HEADERS} target-normal/release/libicu_capi.a -ldl -lm -o 2-release-gcc-stripped.elf -Wl,--gc-sections -Wl,--strip-all
 
 # clang; rust with release, panic-abort (std panic-immediate-abort)
 3-panic-abort-clang.elf: target-panic-abort/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
-	$(CLANG) test.c -I${HEADERS} target-panic-abort/x86_64-unknown-linux-gnu/release/libicu_capi.a -g -o 3-panic-abort-clang.elf
+	$(CLANG) test.c -I${HEADERS} target-panic-abort/x86_64-unknown-linux-gnu/release/libicu_capi.a -o 3-panic-abort-clang.elf
 
 
 # clang with LTO, rust with release, LTO, panic-abort (std panic-immediate-abort)
 4-panic-abort-lto-clang.elf: target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
-	$(CLANG) -flto=thin -fuse-ld=$(LLD) -fdata-sections -ffunction-sections test.c -I${HEADERS} target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -g -o 4-panic-abort-lto-clang.elf
+	$(CLANG) -flto=thin -fuse-ld=$(LLD) -fdata-sections -ffunction-sections test.c -I${HEADERS} target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -o 4-panic-abort-lto-clang.elf
 
 
 # clang with gc-sections, stripping; rust with release, LTO, panic-abort (std panic-immediate-abort)
 5-panic-abort-clang-stripped.elf: target-panic-abort/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
-	$(CLANG) test.c -fdata-sections -ffunction-sections -I${HEADERS} target-panic-abort/x86_64-unknown-linux-gnu/release/libicu_capi.a -g -o 5-panic-abort-clang-stripped.elf  -Wl,--gc-sections -Wl,--strip-all
+	$(CLANG) test.c -fdata-sections -ffunction-sections -I${HEADERS} target-panic-abort/x86_64-unknown-linux-gnu/release/libicu_capi.a -o 5-panic-abort-clang-stripped.elf  -Wl,--gc-sections -Wl,--strip-all
 
 
 # clang with LTO, gc-sections, stripping, rust with release, LTO, panic-abort (std panic-immediate-abort)
 6-panic-abort-lto-clang-stripped.elf: target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
-	$(CLANG) -flto=thin -fuse-ld=$(LLD) -fdata-sections -ffunction-sections test.c -I${HEADERS} target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -g -o 6-panic-abort-lto-clang-stripped.elf -Wl,--gc-sections -Wl,--strip-all
+	$(CLANG) -flto=thin -fuse-ld=$(LLD) -fdata-sections -ffunction-sections test.c -I${HEADERS} target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -o 6-panic-abort-lto-clang-stripped.elf -Wl,--gc-sections -Wl,--strip-all
 
 
 # clang with lld, ThinLTO, gc-sections, stripping, rust with release, LTO, panic-abort (std panic-immediate-abort), with cross-compiler LTO

--- a/tutorials/c-tiny/fixeddecimal/Makefile
+++ b/tutorials/c-tiny/fixeddecimal/Makefile
@@ -78,14 +78,14 @@ panic-abort-clang-stripped.elf: target-panic-abort/x86_64-unknown-linux-gnu/rele
 
 # clang single-step with LTO, rust with release, LTO, panic-abort (std panic-immediate-abort)
 panic-abort-lto-clang.elf: target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
-	$(CLANG) -flto -fdata-sections -ffunction-sections test.c -I${HEADERS} target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -g -o panic-abort-lto-clang.elf
+	$(CLANG) -flto -fuse-ld=$(LLD) -fdata-sections -ffunction-sections test.c -I${HEADERS} target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -g -o panic-abort-lto-clang.elf
 
 # clang single-step with LTO, gc-sections, stripping, rust with release, LTO, panic-abort (std panic-immediate-abort)
 panic-abort-lto-clang-stripped.elf: target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
-	$(CLANG) -flto -fdata-sections -ffunction-sections test.c -I${HEADERS} target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -g -o panic-abort-lto-clang-stripped.elf -Wl,--gc-sections -Wl,--strip-all
+	$(CLANG) -flto -fuse-ld=$(LLD) -fdata-sections -ffunction-sections test.c -I${HEADERS} target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -g -o panic-abort-lto-clang-stripped.elf -Wl,--gc-sections -Wl,--strip-all
 
 panic-abort-lto-clang-twostep.o: target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
-	$(CLANG) -c -flto=thin -fdata-sections -ffunction-sections --target=x86_64-unknown-linux-gnu test.c -I${HEADERS} -g -o panic-abort-lto-clang-twostep.o
+	$(CLANG) -c -flto=thin -fuse-ld=$(LLD) -fdata-sections -ffunction-sections --target=x86_64-unknown-linux-gnu test.c -I${HEADERS} -g -o panic-abort-lto-clang-twostep.o
 
 # clang two-step with lld, rust with release, panic-abort (std panic-immediate-abort)
 panic-abort-lto-clang-twostep.elf: panic-abort-lto-clang-twostep.o
@@ -107,6 +107,9 @@ panic-abort-linker-plugin-lto-clang-twostep.o: target-panic-abort-linker-plugin-
 panic-abort-linker-plugin-lto-clang-twostep.elf: panic-abort-linker-plugin-lto-clang-twostep.o
 	$(CLANG) -flto=thin -fuse-ld=$(LLD) -L . -o panic-abort-linker-plugin-lto-clang-twostep.elf panic-abort-linker-plugin-lto-clang-twostep.o target-panic-abort-linker-plugin-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -Wl,--gc-sections -Wl,--strip-all
 
+# clang one-step with lld, ThinLTO, gc-sections, stripping, rust with release, LTO, panic-abort (std panic-immediate-abort), with cross-compiler LTO
+panic-abort-linker-plugin-lto-clang-stripped.elf:
+	$(CLANG) -flto=thin -fuse-ld=$(LLD) --target=x86_64-unknown-linux-gnu test.c -I${HEADERS} -o panic-abort-linker-plugin-lto-clang-stripped.elf target-panic-abort-linker-plugin-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -Wl,--gc-sections -Wl,--strip-all
 
 panic-abort-linker-plugin-lto-clang-twostep-stripped.o: target-panic-abort-linker-plugin-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
 	$(CLANG) -c -flto=thin -fdata-sections -ffunction-sections --target=x86_64-unknown-linux-gnu test.c -I${HEADERS} -g -o panic-abort-linker-plugin-lto-clang-twostep-stripped.o
@@ -115,7 +118,7 @@ panic-abort-linker-plugin-lto-clang-twostep-stripped.o: target-panic-abort-linke
 panic-abort-linker-plugin-lto-clang-twostep-stripped.elf: panic-abort-linker-plugin-lto-clang-twostep-stripped.o
 	$(CLANG) -flto=thin -fuse-ld=$(LLD) -L . -o panic-abort-linker-plugin-lto-clang-twostep-stripped.elf panic-abort-linker-plugin-lto-clang-twostep-stripped.o target-panic-abort-linker-plugin-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -Wl,--gc-sections -Wl,--strip-all
 
-build: release.elf release-gcc-stripped.elf panic-abort-clang.elf panic-abort-clang-stripped.elf panic-abort-lto-clang.elf panic-abort-lto-clang-stripped.elf panic-abort-lto-clang-twostep.elf panic-abort-lto-clang-twostep-stripped.elf panic-abort-linker-plugin-lto-clang-twostep.elf panic-abort-linker-plugin-lto-clang-twostep-stripped.elf
+build: release.elf release-gcc-stripped.elf panic-abort-clang.elf panic-abort-clang-stripped.elf panic-abort-lto-clang.elf panic-abort-lto-clang-stripped.elf panic-abort-lto-clang-twostep.elf panic-abort-lto-clang-twostep-stripped.elf panic-abort-linker-plugin-lto-clang-stripped.elf panic-abort-linker-plugin-lto-clang-twostep.elf panic-abort-linker-plugin-lto-clang-twostep-stripped.elf
 	ls -l *.elf
 
 test: build
@@ -128,6 +131,7 @@ test: build
 	./panic-abort-lto-clang-twostep.elf bn
 	./panic-abort-lto-clang-twostep-stripped.elf bn
 	./panic-abort-linker-plugin-lto-clang-twostep.elf bn
+	./panic-abort-linker-plugin-lto-clang-stripped.elf bn
 	./panic-abort-linker-plugin-lto-clang-twostep-stripped.elf bn
 
 clean:

--- a/tutorials/c-tiny/fixeddecimal/Makefile
+++ b/tutorials/c-tiny/fixeddecimal/Makefile
@@ -6,11 +6,12 @@
 
 .DEFAULT_GOAL := test
 .PHONY: build test
-FORCE:
 
 ICU_CAPI := $(shell cargo metadata --manifest-path Cargo.toml --format-version 1 | jq '.packages[] | select(.name == "icu_capi").manifest_path' | xargs dirname)
 HEADERS := ${ICU_CAPI}/bindings/c
 ALL_HEADERS := $(wildcard ${HEADERS}/*)
+
+ALL_RUST_SRC = $(wildcard ../../../components/**/*.rs) $(wildcard ../../../provider/**/*.rs) $(wildcard ../../../ffi/capi/**/*.rs)
 
 $(ALL_HEADERS):
 
@@ -19,70 +20,115 @@ CLANG := clang-17
 LLD := lld-17
 LLVM_COMPATIBLE_NIGHTLY = "nightly-2024-01-01"
 
-baked_data/macros.rs:
-	cargo install --path ../../../provider/icu4x-datagen --root target
-	target/bin/icu4x-datagen --locales en bn --markers all --deduplication none --format baked --out baked_data --overwrite
 
-target/debug/libicu_capi.a: FORCE
+target/release/icu4x-datagen: $(ALL_RUST_SRC)
+	cargo build --manifest-path ../../../Cargo.toml -p icu4x-datagen --target-dir target --release
+
+baked_data/mod.rs: target/release/icu4x-datagen
+	target/release/icu4x-datagen --locales en bn --markers all --deduplication none --format baked --out baked_data --overwrite
+
+target/debug/libicu_capi.a: baked_data/mod.rs
 	cargo rustc -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/decimal,icu_capi/std
 
-target/x86_64-unknown-linux-gnu/debug/libicu_capi.a: FORCE baked_data/macros.rs
+
+target-normal/release/libicu_capi.a: baked_data/mod.rs
+	cargo rustc --release --target-dir target-normal -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/decimal,icu_capi/std
+
+
+target-panic-abort/x86_64-unknown-linux-gnu/release/libicu_capi.a: baked_data/mod.rs
 	rustup toolchain install ${LLVM_COMPATIBLE_NIGHTLY}
 	rustup component add rust-src --toolchain ${LLVM_COMPATIBLE_NIGHTLY}
-	RUSTFLAGS="-Clinker-plugin-lto -Clinker=$(CLANG) -Ccodegen-units=1 -Clink-arg=-flto -Cpanic=abort" ICU4X_DATA_DIR=$(shell pwd)/baked_data \
+	RUSTFLAGS="-Cpanic=abort -Copt-level=s" ICU4X_DATA_DIR=$(shell pwd)/baked_data \
 	cargo +${LLVM_COMPATIBLE_NIGHTLY} rustc -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/decimal,icu_capi/looping_panic_handler,icu_capi/libc_alloc \
-	-Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target x86_64-unknown-linux-gnu
+	-Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target x86_64-unknown-linux-gnu --release  --target-dir target-panic-abort 
 
-target/x86_64-unknown-linux-gnu/release/libicu_capi.a: FORCE baked_data/macros.rs
+target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a: baked_data/mod.rs
+	rustup toolchain install ${LLVM_COMPATIBLE_NIGHTLY}
+	rustup component add rust-src --toolchain ${LLVM_COMPATIBLE_NIGHTLY}
+	RUSTFLAGS="-Clto -Cembed-bitcode -Clinker=$(CLANG) -Ccodegen-units=1 -Clink-arg=-flto -Cpanic=abort -Copt-level=s" ICU4X_DATA_DIR=$(shell pwd)/baked_data \
+	cargo +${LLVM_COMPATIBLE_NIGHTLY} rustc -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/decimal,icu_capi/looping_panic_handler,icu_capi/libc_alloc \
+	-Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target x86_64-unknown-linux-gnu --release  --target-dir target-panic-abort-lto 
+
+
+target-panic-abort-linker-plugin-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a: baked_data/mod.rs
 	rustup toolchain install ${LLVM_COMPATIBLE_NIGHTLY}
 	rustup component add rust-src --toolchain ${LLVM_COMPATIBLE_NIGHTLY}
 	RUSTFLAGS="-Clto -Cembed-bitcode -Clinker-plugin-lto -Clinker=$(CLANG) -Ccodegen-units=1 -Clink-arg=-flto -Cpanic=abort -Copt-level=s" ICU4X_DATA_DIR=$(shell pwd)/baked_data \
 	cargo +${LLVM_COMPATIBLE_NIGHTLY} rustc -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/decimal,icu_capi/looping_panic_handler,icu_capi/libc_alloc \
-	-Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target x86_64-unknown-linux-gnu --release
+	-Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target x86_64-unknown-linux-gnu --release  --target-dir target-panic-abort-linker-plugin-lto 
 
-# Naive target: no optimizations, full std
-optim0.elf: target/debug/libicu_capi.a $(ALL_HEADERS) test.c
-	$(GCC) test.c -I${HEADERS} target/debug/libicu_capi.a -ldl -lm -g -o optim0.elf
+# Naive target: basic release mode, full std
+release.elf: target-normal/release/libicu_capi.a $(ALL_HEADERS) test.c
+	$(GCC) test.c -I${HEADERS} target-normal/release/libicu_capi.a -ldl -lm -g -o release.elf
 
-# optim.elf: gcc with maximum link-time code stripping (gc-sections and strip-all)
-optim1.elf: target/debug/libicu_capi.a $(ALL_HEADERS) test.c
-	$(GCC) -fdata-sections -ffunction-sections test.c -I${HEADERS} target/debug/libicu_capi.a -ldl -lm -g -o optim1.elf -Wl,--gc-sections -Wl,--strip-all
+# gcc with maximum link-time code stripping (gc-sections and strip-all)
+release-gcc-stripped.elf: target-normal/release/libicu_capi.a $(ALL_HEADERS) test.c
+	$(GCC) -fdata-sections -ffunction-sections test.c -I${HEADERS} target-normal/release/libicu_capi.a -ldl -lm -g -o release-gcc-stripped.elf -Wl,--gc-sections -Wl,--strip-all
 
-# optim2.elf: clang single-step with gc-sections
-optim2.elf: target/x86_64-unknown-linux-gnu/debug/libicu_capi.a $(ALL_HEADERS) test.c
-	$(CLANG) -flto -fdata-sections -ffunction-sections test.c -I${HEADERS} target/x86_64-unknown-linux-gnu/debug/libicu_capi.a -g -o optim2.elf -Wl,--gc-sections
+# clang single-step; rust with release, panic-abort (std panic-immediate-abort)
+panic-abort-clang.elf: target-panic-abort/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
+	$(CLANG) test.c -I${HEADERS} target-panic-abort/x86_64-unknown-linux-gnu/release/libicu_capi.a -g -o panic-abort-clang.elf
 
-optim3.o: $(ALL_HEADERS) test.c
-	$(CLANG) -c -flto=thin -fdata-sections -ffunction-sections --target=x86_64-unknown-linux-gnu test.c -I${HEADERS} -g -o optim3.o
 
-# optim3.elf: clang two-step with lld, debug mode
-optim3.elf: optim3.o target/x86_64-unknown-linux-gnu/debug/libicu_capi.a
-	$(CLANG) -flto=thin -fuse-ld=$(LLD) -L . -o optim3.elf optim3.o target/x86_64-unknown-linux-gnu/debug/libicu_capi.a -Wl,--gc-sections
 
-optim4.o: $(ALL_HEADERS) test.c
-	$(CLANG) -c -flto=thin -fdata-sections -ffunction-sections --target=x86_64-unknown-linux-gnu test.c -I${HEADERS} -g -o optim4.o
+# clang single-step with gc-sections, stripping; rust with release, LTO, panic-abort (std panic-immediate-abort)
+panic-abort-clang-stripped.elf: target-panic-abort/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
+	$(CLANG) test.c -fdata-sections -ffunction-sections -I${HEADERS} target-panic-abort/x86_64-unknown-linux-gnu/release/libicu_capi.a -g -o panic-abort-clang-stripped.elf  -Wl,--gc-sections -Wl,--strip-all
 
-# optim4.elf: clang two-step with lld, release mode with debug symbols
-optim4.elf: optim4.o target/x86_64-unknown-linux-gnu/release/libicu_capi.a
-	$(CLANG) -flto=thin -fuse-ld=$(LLD) -L . -o optim4.elf optim4.o target/x86_64-unknown-linux-gnu/release/libicu_capi.a -Wl,--gc-sections
 
-optim5.o: $(ALL_HEADERS) test.c
-	$(CLANG) -c -flto=thin -fdata-sections -ffunction-sections --target=x86_64-unknown-linux-gnu test.c -I${HEADERS} -o optim5.o
+# clang single-step with LTO, rust with release, LTO, panic-abort (std panic-immediate-abort)
+panic-abort-lto-clang.elf: target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
+	$(CLANG) -flto -fdata-sections -ffunction-sections test.c -I${HEADERS} target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -g -o panic-abort-lto-clang.elf
 
-# optim5.elf: clang two-step with lld, release mode stripped of debug symbols
-optim5.elf: optim5.o target/x86_64-unknown-linux-gnu/release/libicu_capi.a
-	$(CLANG) -flto=thin -fuse-ld=$(LLD) -L . -o optim5.elf optim5.o target/x86_64-unknown-linux-gnu/release/libicu_capi.a -Wl,--gc-sections -Wl,--strip-all
+# clang single-step with LTO, gc-sections, stripping, rust with release, LTO, panic-abort (std panic-immediate-abort)
+panic-abort-lto-clang-stripped.elf: target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
+	$(CLANG) -flto -fdata-sections -ffunction-sections test.c -I${HEADERS} target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -g -o panic-abort-lto-clang-stripped.elf -Wl,--gc-sections -Wl,--strip-all
 
-build: optim0.elf optim1.elf optim2.elf optim3.elf optim4.elf optim5.elf
-	ls -l optim*.elf
+panic-abort-lto-clang-twostep.o: target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
+	$(CLANG) -c -flto=thin -fdata-sections -ffunction-sections --target=x86_64-unknown-linux-gnu test.c -I${HEADERS} -g -o panic-abort-lto-clang-twostep.o
+
+# clang two-step with lld, rust with release, panic-abort (std panic-immediate-abort)
+panic-abort-lto-clang-twostep.elf: panic-abort-lto-clang-twostep.o
+	$(CLANG) -flto=thin -fuse-ld=$(LLD) -L . -o panic-abort-lto-clang-twostep.elf panic-abort-lto-clang-twostep.o target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a
+
+
+panic-abort-lto-clang-twostep-stripped.o: target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
+	$(CLANG) -c -flto=thin -fdata-sections -ffunction-sections --target=x86_64-unknown-linux-gnu test.c -I${HEADERS} -g -o panic-abort-lto-clang-twostep-stripped.o
+
+# clang two-step with lld, ThinLTO, gc-sections, stripping, rust with release, LTO, panic-abort (std panic-immediate-abort)
+panic-abort-lto-clang-twostep-stripped.elf: panic-abort-lto-clang-twostep-stripped.o
+	$(CLANG) -flto=thin -fuse-ld=$(LLD) -L . -o panic-abort-lto-clang-twostep-stripped.elf panic-abort-lto-clang-twostep.o target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -Wl,--gc-sections -Wl,--strip-all
+
+
+panic-abort-linker-plugin-lto-clang-twostep.o: target-panic-abort-linker-plugin-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
+	$(CLANG) -c -flto=thin -fdata-sections -ffunction-sections --target=x86_64-unknown-linux-gnu test.c -I${HEADERS} -g -o panic-abort-linker-plugin-lto-clang-twostep.o
+
+# clang two-step with lld, ThinLTO, rust with release, LTO, panic-abort (std panic-immediate-abort), with cross-compiler LTO
+panic-abort-linker-plugin-lto-clang-twostep.elf: panic-abort-linker-plugin-lto-clang-twostep.o
+	$(CLANG) -flto=thin -fuse-ld=$(LLD) -L . -o panic-abort-linker-plugin-lto-clang-twostep.elf panic-abort-linker-plugin-lto-clang-twostep.o target-panic-abort-linker-plugin-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -Wl,--gc-sections -Wl,--strip-all
+
+
+panic-abort-linker-plugin-lto-clang-twostep-stripped.o: target-panic-abort-linker-plugin-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
+	$(CLANG) -c -flto=thin -fdata-sections -ffunction-sections --target=x86_64-unknown-linux-gnu test.c -I${HEADERS} -g -o panic-abort-linker-plugin-lto-clang-twostep-stripped.o
+
+# clang two-step with lld, ThinLTO, gc-sections, stripping, rust with release, LTO, panic-abort (std panic-immediate-abort), with cross-compiler LTO
+panic-abort-linker-plugin-lto-clang-twostep-stripped.elf: panic-abort-linker-plugin-lto-clang-twostep-stripped.o
+	$(CLANG) -flto=thin -fuse-ld=$(LLD) -L . -o panic-abort-linker-plugin-lto-clang-twostep-stripped.elf panic-abort-linker-plugin-lto-clang-twostep-stripped.o target-panic-abort-linker-plugin-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -Wl,--gc-sections -Wl,--strip-all
+
+build: release.elf release-gcc-stripped.elf panic-abort-clang.elf panic-abort-clang-stripped.elf panic-abort-lto-clang.elf panic-abort-lto-clang-stripped.elf panic-abort-lto-clang-twostep.elf panic-abort-lto-clang-twostep-stripped.elf panic-abort-linker-plugin-lto-clang-twostep.elf panic-abort-linker-plugin-lto-clang-twostep-stripped.elf
+	ls -l *.elf
 
 test: build
-	./optim0.elf bn
-	./optim1.elf bn
-	./optim2.elf bn
-	./optim2.elf bn
-	./optim4.elf bn
-	./optim5.elf bn
+	./release.elf bn
+	./release-gcc-stripped.elf bn
+	./panic-abort-clang.elf bn
+	./panic-abort-clang-stripped.elf bn
+	./panic-abort-lto-clang.elf bn
+	./panic-abort-lto-clang-stripped.elf bn
+	./panic-abort-lto-clang-twostep.elf bn
+	./panic-abort-lto-clang-twostep-stripped.elf bn
+	./panic-abort-linker-plugin-lto-clang-twostep.elf bn
+	./panic-abort-linker-plugin-lto-clang-twostep-stripped.elf bn
 
 clean:
 	git clean -xf *

--- a/tutorials/c-tiny/fixeddecimal/Makefile
+++ b/tutorials/c-tiny/fixeddecimal/Makefile
@@ -64,49 +64,49 @@ target-panic-abort-linker-plugin-lto/x86_64-unknown-linux-gnu/release/libicu_cap
 	-Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target x86_64-unknown-linux-gnu --release  --target-dir target-panic-abort-linker-plugin-lto 
 
 # Naive target: basic release mode, full std
-release.elf: target-normal/release/libicu_capi.a $(ALL_HEADERS) test.c
-	$(GCC) test.c -I${HEADERS} target-normal/release/libicu_capi.a -ldl -lm -g -o release.elf
+1-release.elf: target-normal/release/libicu_capi.a $(ALL_HEADERS) test.c
+	$(GCC) test.c -I${HEADERS} target-normal/release/libicu_capi.a -ldl -lm -g -o 1-release.elf
 
 # gcc with maximum link-time code stripping (gc-sections and strip-all)
-release-gcc-stripped.elf: target-normal/release/libicu_capi.a $(ALL_HEADERS) test.c
-	$(GCC) -fdata-sections -ffunction-sections test.c -I${HEADERS} target-normal/release/libicu_capi.a -ldl -lm -g -o release-gcc-stripped.elf -Wl,--gc-sections -Wl,--strip-all
+2-release-gcc-stripped.elf: target-normal/release/libicu_capi.a $(ALL_HEADERS) test.c
+	$(GCC) -fdata-sections -ffunction-sections test.c -I${HEADERS} target-normal/release/libicu_capi.a -ldl -lm -g -o 2-release-gcc-stripped.elf -Wl,--gc-sections -Wl,--strip-all
 
-# clang single-step; rust with release, panic-abort (std panic-immediate-abort)
-panic-abort-clang.elf: target-panic-abort/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
-	$(CLANG) test.c -I${HEADERS} target-panic-abort/x86_64-unknown-linux-gnu/release/libicu_capi.a -g -o panic-abort-clang.elf
-
-
-
-# clang single-step with gc-sections, stripping; rust with release, LTO, panic-abort (std panic-immediate-abort)
-panic-abort-clang-stripped.elf: target-panic-abort/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
-	$(CLANG) test.c -fdata-sections -ffunction-sections -I${HEADERS} target-panic-abort/x86_64-unknown-linux-gnu/release/libicu_capi.a -g -o panic-abort-clang-stripped.elf  -Wl,--gc-sections -Wl,--strip-all
+# clang; rust with release, panic-abort (std panic-immediate-abort)
+3-panic-abort-clang.elf: target-panic-abort/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
+	$(CLANG) test.c -I${HEADERS} target-panic-abort/x86_64-unknown-linux-gnu/release/libicu_capi.a -g -o 3-panic-abort-clang.elf
 
 
-# clang single-step with LTO, rust with release, LTO, panic-abort (std panic-immediate-abort)
-panic-abort-lto-clang.elf: target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
-	$(CLANG) -flto=thin -fuse-ld=$(LLD) -fdata-sections -ffunction-sections test.c -I${HEADERS} target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -g -o panic-abort-lto-clang.elf
-
-# clang single-step with LTO, gc-sections, stripping, rust with release, LTO, panic-abort (std panic-immediate-abort)
-panic-abort-lto-clang-stripped.elf: target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
-	$(CLANG) -flto=thin -fuse-ld=$(LLD) -fdata-sections -ffunction-sections test.c -I${HEADERS} target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -g -o panic-abort-lto-clang-stripped.elf -Wl,--gc-sections -Wl,--strip-all
+# clang with LTO, rust with release, LTO, panic-abort (std panic-immediate-abort)
+4-panic-abort-lto-clang.elf: target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
+	$(CLANG) -flto=thin -fuse-ld=$(LLD) -fdata-sections -ffunction-sections test.c -I${HEADERS} target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -g -o 4-panic-abort-lto-clang.elf
 
 
-# clang one-step with lld, ThinLTO, gc-sections, stripping, rust with release, LTO, panic-abort (std panic-immediate-abort), with cross-compiler LTO
-panic-abort-linker-plugin-lto-clang-stripped.elf: target-panic-abort-linker-plugin-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a
-	$(CLANG) -flto=thin -fuse-ld=$(LLD) --target=x86_64-unknown-linux-gnu test.c -I${HEADERS} -o panic-abort-linker-plugin-lto-clang-stripped.elf target-panic-abort-linker-plugin-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -Wl,--gc-sections -Wl,--strip-all
+# clang with gc-sections, stripping; rust with release, LTO, panic-abort (std panic-immediate-abort)
+5-panic-abort-clang-stripped.elf: target-panic-abort/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
+	$(CLANG) test.c -fdata-sections -ffunction-sections -I${HEADERS} target-panic-abort/x86_64-unknown-linux-gnu/release/libicu_capi.a -g -o 5-panic-abort-clang-stripped.elf  -Wl,--gc-sections -Wl,--strip-all
 
 
-build: release.elf release-gcc-stripped.elf panic-abort-clang.elf panic-abort-clang-stripped.elf panic-abort-lto-clang.elf panic-abort-lto-clang-stripped.elf panic-abort-linker-plugin-lto-clang-stripped.elf 
+# clang with LTO, gc-sections, stripping, rust with release, LTO, panic-abort (std panic-immediate-abort)
+6-panic-abort-lto-clang-stripped.elf: target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
+	$(CLANG) -flto=thin -fuse-ld=$(LLD) -fdata-sections -ffunction-sections test.c -I${HEADERS} target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -g -o 6-panic-abort-lto-clang-stripped.elf -Wl,--gc-sections -Wl,--strip-all
+
+
+# clang with lld, ThinLTO, gc-sections, stripping, rust with release, LTO, panic-abort (std panic-immediate-abort), with cross-compiler LTO
+7-panic-abort-linker-plugin-lto-clang-stripped.elf: target-panic-abort-linker-plugin-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a
+	$(CLANG) -flto=thin -fuse-ld=$(LLD) --target=x86_64-unknown-linux-gnu test.c -I${HEADERS} -o 7-panic-abort-linker-plugin-lto-clang-stripped.elf target-panic-abort-linker-plugin-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -Wl,--gc-sections -Wl,--strip-all
+
+
+build: 1-release.elf 2-release-gcc-stripped.elf 3-panic-abort-clang.elf 4-panic-abort-lto-clang.elf 5-panic-abort-clang-stripped.elf  6-panic-abort-lto-clang-stripped.elf 7-panic-abort-linker-plugin-lto-clang-stripped.elf 
 	ls -l *.elf
 
 test: build
-	./release.elf bn
-	./release-gcc-stripped.elf bn
-	./panic-abort-clang.elf bn
-	./panic-abort-clang-stripped.elf bn
-	./panic-abort-lto-clang.elf bn
-	./panic-abort-lto-clang-stripped.elf bn
-	./panic-abort-linker-plugin-lto-clang-stripped.elf bn
+	./1-release.elf bn
+	./2-release-gcc-stripped.elf bn
+	./3-panic-abort-clang.elf bn
+	./4-panic-abort-lto-clang.elf bn
+	./5-panic-abort-clang-stripped.elf bn
+	./6-panic-abort-lto-clang-stripped.elf bn
+	./7-panic-abort-linker-plugin-lto-clang-stripped.elf bn
 
 clean:
 	git clean -xf *

--- a/tutorials/c-tiny/fixeddecimal/Makefile
+++ b/tutorials/c-tiny/fixeddecimal/Makefile
@@ -2,7 +2,13 @@
 # called LICENSE at the top level of the ICU4X source tree
 # (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-# PLEASE KEEP THIS FILE IN SYNC WITH ../segmenter_tiny/Makefile
+# PLEASE KEEP THIS FILE IN SYNC WITH ../segmenter/Makefile
+# Differences between this file and that one:
+# - CAPI_COMPONENT is different
+# - This file does builds datagen, baked_data, and sets ICU4X_DATA_DIR
+
+# The component built by this makefile.
+CAPI_COMPONENT := decimal
 
 .DEFAULT_GOAL := test
 .PHONY: build test
@@ -28,25 +34,25 @@ baked_data/mod.rs: target/release/icu4x-datagen
 	target/release/icu4x-datagen --locales en bn --markers all --deduplication none --format baked --out baked_data --overwrite
 
 target/debug/libicu_capi.a: baked_data/mod.rs
-	cargo rustc -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/decimal,icu_capi/std
+	cargo rustc -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/${CAPI_COMPONENT},icu_capi/std
 
 
-target-normal/release/libicu_capi.a: baked_data/mod.rs
-	cargo rustc --release --target-dir target-normal -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/decimal,icu_capi/std
+target-normal/release/libicu_capi.a:
+	cargo rustc --release --target-dir target-normal -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/${CAPI_COMPONENT},icu_capi/std
 
 
 target-panic-abort/x86_64-unknown-linux-gnu/release/libicu_capi.a: baked_data/mod.rs
 	rustup toolchain install ${LLVM_COMPATIBLE_NIGHTLY}
 	rustup component add rust-src --toolchain ${LLVM_COMPATIBLE_NIGHTLY}
 	RUSTFLAGS="-Cpanic=abort -Copt-level=s" ICU4X_DATA_DIR=$(shell pwd)/baked_data \
-	cargo +${LLVM_COMPATIBLE_NIGHTLY} rustc -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/decimal,icu_capi/looping_panic_handler,icu_capi/libc_alloc \
+	cargo +${LLVM_COMPATIBLE_NIGHTLY} rustc -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/${CAPI_COMPONENT},icu_capi/looping_panic_handler,icu_capi/libc_alloc \
 	-Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target x86_64-unknown-linux-gnu --release  --target-dir target-panic-abort 
 
 target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a: baked_data/mod.rs
 	rustup toolchain install ${LLVM_COMPATIBLE_NIGHTLY}
 	rustup component add rust-src --toolchain ${LLVM_COMPATIBLE_NIGHTLY}
 	RUSTFLAGS="-Clto -Cembed-bitcode -Clinker=$(CLANG) -Ccodegen-units=1 -Clink-arg=-flto -Cpanic=abort -Copt-level=s" ICU4X_DATA_DIR=$(shell pwd)/baked_data \
-	cargo +${LLVM_COMPATIBLE_NIGHTLY} rustc -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/decimal,icu_capi/looping_panic_handler,icu_capi/libc_alloc \
+	cargo +${LLVM_COMPATIBLE_NIGHTLY} rustc -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/${CAPI_COMPONENT},icu_capi/looping_panic_handler,icu_capi/libc_alloc \
 	-Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target x86_64-unknown-linux-gnu --release  --target-dir target-panic-abort-lto 
 
 
@@ -54,7 +60,7 @@ target-panic-abort-linker-plugin-lto/x86_64-unknown-linux-gnu/release/libicu_cap
 	rustup toolchain install ${LLVM_COMPATIBLE_NIGHTLY}
 	rustup component add rust-src --toolchain ${LLVM_COMPATIBLE_NIGHTLY}
 	RUSTFLAGS="-Clto -Cembed-bitcode -Clinker-plugin-lto -Clinker=$(CLANG) -Ccodegen-units=1 -Clink-arg=-flto -Cpanic=abort -Copt-level=s" ICU4X_DATA_DIR=$(shell pwd)/baked_data \
-	cargo +${LLVM_COMPATIBLE_NIGHTLY} rustc -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/decimal,icu_capi/looping_panic_handler,icu_capi/libc_alloc \
+	cargo +${LLVM_COMPATIBLE_NIGHTLY} rustc -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/${CAPI_COMPONENT},icu_capi/looping_panic_handler,icu_capi/libc_alloc \
 	-Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target x86_64-unknown-linux-gnu --release  --target-dir target-panic-abort-linker-plugin-lto 
 
 # Naive target: basic release mode, full std
@@ -78,47 +84,19 @@ panic-abort-clang-stripped.elf: target-panic-abort/x86_64-unknown-linux-gnu/rele
 
 # clang single-step with LTO, rust with release, LTO, panic-abort (std panic-immediate-abort)
 panic-abort-lto-clang.elf: target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
-	$(CLANG) -flto -fuse-ld=$(LLD) -fdata-sections -ffunction-sections test.c -I${HEADERS} target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -g -o panic-abort-lto-clang.elf
+	$(CLANG) -flto=thin -fuse-ld=$(LLD) -fdata-sections -ffunction-sections test.c -I${HEADERS} target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -g -o panic-abort-lto-clang.elf
 
 # clang single-step with LTO, gc-sections, stripping, rust with release, LTO, panic-abort (std panic-immediate-abort)
 panic-abort-lto-clang-stripped.elf: target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
-	$(CLANG) -flto -fuse-ld=$(LLD) -fdata-sections -ffunction-sections test.c -I${HEADERS} target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -g -o panic-abort-lto-clang-stripped.elf -Wl,--gc-sections -Wl,--strip-all
+	$(CLANG) -flto=thin -fuse-ld=$(LLD) -fdata-sections -ffunction-sections test.c -I${HEADERS} target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -g -o panic-abort-lto-clang-stripped.elf -Wl,--gc-sections -Wl,--strip-all
 
-panic-abort-lto-clang-twostep.o: target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
-	$(CLANG) -c -flto=thin -fuse-ld=$(LLD) -fdata-sections -ffunction-sections --target=x86_64-unknown-linux-gnu test.c -I${HEADERS} -g -o panic-abort-lto-clang-twostep.o
-
-# clang two-step with lld, rust with release, panic-abort (std panic-immediate-abort)
-panic-abort-lto-clang-twostep.elf: panic-abort-lto-clang-twostep.o
-	$(CLANG) -flto=thin -fuse-ld=$(LLD) -L . -o panic-abort-lto-clang-twostep.elf panic-abort-lto-clang-twostep.o target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a
-
-
-panic-abort-lto-clang-twostep-stripped.o: target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
-	$(CLANG) -c -flto=thin -fdata-sections -ffunction-sections --target=x86_64-unknown-linux-gnu test.c -I${HEADERS} -g -o panic-abort-lto-clang-twostep-stripped.o
-
-# clang two-step with lld, ThinLTO, gc-sections, stripping, rust with release, LTO, panic-abort (std panic-immediate-abort)
-panic-abort-lto-clang-twostep-stripped.elf: panic-abort-lto-clang-twostep-stripped.o
-	$(CLANG) -flto=thin -fuse-ld=$(LLD) -L . -o panic-abort-lto-clang-twostep-stripped.elf panic-abort-lto-clang-twostep.o target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -Wl,--gc-sections -Wl,--strip-all
-
-
-panic-abort-linker-plugin-lto-clang-twostep.o: target-panic-abort-linker-plugin-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
-	$(CLANG) -c -flto=thin -fdata-sections -ffunction-sections --target=x86_64-unknown-linux-gnu test.c -I${HEADERS} -g -o panic-abort-linker-plugin-lto-clang-twostep.o
-
-# clang two-step with lld, ThinLTO, rust with release, LTO, panic-abort (std panic-immediate-abort), with cross-compiler LTO
-panic-abort-linker-plugin-lto-clang-twostep.elf: panic-abort-linker-plugin-lto-clang-twostep.o
-	$(CLANG) -flto=thin -fuse-ld=$(LLD) -L . -o panic-abort-linker-plugin-lto-clang-twostep.elf panic-abort-linker-plugin-lto-clang-twostep.o target-panic-abort-linker-plugin-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -Wl,--gc-sections -Wl,--strip-all
 
 # clang one-step with lld, ThinLTO, gc-sections, stripping, rust with release, LTO, panic-abort (std panic-immediate-abort), with cross-compiler LTO
-panic-abort-linker-plugin-lto-clang-stripped.elf:
+panic-abort-linker-plugin-lto-clang-stripped.elf: target-panic-abort-linker-plugin-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a
 	$(CLANG) -flto=thin -fuse-ld=$(LLD) --target=x86_64-unknown-linux-gnu test.c -I${HEADERS} -o panic-abort-linker-plugin-lto-clang-stripped.elf target-panic-abort-linker-plugin-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -Wl,--gc-sections -Wl,--strip-all
 
-panic-abort-linker-plugin-lto-clang-twostep-stripped.o: target-panic-abort-linker-plugin-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
-	$(CLANG) -c -flto=thin -fdata-sections -ffunction-sections --target=x86_64-unknown-linux-gnu test.c -I${HEADERS} -g -o panic-abort-linker-plugin-lto-clang-twostep-stripped.o
 
-# clang two-step with lld, ThinLTO, gc-sections, stripping, rust with release, LTO, panic-abort (std panic-immediate-abort), with cross-compiler LTO
-panic-abort-linker-plugin-lto-clang-twostep-stripped.elf: panic-abort-linker-plugin-lto-clang-twostep-stripped.o
-	$(CLANG) -flto=thin -fuse-ld=$(LLD) -L . -o panic-abort-linker-plugin-lto-clang-twostep-stripped.elf panic-abort-linker-plugin-lto-clang-twostep-stripped.o target-panic-abort-linker-plugin-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -Wl,--gc-sections -Wl,--strip-all
-
-build: release.elf release-gcc-stripped.elf panic-abort-clang.elf panic-abort-clang-stripped.elf panic-abort-lto-clang.elf panic-abort-lto-clang-stripped.elf panic-abort-lto-clang-twostep.elf panic-abort-lto-clang-twostep-stripped.elf panic-abort-linker-plugin-lto-clang-stripped.elf panic-abort-linker-plugin-lto-clang-twostep.elf panic-abort-linker-plugin-lto-clang-twostep-stripped.elf
+build: release.elf release-gcc-stripped.elf panic-abort-clang.elf panic-abort-clang-stripped.elf panic-abort-lto-clang.elf panic-abort-lto-clang-stripped.elf panic-abort-linker-plugin-lto-clang-stripped.elf 
 	ls -l *.elf
 
 test: build
@@ -128,11 +106,7 @@ test: build
 	./panic-abort-clang-stripped.elf bn
 	./panic-abort-lto-clang.elf bn
 	./panic-abort-lto-clang-stripped.elf bn
-	./panic-abort-lto-clang-twostep.elf bn
-	./panic-abort-lto-clang-twostep-stripped.elf bn
-	./panic-abort-linker-plugin-lto-clang-twostep.elf bn
 	./panic-abort-linker-plugin-lto-clang-stripped.elf bn
-	./panic-abort-linker-plugin-lto-clang-twostep-stripped.elf bn
 
 clean:
 	git clean -xf *

--- a/tutorials/c-tiny/segmenter/Makefile
+++ b/tutorials/c-tiny/segmenter/Makefile
@@ -54,49 +54,49 @@ target-panic-abort-linker-plugin-lto/x86_64-unknown-linux-gnu/release/libicu_cap
 	-Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target x86_64-unknown-linux-gnu --release  --target-dir target-panic-abort-linker-plugin-lto 
 
 # Naive target: basic release mode, full std
-release.elf: target-normal/release/libicu_capi.a $(ALL_HEADERS) test.c
-	$(GCC) test.c -I${HEADERS} target-normal/release/libicu_capi.a -ldl -lm -g -o release.elf
+1-release.elf: target-normal/release/libicu_capi.a $(ALL_HEADERS) test.c
+	$(GCC) test.c -I${HEADERS} target-normal/release/libicu_capi.a -ldl -lm -g -o 1-release.elf
 
 # gcc with maximum link-time code stripping (gc-sections and strip-all)
-release-gcc-stripped.elf: target-normal/release/libicu_capi.a $(ALL_HEADERS) test.c
-	$(GCC) -fdata-sections -ffunction-sections test.c -I${HEADERS} target-normal/release/libicu_capi.a -ldl -lm -g -o release-gcc-stripped.elf -Wl,--gc-sections -Wl,--strip-all
+2-release-gcc-stripped.elf: target-normal/release/libicu_capi.a $(ALL_HEADERS) test.c
+	$(GCC) -fdata-sections -ffunction-sections test.c -I${HEADERS} target-normal/release/libicu_capi.a -ldl -lm -g -o 2-release-gcc-stripped.elf -Wl,--gc-sections -Wl,--strip-all
 
-# clang single-step; rust with release, panic-abort (std panic-immediate-abort)
-panic-abort-clang.elf: target-panic-abort/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
-	$(CLANG) test.c -I${HEADERS} target-panic-abort/x86_64-unknown-linux-gnu/release/libicu_capi.a -g -o panic-abort-clang.elf
-
-
-
-# clang single-step with gc-sections, stripping; rust with release, LTO, panic-abort (std panic-immediate-abort)
-panic-abort-clang-stripped.elf: target-panic-abort/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
-	$(CLANG) test.c -fdata-sections -ffunction-sections -I${HEADERS} target-panic-abort/x86_64-unknown-linux-gnu/release/libicu_capi.a -g -o panic-abort-clang-stripped.elf  -Wl,--gc-sections -Wl,--strip-all
+# clang; rust with release, panic-abort (std panic-immediate-abort)
+3-panic-abort-clang.elf: target-panic-abort/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
+	$(CLANG) test.c -I${HEADERS} target-panic-abort/x86_64-unknown-linux-gnu/release/libicu_capi.a -g -o 3-panic-abort-clang.elf
 
 
-# clang single-step with LTO, rust with release, LTO, panic-abort (std panic-immediate-abort)
-panic-abort-lto-clang.elf: target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
-	$(CLANG) -flto=thin -fuse-ld=$(LLD) -fdata-sections -ffunction-sections test.c -I${HEADERS} target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -g -o panic-abort-lto-clang.elf
-
-# clang single-step with LTO, gc-sections, stripping, rust with release, LTO, panic-abort (std panic-immediate-abort)
-panic-abort-lto-clang-stripped.elf: target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
-	$(CLANG) -flto=thin -fuse-ld=$(LLD) -fdata-sections -ffunction-sections test.c -I${HEADERS} target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -g -o panic-abort-lto-clang-stripped.elf -Wl,--gc-sections -Wl,--strip-all
+# clang with LTO, rust with release, LTO, panic-abort (std panic-immediate-abort)
+4-panic-abort-lto-clang.elf: target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
+	$(CLANG) -flto=thin -fuse-ld=$(LLD) -fdata-sections -ffunction-sections test.c -I${HEADERS} target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -g -o 4-panic-abort-lto-clang.elf
 
 
-# clang one-step with lld, ThinLTO, gc-sections, stripping, rust with release, LTO, panic-abort (std panic-immediate-abort), with cross-compiler LTO
-panic-abort-linker-plugin-lto-clang-stripped.elf: target-panic-abort-linker-plugin-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a
-	$(CLANG) -flto=thin -fuse-ld=$(LLD) --target=x86_64-unknown-linux-gnu test.c -I${HEADERS} -o panic-abort-linker-plugin-lto-clang-stripped.elf target-panic-abort-linker-plugin-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -Wl,--gc-sections -Wl,--strip-all
+# clang with gc-sections, stripping; rust with release, LTO, panic-abort (std panic-immediate-abort)
+5-panic-abort-clang-stripped.elf: target-panic-abort/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
+	$(CLANG) test.c -fdata-sections -ffunction-sections -I${HEADERS} target-panic-abort/x86_64-unknown-linux-gnu/release/libicu_capi.a -g -o 5-panic-abort-clang-stripped.elf  -Wl,--gc-sections -Wl,--strip-all
 
 
-build: release.elf release-gcc-stripped.elf panic-abort-clang.elf panic-abort-clang-stripped.elf panic-abort-lto-clang.elf panic-abort-lto-clang-stripped.elf panic-abort-linker-plugin-lto-clang-stripped.elf 
+# clang with LTO, gc-sections, stripping, rust with release, LTO, panic-abort (std panic-immediate-abort)
+6-panic-abort-lto-clang-stripped.elf: target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
+	$(CLANG) -flto=thin -fuse-ld=$(LLD) -fdata-sections -ffunction-sections test.c -I${HEADERS} target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -g -o 6-panic-abort-lto-clang-stripped.elf -Wl,--gc-sections -Wl,--strip-all
+
+
+# clang with lld, ThinLTO, gc-sections, stripping, rust with release, LTO, panic-abort (std panic-immediate-abort), with cross-compiler LTO
+7-panic-abort-linker-plugin-lto-clang-stripped.elf: target-panic-abort-linker-plugin-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a
+	$(CLANG) -flto=thin -fuse-ld=$(LLD) --target=x86_64-unknown-linux-gnu test.c -I${HEADERS} -o 7-panic-abort-linker-plugin-lto-clang-stripped.elf target-panic-abort-linker-plugin-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -Wl,--gc-sections -Wl,--strip-all
+
+
+build: 1-release.elf 2-release-gcc-stripped.elf 3-panic-abort-clang.elf 4-panic-abort-lto-clang.elf 5-panic-abort-clang-stripped.elf  6-panic-abort-lto-clang-stripped.elf 7-panic-abort-linker-plugin-lto-clang-stripped.elf 
 	ls -l *.elf
 
 test: build
-	./release.elf bn
-	./release-gcc-stripped.elf bn
-	./panic-abort-clang.elf bn
-	./panic-abort-clang-stripped.elf bn
-	./panic-abort-lto-clang.elf bn
-	./panic-abort-lto-clang-stripped.elf bn
-	./panic-abort-linker-plugin-lto-clang-stripped.elf bn
+	./1-release.elf bn
+	./2-release-gcc-stripped.elf bn
+	./3-panic-abort-clang.elf bn
+	./4-panic-abort-lto-clang.elf bn
+	./5-panic-abort-clang-stripped.elf bn
+	./6-panic-abort-lto-clang-stripped.elf bn
+	./7-panic-abort-linker-plugin-lto-clang-stripped.elf bn
 
 clean:
 	git clean -xf *

--- a/tutorials/c-tiny/segmenter/Makefile
+++ b/tutorials/c-tiny/segmenter/Makefile
@@ -55,35 +55,36 @@ target-panic-abort-linker-plugin-lto/x86_64-unknown-linux-gnu/release/libicu_cap
 
 # Naive target: basic release mode, full std
 1-release.elf: target-normal/release/libicu_capi.a $(ALL_HEADERS) test.c
-	$(GCC) test.c -I${HEADERS} target-normal/release/libicu_capi.a -ldl -lm -g -o 1-release.elf
+	$(GCC) test.c -I${HEADERS} target-normal/release/libicu_capi.a -ldl -lm -o 1-release.elf
 
 # gcc with maximum link-time code stripping (gc-sections and strip-all)
 2-release-gcc-stripped.elf: target-normal/release/libicu_capi.a $(ALL_HEADERS) test.c
-	$(GCC) -fdata-sections -ffunction-sections test.c -I${HEADERS} target-normal/release/libicu_capi.a -ldl -lm -g -o 2-release-gcc-stripped.elf -Wl,--gc-sections -Wl,--strip-all
+	$(GCC) -fdata-sections -ffunction-sections test.c -I${HEADERS} target-normal/release/libicu_capi.a -ldl -lm -o 2-release-gcc-stripped.elf -Wl,--gc-sections -Wl,--strip-all
 
 # clang; rust with release, panic-abort (std panic-immediate-abort)
 3-panic-abort-clang.elf: target-panic-abort/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
-	$(CLANG) test.c -I${HEADERS} target-panic-abort/x86_64-unknown-linux-gnu/release/libicu_capi.a -g -o 3-panic-abort-clang.elf
+	$(CLANG) test.c -I${HEADERS} target-panic-abort/x86_64-unknown-linux-gnu/release/libicu_capi.a -o 3-panic-abort-clang.elf
 
 
 # clang with LTO, rust with release, LTO, panic-abort (std panic-immediate-abort)
 4-panic-abort-lto-clang.elf: target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
-	$(CLANG) -flto=thin -fuse-ld=$(LLD) -fdata-sections -ffunction-sections test.c -I${HEADERS} target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -g -o 4-panic-abort-lto-clang.elf
+	$(CLANG) -flto=thin -fuse-ld=$(LLD) -fdata-sections -ffunction-sections test.c -I${HEADERS} target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -o 4-panic-abort-lto-clang.elf
 
 
 # clang with gc-sections, stripping; rust with release, LTO, panic-abort (std panic-immediate-abort)
 5-panic-abort-clang-stripped.elf: target-panic-abort/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
-	$(CLANG) test.c -fdata-sections -ffunction-sections -I${HEADERS} target-panic-abort/x86_64-unknown-linux-gnu/release/libicu_capi.a -g -o 5-panic-abort-clang-stripped.elf  -Wl,--gc-sections -Wl,--strip-all
+	$(CLANG) test.c -fdata-sections -ffunction-sections -I${HEADERS} target-panic-abort/x86_64-unknown-linux-gnu/release/libicu_capi.a -o 5-panic-abort-clang-stripped.elf  -Wl,--gc-sections -Wl,--strip-all
 
 
 # clang with LTO, gc-sections, stripping, rust with release, LTO, panic-abort (std panic-immediate-abort)
 6-panic-abort-lto-clang-stripped.elf: target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
-	$(CLANG) -flto=thin -fuse-ld=$(LLD) -fdata-sections -ffunction-sections test.c -I${HEADERS} target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -g -o 6-panic-abort-lto-clang-stripped.elf -Wl,--gc-sections -Wl,--strip-all
+	$(CLANG) -flto=thin -fuse-ld=$(LLD) -fdata-sections -ffunction-sections test.c -I${HEADERS} target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -o 6-panic-abort-lto-clang-stripped.elf -Wl,--gc-sections -Wl,--strip-all
 
 
 # clang with lld, ThinLTO, gc-sections, stripping, rust with release, LTO, panic-abort (std panic-immediate-abort), with cross-compiler LTO
 7-panic-abort-linker-plugin-lto-clang-stripped.elf: target-panic-abort-linker-plugin-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a
 	$(CLANG) -flto=thin -fuse-ld=$(LLD) --target=x86_64-unknown-linux-gnu test.c -I${HEADERS} -o 7-panic-abort-linker-plugin-lto-clang-stripped.elf target-panic-abort-linker-plugin-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -Wl,--gc-sections -Wl,--strip-all
+
 
 
 build: 1-release.elf 2-release-gcc-stripped.elf 3-panic-abort-clang.elf 4-panic-abort-lto-clang.elf 5-panic-abort-clang-stripped.elf  6-panic-abort-lto-clang-stripped.elf 7-panic-abort-linker-plugin-lto-clang-stripped.elf 

--- a/tutorials/c-tiny/segmenter/Makefile
+++ b/tutorials/c-tiny/segmenter/Makefile
@@ -2,15 +2,22 @@
 # called LICENSE at the top level of the ICU4X source tree
 # (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-# PLEASE KEEP THIS FILE IN SYNC WITH ../fixeddecimal_tiny/Makefile
+# PLEASE KEEP THIS FILE IN SYNC WITH ../decimal/Makefile
+# Differences between this file and that one:
+# - CAPI_COMPONENT is different
+# - This file does not build datagen, build baked_data, or set ICU4X_DATA_DIR
+
+# The component built by this makefile.
+CAPI_COMPONENT := segmenter
 
 .DEFAULT_GOAL := test
 .PHONY: build test
-FORCE:
 
 ICU_CAPI := $(shell cargo metadata --manifest-path Cargo.toml --format-version 1 | jq '.packages[] | select(.name == "icu_capi").manifest_path' | xargs dirname)
 HEADERS := ${ICU_CAPI}/bindings/c
 ALL_HEADERS := $(wildcard ${HEADERS}/*)
+
+ALL_RUST_SRC = $(wildcard ../../../components/**/*.rs) $(wildcard ../../../provider/**/*.rs) $(wildcard ../../../ffi/capi/**/*.rs)
 
 $(ALL_HEADERS):
 
@@ -19,66 +26,77 @@ CLANG := clang-17
 LLD := lld-17
 LLVM_COMPATIBLE_NIGHTLY = "nightly-2024-01-01"
 
-target/debug/libicu_capi.a: FORCE
-	cargo rustc -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/segmenter,icu_capi/std
 
-target/x86_64-unknown-linux-gnu/debug/libicu_capi.a: FORCE
+target-normal/release/libicu_capi.a:
+	cargo rustc --release --target-dir target-normal -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/${CAPI_COMPONENT},icu_capi/std
+
+
+target-panic-abort/x86_64-unknown-linux-gnu/release/libicu_capi.a:
 	rustup toolchain install ${LLVM_COMPATIBLE_NIGHTLY}
 	rustup component add rust-src --toolchain ${LLVM_COMPATIBLE_NIGHTLY}
-	RUSTFLAGS="-Clinker-plugin-lto -Clinker=$(CLANG) -Ccodegen-units=1 -Clink-arg=-flto -Cpanic=abort" \
-	cargo +${LLVM_COMPATIBLE_NIGHTLY} rustc -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/segmenter,icu_capi/looping_panic_handler,icu_capi/libc_alloc \
-	-Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target x86_64-unknown-linux-gnu
+	RUSTFLAGS="-Cpanic=abort -Copt-level=s" \
+	cargo +${LLVM_COMPATIBLE_NIGHTLY} rustc -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/${CAPI_COMPONENT},icu_capi/looping_panic_handler,icu_capi/libc_alloc \
+	-Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target x86_64-unknown-linux-gnu --release  --target-dir target-panic-abort 
 
-target/x86_64-unknown-linux-gnu/release/libicu_capi.a: FORCE
+target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a:
+	rustup toolchain install ${LLVM_COMPATIBLE_NIGHTLY}
+	rustup component add rust-src --toolchain ${LLVM_COMPATIBLE_NIGHTLY}
+	RUSTFLAGS="-Clto -Cembed-bitcode -Clinker=$(CLANG) -Ccodegen-units=1 -Clink-arg=-flto -Cpanic=abort -Copt-level=s" \
+	cargo +${LLVM_COMPATIBLE_NIGHTLY} rustc -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/${CAPI_COMPONENT},icu_capi/looping_panic_handler,icu_capi/libc_alloc \
+	-Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target x86_64-unknown-linux-gnu --release  --target-dir target-panic-abort-lto 
+
+
+target-panic-abort-linker-plugin-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a:
 	rustup toolchain install ${LLVM_COMPATIBLE_NIGHTLY}
 	rustup component add rust-src --toolchain ${LLVM_COMPATIBLE_NIGHTLY}
 	RUSTFLAGS="-Clto -Cembed-bitcode -Clinker-plugin-lto -Clinker=$(CLANG) -Ccodegen-units=1 -Clink-arg=-flto -Cpanic=abort -Copt-level=s" \
-	cargo +${LLVM_COMPATIBLE_NIGHTLY} rustc -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/segmenter,icu_capi/looping_panic_handler,icu_capi/libc_alloc \
-	-Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target x86_64-unknown-linux-gnu --release
+	cargo +${LLVM_COMPATIBLE_NIGHTLY} rustc -p icu_capi --crate-type staticlib --no-default-features --features icu_capi/compiled_data,icu_capi/${CAPI_COMPONENT},icu_capi/looping_panic_handler,icu_capi/libc_alloc \
+	-Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target x86_64-unknown-linux-gnu --release  --target-dir target-panic-abort-linker-plugin-lto 
 
-# Naive target: no optimizations, full std
-optim0.elf: target/debug/libicu_capi.a $(ALL_HEADERS) test.c
-	$(GCC) test.c -I${HEADERS} target/debug/libicu_capi.a -ldl -lm -g -o optim0.elf
+# Naive target: basic release mode, full std
+release.elf: target-normal/release/libicu_capi.a $(ALL_HEADERS) test.c
+	$(GCC) test.c -I${HEADERS} target-normal/release/libicu_capi.a -ldl -lm -g -o release.elf
 
-# optim.elf: gcc with maximum link-time code stripping (gc-sections and strip-all)
-optim1.elf: target/debug/libicu_capi.a $(ALL_HEADERS) test.c
-	$(GCC) -fdata-sections -ffunction-sections test.c -I${HEADERS} target/debug/libicu_capi.a -ldl -lm -g -o optim1.elf -Wl,--gc-sections -Wl,--strip-all
+# gcc with maximum link-time code stripping (gc-sections and strip-all)
+release-gcc-stripped.elf: target-normal/release/libicu_capi.a $(ALL_HEADERS) test.c
+	$(GCC) -fdata-sections -ffunction-sections test.c -I${HEADERS} target-normal/release/libicu_capi.a -ldl -lm -g -o release-gcc-stripped.elf -Wl,--gc-sections -Wl,--strip-all
 
-# optim2.elf: clang single-step with gc-sections
-optim2.elf: target/x86_64-unknown-linux-gnu/debug/libicu_capi.a $(ALL_HEADERS) test.c
-	$(CLANG) -flto -fdata-sections -ffunction-sections test.c -I${HEADERS} target/x86_64-unknown-linux-gnu/debug/libicu_capi.a -g -o optim2.elf -Wl,--gc-sections
+# clang single-step; rust with release, panic-abort (std panic-immediate-abort)
+panic-abort-clang.elf: target-panic-abort/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
+	$(CLANG) test.c -I${HEADERS} target-panic-abort/x86_64-unknown-linux-gnu/release/libicu_capi.a -g -o panic-abort-clang.elf
 
-optim3.o: $(ALL_HEADERS) test.c
-	$(CLANG) -c -flto=thin -fdata-sections -ffunction-sections --target=x86_64-unknown-linux-gnu test.c -I${HEADERS} -g -o optim3.o
 
-# optim3.elf: clang two-step with lld, debug mode
-optim3.elf: optim3.o target/x86_64-unknown-linux-gnu/debug/libicu_capi.a
-	$(CLANG) -flto=thin -fuse-ld=$(LLD) -L . -o optim3.elf optim3.o target/x86_64-unknown-linux-gnu/debug/libicu_capi.a -Wl,--gc-sections
 
-optim4.o: $(ALL_HEADERS) test.c
-	$(CLANG) -c -flto=thin -fdata-sections -ffunction-sections --target=x86_64-unknown-linux-gnu test.c -I${HEADERS} -g -o optim4.o
+# clang single-step with gc-sections, stripping; rust with release, LTO, panic-abort (std panic-immediate-abort)
+panic-abort-clang-stripped.elf: target-panic-abort/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
+	$(CLANG) test.c -fdata-sections -ffunction-sections -I${HEADERS} target-panic-abort/x86_64-unknown-linux-gnu/release/libicu_capi.a -g -o panic-abort-clang-stripped.elf  -Wl,--gc-sections -Wl,--strip-all
 
-# optim4.elf: clang two-step with lld, release mode with debug symbols
-optim4.elf: optim4.o target/x86_64-unknown-linux-gnu/release/libicu_capi.a
-	$(CLANG) -flto=thin -fuse-ld=$(LLD) -L . -o optim4.elf optim4.o target/x86_64-unknown-linux-gnu/release/libicu_capi.a -Wl,--gc-sections
 
-optim5.o: $(ALL_HEADERS) test.c
-	$(CLANG) -c -flto=thin -fdata-sections -ffunction-sections --target=x86_64-unknown-linux-gnu test.c -I${HEADERS} -o optim5.o
+# clang single-step with LTO, rust with release, LTO, panic-abort (std panic-immediate-abort)
+panic-abort-lto-clang.elf: target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
+	$(CLANG) -flto=thin -fuse-ld=$(LLD) -fdata-sections -ffunction-sections test.c -I${HEADERS} target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -g -o panic-abort-lto-clang.elf
 
-# optim5.elf: clang two-step with lld, release mode stripped of debug symbols
-optim5.elf: optim5.o target/x86_64-unknown-linux-gnu/release/libicu_capi.a
-	$(CLANG) -flto=thin -fuse-ld=$(LLD) -L . -o optim5.elf optim5.o target/x86_64-unknown-linux-gnu/release/libicu_capi.a -Wl,--gc-sections -Wl,--strip-all
+# clang single-step with LTO, gc-sections, stripping, rust with release, LTO, panic-abort (std panic-immediate-abort)
+panic-abort-lto-clang-stripped.elf: target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a $(ALL_HEADERS) test.c
+	$(CLANG) -flto=thin -fuse-ld=$(LLD) -fdata-sections -ffunction-sections test.c -I${HEADERS} target-panic-abort-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -g -o panic-abort-lto-clang-stripped.elf -Wl,--gc-sections -Wl,--strip-all
 
-build: optim0.elf optim1.elf optim2.elf optim3.elf optim4.elf optim5.elf
-	ls -l optim*.elf
+
+# clang one-step with lld, ThinLTO, gc-sections, stripping, rust with release, LTO, panic-abort (std panic-immediate-abort), with cross-compiler LTO
+panic-abort-linker-plugin-lto-clang-stripped.elf: target-panic-abort-linker-plugin-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a
+	$(CLANG) -flto=thin -fuse-ld=$(LLD) --target=x86_64-unknown-linux-gnu test.c -I${HEADERS} -o panic-abort-linker-plugin-lto-clang-stripped.elf target-panic-abort-linker-plugin-lto/x86_64-unknown-linux-gnu/release/libicu_capi.a -Wl,--gc-sections -Wl,--strip-all
+
+
+build: release.elf release-gcc-stripped.elf panic-abort-clang.elf panic-abort-clang-stripped.elf panic-abort-lto-clang.elf panic-abort-lto-clang-stripped.elf panic-abort-linker-plugin-lto-clang-stripped.elf 
+	ls -l *.elf
 
 test: build
-	./optim0.elf
-	./optim1.elf
-	./optim2.elf
-	./optim2.elf
-	./optim4.elf
-	./optim5.elf
+	./release.elf bn
+	./release-gcc-stripped.elf bn
+	./panic-abort-clang.elf bn
+	./panic-abort-clang-stripped.elf bn
+	./panic-abort-lto-clang.elf bn
+	./panic-abort-lto-clang-stripped.elf bn
+	./panic-abort-linker-plugin-lto-clang-stripped.elf bn
 
 clean:
 	git clean -xf *


### PR DESCRIPTION
Progress on #5945

This does not fully enact the vision in #5945, but it does start testing various combinations of tactics. I didn't want to test *all* combinations and I didn't want to spend time figuring out which combinations we really want, so I went ahead and tested the ones most relevant to the current investigation (#5935).


This shows the effects of LTO, linker-plugin-lto, and stripping+gc-sections on panic-abort (with panic-immediate-abort std) release Rust builds.


Benchmarks with just panic=abort but no panic-immediate-abort/panic-abort std would probably be useful to clients but I haven't added them now. It may be worth using makefile magic to truly build a matrix of targets.



<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->