### PR TITLE
Rename `fdf` to `formatter` in decimal formatting examples and benchmarks

### DIFF
--- a/components/decimal/README.md
+++ b/components/decimal/README.md
@@ -20,15 +20,15 @@ use icu::decimal::DecimalFormatter;
 use icu::locale::locale;
 use writeable::assert_writeable_eq;
 
-let df = DecimalFormatter::try_new(
+let formatter = DecimalFormatter::try_new(
     locale!("bn").into(),
     Default::default(),
 )
 .expect("locale should be present");
 
-let fixed_decimal = Decimal::from(1000007);
+let decimal = Decimal::from(1000007);
 
-assert_writeable_eq!(df.format(&fixed_decimal), "১০,০০,০০৭");
+assert_writeable_eq!(formatter.format(&decimal), "১০,০০,০০৭");
 ```
 
 ### Format a number with digits after the decimal separator
@@ -39,17 +39,17 @@ use icu::decimal::DecimalFormatter;
 use icu::locale::Locale;
 use writeable::assert_writeable_eq;
 
-let df =
+let formatter =
     DecimalFormatter::try_new(Default::default(), Default::default())
         .expect("locale should be present");
 
-let fixed_decimal = {
+let decimal = {
     let mut decimal = Decimal::from(200050);
     decimal.multiply_pow10(-2);
     decimal
 };
 
-assert_writeable_eq!(df.format(&fixed_decimal), "2,000.50");
+assert_writeable_eq!(formatter.format(&decimal), "2,000.50");
 ```
 
 ### Format a number using an alternative numbering system
@@ -62,15 +62,15 @@ use icu::decimal::DecimalFormatter;
 use icu::locale::locale;
 use writeable::assert_writeable_eq;
 
-let fdf = DecimalFormatter::try_new(
+let formatter = DecimalFormatter::try_new(
     locale!("th-u-nu-thai").into(),
     Default::default(),
 )
 .expect("locale should be present");
 
-let fixed_decimal = Decimal::from(1000007);
+let decimal = Decimal::from(1000007);
 
-assert_writeable_eq!(fdf.format(&fixed_decimal), "๑,๐๐๐,๐๐๗");
+assert_writeable_eq!(formatter.format(&decimal), "๑,๐๐๐,๐๐๗");
 ```
 
 [`DecimalFormatter`]: DecimalFormatter

--- a/components/decimal/benches/fixed_decimal_format.rs
+++ b/components/decimal/benches/fixed_decimal_format.rs
@@ -32,10 +32,10 @@ fn overview_bench(c: &mut Criterion) {
         b.iter(|| {
             // This benchmark demonstrates the performance of the format function on 1000 numbers
             // ranging from -1e9 to 1e9.
-            let df = DecimalFormatter::try_new(prefs, options).unwrap();
+            let formatter = DecimalFormatter::try_new(prefs, options).unwrap();
             for &num in &nums {
-                let fd = Decimal::from(black_box(num));
-                df.format_to_string(&fd);
+                let decimal = Decimal::from(black_box(num));
+                formatter.format_to_string(&decimal);
             }
         });
     });

--- a/components/decimal/benches/fixed_decimal_format.rs
+++ b/components/decimal/benches/fixed_decimal_format.rs
@@ -32,10 +32,10 @@ fn overview_bench(c: &mut Criterion) {
         b.iter(|| {
             // This benchmark demonstrates the performance of the format function on 1000 numbers
             // ranging from -1e9 to 1e9.
-            let fdf = DecimalFormatter::try_new(prefs, options).unwrap();
+            let df = DecimalFormatter::try_new(prefs, options).unwrap();
             for &num in &nums {
                 let fd = Decimal::from(black_box(num));
-                fdf.format_to_string(&fd);
+                df.format_to_string(&fd);
             }
         });
     });

--- a/components/decimal/src/grouper.rs
+++ b/components/decimal/src/grouper.rs
@@ -201,9 +201,9 @@ fn test_grouper() {
                 grouping_strategy: Some(cas.strategy),
                 ..Default::default()
             };
-            let df =
+            let formatter =
                 DecimalFormatter::try_new_unstable(&provider, Default::default(), options).unwrap();
-            let actual = df.format(&dec);
+            let actual = formatter.format(&dec);
             assert_writeable_eq!(actual, cas.expected[i], "{:?}", cas);
         }
     }

--- a/components/decimal/src/grouper.rs
+++ b/components/decimal/src/grouper.rs
@@ -201,9 +201,9 @@ fn test_grouper() {
                 grouping_strategy: Some(cas.strategy),
                 ..Default::default()
             };
-            let fdf =
+            let df =
                 DecimalFormatter::try_new_unstable(&provider, Default::default(), options).unwrap();
-            let actual = fdf.format(&dec);
+            let actual = df.format(&dec);
             assert_writeable_eq!(actual, cas.expected[i], "{:?}", cas);
         }
     }

--- a/components/decimal/src/lib.rs
+++ b/components/decimal/src/lib.rs
@@ -26,9 +26,9 @@
 //! )
 //! .expect("locale should be present");
 //!
-//! let fixed_decimal = Decimal::from(1000007);
+//! let decimal = Decimal::from(1000007);
 //!
-//! assert_writeable_eq!(df.format(&fixed_decimal), "১০,০০,০০৭");
+//! assert_writeable_eq!(df.format(&decimal), "১০,০০,০০৭");
 //! ```
 //!
 //! ## Format a number with digits after the decimal separator
@@ -62,15 +62,15 @@
 //! use icu::locale::locale;
 //! use writeable::assert_writeable_eq;
 //!
-//! let fdf = DecimalFormatter::try_new(
+//! let df = DecimalFormatter::try_new(
 //!     locale!("th-u-nu-thai").into(),
 //!     Default::default(),
 //! )
 //! .expect("locale should be present");
 //!
-//! let fixed_decimal = Decimal::from(1000007);
+//! let decimal = Decimal::from(1000007);
 //!
-//! assert_writeable_eq!(fdf.format(&fixed_decimal), "๑,๐๐๐,๐๐๗");
+//! assert_writeable_eq!(df.format(&decimal), "๑,๐๐๐,๐๐๗");
 //! ```
 //!
 //! [`DecimalFormatter`]: DecimalFormatter

--- a/components/decimal/src/lib.rs
+++ b/components/decimal/src/lib.rs
@@ -20,7 +20,7 @@
 //! use icu::locale::locale;
 //! use writeable::assert_writeable_eq;
 //!
-//! let df = DecimalFormatter::try_new(
+//! let formatter = DecimalFormatter::try_new(
 //!     locale!("bn").into(),
 //!     Default::default(),
 //! )
@@ -28,7 +28,7 @@
 //!
 //! let decimal = Decimal::from(1000007);
 //!
-//! assert_writeable_eq!(df.format(&decimal), "১০,০০,০০৭");
+//! assert_writeable_eq!(formatter.format(&decimal), "১০,০০,০০৭");
 //! ```
 //!
 //! ## Format a number with digits after the decimal separator
@@ -39,17 +39,17 @@
 //! use icu::locale::Locale;
 //! use writeable::assert_writeable_eq;
 //!
-//! let df =
+//! let formatter =
 //!     DecimalFormatter::try_new(Default::default(), Default::default())
 //!         .expect("locale should be present");
 //!
-//! let fixed_decimal = {
+//! let decimal = {
 //!     let mut decimal = Decimal::from(200050);
 //!     decimal.multiply_pow10(-2);
 //!     decimal
 //! };
 //!
-//! assert_writeable_eq!(df.format(&fixed_decimal), "2,000.50");
+//! assert_writeable_eq!(formatter.format(&decimal), "2,000.50");
 //! ```
 //!
 //! ## Format a number using an alternative numbering system
@@ -62,7 +62,7 @@
 //! use icu::locale::locale;
 //! use writeable::assert_writeable_eq;
 //!
-//! let df = DecimalFormatter::try_new(
+//! let formatter = DecimalFormatter::try_new(
 //!     locale!("th-u-nu-thai").into(),
 //!     Default::default(),
 //! )
@@ -70,7 +70,7 @@
 //!
 //! let decimal = Decimal::from(1000007);
 //!
-//! assert_writeable_eq!(df.format(&decimal), "๑,๐๐๐,๐๐๗");
+//! assert_writeable_eq!(formatter.format(&decimal), "๑,๐๐๐,๐๐๗");
 //! ```
 //!
 //! [`DecimalFormatter`]: DecimalFormatter

--- a/components/decimal/src/options.rs
+++ b/components/decimal/src/options.rs
@@ -36,14 +36,14 @@ impl From<GroupingStrategy> for DecimalFormatterOptions {
 /// let locale = Default::default();
 /// let mut options: options::DecimalFormatterOptions = Default::default();
 /// options.grouping_strategy = Some(options::GroupingStrategy::Min2);
-/// let df = DecimalFormatter::try_new(locale, options)
+/// let formatter = DecimalFormatter::try_new(locale, options)
 ///     .expect("locale should be present");
 ///
 /// let one_thousand = 1000.into();
-/// assert_writeable_eq!(df.format(&one_thousand), "1000");
+/// assert_writeable_eq!(formatter.format(&one_thousand), "1000");
 ///
 /// let ten_thousand = 10000.into();
-/// assert_writeable_eq!(df.format(&ten_thousand), "10,000");
+/// assert_writeable_eq!(formatter.format(&ten_thousand), "10,000");
 /// ```
 #[non_exhaustive]
 #[derive(Debug, Eq, PartialEq, Clone, Copy, Hash, Default)]

--- a/components/decimal/src/parts.rs
+++ b/components/decimal/src/parts.rs
@@ -12,17 +12,17 @@
 //! use icu::locale::locale;
 //! use writeable::assert_writeable_parts_eq;
 //!
-//! let df = DecimalFormatter::try_new(
+//! let formatter = DecimalFormatter::try_new(
 //!     locale!("en").into(),
 //!     Default::default(),
 //! )
 //! .unwrap();
 //!
-//! let fixed_decimal = "-987654.321".parse().unwrap();
+//! let decimal = "-987654.321".parse().unwrap();
 //!
 //! // Missing data is filled in on a best-effort basis, and an error is signaled.
 //! assert_writeable_parts_eq!(
-//!     df.format(&fixed_decimal),
+//!     formatter.format(&decimal),
 //!     "-987,654.321",
 //!     [
 //!         (0, 1, parts::MINUS_SIGN),

--- a/components/decimal/src/provider.rs
+++ b/components/decimal/src/provider.rs
@@ -50,7 +50,7 @@
 //!     numbering_system: RefCell::new(None),
 //! };
 //!
-//! let df = DecimalFormatter::try_new_unstable(
+//! let formatter = DecimalFormatter::try_new_unstable(
 //!     &provider,
 //!     locale!("th").into(),
 //!     Default::default(),
@@ -59,7 +59,7 @@
 //!
 //! assert_eq!(provider.numbering_system.borrow().as_ref().map(|x| x.as_str()), Some("latn"));
 //!
-//! let df = DecimalFormatter::try_new_unstable(
+//! let formatter = DecimalFormatter::try_new_unstable(
 //!     &provider,
 //!     locale!("th-u-nu-thai").into(),
 //!     Default::default(),
@@ -68,7 +68,7 @@
 //!
 //! assert_eq!(provider.numbering_system.borrow().as_ref().map(|x| x.as_str()), Some("thai"));
 //!
-//! let df = DecimalFormatter::try_new_unstable(
+//! let formatter = DecimalFormatter::try_new_unstable(
 //!     &provider,
 //!     locale!("th-u-nu-adlm").into(),
 //!     Default::default(),


### PR DESCRIPTION
# Description

Consistently rename the variable name from `fdf` (fixed decimal formatter) to `formatter` (decimal formatter) across documentation, benchmarks, and tests to match recent type renaming efforts.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->