### PR TITLE
Use longer lifetime when returning normalize iter

### DIFF
--- a/components/normalizer/src/lib.rs
+++ b/components/normalizer/src/lib.rs
@@ -1763,10 +1763,10 @@ impl DecomposingNormalizerBorrowed<'static> {
     }
 }
 
-impl DecomposingNormalizerBorrowed<'_> {
+impl<'data> DecomposingNormalizerBorrowed<'data> {
     /// Wraps a delegate iterator into a decomposing iterator
     /// adapter by using the data already held by this normalizer.
-    pub fn normalize_iter<I: Iterator<Item = char>>(&self, iter: I) -> Decomposition<I> {
+    pub fn normalize_iter<I: Iterator<Item = char>>(&self, iter: I) -> Decomposition<'data, I> {
         Decomposition::new_with_supplements(
             iter,
             self.decompositions,
@@ -2335,10 +2335,10 @@ impl ComposingNormalizerBorrowed<'static> {
     }
 }
 
-impl ComposingNormalizerBorrowed<'_> {
+impl<'data> ComposingNormalizerBorrowed<'data> {
     /// Wraps a delegate iterator into a composing iterator
     /// adapter by using the data already held by this normalizer.
-    pub fn normalize_iter<I: Iterator<Item = char>>(&self, iter: I) -> Composition<I> {
+    pub fn normalize_iter<I: Iterator<Item = char>>(&self, iter: I) -> Composition<'data, I> {
         self.normalize_iter_private(iter, IgnorableBehavior::Unsupported)
     }
 
@@ -2346,7 +2346,7 @@ impl ComposingNormalizerBorrowed<'_> {
         &self,
         iter: I,
         ignorable_behavior: IgnorableBehavior,
-    ) -> Composition<I> {
+    ) -> Composition<'data, I> {
         Composition::new(
             Decomposition::new_with_supplements(
                 iter,


### PR DESCRIPTION
https://github.com/unicode-org/icu4x/discussions/6058

Nothing should borrow from the borrowed type, because the borrowed type should not own anything.