### PR TITLE
Bug fix for subsecond part in `ixdtf`

### DIFF
--- a/utils/ixdtf/src/parsers/tests.rs
+++ b/utils/ixdtf/src/parsers/tests.rs
@@ -975,3 +975,77 @@ fn test_zulu_offset() {
         })
     );
 }
+
+// Examples referenced from
+#[test]
+fn subsecond_string_tests() {
+    let subsecond_time = "2025-01-15T15:23:30.1";
+    let result = IxdtfParser::from_str(subsecond_time).parse();
+    assert_eq!(
+        result,
+        Ok(IxdtfParseRecord {
+            date: Some(DateRecord {
+                year: 2025,
+                month: 1,
+                day: 15,
+            }),
+            time: Some(TimeRecord {
+                hour: 15,
+                minute: 23,
+                second: 30,
+                nanosecond: 100_000_000,
+            }),
+            offset: None,
+            tz: None,
+            calendar: None,
+        })
+    );
+
+    let subsecond_time = "2025-01-15T15:23:30.12345678";
+    let result = IxdtfParser::from_str(subsecond_time).parse();
+    assert_eq!(
+        result,
+        Ok(IxdtfParseRecord {
+            date: Some(DateRecord {
+                year: 2025,
+                month: 1,
+                day: 15,
+            }),
+            time: Some(TimeRecord {
+                hour: 15,
+                minute: 23,
+                second: 30,
+                nanosecond: 123_456_780,
+            }),
+            offset: None,
+            tz: None,
+            calendar: None,
+        })
+    );
+
+    let subsecond_time = "2025-01-15T15:23:30.123456789";
+    let result = IxdtfParser::from_str(subsecond_time).parse();
+    assert_eq!(
+        result,
+        Ok(IxdtfParseRecord {
+            date: Some(DateRecord {
+                year: 2025,
+                month: 1,
+                day: 15,
+            }),
+            time: Some(TimeRecord {
+                hour: 15,
+                minute: 23,
+                second: 30,
+                nanosecond: 123_456_789,
+            }),
+            offset: None,
+            tz: None,
+            calendar: None,
+        })
+    );
+
+    let subsecond_time = "1976-11-18T15:23:30.1234567890";
+    let err = IxdtfParser::from_str(subsecond_time).parse();
+    assert_eq!(err, Err(ParseError::FractionPart));
+}

--- a/utils/ixdtf/src/parsers/time.rs
+++ b/utils/ixdtf/src/parsers/time.rs
@@ -151,7 +151,7 @@ pub(crate) fn parse_fraction(cursor: &mut Cursor) -> ParserResult<Option<u32>> {
     let mut result = 0;
     let mut fraction_len = 0;
     while cursor.check_or(false, |ch| ch.is_ascii_digit()) {
-        if fraction_len > 9 {
+        if fraction_len >= 9 {
             return Err(ParseError::FractionPart);
         }
         result = result * 10 + u32::from(cursor.next_digit()?.ok_or(ParseError::FractionPart)?);


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->

Boa / `temporal_rs` had a subtraction overflow panic when running the test262 suite in debug. This PR addressed the bug and adds some unit tests for it.

Confirmed that it is correct when plugged into Boa and rerun through the Temporal test suite.