### PR TITLE
Audit sealed traits

### DIFF
--- a/components/casemap/src/set.rs
+++ b/components/casemap/src/set.rs
@@ -12,6 +12,9 @@ use icu_collections::codepointinvlist::CodePointInversionListBuilder;
 /// will be some kind of set over codepoints and strings, or something that
 /// can be built into one.
 ///
+/// An implementation is provided for [`CodePointInversionListBuilder`], but users are encouraged
+/// to implement this trait on their own collections as needed.
+///
 /// [`CaseMapCloser::add_string_case_closure_to()`]: crate::CaseMapCloser::add_string_case_closure_to
 /// [`CaseMapCloser::add_case_closure_to()`]: crate::CaseMapCloser::add_case_closure_to
 pub trait ClosureSink {

--- a/components/collections/src/codepointtrie/cptrie.rs
+++ b/components/collections/src/codepointtrie/cptrie.rs
@@ -53,6 +53,8 @@ pub enum TrieType {
 
 /// A trait representing the values stored in the data array of a [`CodePointTrie`].
 /// This trait is used as a type parameter in constructing a `CodePointTrie`.
+///
+/// This trait can be implemented on anything that can be represented as a u32s worth of data.
 pub trait TrieValue: Copy + Eq + PartialEq + zerovec::ule::AsULE + 'static {
     /// Last-resort fallback value to return if we cannot read data from the trie.
     ///

--- a/components/datetime/src/combo.rs
+++ b/components/datetime/src/combo.rs
@@ -140,7 +140,7 @@ impl<DT, Z> Combo<DT, Z> {
     }
 }
 
-impl<DT, Z> UnstableSealed for Combo<DT, Z> {}
+impl<DT, Z> Sealed for Combo<DT, Z> {}
 
 impl<DT, Z> Combo<DT, Z> {
     #[inline]

--- a/components/datetime/src/fieldsets.rs
+++ b/components/datetime/src/fieldsets.rs
@@ -462,7 +462,7 @@ macro_rules! impl_date_or_calendar_period_marker {
             $(alignment: $option_alignment_yes,)?
             $(year_style: $year_yes,)?
         );
-        impl UnstableSealed for $type {}
+        impl Sealed for $type {}
         impl DateTimeNamesMarker for $type {
             type YearNames = datetime_marker_helper!(@names/year, $($years_yes)?);
             type MonthNames = datetime_marker_helper!(@names/month, $($months_yes)?);
@@ -617,7 +617,7 @@ macro_rules! impl_date_marker {
             time_precision: yes,
         );
         impl_zone_combo_helpers!($type_time, DateTimeZone, DateAndTimeFieldSet);
-        impl UnstableSealed for $type_time {}
+        impl Sealed for $type_time {}
         impl DateTimeNamesMarker for $type_time {
             type YearNames = datetime_marker_helper!(@names/year, $($years_yes)?);
             type MonthNames = datetime_marker_helper!(@names/month, $($months_yes)?);
@@ -783,7 +783,7 @@ macro_rules! impl_time_marker {
             time_precision: yes,
         );
         impl_zone_combo_helpers!($type, TimeZone, TimeFieldSet);
-        impl UnstableSealed for $type {}
+        impl Sealed for $type {}
         impl DateTimeNamesMarker for $type {
             type YearNames = datetime_marker_helper!(@names/year,);
             type MonthNames = datetime_marker_helper!(@names/month,);
@@ -892,7 +892,7 @@ macro_rules! impl_zone_marker {
             $type,
             length_override: $length_override,
         );
-        impl UnstableSealed for $type {}
+        impl Sealed for $type {}
         impl DateTimeNamesMarker for $type {
             type YearNames = datetime_marker_helper!(@names/year,);
             type MonthNames = datetime_marker_helper!(@names/month,);

--- a/components/datetime/src/scaffold/calendar.rs
+++ b/components/datetime/src/scaffold/calendar.rs
@@ -5,7 +5,7 @@
 //! Scaffolding traits and impls for calendars.
 
 use crate::provider::{neo::*, *};
-use crate::scaffold::UnstableSealed;
+use crate::scaffold::Sealed;
 use crate::MismatchedCalendarError;
 use core::marker::PhantomData;
 use icu_calendar::any_calendar::AnyCalendarKind;
@@ -29,7 +29,7 @@ use icu_timezone::{DateTime, Time, TimeZoneInfo, TimeZoneModel, UtcOffset, Zoned
 /// 🚫 This trait is sealed; it cannot be implemented by user code. If an API requests an item that implements this
 /// trait, please consider using a type from the implementors listed below.
 /// </div>
-pub trait CldrCalendar: UnstableSealed {
+pub trait CldrCalendar: Sealed {
     /// The data marker for loading year symbols for this calendar.
     type YearNamesV1Marker: DataMarker<DataStruct = YearNamesV1<'static>>;
 
@@ -145,23 +145,23 @@ impl CldrCalendar for Roc {
     type SkeletaV1Marker = RocDateNeoSkeletonPatternsV1Marker;
 }
 
-impl UnstableSealed for () {}
-impl UnstableSealed for Buddhist {}
-impl UnstableSealed for Chinese {}
-impl UnstableSealed for Coptic {}
-impl UnstableSealed for Dangi {}
-impl UnstableSealed for Ethiopian {}
-impl UnstableSealed for Gregorian {}
-impl UnstableSealed for Hebrew {}
-impl UnstableSealed for Indian {}
-impl UnstableSealed for IslamicCivil {}
-impl UnstableSealed for IslamicObservational {}
-impl UnstableSealed for IslamicTabular {}
-impl UnstableSealed for IslamicUmmAlQura {}
-impl UnstableSealed for Japanese {}
-impl UnstableSealed for JapaneseExtended {}
-impl UnstableSealed for Persian {}
-impl UnstableSealed for Roc {}
+impl Sealed for () {}
+impl Sealed for Buddhist {}
+impl Sealed for Chinese {}
+impl Sealed for Coptic {}
+impl Sealed for Dangi {}
+impl Sealed for Ethiopian {}
+impl Sealed for Gregorian {}
+impl Sealed for Hebrew {}
+impl Sealed for Indian {}
+impl Sealed for IslamicCivil {}
+impl Sealed for IslamicObservational {}
+impl Sealed for IslamicTabular {}
+impl Sealed for IslamicUmmAlQura {}
+impl Sealed for Japanese {}
+impl Sealed for JapaneseExtended {}
+impl Sealed for Persian {}
+impl Sealed for Roc {}
 
 /// A collection of marker types associated with all calendars.
 ///
@@ -169,7 +169,7 @@ impl UnstableSealed for Roc {}
 /// [`DynamicDataMarker`]. For example, this trait can be implemented for [`YearNamesV1Marker`].
 ///
 /// This trait serves as a building block for a cross-calendar [`BoundDataProvider`].
-pub trait CalMarkers<M>: UnstableSealed
+pub trait CalMarkers<M>: Sealed
 where
     M: DynamicDataMarker,
 {
@@ -214,14 +214,14 @@ where
 #[allow(clippy::exhaustive_enums)] // empty enum
 pub enum FullDataCalMarkers {}
 
-impl UnstableSealed for FullDataCalMarkers {}
+impl Sealed for FullDataCalMarkers {}
 
 /// Implementation of [`CalMarkers`] that includes data for no calendars.
 #[derive(Debug)]
 #[allow(clippy::exhaustive_enums)] // empty enum
 pub enum NoDataCalMarkers {}
 
-impl UnstableSealed for NoDataCalMarkers {}
+impl Sealed for NoDataCalMarkers {}
 
 impl<M> CalMarkers<M> for NoDataCalMarkers
 where

--- a/components/datetime/src/scaffold/calendar.rs
+++ b/components/datetime/src/scaffold/calendar.rs
@@ -382,6 +382,7 @@ impl_load_any_calendar!([
 ]);
 
 /// A type that can be converted into a specific calendar system.
+// This trait is implementable
 pub trait ConvertCalendar {
     /// The converted type. This can be the same as the receiver type.
     type Converted<'a>: Sized;
@@ -441,6 +442,7 @@ impl<O: TimeZoneModel> ConvertCalendar for TimeZoneInfo<O> {
 }
 
 /// An input that may be associated with a specific runtime calendar.
+// This trait is implementable
 pub trait InSameCalendar {
     /// Checks whether this type is compatible with the given calendar.
     ///
@@ -514,6 +516,7 @@ impl<O: TimeZoneModel> InSameCalendar for TimeZoneInfo<O> {
 }
 
 /// An input associated with a fixed, static calendar.
+// This trait is implementable
 pub trait InFixedCalendar<C> {}
 
 impl<C: CldrCalendar, A: AsCalendar<Calendar = C>> InFixedCalendar<C> for Date<A> {}

--- a/components/datetime/src/scaffold/calendar.rs
+++ b/components/datetime/src/scaffold/calendar.rs
@@ -26,8 +26,8 @@ use icu_timezone::{DateTime, Time, TimeZoneInfo, TimeZoneModel, UtcOffset, Zoned
 /// in the CLDR transformer to support any new era maps.
 ///
 /// <div class="stab unstable">
-/// 🚧 This trait is considered unstable; it may change at any time, in breaking or non-breaking ways,
-/// including in SemVer minor releases. Do not implement this trait in userland.
+/// 🚫 This trait is sealed; it cannot be implemented by user code. If an API requests an item that implements this
+/// trait, please consider using a type from the implementors listed below.
 /// </div>
 pub trait CldrCalendar: UnstableSealed {
     /// The data marker for loading year symbols for this calendar.

--- a/components/datetime/src/scaffold/dynamic_impls.rs
+++ b/components/datetime/src/scaffold/dynamic_impls.rs
@@ -15,7 +15,7 @@ use icu_timezone::{
     Time, TimeZoneBcp47Id, UtcOffset, ZoneVariant,
 };
 
-impl UnstableSealed for DateFieldSet {}
+impl Sealed for DateFieldSet {}
 
 impl DateTimeNamesMarker for DateFieldSet {
     type YearNames = datetime_marker_helper!(@names/year, yes);
@@ -60,7 +60,7 @@ impl DateTimeMarkers for DateFieldSet {
     type GluePatternV1Marker = datetime_marker_helper!(@glue,);
 }
 
-impl UnstableSealed for CalendarPeriodFieldSet {}
+impl Sealed for CalendarPeriodFieldSet {}
 
 impl DateTimeNamesMarker for CalendarPeriodFieldSet {
     type YearNames = datetime_marker_helper!(@names/year, yes);
@@ -105,7 +105,7 @@ impl DateTimeMarkers for CalendarPeriodFieldSet {
     type GluePatternV1Marker = datetime_marker_helper!(@glue,);
 }
 
-impl UnstableSealed for TimeFieldSet {}
+impl Sealed for TimeFieldSet {}
 
 impl DateTimeNamesMarker for TimeFieldSet {
     type YearNames = datetime_marker_helper!(@names/year,);
@@ -137,9 +137,9 @@ impl DateTimeMarkers for TimeFieldSet {
     type GluePatternV1Marker = datetime_marker_helper!(@glue,);
 }
 
-impl UnstableSealed for DateAndTimeFieldSet {}
+impl Sealed for DateAndTimeFieldSet {}
 
-impl UnstableSealed for ZoneFieldSet {}
+impl Sealed for ZoneFieldSet {}
 
 impl DateTimeNamesMarker for ZoneFieldSet {
     type YearNames = datetime_marker_helper!(@names/year,);
@@ -176,7 +176,7 @@ impl DateTimeMarkers for ZoneFieldSet {
     type GluePatternV1Marker = datetime_marker_helper!(@glue,);
 }
 
-impl UnstableSealed for CompositeDateTimeFieldSet {}
+impl Sealed for CompositeDateTimeFieldSet {}
 
 impl DateTimeNamesMarker for CompositeDateTimeFieldSet {
     type YearNames = datetime_marker_helper!(@names/year, yes);
@@ -199,7 +199,7 @@ impl DateTimeMarkers for CompositeDateTimeFieldSet {
     type GluePatternV1Marker = datetime_marker_helper!(@glue, yes);
 }
 
-impl UnstableSealed for CompositeFieldSet {}
+impl Sealed for CompositeFieldSet {}
 
 impl DateTimeNamesMarker for CompositeFieldSet {
     type YearNames = datetime_marker_helper!(@names/year, yes);

--- a/components/datetime/src/scaffold/fieldset_traits.rs
+++ b/components/datetime/src/scaffold/fieldset_traits.rs
@@ -28,7 +28,7 @@ use icu_timezone::{
 /// (input types only).
 ///
 /// This is a sealed trait implemented on field set markers.
-pub trait DateInputMarkers: UnstableSealed {
+pub trait DateInputMarkers: Sealed {
     /// Marker for resolving the year input field.
     type YearInput: IntoOption<YearInfo>;
     /// Marker for resolving the month input field.
@@ -45,7 +45,7 @@ pub trait DateInputMarkers: UnstableSealed {
 /// (data markers only).
 ///
 /// This is a sealed trait implemented on field set markers.
-pub trait TypedDateDataMarkers<C>: UnstableSealed {
+pub trait TypedDateDataMarkers<C>: Sealed {
     /// Marker for loading date skeleton patterns.
     type DateSkeletonPatternsV1Marker: DataMarker<DataStruct = PackedPatternsV1<'static>>;
     /// Marker for loading year names.
@@ -60,7 +60,7 @@ pub trait TypedDateDataMarkers<C>: UnstableSealed {
 /// (data markers only).
 ///
 /// This is a sealed trait implemented on field set markers.
-pub trait DateDataMarkers: UnstableSealed {
+pub trait DateDataMarkers: Sealed {
     /// Cross-calendar data markers for date skeleta.
     type Skel: CalMarkers<ErasedPackedPatterns>;
     /// Cross-calendar data markers for year names.
@@ -75,7 +75,7 @@ pub trait DateDataMarkers: UnstableSealed {
 /// (input types and data markers).
 ///
 /// This is a sealed trait implemented on field set markers.
-pub trait TimeMarkers: UnstableSealed {
+pub trait TimeMarkers: Sealed {
     /// Marker for resolving the day-of-month input field.
     type HourInput: IntoOption<IsoHour>;
     /// Marker for resolving the day-of-week input field.
@@ -94,7 +94,7 @@ pub trait TimeMarkers: UnstableSealed {
 /// (input types and data markers).
 ///
 /// This is a sealed trait implemented on field set markers.
-pub trait ZoneMarkers: UnstableSealed {
+pub trait ZoneMarkers: Sealed {
     /// Marker for resolving the time zone id input field.
     type TimeZoneIdInput: IntoOption<TimeZoneBcp47Id>;
     /// Marker for resolving the time zone offset input field.
@@ -123,7 +123,7 @@ pub trait ZoneMarkers: UnstableSealed {
 /// required for datetime formatting.
 ///
 /// This is a sealed trait implemented on field set markers.
-pub trait DateTimeMarkers: UnstableSealed + DateTimeNamesMarker {
+pub trait DateTimeMarkers: Sealed + DateTimeNamesMarker {
     /// Associated types for date formatting.
     ///
     /// Should implement [`DateDataMarkers`], [`TypedDateDataMarkers`], and [`DateInputMarkers`].

--- a/components/datetime/src/scaffold/fieldset_traits.rs
+++ b/components/datetime/src/scaffold/fieldset_traits.rs
@@ -156,6 +156,7 @@ pub trait DateTimeMarkers: Sealed + DateTimeNamesMarker {
 /// - [`TimeZoneInfo`](icu_timezone::TimeZoneInfo)
 ///
 /// [`fieldsets::YMD`]: crate::fieldsets::YMD
+// This trait is implicitly sealed due to its blanket impl
 pub trait AllInputMarkers<R: DateTimeMarkers>:
     GetField<<R::D as DateInputMarkers>::YearInput>
     + GetField<<R::D as DateInputMarkers>::MonthInput>
@@ -204,6 +205,7 @@ where
 ///
 /// This trait is implemented on all providers that support datetime formatting,
 /// including [`crate::provider::Baked`].
+// This trait is implicitly sealed due to its blanket impl
 pub trait AllFixedCalendarFormattingDataMarkers<C: CldrCalendar, FSet: DateTimeMarkers>:
     DataProvider<<FSet::D as TypedDateDataMarkers<C>>::YearNamesV1Marker>
     + DataProvider<<FSet::D as TypedDateDataMarkers<C>>::MonthNamesV1Marker>
@@ -256,6 +258,7 @@ where
 ///
 /// This trait is implemented on all providers that support datetime formatting,
 /// including [`crate::provider::Baked`].
+// This trait is implicitly sealed due to its blanket impl
 pub trait AllAnyCalendarFormattingDataMarkers<FSet: DateTimeMarkers>:
     DataProvider<<<FSet::D as DateDataMarkers>::Year as CalMarkers<YearNamesV1Marker>>::Buddhist>
     + DataProvider<<<FSet::D as DateDataMarkers>::Year as CalMarkers<YearNamesV1Marker>>::Chinese>
@@ -400,6 +403,7 @@ where
 
 /// Trait to consolidate data provider markers external to this crate
 /// for datetime formatting with a fixed calendar.
+// This trait is implicitly sealed due to its blanket impl
 pub trait AllFixedCalendarExternalDataMarkers:
     DataProvider<DecimalSymbolsV2Marker> + DataProvider<DecimalDigitsV1Marker>
 {
@@ -412,6 +416,7 @@ impl<T> AllFixedCalendarExternalDataMarkers for T where
 
 /// Trait to consolidate data provider markers external to this crate
 /// for datetime formatting with any calendar.
+// This trait is implicitly sealed due to its blanket impl
 pub trait AllAnyCalendarExternalDataMarkers:
     DataProvider<ChineseCacheV1Marker>
     + DataProvider<DangiCacheV1Marker>

--- a/components/datetime/src/scaffold/get_field.rs
+++ b/components/datetime/src/scaffold/get_field.rs
@@ -12,19 +12,19 @@ use icu_timezone::{
     ZonedDateTime,
 };
 
-use super::UnstableSealed;
+use super::Sealed;
 
 /// A type that can return a certain field `T`.
 ///
 /// This is used as a bound on various datetime functions.
-pub trait GetField<T>: UnstableSealed {
+pub trait GetField<T>: Sealed {
     /// Returns the value of this trait's field `T`.
     fn get_field(&self) -> T;
 }
 
 impl<T> GetField<T> for T
 where
-    T: Copy + UnstableSealed,
+    T: Copy + Sealed,
 {
     #[inline]
     fn get_field(&self) -> T {
@@ -32,7 +32,7 @@ where
     }
 }
 
-impl<C: Calendar, A: AsCalendar<Calendar = C>> UnstableSealed for Date<A> {}
+impl<C: Calendar, A: AsCalendar<Calendar = C>> Sealed for Date<A> {}
 
 impl<C: Calendar, A: AsCalendar<Calendar = C>> GetField<YearInfo> for Date<A> {
     #[inline]
@@ -69,7 +69,7 @@ impl<C: Calendar, A: AsCalendar<Calendar = C>> GetField<DayOfYearInfo> for Date<
     }
 }
 
-impl UnstableSealed for Time {}
+impl Sealed for Time {}
 
 impl GetField<IsoHour> for Time {
     #[inline]
@@ -99,7 +99,7 @@ impl GetField<NanoSecond> for Time {
     }
 }
 
-impl<C: Calendar, A: AsCalendar<Calendar = C>> UnstableSealed for DateTime<A> {}
+impl<C: Calendar, A: AsCalendar<Calendar = C>> Sealed for DateTime<A> {}
 
 impl<C: Calendar, A: AsCalendar<Calendar = C>> GetField<YearInfo> for DateTime<A> {
     #[inline]
@@ -164,7 +164,7 @@ impl<C: Calendar, A: AsCalendar<Calendar = C>> GetField<NanoSecond> for DateTime
     }
 }
 
-impl<C: Calendar, A: AsCalendar<Calendar = C>, Z> UnstableSealed for ZonedDateTime<A, Z> {}
+impl<C: Calendar, A: AsCalendar<Calendar = C>, Z> Sealed for ZonedDateTime<A, Z> {}
 
 impl<C: Calendar, A: AsCalendar<Calendar = C>, Z> GetField<YearInfo> for ZonedDateTime<A, Z> {
     #[inline]
@@ -271,7 +271,7 @@ where
     }
 }
 
-impl UnstableSealed for UtcOffset {}
+impl Sealed for UtcOffset {}
 
 impl GetField<Option<UtcOffset>> for UtcOffset {
     #[inline]
@@ -280,7 +280,7 @@ impl GetField<Option<UtcOffset>> for UtcOffset {
     }
 }
 
-impl<O: TimeZoneModel> UnstableSealed for TimeZoneInfo<O> {}
+impl<O: TimeZoneModel> Sealed for TimeZoneInfo<O> {}
 
 impl<O> GetField<TimeZoneBcp47Id> for TimeZoneInfo<O>
 where

--- a/components/datetime/src/scaffold/mod.rs
+++ b/components/datetime/src/scaffold/mod.rs
@@ -46,11 +46,16 @@ pub use names_storage::MaybePayloadError;
 pub use names_storage::NamesContainer;
 pub(crate) use names_storage::OptionalNames;
 
-/// Trait marking other traits that are considered unstable and should not generally be
-/// implemented outside of the datetime crate.
-///
-/// <div class="stab unstable">
-/// 🚧 This trait is considered unstable; it may change at any time, in breaking or non-breaking ways,
-/// including in SemVer minor releases. Do not implement this trait in userland.
-/// </div>
-pub trait UnstableSealed {}
+// Should be private for sealing
+pub(crate) use sealed::UnstableSealed;
+
+mod sealed {
+    /// Trait marking other traits that are considered unstable and should not generally be
+    /// implemented outside of the datetime crate.
+    ///
+    /// <div class="stab unstable">
+    /// 🚧 This trait is considered unstable; it may change at any time, in breaking or non-breaking ways,
+    /// including in SemVer minor releases. Do not implement this trait in userland.
+    /// </div>
+    pub trait UnstableSealed {}
+}

--- a/components/datetime/src/scaffold/mod.rs
+++ b/components/datetime/src/scaffold/mod.rs
@@ -47,9 +47,9 @@ pub use names_storage::NamesContainer;
 pub(crate) use names_storage::OptionalNames;
 
 // Should be private for sealing
-pub(crate) use sealed::UnstableSealed;
+pub(crate) use private::Sealed;
 
-mod sealed {
+mod private {
     /// Trait marking other traits that are considered unstable and should not generally be
     /// implemented outside of the datetime crate.
     ///
@@ -57,5 +57,5 @@ mod sealed {
     /// 🚧 This trait is considered unstable; it may change at any time, in breaking or non-breaking ways,
     /// including in SemVer minor releases. Do not implement this trait in userland.
     /// </div>
-    pub trait UnstableSealed {}
+    pub trait Sealed {}
 }

--- a/components/datetime/src/scaffold/names_storage.rs
+++ b/components/datetime/src/scaffold/names_storage.rs
@@ -334,6 +334,7 @@ where
 /// is_trait_implemented::<TimeFieldSet, CompositeFieldSet>();
 /// ```
 #[allow(missing_docs)]
+// This trait is implicitly sealed by deriving from a sealed trait
 pub trait DateTimeNamesFrom<M: DateTimeNamesMarker>: DateTimeNamesMarker {
     fn map_year_names(
         other: <M::YearNames as NamesContainer<YearNamesV1Marker, YearNameLength>>::Container,

--- a/components/datetime/src/scaffold/names_storage.rs
+++ b/components/datetime/src/scaffold/names_storage.rs
@@ -12,7 +12,7 @@ use core::fmt;
 use icu_provider::prelude::*;
 use yoke::Yokeable;
 
-use super::UnstableSealed;
+use super::Sealed;
 
 /// Trait for a type that owns datetime names data, usually in the form of data payloads.
 ///
@@ -20,7 +20,7 @@ use super::UnstableSealed;
 /// allowing for reduced stack size. For example, a type could contain year and month names but
 /// not weekday, day period, or time zone names.
 #[allow(missing_docs)]
-pub trait DateTimeNamesMarker: UnstableSealed {
+pub trait DateTimeNamesMarker: Sealed {
     type YearNames: NamesContainer<YearNamesV1Marker, YearNameLength>;
     type MonthNames: NamesContainer<MonthNamesV1Marker, MonthNameLength>;
     type WeekdayNames: NamesContainer<WeekdayNamesV1Marker, WeekdayNameLength>;
@@ -36,7 +36,7 @@ pub trait DateTimeNamesMarker: UnstableSealed {
 
 /// Trait that associates a container for a payload parameterized by the given variables.
 #[allow(missing_docs)]
-pub trait NamesContainer<M: DynamicDataMarker, Variables>: UnstableSealed
+pub trait NamesContainer<M: DynamicDataMarker, Variables>: Sealed
 where
     Variables: PartialEq + Copy + fmt::Debug,
 {
@@ -52,7 +52,7 @@ where
 
 macro_rules! impl_holder_trait {
     ($marker:path) => {
-        impl UnstableSealed for $marker {}
+        impl Sealed for $marker {}
         impl<Variables> NamesContainer<$marker, Variables> for $marker
         where
             Variables: PartialEq + Copy + fmt::Debug,
@@ -101,7 +101,7 @@ impl MaybePayloadError {
 ///
 /// Helper trait for [`DateTimeNamesMarker`].
 #[allow(missing_docs)]
-pub trait MaybePayload<M: DynamicDataMarker, Variables>: UnstableSealed {
+pub trait MaybePayload<M: DynamicDataMarker, Variables>: Sealed {
     fn new_empty() -> Self;
     fn load_put<P>(
         &mut self,
@@ -121,7 +121,7 @@ pub struct DataPayloadWithVariables<M: DynamicDataMarker, Variables> {
     inner: OptionalNames<Variables, DataPayload<M>>,
 }
 
-impl<M: DynamicDataMarker, Variables> UnstableSealed for DataPayloadWithVariables<M, Variables> {}
+impl<M: DynamicDataMarker, Variables> Sealed for DataPayloadWithVariables<M, Variables> {}
 
 impl<M: DynamicDataMarker, Variables> fmt::Debug for DataPayloadWithVariables<M, Variables>
 where

--- a/components/pattern/src/common.rs
+++ b/components/pattern/src/common.rs
@@ -115,6 +115,8 @@ pub trait PatternBackend: crate::private::Sealed + 'static + core::fmt::Debug {
 /// This trait can add [`Part`]s for individual literals or placeholders. The implementations
 /// of this trait on standard types do not add any [`Part`]s.
 ///
+/// This trait is not implementable by user code due to the blanket impl.
+///
 /// # Examples
 ///
 /// A custom implementation that adds parts:

--- a/components/properties/src/names.rs
+++ b/components/properties/src/names.rs
@@ -650,6 +650,7 @@ pub trait ParseableEnumeratedProperty: crate::private::Sealed + TrieValue {
 }
 
 // Abstract over Linear/Sparse/Script representation
+// This trait is implicitly sealed by not being exported.
 pub trait PropertyEnumToValueNameLookup {
     fn get(&self, prop: u32) -> Option<&str>;
 }

--- a/components/segmenter/src/lib.rs
+++ b/components/segmenter/src/lib.rs
@@ -167,3 +167,14 @@ pub use crate::word::WordBreakIteratorLatin1;
 pub use crate::word::WordBreakIteratorPotentiallyIllFormedUtf8;
 pub use crate::word::WordBreakIteratorUtf16;
 pub use crate::word::WordBreakIteratorUtf8;
+
+pub(crate) mod private {
+    /// Trait marking other traits that are considered unstable and should not generally be
+    /// implemented outside of the segmenter crate.
+    ///
+    /// <div class="stab unstable">
+    /// 🚧 This trait is considered unstable; it may change at any time, in breaking or non-breaking ways,
+    /// including in SemVer minor releases. Do not implement this trait in userland.
+    /// </div>
+    pub trait Sealed {}
+}

--- a/components/segmenter/src/line.rs
+++ b/components/segmenter/src/line.rs
@@ -715,7 +715,12 @@ fn is_break_utf32_by_loose(
 /// A trait allowing for LineBreakIterator to be generalized to multiple string iteration methods.
 ///
 /// This is implemented by ICU4X for several common string types.
-pub trait LineBreakType<'l, 's> {
+///
+/// <div class="stab unstable">
+/// 🚫 This trait is sealed; it cannot be implemented by user code. If an API requests an item that implements this
+/// trait, please consider using a type from the implementors listed below.
+/// </div>
+pub trait LineBreakType<'l, 's>: crate::private::Sealed {
     /// The iterator over characters.
     type IterAttr: Iterator<Item = (usize, Self::CharType)> + Clone;
 
@@ -1065,6 +1070,8 @@ impl<'l, 's, Y: LineBreakType<'l, 's>> LineBreakIterator<'l, 's, Y> {
 #[derive(Debug)]
 pub struct LineBreakTypeUtf8;
 
+impl crate::private::Sealed for LineBreakTypeUtf8 {}
+
 impl<'l, 's> LineBreakType<'l, 's> for LineBreakTypeUtf8 {
     type IterAttr = CharIndices<'s>;
     type CharType = char;
@@ -1096,6 +1103,8 @@ impl<'l, 's> LineBreakType<'l, 's> for LineBreakTypeUtf8 {
 
 #[derive(Debug)]
 pub struct LineBreakTypePotentiallyIllFormedUtf8;
+
+impl crate::private::Sealed for LineBreakTypePotentiallyIllFormedUtf8 {}
 
 impl<'l, 's> LineBreakType<'l, 's> for LineBreakTypePotentiallyIllFormedUtf8 {
     type IterAttr = Utf8CharIndices<'s>;
@@ -1181,6 +1190,7 @@ where
 
 #[derive(Debug)]
 pub struct LineBreakTypeLatin1;
+impl crate::private::Sealed for LineBreakTypeLatin1 {}
 
 impl<'s> LineBreakType<'_, 's> for LineBreakTypeLatin1 {
     type IterAttr = Latin1Indices<'s>;
@@ -1211,6 +1221,7 @@ impl<'s> LineBreakType<'_, 's> for LineBreakTypeLatin1 {
 
 #[derive(Debug)]
 pub struct LineBreakTypeUtf16;
+impl crate::private::Sealed for LineBreakTypeUtf16 {}
 
 impl<'s> LineBreakType<'_, 's> for LineBreakTypeUtf16 {
     type IterAttr = Utf16Indices<'s>;

--- a/components/segmenter/src/rule_segmenter.rs
+++ b/components/segmenter/src/rule_segmenter.rs
@@ -11,7 +11,12 @@ use utf8_iter::Utf8CharIndices;
 
 /// A trait allowing for RuleBreakIterator to be generalized to multiple string
 /// encoding methods and granularity such as grapheme cluster, word, etc.
-pub trait RuleBreakType<'l, 's> {
+///
+/// <div class="stab unstable">
+/// 🚫 This trait is sealed; it cannot be implemented by user code. If an API requests an item that implements this
+/// trait, please consider using a type from the implementors listed below.
+/// </div>
+pub trait RuleBreakType<'l, 's>: crate::private::Sealed {
     /// The iterator over characters.
     type IterAttr: Iterator<Item = (usize, Self::CharType)> + Clone + core::fmt::Debug;
 
@@ -258,6 +263,8 @@ impl<'l, 's, Y: RuleBreakType<'l, 's> + ?Sized> RuleBreakIterator<'l, 's, Y> {
 #[derive(Debug)]
 pub struct RuleBreakTypeUtf8;
 
+impl crate::private::Sealed for RuleBreakTypeUtf8 {}
+
 impl<'s> RuleBreakType<'_, 's> for RuleBreakTypeUtf8 {
     type IterAttr = CharIndices<'s>;
     type CharType = char;
@@ -276,6 +283,8 @@ impl<'s> RuleBreakType<'_, 's> for RuleBreakTypeUtf8 {
 
 #[derive(Debug)]
 pub struct RuleBreakTypePotentiallyIllFormedUtf8;
+
+impl crate::private::Sealed for RuleBreakTypePotentiallyIllFormedUtf8 {}
 
 impl<'s> RuleBreakType<'_, 's> for RuleBreakTypePotentiallyIllFormedUtf8 {
     type IterAttr = Utf8CharIndices<'s>;
@@ -296,6 +305,8 @@ impl<'s> RuleBreakType<'_, 's> for RuleBreakTypePotentiallyIllFormedUtf8 {
 #[derive(Debug)]
 pub struct RuleBreakTypeLatin1;
 
+impl crate::private::Sealed for RuleBreakTypeLatin1 {}
+
 impl<'s> RuleBreakType<'_, 's> for RuleBreakTypeLatin1 {
     type IterAttr = Latin1Indices<'s>;
     type CharType = u8;
@@ -314,6 +325,8 @@ impl<'s> RuleBreakType<'_, 's> for RuleBreakTypeLatin1 {
 
 #[derive(Debug)]
 pub struct RuleBreakTypeUtf16;
+
+impl crate::private::Sealed for RuleBreakTypeUtf16 {}
 
 impl<'s> RuleBreakType<'_, 's> for RuleBreakTypeUtf16 {
     type IterAttr = Utf16Indices<'s>;

--- a/components/segmenter/src/word.rs
+++ b/components/segmenter/src/word.rs
@@ -546,6 +546,7 @@ impl WordSegmenter {
 
 #[derive(Debug)]
 pub struct WordBreakTypeUtf8;
+impl crate::private::Sealed for WordBreakTypeUtf8 {}
 
 impl<'l, 's> RuleBreakType<'l, 's> for WordBreakTypeUtf8 {
     type IterAttr = CharIndices<'s>;
@@ -565,6 +566,7 @@ impl<'l, 's> RuleBreakType<'l, 's> for WordBreakTypeUtf8 {
 
 #[derive(Debug)]
 pub struct WordBreakTypePotentiallyIllFormedUtf8;
+impl crate::private::Sealed for WordBreakTypePotentiallyIllFormedUtf8 {}
 
 impl<'l, 's> RuleBreakType<'l, 's> for WordBreakTypePotentiallyIllFormedUtf8 {
     type IterAttr = Utf8CharIndices<'s>;
@@ -639,6 +641,8 @@ where
 
 #[derive(Debug)]
 pub struct WordBreakTypeUtf16;
+
+impl crate::private::Sealed for WordBreakTypeUtf16 {}
 
 impl<'s> RuleBreakType<'_, 's> for WordBreakTypeUtf16 {
     type IterAttr = Utf16Indices<'s>;


### PR DESCRIPTION
I've gone through and looked at all the traits, sealing ones I think should be sealed (just the segmenter ones). There are a couple implementable traits in the DateTime scaffolding that I let be.

I did not consistently do this, but I did attempt to document traits as implementable or not.

A clippy lint for unsealed traits sounds rather useful, we could use that to explicitly opt-in to unsealed traits. (https://github.com/rust-lang/rust-clippy/issues/14006)

One question for @sffc: Should we be auditing sealed traits for `doc(hidden)` methods? For example, the segmenter traits here do seem to have methods that the users should not see.

In theory we can *properly* hide those methods by having `trait LineBreakType: LineBreakTypeSealed {}` and a public-in-private-module `trait LineBreakTypeSealed`, but that might be unweildy.

Fixes #4338

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->