### PR TITLE
Fix `cmn-hans-cn-t-ca-u-ca-x_t-u`

### DIFF
--- a/components/locale_core/src/extensions/mod.rs
+++ b/components/locale_core/src/extensions/mod.rs
@@ -264,26 +264,31 @@ impl Extensions {
             if subtag.is_empty() {
                 return Err(ParseError::InvalidExtension);
             }
-            match subtag.first().map(|b| ExtensionType::try_from_byte(*b)) {
-                Some(Ok(ExtensionType::Unicode)) => {
+
+            let &[subtag] = subtag else {
+                return Err(ParseError::InvalidExtension);
+            };
+
+            match ExtensionType::try_from_byte(subtag) {
+                Ok(ExtensionType::Unicode) => {
                     if unicode.is_some() {
                         return Err(ParseError::DuplicatedExtension);
                     }
                     unicode = Some(Unicode::try_from_iter(iter)?);
                 }
-                Some(Ok(ExtensionType::Transform)) => {
+                Ok(ExtensionType::Transform) => {
                     if transform.is_some() {
                         return Err(ParseError::DuplicatedExtension);
                     }
                     transform = Some(Transform::try_from_iter(iter)?);
                 }
-                Some(Ok(ExtensionType::Private)) => {
+                Ok(ExtensionType::Private) => {
                     if private.is_some() {
                         return Err(ParseError::DuplicatedExtension);
                     }
                     private = Some(Private::try_from_iter(iter)?);
                 }
-                Some(Ok(ExtensionType::Other(ext))) => {
+                Ok(ExtensionType::Other(ext)) => {
                     if other.iter().any(|o: &Other| o.get_ext_byte() == ext) {
                         return Err(ParseError::DuplicatedExtension);
                     }

--- a/components/locale_core/tests/fixtures/invalid-extensions.json
+++ b/components/locale_core/tests/fixtures/invalid-extensions.json
@@ -2,6 +2,16 @@
   {
     "input": {
       "type": "Locale",
+      "identifier": "cmn-hans-cn-t-ca-u-ca-x_t-u"
+    },
+    "output": {
+      "error": "InvalidExtension",
+      "text": "unused"
+    }
+  },
+  {
+    "input": {
+      "type": "Locale",
       "identifier": "pl-US-x-waytoolongkey"
     },
     "output": {

--- a/components/locale_core/tests/locale.rs
+++ b/components/locale_core/tests/locale.rs
@@ -47,7 +47,7 @@ fn test_locale_parsing() {
 }
 
 #[test]
-fn test_langid_invalid() {
+fn test_locale_invalid() {
     let data = serde_json::from_str(include_str!("fixtures/invalid-extensions.json"))
         .expect("Failed to read a fixture");
 


### PR DESCRIPTION
The issue here is that once the parser was in extensions mode, it would only look at the first character of the `x_t` subtag (the produced locale was `cmn-hans-cn-t-ca-u-ca-x-u`).

https://github.com/unicode-org/icu4x/pull/5943#issuecomment-2593013344