### PR TITLE
`split_at` audit

### DIFF
--- a/components/collator/src/elements.rs
+++ b/components/collator/src/elements.rs
@@ -1888,11 +1888,9 @@ where
                                     while !remaining.is_empty() {
                                         // Numeric CEs are generated for segments of
                                         // up to 254 digits.
-                                        let (head, tail) = if remaining.len() > 254 {
-                                            remaining.split_at(254)
-                                        } else {
-                                            (remaining, &b""[..])
-                                        };
+                                        let (head, tail) = remaining
+                                            .split_at_checked(254)
+                                            .unwrap_or((remaining, b""));
                                         remaining = tail;
                                         // From ICU4C CollationIterator::appendNumericSegmentCEs
                                         if head.len() <= 7 {

--- a/components/locale_core/src/extensions/unicode/subdivision.rs
+++ b/components/locale_core/src/extensions/unicode/subdivision.rs
@@ -122,10 +122,9 @@ impl SubdivisionId {
             })
             .ok_or(ParseError::InvalidExtension)?;
         let region_len = if is_alpha { 2 } else { 3 };
-        if code_units.len() < region_len + 1 {
-            return Err(ParseError::InvalidExtension);
-        }
-        let (region_code_units, suffix_code_units) = code_units.split_at(region_len);
+        let (region_code_units, suffix_code_units) = code_units
+            .split_at_checked(region_len)
+            .ok_or(ParseError::InvalidExtension)?;
         let region =
             Region::try_from_utf8(region_code_units).map_err(|_| ParseError::InvalidExtension)?;
         let suffix = SubdivisionSuffix::try_from_utf8(suffix_code_units)?;

--- a/components/locale_core/src/parser/mod.rs
+++ b/components/locale_core/src/parser/mod.rs
@@ -27,9 +27,8 @@ const fn skip_before_separator(slice: &[u8]) -> &[u8] {
     }
 
     // Notice: this slice may be empty for cases like `"en-"` or `"en--US"`
-    // MSRV 1.71/1.79: Use split_at/split_at_unchecked
     // SAFETY: end < slice.len() by while loop
-    unsafe { core::slice::from_raw_parts(slice.as_ptr(), end) }
+    unsafe { slice.split_at_unchecked(end).0 }
 }
 
 // `SubtagIterator` is a helper iterator for [`LanguageIdentifier`] and [`Locale`] parsing.
@@ -66,14 +65,8 @@ impl<'a> SubtagIterator<'a> {
 
         self.current = if result.len() < self.remaining.len() {
             // If there is more after `result`, by construction `current` starts with a separator
-            // MSRV 1.79: Use split_at_unchecked
             // SAFETY: `self.remaining` is strictly longer than `result`
-            self.remaining = unsafe {
-                core::slice::from_raw_parts(
-                    self.remaining.as_ptr().add(result.len() + 1),
-                    self.remaining.len() - (result.len() + 1),
-                )
-            };
+            self.remaining = unsafe { self.remaining.split_at_unchecked(result.len() + 1).1 };
             Some(skip_before_separator(self.remaining))
         } else {
             None

--- a/components/normalizer/src/lib.rs
+++ b/components/normalizer/src/lib.rs
@@ -1454,14 +1454,11 @@ macro_rules! normalizer_methods {
         /// is the normalization of the whole input.
         pub fn split_normalized<'a>(&self, text: &'a str) -> (&'a str, &'a str) {
             let up_to = self.is_normalized_up_to(text);
-            if up_to <= text.len() {
-                // not using split_at_checked due to MSRV
-                text.split_at(up_to)
-            } else {
+            text.split_at_checked(up_to).unwrap_or_else(|| {
                 // Internal bug, not even GIGO, never supposed to happen
                 debug_assert!(false);
                 ("", text)
-            }
+            })
         }
 
         /// Return the index a string slice is normalized up to.
@@ -1502,14 +1499,11 @@ macro_rules! normalizer_methods {
         #[cfg(feature = "utf16_iter")]
         pub fn split_normalized_utf16<'a>(&self, text: &'a [u16]) -> (&'a [u16], &'a [u16]) {
             let up_to = self.is_normalized_utf16_up_to(text);
-            if up_to <= text.len() {
-                // not using split_at_checked due to MSRV
-                text.split_at(up_to)
-            } else {
+            text.split_at_checked(up_to).unwrap_or_else(|| {
                 // Internal bug, not even GIGO, never supposed to happen
                 debug_assert!(false);
                 (&[], text)
-            }
+            })
         }
 
         /// Return the index a slice of potentially-invalid UTF-16 is normalized up to.
@@ -1559,17 +1553,14 @@ macro_rules! normalizer_methods {
         #[cfg(feature = "utf8_iter")]
         pub fn split_normalized_utf8<'a>(&self, text: &'a [u8]) -> (&'a str, &'a [u8]) {
             let up_to = self.is_normalized_utf8_up_to(text);
-            if up_to <= text.len() {
-                // not using split_at_checked due to MSRV
-                let (head, tail) = text.split_at(up_to);
-                // SAFETY: The normalization check also checks for
-                // UTF-8 well-formedness.
-                (unsafe { core::str::from_utf8_unchecked(head) }, tail)
-            } else {
+            let (head, tail) = text.split_at_checked(up_to).unwrap_or_else(|| {
                 // Internal bug, not even GIGO, never supposed to happen
                 debug_assert!(false);
-                ("", text)
-            }
+                (&[], text)
+            });
+            // SAFETY: The normalization check also checks for
+            // UTF-8 well-formedness.
+            (unsafe { core::str::from_utf8_unchecked(head) }, tail)
         }
 
         /// Return the index a slice of potentially-invalid UTF-8 is normalized up to

--- a/components/plurals/src/provider.rs
+++ b/components/plurals/src/provider.rs
@@ -451,12 +451,7 @@ where
             })
         } else {
             let (second_byte, remainder) = remainder.split_first()?;
-            // TODO in Rust 1.80: use split_at_checked
-            let v_length = *second_byte as usize;
-            if remainder.len() < v_length {
-                return None;
-            }
-            let (v_bytes, remainder) = remainder.split_at(v_length);
+            let (v_bytes, remainder) = remainder.split_at_checked(*second_byte as usize)?;
             Some(PluralElementsUnpackedBytes {
                 lead_byte: *lead_byte,
                 v_bytes,
@@ -824,7 +819,10 @@ where
                     panic!("other value too long to be packed: {self:?}")
                 }
             };
-            let (v_bytes, specials_bytes) = remainder.split_at_mut(*second_byte as usize);
+            #[allow(clippy::unwrap_used)] // for now okay since it is mostly only during datagen
+            let (v_bytes, specials_bytes) = remainder
+                .split_at_mut_checked(*second_byte as usize)
+                .unwrap();
             builder.default.1.encode_var_ule_write(v_bytes);
             EncodeAsVarULE::<PluralElementsTupleSliceVarULE<V>>::encode_var_ule_write(
                 &specials,

--- a/documents/process/style_guide.md
+++ b/documents/process/style_guide.md
@@ -801,24 +801,7 @@ See also: the [Panics](#Panics--required) section of this document.
 
 #### Special Case: `split_at`
 
-The standard library functions such as `slice::split_at` are panicky, but they are not covered by our Clippy lints.
-
-Instead of using `slice::split_at` directly, it is recommended to use a helper function, which can be saved in the file in which it is being used. Example:
-
-```rust
-/// Like slice::split_at but returns an Option instead of panicking
-#[inline]
-fn debug_split_at(slice: &[u8], mid: usize) -> Option<(&[u8], &[u8])> {
-    if mid > slice.len() {
-        debug_assert!(false, "debug_split_at: index expected to be in range");
-        None
-    } else {
-        // Note: We're trusting the compiler to inline this and remove the assertion
-        // hiding on the top of slice::split_at: `assert(mid <= self.len())`
-        Some(slice.split_at(mid))
-    }
-}
-```
+The standard library functions such as `slice::split_at` are panicky, but they are not covered by our Clippy lints. Be careful to use `slice::split_at_checked` instead.
 
 #### Exception: Poison
 

--- a/utils/writeable/src/cmp.rs
+++ b/utils/writeable/src/cmp.rs
@@ -19,7 +19,8 @@ impl fmt::Write for WriteComparator<'_> {
             return Ok(());
         }
         let cmp_len = core::cmp::min(other.len(), self.code_units.len());
-        let (this, remainder) = self.code_units.split_at(cmp_len);
+        // SAFETY: cmp_len is at most self.code_units.len()
+        let (this, remainder) = unsafe { self.code_units.split_at_unchecked(cmp_len) };
         self.code_units = remainder;
         self.result = this.cmp(other.as_bytes());
         Ok(())

--- a/utils/writeable/src/cmp.rs
+++ b/utils/writeable/src/cmp.rs
@@ -18,9 +18,10 @@ impl fmt::Write for WriteComparator<'_> {
         if self.result != Ordering::Equal {
             return Ok(());
         }
-        let cmp_len = core::cmp::min(other.len(), self.code_units.len());
-        // SAFETY: cmp_len is at most self.code_units.len()
-        let (this, remainder) = unsafe { self.code_units.split_at_unchecked(cmp_len) };
+        let (this, remainder) = self
+            .code_units
+            .split_at_checked(other.len())
+            .unwrap_or((self.code_units, &[]));
         self.code_units = remainder;
         self.result = this.cmp(other.as_bytes());
         Ok(())

--- a/utils/zerotrie/src/helpers.rs
+++ b/utils/zerotrie/src/helpers.rs
@@ -3,9 +3,6 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 pub(crate) trait MaybeSplitAt<T> {
-    /// Like slice::split_at but returns an Option instead of panicking
-    /// if the index is out of range.
-    fn maybe_split_at(&self, mid: usize) -> Option<(&Self, &Self)>;
     /// Like slice::split_at but debug-panics and returns an empty second slice
     /// if the index is out of range.
     fn debug_split_at(&self, mid: usize) -> (&Self, &Self);
@@ -13,25 +10,11 @@ pub(crate) trait MaybeSplitAt<T> {
 
 impl<T> MaybeSplitAt<T> for [T] {
     #[inline]
-    fn maybe_split_at(&self, mid: usize) -> Option<(&Self, &Self)> {
-        if mid > self.len() {
-            None
-        } else {
-            // Note: We're trusting the compiler to inline this and remove the assertion
-            // hiding on the top of slice::split_at: `assert(mid <= self.len())`
-            Some(self.split_at(mid))
-        }
-    }
-    #[inline]
     fn debug_split_at(&self, mid: usize) -> (&Self, &Self) {
-        if mid > self.len() {
-            debug_assert!(false, "debug_split_at: index expected to be in range");
+        self.split_at_checked(mid).unwrap_or_else(|| {
+            debug_assert!(false, "debug_split_at: {mid} expected to be in range");
             (self, &[])
-        } else {
-            // Note: We're trusting the compiler to inline this and remove the assertion
-            // hiding on the top of slice::split_at: `assert(mid <= self.len())`
-            self.split_at(mid)
-        }
+        })
     }
 }
 

--- a/utils/zerotrie/src/reader.rs
+++ b/utils/zerotrie/src/reader.rs
@@ -345,7 +345,7 @@ pub(crate) fn get_parameterized<T: ZeroTrieWithOptions + ?Sized>(
             {
                 let (trie_span, ascii_span);
                 (trie_span, trie) = trie.debug_split_at(x);
-                (ascii_span, ascii) = ascii.maybe_split_at(x)?;
+                (ascii_span, ascii) = ascii.split_at_checked(x)?;
                 if trie_span == ascii_span {
                     // Matched a byte span
                     continue;

--- a/utils/zerovec/src/varzerovec/components.rs
+++ b/utils/zerovec/src/varzerovec/components.rs
@@ -316,8 +316,7 @@ impl<'a, T: VarULE + ?Sized, F: VarZeroVecFormat> VarZeroVecComponents<'a, T, F>
                 marker: PhantomData,
             };
         }
-        // MSRV Rust 1.79: Use split_at_unchecked
-        let len_bytes = slice.get_unchecked(0..F::Len::SIZE);
+        let (len_bytes, data_bytes) = unsafe { slice.split_at_unchecked(F::Len::SIZE) };
         // Safety: F::Len allows all byte sequences
         let len_ule = F::Len::slice_from_bytes_unchecked(len_bytes);
 
@@ -328,7 +327,7 @@ impl<'a, T: VarULE + ?Sized, F: VarZeroVecFormat> VarZeroVecComponents<'a, T, F>
         // whereas we're calling something that asks for `parse_bytes_with_length()`.
         // The two methods perform similar validation, with parse_bytes() validating an additional
         // 4-byte `length` header.
-        Self::from_bytes_unchecked_with_length(len_u32, slice.get_unchecked(F::Len::SIZE..))
+        Self::from_bytes_unchecked_with_length(len_u32, data_bytes)
     }
 
     /// Construct a [`VarZeroVecComponents`] from a byte slice that has previously


### PR DESCRIPTION
With the 1.80 MSRV we can use the non-panicky alternatives now. #5963