### PR TITLE
Consistently wrap all options bags in None in Rust and FFI

### DIFF
--- a/components/casemap/src/casemapper.rs
+++ b/components/casemap/src/casemapper.rs
@@ -182,7 +182,7 @@ impl CaseMapper {
         char_is_lead: impl Fn(&CaseMap, char) -> bool,
     ) -> StringAndWriteable<'a, FullCaseWriteable<'a, true>> {
         let data = self.data.get();
-        let (head, rest) = match options.leading_adjustment {
+        let (head, rest) = match options.leading_adjustment.unwrap_or_default() {
             LeadingAdjustment::Auto | LeadingAdjustment::ToCased => {
                 let first_cased = src.char_indices().find(|(_i, ch)| char_is_lead(data, *ch));
                 if let Some((first_cased, _ch)) = first_cased {
@@ -200,7 +200,7 @@ impl CaseMapper {
             rest,
             CaseMapLocale::from_langid(langid),
             MappingKind::Title,
-            options.trailing_case,
+            options.trailing_case.unwrap_or_default(),
         );
         StringAndWriteable {
             string: head,

--- a/components/casemap/src/titlecase.rs
+++ b/components/casemap/src/titlecase.rs
@@ -28,7 +28,7 @@ use writeable::Writeable;
 ///
 /// let default_options = Default::default();
 /// let mut preserve_case: TitlecaseOptions = Default::default();
-/// preserve_case.trailing_case = TrailingCase::Unchanged;
+/// preserve_case.trailing_case = Some(TrailingCase::Unchanged);
 ///
 /// // Exhibits trailing case when set:
 /// assert_eq!(
@@ -74,8 +74,8 @@ pub enum TrailingCase {
 /// let default_options = Default::default(); // head adjustment set to Auto
 /// let mut no_adjust: TitlecaseOptions = Default::default();
 /// let mut adjust_to_cased: TitlecaseOptions = Default::default();
-/// no_adjust.leading_adjustment = LeadingAdjustment::None;
-/// adjust_to_cased.leading_adjustment = LeadingAdjustment::ToCased;
+/// no_adjust.leading_adjustment = Some(LeadingAdjustment::None);
+/// adjust_to_cased.leading_adjustment = Some(LeadingAdjustment::ToCased);
 ///
 /// // Exhibits leading adjustment when set:
 /// assert_eq!(
@@ -147,10 +147,14 @@ pub enum LeadingAdjustment {
 pub struct TitlecaseOptions {
     /// How to handle the rest of the string once the head of the
     /// string has been titlecased
-    pub trailing_case: TrailingCase,
+    ///
+    /// Default is [`TrailingCase::Lower`]
+    pub trailing_case: Option<TrailingCase>,
     /// Whether to start casing at the beginning of the string or at the first
     /// relevant character.
-    pub leading_adjustment: LeadingAdjustment,
+    ///
+    /// Default is [`LeadingAdjustment::Auto`]
+    pub leading_adjustment: Option<LeadingAdjustment>,
 }
 
 /// A wrapper around [`CaseMapper`] that can compute titlecasing stuff, and is able to load additional data
@@ -301,7 +305,7 @@ impl<CM: AsRef<CaseMapper>> TitlecaseMapper<CM> {
         langid: &LanguageIdentifier,
         options: TitlecaseOptions,
     ) -> impl Writeable + 'a {
-        if options.leading_adjustment == LeadingAdjustment::Auto {
+        if options.leading_adjustment.unwrap_or_default() == LeadingAdjustment::Auto {
             // letter, number, symbol, or private use code point
             const HEAD_GROUPS: GeneralCategoryGroup = GeneralCategoryGroup::Letter
                 .union(GeneralCategoryGroup::Number)
@@ -375,7 +379,7 @@ impl<CM: AsRef<CaseMapper>> TitlecaseMapper<CM> {
     ///
     /// let default_options = Default::default();
     /// let mut no_adjust: TitlecaseOptions = Default::default();
-    /// no_adjust.leading_adjustment = LeadingAdjustment::None;
+    /// no_adjust.leading_adjustment = Some(LeadingAdjustment::None);
     ///
     /// // Exhibits leading adjustment when set:
     /// assert_eq!(
@@ -415,7 +419,7 @@ impl<CM: AsRef<CaseMapper>> TitlecaseMapper<CM> {
     ///
     /// let default_options = Default::default();
     /// let mut preserve_case: TitlecaseOptions = Default::default();
-    /// preserve_case.trailing_case = TrailingCase::Unchanged;
+    /// preserve_case.trailing_case = Some(TrailingCase::Unchanged);
     ///
     /// // Exhibits trailing case when set:
     /// assert_eq!(

--- a/components/datetime/src/format/datetime.rs
+++ b/components/datetime/src/format/datetime.rs
@@ -612,7 +612,7 @@ mod tests {
         ];
 
         let mut decimal_formatter_options = DecimalFormatterOptions::default();
-        decimal_formatter_options.grouping_strategy = GroupingStrategy::Never;
+        decimal_formatter_options.grouping_strategy = Some(GroupingStrategy::Never);
         let decimal_formatter = DecimalFormatter::try_new(
             icu_locale_core::locale!("en").into(),
             decimal_formatter_options,

--- a/components/datetime/src/pattern/names.rs
+++ b/components/datetime/src/pattern/names.rs
@@ -2202,7 +2202,7 @@ impl<FSet: DateTimeNamesMarker> RawDateTimeNames<FSet> {
             return Ok(());
         }
         let mut options = DecimalFormatterOptions::default();
-        options.grouping_strategy = GroupingStrategy::Never;
+        options.grouping_strategy = Some(GroupingStrategy::Never);
         self.decimal_formatter = Some(DecimalFormatterLoader::load(
             loader,
             (&prefs).into(),

--- a/components/decimal/src/format.rs
+++ b/components/decimal/src/format.rs
@@ -67,7 +67,7 @@ impl Writeable for FormattedDecimal<'_> {
                 if grouper::check(
                     upper_magnitude,
                     m,
-                    self.options.grouping_strategy,
+                    self.options.grouping_strategy.unwrap_or_default(),
                     self.symbols.grouping_sizes,
                 ) {
                     w.with_part(parts::GROUP, |w| {

--- a/components/decimal/src/grouper.rs
+++ b/components/decimal/src/grouper.rs
@@ -198,7 +198,7 @@ fn test_grouper() {
             }
             let provider = Provider(RefCell::new(Some(symbols)), digits);
             let options = options::DecimalFormatterOptions {
-                grouping_strategy: cas.strategy,
+                grouping_strategy: Some(cas.strategy),
                 ..Default::default()
             };
             let fdf =

--- a/components/decimal/src/options.rs
+++ b/components/decimal/src/options.rs
@@ -10,12 +10,16 @@
 #[non_exhaustive]
 pub struct DecimalFormatterOptions {
     /// When to render grouping separators.
-    pub grouping_strategy: GroupingStrategy,
+    ///
+    /// Default is [`GroupingStrategy::Auto`]
+    pub grouping_strategy: Option<GroupingStrategy>,
 }
 
 impl From<GroupingStrategy> for DecimalFormatterOptions {
     fn from(grouping_strategy: GroupingStrategy) -> Self {
-        Self { grouping_strategy }
+        Self {
+            grouping_strategy: Some(grouping_strategy),
+        }
     }
 }
 
@@ -31,7 +35,7 @@ impl From<GroupingStrategy> for DecimalFormatterOptions {
 ///
 /// let locale = Default::default();
 /// let mut options: options::DecimalFormatterOptions = Default::default();
-/// options.grouping_strategy = options::GroupingStrategy::Min2;
+/// options.grouping_strategy = Some(options::GroupingStrategy::Min2);
 /// let df = DecimalFormatter::try_new(locale, options)
 ///     .expect("locale should be present");
 ///
@@ -42,9 +46,10 @@ impl From<GroupingStrategy> for DecimalFormatterOptions {
 /// assert_writeable_eq!(df.format(&ten_thousand), "10,000");
 /// ```
 #[non_exhaustive]
-#[derive(Debug, Eq, PartialEq, Clone, Copy, Hash)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy, Hash, Default)]
 pub enum GroupingStrategy {
     /// Render grouping separators according to locale preferences.
+    #[default]
     Auto,
 
     /// Never render grouping separators.
@@ -60,10 +65,4 @@ pub enum GroupingStrategy {
     /// separator. In most locales, this means that numbers between 1000 and 9999 do not get
     /// grouping separators, but numbers 10,000 and above will.
     Min2,
-}
-
-impl Default for GroupingStrategy {
-    fn default() -> Self {
-        Self::Auto
-    }
 }

--- a/components/plurals/src/options.rs
+++ b/components/plurals/src/options.rs
@@ -15,6 +15,8 @@
 #[non_exhaustive]
 pub struct PluralRulesOptions {
     /// Plural rule type to use.
+    ///
+    /// Default is [`PluralRuleType::Cardinal`]
     pub rule_type: Option<PluralRuleType>,
 }
 

--- a/components/segmenter/benches/bench.rs
+++ b/components/segmenter/benches/bench.rs
@@ -20,8 +20,8 @@ fn line_break_iter_latin1(c: &mut Criterion) {
     let segmenter = LineSegmenter::new_dictionary(Default::default());
 
     let mut options = LineBreakOptions::default();
-    options.strictness = LineBreakStrictness::Anywhere;
-    options.word_option = LineBreakWordOption::BreakAll;
+    options.strictness = Some(LineBreakStrictness::Anywhere);
+    options.word_option = Some(LineBreakWordOption::BreakAll);
     let segmenter_css = LineSegmenter::new_dictionary(options);
 
     group.bench_function("En", |b| {
@@ -49,8 +49,8 @@ fn line_break_iter_utf8(c: &mut Criterion) {
     let segmenter_dictionary = LineSegmenter::new_dictionary(Default::default());
 
     let mut options = LineBreakOptions::default();
-    options.strictness = LineBreakStrictness::Anywhere;
-    options.word_option = LineBreakWordOption::BreakAll;
+    options.strictness = Some(LineBreakStrictness::Anywhere);
+    options.word_option = Some(LineBreakWordOption::BreakAll);
     let segmenter_css_dictionary = LineSegmenter::new_dictionary(options);
 
     // No need to test "auto", "lstm", or "dictionary" constructor variants since English uses only
@@ -98,8 +98,8 @@ fn line_break_iter_utf16(c: &mut Criterion) {
     let segmenter_dictionary = LineSegmenter::new_dictionary(Default::default());
 
     let mut options = LineBreakOptions::default();
-    options.strictness = LineBreakStrictness::Anywhere;
-    options.word_option = LineBreakWordOption::BreakAll;
+    options.strictness = Some(LineBreakStrictness::Anywhere);
+    options.word_option = Some(LineBreakWordOption::BreakAll);
     let segmenter_css_dictionary = LineSegmenter::new_dictionary(options);
 
     // No need to test "auto", "lstm", or "dictionary" constructor variants since English uses only

--- a/components/segmenter/src/line.rs
+++ b/components/segmenter/src/line.rs
@@ -134,7 +134,7 @@ const ZWJ: u8 = 54;
 /// property values in the CSS Text spec. See the details in
 /// <https://drafts.csswg.org/css-text-3/#line-break-property>.
 #[non_exhaustive]
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
 pub enum LineBreakStrictness {
     /// Breaks text using the least restrictive set of line-breaking rules.
     /// Typically used for short lines, such as in newspapers.
@@ -152,6 +152,7 @@ pub enum LineBreakStrictness {
     /// resolving class [CJ](https://www.unicode.org/reports/tr14/#CJ) to
     /// [NS](https://www.unicode.org/reports/tr14/#NS);
     /// see rule [LB1](https://www.unicode.org/reports/tr14/#LB1).
+    #[default]
     Strict,
 
     /// Breaks text assuming there is a soft wrap opportunity around every
@@ -168,10 +169,11 @@ pub enum LineBreakStrictness {
 /// property values in the CSS Text spec. See the details in
 /// <https://drafts.csswg.org/css-text-3/#word-break-property>
 #[non_exhaustive]
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
 pub enum LineBreakWordOption {
     /// Words break according to their customary rules. See the details in
     /// <https://drafts.csswg.org/css-text-3/#valdef-word-break-normal>.
+    #[default]
     Normal,
 
     /// Breaking is allowed within "words".
@@ -185,13 +187,17 @@ pub enum LineBreakWordOption {
 
 /// Options to tailor line-breaking behavior.
 #[non_exhaustive]
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
 pub struct LineBreakOptions<'a> {
     /// Strictness of line-breaking rules. See [`LineBreakStrictness`].
-    pub strictness: LineBreakStrictness,
+    ///
+    /// Default is [`LineBreakStrictness::Strict`]
+    pub strictness: Option<LineBreakStrictness>,
 
     /// Line break opportunities between letters. See [`LineBreakWordOption`].
-    pub word_option: LineBreakWordOption,
+    ///
+    /// Default is [`LineBreakStrictness::Normal`]
+    pub word_option: Option<LineBreakWordOption>,
 
     /// Content locale for line segmenter
     ///
@@ -200,16 +206,6 @@ pub struct LineBreakOptions<'a> {
     /// <https://drafts.csswg.org/css-text-3/#line-break-property> for details.
     /// This option has no effect in Latin-1 mode.
     pub content_locale: Option<&'a LanguageIdentifier>,
-}
-
-impl Default for LineBreakOptions<'_> {
-    fn default() -> Self {
-        Self {
-            strictness: LineBreakStrictness::Strict,
-            word_option: LineBreakWordOption::Normal,
-            content_locale: None,
-        }
-    }
 }
 
 #[derive(Debug)]
@@ -227,8 +223,8 @@ impl From<LineBreakOptions<'_>> for ResolvedLineBreakOptions {
             false
         };
         Self {
-            strictness: options.strictness,
-            word_option: options.word_option,
+            strictness: options.strictness.unwrap_or_default(),
+            word_option: options.word_option.unwrap_or_default(),
             ja_zh,
         }
     }
@@ -325,8 +321,8 @@ pub type LineBreakIteratorUtf16<'l, 's> = LineBreakIterator<'l, 's, LineBreakTyp
 /// };
 ///
 /// let mut options = LineBreakOptions::default();
-/// options.strictness = LineBreakStrictness::Strict;
-/// options.word_option = LineBreakWordOption::BreakAll;
+/// options.strictness = Some(LineBreakStrictness::Strict);
+/// options.word_option = Some(LineBreakWordOption::BreakAll);
 /// options.content_locale = None;
 /// let segmenter = LineSegmenter::new_auto(options);
 ///

--- a/components/segmenter/tests/css_line_break.rs
+++ b/components/segmenter/tests/css_line_break.rs
@@ -32,32 +32,32 @@ static JA: LanguageIdentifier = langid!("ja");
 
 fn strict(s: &str, ja_zh: bool, expect_utf8: Vec<usize>, expect_utf16: Vec<usize>) {
     let mut options = LineBreakOptions::default();
-    options.strictness = LineBreakStrictness::Strict;
-    options.word_option = LineBreakWordOption::Normal;
+    options.strictness = Some(LineBreakStrictness::Strict);
+    options.word_option = Some(LineBreakWordOption::Normal);
     options.content_locale = ja_zh.then_some(&JA);
     check_with_options(s, expect_utf8, expect_utf16, options);
 }
 
 fn normal(s: &str, ja_zh: bool, expect_utf8: Vec<usize>, expect_utf16: Vec<usize>) {
     let mut options = LineBreakOptions::default();
-    options.strictness = LineBreakStrictness::Normal;
-    options.word_option = LineBreakWordOption::Normal;
+    options.strictness = Some(LineBreakStrictness::Normal);
+    options.word_option = Some(LineBreakWordOption::Normal);
     options.content_locale = ja_zh.then_some(&JA);
     check_with_options(s, expect_utf8, expect_utf16, options);
 }
 
 fn loose(s: &str, ja_zh: bool, expect_utf8: Vec<usize>, expect_utf16: Vec<usize>) {
     let mut options = LineBreakOptions::default();
-    options.strictness = LineBreakStrictness::Loose;
-    options.word_option = LineBreakWordOption::Normal;
+    options.strictness = Some(LineBreakStrictness::Loose);
+    options.word_option = Some(LineBreakWordOption::Normal);
     options.content_locale = ja_zh.then_some(&JA);
     check_with_options(s, expect_utf8, expect_utf16, options);
 }
 
 fn anywhere(s: &str, ja_zh: bool, expect_utf8: Vec<usize>, expect_utf16: Vec<usize>) {
     let mut options = LineBreakOptions::default();
-    options.strictness = LineBreakStrictness::Anywhere;
-    options.word_option = LineBreakWordOption::Normal;
+    options.strictness = Some(LineBreakStrictness::Anywhere);
+    options.word_option = Some(LineBreakWordOption::Normal);
     options.content_locale = ja_zh.then_some(&JA);
     check_with_options(s, expect_utf8, expect_utf16, options);
 }

--- a/components/segmenter/tests/css_word_break.rs
+++ b/components/segmenter/tests/css_word_break.rs
@@ -29,24 +29,24 @@ fn check_with_options(
 
 fn break_all(s: &str, expect_utf8: Vec<usize>, expect_utf16: Vec<usize>) {
     let mut options = LineBreakOptions::default();
-    options.strictness = LineBreakStrictness::Strict;
-    options.word_option = LineBreakWordOption::BreakAll;
+    options.strictness = Some(LineBreakStrictness::Strict);
+    options.word_option = Some(LineBreakWordOption::BreakAll);
     options.content_locale = None;
     check_with_options(s, expect_utf8, expect_utf16, options);
 }
 
 fn keep_all(s: &str, expect_utf8: Vec<usize>, expect_utf16: Vec<usize>) {
     let mut options = LineBreakOptions::default();
-    options.strictness = LineBreakStrictness::Strict;
-    options.word_option = LineBreakWordOption::KeepAll;
+    options.strictness = Some(LineBreakStrictness::Strict);
+    options.word_option = Some(LineBreakWordOption::KeepAll);
     options.content_locale = None;
     check_with_options(s, expect_utf8, expect_utf16, options);
 }
 
 fn normal(s: &str, expect_utf8: Vec<usize>, expect_utf16: Vec<usize>) {
     let mut options = LineBreakOptions::default();
-    options.strictness = LineBreakStrictness::Strict;
-    options.word_option = LineBreakWordOption::Normal;
+    options.strictness = Some(LineBreakStrictness::Strict);
+    options.word_option = Some(LineBreakWordOption::Normal);
     options.content_locale = None;
     check_with_options(s, expect_utf8, expect_utf16, options);
 }

--- a/ffi/capi/src/casemap.rs
+++ b/ffi/capi/src/casemap.rs
@@ -326,15 +326,9 @@ impl From<ffi::TitlecaseOptionsV1> for TitlecaseOptions {
     fn from(other: ffi::TitlecaseOptionsV1) -> Self {
         let mut ret = Self::default();
 
-        ret.leading_adjustment = other
-            .leading_adjustment
-            .into_converted_option()
-            .unwrap_or(ret.leading_adjustment);
+        ret.leading_adjustment = other.leading_adjustment.into_converted_option();
 
-        ret.trailing_case = other
-            .trailing_case
-            .into_converted_option()
-            .unwrap_or(ret.trailing_case);
+        ret.trailing_case = other.trailing_case.into_converted_option();
 
         ret
     }

--- a/ffi/capi/src/decimal.rs
+++ b/ffi/capi/src/decimal.rs
@@ -47,9 +47,7 @@ pub mod ffi {
             let prefs = DecimalFormatterPreferences::from(&locale.0);
 
             let mut options = DecimalFormatterOptions::default();
-            options.grouping_strategy = grouping_strategy
-                .map(Into::into)
-                .unwrap_or(options.grouping_strategy);
+            options.grouping_strategy = grouping_strategy.map(Into::into);
             Ok(Box::new(DecimalFormatter(
                 icu_decimal::DecimalFormatter::try_new(prefs, options)?,
             )))
@@ -68,9 +66,7 @@ pub mod ffi {
             let prefs = DecimalFormatterPreferences::from(&locale.0);
 
             let mut options = DecimalFormatterOptions::default();
-            options.grouping_strategy = grouping_strategy
-                .map(Into::into)
-                .unwrap_or(options.grouping_strategy);
+            options.grouping_strategy = grouping_strategy.map(Into::into);
             Ok(Box::new(DecimalFormatter(
                 icu_decimal::DecimalFormatter::try_new_with_buffer_provider(
                     provider.get()?,
@@ -142,9 +138,7 @@ pub mod ffi {
             };
 
             let mut options = DecimalFormatterOptions::default();
-            options.grouping_strategy = grouping_strategy
-                .map(Into::into)
-                .unwrap_or(options.grouping_strategy);
+            options.grouping_strategy = grouping_strategy.map(Into::into);
 
             struct Provider(RefCell<Option<DecimalSymbols<'static>>>, DecimalDigits);
             impl DataProvider<DecimalSymbolsV2> for Provider {

--- a/ffi/capi/src/segmenter_line.rs
+++ b/ffi/capi/src/segmenter_line.rs
@@ -312,12 +312,10 @@ impl From<ffi::LineBreakOptionsV2> for icu_segmenter::LineBreakOptions<'_> {
         let mut options = icu_segmenter::LineBreakOptions::default();
         options.strictness = other
             .strictness
-            .into_converted_option()
-            .unwrap_or(options.strictness);
+            .into_converted_option();
         options.word_option = other
             .word_option
-            .into_converted_option()
-            .unwrap_or(options.word_option);
+            .into_converted_option();
         options
     }
 }

--- a/ffi/capi/src/segmenter_line.rs
+++ b/ffi/capi/src/segmenter_line.rs
@@ -310,12 +310,8 @@ pub mod ffi {
 impl From<ffi::LineBreakOptionsV2> for icu_segmenter::LineBreakOptions<'_> {
     fn from(other: ffi::LineBreakOptionsV2) -> Self {
         let mut options = icu_segmenter::LineBreakOptions::default();
-        options.strictness = other
-            .strictness
-            .into_converted_option();
-        options.word_option = other
-            .word_option
-            .into_converted_option();
+        options.strictness = other.strictness.into_converted_option();
+        options.word_option = other.word_option.into_converted_option();
         options
     }
 }


### PR DESCRIPTION
Fixes #5488


This does not touch experimental stuff. We should add this to the graduation checklist.


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->