### PR TITLE
Impl Extend for LiteMap and avoid quadratic behavior in from_iter and deserialize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1966,6 +1966,7 @@ dependencies = [
  "icu_benchmark_macros",
  "icu_locale_core",
  "postcard",
+ "rand 0.9.0",
  "rkyv",
  "serde",
  "serde_json",

--- a/components/locale_core/src/shortvec/litemap.rs
+++ b/components/locale_core/src/shortvec/litemap.rs
@@ -12,6 +12,15 @@ impl<K, V> StoreConstEmpty<K, V> for ShortBoxSlice<(K, V)> {
     const EMPTY: ShortBoxSlice<(K, V)> = ShortBoxSlice::new();
 }
 
+impl<K, V> StoreSlice<K, V> for ShortBoxSlice<(K, V)> {
+    type Slice = [(K, V)];
+
+    #[inline]
+    fn lm_get_range(&self, range: core::ops::Range<usize>) -> Option<&Self::Slice> {
+        self.get(range)
+    }
+}
+
 impl<K, V> Store<K, V> for ShortBoxSlice<(K, V)> {
     #[inline]
     fn lm_len(&self) -> usize {

--- a/components/locale_core/src/shortvec/litemap.rs
+++ b/components/locale_core/src/shortvec/litemap.rs
@@ -107,21 +107,42 @@ impl<K: Ord, V> StoreBulkMut<K, V> for ShortBoxSlice<(K, V)> {
     where
         I: IntoIterator<Item = (K, V)>,
     {
-        let other = other.into_iter();
-        let mut items = alloc::vec::Vec::with_capacity(self.len() + other.size_hint().0);
+        let mut other = other.into_iter();
+        // Use an Option to hold the first item of the map and move it to
+        // items if there are more items. Meaning that if items is not
+        // empty, first is None.
+        let mut first = None;
+        let mut items = alloc::vec::Vec::new();
         match core::mem::take(&mut self.0) {
-            ShortBoxSliceInner::ZeroOne(None) => (),
-            ShortBoxSliceInner::ZeroOne(Some(existing_item)) => {
-                items.push(existing_item);
+            ShortBoxSliceInner::ZeroOne(zo) => {
+                first = zo;
+                // Attempt to avoid the items allocation by advancing the iterator
+                // up to two times. If we eventually find a second item, we can
+                // lm_extend the Vec and with the first, next (second) and the rest
+                // of the iterator.
+                while let Some(next) = other.next() {
+                    if let Some(first) = first.take() {
+                        // lm_extend will take care of sorting and deduplicating
+                        // first, next and the rest of the other iterator.
+                        items.lm_extend([first, next].into_iter().chain(other));
+                        break;
+                    }
+                    first = Some(next);
+                }
             }
             ShortBoxSliceInner::Multi(existing_items) => {
+                items.reserve_exact(existing_items.len() + other.size_hint().0);
+                // We use a plain extend with existing items, which are already valid and
+                // lm_extend will fold over rest of the iterator sorting and deduplicating as needed.
                 items.extend(existing_items);
+                items.lm_extend(other);
             }
         }
-        items.lm_extend(other);
-        if items.len() <= 1 {
-            self.0 = ShortBoxSliceInner::ZeroOne(items.pop());
+        if items.is_empty() {
+            debug_assert!(items.is_empty());
+            self.0 = ShortBoxSliceInner::ZeroOne(first);
         } else {
+            debug_assert!(first.is_none());
             self.0 = ShortBoxSliceInner::Multi(items.into_boxed_slice());
         }
     }

--- a/utils/litemap/Cargo.toml
+++ b/utils/litemap/Cargo.toml
@@ -28,6 +28,7 @@ serde = { workspace = true, optional = true, features = ["alloc"]}
 yoke = { workspace = true, features = ["derive"], optional = true }
 
 [dev-dependencies]
+rand = { workspace = true }
 bincode = { workspace = true }
 icu_benchmark_macros = { path = "../../tools/benchmark/macros" }
 icu_locale_core = { path = "../../components/locale_core" }
@@ -43,7 +44,7 @@ criterion = { workspace = true }
 default = ["alloc"]
 alloc = []
 databake = ["dep:databake"]
-serde = ["dep:serde"]
+serde = ["dep:serde", "alloc"]
 yoke = ["dep:yoke"]
 
 # Enables the `testing` module with tools for testing custom stores.

--- a/utils/litemap/README.md
+++ b/utils/litemap/README.md
@@ -7,13 +7,27 @@
 `litemap` is a crate providing [`LiteMap`], a highly simplistic "flat" key-value map
 based off of a single sorted vector.
 
-The goal of this crate is to provide a map that is good enough for small
+The main goal of this crate is to provide a map that is good enough for small
 sizes, and does not carry the binary size impact of [`HashMap`](std::collections::HashMap)
 or [`BTreeMap`](alloc::collections::BTreeMap).
 
 If binary size is not a concern, [`std::collections::BTreeMap`] may be a better choice
 for your use case. It behaves very similarly to [`LiteMap`] for less than 12 elements,
 and upgrades itself gracefully for larger inputs.
+
+### Performance characteristics
+
+[`LiteMap`] is a data structure with similar characteristics as [`std::collections::BTreeMap`] but
+with slightly different trade-offs as it's implemented on top of a flat storage (e.g. Vec).
+
+* [`LiteMap`] iteration is generally faster than `BTreeMap` because of the flat storage.
+* [`LiteMap`] can be pre-allocated whereas `BTreeMap` can't.
+* [`LiteMap`] has a smaller memory footprint than `BTreeMap` for small collections (< 20 items).
+* Lookup is `O(log(n))` like `BTreeMap`.
+* Insertion is generally `O(n)`, but optimized to `O(1)` if the new item sorts greater than the current items. In `BTreeMap` it's `O(log(n))`.
+* Deletion is `O(n)` whereas `BTreeMap` is `O(log(n))`.
+* Bulk operations like `from_iter`, `extend` and deserialization are optimized for inputs that
+   are already ordered but have `O(n*log(n))` complexity regardless of the order of the input items.
 
 ### Pluggable Backends
 

--- a/utils/litemap/README.md
+++ b/utils/litemap/README.md
@@ -26,8 +26,8 @@ with slightly different trade-offs as it's implemented on top of a flat storage 
 * Lookup is `O(log(n))` like `BTreeMap`.
 * Insertion is generally `O(n)`, but optimized to `O(1)` if the new item sorts greater than the current items. In `BTreeMap` it's `O(log(n))`.
 * Deletion is `O(n)` whereas `BTreeMap` is `O(log(n))`.
-* Bulk operations like `from_iter`, `extend` and deserialization are optimized for inputs that
-   are already ordered but have `O(n*log(n))` complexity regardless of the order of the input items.
+* Bulk operations like `from_iter`, `extend` and deserialization have an optimized `O(n)` path
+   for inputs that are ordered and `O(n*log(n))` complexity otherwise.
 
 ### Pluggable Backends
 

--- a/utils/litemap/benches/litemap.rs
+++ b/utils/litemap/benches/litemap.rs
@@ -103,7 +103,7 @@ fn bench_deserialize_large(c: &mut Criterion) {
 fn bench_from_iter(c: &mut Criterion) {
     c.bench_function("litemap/from_iter_rand/small", |b| {
         let mut ff = build_litemap(false).into_iter().collect::<Vec<_>>();
-        ff[..].shuffle(&mut rand::thread_rng());
+        ff[..].shuffle(&mut rand::rng());
         b.iter(|| {
             let map: LiteMap<&String, &String> = LiteMap::from_iter(ff.iter().map(|(k, v)| (k, v)));
             black_box(map)
@@ -114,7 +114,7 @@ fn bench_from_iter(c: &mut Criterion) {
 fn bench_from_iter_rand_large(c: &mut Criterion) {
     c.bench_function("litemap/from_iter_rand/large", |b| {
         let mut ff = build_litemap(true).into_iter().collect::<Vec<_>>();
-        ff[..].shuffle(&mut rand::thread_rng());
+        ff[..].shuffle(&mut rand::rng());
         b.iter(|| {
             let map: LiteMap<&String, &String> = LiteMap::from_iter(ff.iter().map(|(k, v)| (k, v)));
             black_box(map)
@@ -145,7 +145,7 @@ fn bench_from_iter_large_sorted(c: &mut Criterion) {
 fn bench_extend_rand(c: &mut Criterion) {
     c.bench_function("litemap/extend_rand/large", |b| {
         let mut ff = build_litemap(true).into_iter().collect::<Vec<_>>();
-        ff[..].shuffle(&mut rand::thread_rng());
+        ff[..].shuffle(&mut rand::rng());
         b.iter(|| {
             let mut map: LiteMap<&String, &String> = LiteMap::with_capacity(0);
             let mut iter = ff.iter().map(|(k, v)| (k, v));
@@ -161,7 +161,7 @@ fn bench_extend_rand(c: &mut Criterion) {
 fn bench_extend_rand_dups(c: &mut Criterion) {
     c.bench_function("litemap/extend_rand_dups/large", |b| {
         let mut ff = build_litemap(true).into_iter().collect::<Vec<_>>();
-        ff[..].shuffle(&mut rand::thread_rng());
+        ff[..].shuffle(&mut rand::rng());
         b.iter(|| {
             let mut map: LiteMap<&String, &String> = LiteMap::with_capacity(0);
             for _ in 0..2 {
@@ -179,7 +179,7 @@ fn bench_extend_rand_dups(c: &mut Criterion) {
 fn bench_extend_from_litemap_rand(c: &mut Criterion) {
     c.bench_function("litemap/extend_from_litemap_rand/large", |b| {
         let mut ff = build_litemap(true).into_iter().collect::<Vec<_>>();
-        ff[..].shuffle(&mut rand::thread_rng());
+        ff[..].shuffle(&mut rand::rng());
         b.iter(|| {
             let mut map: LiteMap<&String, &String> = LiteMap::with_capacity(0);
             let mut iter = ff.iter().map(|(k, v)| (k, v));

--- a/utils/litemap/benches/litemap.rs
+++ b/utils/litemap/benches/litemap.rs
@@ -5,6 +5,7 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 use litemap::LiteMap;
+use rand::seq::SliceRandom;
 
 const DATA: [(&str, &str); 16] = [
     ("ar", "Arabic"),
@@ -57,6 +58,13 @@ fn overview_bench(c: &mut Criterion) {
     bench_deserialize_large(c);
     bench_lookup(c);
     bench_lookup_large(c);
+    bench_from_iter(c);
+    bench_from_iter_rand_large(c);
+    bench_from_iter_sorted(c);
+    bench_from_iter_large_sorted(c);
+    bench_extend_rand(c);
+    bench_extend_rand_dups(c);
+    bench_extend_from_litemap_rand(c);
 }
 
 fn build_litemap(large: bool) -> LiteMap<String, String> {
@@ -89,6 +97,99 @@ fn bench_deserialize_large(c: &mut Criterion) {
             let map: LiteMap<String, String> = postcard::from_bytes(black_box(&buf)).unwrap();
             assert_eq!(map.get("iu3333"), Some(&"Inuktitut".to_owned()));
         });
+    });
+}
+
+fn bench_from_iter(c: &mut Criterion) {
+    c.bench_function("litemap/from_iter_rand/small", |b| {
+        let mut ff = build_litemap(false).into_iter().collect::<Vec<_>>();
+        ff[..].shuffle(&mut rand::thread_rng());
+        b.iter(|| {
+            let map: LiteMap<&String, &String> = LiteMap::from_iter(ff.iter().map(|(k, v)| (k, v)));
+            black_box(map)
+        })
+    });
+}
+
+fn bench_from_iter_rand_large(c: &mut Criterion) {
+    c.bench_function("litemap/from_iter_rand/large", |b| {
+        let mut ff = build_litemap(true).into_iter().collect::<Vec<_>>();
+        ff[..].shuffle(&mut rand::thread_rng());
+        b.iter(|| {
+            let map: LiteMap<&String, &String> = LiteMap::from_iter(ff.iter().map(|(k, v)| (k, v)));
+            black_box(map)
+        })
+    });
+}
+
+fn bench_from_iter_sorted(c: &mut Criterion) {
+    c.bench_function("litemap/from_iter_sorted/small", |b| {
+        let ff = build_litemap(false).into_iter().collect::<Vec<_>>();
+        b.iter(|| {
+            let map: LiteMap<&String, &String> = LiteMap::from_iter(ff.iter().map(|(k, v)| (k, v)));
+            black_box(map)
+        })
+    });
+}
+
+fn bench_from_iter_large_sorted(c: &mut Criterion) {
+    c.bench_function("litemap/from_iter_sorted/large", |b| {
+        let ff = build_litemap(true).into_iter().collect::<Vec<_>>();
+        b.iter(|| {
+            let map: LiteMap<&String, &String> = LiteMap::from_iter(ff.iter().map(|(k, v)| (k, v)));
+            black_box(map)
+        })
+    });
+}
+
+fn bench_extend_rand(c: &mut Criterion) {
+    c.bench_function("litemap/extend_rand/large", |b| {
+        let mut ff = build_litemap(true).into_iter().collect::<Vec<_>>();
+        ff[..].shuffle(&mut rand::thread_rng());
+        b.iter(|| {
+            let mut map: LiteMap<&String, &String> = LiteMap::with_capacity(0);
+            let mut iter = ff.iter().map(|(k, v)| (k, v));
+            let step = ff.len().div_ceil(10);
+            for _ in 0..10 {
+                map.extend(iter.by_ref().take(step));
+            }
+            black_box(map)
+        })
+    });
+}
+
+fn bench_extend_rand_dups(c: &mut Criterion) {
+    c.bench_function("litemap/extend_rand_dups/large", |b| {
+        let mut ff = build_litemap(true).into_iter().collect::<Vec<_>>();
+        ff[..].shuffle(&mut rand::thread_rng());
+        b.iter(|| {
+            let mut map: LiteMap<&String, &String> = LiteMap::with_capacity(0);
+            for _ in 0..2 {
+                let mut iter = ff.iter().map(|(k, v)| (k, v));
+                let step = ff.len().div_ceil(10);
+                for _ in 0..10 {
+                    map.extend(iter.by_ref().take(step));
+                }
+            }
+            black_box(map)
+        })
+    });
+}
+
+fn bench_extend_from_litemap_rand(c: &mut Criterion) {
+    c.bench_function("litemap/extend_from_litemap_rand/large", |b| {
+        let mut ff = build_litemap(true).into_iter().collect::<Vec<_>>();
+        ff[..].shuffle(&mut rand::thread_rng());
+        b.iter(|| {
+            let mut map: LiteMap<&String, &String> = LiteMap::with_capacity(0);
+            let mut iter = ff.iter().map(|(k, v)| (k, v));
+            let step = ff.len().div_ceil(10);
+            for _ in 0..10 {
+                let tmp: LiteMap<&String, &String> = LiteMap::from_iter(iter.by_ref().take(step));
+                map.extend_from_litemap(tmp);
+            }
+            black_box(map)
+        })
     });
 }
 

--- a/utils/litemap/src/lib.rs
+++ b/utils/litemap/src/lib.rs
@@ -7,13 +7,27 @@
 //! `litemap` is a crate providing [`LiteMap`], a highly simplistic "flat" key-value map
 //! based off of a single sorted vector.
 //!
-//! The goal of this crate is to provide a map that is good enough for small
+//! The main goal of this crate is to provide a map that is good enough for small
 //! sizes, and does not carry the binary size impact of [`HashMap`](std::collections::HashMap)
 //! or [`BTreeMap`](alloc::collections::BTreeMap).
 //!
 //! If binary size is not a concern, [`std::collections::BTreeMap`] may be a better choice
 //! for your use case. It behaves very similarly to [`LiteMap`] for less than 12 elements,
 //! and upgrades itself gracefully for larger inputs.
+//!
+//! ## Performance characteristics
+//!
+//! [`LiteMap`] is a data structure with similar characteristics as [`std::collections::BTreeMap`] but
+//! with slightly different trade-offs as it's implemented on top of a flat storage (e.g. Vec).
+//!
+//! * [`LiteMap`] iteration is generally faster than `BTreeMap` because of the flat storage.
+//! * [`LiteMap`] can be pre-allocated whereas `BTreeMap` can't.
+//! * [`LiteMap`] has a smaller memory footprint than `BTreeMap` for small collections (< 20 items).
+//! * Lookup is `O(log(n))` like `BTreeMap`.
+//! * Insertion is generally `O(n)`, but optimized to `O(1)` if the new item sorts greater than the current items. In `BTreeMap` it's `O(log(n))`.
+//! * Deletion is `O(n)` whereas `BTreeMap` is `O(log(n))`.
+//! * Bulk operations like `from_iter`, `extend` and deserialization are optimized for inputs that
+//!    are already ordered but have `O(n*log(n))` complexity regardless of the order of the input items.
 //!
 //! ## Pluggable Backends
 //!

--- a/utils/litemap/src/lib.rs
+++ b/utils/litemap/src/lib.rs
@@ -26,8 +26,8 @@
 //! * Lookup is `O(log(n))` like `BTreeMap`.
 //! * Insertion is generally `O(n)`, but optimized to `O(1)` if the new item sorts greater than the current items. In `BTreeMap` it's `O(log(n))`.
 //! * Deletion is `O(n)` whereas `BTreeMap` is `O(log(n))`.
-//! * Bulk operations like `from_iter`, `extend` and deserialization are optimized for inputs that
-//!    are already ordered but have `O(n*log(n))` complexity regardless of the order of the input items.
+//! * Bulk operations like `from_iter`, `extend` and deserialization have an optimized `O(n)` path
+//!    for inputs that are ordered and `O(n*log(n))` complexity otherwise.
 //!
 //! ## Pluggable Backends
 //!

--- a/utils/litemap/src/map.rs
+++ b/utils/litemap/src/map.rs
@@ -966,7 +966,7 @@ where
 
 impl<K, V, S> LiteMap<K, V, S>
 where
-    S: StoreMut<K, V>,
+    S: StoreBulkMut<K, V>,
 {
     /// Retains only the elements specified by the predicate.
     ///
@@ -1389,7 +1389,7 @@ where
 impl<K, V, S> Extend<(K, V)> for LiteMap<K, V, S>
 where
     K: Ord,
-    S: StoreMut<K, V>,
+    S: StoreBulkMut<K, V>,
 {
     fn extend<T: IntoIterator<Item = (K, V)>>(&mut self, iter: T) {
         self.values.lm_extend(iter)

--- a/utils/litemap/src/map.rs
+++ b/utils/litemap/src/map.rs
@@ -1410,6 +1410,16 @@ where
     }
 }
 
+impl<K, V, S> Extend<(K, V)> for LiteMap<K, V, S>
+where
+    K: Ord,
+    S: StoreMut<K, V>,
+{
+    fn extend<T: IntoIterator<Item = (K, V)>>(&mut self, iter: T) {
+        self.values.lm_extend(iter)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -1434,6 +1444,39 @@ mod test {
         .collect::<LiteMap<_, _>>();
 
         assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn extend() {
+        let mut expected: LiteMap<i32, &str> = LiteMap::with_capacity(4);
+        expected.insert(1, "updated-one");
+        expected.insert(2, "original-two");
+        expected.insert(3, "original-three");
+        expected.insert(4, "updated-four");
+
+        let mut actual: LiteMap<i32, &str> = LiteMap::new();
+        actual.insert(1, "original-one");
+        actual.extend([
+            (2, "original-two"),
+            (4, "original-four"),
+            (4, "updated-four"),
+            (1, "updated-one"),
+            (3, "original-three"),
+        ]);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn extend2() {
+        let mut map: LiteMap<usize, &str> = LiteMap::new();
+        map.extend(make_13());
+        map.extend(make_24());
+        map.extend(make_24());
+        map.extend(make_46());
+        map.extend(make_13());
+        map.extend(make_46());
+        assert_eq!(map.len(), 5);
     }
 
     fn make_13() -> LiteMap<usize, &'static str> {

--- a/utils/litemap/src/map.rs
+++ b/utils/litemap/src/map.rs
@@ -1217,20 +1217,12 @@ impl_const_get_with_index_for_integer!(isize);
 
 /// An entry in a `LiteMap`, which may be either occupied or vacant.
 #[allow(clippy::exhaustive_enums)]
-pub enum Entry<'a, K, V, S>
-where
-    K: Ord,
-    S: StoreMut<K, V>,
-{
+pub enum Entry<'a, K, V, S> {
     Occupied(OccupiedEntry<'a, K, V, S>),
     Vacant(VacantEntry<'a, K, V, S>),
 }
 
-impl<K, V, S> Debug for Entry<'_, K, V, S>
-where
-    K: Ord,
-    S: StoreMut<K, V>,
-{
+impl<K, V, S> Debug for Entry<'_, K, V, S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::Occupied(arg0) => f.debug_tuple("Occupied").field(arg0).finish(),
@@ -1240,20 +1232,12 @@ where
 }
 
 /// A view into an occupied entry in a `LiteMap`.
-pub struct OccupiedEntry<'a, K, V, S>
-where
-    K: Ord,
-    S: StoreMut<K, V>,
-{
+pub struct OccupiedEntry<'a, K, V, S> {
     map: &'a mut LiteMap<K, V, S>,
     index: usize,
 }
 
-impl<K, V, S> Debug for OccupiedEntry<'_, K, V, S>
-where
-    K: Ord,
-    S: StoreMut<K, V>,
-{
+impl<K, V, S> Debug for OccupiedEntry<'_, K, V, S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("OccupiedEntry")
             .field("index", &self.index)
@@ -1262,21 +1246,13 @@ where
 }
 
 /// A view into a vacant entry in a `LiteMap`.
-pub struct VacantEntry<'a, K, V, S>
-where
-    K: Ord,
-    S: StoreMut<K, V>,
-{
+pub struct VacantEntry<'a, K, V, S> {
     map: &'a mut LiteMap<K, V, S>,
     key: K,
     index: usize,
 }
 
-impl<K, V, S> Debug for VacantEntry<'_, K, V, S>
-where
-    K: Ord,
-    S: StoreMut<K, V>,
-{
+impl<K, V, S> Debug for VacantEntry<'_, K, V, S> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("VacantEntry")
             .field("index", &self.index)

--- a/utils/litemap/src/serde.rs
+++ b/utils/litemap/src/serde.rs
@@ -68,7 +68,7 @@ impl<'de, K, V, R> Visitor<'de> for LiteMapVisitor<K, V, R>
 where
     K: Deserialize<'de> + Ord,
     V: Deserialize<'de>,
-    R: StoreMut<K, V>,
+    R: StoreBulkMut<K, V>,
 {
     type Value = LiteMap<K, V, R>;
 
@@ -131,7 +131,7 @@ impl<'de, K, V, R> Deserialize<'de> for LiteMap<K, V, R>
 where
     K: Ord + Deserialize<'de>,
     V: Deserialize<'de>,
-    R: StoreMut<K, V>,
+    R: StoreBulkMut<K, V>,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/utils/litemap/src/serde.rs
+++ b/utils/litemap/src/serde.rs
@@ -214,4 +214,23 @@ mod test {
         let deserialized: LiteMap<(u32, String), String> = postcard::from_bytes(&postcard).unwrap();
         assert_eq!(map, deserialized);
     }
+
+    /// Test that a LiteMap<_, _, Vec> is deserialized with an exact capacity
+    /// if the deserializer provides a size hint information, like postcard here.
+    #[test]
+    fn test_deserialize_capacity() {
+        for len in 0..50 {
+            let mut map = (0..len).map(|i| (i, i.to_string())).collect::<Vec<_>>();
+            let postcard = postcard::to_stdvec(&map).unwrap();
+            let deserialized: LiteMap<u32, String> = postcard::from_bytes(&postcard).unwrap();
+            assert_eq!(deserialized.values.capacity(), len);
+            assert_eq!(deserialized.values.len(), len);
+            // again, but with a shuffled map
+            rand::seq::SliceRandom::shuffle(&mut map[..], &mut rand::thread_rng());
+            let postcard = postcard::to_stdvec(&map).unwrap();
+            let deserialized: LiteMap<u32, String> = postcard::from_bytes(&postcard).unwrap();
+            assert_eq!(deserialized.values.capacity(), len);
+            assert_eq!(deserialized.values.len(), len);
+        }
+    }
 }

--- a/utils/litemap/src/store/mod.rs
+++ b/utils/litemap/src/store/mod.rs
@@ -116,41 +116,18 @@ pub trait StoreMut<K, V>: Store<K, V> {
 
     /// Removes all items from the store.
     fn lm_clear(&mut self);
+}
 
+pub trait StoreBulkMut<K, V>: StoreMut<K, V> {
     /// Retains items satisfying a predicate in this store.
-    fn lm_retain<F>(&mut self, mut predicate: F)
+    fn lm_retain<F>(&mut self, predicate: F)
     where
-        F: FnMut(&K, &V) -> bool,
-    {
-        let mut i = 0;
-        while i < self.lm_len() {
-            #[allow(clippy::unwrap_used)] // i is in range
-            let (k, v) = self.lm_get(i).unwrap();
-            if predicate(k, v) {
-                i += 1;
-            } else {
-                self.lm_remove(i);
-            }
-        }
-    }
+        F: FnMut(&K, &V) -> bool;
 
     /// Extends this store with items from an iterator.
     fn lm_extend<I>(&mut self, other: I)
     where
-        I: IntoIterator<Item = (K, V)>,
-        K: Ord,
-    {
-        for item in other {
-            match self.lm_binary_search_by(|k| k.cmp(&item.0)) {
-                #[allow(clippy::unwrap_used)]
-                // Index from binary search is an existing occupied index
-                Ok(index) => *self.lm_get_mut(index).unwrap().1 = item.1,
-                #[allow(clippy::unwrap_used)]
-                // Index from binary search is a valid index for insertion
-                Err(index) => self.lm_insert(index, item.0, item.1),
-            }
-        }
-    }
+        I: IntoIterator<Item = (K, V)>;
 }
 
 /// Iterator methods for the LiteMap store.

--- a/utils/litemap/src/store/mod.rs
+++ b/utils/litemap/src/store/mod.rs
@@ -133,6 +133,24 @@ pub trait StoreMut<K, V>: Store<K, V> {
             }
         }
     }
+
+    /// Extends this store with items from an iterator.
+    fn lm_extend<I>(&mut self, other: I)
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Ord,
+    {
+        for item in other {
+            match self.lm_binary_search_by(|k| k.cmp(&item.0)) {
+                #[allow(clippy::unwrap_used)]
+                // Index from binary search is an existing occupied index
+                Ok(index) => *self.lm_get_mut(index).unwrap().1 = item.1,
+                #[allow(clippy::unwrap_used)]
+                // Index from binary search is a valid index for insertion
+                Err(index) => self.lm_insert(index, item.0, item.1),
+            }
+        }
+    }
 }
 
 /// Iterator methods for the LiteMap store.

--- a/utils/litemap/src/store/vec_impl.rs
+++ b/utils/litemap/src/store/vec_impl.rs
@@ -96,7 +96,9 @@ impl<K, V> StoreMut<K, V> for Vec<(K, V)> {
     fn lm_clear(&mut self) {
         self.clear()
     }
+}
 
+impl<K: Ord, V> StoreBulkMut<K, V> for Vec<(K, V)> {
     #[inline]
     fn lm_retain<F>(&mut self, mut predicate: F)
     where

--- a/utils/litemap/src/store/vec_impl.rs
+++ b/utils/litemap/src/store/vec_impl.rs
@@ -104,38 +104,116 @@ impl<K, V> StoreMut<K, V> for Vec<(K, V)> {
     {
         self.retain(|(k, v)| predicate(k, v))
     }
+
+    /// Extends this store with items from an iterator.
+    ///
+    /// It uses a three-pass approach to avoid any potential quadratic costs.
+    /// The asymptotic worst case complexity of this method is O((n + m) log(n + m)),
+    /// where `n` is the number of elements already in `self` and `m` is the number
+    /// of elements in the iterator.
+    ///
+    /// ```text
+    /// Example:
+    ///   self:         [1,3,5]
+    ///   incoming:     [2,2,4,1,6]
+    ///
+    /// After First Pass
+    ///   self:         [1,3,5,6] <- 6 was directly appended
+    ///   out_of_order: [2,2,1,4] <- elements that couldn't be directly appended
+    ///
+    /// Second Pass
+    ///   1) sort out_of_order → [1,2,2,4]
+    ///   2) merge into self   → [1,3,5,6,2,4]
+    ///                           |       |--> second sorted run starts here but it's deduplicated
+    ///                           |--> 1 was already in self and was updated in place
+    ///
+    /// Third Pass
+    ///   sort self → [1,2,3,4,5,6]
+    /// ```
+    ///
+    /// In practice the function can exit early, skipping the second and/or third passes.
+    #[inline]
+    fn lm_extend<I>(&mut self, iter: I)
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Ord,
+    {
+        // Pre-allocate space to minimize reallocations
+        // From HashBrown's implementation:
+        // Keys may be already present or show multiple times in the iterator.
+        // Reserve the entire hint lower bound if the map is empty (e.g. from_iter).
+        // Otherwise reserve half the hint (rounded up), so the map
+        // will only resize twice in the worst case (assuming growth by doubling).
+        let iter = iter.into_iter();
+        let (size_hint_lower, _) = iter.size_hint();
+        let reserve = if self.is_empty() {
+            size_hint_lower
+        } else {
+            (size_hint_lower + 1) / 2
+        };
+        self.reserve_exact(reserve);
+
+        // Scratch space for elements that can't be directly appended.
+        let mut out_of_order: Vec<(K, V)> = Vec::new();
+
+        // First pass: fast-path append or collect out-of-order elements
+        for (key, value) in iter {
+            // The fast path checks if the incoming key is >= the last key in self.
+            match self.last_mut().map(|l| (key.cmp(&l.0), l)) {
+                // Empty vector or new key is greater than last: append
+                None | Some((Ordering::Greater, _)) => self.push((key, value)),
+                // Key equals last: update in place
+                Some((Ordering::Equal, l)) => *l = (key, value),
+                // Key is less than last: collect for second pass
+                // Note: Attempting to update existing keys here hurts performance.
+                // Likely because of cache misses during search. We'll perform
+                // updates later, after sorting the scratch space.
+                _ => out_of_order.push((key, value)),
+            }
+        }
+
+        // If everything was in order, we're done
+        if out_of_order.is_empty() {
+            return;
+        }
+
+        // Second pass: handle out-of-order elements
+        // Elements already in self are already sorted.
+        let sorted_len = self.len();
+        // Stable sort out_of_order to preserve the order of any repeated keys.
+        out_of_order.sort_by(|a, b| a.0.cmp(&b.0));
+        // Extend the sorted self with the out_of_order (now sorted).
+        // The scratch may have elements that already exist in self that need to be updated.
+        // We'll perform the updates in place to avoid a costly deduplication operation in the end.
+        // This process may create a second sorted run in self that we'll sort later.
+        for pair in out_of_order {
+            // We need to look for the key in the sorted section of self but also the last position
+            // of self to prevent adding duplicated elements from the scratch space.
+            #[allow(clippy::indexing_slicing)]
+            if let Some((Ordering::Equal, last)) = self.last_mut().map(|l| (l.0.cmp(&pair.0), l)) {
+                *last = pair;
+            } else if let Ok(idx) = self[..sorted_len].binary_search_by(|(k, _)| k.cmp(&pair.0)) {
+                // `sorted_len` remains valid as we do not remove items from self and only update existing keys in place.
+                // Note: Attempting to reduce the range of the search slice hurts performance.
+                // Likely due to less predictable memory access.
+                self[idx] = pair
+            } else {
+                self.push(pair);
+            }
+        }
+        // If we pushed new items above we ended up with two sorted runs in self.
+        if self.len() != sorted_len {
+            // While this could be sort_unstable the stable sort is faster when merging two sorted runs.
+            self.sort_by(|a, b| a.0.cmp(&b.0));
+        }
+    }
 }
 
 impl<K: Ord, V> StoreFromIterable<K, V> for Vec<(K, V)> {
     fn lm_sort_from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self {
-        let iter = iter.into_iter();
-        let mut container = match iter.size_hint() {
-            (_, Some(upper)) => Self::with_capacity(upper),
-            (lower, None) => Self::with_capacity(lower),
-        };
-
-        for (key, value) in iter {
-            if let Some(last) = container.lm_last() {
-                if last.0 >= &key {
-                    match container.lm_binary_search_by(|k| k.cmp(&key)) {
-                        #[allow(clippy::unwrap_used)] // Index came from binary_search
-                        Ok(found) => {
-                            let _ =
-                                core::mem::replace(container.lm_get_mut(found).unwrap().1, value);
-                        }
-                        Err(ins) => {
-                            container.insert(ins, (key, value));
-                        }
-                    }
-                } else {
-                    container.push((key, value))
-                }
-            } else {
-                container.push((key, value))
-            }
-        }
-
-        container
+        let mut v = Self::new();
+        v.lm_extend(iter);
+        v
     }
 }
 

--- a/utils/litemap/src/testing.rs
+++ b/utils/litemap/src/testing.rs
@@ -141,12 +141,6 @@ where
     populate_litemap(&mut litemap_std);
     check_equivalence(litemap_test.clone().values, litemap_std.clone().values);
 
-    litemap_test.retain(|_, v| v % 2 == 0);
-    litemap_std.retain(|_, v| v % 2 == 0);
-    assert_eq!(11, litemap_test.len());
-    assert_eq!(11, litemap_std.len());
-    check_equivalence(litemap_test.clone().values, litemap_std.clone().values);
-
     litemap_test
         .remove(&175)
         .ok_or(())
@@ -158,8 +152,8 @@ where
         .expect_err("does not exist");
     litemap_std.remove(&147).ok_or(()).expect("exists");
 
-    assert_eq!(10, litemap_test.len());
-    assert_eq!(10, litemap_std.len());
+    assert_eq!(19, litemap_test.len());
+    assert_eq!(19, litemap_std.len());
     check_equivalence(litemap_test.clone().values, litemap_std.clone().values);
 
     litemap_test.clear();
@@ -168,7 +162,7 @@ where
 }
 
 /// Similar to [`check_store`] function, but also checks the validitiy of [`StoreIterableMut`]
-/// trait.
+/// and [`StoreBulkMut`] traits.
 // Test code
 #[allow(clippy::expect_used)]
 pub fn check_store_full<'a, S>()
@@ -177,6 +171,7 @@ where
         + StoreIterableMut<'a, u32, u64>
         + StoreIntoIterator<u32, u64>
         + StoreFromIterator<u32, u64>
+        + StoreBulkMut<u32, u64>
         + Clone
         + Debug
         + PartialEq
@@ -199,6 +194,7 @@ where
     check_equivalence(litemap_test.clone().values, litemap_std.clone().values);
     check_into_iter_equivalence(litemap_test.clone().values, litemap_std.clone().values);
 
+    assert_eq!(20, litemap_test.len());
     litemap_test.retain(|_, v| v % 2 == 0);
     litemap_std.retain(|_, v| v % 2 == 0);
     assert_eq!(11, litemap_test.len());
@@ -217,8 +213,20 @@ where
     assert_eq!(20, litemap_test.len());
     assert_eq!(20, litemap_std.len());
     check_equivalence(litemap_test.clone().values, litemap_std.clone().values);
-    check_into_iter_equivalence(litemap_test.clone().values, litemap_std.clone().values);
 
+    assert_eq!(20, litemap_test.len());
+    litemap_test.retain(|_, v| v % 2 == 0);
+    litemap_std.retain(|_, v| v % 2 == 0);
+    assert_eq!(11, litemap_test.len());
+    assert_eq!(11, litemap_std.len());
+    let mut extras = LiteMap::<u32, u64>::new();
+    populate_litemap(&mut extras);
+    litemap_test.extend(extras.clone());
+    litemap_std.extend(extras);
+    assert_eq!(20, litemap_test.len());
+    assert_eq!(20, litemap_std.len());
+
+    check_into_iter_equivalence(litemap_test.clone().values, litemap_std.clone().values);
     litemap_test
         .remove(&175)
         .ok_or(())

--- a/utils/litemap/tests/store.rs
+++ b/utils/litemap/tests/store.rs
@@ -136,6 +136,22 @@ impl<A> std::iter::FromIterator<A> for VecWithDefaults<A> {
 
 impl<K, V> StoreFromIterator<K, V> for VecWithDefaults<(K, V)> {}
 
+impl<K: Ord, V> StoreBulkMut<K, V> for VecWithDefaults<(K, V)> {
+    fn lm_retain<F>(&mut self, predicate: F)
+    where
+        F: FnMut(&K, &V) -> bool,
+    {
+        self.0.lm_retain(predicate)
+    }
+
+    fn lm_extend<I>(&mut self, other: I)
+    where
+        I: IntoIterator<Item = (K, V)>,
+    {
+        self.0.lm_extend(other)
+    }
+}
+
 #[test]
 fn test_default_impl() {
     check_store_full::<VecWithDefaults<(u32, u64)>>();

--- a/utils/zerotrie/src/serde.rs
+++ b/utils/zerotrie/src/serde.rs
@@ -87,15 +87,6 @@ impl Serialize for &ByteStr {
     }
 }
 
-impl Serialize for Box<ByteStr> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        self.as_ref().serialize(serializer)
-    }
-}
-
 impl<'data, 'de: 'data, Store> Deserialize<'de> for ZeroTrieSimpleAscii<Store>
 where
     // DISCUSS: There are several possibilities for the bounds here that would
@@ -229,8 +220,8 @@ where
         if serializer.is_human_readable() {
             let lm = self.to_litemap();
             let lm = lm
-                .into_iter()
-                .map(|(k, v)| (ByteStr::from_boxed_bytes(k.into_boxed_slice()), v))
+                .iter()
+                .map(|(k, v)| (ByteStr::from_bytes(k), v))
                 .collect::<LiteMap<_, _>>();
             lm.serialize(serializer)
         } else {
@@ -282,8 +273,8 @@ where
         if serializer.is_human_readable() {
             let lm = self.to_litemap();
             let lm = lm
-                .into_iter()
-                .map(|(k, v)| (ByteStr::from_boxed_bytes(k.into_boxed_slice()), v))
+                .iter()
+                .map(|(k, v)| (ByteStr::from_bytes(k), v))
                 .collect::<LiteMap<_, _>>();
             lm.serialize(serializer)
         } else {
@@ -343,8 +334,8 @@ where
         if serializer.is_human_readable() {
             let lm = self.to_litemap();
             let lm = lm
-                .into_iter()
-                .map(|(k, v)| (ByteStr::from_boxed_bytes(k), v))
+                .iter()
+                .map(|(k, v)| (ByteStr::from_bytes(k), v))
                 .collect::<LiteMap<_, _>>();
             lm.serialize(serializer)
         } else {

--- a/utils/zerotrie/src/serde.rs
+++ b/utils/zerotrie/src/serde.rs
@@ -87,6 +87,15 @@ impl Serialize for &ByteStr {
     }
 }
 
+impl Serialize for Box<ByteStr> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.as_ref().serialize(serializer)
+    }
+}
+
 impl<'data, 'de: 'data, Store> Deserialize<'de> for ZeroTrieSimpleAscii<Store>
 where
     // DISCUSS: There are several possibilities for the bounds here that would
@@ -220,8 +229,8 @@ where
         if serializer.is_human_readable() {
             let lm = self.to_litemap();
             let lm = lm
-                .iter()
-                .map(|(k, v)| (ByteStr::from_bytes(k), v))
+                .into_iter()
+                .map(|(k, v)| (ByteStr::from_boxed_bytes(k.into_boxed_slice()), v))
                 .collect::<LiteMap<_, _>>();
             lm.serialize(serializer)
         } else {
@@ -273,8 +282,8 @@ where
         if serializer.is_human_readable() {
             let lm = self.to_litemap();
             let lm = lm
-                .iter()
-                .map(|(k, v)| (ByteStr::from_bytes(k), v))
+                .into_iter()
+                .map(|(k, v)| (ByteStr::from_boxed_bytes(k.into_boxed_slice()), v))
                 .collect::<LiteMap<_, _>>();
             lm.serialize(serializer)
         } else {
@@ -334,8 +343,8 @@ where
         if serializer.is_human_readable() {
             let lm = self.to_litemap();
             let lm = lm
-                .iter()
-                .map(|(k, v)| (ByteStr::from_bytes(k), v))
+                .into_iter()
+                .map(|(k, v)| (ByteStr::from_boxed_bytes(k), v))
                 .collect::<LiteMap<_, _>>();
             lm.serialize(serializer)
         } else {


### PR DESCRIPTION
Adds `lm_extend` to the `StoreMut` trait. The Vec implementation is optimized to have O(N) performance on sorted inputs and an asymptotic worst case of O(NLog(N)), effectively avoiding quadratic worst cases.

This PR takes advantage of the new `extend` optimization and changes the `FromIterator` and `Deserialize` implementations to also avoid quadratic worst-case.

Before
```
litemap/from_iter_rand/small
                        time:   [916.60 ns 941.77 ns 965.82 ns]
litemap/from_iter_rand/large
                        time:   [2.3779 s 2.3863 s 2.3946 s]
litemap/from_iter_sorted/small
                        time:   [84.010 ns 84.084 ns 84.155 ns]
litemap/from_iter_sorted/large
                        time:   [725.31 µs 739.88 µs 755.20 µs]
```

After

```
litemap/from_iter_rand/small
                        time:   [354.62 ns 365.31 ns 376.02 ns]
litemap/from_iter_rand/large
                        time:   [25.129 ms 25.415 ms 25.704 ms]
litemap/from_iter_sorted/small
                        time:   [76.593 ns 76.767 ns 76.938 ns]
litemap/from_iter_sorted/large
                        time:   [662.70 µs 673.66 µs 686.83 µs]
litemap/extend_rand/large
                        time:   [66.221 ms 67.467 ms 68.814 ms]
litemap/extend_rand_dups/large
                        time:   [190.24 ms 196.05 ms 202.13 ms]
litemap/extend_from_litemap_rand/large
                        time:   [2.0401 s 2.0488 s 2.0575 s]
```

This is a followup of #6068