### PR TITLE
Audit sealed traits, take 2

### DIFF
--- a/components/casemap/src/set.rs
+++ b/components/casemap/src/set.rs
@@ -12,6 +12,9 @@ use icu_collections::codepointinvlist::CodePointInversionListBuilder;
 /// will be some kind of set over codepoints and strings, or something that
 /// can be built into one.
 ///
+/// An implementation is provided for [`CodePointInversionListBuilder`], but users are encouraged
+/// to implement this trait on their own collections as needed.
+///
 /// [`CaseMapCloser::add_string_case_closure_to()`]: crate::CaseMapCloser::add_string_case_closure_to
 /// [`CaseMapCloser::add_case_closure_to()`]: crate::CaseMapCloser::add_case_closure_to
 pub trait ClosureSink {

--- a/components/collections/src/codepointtrie/cptrie.rs
+++ b/components/collections/src/codepointtrie/cptrie.rs
@@ -53,6 +53,8 @@ pub enum TrieType {
 
 /// A trait representing the values stored in the data array of a [`CodePointTrie`].
 /// This trait is used as a type parameter in constructing a `CodePointTrie`.
+///
+/// This trait can be implemented on anything that can be represented as a u32s worth of data.
 pub trait TrieValue: Copy + Eq + PartialEq + zerovec::ule::AsULE + 'static {
     /// Last-resort fallback value to return if we cannot read data from the trie.
     ///

--- a/components/datetime/src/scaffold/calendar.rs
+++ b/components/datetime/src/scaffold/calendar.rs
@@ -382,6 +382,7 @@ impl_load_any_calendar!([
 ]);
 
 /// A type that can be converted into a specific calendar system.
+// This trait is implementable
 pub trait ConvertCalendar {
     /// The converted type. This can be the same as the receiver type.
     type Converted<'a>: Sized;
@@ -441,6 +442,7 @@ impl<O: TimeZoneModel> ConvertCalendar for TimeZoneInfo<O> {
 }
 
 /// An input that may be associated with a specific runtime calendar.
+// This trait is implementable
 pub trait InSameCalendar {
     /// Checks whether this type is compatible with the given calendar.
     ///
@@ -514,6 +516,7 @@ impl<O: TimeZoneModel> InSameCalendar for TimeZoneInfo<O> {
 }
 
 /// An input associated with a fixed, static calendar.
+// This trait is implementable
 pub trait InFixedCalendar<C> {}
 
 impl<C: CldrCalendar, A: AsCalendar<Calendar = C>> InFixedCalendar<C> for Date<A> {}

--- a/components/datetime/src/scaffold/calendar.rs
+++ b/components/datetime/src/scaffold/calendar.rs
@@ -169,6 +169,11 @@ impl UnstableSealed for Roc {}
 /// [`DynamicDataMarker`]. For example, this trait can be implemented for [`YearNamesV1Marker`].
 ///
 /// This trait serves as a building block for a cross-calendar [`BoundDataProvider`].
+///
+/// <div class="stab unstable">
+/// 🚧 This trait is considered unstable; it may change at any time, in breaking or non-breaking ways,
+/// including in SemVer minor releases. Do not implement this trait in userland.
+/// </div>
 pub trait CalMarkers<M>: UnstableSealed
 where
     M: DynamicDataMarker,

--- a/components/datetime/src/scaffold/calendar.rs
+++ b/components/datetime/src/scaffold/calendar.rs
@@ -20,16 +20,20 @@ use icu_provider::marker::NeverMarker;
 use icu_provider::prelude::*;
 use icu_timezone::{DateTime, Time, TimeZoneInfo, TimeZoneModel, UtcOffset, ZonedDateTime};
 
+mod private {
+    pub trait Sealed {}
+}
+
 /// A calendar that can be found in CLDR.
 ///
 /// New implementors of this trait will likely also wish to modify `get_era_code_map()`
 /// in the CLDR transformer to support any new era maps.
 ///
 /// <div class="stab unstable">
-/// 🚧 This trait is considered unstable; it may change at any time, in breaking or non-breaking ways,
-/// including in SemVer minor releases. Do not implement this trait in userland.
+/// 🚫 This trait is sealed; it cannot be implemented by user code. If an API requests an item that implements this
+/// trait, please consider using a type from the implementors listed below.
 /// </div>
-pub trait CldrCalendar: UnstableSealed {
+pub trait CldrCalendar: private::Sealed {
     /// The data marker for loading year symbols for this calendar.
     type YearNamesV1Marker: DataMarker<DataStruct = YearNamesV1<'static>>;
 
@@ -40,60 +44,70 @@ pub trait CldrCalendar: UnstableSealed {
     type SkeletaV1Marker: DataMarker<DataStruct = PackedPatternsV1<'static>>;
 }
 
+impl private::Sealed for () {}
 impl CldrCalendar for () {
     type YearNamesV1Marker = NeverMarker<YearNamesV1<'static>>;
     type MonthNamesV1Marker = NeverMarker<MonthNamesV1<'static>>;
     type SkeletaV1Marker = NeverMarker<PackedPatternsV1<'static>>;
 }
 
+impl private::Sealed for Buddhist {}
 impl CldrCalendar for Buddhist {
     type YearNamesV1Marker = BuddhistYearNamesV1Marker;
     type MonthNamesV1Marker = BuddhistMonthNamesV1Marker;
     type SkeletaV1Marker = BuddhistDateNeoSkeletonPatternsV1Marker;
 }
 
+impl private::Sealed for Chinese {}
 impl CldrCalendar for Chinese {
     type YearNamesV1Marker = ChineseYearNamesV1Marker;
     type MonthNamesV1Marker = ChineseMonthNamesV1Marker;
     type SkeletaV1Marker = ChineseDateNeoSkeletonPatternsV1Marker;
 }
 
+impl private::Sealed for Coptic {}
 impl CldrCalendar for Coptic {
     type YearNamesV1Marker = CopticYearNamesV1Marker;
     type MonthNamesV1Marker = CopticMonthNamesV1Marker;
     type SkeletaV1Marker = CopticDateNeoSkeletonPatternsV1Marker;
 }
 
+impl private::Sealed for Dangi {}
 impl CldrCalendar for Dangi {
     type YearNamesV1Marker = DangiYearNamesV1Marker;
     type MonthNamesV1Marker = DangiMonthNamesV1Marker;
     type SkeletaV1Marker = DangiDateNeoSkeletonPatternsV1Marker;
 }
 
+impl private::Sealed for Ethiopian {}
 impl CldrCalendar for Ethiopian {
     type YearNamesV1Marker = EthiopianYearNamesV1Marker;
     type MonthNamesV1Marker = EthiopianMonthNamesV1Marker;
     type SkeletaV1Marker = EthiopianDateNeoSkeletonPatternsV1Marker;
 }
 
+impl private::Sealed for Gregorian {}
 impl CldrCalendar for Gregorian {
     type YearNamesV1Marker = GregorianYearNamesV1Marker;
     type MonthNamesV1Marker = GregorianMonthNamesV1Marker;
     type SkeletaV1Marker = GregorianDateNeoSkeletonPatternsV1Marker;
 }
 
+impl private::Sealed for Hebrew {}
 impl CldrCalendar for Hebrew {
     type YearNamesV1Marker = HebrewYearNamesV1Marker;
     type MonthNamesV1Marker = HebrewMonthNamesV1Marker;
     type SkeletaV1Marker = HebrewDateNeoSkeletonPatternsV1Marker;
 }
 
+impl private::Sealed for Indian {}
 impl CldrCalendar for Indian {
     type YearNamesV1Marker = IndianYearNamesV1Marker;
     type MonthNamesV1Marker = IndianMonthNamesV1Marker;
     type SkeletaV1Marker = IndianDateNeoSkeletonPatternsV1Marker;
 }
 
+impl private::Sealed for IslamicCivil {}
 impl CldrCalendar for IslamicCivil {
     // this value is not actually a valid identifier for this calendar,
     // however since we are overriding is_identifier_allowed_for_calendar we are using
@@ -103,42 +117,49 @@ impl CldrCalendar for IslamicCivil {
     type SkeletaV1Marker = IslamicDateNeoSkeletonPatternsV1Marker;
 }
 
+impl private::Sealed for IslamicObservational {}
 impl CldrCalendar for IslamicObservational {
     type YearNamesV1Marker = IslamicYearNamesV1Marker;
     type MonthNamesV1Marker = IslamicMonthNamesV1Marker;
     type SkeletaV1Marker = IslamicDateNeoSkeletonPatternsV1Marker;
 }
 
+impl private::Sealed for IslamicTabular {}
 impl CldrCalendar for IslamicTabular {
     type YearNamesV1Marker = IslamicYearNamesV1Marker;
     type MonthNamesV1Marker = IslamicMonthNamesV1Marker;
     type SkeletaV1Marker = IslamicDateNeoSkeletonPatternsV1Marker;
 }
 
+impl private::Sealed for IslamicUmmAlQura {}
 impl CldrCalendar for IslamicUmmAlQura {
     type YearNamesV1Marker = IslamicYearNamesV1Marker;
     type MonthNamesV1Marker = IslamicMonthNamesV1Marker;
     type SkeletaV1Marker = IslamicDateNeoSkeletonPatternsV1Marker;
 }
 
+impl private::Sealed for Japanese {}
 impl CldrCalendar for Japanese {
     type YearNamesV1Marker = JapaneseYearNamesV1Marker;
     type MonthNamesV1Marker = JapaneseMonthNamesV1Marker;
     type SkeletaV1Marker = JapaneseDateNeoSkeletonPatternsV1Marker;
 }
 
+impl private::Sealed for JapaneseExtended {}
 impl CldrCalendar for JapaneseExtended {
     type YearNamesV1Marker = JapaneseExtendedYearNamesV1Marker;
     type MonthNamesV1Marker = JapaneseExtendedMonthNamesV1Marker;
     type SkeletaV1Marker = JapaneseExtendedDateNeoSkeletonPatternsV1Marker;
 }
 
+impl private::Sealed for Persian {}
 impl CldrCalendar for Persian {
     type YearNamesV1Marker = PersianYearNamesV1Marker;
     type MonthNamesV1Marker = PersianMonthNamesV1Marker;
     type SkeletaV1Marker = PersianDateNeoSkeletonPatternsV1Marker;
 }
 
+impl private::Sealed for Roc {}
 impl CldrCalendar for Roc {
     type YearNamesV1Marker = RocYearNamesV1Marker;
     type MonthNamesV1Marker = RocMonthNamesV1Marker;

--- a/components/datetime/src/scaffold/calendar.rs
+++ b/components/datetime/src/scaffold/calendar.rs
@@ -193,7 +193,7 @@ impl UnstableSealed for Roc {}
 ///
 /// <div class="stab unstable">
 /// 🚧 This trait is considered unstable; it may change at any time, in breaking or non-breaking ways,
-/// including in SemVer minor releases. Do not implement this trait in userland.
+/// including in SemVer minor releases. Do not implement this trait in userland unless you are prepared for things to occasionally break.
 /// </div>
 pub trait CalMarkers<M>: UnstableSealed
 where

--- a/components/datetime/src/scaffold/fieldset_traits.rs
+++ b/components/datetime/src/scaffold/fieldset_traits.rs
@@ -28,6 +28,11 @@ use icu_timezone::{
 /// (input types only).
 ///
 /// This is a sealed trait implemented on field set markers.
+///
+/// <div class="stab unstable">
+/// 🚧 This trait is considered unstable; it may change at any time, in breaking or non-breaking ways,
+/// including in SemVer minor releases. Do not implement this trait in userland.
+/// </div>
 pub trait DateInputMarkers: UnstableSealed {
     /// Marker for resolving the year input field.
     type YearInput: IntoOption<YearInfo>;
@@ -45,6 +50,11 @@ pub trait DateInputMarkers: UnstableSealed {
 /// (data markers only).
 ///
 /// This is a sealed trait implemented on field set markers.
+///
+/// <div class="stab unstable">
+/// 🚧 This trait is considered unstable; it may change at any time, in breaking or non-breaking ways,
+/// including in SemVer minor releases. Do not implement this trait in userland.
+/// </div>
 pub trait TypedDateDataMarkers<C>: UnstableSealed {
     /// Marker for loading date skeleton patterns.
     type DateSkeletonPatternsV1Marker: DataMarker<DataStruct = PackedPatternsV1<'static>>;
@@ -60,6 +70,11 @@ pub trait TypedDateDataMarkers<C>: UnstableSealed {
 /// (data markers only).
 ///
 /// This is a sealed trait implemented on field set markers.
+///
+/// <div class="stab unstable">
+/// 🚧 This trait is considered unstable; it may change at any time, in breaking or non-breaking ways,
+/// including in SemVer minor releases. Do not implement this trait in userland.
+/// </div>
 pub trait DateDataMarkers: UnstableSealed {
     /// Cross-calendar data markers for date skeleta.
     type Skel: CalMarkers<ErasedPackedPatterns>;
@@ -75,6 +90,11 @@ pub trait DateDataMarkers: UnstableSealed {
 /// (input types and data markers).
 ///
 /// This is a sealed trait implemented on field set markers.
+///
+/// <div class="stab unstable">
+/// 🚧 This trait is considered unstable; it may change at any time, in breaking or non-breaking ways,
+/// including in SemVer minor releases. Do not implement this trait in userland.
+/// </div>
 pub trait TimeMarkers: UnstableSealed {
     /// Marker for resolving the day-of-month input field.
     type HourInput: IntoOption<IsoHour>;
@@ -94,6 +114,11 @@ pub trait TimeMarkers: UnstableSealed {
 /// (input types and data markers).
 ///
 /// This is a sealed trait implemented on field set markers.
+///
+/// <div class="stab unstable">
+/// 🚧 This trait is considered unstable; it may change at any time, in breaking or non-breaking ways,
+/// including in SemVer minor releases. Do not implement this trait in userland.
+/// </div>
 pub trait ZoneMarkers: UnstableSealed {
     /// Marker for resolving the time zone id input field.
     type TimeZoneIdInput: IntoOption<TimeZoneBcp47Id>;
@@ -123,6 +148,11 @@ pub trait ZoneMarkers: UnstableSealed {
 /// required for datetime formatting.
 ///
 /// This is a sealed trait implemented on field set markers.
+///
+/// <div class="stab unstable">
+/// 🚧 This trait is considered unstable; it may change at any time, in breaking or non-breaking ways,
+/// including in SemVer minor releases. Do not implement this trait in userland.
+/// </div>
 pub trait DateTimeMarkers: UnstableSealed + DateTimeNamesMarker {
     /// Associated types for date formatting.
     ///

--- a/components/datetime/src/scaffold/fieldset_traits.rs
+++ b/components/datetime/src/scaffold/fieldset_traits.rs
@@ -186,7 +186,7 @@ pub trait DateTimeMarkers: UnstableSealed + DateTimeNamesMarker {
 /// - [`TimeZoneInfo`](icu_timezone::TimeZoneInfo)
 ///
 /// [`fieldsets::YMD`]: crate::fieldsets::YMD
-// This trait is implicitly sealed due to its blanket impl
+// This trait is implicitly sealed due to sealed supertraits
 pub trait AllInputMarkers<R: DateTimeMarkers>:
     GetField<<R::D as DateInputMarkers>::YearInput>
     + GetField<<R::D as DateInputMarkers>::MonthInput>

--- a/components/datetime/src/scaffold/fieldset_traits.rs
+++ b/components/datetime/src/scaffold/fieldset_traits.rs
@@ -186,7 +186,7 @@ pub trait DateTimeMarkers: UnstableSealed + DateTimeNamesMarker {
 /// - [`TimeZoneInfo`](icu_timezone::TimeZoneInfo)
 ///
 /// [`fieldsets::YMD`]: crate::fieldsets::YMD
-// This trait is implicitly sealed due to its blanket impl
+// This trait is implicitly sealed due to sealed supertraits
 pub trait AllInputMarkers<R: DateTimeMarkers>:
     GetField<<R::D as DateInputMarkers>::YearInput>
     + GetField<<R::D as DateInputMarkers>::MonthInput>
@@ -235,7 +235,7 @@ where
 ///
 /// This trait is implemented on all providers that support datetime formatting,
 /// including [`crate::provider::Baked`].
-// This trait is implicitly sealed due to its blanket impl
+// This trait is implicitly sealed due to sealed supertraits
 pub trait AllFixedCalendarFormattingDataMarkers<C: CldrCalendar, FSet: DateTimeMarkers>:
     DataProvider<<FSet::D as TypedDateDataMarkers<C>>::YearNamesV1Marker>
     + DataProvider<<FSet::D as TypedDateDataMarkers<C>>::MonthNamesV1Marker>
@@ -288,7 +288,7 @@ where
 ///
 /// This trait is implemented on all providers that support datetime formatting,
 /// including [`crate::provider::Baked`].
-// This trait is implicitly sealed due to its blanket impl
+// This trait is implicitly sealed due to sealed supertraits
 pub trait AllAnyCalendarFormattingDataMarkers<FSet: DateTimeMarkers>:
     DataProvider<<<FSet::D as DateDataMarkers>::Year as CalMarkers<YearNamesV1Marker>>::Buddhist>
     + DataProvider<<<FSet::D as DateDataMarkers>::Year as CalMarkers<YearNamesV1Marker>>::Chinese>
@@ -433,7 +433,7 @@ where
 
 /// Trait to consolidate data provider markers external to this crate
 /// for datetime formatting with a fixed calendar.
-// This trait is implicitly sealed due to its blanket impl
+// This trait is implicitly sealed due to sealed supertraits
 pub trait AllFixedCalendarExternalDataMarkers:
     DataProvider<DecimalSymbolsV2Marker> + DataProvider<DecimalDigitsV1Marker>
 {
@@ -446,7 +446,7 @@ impl<T> AllFixedCalendarExternalDataMarkers for T where
 
 /// Trait to consolidate data provider markers external to this crate
 /// for datetime formatting with any calendar.
-// This trait is implicitly sealed due to its blanket impl
+// This trait is implicitly sealed due to sealed supertraits
 pub trait AllAnyCalendarExternalDataMarkers:
     DataProvider<ChineseCacheV1Marker>
     + DataProvider<DangiCacheV1Marker>

--- a/components/datetime/src/scaffold/fieldset_traits.rs
+++ b/components/datetime/src/scaffold/fieldset_traits.rs
@@ -156,6 +156,7 @@ pub trait DateTimeMarkers: UnstableSealed + DateTimeNamesMarker {
 /// - [`TimeZoneInfo`](icu_timezone::TimeZoneInfo)
 ///
 /// [`fieldsets::YMD`]: crate::fieldsets::YMD
+// This trait is implicitly sealed due to its blanket impl
 pub trait AllInputMarkers<R: DateTimeMarkers>:
     GetField<<R::D as DateInputMarkers>::YearInput>
     + GetField<<R::D as DateInputMarkers>::MonthInput>
@@ -204,6 +205,7 @@ where
 ///
 /// This trait is implemented on all providers that support datetime formatting,
 /// including [`crate::provider::Baked`].
+// This trait is implicitly sealed due to its blanket impl
 pub trait AllFixedCalendarFormattingDataMarkers<C: CldrCalendar, FSet: DateTimeMarkers>:
     DataProvider<<FSet::D as TypedDateDataMarkers<C>>::YearNamesV1Marker>
     + DataProvider<<FSet::D as TypedDateDataMarkers<C>>::MonthNamesV1Marker>
@@ -256,6 +258,7 @@ where
 ///
 /// This trait is implemented on all providers that support datetime formatting,
 /// including [`crate::provider::Baked`].
+// This trait is implicitly sealed due to its blanket impl
 pub trait AllAnyCalendarFormattingDataMarkers<FSet: DateTimeMarkers>:
     DataProvider<<<FSet::D as DateDataMarkers>::Year as CalMarkers<YearNamesV1Marker>>::Buddhist>
     + DataProvider<<<FSet::D as DateDataMarkers>::Year as CalMarkers<YearNamesV1Marker>>::Chinese>
@@ -400,6 +403,7 @@ where
 
 /// Trait to consolidate data provider markers external to this crate
 /// for datetime formatting with a fixed calendar.
+// This trait is implicitly sealed due to its blanket impl
 pub trait AllFixedCalendarExternalDataMarkers:
     DataProvider<DecimalSymbolsV2Marker> + DataProvider<DecimalDigitsV1Marker>
 {
@@ -412,6 +416,7 @@ impl<T> AllFixedCalendarExternalDataMarkers for T where
 
 /// Trait to consolidate data provider markers external to this crate
 /// for datetime formatting with any calendar.
+// This trait is implicitly sealed due to its blanket impl
 pub trait AllAnyCalendarExternalDataMarkers:
     DataProvider<ChineseCacheV1Marker>
     + DataProvider<DangiCacheV1Marker>

--- a/components/datetime/src/scaffold/fieldset_traits.rs
+++ b/components/datetime/src/scaffold/fieldset_traits.rs
@@ -31,7 +31,7 @@ use icu_timezone::{
 ///
 /// <div class="stab unstable">
 /// 🚧 This trait is considered unstable; it may change at any time, in breaking or non-breaking ways,
-/// including in SemVer minor releases. Do not implement this trait in userland.
+/// including in SemVer minor releases. Do not implement this trait in userland unless you are prepared for things to occasionally break.
 /// </div>
 pub trait DateInputMarkers: UnstableSealed {
     /// Marker for resolving the year input field.
@@ -53,7 +53,7 @@ pub trait DateInputMarkers: UnstableSealed {
 ///
 /// <div class="stab unstable">
 /// 🚧 This trait is considered unstable; it may change at any time, in breaking or non-breaking ways,
-/// including in SemVer minor releases. Do not implement this trait in userland.
+/// including in SemVer minor releases. Do not implement this trait in userland unless you are prepared for things to occasionally break.
 /// </div>
 pub trait TypedDateDataMarkers<C>: UnstableSealed {
     /// Marker for loading date skeleton patterns.
@@ -73,7 +73,7 @@ pub trait TypedDateDataMarkers<C>: UnstableSealed {
 ///
 /// <div class="stab unstable">
 /// 🚧 This trait is considered unstable; it may change at any time, in breaking or non-breaking ways,
-/// including in SemVer minor releases. Do not implement this trait in userland.
+/// including in SemVer minor releases. Do not implement this trait in userland unless you are prepared for things to occasionally break.
 /// </div>
 pub trait DateDataMarkers: UnstableSealed {
     /// Cross-calendar data markers for date skeleta.
@@ -93,7 +93,7 @@ pub trait DateDataMarkers: UnstableSealed {
 ///
 /// <div class="stab unstable">
 /// 🚧 This trait is considered unstable; it may change at any time, in breaking or non-breaking ways,
-/// including in SemVer minor releases. Do not implement this trait in userland.
+/// including in SemVer minor releases. Do not implement this trait in userland unless you are prepared for things to occasionally break.
 /// </div>
 pub trait TimeMarkers: UnstableSealed {
     /// Marker for resolving the day-of-month input field.
@@ -117,7 +117,7 @@ pub trait TimeMarkers: UnstableSealed {
 ///
 /// <div class="stab unstable">
 /// 🚧 This trait is considered unstable; it may change at any time, in breaking or non-breaking ways,
-/// including in SemVer minor releases. Do not implement this trait in userland.
+/// including in SemVer minor releases. Do not implement this trait in userland unless you are prepared for things to occasionally break.
 /// </div>
 pub trait ZoneMarkers: UnstableSealed {
     /// Marker for resolving the time zone id input field.
@@ -151,7 +151,7 @@ pub trait ZoneMarkers: UnstableSealed {
 ///
 /// <div class="stab unstable">
 /// 🚧 This trait is considered unstable; it may change at any time, in breaking or non-breaking ways,
-/// including in SemVer minor releases. Do not implement this trait in userland.
+/// including in SemVer minor releases. Do not implement this trait in userland unless you are prepared for things to occasionally break.
 /// </div>
 pub trait DateTimeMarkers: UnstableSealed + DateTimeNamesMarker {
     /// Associated types for date formatting.

--- a/components/datetime/src/scaffold/fieldset_traits.rs
+++ b/components/datetime/src/scaffold/fieldset_traits.rs
@@ -186,7 +186,7 @@ pub trait DateTimeMarkers: UnstableSealed + DateTimeNamesMarker {
 /// - [`TimeZoneInfo`](icu_timezone::TimeZoneInfo)
 ///
 /// [`fieldsets::YMD`]: crate::fieldsets::YMD
-// This trait is implicitly sealed due to sealed supertraits
+// This trait is implicitly sealed due to its blanket impl
 pub trait AllInputMarkers<R: DateTimeMarkers>:
     GetField<<R::D as DateInputMarkers>::YearInput>
     + GetField<<R::D as DateInputMarkers>::MonthInput>

--- a/components/datetime/src/scaffold/get_field.rs
+++ b/components/datetime/src/scaffold/get_field.rs
@@ -17,6 +17,11 @@ use super::UnstableSealed;
 /// A type that can return a certain field `T`.
 ///
 /// This is used as a bound on various datetime functions.
+///
+/// <div class="stab unstable">
+/// 🚧 This trait is considered unstable; it may change at any time, in breaking or non-breaking ways,
+/// including in SemVer minor releases. Do not implement this trait in userland.
+/// </div>
 pub trait GetField<T>: UnstableSealed {
     /// Returns the value of this trait's field `T`.
     fn get_field(&self) -> T;

--- a/components/datetime/src/scaffold/get_field.rs
+++ b/components/datetime/src/scaffold/get_field.rs
@@ -20,7 +20,7 @@ use super::UnstableSealed;
 ///
 /// <div class="stab unstable">
 /// 🚧 This trait is considered unstable; it may change at any time, in breaking or non-breaking ways,
-/// including in SemVer minor releases. Do not implement this trait in userland.
+/// including in SemVer minor releases. Do not implement this trait in userland unless you are prepared for things to occasionally break.
 /// </div>
 pub trait GetField<T>: UnstableSealed {
     /// Returns the value of this trait's field `T`.

--- a/components/datetime/src/scaffold/mod.rs
+++ b/components/datetime/src/scaffold/mod.rs
@@ -51,6 +51,6 @@ pub(crate) use names_storage::OptionalNames;
 ///
 /// <div class="stab unstable">
 /// 🚧 This trait is considered unstable; it may change at any time, in breaking or non-breaking ways,
-/// including in SemVer minor releases. Do not implement this trait in userland.
+/// including in SemVer minor releases. Do not implement this trait in userland unless you are prepared for things to occasionally break.
 /// </div>
 pub trait UnstableSealed {}

--- a/components/datetime/src/scaffold/names_storage.rs
+++ b/components/datetime/src/scaffold/names_storage.rs
@@ -334,6 +334,7 @@ where
 /// is_trait_implemented::<TimeFieldSet, CompositeFieldSet>();
 /// ```
 #[allow(missing_docs)]
+// This trait is implicitly sealed by deriving from a sealed trait
 pub trait DateTimeNamesFrom<M: DateTimeNamesMarker>: DateTimeNamesMarker {
     fn map_year_names(
         other: <M::YearNames as NamesContainer<YearNamesV1Marker, YearNameLength>>::Container,

--- a/components/datetime/src/scaffold/names_storage.rs
+++ b/components/datetime/src/scaffold/names_storage.rs
@@ -22,7 +22,7 @@ use super::UnstableSealed;
 ///
 /// <div class="stab unstable">
 /// 🚧 This trait is considered unstable; it may change at any time, in breaking or non-breaking ways,
-/// including in SemVer minor releases. Do not implement this trait in userland.
+/// including in SemVer minor releases. Do not implement this trait in userland unless you are prepared for things to occasionally break.
 /// </div>
 #[allow(missing_docs)]
 pub trait DateTimeNamesMarker: UnstableSealed {
@@ -43,7 +43,7 @@ pub trait DateTimeNamesMarker: UnstableSealed {
 ///
 /// <div class="stab unstable">
 /// 🚧 This trait is considered unstable; it may change at any time, in breaking or non-breaking ways,
-/// including in SemVer minor releases. Do not implement this trait in userland.
+/// including in SemVer minor releases. Do not implement this trait in userland unless you are prepared for things to occasionally break.
 /// </div>
 #[allow(missing_docs)]
 pub trait NamesContainer<M: DynamicDataMarker, Variables>: UnstableSealed
@@ -113,7 +113,7 @@ impl MaybePayloadError {
 ///
 /// <div class="stab unstable">
 /// 🚧 This trait is considered unstable; it may change at any time, in breaking or non-breaking ways,
-/// including in SemVer minor releases. Do not implement this trait in userland.
+/// including in SemVer minor releases. Do not implement this trait in userland unless you are prepared for things to occasionally break.
 /// </div>
 #[allow(missing_docs)]
 pub trait MaybePayload<M: DynamicDataMarker, Variables>: UnstableSealed {

--- a/components/datetime/src/scaffold/names_storage.rs
+++ b/components/datetime/src/scaffold/names_storage.rs
@@ -19,6 +19,11 @@ use super::UnstableSealed;
 /// This trait allows for types that contain data for some but not all types of datetime names,
 /// allowing for reduced stack size. For example, a type could contain year and month names but
 /// not weekday, day period, or time zone names.
+///
+/// <div class="stab unstable">
+/// 🚧 This trait is considered unstable; it may change at any time, in breaking or non-breaking ways,
+/// including in SemVer minor releases. Do not implement this trait in userland.
+/// </div>
 #[allow(missing_docs)]
 pub trait DateTimeNamesMarker: UnstableSealed {
     type YearNames: NamesContainer<YearNamesV1Marker, YearNameLength>;
@@ -35,6 +40,11 @@ pub trait DateTimeNamesMarker: UnstableSealed {
 }
 
 /// Trait that associates a container for a payload parameterized by the given variables.
+///
+/// <div class="stab unstable">
+/// 🚧 This trait is considered unstable; it may change at any time, in breaking or non-breaking ways,
+/// including in SemVer minor releases. Do not implement this trait in userland.
+/// </div>
 #[allow(missing_docs)]
 pub trait NamesContainer<M: DynamicDataMarker, Variables>: UnstableSealed
 where
@@ -100,6 +110,11 @@ impl MaybePayloadError {
 /// a value depending on the type parameter `Variables`.
 ///
 /// Helper trait for [`DateTimeNamesMarker`].
+///
+/// <div class="stab unstable">
+/// 🚧 This trait is considered unstable; it may change at any time, in breaking or non-breaking ways,
+/// including in SemVer minor releases. Do not implement this trait in userland.
+/// </div>
 #[allow(missing_docs)]
 pub trait MaybePayload<M: DynamicDataMarker, Variables>: UnstableSealed {
     fn new_empty() -> Self;

--- a/components/datetime/src/scaffold/names_storage.rs
+++ b/components/datetime/src/scaffold/names_storage.rs
@@ -349,7 +349,7 @@ where
 /// is_trait_implemented::<TimeFieldSet, CompositeFieldSet>();
 /// ```
 #[allow(missing_docs)]
-// This trait is implicitly sealed by deriving from a sealed trait
+// This trait is implicitly sealed due to sealed supertraits
 pub trait DateTimeNamesFrom<M: DateTimeNamesMarker>: DateTimeNamesMarker {
     fn map_year_names(
         other: <M::YearNames as NamesContainer<YearNamesV1Marker, YearNameLength>>::Container,

--- a/components/experimental/src/transliterate/transliterator/replaceable.rs
+++ b/components/experimental/src/transliterate/transliterator/replaceable.rs
@@ -579,6 +579,11 @@ pub(super) struct Reverse;
 /// The direction a match can be applied. Used in [`Utf8Matcher`].
 ///
 /// See [`Forward`] and [`Reverse`] for implementors.
+///
+/// <div class="stab unstable">
+/// 🚫 This trait is sealed; it cannot be implemented by user code. If an API requests an item that implements this
+/// trait, please consider using a type from the implementors listed below.
+/// </div>
 pub(super) trait MatchDirection: sealed::Sealed {}
 impl MatchDirection for Forward {}
 impl MatchDirection for Reverse {}

--- a/components/pattern/src/common.rs
+++ b/components/pattern/src/common.rs
@@ -115,6 +115,8 @@ pub trait PatternBackend: crate::private::Sealed + 'static + core::fmt::Debug {
 /// This trait can add [`Part`]s for individual literals or placeholders. The implementations
 /// of this trait on standard types do not add any [`Part`]s.
 ///
+/// This trait is not implementable by user code due to the blanket impl.
+///
 /// # Examples
 ///
 /// A custom implementation that adds parts:

--- a/components/pattern/src/common.rs
+++ b/components/pattern/src/common.rs
@@ -62,6 +62,11 @@ where
 ///
 /// The trait has no public methods and is not implementable outside of this crate.
 ///
+/// <div class="stab unstable">
+/// 🚫 This trait is sealed; it cannot be implemented by user code. If an API requests an item that implements this
+/// trait, please consider using a type from the implementors listed below.
+/// </div>
+///
 /// [`Pattern`]: crate::Pattern
 // Debug so that `#[derive(Debug)]` on types generic in `PatternBackend` works
 pub trait PatternBackend: crate::private::Sealed + 'static + core::fmt::Debug {

--- a/components/pattern/src/common.rs
+++ b/components/pattern/src/common.rs
@@ -120,7 +120,7 @@ pub trait PatternBackend: crate::private::Sealed + 'static + core::fmt::Debug {
 /// This trait can add [`Part`]s for individual literals or placeholders. The implementations
 /// of this trait on standard types do not add any [`Part`]s.
 ///
-/// This trait is not implementable by user code due to the blanket impl.
+/// This trait has a blanket implementation and is therefore not implementable by user code.
 ///
 /// # Examples
 ///

--- a/components/properties/src/code_point_map.rs
+++ b/components/properties/src/code_point_map.rs
@@ -342,6 +342,11 @@ impl<'a> CodePointMapDataBorrowed<'a, GeneralCategory> {
 /// The descriptions of most properties are taken from [`TR44`], the documentation for the
 /// Unicode Character Database.
 ///
+/// <div class="stab unstable">
+/// 🚫 This trait is sealed; it cannot be implemented by user code. If an API requests an item that implements this
+/// trait, please consider using a type from the implementors listed below.
+/// </div>
+///
 /// [`TR44`]: https://www.unicode.org/reports/tr44
 pub trait EnumeratedProperty: crate::private::Sealed + TrieValue {
     #[doc(hidden)]

--- a/components/properties/src/code_point_set.rs
+++ b/components/properties/src/code_point_set.rs
@@ -204,6 +204,11 @@ impl<'a> CodePointSetDataBorrowed<'a> {
 /// documentation for Unicode regular expressions. In particular, Annex C of this document
 /// defines properties for POSIX compatibility.
 ///
+/// <div class="stab unstable">
+/// 🚫 This trait is sealed; it cannot be implemented by user code. If an API requests an item that implements this
+/// trait, please consider using a type from the implementors listed below.
+/// </div>
+///
 /// [`CodePointSetData`]: crate::sets::CodePointSetData
 /// [`TR44`]: https://www.unicode.org/reports/tr44
 /// [`TR18`]: https://www.unicode.org/reports/tr18

--- a/components/properties/src/emoji.rs
+++ b/components/properties/src/emoji.rs
@@ -144,6 +144,11 @@ impl EmojiSetDataBorrowed<'static> {
 }
 
 /// An Emoji set as defined by [`Unicode Technical Standard #51`](https://unicode.org/reports/tr51/#Emoji_Sets>).
+///
+/// <div class="stab unstable">
+/// 🚫 This trait is sealed; it cannot be implemented by user code. If an API requests an item that implements this
+/// trait, please consider using a type from the implementors listed below.
+/// </div>
 pub trait EmojiSet: crate::private::Sealed {
     #[doc(hidden)]
     type DataMarker: DataMarker<DataStruct = PropertyUnicodeSetV1<'static>>;

--- a/components/properties/src/names.rs
+++ b/components/properties/src/names.rs
@@ -650,6 +650,7 @@ pub trait ParseableEnumeratedProperty: crate::private::Sealed + TrieValue {
 }
 
 // Abstract over Linear/Sparse/Script representation
+// This trait is implicitly sealed by not being exported.
 pub trait PropertyEnumToValueNameLookup {
     fn get(&self, prop: u32) -> Option<&str>;
 }

--- a/components/segmenter/src/lib.rs
+++ b/components/segmenter/src/lib.rs
@@ -167,3 +167,14 @@ pub use crate::word::WordBreakIteratorLatin1;
 pub use crate::word::WordBreakIteratorPotentiallyIllFormedUtf8;
 pub use crate::word::WordBreakIteratorUtf16;
 pub use crate::word::WordBreakIteratorUtf8;
+
+pub(crate) mod private {
+    /// Trait marking other traits that are considered unstable and should not generally be
+    /// implemented outside of the segmenter crate.
+    ///
+    /// <div class="stab unstable">
+    /// 🚧 This trait is considered unstable; it may change at any time, in breaking or non-breaking ways,
+    /// including in SemVer minor releases. Do not implement this trait in userland.
+    /// </div>
+    pub trait Sealed {}
+}

--- a/components/segmenter/src/lib.rs
+++ b/components/segmenter/src/lib.rs
@@ -171,10 +171,5 @@ pub use crate::word::WordBreakIteratorUtf8;
 pub(crate) mod private {
     /// Trait marking other traits that are considered unstable and should not generally be
     /// implemented outside of the segmenter crate.
-    ///
-    /// <div class="stab unstable">
-    /// 🚧 This trait is considered unstable; it may change at any time, in breaking or non-breaking ways,
-    /// including in SemVer minor releases. Do not implement this trait in userland.
-    /// </div>
     pub trait Sealed {}
 }

--- a/components/segmenter/src/line.rs
+++ b/components/segmenter/src/line.rs
@@ -715,7 +715,12 @@ fn is_break_utf32_by_loose(
 /// A trait allowing for LineBreakIterator to be generalized to multiple string iteration methods.
 ///
 /// This is implemented by ICU4X for several common string types.
-pub trait LineBreakType<'l, 's> {
+///
+/// <div class="stab unstable">
+/// 🚫 This trait is sealed; it cannot be implemented by user code. If an API requests an item that implements this
+/// trait, please consider using a type from the implementors listed below.
+/// </div>
+pub trait LineBreakType<'l, 's>: crate::private::Sealed {
     /// The iterator over characters.
     type IterAttr: Iterator<Item = (usize, Self::CharType)> + Clone;
 
@@ -1065,6 +1070,8 @@ impl<'l, 's, Y: LineBreakType<'l, 's>> LineBreakIterator<'l, 's, Y> {
 #[derive(Debug)]
 pub struct LineBreakTypeUtf8;
 
+impl crate::private::Sealed for LineBreakTypeUtf8 {}
+
 impl<'l, 's> LineBreakType<'l, 's> for LineBreakTypeUtf8 {
     type IterAttr = CharIndices<'s>;
     type CharType = char;
@@ -1096,6 +1103,8 @@ impl<'l, 's> LineBreakType<'l, 's> for LineBreakTypeUtf8 {
 
 #[derive(Debug)]
 pub struct LineBreakTypePotentiallyIllFormedUtf8;
+
+impl crate::private::Sealed for LineBreakTypePotentiallyIllFormedUtf8 {}
 
 impl<'l, 's> LineBreakType<'l, 's> for LineBreakTypePotentiallyIllFormedUtf8 {
     type IterAttr = Utf8CharIndices<'s>;
@@ -1181,6 +1190,7 @@ where
 
 #[derive(Debug)]
 pub struct LineBreakTypeLatin1;
+impl crate::private::Sealed for LineBreakTypeLatin1 {}
 
 impl<'s> LineBreakType<'_, 's> for LineBreakTypeLatin1 {
     type IterAttr = Latin1Indices<'s>;
@@ -1211,6 +1221,7 @@ impl<'s> LineBreakType<'_, 's> for LineBreakTypeLatin1 {
 
 #[derive(Debug)]
 pub struct LineBreakTypeUtf16;
+impl crate::private::Sealed for LineBreakTypeUtf16 {}
 
 impl<'s> LineBreakType<'_, 's> for LineBreakTypeUtf16 {
     type IterAttr = Utf16Indices<'s>;

--- a/components/segmenter/src/line.rs
+++ b/components/segmenter/src/line.rs
@@ -727,15 +727,19 @@ pub trait LineBreakType<'l, 's>: crate::private::Sealed {
     /// The character type.
     type CharType: Copy + Into<u32>;
 
+    #[doc(hidden)]
     fn use_complex_breaking(iterator: &LineBreakIterator<'l, 's, Self>, c: Self::CharType) -> bool;
 
+    #[doc(hidden)]
     fn get_linebreak_property_with_rule(
         iterator: &LineBreakIterator<'l, 's, Self>,
         c: Self::CharType,
     ) -> u8;
 
+    #[doc(hidden)]
     fn get_current_position_character_len(iterator: &LineBreakIterator<'l, 's, Self>) -> usize;
 
+    #[doc(hidden)]
     fn handle_complex_language(
         iterator: &mut LineBreakIterator<'l, 's, Self>,
         left_codepoint: Self::CharType,

--- a/components/segmenter/src/rule_segmenter.rs
+++ b/components/segmenter/src/rule_segmenter.rs
@@ -23,8 +23,10 @@ pub trait RuleBreakType<'l, 's>: crate::private::Sealed {
     /// The character type.
     type CharType: Copy + Into<u32> + core::fmt::Debug;
 
+    #[doc(hidden)]
     fn get_current_position_character_len(iter: &RuleBreakIterator<'l, 's, Self>) -> usize;
 
+    #[doc(hidden)]
     fn handle_complex_language(
         iter: &mut RuleBreakIterator<'l, 's, Self>,
         left_codepoint: Self::CharType,

--- a/components/segmenter/src/rule_segmenter.rs
+++ b/components/segmenter/src/rule_segmenter.rs
@@ -11,7 +11,12 @@ use utf8_iter::Utf8CharIndices;
 
 /// A trait allowing for RuleBreakIterator to be generalized to multiple string
 /// encoding methods and granularity such as grapheme cluster, word, etc.
-pub trait RuleBreakType<'l, 's> {
+///
+/// <div class="stab unstable">
+/// 🚫 This trait is sealed; it cannot be implemented by user code. If an API requests an item that implements this
+/// trait, please consider using a type from the implementors listed below.
+/// </div>
+pub trait RuleBreakType<'l, 's>: crate::private::Sealed {
     /// The iterator over characters.
     type IterAttr: Iterator<Item = (usize, Self::CharType)> + Clone + core::fmt::Debug;
 
@@ -258,6 +263,8 @@ impl<'l, 's, Y: RuleBreakType<'l, 's> + ?Sized> RuleBreakIterator<'l, 's, Y> {
 #[derive(Debug)]
 pub struct RuleBreakTypeUtf8;
 
+impl crate::private::Sealed for RuleBreakTypeUtf8 {}
+
 impl<'s> RuleBreakType<'_, 's> for RuleBreakTypeUtf8 {
     type IterAttr = CharIndices<'s>;
     type CharType = char;
@@ -276,6 +283,8 @@ impl<'s> RuleBreakType<'_, 's> for RuleBreakTypeUtf8 {
 
 #[derive(Debug)]
 pub struct RuleBreakTypePotentiallyIllFormedUtf8;
+
+impl crate::private::Sealed for RuleBreakTypePotentiallyIllFormedUtf8 {}
 
 impl<'s> RuleBreakType<'_, 's> for RuleBreakTypePotentiallyIllFormedUtf8 {
     type IterAttr = Utf8CharIndices<'s>;
@@ -296,6 +305,8 @@ impl<'s> RuleBreakType<'_, 's> for RuleBreakTypePotentiallyIllFormedUtf8 {
 #[derive(Debug)]
 pub struct RuleBreakTypeLatin1;
 
+impl crate::private::Sealed for RuleBreakTypeLatin1 {}
+
 impl<'s> RuleBreakType<'_, 's> for RuleBreakTypeLatin1 {
     type IterAttr = Latin1Indices<'s>;
     type CharType = u8;
@@ -314,6 +325,8 @@ impl<'s> RuleBreakType<'_, 's> for RuleBreakTypeLatin1 {
 
 #[derive(Debug)]
 pub struct RuleBreakTypeUtf16;
+
+impl crate::private::Sealed for RuleBreakTypeUtf16 {}
 
 impl<'s> RuleBreakType<'_, 's> for RuleBreakTypeUtf16 {
     type IterAttr = Utf16Indices<'s>;

--- a/components/segmenter/src/word.rs
+++ b/components/segmenter/src/word.rs
@@ -546,6 +546,7 @@ impl WordSegmenter {
 
 #[derive(Debug)]
 pub struct WordBreakTypeUtf8;
+impl crate::private::Sealed for WordBreakTypeUtf8 {}
 
 impl<'l, 's> RuleBreakType<'l, 's> for WordBreakTypeUtf8 {
     type IterAttr = CharIndices<'s>;
@@ -565,6 +566,7 @@ impl<'l, 's> RuleBreakType<'l, 's> for WordBreakTypeUtf8 {
 
 #[derive(Debug)]
 pub struct WordBreakTypePotentiallyIllFormedUtf8;
+impl crate::private::Sealed for WordBreakTypePotentiallyIllFormedUtf8 {}
 
 impl<'l, 's> RuleBreakType<'l, 's> for WordBreakTypePotentiallyIllFormedUtf8 {
     type IterAttr = Utf8CharIndices<'s>;
@@ -639,6 +641,8 @@ where
 
 #[derive(Debug)]
 pub struct WordBreakTypeUtf16;
+
+impl crate::private::Sealed for WordBreakTypeUtf16 {}
 
 impl<'s> RuleBreakType<'_, 's> for WordBreakTypeUtf16 {
     type IterAttr = Utf16Indices<'s>;

--- a/components/timezone/src/time_zone.rs
+++ b/components/timezone/src/time_zone.rs
@@ -12,6 +12,11 @@ mod private {
 }
 
 /// Trait encoding a particular data model for time zones.
+///
+/// <div class="stab unstable">
+/// 🚫 This trait is sealed; it cannot be implemented by user code. If an API requests an item that implements this
+/// trait, please consider using a type from the implementors listed below.
+/// </div>
 pub trait TimeZoneModel: private::Sealed {
     /// The zone variant, if required for this time zone model.
     type ZoneVariant: IntoOption<ZoneVariant> + fmt::Debug + Copy;


### PR DESCRIPTION
Fixes #4338

This:

 - Adds a doc header to all sealed traits
 - Adds a (different) doc header to all UnstableSealed traits
 - Ensures all sealed traits have hidden methods
 - Seals the segmenter type traits since they're implementing a "compile time enum" pattern
 - Audits the rest of the traits and adds comments explaining that they are explicitly implementable (or de-facto sealed by dint of having a blanket impl)
 - Makes CldrCalendar Sealed instead of UnstableSealed



Thought: We have other traits in Datetime that are UnstableSealed:

 - Traits implemented on datetime types, like GetField. These make sense to be unstablesealed for external clients
 - Traits implemented on fieldsets, like `FooMarkers`. I'm not sure if we expect users to make custom fieldset types?
 - Traits implemented on marker types, like `NamesContainer`. I don't see a purpose for these being unstable-sealed


IMO sealed traits should be fully-sealed unless we have a good argument for custom implementability. We have that argument for GetField, we _may_ have that argument for `FooMarkers`, I don't think we have it for `NamesContainer`. Thoughts?


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->