### PR TITLE
Add explicit features list to tinystr

### DIFF
--- a/utils/tinystr/Cargo.toml
+++ b/utils/tinystr/Cargo.toml
@@ -41,6 +41,9 @@ criterion = { workspace = true }
 [features]
 default = ["alloc"]
 alloc = []
+zerovec = ["dep:zerovec"]
+databake = ["dep:databake"]
+serde = ["dep:serde"]
 
 [lib]
 bench = false  # This option is required for Benchmark CI


### PR DESCRIPTION
At this point we should always be using `dep:` to avoid confusion, and it helps when people are looking at the features list.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->