### PR TITLE
Implement Entry apis for LiteMap

### DIFF
--- a/utils/litemap/src/lib.rs
+++ b/utils/litemap/src/lib.rs
@@ -66,4 +66,4 @@ pub mod store;
 #[cfg(any(test, feature = "testing"))]
 pub mod testing;
 
-pub use map::LiteMap;
+pub use map::{Entry, LiteMap, OccupiedEntry, VacantEntry};


### PR DESCRIPTION
Add BTreeMap-like APIs to LiteMap to get closer to the std lib BTreeMap, which has familiarity benefits and allows easier integration of LiteMap into existing projects.

Even though `try_get_or_insert` exists, the Entry API is a more familiar API with good performance, as it may avoid a potentially wasted second binary search.

This is a follow-up of https://github.com/unicode-org/icu4x/pull/5894 and #6068