### PR TITLE
Use `core::error`

### DIFF
--- a/components/calendar/Cargo.toml
+++ b/components/calendar/Cargo.toml
@@ -50,7 +50,6 @@ criterion = { workspace = true }
 default = ["compiled_data", "ixdtf"]
 ixdtf = ["dep:ixdtf"]
 logging = ["calendrical_calculations/logging"]
-std = ["icu_provider/std", "icu_locale_core/std", "calendrical_calculations/std"]
 serde = ["dep:serde", "zerovec/serde", "tinystr/serde", "icu_provider/serde"]
 datagen = ["serde", "dep:databake", "zerovec/databake", "tinystr/databake"]
 bench = []

--- a/components/calendar/src/error.rs
+++ b/components/calendar/src/error.rs
@@ -29,6 +29,8 @@ pub enum DateError {
     UnknownMonthCode(MonthCode),
 }
 
+impl core::error::Error for DateError {}
+
 #[derive(Debug, Copy, Clone, PartialEq, Display)]
 /// An argument is out of range for its domain.
 #[displaydoc("The {field} = {value} argument is out of range {min}..={max}")]
@@ -43,6 +45,8 @@ pub struct RangeError {
     /// The maximum value (inclusive). This might not be tight.
     pub max: i32,
 }
+
+impl core::error::Error for RangeError {}
 
 impl From<RangeError> for DateError {
     fn from(value: RangeError) -> Self {

--- a/components/calendar/src/lib.rs
+++ b/components/calendar/src/lib.rs
@@ -94,7 +94,7 @@
 //! [`ICU4X`]: ../icu/index.html
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, feature = "std")), no_std)]
+#![cfg_attr(not(any(test, doc)), no_std)]
 #![cfg_attr(
     not(test),
     deny(

--- a/components/casemap/Cargo.toml
+++ b/components/casemap/Cargo.toml
@@ -45,7 +45,6 @@ criterion = { workspace = true }
 
 [features]
 default = ["compiled_data"]
-std = ["icu_collections/std", "icu_provider/std"]
 bench = []
 serde = ["dep:serde", "zerovec/serde", "icu_collections/serde", "icu_provider/serde", "icu_properties/serde", "potential_utf/serde"]
 datagen = ["serde", "dep:databake", "zerovec/databake", "icu_collections/databake"]

--- a/components/casemap/src/lib.rs
+++ b/components/casemap/src/lib.rs
@@ -28,7 +28,7 @@
 //! [`ICU4X`]: ../icu/index.html
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, feature = "std")), no_std)]
+#![cfg_attr(not(any(test, doc)), no_std)]
 #![cfg_attr(
     not(test),
     deny(

--- a/components/collator/Cargo.toml
+++ b/components/collator/Cargo.toml
@@ -48,7 +48,6 @@ criterion = { workspace = true }
 
 [features]
 default = ["compiled_data"]
-std = ["icu_collections/std", "icu_locale_core/std", "icu_normalizer/std", "icu_properties/std", "icu_provider/std"]
 serde = ["dep:serde", "zerovec/serde", "icu_properties/serde", "icu_normalizer/serde", "icu_collections/serde", "icu_provider/serde"]
 datagen = ["serde", "dep:databake", "zerovec/databake", "icu_properties/datagen", "icu_normalizer/datagen", "icu_collections/databake"]
 compiled_data = ["dep:icu_collator_data", "icu_normalizer/compiled_data"]

--- a/components/collator/src/lib.rs
+++ b/components/collator/src/lib.rs
@@ -7,7 +7,7 @@
 // described in LICENSE.
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, feature = "std")), no_std)]
+#![cfg_attr(not(any(test, doc)), no_std)]
 #![cfg_attr(
     not(test),
     deny(

--- a/components/collections/Cargo.toml
+++ b/components/collections/Cargo.toml
@@ -44,7 +44,6 @@ toml = { workspace = true }
 criterion = { workspace = true }
 
 [features]
-std = []
 serde = ["dep:serde", "zerovec/serde", "potential_utf/serde"]
 databake = ["dep:databake", "zerovec/databake"]
 bench = []

--- a/components/collections/src/codepointtrie/error.rs
+++ b/components/collections/src/codepointtrie/error.rs
@@ -20,3 +20,5 @@ pub enum Error {
     #[displaydoc("CodePointTrie must be constructed from data vector with at least one element")]
     EmptyDataVector,
 }
+
+impl core::error::Error for Error {}

--- a/components/collections/src/lib.rs
+++ b/components/collections/src/lib.rs
@@ -21,7 +21,7 @@
 //! / [ICU4J CharsTrie](https://unicode-org.github.io/icu-docs/apidoc/released/icu4j/com/ibm/icu/util/CharsTrie.html) API.
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, feature = "std")), no_std)]
+#![cfg_attr(not(any(test, doc)), no_std)]
 #![cfg_attr(
     not(test),
     deny(

--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -63,14 +63,6 @@ criterion = { workspace = true }
 
 [features]
 default = ["compiled_data"]
-std = [
-    "icu_calendar/std",
-    "icu_decimal/std",
-    "icu_locale_core/std",
-    "icu_plurals/std",
-    "icu_provider/std",
-    "icu_timezone/std",
-]
 serde = [
     "dep:serde",
     "icu_calendar/serde",
@@ -93,7 +85,6 @@ datagen = [
     "icu_plurals/datagen",
     "icu_timezone/datagen",
     "serde",
-    "std",
 ]
 logging = ["icu_calendar/logging"]
 experimental = ["dep:litemap"]

--- a/components/datetime/src/builder.rs
+++ b/components/datetime/src/builder.rs
@@ -163,6 +163,8 @@ pub enum BuilderError {
     InvalidOptions,
 }
 
+impl core::error::Error for BuilderError {}
+
 /// A builder for [dynamic field sets](crate::fieldsets::enums).
 ///
 /// This builder is useful if you do not know the field set at code compilation time. If you do,

--- a/components/datetime/src/error.rs
+++ b/components/datetime/src/error.rs
@@ -30,6 +30,8 @@ pub enum DateTimeFormatterLoadError {
     Data(DataError),
 }
 
+impl core::error::Error for DateTimeFormatterLoadError {}
+
 impl From<DataError> for DateTimeFormatterLoadError {
     fn from(error: DataError) -> Self {
         Self::Data(error)
@@ -51,6 +53,8 @@ pub struct MismatchedCalendarError {
     /// Can be `None` if the input calendar was not specified.
     pub date_kind: Option<AnyCalendarKind>,
 }
+
+impl core::error::Error for MismatchedCalendarError {}
 
 #[non_exhaustive]
 #[derive(Debug, PartialEq, Copy, Clone, displaydoc::Display)]
@@ -129,3 +133,5 @@ pub enum DateTimeWriteError {
     #[displaydoc("Unsupported field {0:?}")]
     UnsupportedField(ErrorField),
 }
+
+impl core::error::Error for DateTimeWriteError {}

--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -70,7 +70,7 @@
 //! ```
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, feature = "std")), no_std)]
+#![cfg_attr(not(any(test, doc)), no_std)]
 #![cfg_attr(
     not(test),
     deny(

--- a/components/datetime/src/neo_serde.rs
+++ b/components/datetime/src/neo_serde.rs
@@ -34,6 +34,8 @@ pub enum CompositeFieldSetSerdeError {
     InvalidFields,
 }
 
+impl core::error::Error for CompositeFieldSetSerdeError {}
+
 /// 🚧 \[Experimental\] A type corresponding to [`CompositeFieldSet`] that implements
 /// [`serde::Serialize`] and [`serde::Deserialize`].
 ///

--- a/components/datetime/src/options/mod.rs
+++ b/components/datetime/src/options/mod.rs
@@ -521,6 +521,8 @@ pub enum FractionalSecondError {
     OutOfRange,
 }
 
+impl core::error::Error for FractionalSecondError {}
+
 impl From<FractionalSecondDigits> for u8 {
     fn from(value: FractionalSecondDigits) -> u8 {
         use FractionalSecondDigits::*;

--- a/components/datetime/src/pattern/mod.rs
+++ b/components/datetime/src/pattern/mod.rs
@@ -89,3 +89,5 @@ pub enum PatternLoadError {
     #[displaydoc("Problem loading data for field {1:?}: {0}")]
     Data(icu_provider::DataError, ErrorField),
 }
+
+impl core::error::Error for PatternLoadError {}

--- a/components/datetime/src/provider/fields/length.rs
+++ b/components/datetime/src/provider/fields/length.rs
@@ -17,8 +17,7 @@ pub enum LengthError {
     InvalidLength,
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for LengthError {}
+impl core::error::Error for LengthError {}
 
 /// An enum representing the length of a field within a date or time formatting pattern string.
 ///

--- a/components/datetime/src/provider/fields/mod.rs
+++ b/components/datetime/src/provider/fields/mod.rs
@@ -36,8 +36,7 @@ pub enum Error {
     InvalidLength(FieldSymbol),
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}
 
 /// A field within a date pattern string, also referred to as a date field.
 ///

--- a/components/datetime/src/provider/fields/symbols.rs
+++ b/components/datetime/src/provider/fields/symbols.rs
@@ -26,8 +26,7 @@ pub enum SymbolError {
     Invalid(u8),
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for SymbolError {}
+impl core::error::Error for SymbolError {}
 
 /// A field symbol for a date formatting pattern.
 ///

--- a/components/datetime/src/provider/pattern/error.rs
+++ b/components/datetime/src/provider/pattern/error.rs
@@ -30,8 +30,7 @@ pub enum PatternError {
     UnsupportedPluralPivot,
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for PatternError {}
+impl core::error::Error for PatternError {}
 
 impl From<fields::Error> for PatternError {
     fn from(input: fields::Error) -> Self {

--- a/components/datetime/src/provider/skeleton/error.rs
+++ b/components/datetime/src/provider/skeleton/error.rs
@@ -32,8 +32,7 @@ pub enum SkeletonError {
     Fields(fields::Error),
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for SkeletonError {}
+impl core::error::Error for SkeletonError {}
 
 impl From<fields::Error> for SkeletonError {
     fn from(e: fields::Error) -> Self {

--- a/components/datetime/src/provider/skeleton/serde.rs
+++ b/components/datetime/src/provider/skeleton/serde.rs
@@ -3,6 +3,8 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use alloc::format;
+#[cfg(feature = "datagen")]
+use alloc::string::ToString;
 use core::convert::TryFrom;
 use smallvec::SmallVec;
 
@@ -75,11 +77,12 @@ pub mod reference {
 
 pub mod runtime {
     use super::super::runtime::Skeleton;
-    use zerovec::ZeroVec;
+    use super::*;
 
     #[cfg(feature = "datagen")]
     use ::serde::{ser, Serialize};
     use serde::{de, Deserialize, Deserializer};
+    use zerovec::ZeroVec;
     /// This is an implementation of the serde deserialization visitor pattern.
     #[allow(clippy::upper_case_acronyms)]
     struct DeserializeSkeletonUTS35String;

--- a/components/datetime/src/scaffold/names_storage.rs
+++ b/components/datetime/src/scaffold/names_storage.rs
@@ -76,12 +76,16 @@ impl_holder_trait!(tz::MzPeriodV1Marker);
 
 /// An error returned by [`MaybePayload`].
 #[allow(missing_docs)]
-#[derive(Debug)]
+#[derive(Debug, displaydoc::Display)]
 #[non_exhaustive]
 pub enum MaybePayloadError {
+    /// TODO
     TypeTooSpecific,
+    /// TODO
     ConflictingField,
 }
+
+impl core::error::Error for MaybePayloadError {}
 
 impl MaybePayloadError {
     pub(crate) fn into_load_error(self, error_field: ErrorField) -> PatternLoadError {

--- a/components/decimal/Cargo.toml
+++ b/components/decimal/Cargo.toml
@@ -46,7 +46,6 @@ criterion = { workspace = true }
 
 [features]
 default = ["compiled_data"]
-std = ["fixed_decimal/std", "icu_locale_core/std", "icu_provider/std"]
 serde = ["dep:serde", "icu_provider/serde", "zerovec/serde", "tinystr/serde"]
 datagen = ["serde", "dep:databake", "zerovec/databake", "tinystr/databake"]
 bench = ["serde"]

--- a/components/decimal/src/lib.rs
+++ b/components/decimal/src/lib.rs
@@ -76,7 +76,7 @@
 //! [`FixedDecimalFormatter`]: FixedDecimalFormatter
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, feature = "std")), no_std)]
+#![cfg_attr(not(any(test, doc)), no_std)]
 #![cfg_attr(
     not(test),
     deny(

--- a/components/experimental/Cargo.toml
+++ b/components/experimental/Cargo.toml
@@ -71,10 +71,9 @@ icu_normalizer_data = { workspace = true }
 [features]
 default = ["compiled_data"]
 compiled_data = ["dep:icu_experimental_data", "icu_decimal/compiled_data", "icu_list/compiled_data", "icu_plurals/compiled_data", "icu_properties/compiled_data", "icu_normalizer/compiled_data"]
-datagen = ["serde", "std", "dep:databake", "zerovec/databake", "zerotrie/databake", "tinystr/databake", "icu_collections/databake", "std", "log", "icu_pattern/databake", "icu_plurals/datagen", "icu_pattern/alloc"]
+datagen = ["serde", "dep:databake", "zerovec/databake", "zerotrie/databake", "tinystr/databake", "icu_collections/databake", "log", "icu_pattern/databake", "icu_plurals/datagen", "icu_pattern/alloc"]
 ryu = ["fixed_decimal/ryu"]
 serde = ["dep:serde", "zerovec/serde", "potential_utf/serde", "tinystr/serde", "icu_collections/serde", "icu_decimal/serde", "icu_list/serde", "icu_pattern/serde", "icu_plurals/serde", "icu_provider/serde", "zerotrie/serde", "icu_normalizer/serde"]
-std = ["fixed_decimal/std", "icu_decimal/std", "icu_pattern/std", "icu_plurals/std", "icu_provider/std", "icu_locale_core/std"]
 
 bench = []
 

--- a/components/experimental/src/compactdecimal/error.rs
+++ b/components/experimental/src/compactdecimal/error.rs
@@ -17,3 +17,5 @@ pub struct ExponentError {
     /// The magnitude of the number being formatted.
     pub(crate) log10_type: i16,
 }
+
+impl core::error::Error for ExponentError {}

--- a/components/experimental/src/duration/validated_options.rs
+++ b/components/experimental/src/duration/validated_options.rs
@@ -81,6 +81,8 @@ pub enum DurationFormatterOptionsError {
     FractionalDigitsOutOfRange,
 }
 
+impl core::error::Error for DurationFormatterOptionsError {}
+
 impl ValidatedDurationFormatterOptions {
     pub fn validate(
         value: DurationFormatterOptions,

--- a/components/experimental/src/lib.rs
+++ b/components/experimental/src/lib.rs
@@ -11,7 +11,7 @@
 //! crate will eventually stabilize and move to their own top-level components.
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, feature = "std")), no_std)]
+#![cfg_attr(not(any(test, doc)), no_std)]
 // No boilerplate, each module has their own
 #![allow(clippy::module_inception)]
 

--- a/components/experimental/src/personnames/api.rs
+++ b/components/experimental/src/personnames/api.rs
@@ -49,6 +49,8 @@ pub enum PersonNamesFormatterError {
     Pattern(icu_pattern::Error),
 }
 
+impl core::error::Error for PersonNamesFormatterError {}
+
 impl From<DataError> for PersonNamesFormatterError {
     fn from(e: DataError) -> Self {
         PersonNamesFormatterError::Data(e)

--- a/components/experimental/src/transliterate/compile/mod.rs
+++ b/components/experimental/src/transliterate/compile/mod.rs
@@ -491,7 +491,7 @@ where
         + DataProvider<XidStartV1Marker>,
     NP: ?Sized,
 {
-    fn iter_ids(&self) -> Result<std::collections::BTreeSet<DataIdentifierCow>, DataError> {
+    fn iter_ids(&self) -> Result<alloc::collections::BTreeSet<DataIdentifierCow>, DataError> {
         let exclusive_data = self.collection.data.borrow();
         Ok(exclusive_data
             .0

--- a/components/experimental/src/transliterate/transliterator/mod.rs
+++ b/components/experimental/src/transliterate/transliterator/mod.rs
@@ -194,7 +194,7 @@ type Env = LiteMap<String, InternalTransliterator>;
 /// #[derive(Debug)]
 /// struct AsciiUpperTransliterator;
 /// impl CustomTransliterator for AsciiUpperTransliterator {
-///     fn transliterate(&self, input: &str, range: std::ops::Range<usize>) -> String {
+///     fn transliterate(&self, input: &str, range: core::ops::Range<usize>) -> String {
 ///         input.to_ascii_uppercase()
 ///     }
 /// }

--- a/components/experimental/src/units/ratio.rs
+++ b/components/experimental/src/units/ratio.rs
@@ -67,6 +67,8 @@ pub enum RatioFromStrError {
     ParsingBigIntError(num_bigint::ParseBigIntError),
 }
 
+impl core::error::Error for RatioFromStrError {}
+
 impl IcuRatio {
     /// Creates a new `IcuRatio` from the given numerator and denominator.
     pub fn from_big_ints(numerator: BigInt, denominator: BigInt) -> Self {

--- a/components/icu/Cargo.toml
+++ b/components/icu/Cargo.toml
@@ -66,23 +66,6 @@ default = [
     "icu_experimental?/default",
     "icu_pattern?/default",
 ]
-std = [
-    "icu_calendar/std",
-    "icu_casemap/std",
-    "icu_collator/std",
-    "icu_collections/std",
-    "icu_datetime/std",
-    "icu_decimal/std",
-    "icu_list/std",
-    "icu_locale/std",
-    "icu_normalizer/std",
-    "icu_plurals/std",
-    "icu_properties/std",
-    "icu_segmenter/std",
-    "icu_timezone/std",
-    "icu_experimental?/std",
-    "icu_pattern?/std",
-]
 serde = [
     "icu_calendar/serde",
     "icu_casemap/serde",
@@ -116,7 +99,6 @@ compiled_data = [
     "icu_experimental?/compiled_data",
 ]
 datagen = [
-    "std",
     "dep:icu_provider_registry",
     "dep:memchr",
     "icu_calendar/datagen",

--- a/components/icu/README.md
+++ b/components/icu/README.md
@@ -100,7 +100,6 @@ functionality are compiled. These features are:
 
 - `compiled_data` (default): Whether to include compiled data. Without this flag, only constructors with
    explicit `provider` arguments are available.
-- `std`: Whether to include `std` support. Without this Cargo feature, `icu` is `#[no_std]`-compatible.
 - `sync`: makes most ICU4X objects implement `Send + Sync`. Has a small performance impact when used with non-static data.
 - `logging`: Enables logging through the `log` crate.
 - `serde`: Activates `serde` implementations for core library types, such as `Locale`, as well

--- a/components/icu/src/datagen.rs
+++ b/components/icu/src/datagen.rs
@@ -2,17 +2,39 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+extern crate alloc;
+
+use alloc::collections::{BTreeMap, BTreeSet};
 use icu_provider::prelude::*;
-use std::collections::HashSet;
-use std::path::Path;
 
 macro_rules! cb {
     ($($marker:path = $path:literal,)+ #[experimental] $($emarker:path = $epath:literal,)+) => {
-        fn markers_for_bin_inner(bytes: &[u8]) -> Result<HashSet<DataMarkerInfo>, DataError> {
-            use std::sync::OnceLock;
+        /// Parses a compiled binary and returns a list of [`DataMarkerInfo`]s that it uses *at runtime*.
+        ///
+        /// This function is intended to be used for binaries that use `AnyProvider` or `BufferProvider`,
+        /// for which the compiler cannot remove unused data. Using this function on a binary that only
+        /// uses compiled data (through the `compiled_data` feature or manual baked data) will not return
+        /// any markers, as the markers only exist in the type system.
+        ///
+        /// # Example
+        ///
+        /// ```no_run
+        /// # use icu_provider::DataMarker;
+        /// # use std::path::Path;
+        /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+        /// assert_eq!(
+        ///     icu::markers_for_bin(&std::fs::read(Path::new("target/release/my-app"))?)?,
+        ///     std::collections::BTreeSet::from_iter([
+        ///         icu::list::provider::AndListV2Marker::INFO,
+        ///         icu::list::provider::OrListV2Marker::INFO,
+        ///     ]),
+        /// );
+        /// # Ok(())
+        /// # }
+        /// ```
+        pub fn markers_for_bin(bytes: &[u8]) -> Result<BTreeSet<DataMarkerInfo>, DataError> {
             use crate as icu;
-            static LOOKUP: OnceLock<std::collections::HashMap<&'static str, Option<DataMarkerInfo>>> = OnceLock::new();
-            let lookup = LOOKUP.get_or_init(|| {
+            let lookup =
                 [
                     ("core/helloworld@1", Some(icu_provider::hello_world::HelloWorldV1Marker::INFO)),
                     $(
@@ -27,8 +49,7 @@ macro_rules! cb {
 
                 ]
                 .into_iter()
-                .collect()
-            });
+                .collect::<BTreeMap<_,_>>();
 
             use memchr::memmem::*;
 
@@ -45,7 +66,7 @@ macro_rules! cb {
                         .find(marker_fragment)
                         .and_then(|end| marker_fragment.get(..end))
                 })
-                .map(std::str::from_utf8)
+                .map(core::str::from_utf8)
                 .filter_map(Result::ok)
                 .filter_map(|p| {
                     match lookup.get(p) {
@@ -60,37 +81,9 @@ macro_rules! cb {
 }
 icu_provider_registry::registry!(cb);
 
-/// Parses a compiled binary and returns a list of [`DataMarkerInfo`]s that it uses *at runtime*.
-///
-/// This function is intended to be used for binaries that use `AnyProvider` or `BufferProvider`,
-/// for which the compiler cannot remove unused data. Using this function on a binary that only
-/// uses compiled data (through the `compiled_data` feature or manual baked data) will not return
-/// any markers, as the markers only exist in the type system.
-///
-/// # Example
-///
-/// ```no_run
-/// # use icu_provider::DataMarker;
-/// # use std::path::Path;
-/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// assert_eq!(
-///     icu::markers_for_bin(Path::new("target/release/my-app"))?,
-///     std::collections::HashSet::from_iter([
-///         icu::list::provider::AndListV2Marker::INFO,
-///         icu::list::provider::OrListV2Marker::INFO,
-///     ]),
-/// );
-/// # Ok(())
-/// # }
-/// ```
-pub fn markers_for_bin(path: &Path) -> Result<HashSet<DataMarkerInfo>, DataError> {
-    markers_for_bin_inner(&std::fs::read(path)?)
-}
-
 #[test]
 fn test_markers_for_bin() {
-    let hashset =
-        markers_for_bin_inner(include_bytes!("../tests/data/tutorial_buffer.wasm")).unwrap();
+    let hashset = markers_for_bin(include_bytes!("../tests/data/tutorial_buffer.wasm")).unwrap();
     let mut sorted = hashset.into_iter().collect::<Vec<_>>();
     sorted.sort();
     assert_eq!(

--- a/components/icu/src/lib.rs
+++ b/components/icu/src/lib.rs
@@ -100,7 +100,6 @@
 //!
 //! - `compiled_data` (default): Whether to include compiled data. Without this flag, only constructors with
 //!    explicit `provider` arguments are available.
-//! - `std`: Whether to include `std` support. Without this Cargo feature, `icu` is `#[no_std]`-compatible.
 //! - `sync`: makes most ICU4X objects implement `Send + Sync`. Has a small performance impact when used with non-static data.
 //! - `logging`: Enables logging through the `log` crate.
 //! - `serde`: Activates `serde` implementations for core library types, such as [`Locale`], as well
@@ -127,7 +126,7 @@
 //! [data management tutorial]: https://github.com/unicode-org/icu4x/blob/main/tutorials/data_provider.md#loading-additional-data-at-runtime
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, feature = "std")), no_std)]
+#![cfg_attr(not(any(test, doc)), no_std)]
 #![cfg_attr(
     not(test),
     deny(

--- a/components/list/Cargo.toml
+++ b/components/list/Cargo.toml
@@ -39,10 +39,9 @@ serde_json = { workspace = true }
 
 [features]
 default = ["compiled_data"]
-std = ["icu_provider/std"]
 serde = ["dep:serde", "icu_provider/serde"]
 serde_human = ["serde", "regex-automata/dfa-build", "regex-automata/syntax"]
-datagen = ["serde", "std", "dep:databake", "regex-automata/dfa-build", "regex-automata/syntax"]
+datagen = ["serde", "dep:databake", "regex-automata/dfa-build", "regex-automata/syntax"]
 bench = []
 compiled_data = ["dep:icu_list_data"]
 

--- a/components/list/src/lib.rs
+++ b/components/list/src/lib.rs
@@ -72,7 +72,7 @@
 //! Note: this last example is not fully internationalized. See [icu4x/2192](https://github.com/unicode-org/icu4x/issues/2192)
 //! for full unit handling.
 
-#![cfg_attr(not(any(test, feature = "std")), no_std)]
+#![cfg_attr(not(any(test, doc)), no_std)]
 #![cfg_attr(
     not(test),
     deny(

--- a/components/list/src/patterns.rs
+++ b/components/list/src/patterns.rs
@@ -7,6 +7,8 @@ use crate::provider::*;
 #[cfg(feature = "datagen")]
 use alloc::borrow::Cow;
 #[cfg(feature = "datagen")]
+use alloc::string::ToString;
+#[cfg(feature = "datagen")]
 use icu_provider::DataError;
 use writeable::{LengthHint, Writeable};
 

--- a/components/list/src/provider/serde_dfa.rs
+++ b/components/list/src/provider/serde_dfa.rs
@@ -94,7 +94,6 @@ impl<'data> SerdeDFA<'data> {
 
         #[cfg(feature = "serde_human")]
         if deserializer.is_human_readable() {
-            #[cfg(not(feature = "std"))]
             use alloc::string::ToString;
             use serde::de::Error;
             return SerdeDFA::new(Cow::<str>::deserialize(deserializer)?)

--- a/components/locale/Cargo.toml
+++ b/components/locale/Cargo.toml
@@ -52,7 +52,6 @@ bench = false  # This option is required for Benchmark CI
 
 [features]
 default = ["compiled_data"]
-std = []
 bench = ["serde"]
 serde = ["dep:serde", "icu_locale_core/serde", "tinystr/serde", "zerovec/serde", "icu_provider/serde", "potential_utf/serde", "icu_collections/serde"]
 datagen = ["serde", "dep:databake", "zerovec/databake", "icu_locale_core/databake", "tinystr/databake", "icu_collections/databake"]

--- a/components/locale/src/lib.rs
+++ b/components/locale/src/lib.rs
@@ -69,7 +69,7 @@
 //! [`UTS #35: Unicode LDML 3. LocaleId Canonicalization`]: http://unicode.org/reports/tr35/#LocaleId_Canonicalization,
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, feature = "std")), no_std)]
+#![cfg_attr(not(any(test, doc)), no_std)]
 #![cfg_attr(
     not(test),
     deny(

--- a/components/locale_core/Cargo.toml
+++ b/components/locale_core/Cargo.toml
@@ -45,7 +45,6 @@ serde_json = { workspace = true }
 criterion = { workspace = true }
 
 [features]
-std = []
 databake = ["dep:databake"]
 serde = ["dep:serde", "tinystr/serde"]
 zerovec = ["dep:zerovec", "tinystr/zerovec"]

--- a/components/locale_core/src/lib.rs
+++ b/components/locale_core/src/lib.rs
@@ -49,7 +49,7 @@
 //! [`Unicode Extensions`]: extensions
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, feature = "std")), no_std)]
+#![cfg_attr(not(any(test, doc)), no_std)]
 #![cfg_attr(
     not(test),
     deny(

--- a/components/locale_core/src/parser/errors.rs
+++ b/components/locale_core/src/parser/errors.rs
@@ -66,5 +66,4 @@ pub enum ParseError {
     DuplicatedExtension,
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for ParseError {}
+impl core::error::Error for ParseError {}

--- a/components/locale_core/src/preferences/extensions/unicode/errors.rs
+++ b/components/locale_core/src/preferences/extensions/unicode/errors.rs
@@ -11,3 +11,5 @@ pub enum PreferencesParseError {
     /// The given keyword value is not a valid preference variant.
     InvalidKeywordValue,
 }
+
+impl core::error::Error for PreferencesParseError {}

--- a/components/normalizer/Cargo.toml
+++ b/components/normalizer/Cargo.toml
@@ -48,7 +48,6 @@ criterion = { workspace = true }
 
 [features]
 default = ["compiled_data", "utf8_iter", "utf16_iter"]
-std = ["icu_collections/std", "icu_properties?/std", "icu_provider/std"]
 serde = ["dep:serde", "icu_collections/serde", "zerovec/serde", "icu_properties?/serde", "icu_provider/serde"]
 # n.b. "icu_properties" + "icu_properties?/datagen" is equivalent to "icu_properties/datagen", however
 # we specify this explicitly since "optional_dep/feature" is a footgun that leads to us often accidentally enabling features

--- a/components/normalizer/src/lib.rs
+++ b/components/normalizer/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, feature = "std")), no_std)]
+#![cfg_attr(not(any(test, doc)), no_std)]
 #![cfg_attr(
     not(test),
     deny(

--- a/components/pattern/Cargo.toml
+++ b/components/pattern/Cargo.toml
@@ -40,7 +40,6 @@ postcard = { workspace = true, features = ["use-std"] }
 [features]
 default = []
 alloc = []
-std = ["alloc"]
 databake = ["dep:databake"]
 litemap = ["dep:litemap"]
 serde = ["alloc", "dep:serde"]

--- a/components/pattern/src/error.rs
+++ b/components/pattern/src/error.rs
@@ -13,5 +13,4 @@ pub enum PatternError {
     InvalidPlaceholder,
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for PatternError {}
+impl core::error::Error for PatternError {}

--- a/components/pattern/src/lib.rs
+++ b/components/pattern/src/lib.rs
@@ -31,7 +31,7 @@
 //! [`FromStr`]: core::str::FromStr
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, feature = "std")), no_std)]
+#![cfg_attr(not(any(test, doc)), no_std)]
 #![cfg_attr(
     not(test),
     deny(

--- a/components/pattern/src/parser/error.rs
+++ b/components/pattern/src/parser/error.rs
@@ -45,5 +45,4 @@ where
     UnclosedQuotedLiteral,
 }
 
-#[cfg(feature = "std")]
-impl<E: Debug> std::error::Error for ParserError<E> {}
+impl<E: Debug> core::error::Error for ParserError<E> {}

--- a/components/plurals/Cargo.toml
+++ b/components/plurals/Cargo.toml
@@ -43,9 +43,8 @@ criterion = { workspace = true }
 
 [features]
 default = ["compiled_data"]
-std = ["fixed_decimal/std", "icu_locale_core/std", "icu_provider/std"]
 serde = ["dep:serde", "zerovec/serde", "icu_locale_core/serde", "icu_provider/serde"]
-datagen = ["std", "serde", "zerovec/databake", "dep:databake"]
+datagen = ["serde", "zerovec/databake", "dep:databake"]
 experimental = []
 bench = ["serde", "datagen"]
 compiled_data = ["dep:icu_plurals_data"]
@@ -77,7 +76,7 @@ required-features = ["serde"]
 
 [[test]]
 name = "operands"
-required-features = ["serde", "std", "experimental"]
+required-features = ["serde", "experimental"]
 
 [[test]]
 name = "rules"

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -58,7 +58,7 @@
 //! [Language Plural Rules]: https://unicode.org/reports/tr35/tr35-numbers.html#Language_Plural_Rules
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, feature = "std")), no_std)]
+#![cfg_attr(not(any(test, doc)), no_std)]
 #![cfg_attr(
     not(test),
     deny(

--- a/components/plurals/src/operands.rs
+++ b/components/plurals/src/operands.rs
@@ -116,6 +116,9 @@ pub enum OperandsError {
 }
 
 #[cfg(feature = "datagen")]
+impl core::error::Error for OperandsError {}
+
+#[cfg(feature = "datagen")]
 impl From<core::num::ParseIntError> for OperandsError {
     fn from(_: core::num::ParseIntError) -> Self {
         Self::Invalid

--- a/components/plurals/src/rules/reference/lexer.rs
+++ b/components/plurals/src/rules/reference/lexer.rs
@@ -35,8 +35,7 @@ pub enum LexerError {
     UnknownToken(u8),
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for LexerError {}
+impl core::error::Error for LexerError {}
 
 /// Unicode Plural Rule lexer is an iterator
 /// over tokens produced from an input string.

--- a/components/plurals/src/rules/reference/parser.rs
+++ b/components/plurals/src/rules/reference/parser.rs
@@ -31,8 +31,7 @@ pub enum ParseError {
     ValueTooLarge,
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for ParseError {}
+impl core::error::Error for ParseError {}
 
 /// Unicode Plural Rule parser converts an
 /// input string into a Rule [`AST`].

--- a/components/properties/Cargo.toml
+++ b/components/properties/Cargo.toml
@@ -39,7 +39,6 @@ icu = { path = "../../components/icu", default-features = false }
 
 [features]
 default = ["compiled_data"]
-std = ["icu_collections/std", "icu_provider/std"]
 serde = ["dep:serde", "icu_locale_core/serde", "potential_utf/serde", "zerovec/serde", "icu_collections/serde", "icu_provider/serde", "zerotrie/serde"]
 datagen = ["serde", "dep:databake", "potential_utf/databake", "zerovec/databake", "icu_collections/databake", "icu_locale_core/databake", "zerotrie/databake"]
 unicode_bidi = [ "dep:unicode-bidi" ]

--- a/components/properties/src/lib.rs
+++ b/components/properties/src/lib.rs
@@ -52,7 +52,7 @@
 //! [`CodePointMapData`]: crate::CodePointMapData
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, feature = "std")), no_std)]
+#![cfg_attr(not(any(test, doc)), no_std)]
 #![cfg_attr(
     not(test),
     deny(

--- a/components/segmenter/Cargo.toml
+++ b/components/segmenter/Cargo.toml
@@ -47,7 +47,6 @@ criterion = { workspace = true }
 
 [features]
 default = ["compiled_data", "auto"]
-std = ["icu_collections/std", "icu_locale_core/std", "icu_provider/std"]
 serde = ["dep:serde", "potential_utf/serde", "zerovec/serde", "icu_collections/serde", "icu_provider/serde"]
 datagen = ["serde", "dep:databake", "potential_utf/databake", "zerovec/databake", "icu_collections/databake"]
 lstm = ["dep:core_maths"]

--- a/components/segmenter/src/lib.rs
+++ b/components/segmenter/src/lib.rs
@@ -100,7 +100,7 @@
 //! See [`SentenceSegmenter`] for more examples.
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, feature = "std")), no_std)]
+#![cfg_attr(not(any(test, doc)), no_std)]
 #![cfg_attr(
     not(test),
     deny(

--- a/components/timezone/Cargo.toml
+++ b/components/timezone/Cargo.toml
@@ -41,7 +41,6 @@ icu = { path = "../../components/icu", default-features = false }
 [features]
 default = ["compiled_data", "ixdtf"]
 ixdtf = ["dep:ixdtf"]
-std = ["icu_calendar/std", "icu_provider/std"]
 serde = ["dep:serde", "zerovec/serde", "zerotrie/serde", "tinystr/serde", "icu_provider/serde"]
 datagen = ["serde", "dep:databake", "zerovec/databake", "zerotrie/databake", "tinystr/databake"]
 compiled_data = ["dep:icu_timezone_data", "icu_calendar/compiled_data"]

--- a/components/timezone/src/ixdtf.rs
+++ b/components/timezone/src/ixdtf.rs
@@ -69,6 +69,8 @@ pub enum ParseError {
     RequiresCalculation,
 }
 
+impl core::error::Error for ParseError {}
+
 impl From<IxdtfParseError> for ParseError {
     fn from(value: IxdtfParseError) -> Self {
         Self::Syntax(value)

--- a/components/timezone/src/lib.rs
+++ b/components/timezone/src/lib.rs
@@ -83,7 +83,7 @@
 //! ```
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, feature = "std")), no_std)]
+#![cfg_attr(not(any(test, doc)), no_std)]
 #![cfg_attr(
     not(test),
     deny(

--- a/documents/process/boilerplate.md
+++ b/documents/process/boilerplate.md
@@ -13,7 +13,7 @@ In order to assert that library crates conform to the ICU4X style guide, the fol
 If the crate has no `std` feature:
 
     // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-    #![cfg_attr(not(test), no_std)]
+    #![cfg_attr(not(any(test, doc)), no_std)]
     #![cfg_attr(
         not(test),
         deny(
@@ -33,7 +33,7 @@ Not all crates are yet able to be annotated in this way. Annotations may be omit
 If the crate has an `std` feature, specify this in the first line:
 
     // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-    #![cfg_attr(not(any(test, feature = "std")), no_std)]
+    #![cfg_attr(not(any(test, doc)), no_std)]
     #![cfg_attr(
         not(test),
         deny(

--- a/ffi/capi/Cargo.toml
+++ b/ffi/capi/Cargo.toml
@@ -30,7 +30,7 @@ all-features = true
 [package.metadata.cargo-all-features]
 # Bench feature gets tested separately and is only relevant for CI.
 # logging enables a feature of a dependency that has no externally visible API changes
-denylist = ["bench"]
+denylist = ["bench", "looping_panic_handler", "libc_alloc"]
 # This has a lot of features, run a reduced test that is likely to catch 99% of bugs
 max_combination_size = 2
 

--- a/ffi/ecma402/Cargo.toml
+++ b/ffi/ecma402/Cargo.toml
@@ -22,6 +22,6 @@ all-features = true
 [dependencies]
 ecma402_traits = "4"
 fixed_decimal = { workspace = true, features = ["ryu"] }
-icu = { workspace = true, features = ["std", "compiled_data", "experimental"] }
+icu = { workspace = true, features = ["compiled_data", "experimental"] }
 icu_provider = { workspace = true }
 writeable = { workspace = true }

--- a/ffi/harfbuzz/Cargo.toml
+++ b/ffi/harfbuzz/Cargo.toml
@@ -40,5 +40,4 @@ displaydoc = { workspace = true }
 [features]
 default = []
 compiled_data = ["icu_normalizer/compiled_data", "icu_properties/compiled_data"]
-std = []
 serde = ["icu_properties/serde", "icu_normalizer/serde", "icu_provider/serde"]

--- a/ffi/harfbuzz/src/lib.rs
+++ b/ffi/harfbuzz/src/lib.rs
@@ -4,7 +4,7 @@
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
 
-#![cfg_attr(not(any(test, feature = "std")), no_std)]
+#![cfg_attr(not(any(test, doc)), no_std)]
 #![cfg_attr(
     not(test),
     deny(

--- a/provider/adapters/Cargo.toml
+++ b/provider/adapters/Cargo.toml
@@ -31,5 +31,4 @@ icu_locale = { path = "../../components/locale" }
 writeable = { path = "../../utils/writeable" }
 
 [features]
-std = []
-export = ["icu_provider/export", "std"]
+export = ["icu_provider/export"]

--- a/provider/adapters/src/either.rs
+++ b/provider/adapters/src/either.rs
@@ -131,7 +131,7 @@ where
     P0: ExportableProvider,
     P1: ExportableProvider,
 {
-    fn supported_markers(&self) -> std::collections::HashSet<DataMarkerInfo> {
+    fn supported_markers(&self) -> alloc::collections::BTreeSet<DataMarkerInfo> {
         use EitherProvider::*;
         match self {
             A(p) => p.supported_markers(),

--- a/provider/adapters/src/empty.rs
+++ b/provider/adapters/src/empty.rs
@@ -112,7 +112,7 @@ where
 
 #[cfg(feature = "export")]
 impl ExportableProvider for EmptyDataProvider {
-    fn supported_markers(&self) -> std::collections::HashSet<DataMarkerInfo> {
+    fn supported_markers(&self) -> alloc::collections::BTreeSet<DataMarkerInfo> {
         Default::default()
     }
 }

--- a/provider/adapters/src/filter/mod.rs
+++ b/provider/adapters/src/filter/mod.rs
@@ -174,7 +174,7 @@ where
     P0: ExportableProvider,
     F: Fn(DataIdentifierBorrowed) -> bool + Sync,
 {
-    fn supported_markers(&self) -> std::collections::HashSet<DataMarkerInfo> {
+    fn supported_markers(&self) -> alloc::collections::BTreeSet<DataMarkerInfo> {
         // The predicate only takes DataIdentifier, not DataMarker, so we are not impacted
         self.inner.supported_markers()
     }

--- a/provider/adapters/src/fork/by_error.rs
+++ b/provider/adapters/src/fork/by_error.rs
@@ -168,7 +168,7 @@ where
     P1: ExportableProvider,
     F: ForkByErrorPredicate + Sync,
 {
-    fn supported_markers(&self) -> std::collections::HashSet<DataMarkerInfo> {
+    fn supported_markers(&self) -> alloc::collections::BTreeSet<DataMarkerInfo> {
         let mut markers = self.0.supported_markers();
         markers.extend(self.1.supported_markers());
         markers
@@ -357,7 +357,7 @@ where
     P: ExportableProvider,
     F: ForkByErrorPredicate + Sync,
 {
-    fn supported_markers(&self) -> std::collections::HashSet<DataMarkerInfo> {
+    fn supported_markers(&self) -> alloc::collections::BTreeSet<DataMarkerInfo> {
         self.providers
             .iter()
             .flat_map(|p| p.supported_markers())

--- a/provider/adapters/src/lib.rs
+++ b/provider/adapters/src/lib.rs
@@ -10,7 +10,7 @@
 //! - Use the [`fallback`] module to automatically resolve arbitrary locales for data loading.
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, feature = "std")), no_std)]
+#![cfg_attr(not(any(test, doc)), no_std)]
 #![cfg_attr(
     not(test),
     deny(

--- a/provider/blob/Cargo.toml
+++ b/provider/blob/Cargo.toml
@@ -43,11 +43,9 @@ criterion = { workspace = true }
 
 [features]
 bench = []
-std = ["icu_provider/std"]
 export = [
     "icu_provider/export",
     "log",
-    "std",
 ]
 
 [lib]

--- a/provider/blob/src/lib.rs
+++ b/provider/blob/src/lib.rs
@@ -16,7 +16,7 @@
 //! [`icu_provider_export`]: ../icu_provider_export/index.html
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, feature = "std")), no_std)]
+#![cfg_attr(not(any(test, feature = "export")), no_std)]
 #![cfg_attr(
     not(test),
     deny(

--- a/provider/blob/tests/test_versions.rs
+++ b/provider/blob/tests/test_versions.rs
@@ -204,4 +204,5 @@ impl IterableDataProvider<HelloWorldV1Marker> for ManyLocalesProvider {
     }
 }
 
+extern crate alloc;
 icu_provider::export::make_exportable_provider!(ManyLocalesProvider, [HelloWorldV1Marker,]);

--- a/provider/core/Cargo.toml
+++ b/provider/core/Cargo.toml
@@ -56,7 +56,7 @@ criterion = { workspace = true }
 
 [features]
 bench = []
-std = ["icu_locale_core/std"]
+std = []
 sync = []
 macros = ["dep:icu_provider_macros"]
 # Enable logging of additional context of data errors

--- a/provider/core/src/dynutil.rs
+++ b/provider/core/src/dynutil.rs
@@ -280,7 +280,7 @@ pub use __impl_dynamic_data_provider as impl_dynamic_data_provider;
 macro_rules! __impl_iterable_dynamic_data_provider {
     ($provider:ty, [ $($(#[$cfg:meta])? $struct_m:ty),+, ], $dyn_m:path) => {
         impl $crate::IterableDynamicDataProvider<$dyn_m> for $provider {
-            fn iter_ids_for_marker(&self, marker: $crate::DataMarkerInfo) -> Result<std::collections::BTreeSet<$crate::DataIdentifierCow>, $crate::DataError> {
+            fn iter_ids_for_marker(&self, marker: $crate::DataMarkerInfo) -> Result<alloc::collections::BTreeSet<$crate::DataIdentifierCow>, $crate::DataError> {
                 match marker.path.hashed() {
                     $(
                         $(#[$cfg])?

--- a/provider/core/src/error.rs
+++ b/provider/core/src/error.rs
@@ -251,8 +251,7 @@ impl DataError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for DataError {}
+impl core::error::Error for DataError {}
 
 #[cfg(feature = "std")]
 impl From<std::io::Error> for DataError {

--- a/provider/core/src/export/mod.rs
+++ b/provider/core/src/export/mod.rs
@@ -12,7 +12,7 @@ mod payload;
 pub use payload::{ExportBox, ExportMarker};
 
 use crate::prelude::*;
-use std::collections::HashSet;
+use alloc::collections::BTreeSet;
 
 /// An object capable of exporting data payloads in some form.
 pub trait DataExporter: Sync {
@@ -103,11 +103,11 @@ pub trait ExportableProvider:
     crate::data_provider::IterableDynamicDataProvider<ExportMarker> + Sync
 {
     /// Returns the set of supported markers
-    fn supported_markers(&self) -> HashSet<DataMarkerInfo>;
+    fn supported_markers(&self) -> BTreeSet<DataMarkerInfo>;
 }
 
 impl ExportableProvider for Box<dyn ExportableProvider> {
-    fn supported_markers(&self) -> HashSet<DataMarkerInfo> {
+    fn supported_markers(&self) -> BTreeSet<DataMarkerInfo> {
         (**self).supported_markers()
     }
 }
@@ -126,8 +126,8 @@ impl ExportableProvider for Box<dyn ExportableProvider> {
 macro_rules! __make_exportable_provider {
     ($provider:ty, [ $($(#[$cfg:meta])? $struct_m:ty),+, ]) => {
         impl $crate::export::ExportableProvider for $provider {
-            fn supported_markers(&self) -> std::collections::HashSet<$crate::DataMarkerInfo> {
-                std::collections::HashSet::from_iter([
+            fn supported_markers(&self) -> alloc::collections::BTreeSet<$crate::DataMarkerInfo> {
+                alloc::collections::BTreeSet::from_iter([
                     $(
                         $(#[$cfg])?
                         <$struct_m>::INFO,
@@ -164,7 +164,7 @@ impl MultiExporter {
 }
 
 impl core::fmt::Debug for MultiExporter {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut alloc::fmt::Formatter<'_>) -> alloc::fmt::Result {
         f.debug_struct("MultiExporter")
             .field("0", &format!("vec[len = {}]", self.0.len()))
             .finish()

--- a/provider/core/src/lib.rs
+++ b/provider/core/src/lib.rs
@@ -191,8 +191,9 @@ pub mod fallback;
 pub use log;
 
 #[doc(hidden)] // internal
-#[cfg(all(not(feature = "logging"), debug_assertions, feature = "std"))]
+#[cfg(all(not(feature = "logging"), debug_assertions, not(target_os = "none")))]
 pub mod log {
+    extern crate std;
     pub use std::eprintln as error;
     pub use std::eprintln as warn;
     pub use std::eprintln as info;
@@ -202,7 +203,7 @@ pub mod log {
 
 #[cfg(all(
     not(feature = "logging"),
-    any(not(debug_assertions), not(feature = "std"))
+    any(not(debug_assertions), target_os = "none")
 ))]
 #[doc(hidden)] // internal
 pub mod log {

--- a/provider/core/src/request.rs
+++ b/provider/core/src/request.rs
@@ -455,7 +455,7 @@ impl DataLocale {
     ///
     /// ```
     /// use icu_provider::DataLocale;
-    /// use std::cmp::Ordering;
+    /// use core::cmp::Ordering;
     ///
     /// let bcp47_strings: &[&str] = &[
     ///     "ca",

--- a/provider/core/src/response.rs
+++ b/provider/core/src/response.rs
@@ -764,7 +764,7 @@ where
     /// use icu_provider::hello_world::*;
     /// use icu_provider::prelude::*;
     /// use icu_provider_adapters::empty::EmptyDataProvider;
-    /// use std::any::TypeId;
+    /// use core::any::TypeId;
     /// use std::borrow::Cow;
     ///
     /// struct MyForkingProvider<P0, P1> {

--- a/provider/export/src/export_impl.rs
+++ b/provider/export/src/export_impl.rs
@@ -516,6 +516,7 @@ fn test_collation_filtering() {
         }
     }
 
+    extern crate alloc;
     icu_provider::export::make_exportable_provider!(
         Provider,
         [icu::collator::provider::CollationTailoringV1Marker,]

--- a/provider/export/src/lib.rs
+++ b/provider/export/src/lib.rs
@@ -88,6 +88,7 @@ use icu_locale::LocaleFallbacker;
 use icu_provider::export::DataExporter;
 use icu_provider::export::ExportableProvider;
 use icu_provider::prelude::*;
+use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::hash::Hash;
@@ -121,7 +122,7 @@ use std::sync::Arc;
 /// ```
 #[derive(Clone)]
 pub struct ExportDriver {
-    markers: Option<HashSet<DataMarkerInfo>>,
+    markers: Option<BTreeSet<DataMarkerInfo>>,
     requested_families: HashMap<DataLocale, DataLocaleFamilyAnnotations>,
     #[allow(clippy::type_complexity)] // sigh
     attributes_filters:

--- a/provider/export/tests/test-options.rs
+++ b/provider/export/tests/test-options.rs
@@ -84,6 +84,7 @@ impl IterableDataProvider<HelloWorldV1Marker> for TestingProvider {
     }
 }
 
+extern crate alloc;
 make_exportable_provider!(TestingProvider, [HelloWorldV1Marker,]);
 
 fn families(

--- a/provider/icu4x-datagen/src/main.rs
+++ b/provider/icu4x-datagen/src/main.rs
@@ -321,7 +321,9 @@ fn main() -> eyre::Result<()> {
                 .collect::<Result<_, _>>()?,
         }
     } else if let Some(bin_path) = &cli.markers_for_bin {
-        icu::markers_for_bin(bin_path)?.into_iter().collect()
+        icu::markers_for_bin(&std::fs::read(bin_path)?)?
+            .into_iter()
+            .collect()
     } else {
         eyre::bail!("--markers or --markers-for-bin are required.")
     };

--- a/provider/icu4x-datagen/src/main.rs
+++ b/provider/icu4x-datagen/src/main.rs
@@ -669,6 +669,8 @@ macro_rules! cb {
         );
     }
 }
+
+extern crate alloc;
 icu_provider_registry::registry!(cb);
 
 #[cfg(feature = "blob_input")]

--- a/provider/source/src/decimal/decimal_pattern.rs
+++ b/provider/source/src/decimal/decimal_pattern.rs
@@ -20,8 +20,6 @@ pub(crate) enum Error {
     UnknownPatternBody(String),
 }
 
-impl std::error::Error for Error {}
-
 /// Representation of a UTS-35 number subpattern (part of a number pattern between ';'s).
 #[derive(Debug, PartialEq)]
 pub(crate) struct DecimalSubPattern {

--- a/provider/source/src/lib.rs
+++ b/provider/source/src/lib.rs
@@ -104,6 +104,7 @@ macro_rules! cb {
         ], icu_provider::any::AnyMarker);
     }
 }
+extern crate alloc;
 icu_provider_registry::registry!(cb);
 
 icu_provider::marker::impl_data_provider_never_marker!(SourceDataProvider);

--- a/tutorials/data_provider.md
+++ b/tutorials/data_provider.md
@@ -305,6 +305,7 @@ impl IterableDataProvider<CustomMarker> for CustomProvider {
     }
 }
 
+extern crate alloc;
 icu_provider::export::make_exportable_provider!(CustomProvider, [CustomMarker,]);
 
 let icu4x_source_provider = SourceDataProvider::new_latest_tested();

--- a/utils/calendrical_calculations/Cargo.toml
+++ b/utils/calendrical_calculations/Cargo.toml
@@ -38,7 +38,6 @@ log = { workspace = true, optional = true }
 
 [features]
 logging = ["dep:log"]
-std = []
 
 [package.metadata.cargo-all-features]
 # Bench feature gets tested separately and is only relevant for CI

--- a/utils/calendrical_calculations/src/error.rs
+++ b/utils/calendrical_calculations/src/error.rs
@@ -25,3 +25,5 @@ pub enum LocationOutOfBoundsError {
     #[displaydoc("Offset {0} outside bounds of {1} to {2}")]
     Offset(f64, f64, f64),
 }
+
+impl core::error::Error for LocationOutOfBoundsError {}

--- a/utils/calendrical_calculations/src/helpers.rs
+++ b/utils/calendrical_calculations/src/helpers.rs
@@ -282,7 +282,7 @@ fn test_invert_angular() {
 }
 
 /// Error returned when casting from an i32
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, displaydoc::Display)]
 #[allow(clippy::exhaustive_enums)] // enum is specific to function and has a closed set of possible values
 pub enum I32CastError {
     /// Less than i32::MIN
@@ -290,6 +290,8 @@ pub enum I32CastError {
     /// Greater than i32::MAX
     AboveMax,
 }
+
+impl core::error::Error for I32CastError {}
 
 impl I32CastError {
     pub(crate) const fn saturate(self) -> i32 {

--- a/utils/calendrical_calculations/src/lib.rs
+++ b/utils/calendrical_calculations/src/lib.rs
@@ -19,7 +19,7 @@
 //! The primary purpose of this crate is use by ICU4X, however if non-ICU4X users need this we are happy
 //! to add more structure to this crate as needed.
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, feature = "std")), no_std)]
+#![cfg_attr(not(any(test, doc)), no_std)]
 #![cfg_attr(
     not(test),
     deny(

--- a/utils/deduplicating_array/src/lib.rs
+++ b/utils/deduplicating_array/src/lib.rs
@@ -29,7 +29,7 @@
 //! but there's really not much point in using them).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(test), no_std)]
+#![cfg_attr(not(any(test, doc)), no_std)]
 #![cfg_attr(
     not(test),
     deny(

--- a/utils/fixed_decimal/Cargo.toml
+++ b/utils/fixed_decimal/Cargo.toml
@@ -39,7 +39,6 @@ rand_pcg = { workspace = true }
 criterion = { workspace = true }
 
 [features]
-std = []
 bench = ["ryu"]
 experimental = []
 ryu = ["dep:ryu"]

--- a/utils/fixed_decimal/src/lib.rs
+++ b/utils/fixed_decimal/src/lib.rs
@@ -37,7 +37,7 @@
 //! [`ICU4X`]: ../icu/index.html
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, feature = "std")), no_std)]
+#![cfg_attr(not(any(test, doc)), no_std)]
 #![cfg_attr(
     not(test),
     deny(
@@ -129,8 +129,7 @@ pub enum ParseError {
     Syntax,
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for ParseError {}
+impl core::error::Error for ParseError {}
 
 // TODO(#5065): implement these while `WithCompactExponent` and `WithScientificExponent` are implemented.
 // pub type FixedDecimalOrInfinity = WithInfinity<UnsignedFixedDecimal>;

--- a/utils/ixdtf/src/error.rs
+++ b/utils/ixdtf/src/error.rs
@@ -106,6 +106,8 @@ pub enum ParseError {
     TimeDurationDesignator,
 }
 
+impl core::error::Error for ParseError {}
+
 impl ParseError {
     pub(crate) fn abrupt_end(location: &'static str) -> Self {
         ParseError::AbruptEnd { location }

--- a/utils/litemap/src/lib.rs
+++ b/utils/litemap/src/lib.rs
@@ -31,7 +31,7 @@
 //! [`Vec`]: alloc::vec::Vec
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(test), no_std)]
+#![cfg_attr(not(any(test, doc)), no_std)]
 #![cfg_attr(
     not(test),
     deny(

--- a/utils/potential_utf/src/lib.rs
+++ b/utils/potential_utf/src/lib.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-#![cfg_attr(not(test), no_std)]
+#![cfg_attr(not(any(test, doc)), no_std)]
 #![cfg_attr(
     not(test),
     deny(

--- a/utils/tinystr/Cargo.toml
+++ b/utils/tinystr/Cargo.toml
@@ -42,7 +42,6 @@ criterion = { workspace = true }
 default = ["alloc"]
 alloc = []
 bench = []
-std = []
 
 [package.metadata.cargo-all-features]
 # Bench feature gets tested separately and is only relevant for CI

--- a/utils/tinystr/src/error.rs
+++ b/utils/tinystr/src/error.rs
@@ -4,8 +4,7 @@
 
 use displaydoc::Display;
 
-#[cfg(feature = "std")]
-impl std::error::Error for ParseError {}
+impl core::error::Error for ParseError {}
 
 #[derive(Display, Debug, PartialEq, Eq)]
 #[non_exhaustive]

--- a/utils/tinystr/src/lib.rs
+++ b/utils/tinystr/src/lib.rs
@@ -52,7 +52,7 @@
 //! [`ICU4X`]: ../icu/index.html
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, feature = "std")), no_std)]
+#![cfg_attr(not(any(test, doc)), no_std)]
 #![cfg_attr(
     not(test),
     deny(

--- a/utils/writeable/src/lib.rs
+++ b/utils/writeable/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(all(not(test), not(doc)), no_std)]
+#![cfg_attr(not(any(test, doc)), no_std)]
 #![cfg_attr(
     not(test),
     deny(

--- a/utils/yoke/src/lib.rs
+++ b/utils/yoke/src/lib.rs
@@ -25,7 +25,7 @@
 //! See the documentation of [`Yoke`] for more details.
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(all(not(test), not(doc)), no_std)]
+#![cfg_attr(not(any(test, doc)), no_std)]
 #![cfg_attr(
     not(test),
     deny(

--- a/utils/zerofrom/src/lib.rs
+++ b/utils/zerofrom/src/lib.rs
@@ -7,7 +7,7 @@
 //! See the documentation of [`ZeroFrom`] for more details.
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(test), no_std)]
+#![cfg_attr(not(any(test, doc)), no_std)]
 #![cfg_attr(
     not(test),
     deny(

--- a/utils/zerotrie/src/error.rs
+++ b/utils/zerotrie/src/error.rs
@@ -21,3 +21,5 @@ pub enum ZeroTrieBuildError {
     #[displaydoc("Mixed-case data added to case-insensitive trie")]
     MixedCase,
 }
+
+impl core::error::Error for ZeroTrieBuildError {}

--- a/utils/zerotrie/src/lib.rs
+++ b/utils/zerotrie/src/lib.rs
@@ -35,7 +35,7 @@
 //! [`BTreeMap`]: alloc::collections::BTreeMap
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(test), no_std)]
+#![cfg_attr(not(any(test, doc)), no_std)]
 #![cfg_attr(
     not(test),
     deny(

--- a/utils/zerovec/Cargo.toml
+++ b/utils/zerovec/Cargo.toml
@@ -53,7 +53,6 @@ zerofrom = { path = "../../utils/zerofrom", features = ["derive"] }
 criterion = { workspace = true }
 
 [features]
-std = []
 derive = ["dep:zerovec-derive"]
 hashmap = ["dep:twox-hash"]
 bench = ["serde", "databake"]

--- a/utils/zerovec/src/lib.rs
+++ b/utils/zerovec/src/lib.rs
@@ -194,7 +194,7 @@
 //! is appended for baseline comparisons, e.g. `zeromap/lookup/small/hashmap`.
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, feature = "std")), no_std)]
+#![cfg_attr(not(any(test, doc)), no_std)]
 #![cfg_attr(
     not(test),
     deny(

--- a/utils/zerovec/src/ule/mod.rs
+++ b/utils/zerovec/src/ule/mod.rs
@@ -445,5 +445,4 @@ impl UleError {
     }
 }
 
-#[cfg(feature = "std")]
-impl ::std::error::Error for UleError {}
+impl core::error::Error for UleError {}

--- a/utils/zerovec/src/varzerovec/error.rs
+++ b/utils/zerovec/src/varzerovec/error.rs
@@ -2,10 +2,23 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use core::fmt::Display;
+
 #[derive(Debug)]
 pub enum VarZeroVecFormatError {
     /// The byte buffer was not in the appropriate format for VarZeroVec.
     Metadata,
-    #[allow(dead_code)]
+    /// One of the values could not be decoded.
     Values(crate::ule::UleError),
+}
+
+impl core::error::Error for VarZeroVecFormatError {}
+
+impl Display for VarZeroVecFormatError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Metadata => write!(f, "VarZeroVecFormatError: metadata"),
+            Self::Values(e) => write!(f, "VarZeroVecFormatError: {e}"),
+        }
+    }
 }


### PR DESCRIPTION
Fixes #5964 

The only remaining uses of `std` are:
* `DataError::Io` and `DataError::with_path`
  * `with_path` can be replaced by `with_display_context(path.display())`, but the `std::io::ErrorKind` is not in `core` (it could be, it's a fieldless enum). 
* `icu_provider::log` falling back to `println!` (negative `logging` feature)
* `icu_capi` keeps its std feature, as that's required to build a static library with panic=unwind. I'm not sure what the use case for this is, but we use it as a baseline in the size benchmark.