### PR TITLE
Remove mutable era style

### DIFF
--- a/components/calendar/src/ethiopian.rs
+++ b/components/calendar/src/ethiopian.rs
@@ -241,10 +241,6 @@ impl Ethiopian {
     pub const fn new_with_era_style(era_style: EthiopianEraStyle) -> Self {
         Self(matches!(era_style, EthiopianEraStyle::AmeteAlem))
     }
-    /// Set whether or not this uses the Amete Alem era scheme
-    pub fn set_era_style(&mut self, era_style: EthiopianEraStyle) {
-        self.0 = era_style == EthiopianEraStyle::AmeteAlem
-    }
 
     /// Returns whether this has the Amete Alem era
     pub fn era_style(&self) -> EthiopianEraStyle {


### PR DESCRIPTION
Part of https://github.com/unicode-org/icu4x/issues/2856

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->