### PR TITLE
Handle currency pattern parsing with TODO for negative sub-pattern

### DIFF
--- a/provider/source/src/currency/essentials.rs
+++ b/provider/source/src/currency/essentials.rs
@@ -47,6 +47,9 @@ fn currency_pattern_selection(
         return Err(DataError::custom("Place holder value must not be empty"));
     }
 
+    // TODO(#6064): Handle the negative sub pattern.
+    let pattern = pattern.split(';').next().unwrap();
+
     let currency_sign = '¤';
     let currency_sign_index = pattern.find(currency_sign).unwrap();
     let first_num_index = pattern.find(['0', '#']).unwrap();


### PR DESCRIPTION
# Description:
Adds a temporary handling of currency pattern parsing by taking the first part of the pattern before any semicolon. Includes a TODO comment to address handling of negative sub-patterns in the future.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->