### PR TITLE
DateTime: Add conversions between Formatter and Names

### DIFF
--- a/components/datetime/src/neo.rs
+++ b/components/datetime/src/neo.rs
@@ -247,6 +247,7 @@ where
             .map_err(|e| e.0)
     }
 
+    #[allow(clippy::result_large_err)] // returning ownership of an argument to the caller
     pub(crate) fn try_new_internal_with_names<P0, P1, L>(
         provider_p: &P0,
         provider: &P1,
@@ -498,6 +499,7 @@ where
         .map_err(|e| e.0)
     }
 
+    #[allow(clippy::result_large_err)] // returning ownership of an argument to the caller
     pub(crate) fn try_new_internal_with_calendar_and_names<P0, P1, L>(
         provider_p: &P0,
         provider: &P1,

--- a/components/datetime/src/pattern/mod.rs
+++ b/components/datetime/src/pattern/mod.rs
@@ -19,6 +19,7 @@ use crate::error::ErrorField;
 pub use formatter::DateTimePatternFormatter;
 pub use formatter::FormattedDateTimePattern;
 use icu_pattern::SinglePlaceholderPattern;
+pub use names::DateTimeNames;
 pub use names::DayPeriodNameLength;
 pub use names::MonthNameLength;
 pub(crate) use names::RawDateTimeNames;

--- a/components/datetime/src/pattern/names.rs
+++ b/components/datetime/src/pattern/names.rs
@@ -877,6 +877,47 @@ where
         )
         .map_err(|e| (e.0, Self::from_parts(self.prefs, e.1)))
     }
+
+    #[doc = icu_provider::gen_buffer_unstable_docs!(UNSTABLE, Self::try_into_formatter)]
+    pub fn try_into_formatter_unstable<P>(
+        self,
+        provider: &P,
+        field_set: FSet,
+    ) -> Result<FixedCalendarDateTimeFormatter<C, FSet>, (DateTimeFormatterLoadError, Self)>
+    where
+        P: AllFixedCalendarPatternDataMarkers<C, FSet> + ?Sized,
+    {
+        FixedCalendarDateTimeFormatter::try_new_internal_with_names(
+            provider,
+            &EmptyDataProvider,
+            &ExternalLoaderUnstable(&EmptyDataProvider), // for decimals only
+            self.prefs,
+            field_set.get_field(),
+            self.inner,
+        )
+        .map_err(|e| (e.0, Self::from_parts(self.prefs, e.1)))
+    }
+
+    #[doc = icu_provider::gen_buffer_unstable_docs!(BUFFER, Self::try_into_formatter)]
+    #[cfg(feature = "serde")]
+    pub fn try_into_formatter_with_buffer_provider<P>(
+        self,
+        provider: &P,
+        field_set: FSet,
+    ) -> Result<FixedCalendarDateTimeFormatter<C, FSet>, (DateTimeFormatterLoadError, Self)>
+    where
+        P: BufferProvider + ?Sized,
+    {
+        FixedCalendarDateTimeFormatter::try_new_internal_with_names(
+            &provider.as_deserializing(),
+            &EmptyDataProvider,
+            &ExternalLoaderUnstable(&EmptyDataProvider), // for decimals only
+            self.prefs,
+            field_set.get_field(),
+            self.inner,
+        )
+        .map_err(|e| (e.0, Self::from_parts(self.prefs, e.1)))
+    }
 }
 
 impl<FSet: DateTimeNamesMarker> DateTimeNames<FSet> {

--- a/components/datetime/src/pattern/names.rs
+++ b/components/datetime/src/pattern/names.rs
@@ -859,6 +859,7 @@ where
     ///     "12:00 a.m."
     /// );
     /// ```
+    #[allow(clippy::result_large_err)] // returning self as the error
     #[cfg(feature = "compiled_data")]
     pub fn try_into_formatter(
         self,
@@ -879,6 +880,7 @@ where
     }
 
     #[doc = icu_provider::gen_buffer_unstable_docs!(UNSTABLE, Self::try_into_formatter)]
+    #[allow(clippy::result_large_err)] // returning self as the error
     pub fn try_into_formatter_unstable<P>(
         self,
         provider: &P,
@@ -899,6 +901,7 @@ where
     }
 
     #[doc = icu_provider::gen_buffer_unstable_docs!(BUFFER, Self::try_into_formatter)]
+    #[allow(clippy::result_large_err)] // returning self as the error
     #[cfg(feature = "serde")]
     pub fn try_into_formatter_with_buffer_provider<P>(
         self,
@@ -1042,6 +1045,7 @@ where
     ///     "12:00 a.m."
     /// );
     /// ```
+    #[allow(clippy::result_large_err)] // returning self as the error
     #[cfg(feature = "compiled_data")]
     pub fn try_into_formatter(
         self,
@@ -1063,6 +1067,7 @@ where
     }
 
     #[doc = icu_provider::gen_buffer_unstable_docs!(UNSTABLE, Self::try_into_formatter)]
+    #[allow(clippy::result_large_err)] // returning self as the error
     pub fn try_into_formatter_unstable<P>(
         self,
         provider: &P,
@@ -1084,6 +1089,7 @@ where
     }
 
     #[doc = icu_provider::gen_buffer_unstable_docs!(BUFFER, Self::try_into_formatter)]
+    #[allow(clippy::result_large_err)] // returning self as the error
     #[cfg(feature = "serde")]
     pub fn try_into_formatter_with_buffer_provider<P>(
         self,

--- a/components/datetime/src/scaffold/fieldset_traits.rs
+++ b/components/datetime/src/scaffold/fieldset_traits.rs
@@ -237,18 +237,50 @@ where
 }
 
 /// Trait to consolidate data provider markers defined by this crate
+/// for datetime skeleton patterns with a fixed calendar.
+///
+/// This trait is implemented on all providers that support datetime skeleton patterns,
+/// including [`crate::provider::Baked`].
+// This trait is implicitly sealed due to sealed supertraits
+#[rustfmt::skip]
+pub trait AllFixedCalendarPatternDataMarkers<C: CldrCalendar, FSet: DateTimeMarkers>:
+DataProvider<<FSet::D as TypedDateDataMarkers<C>>::DateSkeletonPatternsV1>
+    + DataProvider<<FSet::T as TimeMarkers>::TimeSkeletonPatternsV1>
+    + DataProvider<FSet::GluePatternV1>
+where
+    FSet::D: TypedDateDataMarkers<C>,
+    FSet::T: TimeMarkers,
+    FSet::Z: ZoneMarkers,
+{
+}
+
+#[rustfmt::skip]
+impl<T, C, FSet> AllFixedCalendarPatternDataMarkers<C, FSet> for T
+where
+    C: CldrCalendar,
+    FSet: DateTimeMarkers,
+    FSet::D: TypedDateDataMarkers<C>,
+    FSet::T: TimeMarkers,
+    FSet::Z: ZoneMarkers,
+    T: ?Sized
+        + DataProvider<<FSet::D as TypedDateDataMarkers<C>>::DateSkeletonPatternsV1>
+        + DataProvider<<FSet::T as TimeMarkers>::TimeSkeletonPatternsV1>
+        + DataProvider<FSet::GluePatternV1>,
+{
+}
+
+/// Trait to consolidate data provider markers defined by this crate
 /// for datetime formatting with a fixed calendar.
 ///
 /// This trait is implemented on all providers that support datetime formatting,
 /// including [`crate::provider::Baked`].
 // This trait is implicitly sealed due to sealed supertraits
+#[rustfmt::skip]
 pub trait AllFixedCalendarFormattingDataMarkers<C: CldrCalendar, FSet: DateTimeMarkers>:
     DataProvider<<FSet::D as TypedDateDataMarkers<C>>::YearNamesV1>
     + DataProvider<<FSet::D as TypedDateDataMarkers<C>>::MonthNamesV1>
-    + DataProvider<<FSet::D as TypedDateDataMarkers<C>>::DateSkeletonPatternsV1>
     + DataProvider<<FSet::D as TypedDateDataMarkers<C>>::WeekdayNamesV1>
     + DataProvider<<FSet::T as TimeMarkers>::DayPeriodNamesV1>
-    + DataProvider<<FSet::T as TimeMarkers>::TimeSkeletonPatternsV1>
     + DataProvider<<FSet::Z as ZoneMarkers>::EssentialsV1>
     + DataProvider<<FSet::Z as ZoneMarkers>::LocationsV1>
     + DataProvider<<FSet::Z as ZoneMarkers>::LocationsRootV1>
@@ -259,7 +291,7 @@ pub trait AllFixedCalendarFormattingDataMarkers<C: CldrCalendar, FSet: DateTimeM
     + DataProvider<<FSet::Z as ZoneMarkers>::SpecificLongV1>
     + DataProvider<<FSet::Z as ZoneMarkers>::SpecificShortV1>
     + DataProvider<<FSet::Z as ZoneMarkers>::MetazonePeriodV1>
-    + DataProvider<FSet::GluePatternV1>
+    + AllFixedCalendarPatternDataMarkers<C, FSet>
 where
     FSet::D: TypedDateDataMarkers<C>,
     FSet::T: TimeMarkers,
@@ -267,6 +299,7 @@ where
 {
 }
 
+#[rustfmt::skip]
 impl<T, C, FSet> AllFixedCalendarFormattingDataMarkers<C, FSet> for T
 where
     C: CldrCalendar,
@@ -291,7 +324,8 @@ where
         + DataProvider<<FSet::Z as ZoneMarkers>::SpecificLongV1>
         + DataProvider<<FSet::Z as ZoneMarkers>::SpecificShortV1>
         + DataProvider<<FSet::Z as ZoneMarkers>::MetazonePeriodV1>
-        + DataProvider<FSet::GluePatternV1>,
+        + DataProvider<FSet::GluePatternV1>
+        + AllFixedCalendarPatternDataMarkers<C, FSet>
 {
 }
 
@@ -475,7 +509,7 @@ where
         + DataProvider<<FSet::Z as ZoneMarkers>::SpecificLongV1>
         + DataProvider<<FSet::Z as ZoneMarkers>::SpecificShortV1>
         + DataProvider<<FSet::Z as ZoneMarkers>::MetazonePeriodV1>
-        + AllAnyCalendarPatternDataMarkers<FSet>,
+        + AllAnyCalendarPatternDataMarkers<FSet>
 {
 }
 

--- a/components/datetime/src/scaffold/fieldset_traits.rs
+++ b/components/datetime/src/scaffold/fieldset_traits.rs
@@ -296,11 +296,76 @@ where
 }
 
 /// Trait to consolidate data provider markers defined by this crate
+/// for datetime skeleton patterns with any calendar.
+///
+/// This trait is implemented on all providers that support datetime skeleton patterns,
+/// including [`crate::provider::Baked`].
+// This trait is implicitly sealed due to sealed supertraits
+#[rustfmt::skip]
+pub trait AllAnyCalendarPatternDataMarkers<FSet: DateTimeMarkers>:
+    DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Buddhist>
+    + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Chinese>
+    + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Coptic>
+    + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Dangi>
+    + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Ethiopian>
+    + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::EthiopianAmeteAlem>
+    + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Gregorian>
+    + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Hebrew>
+    + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Indian>
+    + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::IslamicCivil>
+    + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::IslamicObservational>
+    + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::IslamicTabular>
+    + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::IslamicUmmAlQura>
+    + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Japanese>
+    + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::JapaneseExtended>
+    + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Persian>
+    + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Roc>
+    + DataProvider<<FSet::T as TimeMarkers>::TimeSkeletonPatternsV1>
+    + DataProvider<FSet::GluePatternV1>
+where
+    FSet::D: DateDataMarkers,
+    FSet::T: TimeMarkers,
+    FSet::Z: ZoneMarkers,
+{
+}
+
+#[rustfmt::skip]
+impl<T, FSet> AllAnyCalendarPatternDataMarkers<FSet> for T
+where
+    FSet: DateTimeMarkers,
+    FSet::D: DateDataMarkers,
+    FSet::T: TimeMarkers,
+    FSet::Z: ZoneMarkers,
+    T: ?Sized
+        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Buddhist>
+        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Chinese>
+        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Coptic>
+        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Dangi>
+        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Ethiopian>
+        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::EthiopianAmeteAlem>
+        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Gregorian>
+        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Hebrew>
+        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Indian>
+        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::IslamicCivil>
+        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::IslamicObservational>
+        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::IslamicTabular>
+        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::IslamicUmmAlQura>
+        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Japanese>
+        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::JapaneseExtended>
+        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Persian>
+        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Roc>
+        + DataProvider<<FSet::T as TimeMarkers>::TimeSkeletonPatternsV1>
+        + DataProvider<FSet::GluePatternV1>
+{
+}
+
+/// Trait to consolidate data provider markers defined by this crate
 /// for datetime formatting with any calendar.
 ///
 /// This trait is implemented on all providers that support datetime formatting,
 /// including [`crate::provider::Baked`].
 // This trait is implicitly sealed due to sealed supertraits
+#[rustfmt::skip]
 pub trait AllAnyCalendarFormattingDataMarkers<FSet: DateTimeMarkers>:
     DataProvider<<<FSet::D as DateDataMarkers>::Year as CalMarkers<YearNamesV1>>::Buddhist>
     + DataProvider<<<FSet::D as DateDataMarkers>::Year as CalMarkers<YearNamesV1>>::Chinese>
@@ -336,26 +401,8 @@ pub trait AllAnyCalendarFormattingDataMarkers<FSet: DateTimeMarkers>:
     + DataProvider<<<FSet::D as DateDataMarkers>::Month as CalMarkers<MonthNamesV1>>::JapaneseExtended>
     + DataProvider<<<FSet::D as DateDataMarkers>::Month as CalMarkers<MonthNamesV1>>::Persian>
     + DataProvider<<<FSet::D as DateDataMarkers>::Month as CalMarkers<MonthNamesV1>>::Roc>
-    + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Buddhist>
-    + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Chinese>
-    + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Coptic>
-    + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Dangi>
-    + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Ethiopian>
-    + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::EthiopianAmeteAlem>
-    + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Gregorian>
-    + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Hebrew>
-    + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Indian>
-    + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::IslamicCivil>
-    + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::IslamicObservational>
-    + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::IslamicTabular>
-    + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::IslamicUmmAlQura>
-    + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Japanese>
-    + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::JapaneseExtended>
-    + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Persian>
-    + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Roc>
     + DataProvider<<FSet::D as DateDataMarkers>::WeekdayNamesV1>
     + DataProvider<<FSet::T as TimeMarkers>::DayPeriodNamesV1>
-    + DataProvider<<FSet::T as TimeMarkers>::TimeSkeletonPatternsV1>
     + DataProvider<<FSet::Z as ZoneMarkers>::EssentialsV1>
     + DataProvider<<FSet::Z as ZoneMarkers>::LocationsV1>
     + DataProvider<<FSet::Z as ZoneMarkers>::LocationsRootV1>
@@ -366,7 +413,7 @@ pub trait AllAnyCalendarFormattingDataMarkers<FSet: DateTimeMarkers>:
     + DataProvider<<FSet::Z as ZoneMarkers>::SpecificLongV1>
     + DataProvider<<FSet::Z as ZoneMarkers>::SpecificShortV1>
     + DataProvider<<FSet::Z as ZoneMarkers>::MetazonePeriodV1>
-    + DataProvider<FSet::GluePatternV1>
+    + AllAnyCalendarPatternDataMarkers<FSet>
 where
     FSet::D: DateDataMarkers,
     FSet::T: TimeMarkers,
@@ -374,6 +421,7 @@ where
 {
 }
 
+#[rustfmt::skip]
 impl<T, FSet> AllAnyCalendarFormattingDataMarkers<FSet> for T
 where
     FSet: DateTimeMarkers,
@@ -415,26 +463,8 @@ where
         + DataProvider<<<FSet::D as DateDataMarkers>::Month as CalMarkers<MonthNamesV1>>::JapaneseExtended>
         + DataProvider<<<FSet::D as DateDataMarkers>::Month as CalMarkers<MonthNamesV1>>::Persian>
         + DataProvider<<<FSet::D as DateDataMarkers>::Month as CalMarkers<MonthNamesV1>>::Roc>
-        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Buddhist>
-        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Chinese>
-        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Coptic>
-        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Dangi>
-        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Ethiopian>
-        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::EthiopianAmeteAlem>
-        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Gregorian>
-        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Hebrew>
-        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Indian>
-        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::IslamicCivil>
-        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::IslamicObservational>
-        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::IslamicTabular>
-        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::IslamicUmmAlQura>
-        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Japanese>
-        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::JapaneseExtended>
-        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Persian>
-        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Roc>
         + DataProvider<<FSet::D as DateDataMarkers>::WeekdayNamesV1>
         + DataProvider<<FSet::T as TimeMarkers>::DayPeriodNamesV1>
-        + DataProvider<<FSet::T as TimeMarkers>::TimeSkeletonPatternsV1>
         + DataProvider<<FSet::Z as ZoneMarkers>::EssentialsV1>
         + DataProvider<<FSet::Z as ZoneMarkers>::LocationsV1>
         + DataProvider<<FSet::Z as ZoneMarkers>::LocationsRootV1>
@@ -445,7 +475,7 @@ where
         + DataProvider<<FSet::Z as ZoneMarkers>::SpecificLongV1>
         + DataProvider<<FSet::Z as ZoneMarkers>::SpecificShortV1>
         + DataProvider<<FSet::Z as ZoneMarkers>::MetazonePeriodV1>
-        + DataProvider<FSet::GluePatternV1>
+        + AllAnyCalendarPatternDataMarkers<FSet>,
 {
 }
 

--- a/components/datetime/src/scaffold/mod.rs
+++ b/components/datetime/src/scaffold/mod.rs
@@ -25,6 +25,7 @@ pub use calendar::NoDataCalMarkers;
 pub(crate) use fieldset_traits::datetime_marker_helper;
 pub use fieldset_traits::AllAnyCalendarExternalDataMarkers;
 pub use fieldset_traits::AllAnyCalendarFormattingDataMarkers;
+pub use fieldset_traits::AllAnyCalendarPatternDataMarkers;
 pub use fieldset_traits::AllFixedCalendarExternalDataMarkers;
 pub use fieldset_traits::AllFixedCalendarFormattingDataMarkers;
 pub use fieldset_traits::AllInputMarkers;

--- a/components/datetime/src/scaffold/mod.rs
+++ b/components/datetime/src/scaffold/mod.rs
@@ -28,6 +28,7 @@ pub use fieldset_traits::AllAnyCalendarFormattingDataMarkers;
 pub use fieldset_traits::AllAnyCalendarPatternDataMarkers;
 pub use fieldset_traits::AllFixedCalendarExternalDataMarkers;
 pub use fieldset_traits::AllFixedCalendarFormattingDataMarkers;
+pub use fieldset_traits::AllFixedCalendarPatternDataMarkers;
 pub use fieldset_traits::AllInputMarkers;
 pub use fieldset_traits::DateDataMarkers;
 pub use fieldset_traits::DateInputMarkers;


### PR DESCRIPTION
Toward #5940 

This allows a client such as FFI to add arbitrary data to a DateTimeFormatter instance.

I put the conversion functions and docs on the DateTimeNames types because this is a power-user feature.