### PR TITLE
 Avoid accidental quadratic behavior in LiteMap deserialization 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1898,6 +1898,7 @@ dependencies = [
  "icu_benchmark_macros",
  "icu_locale_core",
  "postcard",
+ "rand",
  "rkyv",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,7 +1890,7 @@ dependencies = [
 
 [[package]]
 name = "litemap"
-version = "0.7.4"
+version = "0.8.0"
 dependencies = [
  "bincode",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,7 +192,7 @@ databake-derive = { version = "0.2.0", path = "utils/databake/derive", default-f
 deduplicating_array = { version = "0.1.6", path = "utils/deduplicating_array", default-features = false }
 fixed_decimal = { version = "0.6.0", path = "utils/fixed_decimal", default-features = false }
 ixdtf = { version = "0.3.0", path = "utils/ixdtf", default-features = false }
-litemap = { version = "0.7.3", path = "utils/litemap", default-features = false }
+litemap = { version = "0.8.0", path = "utils/litemap", default-features = false }
 tinystr = { version = "0.8.0", path = "utils/tinystr", default-features = false }
 tzif = { version = "0.3.0", path = "utils/tzif", default-features = false }
 # potential-utf can stay on 0.1.0 during release.

--- a/components/locale_core/src/shortvec/litemap.rs
+++ b/components/locale_core/src/shortvec/litemap.rs
@@ -55,6 +55,18 @@ impl<K: Ord, V> StoreFromIterable<K, V> for ShortBoxSlice<(K, V)> {
     }
 }
 
+impl<K: Ord, V> SortedStoreFromStore<K, V> for ShortBoxSlice<(K, V)> {
+    fn lm_sorted_store_from_store(self) -> Self {
+        match self {
+            ShortBoxSlice(ShortBoxSliceInner::ZeroOne(_)) => self,
+            ShortBoxSlice(ShortBoxSliceInner::Multi(v)) => {
+                let v: Vec<(K, V)> = Vec::lm_sort_from_iter(v);
+                v.into()
+            }
+        }
+    }
+}
+
 impl<K, V> StoreMut<K, V> for ShortBoxSlice<(K, V)> {
     fn lm_with_capacity(_capacity: usize) -> Self {
         ShortBoxSlice::new()

--- a/utils/litemap/Cargo.toml
+++ b/utils/litemap/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "litemap"
-version = "0.7.4"
+version = "0.8.0"
 keywords = ["sorted", "vec", "map", "hashmap", "btreemap"]
 description = "A key-value Map implementation based on a flat, sorted Vec."
 documentation = "https://docs.rs/litemap"

--- a/utils/litemap/Cargo.toml
+++ b/utils/litemap/Cargo.toml
@@ -28,6 +28,7 @@ serde = { workspace = true, optional = true, features = ["alloc"]}
 yoke = { workspace = true, features = ["derive"], optional = true }
 
 [dev-dependencies]
+rand = { workspace = true }
 bincode = { workspace = true }
 icu_benchmark_macros = { path = "../../tools/benchmark/macros" }
 icu_locale_core = { path = "../../components/locale_core" }

--- a/utils/litemap/benches/litemap.rs
+++ b/utils/litemap/benches/litemap.rs
@@ -5,6 +5,7 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 use litemap::LiteMap;
+use rand::seq::SliceRandom;
 
 const DATA: [(&str, &str); 16] = [
     ("ar", "Arabic"),
@@ -57,6 +58,12 @@ fn overview_bench(c: &mut Criterion) {
     bench_deserialize_large(c);
     bench_lookup(c);
     bench_lookup_large(c);
+    bench_from_iter(c);
+    bench_from_iter_large(c);
+    bench_from_iter_sorted(c);
+    bench_from_iter_large_sorted(c);
+    bench_extend(c);
+    bench_extend_via_litemap(c);
 }
 
 fn build_litemap(large: bool) -> LiteMap<String, String> {
@@ -89,6 +96,81 @@ fn bench_deserialize_large(c: &mut Criterion) {
             let map: LiteMap<String, String> = postcard::from_bytes(black_box(&buf)).unwrap();
             assert_eq!(map.get("iu3333"), Some(&"Inuktitut".to_owned()));
         });
+    });
+}
+
+fn bench_from_iter(c: &mut Criterion) {
+    c.bench_function("litemap/from_iter/small", |b| {
+        let mut ff = build_litemap(false).into_iter().collect::<Vec<_>>();
+        ff[..].shuffle(&mut rand::thread_rng());
+        b.iter(|| {
+            let map: LiteMap<&String, &String> = LiteMap::from_iter(ff.iter().map(|(k, v)| (k, v)));
+            black_box(map)
+        })
+    });
+}
+
+fn bench_from_iter_large(c: &mut Criterion) {
+    c.bench_function("litemap/from_iter/large", |b| {
+        let mut ff = build_litemap(true).into_iter().collect::<Vec<_>>();
+        ff[..].shuffle(&mut rand::thread_rng());
+        b.iter(|| {
+            let map: LiteMap<&String, &String> = LiteMap::from_iter(ff.iter().map(|(k, v)| (k, v)));
+            black_box(map)
+        })
+    });
+}
+
+fn bench_from_iter_sorted(c: &mut Criterion) {
+    c.bench_function("litemap/from_iter_sorted/small", |b| {
+        let ff = build_litemap(false).into_iter().collect::<Vec<_>>();
+        b.iter(|| {
+            let map: LiteMap<&String, &String> = LiteMap::from_iter(ff.iter().map(|(k, v)| (k, v)));
+            black_box(map)
+        })
+    });
+}
+
+fn bench_from_iter_large_sorted(c: &mut Criterion) {
+    c.bench_function("litemap/from_iter_sorted/large", |b| {
+        let ff = build_litemap(true).into_iter().collect::<Vec<_>>();
+        b.iter(|| {
+            let map: LiteMap<&String, &String> = LiteMap::from_iter(ff.iter().map(|(k, v)| (k, v)));
+            black_box(map)
+        })
+    });
+}
+
+fn bench_extend(c: &mut Criterion) {
+    c.bench_function("litemap/extend/large", |b| {
+        let mut ff = build_litemap(true).into_iter().collect::<Vec<_>>();
+        ff[..].shuffle(&mut rand::thread_rng());
+        b.iter(|| {
+            let mut map: LiteMap<&String, &String> = LiteMap::with_capacity(0);
+            let mut iter = ff.iter().map(|(k, v)| (k, v));
+            let step = ff.len().div_ceil(10);
+            for _ in 0..10 {
+                map.extend(iter.by_ref().take(step));
+            }
+            black_box(map)
+        })
+    });
+}
+
+fn bench_extend_via_litemap(c: &mut Criterion) {
+    c.bench_function("litemap/extend_via_litemap/large", |b| {
+        let mut ff = build_litemap(true).into_iter().collect::<Vec<_>>();
+        ff[..].shuffle(&mut rand::thread_rng());
+        b.iter(|| {
+            let mut map: LiteMap<&String, &String> = LiteMap::with_capacity(0);
+            let mut iter = ff.iter().map(|(k, v)| (k, v));
+            let step = ff.len().div_ceil(10);
+            for _ in 0..10 {
+                let tmp: LiteMap<&String, &String> = LiteMap::from_iter(iter.by_ref().take(step));
+                map.extend_from_litemap(tmp);
+            }
+            black_box(map)
+        })
     });
 }
 

--- a/utils/litemap/src/lib.rs
+++ b/utils/litemap/src/lib.rs
@@ -7,13 +7,17 @@
 //! `litemap` is a crate providing [`LiteMap`], a highly simplistic "flat" key-value map
 //! based off of a single sorted vector.
 //!
-//! The goal of this crate is to provide a map that is good enough for small
+//! The main goal of this crate is to provide a map that is good enough for small
 //! sizes, and does not carry the binary size impact of [`HashMap`](std::collections::HashMap)
 //! or [`BTreeMap`](alloc::collections::BTreeMap).
 //!
+//! The flat nature of [`LiteMap`] allows it to be pre-allocated and sized more finely than
+//! [`std::collections::BTreeMap`] so it also has a smaller memory footprint for small collections.
+//!
 //! If binary size is not a concern, [`std::collections::BTreeMap`] may be a better choice
 //! for your use case. It behaves very similarly to [`LiteMap`] for less than 12 elements,
-//! and upgrades itself gracefully for larger inputs.
+//! and upgrades itself gracefully for larger inputs. For larger inputs mutating [`LiteMap`]
+//! in random or reverse order might be slower than [`std::collections::BTreeMap`].
 //!
 //! ## Pluggable Backends
 //!
@@ -65,4 +69,4 @@ pub mod store;
 #[cfg(any(test, feature = "testing"))]
 pub mod testing;
 
-pub use map::LiteMap;
+pub use map::{Entry, LiteMap, OccupiedEntry, VacantEntry};

--- a/utils/litemap/src/store/mod.rs
+++ b/utils/litemap/src/store/mod.rs
@@ -175,6 +175,24 @@ pub trait StoreIntoIterator<K, V>: StoreMut<K, V> {
             self.lm_insert(i, item.0, item.1);
         }
     }
+
+    /// Extends this store with items from an iterator.
+    fn lm_extend<I>(&mut self, other: I)
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Ord,
+    {
+        for item in other {
+            match self.lm_binary_search_by(|k| k.cmp(&item.0)) {
+                #[allow(clippy::unwrap_used)]
+                // Index from binary search is an existing occupied index
+                Ok(index) => *self.lm_get_mut(index).unwrap().1 = item.1,
+                #[allow(clippy::unwrap_used)]
+                // Index from binary search is a valid index for insertion
+                Err(index) => self.lm_insert(index, item.0, item.1),
+            }
+        }
+    }
 }
 
 /// A store that can be built from a tuple iterator.

--- a/utils/litemap/src/store/mod.rs
+++ b/utils/litemap/src/store/mod.rs
@@ -77,6 +77,12 @@ pub trait StoreFromIterable<K, V>: Store<K, V> {
     fn lm_sort_from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self;
 }
 
+pub trait SortedStoreFromStore<K, V>: Store<K, V> {
+    /// Create a sorted and deduplicated store from an existing store.
+    /// This is a specialized version of StoreFromIterable::lm_sort_from_iter.
+    fn lm_sorted_store_from_store(self) -> Self;
+}
+
 pub trait StoreSlice<K: ?Sized, V: ?Sized>: Store<K, V> {
     type Slice: ?Sized;
 

--- a/utils/litemap/tests/store.rs
+++ b/utils/litemap/tests/store.rs
@@ -59,6 +59,12 @@ impl<K: Ord, V> StoreFromIterable<K, V> for VecWithDefaults<(K, V)> {
     }
 }
 
+impl<K: Ord, V> SortedStoreFromStore<K, V> for VecWithDefaults<(K, V)> {
+    fn lm_sorted_store_from_store(self) -> Self {
+        Self(self.0.lm_sorted_store_from_store())
+    }
+}
+
 impl<K, V> StoreMut<K, V> for VecWithDefaults<(K, V)> {
     #[inline]
     fn lm_with_capacity(capacity: usize) -> Self {


### PR DESCRIPTION
The existing deserialization fallback uses binary-search + insertion. This fallback can have quadratic worst-case performance, which is also a potential attack vector in deserialization.

This PR adopts the same strategy as from_iter after in #6068. The `from_iter` benchmarks can illustrate the performance delta https://github.com/unicode-org/icu4x/pull/6068#issuecomment-2638266210

To preserve the extensibility via traits, I had to add another trait (SortedStoreFromStore) so that deserialization could deserialize into the Store and sort it after if necessary.

Unfortunately, I couldn't find a way to make this backward compatible. So, the PR also includes a version bump.