### PR TITLE
Audit exhaustiveness of icu_calendar::types

### DIFF
--- a/components/calendar/src/types.rs
+++ b/components/calendar/src/types.rs
@@ -316,7 +316,7 @@ impl fmt::Display for MonthCode {
 
 /// Representation of a formattable month.
 #[derive(Copy, Clone, Debug, PartialEq)]
-#[allow(clippy::exhaustive_structs)] // this type is stable
+#[non_exhaustive]
 pub struct MonthInfo {
     /// The month number in this given year. For calendars with leap months, all months after
     /// the leap month will end up with an incremented number.
@@ -355,9 +355,10 @@ impl MonthInfo {
         self.standard_code.parsed().map(|(_, l)| l).unwrap_or(false)
     }
 }
+
 /// A struct containing various details about the position of the day within a year. It is returned
-// by the [`day_of_year_info()`](trait.DateInput.html#tymethod.day_of_year_info) method of the
-// [`DateInput`] trait.
+/// by the [`day_of_year_info()`](trait.DateInput.html#tymethod.day_of_year_info) method of the
+/// [`DateInput`] trait.
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct DayOfYearInfo {

--- a/components/calendar/src/types.rs
+++ b/components/calendar/src/types.rs
@@ -357,7 +357,7 @@ impl MonthInfo {
 }
 
 /// A struct containing various details about the position of the day within a year. It is returned
-/// by [`Calendar::day_of_year_info()`].
+/// by [`Calendar::day_of_year_info()`](crate::Calendar::day_of_year_info).
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[non_exhaustive]
 pub struct DayOfYearInfo {

--- a/components/calendar/src/types.rs
+++ b/components/calendar/src/types.rs
@@ -357,7 +357,7 @@ impl MonthInfo {
 }
 
 /// A struct containing various details about the position of the day within a year. It is returned
-/// by the `day_of_year_info()` method of the `DateInput` trait.
+/// by [`Calendar::day_of_year_info()`].
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct DayOfYearInfo {

--- a/components/calendar/src/types.rs
+++ b/components/calendar/src/types.rs
@@ -357,8 +357,7 @@ impl MonthInfo {
 }
 
 /// A struct containing various details about the position of the day within a year. It is returned
-/// by the [`day_of_year_info()`](trait.DateInput.html#tymethod.day_of_year_info) method of the
-/// [`DateInput`] trait.
+/// by the `day_of_year_info()` method of the `DateInput` trait.
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct DayOfYearInfo {

--- a/components/calendar/src/types.rs
+++ b/components/calendar/src/types.rs
@@ -359,7 +359,7 @@ impl MonthInfo {
 /// A struct containing various details about the position of the day within a year. It is returned
 /// by [`Calendar::day_of_year_info()`].
 #[derive(Copy, Clone, Debug, PartialEq)]
-#[allow(clippy::exhaustive_structs)] // this type is stable
+#[non_exhaustive]
 pub struct DayOfYearInfo {
     /// The current day of the year, 1-based.
     pub day_of_year: u16,


### PR DESCRIPTION
Fixes #5797

Currently in this scheme, MonthInfo and EraYear are not constructible by external users. I think that's okay for now, nad we can revisit if someone wishes to make custom calendars and needs these.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->