### PR TITLE
Move FilesystemExporter from trait object to generic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1590,6 +1590,7 @@ dependencies = [
  "crlify",
  "displaydoc",
  "icu_benchmark_macros",
+ "icu_locale",
  "icu_locale_core",
  "icu_provider",
  "icu_provider_export",

--- a/provider/fs/Cargo.toml
+++ b/provider/fs/Cargo.toml
@@ -36,6 +36,7 @@ serde_json = { workspace = true, features = ["std"], optional = true }
 [dev-dependencies]
 icu_benchmark_macros = { path = "../../tools/benchmark/macros" }
 icu_locale_core = { path = "../../components/locale_core", default-features = false, features = ["serde"] }
+icu_locale = { path = "../../components/locale", default-features = false, features = ["compiled_data"] }
 icu_provider = { path = "../../provider/core", default-features = false, features = ["deserialize_json", "deserialize_bincode_1", "deserialize_postcard_1", "export"] }
 icu_provider_export = { path = "../../provider/export", default-features = false }
 writeable = { path = "../../utils/writeable" }

--- a/provider/fs/src/export/fs_exporter.rs
+++ b/provider/fs/src/export/fs_exporter.rs
@@ -61,23 +61,20 @@ impl From<PathBuf> for Options {
 /// A data exporter that writes data to a filesystem hierarchy.
 /// See the module-level docs for an example.
 #[derive(Debug)]
-pub struct FilesystemExporter {
+pub struct FilesystemExporter<Serializer> {
     root: PathBuf,
     manifest: Manifest,
-    serializer: Box<dyn AbstractSerializer + Sync>,
+    serializer: Serializer,
 }
 
-impl FilesystemExporter {
+impl<Serializer: AbstractSerializer> FilesystemExporter<Serializer> {
     /// Creates a new [`FilesystemExporter`] with a [serializer] and [options].
     ///
     /// See the module-level docs for an example.
     ///
     /// [serializer]: crate::export::serializers
     /// [options]: Options
-    pub fn try_new(
-        serializer: Box<dyn AbstractSerializer + Sync>,
-        options: Options,
-    ) -> Result<Self, DataError> {
+    pub fn try_new(serializer: Serializer, options: Options) -> Result<Self, DataError> {
         let result = FilesystemExporter {
             root: options.root,
             manifest: Manifest::for_format(serializer.get_buffer_format())?,
@@ -99,7 +96,7 @@ impl FilesystemExporter {
     }
 }
 
-impl DataExporter for FilesystemExporter {
+impl<Serializer: AbstractSerializer + Sync> DataExporter for FilesystemExporter<Serializer> {
     fn put_payload(
         &self,
         marker: DataMarkerInfo,

--- a/provider/fs/src/export/mod.rs
+++ b/provider/fs/src/export/mod.rs
@@ -21,7 +21,7 @@
 //! // Set up the exporter
 //! let mut options = Options::default();
 //! options.root = demo_path.clone();
-//! let serializer = Box::new(serializers::Json::default());
+//! let serializer = serializers::Json::default();
 //! let mut exporter = FilesystemExporter::try_new(serializer, options)
 //!     .expect("Should successfully initialize data output directory");
 //!

--- a/provider/fs/src/export/serializers/bincode.rs
+++ b/provider/fs/src/export/serializers/bincode.rs
@@ -24,7 +24,7 @@ use std::io;
 /// // Then pass it to a FilesystemExporter:
 /// let demo_path = std::env::temp_dir().join("icu4x_bincode_serializer_demo");
 /// FilesystemExporter::try_new(
-///     Box::from(serializer),
+///     serializer,
 ///     demo_path.clone().into(),
 /// )
 /// .unwrap();

--- a/provider/fs/src/export/serializers/json.rs
+++ b/provider/fs/src/export/serializers/json.rs
@@ -34,7 +34,7 @@ pub enum StyleOption {
 /// // Then pass it to a FilesystemExporter:
 /// let demo_path = std::env::temp_dir().join("icu4x_json_serializer_demo");
 /// FilesystemExporter::try_new(
-///     Box::from(serializer),
+///     serializer,
 ///     demo_path.clone().into(),
 /// )
 /// .unwrap();

--- a/provider/fs/src/export/serializers/postcard.rs
+++ b/provider/fs/src/export/serializers/postcard.rs
@@ -24,7 +24,7 @@ use std::io;
 /// // Then pass it to a FilesystemExporter:
 /// let demo_path = std::env::temp_dir().join("icu4x_postcard_serializer_demo");
 /// FilesystemExporter::try_new(
-///     Box::from(serializer),
+///     serializer,
 ///     demo_path.clone().into(),
 /// )
 /// .unwrap();


### PR DESCRIPTION
I don't know why we wanted to do this, but it's listed in https://github.com/unicode-org/icu4x/issues/2856 so I did it. Feel free to close if we don't want to do it anymore.


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->