### PR TITLE
Add more BTreeMap like apis to LiteMap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1898,6 +1898,7 @@ dependencies = [
  "icu_benchmark_macros",
  "icu_locale_core",
  "postcard",
+ "rand",
  "rkyv",
  "serde",
  "serde_json",

--- a/utils/litemap/Cargo.toml
+++ b/utils/litemap/Cargo.toml
@@ -28,6 +28,7 @@ serde = { workspace = true, optional = true, features = ["alloc"]}
 yoke = { workspace = true, features = ["derive"], optional = true }
 
 [dev-dependencies]
+rand = { workspace = true }
 bincode = { workspace = true }
 icu_benchmark_macros = { path = "../../tools/benchmark/macros" }
 icu_locale_core = { path = "../../components/locale_core" }

--- a/utils/litemap/benches/litemap.rs
+++ b/utils/litemap/benches/litemap.rs
@@ -5,6 +5,7 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 use litemap::LiteMap;
+use rand::seq::SliceRandom;
 
 const DATA: [(&str, &str); 16] = [
     ("ar", "Arabic"),
@@ -57,6 +58,12 @@ fn overview_bench(c: &mut Criterion) {
     bench_deserialize_large(c);
     bench_lookup(c);
     bench_lookup_large(c);
+    bench_from_iter(c);
+    bench_from_iter_large(c);
+    bench_from_iter_sorted(c);
+    bench_from_iter_large_sorted(c);
+    bench_extend(c);
+    bench_extend_via_litemap(c);
 }
 
 fn build_litemap(large: bool) -> LiteMap<String, String> {
@@ -89,6 +96,81 @@ fn bench_deserialize_large(c: &mut Criterion) {
             let map: LiteMap<String, String> = postcard::from_bytes(black_box(&buf)).unwrap();
             assert_eq!(map.get("iu3333"), Some(&"Inuktitut".to_owned()));
         });
+    });
+}
+
+fn bench_from_iter(c: &mut Criterion) {
+    c.bench_function("litemap/from_iter/small", |b| {
+        let mut ff = build_litemap(false).into_iter().collect::<Vec<_>>();
+        ff[..].shuffle(&mut rand::thread_rng());
+        b.iter(|| {
+            let map: LiteMap<&String, &String> = LiteMap::from_iter(ff.iter().map(|(k, v)| (k, v)));
+            black_box(map)
+        })
+    });
+}
+
+fn bench_from_iter_large(c: &mut Criterion) {
+    c.bench_function("litemap/from_iter/large", |b| {
+        let mut ff = build_litemap(true).into_iter().collect::<Vec<_>>();
+        ff[..].shuffle(&mut rand::thread_rng());
+        b.iter(|| {
+            let map: LiteMap<&String, &String> = LiteMap::from_iter(ff.iter().map(|(k, v)| (k, v)));
+            black_box(map)
+        })
+    });
+}
+
+fn bench_from_iter_sorted(c: &mut Criterion) {
+    c.bench_function("litemap/from_iter_sorted/small", |b| {
+        let ff = build_litemap(false).into_iter().collect::<Vec<_>>();
+        b.iter(|| {
+            let map: LiteMap<&String, &String> = LiteMap::from_iter(ff.iter().map(|(k, v)| (k, v)));
+            black_box(map)
+        })
+    });
+}
+
+fn bench_from_iter_large_sorted(c: &mut Criterion) {
+    c.bench_function("litemap/from_iter_sorted/large", |b| {
+        let ff = build_litemap(true).into_iter().collect::<Vec<_>>();
+        b.iter(|| {
+            let map: LiteMap<&String, &String> = LiteMap::from_iter(ff.iter().map(|(k, v)| (k, v)));
+            black_box(map)
+        })
+    });
+}
+
+fn bench_extend(c: &mut Criterion) {
+    c.bench_function("litemap/extend/large", |b| {
+        let mut ff = build_litemap(true).into_iter().collect::<Vec<_>>();
+        ff[..].shuffle(&mut rand::thread_rng());
+        b.iter(|| {
+            let mut map: LiteMap<&String, &String> = LiteMap::with_capacity(0);
+            let mut iter = ff.iter().map(|(k, v)| (k, v));
+            let step = ff.len().div_ceil(10);
+            for _ in 0..10 {
+                map.extend(iter.by_ref().take(step));
+            }
+            black_box(map)
+        })
+    });
+}
+
+fn bench_extend_via_litemap(c: &mut Criterion) {
+    c.bench_function("litemap/extend_via_litemap/large", |b| {
+        let mut ff = build_litemap(true).into_iter().collect::<Vec<_>>();
+        ff[..].shuffle(&mut rand::thread_rng());
+        b.iter(|| {
+            let mut map: LiteMap<&String, &String> = LiteMap::with_capacity(0);
+            let mut iter = ff.iter().map(|(k, v)| (k, v));
+            let step = ff.len().div_ceil(10);
+            for _ in 0..10 {
+                let tmp: LiteMap<&String, &String> = LiteMap::from_iter(iter.by_ref().take(step));
+                map.extend_from_litemap(tmp);
+            }
+            black_box(map)
+        })
     });
 }
 

--- a/utils/litemap/benches/litemap.rs
+++ b/utils/litemap/benches/litemap.rs
@@ -59,11 +59,12 @@ fn overview_bench(c: &mut Criterion) {
     bench_lookup(c);
     bench_lookup_large(c);
     bench_from_iter(c);
-    bench_from_iter_large(c);
+    bench_from_iter_rand_large(c);
     bench_from_iter_sorted(c);
     bench_from_iter_large_sorted(c);
-    bench_extend(c);
-    bench_extend_via_litemap(c);
+    bench_extend_rand(c);
+    bench_extend_rand_dups(c);
+    bench_extend_from_litemap_rand(c);
 }
 
 fn build_litemap(large: bool) -> LiteMap<String, String> {
@@ -100,7 +101,7 @@ fn bench_deserialize_large(c: &mut Criterion) {
 }
 
 fn bench_from_iter(c: &mut Criterion) {
-    c.bench_function("litemap/from_iter/small", |b| {
+    c.bench_function("litemap/from_iter_rand/small", |b| {
         let mut ff = build_litemap(false).into_iter().collect::<Vec<_>>();
         ff[..].shuffle(&mut rand::thread_rng());
         b.iter(|| {
@@ -110,8 +111,8 @@ fn bench_from_iter(c: &mut Criterion) {
     });
 }
 
-fn bench_from_iter_large(c: &mut Criterion) {
-    c.bench_function("litemap/from_iter/large", |b| {
+fn bench_from_iter_rand_large(c: &mut Criterion) {
+    c.bench_function("litemap/from_iter_rand/large", |b| {
         let mut ff = build_litemap(true).into_iter().collect::<Vec<_>>();
         ff[..].shuffle(&mut rand::thread_rng());
         b.iter(|| {
@@ -141,8 +142,8 @@ fn bench_from_iter_large_sorted(c: &mut Criterion) {
     });
 }
 
-fn bench_extend(c: &mut Criterion) {
-    c.bench_function("litemap/extend/large", |b| {
+fn bench_extend_rand(c: &mut Criterion) {
+    c.bench_function("litemap/extend_rand/large", |b| {
         let mut ff = build_litemap(true).into_iter().collect::<Vec<_>>();
         ff[..].shuffle(&mut rand::thread_rng());
         b.iter(|| {
@@ -157,8 +158,26 @@ fn bench_extend(c: &mut Criterion) {
     });
 }
 
-fn bench_extend_via_litemap(c: &mut Criterion) {
-    c.bench_function("litemap/extend_via_litemap/large", |b| {
+fn bench_extend_rand_dups(c: &mut Criterion) {
+    c.bench_function("litemap/extend_rand_dups/large", |b| {
+        let mut ff = build_litemap(true).into_iter().collect::<Vec<_>>();
+        ff[..].shuffle(&mut rand::thread_rng());
+        b.iter(|| {
+            let mut map: LiteMap<&String, &String> = LiteMap::with_capacity(0);
+            for _ in 0..2 {
+                let mut iter = ff.iter().map(|(k, v)| (k, v));
+                let step = ff.len().div_ceil(10);
+                for _ in 0..10 {
+                    map.extend(iter.by_ref().take(step));
+                }
+            }
+            black_box(map)
+        })
+    });
+}
+
+fn bench_extend_from_litemap_rand(c: &mut Criterion) {
+    c.bench_function("litemap/extend_from_litemap_rand/large", |b| {
         let mut ff = build_litemap(true).into_iter().collect::<Vec<_>>();
         ff[..].shuffle(&mut rand::thread_rng());
         b.iter(|| {

--- a/utils/litemap/src/lib.rs
+++ b/utils/litemap/src/lib.rs
@@ -7,13 +7,17 @@
 //! `litemap` is a crate providing [`LiteMap`], a highly simplistic "flat" key-value map
 //! based off of a single sorted vector.
 //!
-//! The goal of this crate is to provide a map that is good enough for small
+//! The main goal of this crate is to provide a map that is good enough for small
 //! sizes, and does not carry the binary size impact of [`HashMap`](std::collections::HashMap)
 //! or [`BTreeMap`](alloc::collections::BTreeMap).
 //!
+//! The flat nature of [`LiteMap`] allows it to be pre-allocated and sized more finely than
+//! [`std::collections::BTreeMap`] so it also has a smaller memory footprint for small collections.
+//!
 //! If binary size is not a concern, [`std::collections::BTreeMap`] may be a better choice
 //! for your use case. It behaves very similarly to [`LiteMap`] for less than 12 elements,
-//! and upgrades itself gracefully for larger inputs.
+//! and upgrades itself gracefully for larger inputs. For larger inputs mutating [`LiteMap`]
+//! in random or reverse order might be slower than [`std::collections::BTreeMap`].
 //!
 //! ## Pluggable Backends
 //!
@@ -65,4 +69,4 @@ pub mod store;
 #[cfg(any(test, feature = "testing"))]
 pub mod testing;
 
-pub use map::LiteMap;
+pub use map::{Entry, LiteMap, OccupiedEntry, VacantEntry};

--- a/utils/litemap/src/map.rs
+++ b/utils/litemap/src/map.rs
@@ -1453,12 +1453,12 @@ mod test {
     #[test]
     fn extend2() {
         let mut map: LiteMap<usize, &str> = LiteMap::new();
-        map.extend(make_13().into_iter());
-        map.extend(make_24().into_iter());
-        map.extend(make_24().into_iter());
-        map.extend(make_46().into_iter());
-        map.extend(make_13().into_iter());
-        map.extend(make_46().into_iter());
+        map.extend(make_13());
+        map.extend(make_24());
+        map.extend(make_24());
+        map.extend(make_46());
+        map.extend(make_13());
+        map.extend(make_46());
         assert_eq!(map.len(), 5);
     }
 

--- a/utils/litemap/src/store/mod.rs
+++ b/utils/litemap/src/store/mod.rs
@@ -175,6 +175,24 @@ pub trait StoreIntoIterator<K, V>: StoreMut<K, V> {
             self.lm_insert(i, item.0, item.1);
         }
     }
+
+    /// Extends this store with items from an iterator.
+    fn lm_extend<I>(&mut self, other: I)
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Ord,
+    {
+        for item in other {
+            match self.lm_binary_search_by(|k| k.cmp(&item.0)) {
+                #[allow(clippy::unwrap_used)]
+                // Index from binary search is an existing occupied index
+                Ok(index) => *self.lm_get_mut(index).unwrap().1 = item.1,
+                #[allow(clippy::unwrap_used)]
+                // Index from binary search is a valid index for insertion
+                Err(index) => self.lm_insert(index, item.0, item.1),
+            }
+        }
+    }
 }
 
 /// A store that can be built from a tuple iterator.


### PR DESCRIPTION
Add BTreeMap-like APIs to LiteMap to get closer to the std lib BTreeMap, which has familiarity benefits and allows easier integration of LiteMap into existing projects. This is a follow up of https://github.com/unicode-org/icu4x/pull/5894 

* Add `lm_extend` to the traits. The vec implementation attempts have O(N) performance on the best case and an asymptotic worst case of O(NLog(N)), effectively avoiding quadratic worst cases. The end goal is to use this in the deserialization code path, which will also come in a follow-up PR.
* Implements `Extend` for `LiteMap`. This is based on `lm_extend`.
* Prevent quadratic worst case in the existing FromIter implementation by using the newly added `lm_extend`
* Even though `try_get_or_insert` exists, the Entry API is a more familiar API with good performance, as it may avoid a potentially wasted second binary search.