### PR TITLE
Reexport preferences enums from `component::preferences`

### DIFF
--- a/components/calendar/src/any_calendar.rs
+++ b/components/calendar/src/any_calendar.rs
@@ -20,11 +20,9 @@ use crate::persian::Persian;
 use crate::roc::Roc;
 use crate::{types, AsCalendar, Calendar, Date, DateDuration, DateDurationUnit, Ref};
 
+use crate::preferences::{CalendarAlgorithm, IslamicCalendarAlgorithm};
 use icu_locale_core::extensions::unicode::{key, value, Value};
 use icu_locale_core::preferences::define_preferences;
-use icu_locale_core::preferences::extensions::unicode::keywords::{
-    CalendarAlgorithm, IslamicCalendarAlgorithm,
-};
 use icu_locale_core::subtags::language;
 use icu_locale_core::Locale;
 use icu_provider::prelude::*;

--- a/components/calendar/src/lib.rs
+++ b/components/calendar/src/lib.rs
@@ -190,3 +190,15 @@ pub use error::{DateError, RangeError};
 pub use gregorian::Gregorian;
 #[doc(no_inline)]
 pub use iso::Iso;
+
+/// Locale preferences used by this crate
+pub mod preferences {
+    #[doc(inline)]
+    /// **This is a reexport of a type in [`icu::locale`](icu_locale_core::preferences::extensions::unicode::keywords)**.
+    #[doc = "\n"] // prevent autoformatting
+    pub use icu_locale_core::preferences::extensions::unicode::keywords::CalendarAlgorithm;
+    #[doc(inline)]
+    /// **This is a reexport of a type in [`icu::locale`](icu_locale_core::preferences::extensions::unicode::keywords)**.
+    #[doc = "\n"] // prevent autoformatting
+    pub use icu_locale_core::preferences::extensions::unicode::keywords::IslamicCalendarAlgorithm;
+}

--- a/components/collator/README.md
+++ b/components/collator/README.md
@@ -230,6 +230,7 @@ Whether to swap the ordering of uppercase and lowercase.
 ```rust
 use core::cmp::Ordering;
 use icu::collator::*;
+use icu::collator::preferences::*;
 
 // Use the locale's default.
 
@@ -265,6 +266,7 @@ numeric value.
 ```rust
 use core::cmp::Ordering;
 use icu::collator::*;
+use icu::collator::preferences::*;
 
 // Numerical sorting off
 

--- a/components/collator/README.md
+++ b/components/collator/README.md
@@ -234,7 +234,7 @@ use icu::collator::*;
 // Use the locale's default.
 
 let mut prefs_no_case = CollatorPreferences::default();
-prefs_no_case.case_first = Some(CaseFirst::False);
+prefs_no_case.case_first = Some(CollationCaseFirst::False);
 let collator_no_case =
     Collator::try_new(prefs_no_case, Default::default()).unwrap();
 assert_eq!(collator_no_case.compare("ab", "AB"), Ordering::Less);
@@ -242,7 +242,7 @@ assert_eq!(collator_no_case.compare("ab", "AB"), Ordering::Less);
 // Lowercase is less
 
 let mut prefs_lower_less = CollatorPreferences::default();
-prefs_lower_less.case_first = Some(CaseFirst::Lower);
+prefs_lower_less.case_first = Some(CollationCaseFirst::Lower);
 let collator_lower_less =
     Collator::try_new(prefs_lower_less, Default::default()).unwrap();
 assert_eq!(collator_lower_less.compare("ab", "AB"), Ordering::Less);
@@ -250,7 +250,7 @@ assert_eq!(collator_lower_less.compare("ab", "AB"), Ordering::Less);
 // Uppercase is less
 
 let mut prefs_upper_greater = CollatorPreferences::default();
-prefs_upper_greater.case_first = Some(CaseFirst::Upper);
+prefs_upper_greater.case_first = Some(CollationCaseFirst::Upper);
 let collator_upper_greater =
     Collator::try_new(prefs_upper_greater, Default::default()).unwrap();
 assert_eq!(collator_upper_greater.compare("AB", "ab"), Ordering::Less);
@@ -269,7 +269,7 @@ use icu::collator::*;
 // Numerical sorting off
 
 let mut prefs_num_off = CollatorPreferences::default();
-prefs_num_off.numeric_ordering = Some(NumericOrdering::False);
+prefs_num_off.numeric_ordering = Some(CollationNumericOrdering::False);
 let collator_num_off =
     Collator::try_new(prefs_num_off, Default::default()).unwrap();
 assert_eq!(collator_num_off.compare("a10b", "a2b"), Ordering::Less);
@@ -277,7 +277,7 @@ assert_eq!(collator_num_off.compare("a10b", "a2b"), Ordering::Less);
 // Numerical sorting on
 
 let mut prefs_num_on = CollatorPreferences::default();
-prefs_num_on.numeric_ordering = Some(NumericOrdering::True);
+prefs_num_on.numeric_ordering = Some(CollationNumericOrdering::True);
 let collator_num_on =
     Collator::try_new(prefs_num_on, Default::default()).unwrap();
 assert_eq!(collator_num_on.compare("a10b", "a2b"), Ordering::Greater);

--- a/components/collator/fuzz/fuzz_targets/compare_utf16.rs
+++ b/components/collator/fuzz/fuzz_targets/compare_utf16.rs
@@ -6,7 +6,7 @@
 use core::cmp::Ordering;
 use core::convert::TryFrom;
 use icu_collator::AlternateHandling;
-use icu_collator::CaseFirst;
+use icu_collator::CollationCaseFirst;
 use icu_collator::Collator;
 use icu_collator::CollatorOptions;
 use icu_collator::MaxVariable;
@@ -102,9 +102,9 @@ fn compare_icu4c(
         .unwrap();
 
     let case_first = match options.case_first() {
-        CaseFirst::UpperFirst => UColAttributeValue::UCOL_UPPER_FIRST,
-        CaseFirst::LowerFirst => UColAttributeValue::UCOL_LOWER_FIRST,
-        CaseFirst::Off => UColAttributeValue::UCOL_OFF,
+        CollationCaseFirst::UpperFirst => UColAttributeValue::UCOL_UPPER_FIRST,
+        CollationCaseFirst::LowerFirst => UColAttributeValue::UCOL_LOWER_FIRST,
+        CollationCaseFirst::Off => UColAttributeValue::UCOL_OFF,
     };
     collator
         .set_attribute(UColAttribute::UCOL_CASE_FIRST, case_first)

--- a/components/collator/src/comparison.rs
+++ b/components/collator/src/comparison.rs
@@ -27,7 +27,8 @@ use crate::provider::CollationSpecialPrimaries;
 use crate::provider::CollationSpecialPrimariesV1;
 use crate::provider::CollationTailoringV1;
 use crate::{
-    AlternateHandling, CaseFirst, CollationType, CollatorOptions, MaxVariable, NumericOrdering,
+    preferences::CollationCaseFirst, preferences::CollationNumericOrdering,
+    preferences::CollationType, AlternateHandling, CollatorOptions, MaxVariable,
     ResolvedCollatorOptions, Strength,
 };
 use core::cmp::Ordering;
@@ -83,15 +84,15 @@ icu_locale_core::preferences::define_preferences!(
     /// ## Case First
     ///
     /// See the [spec](https://www.unicode.org/reports/tr35/tr35-collation.html#Case_Parameters).
-    /// This is the BCP47 key `kf`. Three possibilities: [`CaseFirst::False`] (default,
-    /// except for Danish and Maltese), [`CaseFirst::Lower`], and [`CaseFirst::Upper`]
+    /// This is the BCP47 key `kf`. Three possibilities: [`CollationCaseFirst::False`] (default,
+    /// except for Danish and Maltese), [`CollationCaseFirst::Lower`], and [`CollationCaseFirst::Upper`]
     /// (default for Danish and Maltese).
     ///
     /// ## Numeric
     ///
-    /// This is the BCP47 key `kn`. When set to [`NumericOrdering::True`], any sequence of decimal
+    /// This is the BCP47 key `kn`. When set to [`CollationNumericOrdering::True`], any sequence of decimal
     /// digits (General_Category = Nd) is sorted at the primary level according to the
-    /// numeric value. The default is [`NumericOrdering::False`].
+    /// numeric value. The default is [`CollationNumericOrdering::False`].
     [Copy]
     CollatorPreferences,
     {
@@ -99,11 +100,11 @@ icu_locale_core::preferences::define_preferences!(
         collation_type: CollationType,
         /// Treatment of case. (Large and small kana differences are treated as case differences.)
         /// This corresponds to the `-u-kf` BCP-47 tag.
-        case_first: CaseFirst,
+        case_first: CollationCaseFirst,
         /// When set to `True`, any sequence of decimal digits is sorted at a primary level according
         /// to the numeric value.
         /// This corresponds to the `-u-kn` BPC-47 tag.
-        numeric_ordering: NumericOrdering
+        numeric_ordering: CollationNumericOrdering
     }
 );
 

--- a/components/collator/src/lib.rs
+++ b/components/collator/src/lib.rs
@@ -255,7 +255,7 @@
 //! // Use the locale's default.
 //!
 //! let mut prefs_no_case = CollatorPreferences::default();
-//! prefs_no_case.case_first = Some(CaseFirst::False);
+//! prefs_no_case.case_first = Some(CollationCaseFirst::False);
 //! let collator_no_case =
 //!     Collator::try_new(prefs_no_case, Default::default()).unwrap();
 //! assert_eq!(collator_no_case.compare("ab", "AB"), Ordering::Less);
@@ -263,7 +263,7 @@
 //! // Lowercase is less
 //!
 //! let mut prefs_lower_less = CollatorPreferences::default();
-//! prefs_lower_less.case_first = Some(CaseFirst::Lower);
+//! prefs_lower_less.case_first = Some(CollationCaseFirst::Lower);
 //! let collator_lower_less =
 //!     Collator::try_new(prefs_lower_less, Default::default()).unwrap();
 //! assert_eq!(collator_lower_less.compare("ab", "AB"), Ordering::Less);
@@ -271,7 +271,7 @@
 //! // Uppercase is less
 //!
 //! let mut prefs_upper_greater = CollatorPreferences::default();
-//! prefs_upper_greater.case_first = Some(CaseFirst::Upper);
+//! prefs_upper_greater.case_first = Some(CollationCaseFirst::Upper);
 //! let collator_upper_greater =
 //!     Collator::try_new(prefs_upper_greater, Default::default()).unwrap();
 //! assert_eq!(collator_upper_greater.compare("AB", "ab"), Ordering::Less);
@@ -290,7 +290,7 @@
 //! // Numerical sorting off
 //!
 //! let mut prefs_num_off = CollatorPreferences::default();
-//! prefs_num_off.numeric_ordering = Some(NumericOrdering::False);
+//! prefs_num_off.numeric_ordering = Some(CollationNumericOrdering::False);
 //! let collator_num_off =
 //!     Collator::try_new(prefs_num_off, Default::default()).unwrap();
 //! assert_eq!(collator_num_off.compare("a10b", "a2b"), Ordering::Less);
@@ -298,7 +298,7 @@
 //! // Numerical sorting on
 //!
 //! let mut prefs_num_on = CollatorPreferences::default();
-//! prefs_num_on.numeric_ordering = Some(NumericOrdering::True);
+//! prefs_num_on.numeric_ordering = Some(CollationNumericOrdering::True);
 //! let collator_num_on =
 //!     Collator::try_new(prefs_num_on, Default::default()).unwrap();
 //! assert_eq!(collator_num_on.compare("a10b", "a2b"), Ordering::Greater);
@@ -320,9 +320,6 @@ pub mod provider;
 pub use comparison::Collator;
 pub use comparison::CollatorBorrowed;
 pub use comparison::CollatorPreferences;
-pub use icu_locale_core::preferences::extensions::unicode::keywords::CollationCaseFirst as CaseFirst;
-pub use icu_locale_core::preferences::extensions::unicode::keywords::CollationNumericOrdering as NumericOrdering;
-pub use icu_locale_core::preferences::extensions::unicode::keywords::CollationType;
 pub use options::AlternateHandling;
 pub use options::BackwardSecondLevel;
 pub use options::CaseLevel;
@@ -330,3 +327,16 @@ pub use options::CollatorOptions;
 pub use options::MaxVariable;
 pub use options::ResolvedCollatorOptions;
 pub use options::Strength;
+
+/// Locale preferences used by this crate
+pub mod preferences {
+    /// **This is a reexport of a type in [`icu::locale`](icu_locale_core::preferences::extensions::unicode::keywords)**.
+    #[doc = "\n"] // prevent autoformatting
+    pub use icu_locale_core::preferences::extensions::unicode::keywords::CollationCaseFirst;
+    /// **This is a reexport of a type in [`icu::locale`](icu_locale_core::preferences::extensions::unicode::keywords)**.
+    #[doc = "\n"] // prevent autoformatting
+    pub use icu_locale_core::preferences::extensions::unicode::keywords::CollationNumericOrdering;
+    /// **This is a reexport of a type in [`icu::locale`](icu_locale_core::preferences::extensions::unicode::keywords)**.
+    #[doc = "\n"] // prevent autoformatting
+    pub use icu_locale_core::preferences::extensions::unicode::keywords::CollationType;
+}

--- a/components/collator/src/lib.rs
+++ b/components/collator/src/lib.rs
@@ -251,6 +251,7 @@
 //! ```
 //! use core::cmp::Ordering;
 //! use icu::collator::*;
+//! use icu::collator::preferences::*;
 //!
 //! // Use the locale's default.
 //!
@@ -286,6 +287,7 @@
 //! ```
 //! use core::cmp::Ordering;
 //! use icu::collator::*;
+//! use icu::collator::preferences::*;
 //!
 //! // Numerical sorting off
 //!

--- a/components/collator/src/options.rs
+++ b/components/collator/src/options.rs
@@ -10,7 +10,9 @@
 
 use crate::{
     elements::{CASE_MASK, TERTIARY_MASK},
-    CaseFirst, CollatorPreferences, NumericOrdering,
+    preferences::CollationCaseFirst,
+    preferences::CollationNumericOrdering,
+    CollatorPreferences,
 };
 
 /// The collation strength that indicates how many levels to compare.
@@ -373,7 +375,7 @@ impl From<ResolvedCollatorOptions> for CollatorPreferences {
     /// those are only relevant when loading the collation data.
     ///
     /// [`LocalePreferences`]: icu_locale_core::preferences::LocalePreferences
-    /// [`CollationType`]: crate::CollationType
+    /// [`CollationType`]: crate::preferences::CollationType
     fn from(options: ResolvedCollatorOptions) -> CollatorPreferences {
         CollatorPreferences {
             case_first: Some(options.case_first),
@@ -394,13 +396,13 @@ pub struct ResolvedCollatorOptions {
     /// Resolved alternate handling collation option.
     pub alternate_handling: AlternateHandling,
     /// Resolved case first collation option.
-    pub case_first: CaseFirst,
+    pub case_first: CollationCaseFirst,
     /// Resolved max variable collation option.
     pub max_variable: MaxVariable,
     /// Resolved case level collation option.
     pub case_level: CaseLevel,
     /// Resolved numeric collation option.
-    pub numeric: NumericOrdering,
+    pub numeric: CollationNumericOrdering,
     /// Resolved backward second level collation option.
     pub backward_second_level: BackwardSecondLevel,
 }
@@ -418,9 +420,9 @@ impl From<CollatorOptionsBitField> for ResolvedCollatorOptions {
                 CaseLevel::Off
             },
             numeric: if options.numeric() {
-                NumericOrdering::True
+                CollationNumericOrdering::True
             } else {
-                NumericOrdering::False
+                CollationNumericOrdering::False
             },
             backward_second_level: if options.backward_second_level() {
                 BackwardSecondLevel::On
@@ -599,15 +601,15 @@ impl CollatorOptionsBitField {
         }
     }
 
-    fn case_first(self) -> CaseFirst {
+    fn case_first(self) -> CollationCaseFirst {
         if (self.0 & CollatorOptionsBitField::CASE_FIRST_MASK) != 0 {
             if (self.0 & CollatorOptionsBitField::UPPER_FIRST_MASK) != 0 {
-                CaseFirst::Upper
+                CollationCaseFirst::Upper
             } else {
-                CaseFirst::Lower
+                CollationCaseFirst::Lower
             }
         } else {
-            CaseFirst::False
+            CollationCaseFirst::False
         }
     }
 
@@ -615,17 +617,17 @@ impl CollatorOptionsBitField {
     /// level.
     ///
     /// See [the ICU guide](https://unicode-org.github.io/icu/userguide/collation/concepts.html#caselevel).
-    pub fn set_case_first(&mut self, case_first: Option<CaseFirst>) {
+    pub fn set_case_first(&mut self, case_first: Option<CollationCaseFirst>) {
         self.0 &=
             !(CollatorOptionsBitField::CASE_FIRST_MASK | CollatorOptionsBitField::UPPER_FIRST_MASK);
         if let Some(case_first) = case_first {
             self.0 |= CollatorOptionsBitField::EXPLICIT_CASE_FIRST_MASK;
             match case_first {
-                CaseFirst::False => {}
-                CaseFirst::Lower => {
+                CollationCaseFirst::False => {}
+                CollationCaseFirst::Lower => {
                     self.0 |= CollatorOptionsBitField::CASE_FIRST_MASK;
                 }
-                CaseFirst::Upper => {
+                CollationCaseFirst::Upper => {
                     self.0 |= CollatorOptionsBitField::CASE_FIRST_MASK;
                     self.0 |= CollatorOptionsBitField::UPPER_FIRST_MASK;
                 }
@@ -693,12 +695,12 @@ impl CollatorOptionsBitField {
         }
     }
 
-    pub fn set_numeric_from_enum(&mut self, numeric: Option<NumericOrdering>) {
+    pub fn set_numeric_from_enum(&mut self, numeric: Option<CollationNumericOrdering>) {
         match numeric {
-            Some(NumericOrdering::True) => {
+            Some(CollationNumericOrdering::True) => {
                 self.set_numeric(Some(true));
             }
-            Some(NumericOrdering::False) => {
+            Some(CollationNumericOrdering::False) => {
                 self.set_numeric(Some(false));
             }
             Some(_) => {

--- a/components/collator/src/provider.rs
+++ b/components/collator/src/provider.rs
@@ -34,7 +34,7 @@ use crate::elements::FFFD_CE32;
 use crate::elements::FFFD_CE32_VALUE;
 use crate::elements::FFFD_CE_VALUE;
 use crate::elements::NO_CE_PRIMARY;
-use crate::CaseFirst;
+use crate::preferences::CollationCaseFirst;
 
 use super::MaxVariable;
 
@@ -447,15 +447,15 @@ impl CollationMetadata {
     }
 
     #[inline(always)]
-    pub(crate) fn case_first(self) -> CaseFirst {
+    pub(crate) fn case_first(self) -> CollationCaseFirst {
         if self.bits & CollationMetadata::CASE_FIRST_MASK != 0 {
             if self.bits & CollationMetadata::UPPER_FIRST_MASK != 0 {
-                CaseFirst::Upper
+                CollationCaseFirst::Upper
             } else {
-                CaseFirst::Lower
+                CollationCaseFirst::Lower
             }
         } else {
-            CaseFirst::False
+            CollationCaseFirst::False
         }
     }
 }

--- a/components/collator/tests/tests.rs
+++ b/components/collator/tests/tests.rs
@@ -6,7 +6,7 @@ use core::cmp::Ordering;
 
 use atoi::FromRadix16;
 use icu_collator::provider::*;
-use icu_collator::*;
+use icu_collator::{preferences::*, *};
 use icu_locale_core::{langid, locale, Locale};
 use icu_provider::prelude::*;
 
@@ -1535,7 +1535,7 @@ fn test_basics() {
 #[test]
 fn test_numeric_long() {
     let mut prefs = CollatorPreferences::default();
-    prefs.numeric_ordering = Some(NumericOrdering::True);
+    prefs.numeric_ordering = Some(CollationNumericOrdering::True);
 
     let collator = Collator::try_new(prefs, CollatorOptions::default()).unwrap();
     let mut left = String::new();
@@ -1570,7 +1570,7 @@ fn test_numeric_long() {
 #[test]
 fn test_numeric_after() {
     let mut prefs = CollatorPreferences::default();
-    prefs.numeric_ordering = Some(NumericOrdering::True);
+    prefs.numeric_ordering = Some(CollationNumericOrdering::True);
 
     let collator = Collator::try_new(prefs, CollatorOptions::default()).unwrap();
     assert_eq!(collator.compare("0001000b", "1000a"), Ordering::Greater);
@@ -1802,10 +1802,10 @@ fn test_default_resolved_options() {
     let resolved = collator.resolved_options();
     assert_eq!(resolved.strength, Strength::Tertiary);
     assert_eq!(resolved.alternate_handling, AlternateHandling::NonIgnorable);
-    assert_eq!(resolved.case_first, CaseFirst::False);
+    assert_eq!(resolved.case_first, CollationCaseFirst::False);
     assert_eq!(resolved.max_variable, MaxVariable::Punctuation);
     assert_eq!(resolved.case_level, CaseLevel::Off);
-    assert_eq!(resolved.numeric, NumericOrdering::False);
+    assert_eq!(resolved.numeric, CollationNumericOrdering::False);
     assert_eq!(resolved.backward_second_level, BackwardSecondLevel::Off);
 
     assert_eq!(collator.compare("𝕒", "A"), core::cmp::Ordering::Less);
@@ -1819,10 +1819,10 @@ fn test_data_resolved_options_th() {
     let resolved = collator.resolved_options();
     assert_eq!(resolved.strength, Strength::Tertiary);
     assert_eq!(resolved.alternate_handling, AlternateHandling::Shifted);
-    assert_eq!(resolved.case_first, CaseFirst::False);
+    assert_eq!(resolved.case_first, CollationCaseFirst::False);
     assert_eq!(resolved.max_variable, MaxVariable::Punctuation);
     assert_eq!(resolved.case_level, CaseLevel::Off);
-    assert_eq!(resolved.numeric, NumericOrdering::False);
+    assert_eq!(resolved.numeric, CollationNumericOrdering::False);
     assert_eq!(resolved.backward_second_level, BackwardSecondLevel::Off);
 
     // There's a separate more comprehensive test for the shifted behavior
@@ -1837,10 +1837,10 @@ fn test_data_resolved_options_da() {
     let resolved = collator.resolved_options();
     assert_eq!(resolved.strength, Strength::Tertiary);
     assert_eq!(resolved.alternate_handling, AlternateHandling::NonIgnorable);
-    assert_eq!(resolved.case_first, CaseFirst::Upper);
+    assert_eq!(resolved.case_first, CollationCaseFirst::Upper);
     assert_eq!(resolved.max_variable, MaxVariable::Punctuation);
     assert_eq!(resolved.case_level, CaseLevel::Off);
-    assert_eq!(resolved.numeric, NumericOrdering::False);
+    assert_eq!(resolved.numeric, CollationNumericOrdering::False);
     assert_eq!(resolved.backward_second_level, BackwardSecondLevel::Off);
 
     assert_eq!(collator.compare("𝕒", "A"), core::cmp::Ordering::Greater);
@@ -1854,10 +1854,10 @@ fn test_data_resolved_options_fr_ca() {
     let resolved = collator.resolved_options();
     assert_eq!(resolved.strength, Strength::Tertiary);
     assert_eq!(resolved.alternate_handling, AlternateHandling::NonIgnorable);
-    assert_eq!(resolved.case_first, CaseFirst::False);
+    assert_eq!(resolved.case_first, CollationCaseFirst::False);
     assert_eq!(resolved.max_variable, MaxVariable::Punctuation);
     assert_eq!(resolved.case_level, CaseLevel::Off);
-    assert_eq!(resolved.numeric, NumericOrdering::False);
+    assert_eq!(resolved.numeric, CollationNumericOrdering::False);
     assert_eq!(resolved.backward_second_level, BackwardSecondLevel::On);
 
     assert_eq!(collator.compare("𝕒", "A"), core::cmp::Ordering::Less);
@@ -1870,16 +1870,16 @@ fn test_data_resolved_options_fr_ca() {
 #[test]
 fn test_manual_and_data_resolved_options_fr_ca() {
     let mut prefs: CollatorPreferences = locale!("fr-CA").into();
-    prefs.case_first = Some(CaseFirst::Upper);
+    prefs.case_first = Some(CollationCaseFirst::Upper);
 
     let collator = Collator::try_new(prefs, CollatorOptions::default()).unwrap();
     let resolved = collator.resolved_options();
     assert_eq!(resolved.strength, Strength::Tertiary);
     assert_eq!(resolved.alternate_handling, AlternateHandling::NonIgnorable);
-    assert_eq!(resolved.case_first, CaseFirst::Upper);
+    assert_eq!(resolved.case_first, CollationCaseFirst::Upper);
     assert_eq!(resolved.max_variable, MaxVariable::Punctuation);
     assert_eq!(resolved.case_level, CaseLevel::Off);
-    assert_eq!(resolved.numeric, NumericOrdering::False);
+    assert_eq!(resolved.numeric, CollationNumericOrdering::False);
     assert_eq!(resolved.backward_second_level, BackwardSecondLevel::On);
 
     assert_eq!(collator.compare("𝕒", "A"), core::cmp::Ordering::Greater);
@@ -1892,16 +1892,16 @@ fn test_manual_and_data_resolved_options_fr_ca() {
 #[test]
 fn test_manual_resolved_options_da() {
     let mut prefs: CollatorPreferences = locale!("da").into();
-    prefs.case_first = Some(CaseFirst::False);
+    prefs.case_first = Some(CollationCaseFirst::False);
 
     let collator = Collator::try_new(prefs, CollatorOptions::default()).unwrap();
     let resolved = collator.resolved_options();
     assert_eq!(resolved.strength, Strength::Tertiary);
     assert_eq!(resolved.alternate_handling, AlternateHandling::NonIgnorable);
-    assert_eq!(resolved.case_first, CaseFirst::False);
+    assert_eq!(resolved.case_first, CollationCaseFirst::False);
     assert_eq!(resolved.max_variable, MaxVariable::Punctuation);
     assert_eq!(resolved.case_level, CaseLevel::Off);
-    assert_eq!(resolved.numeric, NumericOrdering::False);
+    assert_eq!(resolved.numeric, CollationNumericOrdering::False);
     assert_eq!(resolved.backward_second_level, BackwardSecondLevel::Off);
 
     assert_eq!(collator.compare("𝕒", "A"), core::cmp::Ordering::Less);
@@ -1954,8 +1954,8 @@ fn test_prefs_overrides() {
         let prefs = locale_prefs;
         let collator = Collator::try_new(prefs, CollatorOptions::default()).unwrap();
         let resolved = collator.resolved_options();
-        assert_eq!(resolved.case_first, CaseFirst::Upper);
-        assert_eq!(resolved.numeric, NumericOrdering::True);
+        assert_eq!(resolved.case_first, CollationCaseFirst::Upper);
+        assert_eq!(resolved.numeric, CollationNumericOrdering::True);
 
         assert_eq!(collator.compare("𝕒", "A"), core::cmp::Ordering::Greater);
         assert_eq!(collator.compare("10", "2"), core::cmp::Ordering::Greater);
@@ -1965,14 +1965,14 @@ fn test_prefs_overrides() {
     {
         let mut prefs = locale_prefs;
         let mut explicit_prefs = CollatorPreferences::default();
-        explicit_prefs.case_first = Some(CaseFirst::False);
-        explicit_prefs.numeric_ordering = Some(NumericOrdering::False);
+        explicit_prefs.case_first = Some(CollationCaseFirst::False);
+        explicit_prefs.numeric_ordering = Some(CollationNumericOrdering::False);
         prefs.extend(explicit_prefs);
 
         let collator = Collator::try_new(prefs, CollatorOptions::default()).unwrap();
         let resolved = collator.resolved_options();
-        assert_eq!(resolved.case_first, CaseFirst::False);
-        assert_eq!(resolved.numeric, NumericOrdering::False);
+        assert_eq!(resolved.case_first, CollationCaseFirst::False);
+        assert_eq!(resolved.numeric, CollationNumericOrdering::False);
 
         assert_eq!(collator.compare("𝕒", "A"), core::cmp::Ordering::Less);
         assert_eq!(collator.compare("10", "2"), core::cmp::Ordering::Less);

--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -112,3 +112,16 @@ pub use neo::FixedCalendarDateTimeFormatter;
 pub use neo::FormattedDateTime;
 pub use neo::TimeFormatter;
 pub use options::Length;
+
+/// Locale preferences used by this crate
+pub mod preferences {
+    /// **This is a reexport of a type in [`icu::locale`](icu_locale_core::preferences::extensions::unicode::keywords)**.
+    #[doc = "\n"] // prevent autoformatting
+    pub use icu_locale_core::preferences::extensions::unicode::keywords::CalendarAlgorithm;
+    /// **This is a reexport of a type in [`icu::locale`](icu_locale_core::preferences::extensions::unicode::keywords)**.
+    #[doc = "\n"] // prevent autoformatting
+    pub use icu_locale_core::preferences::extensions::unicode::keywords::HourCycle;
+    /// **This is a reexport of a type in [`icu::locale`](icu_locale_core::preferences::extensions::unicode::keywords)**.
+    #[doc = "\n"] // prevent autoformatting
+    pub use icu_locale_core::preferences::extensions::unicode::keywords::NumberingSystem;
+}

--- a/components/datetime/src/neo.rs
+++ b/components/datetime/src/neo.rs
@@ -10,6 +10,7 @@ use crate::fieldsets::enums::CompositeFieldSet;
 use crate::format::datetime::try_write_pattern_items;
 use crate::input::ExtractedInput;
 use crate::pattern::*;
+use crate::preferences::{CalendarAlgorithm, HourCycle, NumberingSystem};
 use crate::raw::neo::*;
 use crate::scaffold::*;
 use crate::scaffold::{
@@ -23,9 +24,6 @@ use core::marker::PhantomData;
 use icu_calendar::any_calendar::IntoAnyCalendar;
 use icu_calendar::{AnyCalendar, AnyCalendarPreferences};
 use icu_decimal::DecimalFormatterPreferences;
-use icu_locale_core::preferences::extensions::unicode::keywords::{
-    CalendarAlgorithm, HourCycle, NumberingSystem,
-};
 use icu_locale_core::preferences::{define_preferences, prefs_convert};
 use icu_provider::prelude::*;
 use writeable::{impl_display_with_writeable, Writeable};

--- a/components/decimal/Cargo.toml
+++ b/components/decimal/Cargo.toml
@@ -23,6 +23,7 @@ all-features = true
 displaydoc = { workspace = true }
 fixed_decimal = { workspace = true }
 icu_provider = { workspace = true, features = ["alloc", "macros"] }
+icu_locale_core = { path = "../../components/locale_core" }
 writeable = { workspace = true }
 zerovec = { workspace = true }
 databake = { workspace = true, features = ["derive"], optional = true}
@@ -34,7 +35,6 @@ tinystr = { workspace = true }
 [dev-dependencies]
 icu = { path = "../../components/icu", default-features = false }
 icu_benchmark_macros = { path = "../../tools/benchmark/macros" }
-icu_locale_core = { path = "../../components/locale_core" }
 icu_provider_adapters = { path = "../../provider/adapters" }
 rand = { workspace = true }
 rand_pcg = { workspace = true }

--- a/components/decimal/src/lib.rs
+++ b/components/decimal/src/lib.rs
@@ -106,9 +106,7 @@ pub use format::FormattedDecimal;
 use alloc::string::String;
 use fixed_decimal::SignedFixedDecimal;
 use icu_locale_core::locale;
-use icu_locale_core::preferences::{
-    define_preferences, extensions::unicode::keywords::NumberingSystem,
-};
+use icu_locale_core::preferences::define_preferences;
 use icu_provider::prelude::*;
 use size_test_macro::size_test;
 use writeable::Writeable;
@@ -126,9 +124,16 @@ define_preferences!(
         ///
         /// To get the resolved numbering system, you can inspect the data provider.
         /// See the [`provider`] module for an example.
-        numbering_system: NumberingSystem
+        numbering_system: preferences::NumberingSystem
     }
 );
+
+/// Locale preferences used by this crate
+pub mod preferences {
+    /// **This is a reexport of a type in [`icu::locale`](icu_locale_core::preferences::extensions::unicode::keywords)**.
+    #[doc = "\n"] // prevent autoformatting
+    pub use icu_locale_core::preferences::extensions::unicode::keywords::NumberingSystem;
+}
 
 /// A formatter for [`SignedFixedDecimal`], rendering decimal digits in an i18n-friendly way.
 ///

--- a/components/experimental/src/compactdecimal/formatter.rs
+++ b/components/experimental/src/compactdecimal/formatter.rs
@@ -15,9 +15,7 @@ use alloc::borrow::Cow;
 use core::convert::TryFrom;
 use fixed_decimal::{CompactDecimal, SignedFixedDecimal};
 use icu_decimal::{DecimalFormatter, DecimalFormatterPreferences};
-use icu_locale_core::preferences::{
-    define_preferences, extensions::unicode::keywords::NumberingSystem, prefs_convert,
-};
+use icu_locale_core::preferences::{define_preferences, prefs_convert};
 use icu_plurals::{PluralRules, PluralRulesPreferences};
 use icu_provider::DataError;
 use icu_provider::{marker::ErasedMarker, prelude::*};
@@ -31,7 +29,7 @@ define_preferences!(
         /// The user's preferred numbering system.
         ///
         /// Corresponds to the `-u-nu` in Unicode Locale Identifier.
-        numbering_system: NumberingSystem
+        numbering_system: super::preferences::NumberingSystem
     }
 );
 

--- a/components/experimental/src/compactdecimal/mod.rs
+++ b/components/experimental/src/compactdecimal/mod.rs
@@ -30,3 +30,11 @@ pub use error::ExponentError;
 pub use formatter::CompactDecimalFormatter;
 pub use formatter::CompactDecimalFormatterPreferences;
 pub use options::CompactDecimalFormatterOptions;
+
+/// Locale preferences used by this crate
+pub mod preferences {
+    #[doc(inline)]
+    /// **This is a reexport of a type in [`icu::locale`](icu_locale_core::preferences::extensions::unicode::keywords)**.
+    #[doc = "\n"] // prevent autoformatting
+    pub use icu_locale_core::preferences::extensions::unicode::keywords::NumberingSystem;
+}

--- a/components/experimental/src/dimension/currency/compact_formatter.rs
+++ b/components/experimental/src/dimension/currency/compact_formatter.rs
@@ -12,9 +12,7 @@ use crate::{
 };
 use fixed_decimal::SignedFixedDecimal;
 use icu_decimal::DecimalFormatterPreferences;
-use icu_locale_core::preferences::{
-    define_preferences, extensions::unicode::keywords::NumberingSystem, prefs_convert,
-};
+use icu_locale_core::preferences::{define_preferences, prefs_convert};
 use icu_provider::prelude::*;
 
 use super::{
@@ -32,7 +30,7 @@ define_preferences!(
         /// The user's preferred numbering system.
         ///
         /// Corresponds to the `-u-nu` in Unicode Locale Identifier.
-        numbering_system: NumberingSystem
+        numbering_system: super::super::preferences::NumberingSystem
     }
 );
 

--- a/components/experimental/src/dimension/currency/formatter.rs
+++ b/components/experimental/src/dimension/currency/formatter.rs
@@ -8,9 +8,7 @@ use fixed_decimal::SignedFixedDecimal;
 use icu_decimal::{
     options::DecimalFormatterOptions, DecimalFormatter, DecimalFormatterPreferences,
 };
-use icu_locale_core::preferences::{
-    define_preferences, extensions::unicode::keywords::NumberingSystem, prefs_convert,
-};
+use icu_locale_core::preferences::{define_preferences, prefs_convert};
 use icu_plurals::PluralRulesPreferences;
 use icu_provider::prelude::*;
 
@@ -29,7 +27,7 @@ define_preferences!(
         /// The user's preferred numbering system.
         ///
         /// Corresponds to the `-u-nu` in Unicode Locale Identifier.
-        numbering_system: NumberingSystem
+        numbering_system: super::super::preferences::NumberingSystem
     }
 );
 

--- a/components/experimental/src/dimension/currency/long_compact_formatter.rs
+++ b/components/experimental/src/dimension/currency/long_compact_formatter.rs
@@ -16,9 +16,7 @@ use crate::{
         currency_patterns::CurrencyPatternsDataV1, extended_currency::CurrencyExtendedDataV1,
     },
 };
-use icu_locale_core::preferences::{
-    define_preferences, extensions::unicode::keywords::NumberingSystem, prefs_convert,
-};
+use icu_locale_core::preferences::{define_preferences, prefs_convert};
 
 use super::{long_compact_format::FormattedLongCompactCurrency, CurrencyCode};
 
@@ -29,7 +27,7 @@ define_preferences!(
     [Copy]
     LongCompactCurrencyFormatterPreferences,
     {
-        numbering_system: NumberingSystem
+        numbering_system: super::super::preferences::NumberingSystem
     }
 );
 

--- a/components/experimental/src/dimension/mod.rs
+++ b/components/experimental/src/dimension/mod.rs
@@ -8,3 +8,11 @@ pub mod currency;
 pub mod percent;
 pub mod provider;
 pub mod units;
+
+/// Locale preferences used by this crate
+pub mod preferences {
+    #[doc(inline)]
+    /// **This is a reexport of a type in [`icu::locale`](icu_locale_core::preferences::extensions::unicode::keywords)**.
+    #[doc = "\n"] // prevent autoformatting
+    pub use icu_locale_core::preferences::extensions::unicode::keywords::NumberingSystem;
+}

--- a/components/experimental/src/dimension/percent/formatter.rs
+++ b/components/experimental/src/dimension/percent/formatter.rs
@@ -7,9 +7,7 @@
 use fixed_decimal::SignedFixedDecimal;
 use icu_decimal::options::DecimalFormatterOptions;
 use icu_decimal::{DecimalFormatter, DecimalFormatterPreferences};
-use icu_locale_core::preferences::{
-    define_preferences, extensions::unicode::keywords::NumberingSystem, prefs_convert,
-};
+use icu_locale_core::preferences::{define_preferences, prefs_convert};
 
 use icu_provider::prelude::*;
 
@@ -27,7 +25,7 @@ define_preferences!(
         /// The user's preferred numbering system.
         ///
         /// Corresponds to the `-u-nu` in Unicode Locale Identifier.
-        numbering_system: NumberingSystem
+        numbering_system: super::super::preferences::NumberingSystem
     }
 );
 

--- a/components/experimental/src/dimension/units/formatter.rs
+++ b/components/experimental/src/dimension/units/formatter.rs
@@ -7,9 +7,7 @@
 use fixed_decimal::SignedFixedDecimal;
 use icu_decimal::options::DecimalFormatterOptions;
 use icu_decimal::{DecimalFormatter, DecimalFormatterPreferences};
-use icu_locale_core::preferences::{
-    define_preferences, extensions::unicode::keywords::NumberingSystem, prefs_convert,
-};
+use icu_locale_core::preferences::{define_preferences, prefs_convert};
 use icu_plurals::{PluralRules, PluralRulesPreferences};
 use icu_provider::DataPayload;
 
@@ -29,7 +27,7 @@ define_preferences!(
         /// The user's preferred numbering system.
         ///
         /// Corresponds to the `-u-nu` in Unicode Locale Identifier.
-        numbering_system: NumberingSystem
+        numbering_system: super::super::preferences::NumberingSystem
     }
 );
 prefs_convert!(UnitsFormatterPreferences, DecimalFormatterPreferences, {

--- a/ffi/capi/src/collator.rs
+++ b/ffi/capi/src/collator.rs
@@ -211,46 +211,60 @@ impl From<icu_collator::ResolvedCollatorOptions> for ffi::CollatorResolvedOption
     }
 }
 
-impl From<icu_collator::CaseFirst> for ffi::CollatorCaseFirst {
-    fn from(other: icu_collator::CaseFirst) -> Self {
+impl From<icu_collator::preferences::CollationCaseFirst> for ffi::CollatorCaseFirst {
+    fn from(other: icu_collator::preferences::CollationCaseFirst) -> Self {
         match other {
-            icu_collator::CaseFirst::Upper => ffi::CollatorCaseFirst::Upper,
-            icu_collator::CaseFirst::Lower => ffi::CollatorCaseFirst::Lower,
-            icu_collator::CaseFirst::False => ffi::CollatorCaseFirst::Off,
+            icu_collator::preferences::CollationCaseFirst::Upper => ffi::CollatorCaseFirst::Upper,
+            icu_collator::preferences::CollationCaseFirst::Lower => ffi::CollatorCaseFirst::Lower,
+            icu_collator::preferences::CollationCaseFirst::False => ffi::CollatorCaseFirst::Off,
             _ => {
-                debug_assert!(false, "unknown variant for icu_collator::CaseFirst");
+                debug_assert!(
+                    false,
+                    "unknown variant for icu_collator::preferences::CollationCaseFirst"
+                );
                 ffi::CollatorCaseFirst::Off
             }
         }
     }
 }
-impl From<ffi::CollatorCaseFirst> for icu_collator::CaseFirst {
+impl From<ffi::CollatorCaseFirst> for icu_collator::preferences::CollationCaseFirst {
     fn from(this: ffi::CollatorCaseFirst) -> Self {
         match this {
-            ffi::CollatorCaseFirst::Off => icu_collator::CaseFirst::False,
-            ffi::CollatorCaseFirst::Lower => icu_collator::CaseFirst::Lower,
-            ffi::CollatorCaseFirst::Upper => icu_collator::CaseFirst::Upper,
+            ffi::CollatorCaseFirst::Off => icu_collator::preferences::CollationCaseFirst::False,
+            ffi::CollatorCaseFirst::Lower => icu_collator::preferences::CollationCaseFirst::Lower,
+            ffi::CollatorCaseFirst::Upper => icu_collator::preferences::CollationCaseFirst::Upper,
         }
     }
 }
 
-impl From<icu_collator::NumericOrdering> for ffi::CollatorNumericOrdering {
-    fn from(other: icu_collator::NumericOrdering) -> Self {
+impl From<icu_collator::preferences::CollationNumericOrdering> for ffi::CollatorNumericOrdering {
+    fn from(other: icu_collator::preferences::CollationNumericOrdering) -> Self {
         match other {
-            icu_collator::NumericOrdering::True => ffi::CollatorNumericOrdering::On,
-            icu_collator::NumericOrdering::False => ffi::CollatorNumericOrdering::Off,
+            icu_collator::preferences::CollationNumericOrdering::True => {
+                ffi::CollatorNumericOrdering::On
+            }
+            icu_collator::preferences::CollationNumericOrdering::False => {
+                ffi::CollatorNumericOrdering::Off
+            }
             _ => {
-                debug_assert!(false, "unknown variant for icu_collator::NumericOrdering");
+                debug_assert!(
+                    false,
+                    "unknown variant for icu_collator::preferences::CollationNumericOrdering"
+                );
                 ffi::CollatorNumericOrdering::Off
             }
         }
     }
 }
-impl From<ffi::CollatorNumericOrdering> for icu_collator::NumericOrdering {
+impl From<ffi::CollatorNumericOrdering> for icu_collator::preferences::CollationNumericOrdering {
     fn from(this: ffi::CollatorNumericOrdering) -> Self {
         match this {
-            ffi::CollatorNumericOrdering::Off => icu_collator::NumericOrdering::False,
-            ffi::CollatorNumericOrdering::On => icu_collator::NumericOrdering::True,
+            ffi::CollatorNumericOrdering::Off => {
+                icu_collator::preferences::CollationNumericOrdering::False
+            }
+            ffi::CollatorNumericOrdering::On => {
+                icu_collator::preferences::CollationNumericOrdering::True
+            }
         }
     }
 }

--- a/ffi/capi/tests/missing_apis.txt
+++ b/ffi/capi/tests/missing_apis.txt
@@ -14,21 +14,6 @@
 # Please check in with @Manishearth, @robertbastian, or @sffc if you have questions
 
 
-icu::collator::CollationCaseFirst#Enum
-icu::collator::CollationCaseFirst::as_str#FnInEnum
-icu::collator::CollationCaseFirst::try_from_key_value#FnInEnum
-icu::collator::CollationCaseFirst::unicode_extension_key#FnInEnum
-icu::collator::CollationCaseFirst::unicode_extension_value#FnInEnum
-icu::collator::CollationNumericOrdering#Enum
-icu::collator::CollationNumericOrdering::as_str#FnInEnum
-icu::collator::CollationNumericOrdering::try_from_key_value#FnInEnum
-icu::collator::CollationNumericOrdering::unicode_extension_key#FnInEnum
-icu::collator::CollationNumericOrdering::unicode_extension_value#FnInEnum
-icu::collator::CollationType#Enum
-icu::collator::CollationType::as_str#FnInEnum
-icu::collator::CollationType::try_from_key_value#FnInEnum
-icu::collator::CollationType::unicode_extension_key#FnInEnum
-icu::collator::CollationType::unicode_extension_value#FnInEnum
 icu::collator::CollatorPreferences::extend#FnInStruct
 icu::datetime::fieldsets::Combo#Struct
 icu::datetime::fieldsets::Combo::into_enums#FnInStruct

--- a/tools/make/diplomat-coverage/src/allowlist.rs
+++ b/tools/make/diplomat-coverage/src/allowlist.rs
@@ -180,6 +180,12 @@ lazy_static::lazy_static! {
         "icu::locale::preferences::LocalePreferences",
         "icu::plurals::PluralRulesPreferences",
         "icu::locale::preferences::PreferenceKey",
+        // And the preference enums
+        "icu::calendar::preferences",
+        "icu::collator::preferences",
+        "icu::datetime::preferences",
+        "icu::decimal::preferences",
+
 
         // TODO-2.0: decide later when we have figured out prefs/ctors and have APIs using this
         "icu::locale::LanguageIdentifier",


### PR DESCRIPTION
Fixes #5915, including the stretch goal.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->