### PR TITLE
Remove unnecessary verbosity in error docs/Display

### DIFF
--- a/components/experimental/src/duration/validated_options.rs
+++ b/components/experimental/src/duration/validated_options.rs
@@ -79,7 +79,7 @@ pub enum DurationFormatterOptionsError {
     PreviousNumeric,
 
     /// The number of fractional digits is out of acceptable range. See [`FractionalDigits::Fixed`].
-    #[displaydoc("Returned when tThehe number of fractional digits is out of acceptable range")]
+    #[displaydoc("The number of fractional digits is out of acceptable range")]
     FractionalDigitsOutOfRange,
 }
 

--- a/components/experimental/src/duration/validated_options.rs
+++ b/components/experimental/src/duration/validated_options.rs
@@ -63,21 +63,23 @@ pub struct ValidatedDurationFormatterOptions {
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, displaydoc::Display)]
 pub enum DurationFormatterOptionsError {
-    /// Returned when a unit field is set to [`FieldDisplay::Always`] and the style is set to [`FieldStyle::Fractional`].
-    #[displaydoc("Returned when a unit field is set to Always and the style is set to Fractional")]
+    /// A unit field is set to [`FieldDisplay::Always`] and the style is set to [`FieldStyle::Fractional`].
+    #[displaydoc("A unit field is set to Always and the style is set to Fractional")]
     DisplayAlwaysFractional,
 
-    /// Returned when a previous unit's style is [`FieldStyle::Fractional`], but the following unit's style is not [`FieldStyle::Fractional`].
-    #[displaydoc("Returned when a previous unit's style is Fractional, but the following unit's style is not Fractional")]
+    /// A previous unit's style is [`FieldStyle::Fractional`], but the following unit's style is not [`FieldStyle::Fractional`].
+    #[displaydoc(
+        "A previous unit's style is Fractional, but the following unit's style is not Fractional"
+    )]
     PreviousFractional,
 
-    /// Returned when a previous unit's style is set to [`FieldStyle::Numeric`] or [`FieldStyle::TwoDigit`] and the following unit's style is not
+    /// A previous unit's style is set to [`FieldStyle::Numeric`] or [`FieldStyle::TwoDigit`] and the following unit's style is not
     /// [`FieldStyle::Fractional`], [`FieldStyle::Numeric`], or [`FieldStyle::TwoDigit`].
-    #[displaydoc("Returned when a previous unit's style is set to Numeric or TwoDigit and the following unit's style is not Fractional, Numeric, or TwoDigit")]
+    #[displaydoc("A previous unit's style is set to Numeric or TwoDigit and the following unit's style is not Fractional, Numeric, or TwoDigit")]
     PreviousNumeric,
 
-    /// Returned when the number of fractional digits is out of acceptable range. See [`FractionalDigits::Fixed`].
-    #[displaydoc("Returned when the number of fractional digits is out of acceptable range")]
+    /// The number of fractional digits is out of acceptable range. See [`FractionalDigits::Fixed`].
+    #[displaydoc("Returned when tThehe number of fractional digits is out of acceptable range")]
     FractionalDigitsOutOfRange,
 }
 

--- a/components/experimental/src/units/ratio.rs
+++ b/components/experimental/src/units/ratio.rs
@@ -57,7 +57,7 @@ pub enum RatioFromStrError {
     #[displaydoc("The exponent part of the ratio string is not an integer")]
     ExponentPartIsNotAnInteger,
 
-    /// The ratio string is dificient in some other way.
+    /// The ratio string is deficient in some other way.
     ParsingBigIntError(num_bigint::ParseBigIntError),
 }
 

--- a/components/experimental/src/units/ratio.rs
+++ b/components/experimental/src/units/ratio.rs
@@ -21,49 +21,43 @@ use crate::measure::provider::si_prefix::{Base, SiPrefix};
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct IcuRatio(Ratio<BigInt>);
 
-/// Represents an error when the ratio string is invalid and cannot be parsed.
+/// The ratio string is invalid and cannot be parsed.
 #[derive(Debug, PartialEq, displaydoc::Display)]
 pub enum RatioFromStrError {
-    /// Represents an error when the ratio string is divided by zero.
+    /// The ratio string is divided by zero.
     DivisionByZero,
 
-    /// Represents an error when the ratio string contains multiple slashes.
+    /// The ratio string contains multiple slashes.
     ///
     /// For example, "1/2/3".
-    #[displaydoc("Represents an error when the ratio string contains multiple slashes")]
+    #[displaydoc("The ratio string contains multiple slashes")]
     MultipleSlashes,
 
-    /// Represents an error when the ratio string contains non-numeric characters in fractions.
+    /// The ratio string contains non-numeric characters in fractions.
     ///
     /// For example, "1/2A".
-    #[displaydoc(
-        "Represents an error when the ratio string contains non-numeric characters in fractions"
-    )]
+    #[displaydoc("The ratio string contains non-numeric characters in fractions")]
     NonNumericCharactersInFractions,
 
-    /// Represents an error when the ratio string contains multiple scientific notations.
+    /// The ratio string contains multiple scientific notations.
     ///
     /// For example, "1.5E6E6".
-    #[displaydoc(
-        "Represents an error when the ratio string contains multiple scientific notations"
-    )]
+    #[displaydoc("The ratio string contains multiple scientific notations")]
     MultipleScientificNotations,
 
-    /// Represents an error when the ratio string contains multiple decimal points.
+    /// The ratio string contains multiple decimal points.
     ///
     /// For example, "1.5.6".
-    #[displaydoc("Represents an error when the ratio string contains multiple decimal points")]
+    #[displaydoc("The ratio string contains multiple decimal points")]
     MultipleDecimalPoints,
 
-    /// Represents an error when the exponent part of the ratio string is not an integer.
+    /// The exponent part of the ratio string is not an integer.
     ///
     /// For example, "1.5E6.5".
-    #[displaydoc(
-        "Represents an error when the exponent part of the ratio string is not an integer"
-    )]
+    #[displaydoc("The exponent part of the ratio string is not an integer")]
     ExponentPartIsNotAnInteger,
 
-    /// Represents an error when the ratio string is dificient in some other way.
+    /// The ratio string is dificient in some other way.
     ParsingBigIntError(num_bigint::ParseBigIntError),
 }
 


### PR DESCRIPTION
Followup from #5969

I fixed both the docs and the Display, it's similarly unnecessary for the docs to say "represents an error when".

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->