### PR TITLE
Rename `df` to `formatter` in C++ decimal formatting tutorial

### DIFF
--- a/tutorials/cpp.md
+++ b/tutorials/cpp.md
@@ -82,14 +82,14 @@ int main() {
     DataProvider dp = DataProvider::create_compiled();
 
     // Create a formatter object with the appropriate settings
-    DecimalFormatter df = DecimalFormatter::create_with_grouping_strategy(
+    DecimalFormatter formatter = DecimalFormatter::create_with_grouping_strategy(
             dp, locale, DecimalGroupingStrategy::Auto).ok().value();
 
     // Create a decimal representing the number 1,000,007
     Decimal decimal = Decimal::create_from_u64(1000007);
 
     // Format it to a string
-    std::string out = df.format(decimal).ok().value();
+    std::string out = formatter.format(decimal).ok().value();
 
     // Report formatted value
     std::cout << "Formatted value is " << out << std::endl;


### PR DESCRIPTION
Update variable name for consistency with recent renaming efforts in the project.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->