### PR TITLE
Remove myself from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,7 +13,7 @@ components/collator/              @hsivonen @echeran
 components/collections/           @echeran
 components/datetime/              @sffc @zbraniecki
 components/decimal/               @sffc
-components/experimental/src/compactdecimal/      @eggrobin
+components/experimental/src/compactdecimal/      @younies
 components/experimental/src/dimension/           @younies
 components/experimental/src/displaynames/        @sffc @snktd
 components/experimental/src/relativetime/        @pdogr


### PR DESCRIPTION
I have not touched nor really looked at compactdecimal since 2022, and the couple of irrelevant emails a week I get from cross-cutting changes in that directory hide actual cases where someone wants me to look at something.