### PR TITLE
IXDTF parsers: Improve docs and add PartialEq

### DIFF
--- a/components/calendar/src/ixdtf.rs
+++ b/components/calendar/src/ixdtf.rs
@@ -60,6 +60,9 @@ impl Date<Iso> {
     ///     icu::calendar::types::MonthCode(tinystr::tinystr!(4, "M07"))
     /// );
     /// assert_eq!(date.day_of_month().0, 17);
+    ///
+    /// // Calendar annotations are ignored:
+    /// assert_eq!(date, Date::try_iso_from_str("2024-07-17[u-ca=buddhist]").unwrap());
     /// ```
     pub fn try_iso_from_str(ixdtf_str: &str) -> Result<Self, ParseError> {
         Self::try_iso_from_utf8(ixdtf_str.as_bytes())
@@ -92,7 +95,8 @@ impl FromStr for Date<Iso> {
 impl<A: AsCalendar> Date<A> {
     /// Creates a [`Date`] in the given calendar from an IXDTF syntax string.
     ///
-    /// Ignores any calendar annotations in the string.
+    /// Returns an error if the string has a calendar annotation that does not
+    /// match the calendar argument.
     ///
     /// ✨ *Enabled with the `ixdtf` Cargo feature.*
     ///
@@ -117,6 +121,9 @@ impl<A: AsCalendar> Date<A> {
     }
 
     /// Creates a [`Date`] in the given calendar from an IXDTF syntax string.
+    ///
+    /// Returns an error if the string has a calendar annotation that does not
+    /// match the calendar argument.
     ///
     /// See [`Self::try_from_str()`].
     ///

--- a/components/timezone/src/time_zone.rs
+++ b/components/timezone/src/time_zone.rs
@@ -24,7 +24,7 @@ pub mod models {
     use super::*;
 
     /// A time zone containing a time zone ID and optional offset.
-    #[derive(Debug)]
+    #[derive(Debug, PartialEq, Eq)]
     #[non_exhaustive]
     pub enum Base {}
 
@@ -35,7 +35,7 @@ pub mod models {
     }
 
     /// A time zone containing a time zone ID, optional offset, and local time.
-    #[derive(Debug)]
+    #[derive(Debug, PartialEq, Eq)]
     #[non_exhaustive]
     pub enum AtTime {}
 
@@ -46,7 +46,7 @@ pub mod models {
     }
 
     /// A time zone containing a time zone ID, optional offset, local time, and zone variant.
-    #[derive(Debug)]
+    #[derive(Debug, PartialEq, Eq)]
     #[non_exhaustive]
     pub enum Full {}
 

--- a/components/timezone/src/types.rs
+++ b/components/timezone/src/types.rs
@@ -315,7 +315,7 @@ impl Time {
 }
 
 /// A date + time for a given calendar.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 #[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct DateTime<A: AsCalendar> {
     /// The date
@@ -325,7 +325,7 @@ pub struct DateTime<A: AsCalendar> {
 }
 
 /// A date and time local to a specified custom time zone.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 #[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct ZonedDateTime<A: AsCalendar, Z> {
     /// The date, local to the time zone


### PR DESCRIPTION
#5739

This is mostly docs. The only non-docs is adding PartialEq bounds, including to DateTime and ZonedDateTime, which became reachable via one of my new docs tests. I think adding PartialEq to DateTime is not in contradiction to the thin DateTime effort.