### PR TITLE
Expand size of duration records to support ECMA402

### DIFF
--- a/utils/ixdtf/src/parsers/records.rs
+++ b/utils/ixdtf/src/parsers/records.rs
@@ -177,7 +177,7 @@ pub struct DateDurationRecord {
     /// Weeks value.
     pub weeks: u32,
     /// Days value.
-    pub days: u32,
+    pub days: u64,
 }
 
 /// A `TimeDurationRecord` represents the result of parsing the time component of a Duration string.
@@ -189,27 +189,27 @@ pub enum TimeDurationRecord {
     // An hours Time duration record.
     Hours {
         /// Hours value.
-        hours: u32,
+        hours: u64,
         /// The parsed fraction value in nanoseconds.
         fraction: u64,
     },
     // A Minutes Time duration record.
     Minutes {
         /// Hours value.
-        hours: u32,
+        hours: u64,
         /// Minutes value.
-        minutes: u32,
+        minutes: u64,
         /// The parsed fraction value in nanoseconds.
         fraction: u64,
     },
     // A Seconds Time duration record.
     Seconds {
         /// Hours value.
-        hours: u32,
+        hours: u64,
         /// Minutes value.
-        minutes: u32,
+        minutes: u64,
         /// Seconds value.
-        seconds: u32,
+        seconds: u64,
         /// The parsed fraction value in nanoseconds.
         fraction: u32,
     },

--- a/utils/ixdtf/src/parsers/tests.rs
+++ b/utils/ixdtf/src/parsers/tests.rs
@@ -653,6 +653,38 @@ fn duration_exceeds_range() {
 }
 
 #[test]
+fn maximum_duration_units() {
+    use crate::parsers::IsoDurationParser;
+
+    // All the values below represent the value 90,071,992,547,409,910,000,000,000
+    // which is the maximum representable duration in nanoseconds for ECMA402
+
+    let result = IsoDurationParser::from_str("P416999965497D").parse();
+    assert!(result.is_ok());
+
+    let result = IsoDurationParser::from_str("PT25019997929836H").parse();
+    assert!(result.is_ok());
+
+    let result = IsoDurationParser::from_str("PT1501199875790165M").parse();
+    assert!(result.is_ok());
+
+    let result = IsoDurationParser::from_str("PT90071992547409910S").parse();
+    assert!(result.is_ok());
+
+    let result = IsoDurationParser::from_str("-P416999965497D").parse();
+    assert!(result.is_ok());
+
+    let result = IsoDurationParser::from_str("-PT25019997929836H").parse();
+    assert!(result.is_ok());
+
+    let result = IsoDurationParser::from_str("-PT1501199875790165M").parse();
+    assert!(result.is_ok());
+
+    let result = IsoDurationParser::from_str("-PT90071992547409910S").parse();
+    assert!(result.is_ok());
+}
+
+#[test]
 fn temporal_invalid_iso_datetime_strings() {
     // NOTE: The below tests were initially pulled from test262's `argument-string-invalid`
     const INVALID_DATETIME_STRINGS: [&str; 32] = [


### PR DESCRIPTION
This updates `IsoDurationParser` to support parsing at least the maximum representable duration in the Temporal proposal; Number.MAX_SAFE_INTEGER * 10^9, which is exactly
90,071,992,547,409,910,000,000,000 nanoseconds.

From some quick calculations, changing the time-related types to `u64` is enough to fit the required range:

| Max nanos  |              90071992547409910000000000 |
|------------|----------------------------------------:|
| In seconds |                       90071992547409910 |
| In minutes |                        1501199875790165 |
| In hours   |                          25019997929836 |
| In days    |                            416999965497 |
| In weeks   |                             59571423642 |
| In months  |                             13899998849 |
| In years   |                              1158333237 |
| u64::MAX   |                    18446744073709551615 |

Years, months and weeks don't matter because the specification requires that they must be smaller than 2^32 - 1.