### PR TITLE
Move types over to uniform ::new() ctor convention

### DIFF
--- a/components/locale/src/exemplar_chars.rs
+++ b/components/locale/src/exemplar_chars.rs
@@ -91,204 +91,215 @@ macro_rules! make_exemplar_chars_unicode_set_property {
         $(#[$attr:meta])*
         pub fn $compiled:ident();
     ) => {
-        $(#[$attr])*
-        #[cfg(feature = "compiled_data")]
-        pub fn $compiled(
-            locale: &DataLocale,
-        ) -> Result<ExemplarCharactersBorrowed<'static>, DataError> {
-            Ok(ExemplarCharactersBorrowed {
-                data: DataProvider::<$data_marker>::load(
-                    &crate::provider::Baked,
-                    DataRequest {
-                        id: DataIdentifierBorrowed::for_locale(locale),
-                        ..Default::default()
-                    })?
-                .payload
-                .get_static()
-                .ok_or_else(|| DataError::custom("Baked provider didn't return static payload"))?
-            })
-        }
+        impl ExemplarCharactersBorrowed<'static> {
+            $(#[$attr])*
+            #[cfg(feature = "compiled_data")]
+            #[inline]
+            pub fn $compiled(
+                locale: &DataLocale,
+            ) -> Result<Self, DataError> {
+                Ok(ExemplarCharactersBorrowed {
+                    data: DataProvider::<$data_marker>::load(
+                        &crate::provider::Baked,
+                        DataRequest {
+                            id: DataIdentifierBorrowed::for_locale(locale),
+                            ..Default::default()
+                        })?
+                    .payload
+                    .get_static()
+                    .ok_or_else(|| DataError::custom("Baked provider didn't return static payload"))?
+                })
+            }
 
-        #[doc = concat!("A version of [`Self::", stringify!($compiled), "()`] that uses custom data provided by a [`DataProvider`].")]
-        ///
-        /// [📚 Help choosing a constructor](icu_provider::constructors)
-        pub fn $unstable(
-            provider: &(impl DataProvider<$data_marker> + ?Sized),
-            locale: &DataLocale,
-        ) -> Result<Self, DataError> {
-            Ok(Self {
-                data:
-                provider.load(
-                    DataRequest {
-                        id: DataIdentifierBorrowed::for_locale(locale),
-                        ..Default::default()
-                })?
-                .payload
-                .cast()
-            })
+        }
+        impl ExemplarCharacters {
+            $(#[$attr])*
+            #[cfg(feature = "compiled_data")]
+            pub fn $compiled(
+                locale: &DataLocale,
+            ) -> Result<ExemplarCharactersBorrowed<'static>, DataError> {
+                ExemplarCharactersBorrowed::$compiled(locale)
+            }
+
+            #[doc = concat!("A version of [`Self::", stringify!($compiled), "()`] that uses custom data provided by a [`DataProvider`].")]
+            ///
+            /// [📚 Help choosing a constructor](icu_provider::constructors)
+            pub fn $unstable(
+                provider: &(impl DataProvider<$data_marker> + ?Sized),
+                locale: &DataLocale,
+            ) -> Result<Self, DataError> {
+                Ok(Self {
+                    data:
+                    provider.load(
+                        DataRequest {
+                            id: DataIdentifierBorrowed::for_locale(locale),
+                            ..Default::default()
+                    })?
+                    .payload
+                    .cast()
+                })
+            }
         }
     }
 }
 
-impl ExemplarCharacters {
-    make_exemplar_chars_unicode_set_property!(
-        dyn_data_marker: ExemplarCharactersMain;
-        data_marker: ExemplarCharactersMainV1;
-        func:
-        pub fn try_new_main_unstable();
+make_exemplar_chars_unicode_set_property!(
+    dyn_data_marker: ExemplarCharactersMain;
+    data_marker: ExemplarCharactersMainV1;
+    func:
+    pub fn try_new_main_unstable();
 
-        /// Get the "main" set of exemplar characters.
-        ///
-        /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-        ///
-        /// [📚 Help choosing a constructor](icu_provider::constructors)
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use icu::locale::locale;
-        /// use icu::locale::exemplar_chars::ExemplarCharacters;
-        ///
-        /// let exemplars_main = ExemplarCharacters::try_new_main(&locale!("en").into())
-        ///     .expect("locale should be present");
-        ///
-        /// assert!(exemplars_main.contains('a'));
-        /// assert!(exemplars_main.contains('z'));
-        /// assert!(exemplars_main.contains_str("a"));
-        /// assert!(!exemplars_main.contains_str("ä"));
-        /// assert!(!exemplars_main.contains_str("ng"));
-        /// assert!(!exemplars_main.contains_str("A"));
-        /// ```
-        pub fn try_new_main();
-    );
+    /// Get the "main" set of exemplar characters.
+    ///
+    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
+    ///
+    /// [📚 Help choosing a constructor](icu_provider::constructors)
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu::locale::locale;
+    /// use icu::locale::exemplar_chars::ExemplarCharacters;
+    ///
+    /// let exemplars_main = ExemplarCharacters::try_new_main(&locale!("en").into())
+    ///     .expect("locale should be present");
+    ///
+    /// assert!(exemplars_main.contains('a'));
+    /// assert!(exemplars_main.contains('z'));
+    /// assert!(exemplars_main.contains_str("a"));
+    /// assert!(!exemplars_main.contains_str("ä"));
+    /// assert!(!exemplars_main.contains_str("ng"));
+    /// assert!(!exemplars_main.contains_str("A"));
+    /// ```
+    pub fn try_new_main();
+);
 
-    make_exemplar_chars_unicode_set_property!(
-        dyn_data_marker: ExemplarCharactersAuxiliary;
-        data_marker: ExemplarCharactersAuxiliaryV1;
-        func:
-        pub fn try_new_auxiliary_unstable();
+make_exemplar_chars_unicode_set_property!(
+    dyn_data_marker: ExemplarCharactersAuxiliary;
+    data_marker: ExemplarCharactersAuxiliaryV1;
+    func:
+    pub fn try_new_auxiliary_unstable();
 
-        /// Get the "auxiliary" set of exemplar characters.
-        ///
-        /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-        ///
-        /// [📚 Help choosing a constructor](icu_provider::constructors)
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use icu::locale::locale;
-        /// use icu::locale::exemplar_chars::ExemplarCharacters;
-        ///
-        /// let exemplars_auxiliary =
-        ///     ExemplarCharacters::try_new_auxiliary(&locale!("en").into())
-        ///     .expect("locale should be present");
-        ///
-        /// assert!(!exemplars_auxiliary.contains('a'));
-        /// assert!(!exemplars_auxiliary.contains('z'));
-        /// assert!(!exemplars_auxiliary.contains_str("a"));
-        /// assert!(exemplars_auxiliary.contains_str("ä"));
-        /// assert!(!exemplars_auxiliary.contains_str("ng"));
-        /// assert!(!exemplars_auxiliary.contains_str("A"));
-        /// ```
-        pub fn try_new_auxiliary();
-    );
+    /// Get the "auxiliary" set of exemplar characters.
+    ///
+    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
+    ///
+    /// [📚 Help choosing a constructor](icu_provider::constructors)
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu::locale::locale;
+    /// use icu::locale::exemplar_chars::ExemplarCharacters;
+    ///
+    /// let exemplars_auxiliary =
+    ///     ExemplarCharacters::try_new_auxiliary(&locale!("en").into())
+    ///     .expect("locale should be present");
+    ///
+    /// assert!(!exemplars_auxiliary.contains('a'));
+    /// assert!(!exemplars_auxiliary.contains('z'));
+    /// assert!(!exemplars_auxiliary.contains_str("a"));
+    /// assert!(exemplars_auxiliary.contains_str("ä"));
+    /// assert!(!exemplars_auxiliary.contains_str("ng"));
+    /// assert!(!exemplars_auxiliary.contains_str("A"));
+    /// ```
+    pub fn try_new_auxiliary();
+);
 
-    make_exemplar_chars_unicode_set_property!(
-        dyn_data_marker: ExemplarCharactersPunctuation;
-        data_marker: ExemplarCharactersPunctuationV1;
-        func:
-        pub fn try_new_punctuation_unstable();
+make_exemplar_chars_unicode_set_property!(
+    dyn_data_marker: ExemplarCharactersPunctuation;
+    data_marker: ExemplarCharactersPunctuationV1;
+    func:
+    pub fn try_new_punctuation_unstable();
 
-        /// Get the "punctuation" set of exemplar characters.
-        ///
-        /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-        ///
-        /// [📚 Help choosing a constructor](icu_provider::constructors)
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use icu::locale::locale;
-        /// use icu::locale::exemplar_chars::ExemplarCharacters;
-        ///
-        /// let exemplars_punctuation =
-        ///     ExemplarCharacters::try_new_punctuation(&locale!("en").into())
-        ///     .expect("locale should be present");
-        ///
-        /// assert!(!exemplars_punctuation.contains('0'));
-        /// assert!(!exemplars_punctuation.contains('9'));
-        /// assert!(!exemplars_punctuation.contains('%'));
-        /// assert!(exemplars_punctuation.contains(','));
-        /// assert!(exemplars_punctuation.contains('.'));
-        /// assert!(exemplars_punctuation.contains('!'));
-        /// assert!(exemplars_punctuation.contains('?'));
-        /// ```
-        pub fn try_new_punctuation();
-    );
+    /// Get the "punctuation" set of exemplar characters.
+    ///
+    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
+    ///
+    /// [📚 Help choosing a constructor](icu_provider::constructors)
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu::locale::locale;
+    /// use icu::locale::exemplar_chars::ExemplarCharacters;
+    ///
+    /// let exemplars_punctuation =
+    ///     ExemplarCharacters::try_new_punctuation(&locale!("en").into())
+    ///     .expect("locale should be present");
+    ///
+    /// assert!(!exemplars_punctuation.contains('0'));
+    /// assert!(!exemplars_punctuation.contains('9'));
+    /// assert!(!exemplars_punctuation.contains('%'));
+    /// assert!(exemplars_punctuation.contains(','));
+    /// assert!(exemplars_punctuation.contains('.'));
+    /// assert!(exemplars_punctuation.contains('!'));
+    /// assert!(exemplars_punctuation.contains('?'));
+    /// ```
+    pub fn try_new_punctuation();
+);
 
-    make_exemplar_chars_unicode_set_property!(
-        dyn_data_marker: ExemplarCharactersNumbers;
-        data_marker: ExemplarCharactersNumbersV1;
-        func:
-        pub fn try_new_numbers_unstable();
+make_exemplar_chars_unicode_set_property!(
+    dyn_data_marker: ExemplarCharactersNumbers;
+    data_marker: ExemplarCharactersNumbersV1;
+    func:
+    pub fn try_new_numbers_unstable();
 
-        /// Get the "numbers" set of exemplar characters.
-        ///
-        /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-        ///
-        /// [📚 Help choosing a constructor](icu_provider::constructors)
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use icu::locale::locale;
-        /// use icu::locale::exemplar_chars::ExemplarCharacters;
-        ///
-        /// let exemplars_numbers =
-        ///     ExemplarCharacters::try_new_numbers(&locale!("en").into())
-        ///     .expect("locale should be present");
-        ///
-        /// assert!(exemplars_numbers.contains('0'));
-        /// assert!(exemplars_numbers.contains('9'));
-        /// assert!(exemplars_numbers.contains('%'));
-        /// assert!(exemplars_numbers.contains(','));
-        /// assert!(exemplars_numbers.contains('.'));
-        /// assert!(!exemplars_numbers.contains('!'));
-        /// assert!(!exemplars_numbers.contains('?'));
-        /// ```
-        pub fn try_new_numbers();
-    );
+    /// Get the "numbers" set of exemplar characters.
+    ///
+    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
+    ///
+    /// [📚 Help choosing a constructor](icu_provider::constructors)
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu::locale::locale;
+    /// use icu::locale::exemplar_chars::ExemplarCharacters;
+    ///
+    /// let exemplars_numbers =
+    ///     ExemplarCharacters::try_new_numbers(&locale!("en").into())
+    ///     .expect("locale should be present");
+    ///
+    /// assert!(exemplars_numbers.contains('0'));
+    /// assert!(exemplars_numbers.contains('9'));
+    /// assert!(exemplars_numbers.contains('%'));
+    /// assert!(exemplars_numbers.contains(','));
+    /// assert!(exemplars_numbers.contains('.'));
+    /// assert!(!exemplars_numbers.contains('!'));
+    /// assert!(!exemplars_numbers.contains('?'));
+    /// ```
+    pub fn try_new_numbers();
+);
 
-    make_exemplar_chars_unicode_set_property!(
-        dyn_data_marker: ExemplarCharactersIndex;
-        data_marker: ExemplarCharactersIndexV1;
-        func:
-        pub fn try_new_index_unstable();
+make_exemplar_chars_unicode_set_property!(
+    dyn_data_marker: ExemplarCharactersIndex;
+    data_marker: ExemplarCharactersIndexV1;
+    func:
+    pub fn try_new_index_unstable();
 
-        /// Get the "index" set of exemplar characters.
-        ///
-        /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-        ///
-        /// [📚 Help choosing a constructor](icu_provider::constructors)
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use icu::locale::locale;
-        /// use icu::locale::exemplar_chars::ExemplarCharacters;
-        ///
-        /// let exemplars_index =
-        ///     ExemplarCharacters::try_new_index(&locale!("en").into())
-        ///     .expect("locale should be present");
-        ///
-        /// assert!(!exemplars_index.contains('a'));
-        /// assert!(!exemplars_index.contains('z'));
-        /// assert!(!exemplars_index.contains_str("a"));
-        /// assert!(!exemplars_index.contains_str("ä"));
-        /// assert!(!exemplars_index.contains_str("ng"));
-        /// assert!(exemplars_index.contains_str("A"));
-        /// ```
-        pub fn try_new_index();
-    );
-}
+    /// Get the "index" set of exemplar characters.
+    ///
+    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
+    ///
+    /// [📚 Help choosing a constructor](icu_provider::constructors)
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu::locale::locale;
+    /// use icu::locale::exemplar_chars::ExemplarCharacters;
+    ///
+    /// let exemplars_index =
+    ///     ExemplarCharacters::try_new_index(&locale!("en").into())
+    ///     .expect("locale should be present");
+    ///
+    /// assert!(!exemplars_index.contains('a'));
+    /// assert!(!exemplars_index.contains('z'));
+    /// assert!(!exemplars_index.contains_str("a"));
+    /// assert!(!exemplars_index.contains_str("ä"));
+    /// assert!(!exemplars_index.contains_str("ng"));
+    /// assert!(exemplars_index.contains_str("A"));
+    /// ```
+    pub fn try_new_index();
+);

--- a/components/properties/src/code_point_set.rs
+++ b/components/properties/src/code_point_set.rs
@@ -29,7 +29,7 @@ pub struct CodePointSetData {
 }
 
 impl CodePointSetData {
-    /// Creates a new [`CodePointSetData`] for a [`BinaryProperty`].
+    /// Creates a new [`CodePointSetDataBorrowed`] for a [`BinaryProperty`].
     ///
     /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
@@ -37,7 +37,7 @@ impl CodePointSetData {
     #[allow(clippy::new_ret_no_self)]
     #[cfg(feature = "compiled_data")]
     pub const fn new<P: BinaryProperty>() -> CodePointSetDataBorrowed<'static> {
-        CodePointSetDataBorrowed { set: P::SINGLETON }
+        CodePointSetDataBorrowed::new::<P>()
     }
 
     #[doc = icu_provider::gen_buffer_unstable_docs!(UNSTABLE, Self::new)]
@@ -112,6 +112,16 @@ pub struct CodePointSetDataBorrowed<'a> {
 }
 
 impl CodePointSetDataBorrowed<'static> {
+    /// Creates a new [`CodePointSetData`] for a [`BinaryProperty`].
+    ///
+    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
+    ///
+    /// [📚 Help choosing a constructor](icu_provider::constructors)
+    #[inline]
+    #[cfg(feature = "compiled_data")]
+    pub const fn new<P: BinaryProperty>() -> Self {
+        CodePointSetDataBorrowed { set: P::SINGLETON }
+    }
     /// Cheaply converts a [`CodePointSetDataBorrowed<'static>`] into a [`CodePointSetData`].
     ///
     /// Note: Due to branching and indirection, using [`CodePointSetData`] might inhibit some

--- a/components/properties/src/emoji.rs
+++ b/components/properties/src/emoji.rs
@@ -14,7 +14,7 @@ pub struct EmojiSetData {
 }
 
 impl EmojiSetData {
-    /// Creates a new [`EmojiSetData`] for a [`EmojiSet`].
+    /// Creates a new [`EmojiSetDataBorrowed`] for a [`EmojiSet`].
     ///
     /// See the documentation on [`EmojiSet`] implementations for details.
     ///
@@ -24,7 +24,7 @@ impl EmojiSetData {
     #[cfg(feature = "compiled_data")]
     #[allow(clippy::new_ret_no_self)]
     pub const fn new<P: EmojiSet>() -> EmojiSetDataBorrowed<'static> {
-        EmojiSetDataBorrowed { set: P::SINGLETON }
+        EmojiSetDataBorrowed::new::<P>()
     }
 
     /// A version of `new()` that uses custom data provided by a [`DataProvider`].
@@ -132,6 +132,19 @@ impl EmojiSetDataBorrowed<'_> {
 }
 
 impl EmojiSetDataBorrowed<'static> {
+    /// Creates a new [`EmojiSetDataBorrowed`] for a [`EmojiSet`].
+    ///
+    /// See the documentation on [`EmojiSet`] implementations for details.
+    ///
+    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
+    ///
+    /// [📚 Help choosing a constructor](icu_provider::constructors)
+    #[inline]
+    #[cfg(feature = "compiled_data")]
+    pub const fn new<P: EmojiSet>() -> Self {
+        EmojiSetDataBorrowed { set: P::SINGLETON }
+    }
+
     /// Cheaply converts a [`EmojiSetDataBorrowed<'static>`] into a [`EmojiSetData`].
     ///
     /// Note: Due to branching and indirection, using [`EmojiSetData`] might inhibit some

--- a/ffi/capi/bindings/dart/ExemplarCharacters.g.dart
+++ b/ffi/capi/bindings/dart/ExemplarCharacters.g.dart
@@ -123,7 +123,7 @@ final class ExemplarCharacters implements ffi.Finalizable {
     return ExemplarCharacters._fromFfi(result.union.ok, []);
   }
 
-  /// Create an [`ExemplarCharacters`] for the "index" set of exemplar characters for a given locale, using compiled data.
+  /// Create an [`ExemplarCharacters`] for the "numbers" set of exemplar characters for a given locale, using compiled data.
   ///
   /// See the [Rust documentation for `try_new_numbers`](https://docs.rs/icu/latest/icu/locale/exemplar_chars/struct.ExemplarCharacters.html#method.try_new_numbers) for more information.
   ///
@@ -136,7 +136,7 @@ final class ExemplarCharacters implements ffi.Finalizable {
     return ExemplarCharacters._fromFfi(result.union.ok, []);
   }
 
-  /// Create an [`ExemplarCharacters`] for the "index" set of exemplar characters for a given locale, using compiled data.
+  /// Create an [`ExemplarCharacters`] for the "numbers" set of exemplar characters for a given locale, using compiled data.
   ///
   /// See the [Rust documentation for `try_new_numbers`](https://docs.rs/icu/latest/icu/locale/exemplar_chars/struct.ExemplarCharacters.html#method.try_new_numbers) for more information.
   ///
@@ -149,7 +149,7 @@ final class ExemplarCharacters implements ffi.Finalizable {
     return ExemplarCharacters._fromFfi(result.union.ok, []);
   }
 
-  /// Create an [`ExemplarCharacters`] for the "main" set of exemplar characters for a given locale, using compiled data.
+  /// Create an [`ExemplarCharacters`] for the "index" set of exemplar characters for a given locale, using compiled data.
   ///
   /// See the [Rust documentation for `try_new_index`](https://docs.rs/icu/latest/icu/locale/exemplar_chars/struct.ExemplarCharacters.html#method.try_new_index) for more information.
   ///
@@ -162,7 +162,7 @@ final class ExemplarCharacters implements ffi.Finalizable {
     return ExemplarCharacters._fromFfi(result.union.ok, []);
   }
 
-  /// Create an [`ExemplarCharacters`] for the "main" set of exemplar characters for a given locale, using compiled data.
+  /// Create an [`ExemplarCharacters`] for the "index" set of exemplar characters for a given locale, using compiled data.
   ///
   /// See the [Rust documentation for `try_new_index`](https://docs.rs/icu/latest/icu/locale/exemplar_chars/struct.ExemplarCharacters.html#method.try_new_index) for more information.
   ///

--- a/ffi/capi/src/exemplar_chars.rs
+++ b/ffi/capi/src/exemplar_chars.rs
@@ -52,6 +52,11 @@ pub mod ffi {
             icu::locale::exemplar_chars::ExemplarCharacters::try_new_main,
             FnInStruct
         )]
+        #[diplomat::rust_link(
+            icu::locale::exemplar_chars::ExemplarCharactersBorrowed::try_new_main,
+            FnInStruct,
+            hidden
+        )]
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "main")]
         #[cfg(feature = "compiled_data")]
         pub fn create_main(locale: &Locale) -> Result<Box<ExemplarCharacters>, DataError> {
@@ -87,6 +92,11 @@ pub mod ffi {
             icu::locale::exemplar_chars::ExemplarCharacters::try_new_auxiliary,
             FnInStruct
         )]
+        #[diplomat::rust_link(
+            icu::locale::exemplar_chars::ExemplarCharactersBorrowed::try_new_auxiliary,
+            FnInStruct,
+            hidden
+        )]
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "auxiliary")]
         #[cfg(feature = "compiled_data")]
         pub fn create_auxiliary(locale: &Locale) -> Result<Box<ExemplarCharacters>, DataError> {
@@ -121,6 +131,11 @@ pub mod ffi {
             icu::locale::exemplar_chars::ExemplarCharacters::try_new_punctuation,
             FnInStruct
         )]
+        #[diplomat::rust_link(
+            icu::locale::exemplar_chars::ExemplarCharactersBorrowed::try_new_punctuation,
+            FnInStruct,
+            hidden
+        )]
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "punctuation")]
         #[cfg(feature = "compiled_data")]
         pub fn create_punctuation(locale: &Locale) -> Result<Box<ExemplarCharacters>, DataError> {
@@ -150,10 +165,15 @@ pub mod ffi {
             )))
         }
 
-        /// Create an [`ExemplarCharacters`] for the "index" set of exemplar characters for a given locale, using compiled data.
+        /// Create an [`ExemplarCharacters`] for the "numbers" set of exemplar characters for a given locale, using compiled data.
         #[diplomat::rust_link(
             icu::locale::exemplar_chars::ExemplarCharacters::try_new_numbers,
             FnInStruct
+        )]
+        #[diplomat::rust_link(
+            icu::locale::exemplar_chars::ExemplarCharactersBorrowed::try_new_numbers,
+            FnInStruct,
+            hidden
         )]
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "numbers")]
         #[cfg(feature = "compiled_data")]
@@ -165,7 +185,7 @@ pub mod ffi {
             )))
         }
 
-        /// Create an [`ExemplarCharacters`] for the "index" set of exemplar characters for a given locale, using compiled data.
+        /// Create an [`ExemplarCharacters`] for the "numbers" set of exemplar characters for a given locale, using compiled data.
         #[diplomat::rust_link(
             icu::locale::exemplar_chars::ExemplarCharacters::try_new_numbers,
             FnInStruct
@@ -185,10 +205,15 @@ pub mod ffi {
             )))
         }
 
-        /// Create an [`ExemplarCharacters`] for the "main" set of exemplar characters for a given locale, using compiled data.
+        /// Create an [`ExemplarCharacters`] for the "index" set of exemplar characters for a given locale, using compiled data.
         #[diplomat::rust_link(
             icu::locale::exemplar_chars::ExemplarCharacters::try_new_index,
             FnInStruct
+        )]
+        #[diplomat::rust_link(
+            icu::locale::exemplar_chars::ExemplarCharactersBorrowed::try_new_index,
+            FnInStruct,
+            hidden
         )]
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "index")]
         #[cfg(feature = "compiled_data")]
@@ -200,7 +225,7 @@ pub mod ffi {
             )))
         }
 
-        /// Create an [`ExemplarCharacters`] for the "main" set of exemplar characters for a given locale, using compiled data.
+        /// Create an [`ExemplarCharacters`] for the "index" set of exemplar characters for a given locale, using compiled data.
         #[diplomat::rust_link(
             icu::locale::exemplar_chars::ExemplarCharacters::try_new_index,
             FnInStruct

--- a/ffi/capi/src/properties_sets.rs
+++ b/ffi/capi/src/properties_sets.rs
@@ -36,6 +36,7 @@ pub mod ffi {
     #[diplomat::rust_link(icu::properties, Mod)]
     #[diplomat::rust_link(icu::properties::CodePointSetData, Struct)]
     #[diplomat::rust_link(icu::properties::CodePointSetData::new, FnInStruct, hidden)]
+    #[diplomat::rust_link(icu::properties::CodePointSetDataBorrowed::new, FnInStruct, hidden)]
     #[diplomat::rust_link(icu::properties::CodePointSetDataBorrowed, Struct)]
     pub struct CodePointSetData(pub icu_properties::CodePointSetData);
 

--- a/ffi/capi/src/properties_unisets.rs
+++ b/ffi/capi/src/properties_unisets.rs
@@ -18,6 +18,7 @@ pub mod ffi {
     #[diplomat::rust_link(icu::properties, Mod)]
     #[diplomat::rust_link(icu::properties::EmojiSetData, Struct)]
     #[diplomat::rust_link(icu::properties::EmojiSetData::new, FnInStruct)]
+    #[diplomat::rust_link(icu::properties::EmojiSetDataBorrowed::new, FnInStruct, hidden)]
     #[diplomat::rust_link(icu::properties::EmojiSetDataBorrowed, Struct)]
     pub struct EmojiSetData(pub icu_properties::EmojiSetData);
 


### PR DESCRIPTION
I did not touch LocaleExpander since its borrowed type is currently not public.

Fixes #5440
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->