### PR TITLE
Fix timezone naming convention in env_preferences

### DIFF
--- a/utils/env_preferences/src/apple.rs
+++ b/utils/env_preferences/src/apple.rs
@@ -152,7 +152,7 @@ pub fn get_system_calendars() -> Result<Vec<(String, String)>, RetrievalError> {
 }
 
 /// Get the current time zone of the system
-pub fn get_system_timezone() -> Result<String, RetrievalError> {
+pub fn get_system_time_zone() -> Result<String, RetrievalError> {
     // SAFETY: Returns the time zone currently used by the system
     // Returns an immutable reference to TimeZone object owned by us
     let timezone = unsafe { timezone::CFTimeZoneCopySystem() };

--- a/utils/env_preferences/src/windows.rs
+++ b/utils/env_preferences/src/windows.rs
@@ -36,7 +36,7 @@ pub fn get_system_calendars() -> Result<Vec<(String, String)>, RetrievalError> {
 }
 
 /// Get the current time zone of the system
-pub fn get_system_timezone() -> Result<String, RetrievalError> {
+pub fn get_system_time_zone() -> Result<String, RetrievalError> {
     let calendar = Globalization::Calendar::new()?;
     let timezone = calendar.GetTimeZone()?;
     Ok(timezone.to_string_lossy())

--- a/utils/env_preferences/tests/test.rs
+++ b/utils/env_preferences/tests/test.rs
@@ -68,7 +68,7 @@ mod linux_tests {
 #[cfg(target_os = "macos")]
 #[cfg(test)]
 mod macos_test {
-    use env_preferences::{get_locales, get_system_calendars, get_system_timezone};
+    use env_preferences::{get_locales, get_system_calendars, get_system_time_zone};
     use icu_locale::Locale;
 
     #[test]
@@ -111,7 +111,7 @@ mod macos_test {
 
     #[test]
     fn test_time_zone() {
-        let time_zone = get_system_timezone().unwrap();
+        let time_zone = get_system_time_zone().unwrap();
         assert!(!time_zone.is_empty(), "Couldn't retreive time_zone");
     }
 }
@@ -119,7 +119,7 @@ mod macos_test {
 #[cfg(target_os = "windows")]
 #[cfg(test)]
 mod windows_test {
-    use env_preferences::{get_locales, get_system_calendars, get_system_timezone};
+    use env_preferences::{get_locales, get_system_calendars, get_system_time_zone};
     use icu_locale::Locale;
 
     #[test]
@@ -155,7 +155,7 @@ mod windows_test {
 
     #[test]
     fn test_time_zone() {
-        let time_zone = get_system_timezone().unwrap();
+        let time_zone = get_system_time_zone().unwrap();
         assert!(!time_zone.is_empty(), "Couldn't retreive time_zone");
         assert!(time_zone.is_ascii(), "Invalid TimeZone format");
     }


### PR DESCRIPTION
As decided in https://github.com/unicode-org/icu4x/issues/4350


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->