### PR TITLE
Rename FixedDecimal to Decimal across tutorials and demos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -663,7 +663,7 @@ Note: A subset of crates received patch releases in the 1.2 stream.
     - Allow inversion lists to be built from ranges that include `char::MAX` (#3203)
   - `icu_datetime`: No other changes
   - `icu_decimal`
-    - Add `From<GroupingStrategy>` for `FixedDecimalFormatterOptions` (#3045)
+    - Add `From<GroupingStrategy>` for `DecimalFormatterOptions` (#3045)
   - `icu_list`
     - `ListJoinerPattern::from_parts_unchecked()` is now `from_parts()` and panics when necessary (#3052)
   - `icu_locid`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -663,7 +663,7 @@ Note: A subset of crates received patch releases in the 1.2 stream.
     - Allow inversion lists to be built from ranges that include `char::MAX` (#3203)
   - `icu_datetime`: No other changes
   - `icu_decimal`
-    - Add `From<GroupingStrategy>` for `DecimalFormatterOptions` (#3045)
+    - Add `From<GroupingStrategy>` for `FixedDecimalFormatterOptions` (#3045)
   - `icu_list`
     - `ListJoinerPattern::from_parts_unchecked()` is now `from_parts()` and panics when necessary (#3052)
   - `icu_locid`

--- a/tutorials/c-tiny/fixeddecimal/README.md
+++ b/tutorials/c-tiny/fixeddecimal/README.md
@@ -1,6 +1,6 @@
-# Tiny FixedDecimal FFI Demo
+# Tiny Decimal FFI Demo
 
-This example contains tooling to build a size-optimized binary using FixedDecimal and FixedDecimalFormatter in C over FFI.
+This example contains tooling to build a size-optimized binary using FixedDecimal and DecimalFormatter in C over FFI.
 
 Prerequisites: `clang` and `lld` 14. `apt-get install clang lld` *might* work, but if you run into errors, refer to the following thread for tips:
 

--- a/tutorials/cpp.md
+++ b/tutorials/cpp.md
@@ -64,7 +64,7 @@ You should now have a `target/release/libicu_capi.a`, ready to compile into your
 Here's an annotated, shorter version of the fixed decimal example:
 
  ```cpp
-#include "FixedDecimalFormatter.hpp"
+#include "DecimalFormatter.hpp"
 #include "DataStruct.hpp"
 #include "Logger.hpp"
 
@@ -82,14 +82,14 @@ int main() {
     DataProvider dp = DataProvider::create_compiled();
 
     // Create a formatter object with the appropriate settings
-    FixedDecimalFormatter fdf = FixedDecimalFormatter::create_with_grouping_strategy(
-        dp, locale, FixedDecimalGroupingStrategy::Auto).ok().value();
+    DecimalFormatter df = DecimalFormatter::create_with_grouping_strategy(
+            dp, locale, DecimalGroupingStrategy::Auto).ok().value();
 
     // Create a decimal representing the number 1,000,007
-    FixedDecimal decimal = FixedDecimal::create_from_u64(1000007);
+    Decimal decimal = Decimal::create_from_u64(1000007);
 
     // Format it to a string
-    std::string out = fdf.format(decimal).ok().value();
+    std::string out = df.format(decimal).ok().value();
 
     // Report formatted value
     std::cout << "Formatted value is " << out << std::endl;

--- a/tutorials/npm/src/ts/fixed-decimal.ts
+++ b/tutorials/npm/src/ts/fixed-decimal.ts
@@ -1,19 +1,19 @@
-import { Decimal, FixedDecimalFormatter, FixedDecimalGroupingStrategy, Locale } from "icu4x";
+import { Decimal, DecimalFormatter, DecimalGroupingStrategy, Locale } from "icu4x";
 import { Result, Ok, result, unwrap } from './index';
 
-export class FixedDecimalDemo {
+export class DecimalDemo {
     #displayFn: (formatted: string) => void;
 
     #locale: Result<Locale>;
-    #groupingStrategy: FixedDecimalGroupingStrategy;
-    #formatter: Result<FixedDecimalFormatter>;
+    #groupingStrategy: DecimalGroupingStrategy;
+    #formatter: Result<DecimalFormatter>;
     #fixedDecimal: Result<Decimal> | null;
 
     constructor(displayFn: (formatted: string) => void) {
         this.#displayFn = displayFn;
 
         this.#locale = Ok(Locale.fromString("en"));
-        this.#groupingStrategy = FixedDecimalGroupingStrategy.Auto;
+        this.#groupingStrategy = DecimalGroupingStrategy.Auto;
         this.#fixedDecimal = null;
         this.#updateFormatter()
     }
@@ -24,7 +24,7 @@ export class FixedDecimalDemo {
     }
 
     setGroupingStrategy(strategy: string): void {
-        this.#groupingStrategy = FixedDecimalGroupingStrategy[strategy];
+        this.#groupingStrategy = DecimalGroupingStrategy[strategy];
         this.#updateFormatter()
     }
 
@@ -34,7 +34,7 @@ export class FixedDecimalDemo {
     }
 
     #updateFormatter(): void {
-        this.#formatter = result(() => FixedDecimalFormatter.createWithGroupingStrategy(
+        this.#formatter = result(() => DecimalFormatter.createWithGroupingStrategy(
             unwrap(this.#locale),
             this.#groupingStrategy,
         ));
@@ -62,31 +62,31 @@ export class FixedDecimalDemo {
 
 export function setup(): void {
     const formattedDecimal = document.getElementById('fdf-formatted') as HTMLParagraphElement;
-    const fixedDecimalDemo = new FixedDecimalDemo((formatted) => {
+    const decimalDemo = new DecimalDemo((formatted) => {
         formattedDecimal.innerText = formatted;
     });
 
     const otherLocaleBtn = document.getElementById('fdf-locale-other') as HTMLInputElement | null;
-    otherLocaleBtn?.addEventListener('click', () => fixedDecimalDemo.setLocale(otherLocaleInput.value));
+    otherLocaleBtn?.addEventListener('click', () => decimalDemo.setLocale(otherLocaleInput.value));
 
     const otherLocaleInput = document.getElementById('fdf-locale-other-input') as HTMLInputElement | null;
     otherLocaleInput?.addEventListener('input', () => {
         if (otherLocaleBtn != null) {
             otherLocaleBtn.checked = true;
-            fixedDecimalDemo.setLocale(otherLocaleInput.value);
+            decimalDemo.setLocale(otherLocaleInput.value);
         }
     });
 
     for (let btn of document.querySelectorAll<HTMLInputElement | null>('input[name="fdf-locale"]')) {
         if (btn?.value !== 'other') {
-            btn.addEventListener('click', () => fixedDecimalDemo.setLocale(btn.value));
+            btn.addEventListener('click', () => decimalDemo.setLocale(btn.value));
         }
     }
 
     for (let btn of document.querySelectorAll<HTMLInputElement | null>('input[name="fdf-grouping"]')) {
-        btn?.addEventListener('click', () => fixedDecimalDemo.setGroupingStrategy(btn.value));
+        btn?.addEventListener('click', () => decimalDemo.setGroupingStrategy(btn.value));
     }
 
     const inputDecimal = document.getElementById('fdf-input') as HTMLTextAreaElement | null;
-    inputDecimal?.addEventListener('input', () => fixedDecimalDemo.setFixedDecimal(inputDecimal.value));
+    inputDecimal?.addEventListener('input', () => decimalDemo.setFixedDecimal(inputDecimal.value));
 }


### PR DESCRIPTION
# Description

This commit updates various tutorial and demo files to reflect the recent renaming of FixedDecimal-related types to Decimal, including:
- Updating include files and class names in C++ tutorial
- Renaming README and demo files
- Updating TypeScript demo code with new type names

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->