### PR TITLE
Rename `fdf` to `formatter` in datetime and time zone formatting

### DIFF
--- a/components/datetime/src/format/datetime.rs
+++ b/components/datetime/src/format/datetime.rs
@@ -103,7 +103,7 @@ fn try_write_field<W>(
     pattern_metadata: PatternMetadata,
     input: &ExtractedInput,
     datetime_names: &RawDateTimeNamesBorrowed,
-    formatter: Option<&DecimalFormatter>,
+    decimal_formatter: Option<&DecimalFormatter>,
     w: &mut W,
 ) -> Result<Result<(), DateTimeWriteError>, fmt::Error>
 where
@@ -164,7 +164,7 @@ where
                 // 'yy' and 'YY' truncate
                 year.set_max_position(2);
             }
-            try_write_number(PART, w, formatter, year, l)?
+            try_write_number(PART, w, decimal_formatter, year, l)?
         }
         (FieldSymbol::Year(Year::Cyclic), l) => {
             const PART: Part = parts::YEAR_NAME;
@@ -178,7 +178,7 @@ where
                         w.with_part(Part::ERROR, |w| {
                             try_write_number_without_part(
                                 w,
-                                formatter,
+                                decimal_formatter,
                                 year.era_year_or_extended().into(),
                                 FieldLength::One,
                             )
@@ -218,7 +218,7 @@ where
         (FieldSymbol::Month(_), l @ (FieldLength::One | FieldLength::Two)) => {
             const PART: Part = parts::MONTH;
             input!(PART, month = input.month);
-            try_write_number(PART, w, formatter, month.ordinal.into(), l)?
+            try_write_number(PART, w, decimal_formatter, month.ordinal.into(), l)?
         }
         (FieldSymbol::Month(symbol), l) => {
             const PART: Part = parts::MONTH;
@@ -230,11 +230,11 @@ where
                 }
                 Ok(MonthPlaceholderValue::Numeric) => {
                     debug_assert!(l == FieldLength::One);
-                    try_write_number(PART, w, formatter, month.ordinal.into(), l)?
+                    try_write_number(PART, w, decimal_formatter, month.ordinal.into(), l)?
                 }
                 Ok(MonthPlaceholderValue::NumericPattern(substitution_pattern)) => {
                     debug_assert!(l == FieldLength::One);
-                    if let Some(formatter) = formatter {
+                    if let Some(formatter) = decimal_formatter {
                         let mut num = Decimal::from(month.ordinal);
                         num.pad_start(l.to_len() as i16);
                         w.with_part(PART, |w| {
@@ -312,20 +312,20 @@ where
         (FieldSymbol::Day(fields::Day::DayOfMonth), l) => {
             const PART: Part = parts::DAY;
             input!(PART, day_of_month = input.day_of_month);
-            try_write_number(PART, w, formatter, day_of_month.0.into(), l)?
+            try_write_number(PART, w, decimal_formatter, day_of_month.0.into(), l)?
         }
         (FieldSymbol::Day(fields::Day::DayOfWeekInMonth), l) => {
             input!(_, day_of_month = input.day_of_month);
             try_write_number_without_part(
                 w,
-                formatter,
+                decimal_formatter,
                 DayOfWeekInMonth::from(day_of_month).0.into(),
                 l,
             )?
         }
         (FieldSymbol::Day(fields::Day::DayOfYear), l) => {
             input!(_, day_of_year = input.day_of_year);
-            try_write_number_without_part(w, formatter, day_of_year.day_of_year.into(), l)?
+            try_write_number_without_part(w, decimal_formatter, day_of_year.day_of_year.into(), l)?
         }
         (FieldSymbol::Hour(symbol), l) => {
             const PART: Part = parts::HOUR;
@@ -350,17 +350,17 @@ where
                     }
                 }
             };
-            try_write_number(PART, w, formatter, h.into(), l)?
+            try_write_number(PART, w, decimal_formatter, h.into(), l)?
         }
         (FieldSymbol::Minute, l) => {
             const PART: Part = parts::MINUTE;
             input!(PART, minute = input.minute);
-            try_write_number(PART, w, formatter, minute.number().into(), l)?
+            try_write_number(PART, w, decimal_formatter, minute.number().into(), l)?
         }
         (FieldSymbol::Second(Second::Second), l) => {
             const PART: Part = parts::SECOND;
             input!(PART, second = input.second);
-            try_write_number(PART, w, formatter, second.number().into(), l)?
+            try_write_number(PART, w, decimal_formatter, second.number().into(), l)?
         }
         (FieldSymbol::Second(Second::MillisInDay), l) => {
             input!(_, hour = input.hour);
@@ -372,7 +372,7 @@ where
                 + second.number() as u32)
                 * 1000
                 + subsecond.number() / 1_000_000;
-            try_write_number_without_part(w, formatter, milliseconds.into(), l)?
+            try_write_number_without_part(w, decimal_formatter, milliseconds.into(), l)?
         }
         (FieldSymbol::DecimalSecond(decimal_second), l) => {
             const PART: Part = parts::SECOND;
@@ -390,7 +390,7 @@ where
             let position = -(decimal_second as i16);
             s.trunc(position);
             s.pad_end(position);
-            try_write_number(PART, w, formatter, s, l)?
+            try_write_number(PART, w, decimal_formatter, s, l)?
         }
         (FieldSymbol::DayPeriod(period), l) => {
             const PART: Part = parts::DAY_PERIOD;
@@ -429,7 +429,7 @@ where
                 w,
                 input,
                 datetime_names,
-                formatter,
+                decimal_formatter,
                 field,
                 &[
                     TimeZoneFormatterUnit::SpecificNonLocation(FieldLength::Four),
@@ -443,7 +443,7 @@ where
                 w,
                 input,
                 datetime_names,
-                formatter,
+                decimal_formatter,
                 field,
                 &[
                     TimeZoneFormatterUnit::SpecificNonLocation(l),
@@ -456,7 +456,7 @@ where
                 w,
                 input,
                 datetime_names,
-                formatter,
+                decimal_formatter,
                 field,
                 &[
                     TimeZoneFormatterUnit::GenericNonLocation(l),
@@ -470,7 +470,7 @@ where
                 w,
                 input,
                 datetime_names,
-                formatter,
+                decimal_formatter,
                 field,
                 &[
                     TimeZoneFormatterUnit::GenericLocation,
@@ -483,7 +483,7 @@ where
                 w,
                 input,
                 datetime_names,
-                formatter,
+                decimal_formatter,
                 field,
                 &[TimeZoneFormatterUnit::ExemplarCity],
             )?
@@ -492,7 +492,7 @@ where
             w,
             input,
             datetime_names,
-            formatter,
+            decimal_formatter,
             field,
             &[TimeZoneFormatterUnit::LocalizedOffset(l)],
         )?,
@@ -500,7 +500,7 @@ where
             w,
             input,
             datetime_names,
-            formatter,
+            decimal_formatter,
             field,
             &[TimeZoneFormatterUnit::Bcp47Id],
         )?,
@@ -508,7 +508,7 @@ where
             w,
             input,
             datetime_names,
-            formatter,
+            decimal_formatter,
             field,
             &[TimeZoneFormatterUnit::Iso8601(Iso8601Format::with_z(l))],
         )?,
@@ -516,7 +516,7 @@ where
             w,
             input,
             datetime_names,
-            formatter,
+            decimal_formatter,
             field,
             &[TimeZoneFormatterUnit::Iso8601(Iso8601Format::without_z(l))],
         )?,

--- a/components/datetime/src/format/datetime.rs
+++ b/components/datetime/src/format/datetime.rs
@@ -103,7 +103,7 @@ fn try_write_field<W>(
     pattern_metadata: PatternMetadata,
     input: &ExtractedInput,
     datetime_names: &RawDateTimeNamesBorrowed,
-    fdf: Option<&DecimalFormatter>,
+    formatter: Option<&DecimalFormatter>,
     w: &mut W,
 ) -> Result<Result<(), DateTimeWriteError>, fmt::Error>
 where
@@ -164,7 +164,7 @@ where
                 // 'yy' and 'YY' truncate
                 year.set_max_position(2);
             }
-            try_write_number(PART, w, fdf, year, l)?
+            try_write_number(PART, w, formatter, year, l)?
         }
         (FieldSymbol::Year(Year::Cyclic), l) => {
             const PART: Part = parts::YEAR_NAME;
@@ -178,7 +178,7 @@ where
                         w.with_part(Part::ERROR, |w| {
                             try_write_number_without_part(
                                 w,
-                                fdf,
+                                formatter,
                                 year.era_year_or_extended().into(),
                                 FieldLength::One,
                             )
@@ -218,7 +218,7 @@ where
         (FieldSymbol::Month(_), l @ (FieldLength::One | FieldLength::Two)) => {
             const PART: Part = parts::MONTH;
             input!(PART, month = input.month);
-            try_write_number(PART, w, fdf, month.ordinal.into(), l)?
+            try_write_number(PART, w, formatter, month.ordinal.into(), l)?
         }
         (FieldSymbol::Month(symbol), l) => {
             const PART: Part = parts::MONTH;
@@ -230,16 +230,16 @@ where
                 }
                 Ok(MonthPlaceholderValue::Numeric) => {
                     debug_assert!(l == FieldLength::One);
-                    try_write_number(PART, w, fdf, month.ordinal.into(), l)?
+                    try_write_number(PART, w, formatter, month.ordinal.into(), l)?
                 }
                 Ok(MonthPlaceholderValue::NumericPattern(substitution_pattern)) => {
                     debug_assert!(l == FieldLength::One);
-                    if let Some(fdf) = fdf {
+                    if let Some(formatter) = formatter {
                         let mut num = Decimal::from(month.ordinal);
                         num.pad_start(l.to_len() as i16);
                         w.with_part(PART, |w| {
                             substitution_pattern
-                                .interpolate([fdf.format(&num)])
+                                .interpolate([formatter.format(&num)])
                                 .write_to(w)
                         })?;
                         Ok(())
@@ -312,15 +312,20 @@ where
         (FieldSymbol::Day(fields::Day::DayOfMonth), l) => {
             const PART: Part = parts::DAY;
             input!(PART, day_of_month = input.day_of_month);
-            try_write_number(PART, w, fdf, day_of_month.0.into(), l)?
+            try_write_number(PART, w, formatter, day_of_month.0.into(), l)?
         }
         (FieldSymbol::Day(fields::Day::DayOfWeekInMonth), l) => {
             input!(_, day_of_month = input.day_of_month);
-            try_write_number_without_part(w, fdf, DayOfWeekInMonth::from(day_of_month).0.into(), l)?
+            try_write_number_without_part(
+                w,
+                formatter,
+                DayOfWeekInMonth::from(day_of_month).0.into(),
+                l,
+            )?
         }
         (FieldSymbol::Day(fields::Day::DayOfYear), l) => {
             input!(_, day_of_year = input.day_of_year);
-            try_write_number_without_part(w, fdf, day_of_year.day_of_year.into(), l)?
+            try_write_number_without_part(w, formatter, day_of_year.day_of_year.into(), l)?
         }
         (FieldSymbol::Hour(symbol), l) => {
             const PART: Part = parts::HOUR;
@@ -345,17 +350,17 @@ where
                     }
                 }
             };
-            try_write_number(PART, w, fdf, h.into(), l)?
+            try_write_number(PART, w, formatter, h.into(), l)?
         }
         (FieldSymbol::Minute, l) => {
             const PART: Part = parts::MINUTE;
             input!(PART, minute = input.minute);
-            try_write_number(PART, w, fdf, minute.number().into(), l)?
+            try_write_number(PART, w, formatter, minute.number().into(), l)?
         }
         (FieldSymbol::Second(Second::Second), l) => {
             const PART: Part = parts::SECOND;
             input!(PART, second = input.second);
-            try_write_number(PART, w, fdf, second.number().into(), l)?
+            try_write_number(PART, w, formatter, second.number().into(), l)?
         }
         (FieldSymbol::Second(Second::MillisInDay), l) => {
             input!(_, hour = input.hour);
@@ -367,7 +372,7 @@ where
                 + second.number() as u32)
                 * 1000
                 + subsecond.number() / 1_000_000;
-            try_write_number_without_part(w, fdf, milliseconds.into(), l)?
+            try_write_number_without_part(w, formatter, milliseconds.into(), l)?
         }
         (FieldSymbol::DecimalSecond(decimal_second), l) => {
             const PART: Part = parts::SECOND;
@@ -385,7 +390,7 @@ where
             let position = -(decimal_second as i16);
             s.trunc(position);
             s.pad_end(position);
-            try_write_number(PART, w, fdf, s, l)?
+            try_write_number(PART, w, formatter, s, l)?
         }
         (FieldSymbol::DayPeriod(period), l) => {
             const PART: Part = parts::DAY_PERIOD;
@@ -424,7 +429,7 @@ where
                 w,
                 input,
                 datetime_names,
-                fdf,
+                formatter,
                 field,
                 &[
                     TimeZoneFormatterUnit::SpecificNonLocation(FieldLength::Four),
@@ -438,7 +443,7 @@ where
                 w,
                 input,
                 datetime_names,
-                fdf,
+                formatter,
                 field,
                 &[
                     TimeZoneFormatterUnit::SpecificNonLocation(l),
@@ -451,7 +456,7 @@ where
                 w,
                 input,
                 datetime_names,
-                fdf,
+                formatter,
                 field,
                 &[
                     TimeZoneFormatterUnit::GenericNonLocation(l),
@@ -465,7 +470,7 @@ where
                 w,
                 input,
                 datetime_names,
-                fdf,
+                formatter,
                 field,
                 &[
                     TimeZoneFormatterUnit::GenericLocation,
@@ -478,7 +483,7 @@ where
                 w,
                 input,
                 datetime_names,
-                fdf,
+                formatter,
                 field,
                 &[TimeZoneFormatterUnit::ExemplarCity],
             )?
@@ -487,7 +492,7 @@ where
             w,
             input,
             datetime_names,
-            fdf,
+            formatter,
             field,
             &[TimeZoneFormatterUnit::LocalizedOffset(l)],
         )?,
@@ -495,7 +500,7 @@ where
             w,
             input,
             datetime_names,
-            fdf,
+            formatter,
             field,
             &[TimeZoneFormatterUnit::Bcp47Id],
         )?,
@@ -503,7 +508,7 @@ where
             w,
             input,
             datetime_names,
-            fdf,
+            formatter,
             field,
             &[TimeZoneFormatterUnit::Iso8601(Iso8601Format::with_z(l))],
         )?,
@@ -511,7 +516,7 @@ where
             w,
             input,
             datetime_names,
-            fdf,
+            formatter,
             field,
             &[TimeZoneFormatterUnit::Iso8601(Iso8601Format::without_z(l))],
         )?,

--- a/components/datetime/src/format/time_zone.rs
+++ b/components/datetime/src/format/time_zone.rs
@@ -212,12 +212,12 @@ impl FormatTimeZone for LocalizedOffsetFormat {
         sink: &mut W,
         input: &ExtractedInput,
         data_payloads: TimeZoneDataPayloadsBorrowed,
-        fdf: Option<&DecimalFormatter>,
+        formatter: Option<&DecimalFormatter>,
     ) -> Result<Result<(), FormatTimeZoneError>, fmt::Error> {
         let Some(essentials) = data_payloads.essentials else {
             return Ok(Err(FormatTimeZoneError::NamesNotLoaded));
         };
-        let Some(fdf) = fdf else {
+        let Some(formatter) = formatter else {
             return Ok(Err(FormatTimeZoneError::DecimalFormatterNotLoaded));
         };
         let Some(offset) = input.offset else {
@@ -231,7 +231,7 @@ impl FormatTimeZone for LocalizedOffsetFormat {
             struct FormattedOffset<'a> {
                 offset: UtcOffset,
                 separator: &'a str,
-                fdf: &'a DecimalFormatter,
+                formatter: &'a DecimalFormatter,
                 length: FieldLength,
             }
 
@@ -240,34 +240,34 @@ impl FormatTimeZone for LocalizedOffsetFormat {
                     &self,
                     sink: &mut S,
                 ) -> fmt::Result {
-                    let fd = {
-                        let mut fd = Decimal::from(self.offset.hours_part())
+                    let decimal = {
+                        let mut decimal = Decimal::from(self.offset.hours_part())
                             .with_sign_display(fixed_decimal::SignDisplay::Always);
-                        fd.pad_start(if self.length == FieldLength::Four {
+                        decimal.pad_start(if self.length == FieldLength::Four {
                             2
                         } else {
                             0
                         });
-                        fd
+                        decimal
                     };
-                    self.fdf.format(&fd).write_to(sink)?;
+                    self.formatter.format(&decimal).write_to(sink)?;
 
                     if self.length == FieldLength::Four
                         || self.offset.minutes_part() != 0
                         || self.offset.seconds_part() != 0
                     {
-                        let mut signed_fdf = Decimal::from(self.offset.minutes_part());
-                        signed_fdf.absolute.pad_start(2);
+                        let mut decimal = Decimal::from(self.offset.minutes_part());
+                        decimal.absolute.pad_start(2);
                         sink.write_str(self.separator)?;
-                        self.fdf.format(&signed_fdf).write_to(sink)?;
+                        self.formatter.format(&decimal).write_to(sink)?;
                     }
 
                     if self.offset.seconds_part() != 0 {
                         sink.write_str(self.separator)?;
 
-                        let mut signed_fdf = Decimal::from(self.offset.seconds_part());
-                        signed_fdf.absolute.pad_start(2);
-                        self.fdf.format(&signed_fdf).write_to(sink)?;
+                        let mut decimal = Decimal::from(self.offset.seconds_part());
+                        decimal.absolute.pad_start(2);
+                        self.formatter.format(&decimal).write_to(sink)?;
                     }
 
                     Ok(())
@@ -279,7 +279,7 @@ impl FormatTimeZone for LocalizedOffsetFormat {
                 .interpolate([FormattedOffset {
                     offset,
                     separator: &essentials.offset_separator,
-                    fdf,
+                    formatter,
                     length: self.0,
                 }])
                 .write_to(sink)?;
@@ -301,7 +301,7 @@ impl FormatTimeZone for GenericLocationFormat {
         sink: &mut W,
         input: &ExtractedInput,
         data_payloads: TimeZoneDataPayloadsBorrowed,
-        _fdf: Option<&DecimalFormatter>,
+        _decimal_formatter: Option<&DecimalFormatter>,
     ) -> Result<Result<(), FormatTimeZoneError>, fmt::Error> {
         let Some(time_zone_id) = input.time_zone_id else {
             return Ok(Err(FormatTimeZoneError::MissingInputField("time_zone_id")));
@@ -344,7 +344,7 @@ impl FormatTimeZone for SpecificLocationFormat {
         sink: &mut W,
         input: &ExtractedInput,
         data_payloads: TimeZoneDataPayloadsBorrowed,
-        _fdf: Option<&DecimalFormatter>,
+        _decimal_formatter: Option<&DecimalFormatter>,
     ) -> Result<Result<(), FormatTimeZoneError>, fmt::Error> {
         let Some(time_zone_id) = input.time_zone_id else {
             return Ok(Err(FormatTimeZoneError::MissingInputField("time_zone_id")));

--- a/components/decimal/examples/code_line_diff.rs
+++ b/components/decimal/examples/code_line_diff.rs
@@ -21,12 +21,12 @@ const LINES_REMOVED_ADDED: [(i64, i64); 5] = [
 ];
 
 fn main() {
-    let fdf = DecimalFormatter::try_new(locale!("bn").into(), Default::default())
+    let formatter = DecimalFormatter::try_new(locale!("bn").into(), Default::default())
         .expect("locale should be present");
 
     for (removed, added) in LINES_REMOVED_ADDED {
-        let removed = fdf.format_to_string(&removed.into());
-        let added = fdf.format_to_string(&added.into());
+        let removed = formatter.format_to_string(&removed.into());
+        let added = formatter.format_to_string(&added.into());
         assert!(!removed.is_empty());
         assert!(!added.is_empty());
         println!("Added/Removed: {added}/{removed}",);

--- a/tutorials/c-tiny/fixeddecimal/test.c
+++ b/tutorials/c-tiny/fixeddecimal/test.c
@@ -29,18 +29,18 @@ int main(int argc, char *argv[]) {
 
     DecimalGroupingStrategy_option o = {.ok = DecimalGroupingStrategy_Auto, .is_ok = true};
 
-    icu4x_DecimalFormatter_create_with_grouping_strategy_mv1_result fdf_result =
+    icu4x_DecimalFormatter_create_with_grouping_strategy_mv1_result formatter_result =
         icu4x_DecimalFormatter_create_with_grouping_strategy_mv1(locale, o);
-    if (!fdf_result.is_ok)  {
+    if (!formatter_result.is_ok)  {
         printf("Failed to create DecimalFormatter\n");
         return 1;
     }
-    DecimalFormatter* fdf = fdf_result.ok;
+    DecimalFormatter* formatter = formatter_result.ok;
     char output[40];
 
     DiplomatWrite write = diplomat_simple_write(output, 40);
 
-    icu4x_DecimalFormatter_format_mv1(fdf, decimal, &write);
+    icu4x_DecimalFormatter_format_mv1(formatter, decimal, &write);
     if (write.grow_failed) {
         printf("format overflowed the string.\n");
         return 1;
@@ -54,7 +54,7 @@ int main(int argc, char *argv[]) {
     }
 
     icu4x_Decimal_destroy_mv1(decimal);
-    icu4x_DecimalFormatter_destroy_mv1(fdf);
+    icu4x_DecimalFormatter_destroy_mv1(formatter);
     icu4x_Locale_destroy_mv1(locale);
 
     return 0;

--- a/tutorials/c/fixeddecimal.c
+++ b/tutorials/c/fixeddecimal.c
@@ -27,18 +27,18 @@ int main() {
 
     DecimalGroupingStrategy_option o = {.ok = DecimalGroupingStrategy_Auto, .is_ok = true};
 
-    icu4x_DecimalFormatter_create_with_grouping_strategy_mv1_result fdf_result =
+    icu4x_DecimalFormatter_create_with_grouping_strategy_mv1_result formatter_result =
         icu4x_DecimalFormatter_create_with_grouping_strategy_mv1(locale, o);
-    if (!fdf_result.is_ok)  {
+    if (!formatter_result.is_ok)  {
         printf("Failed to create DecimalFormatter\n");
         return 1;
     }
-    DecimalFormatter* fdf = fdf_result.ok;
+    DecimalFormatter* formatter = formatter_result.ok;
     char output[40];
 
     DiplomatWrite write = diplomat_simple_write(output, 40);
 
-    icu4x_DecimalFormatter_format_mv1(fdf, decimal, &write);
+    icu4x_DecimalFormatter_format_mv1(formatter, decimal, &write);
     if (write.grow_failed) {
         printf("format overflowed the string.\n");
         return 1;
@@ -57,7 +57,7 @@ int main() {
 
     write = diplomat_simple_write(output, 40);
 
-    icu4x_DecimalFormatter_format_mv1(fdf, decimal, &write);
+    icu4x_DecimalFormatter_format_mv1(formatter, decimal, &write);
     if (write.grow_failed) {
         printf("format overflowed the string.\n");
         return 1;
@@ -86,7 +86,7 @@ int main() {
 
     write = diplomat_simple_write(output, 40);
 
-    icu4x_DecimalFormatter_format_mv1(fdf, decimal, &write);
+    icu4x_DecimalFormatter_format_mv1(formatter, decimal, &write);
     if (write.grow_failed) {
         printf("format overflowed the string.\n");
         return 1;
@@ -100,7 +100,7 @@ int main() {
     }
 
     icu4x_Decimal_destroy_mv1(decimal);
-    icu4x_DecimalFormatter_destroy_mv1(fdf);
+    icu4x_DecimalFormatter_destroy_mv1(formatter);
     icu4x_Locale_destroy_mv1(locale);
 
     return 0;

--- a/tutorials/cpp/fixeddecimal.cpp
+++ b/tutorials/cpp/fixeddecimal.cpp
@@ -14,11 +14,11 @@ int main() {
     Logger::init_simple_logger();
     std::unique_ptr<Locale> locale = Locale::from_string("bn").ok().value();
     std::cout << "Running test for locale " << locale->to_string() << std::endl;
-    std::unique_ptr<DecimalFormatter> fdf = DecimalFormatter::create_with_grouping_strategy(
+    std::unique_ptr<DecimalFormatter> formatter = DecimalFormatter::create_with_grouping_strategy(
         *locale.get(), DecimalGroupingStrategy::Auto).ok().value();
 
     std::unique_ptr<Decimal> decimal = Decimal::from(1000007);
-    std::string out = fdf->format(*decimal.get());
+    std::string out = formatter->format(*decimal.get());
     std::cout << "Formatted value is " << out << std::endl;
     if (out != "১০,০০,০০৭") {
         std::cout << "Output does not match expected output" << std::endl;
@@ -27,7 +27,7 @@ int main() {
 
     decimal->multiply_pow10(2);
     decimal->set_sign(FixedDecimalSign::Negative);
-    out = fdf->format(*decimal.get());
+    out = formatter->format(*decimal.get());
     std::cout << "Value x100 and negated is " << out << std::endl;
     if (out != "-১০,০০,০০,৭০০") {
         std::cout << "Output does not match expected output" << std::endl;
@@ -35,7 +35,7 @@ int main() {
     }
 
     decimal = Decimal::from_double_with_round_trip_precision(100.01).ok().value();
-    out = fdf->format(*decimal.get());
+    out = formatter->format(*decimal.get());
     std::cout << "Formatted float value is " << out << std::endl;
     if (out != "১০০.০১") {
         std::cout << "Output does not match expected output" << std::endl;
@@ -43,7 +43,7 @@ int main() {
     }
 
     decimal->pad_end(-4);
-    out = fdf->format(*decimal.get());
+    out = formatter->format(*decimal.get());
     std::cout << "Formatted left-padded float value is " << out << std::endl;
     if (out != "১০০.০১০০") {
         std::cout << "Output does not match expected output" << std::endl;
@@ -51,7 +51,7 @@ int main() {
     }
 
     decimal->pad_start(4);
-    out = fdf->format(*decimal.get());
+    out = formatter->format(*decimal.get());
     std::cout << "Formatted right-padded float value is " << out << std::endl;
     if (out != "০,১০০.০১০০") {
         std::cout << "Output does not match expected output" << std::endl;
@@ -59,7 +59,7 @@ int main() {
     }
 
     decimal->set_max_position(3);
-    out = fdf->format(*decimal.get());
+    out = formatter->format(*decimal.get());
     std::cout << "Formatted truncated float value is " << out << std::endl;
     if (out != "১০০.০১০০") {
         std::cout << "Output does not match expected output" << std::endl;
@@ -67,7 +67,7 @@ int main() {
     }
 
     decimal = Decimal::from_double_with_lower_magnitude(100.0006, -2).ok().value();
-    out = fdf->format(*decimal.get());
+    out = formatter->format(*decimal.get());
     std::cout << "Formatted float value from precision 2 is " << out << std::endl;
     if (out != "১০০.০০") {
         std::cout << "Output does not match expected output" << std::endl;
@@ -75,7 +75,7 @@ int main() {
     }
 
     decimal = Decimal::from_double_with_significant_digits(100.0006, 5).ok().value();
-    out = fdf->format(*decimal.get());
+    out = formatter->format(*decimal.get());
     std::cout << "Formatted float value with 5 digits is " << out << std::endl;
     if (out != "১০০.০০") {
         std::cout << "Output does not match expected output" << std::endl;
@@ -84,17 +84,17 @@ int main() {
 
     std::array<char32_t, 10> digits = {U'a', U'b', U'c', U'd', U'e', U'f', U'g', U'h', U'i', U'j'};
 
-    fdf = DecimalFormatter::create_with_manual_data("+", "", "-", "", "/", "_", 4, 2, 4, digits, DecimalGroupingStrategy::Auto).ok().value();
+    formatter = DecimalFormatter::create_with_manual_data("+", "", "-", "", "/", "_", 4, 2, 4, digits, DecimalGroupingStrategy::Auto).ok().value();
 
     decimal = Decimal::from_double_with_round_trip_precision(123456.8901).ok().value();
-    out = fdf->format(*decimal.get());
+    out = formatter->format(*decimal.get());
     std::cout << "Formatted float value for custom numeric system is " << out << std::endl;
     if (out != "bcdefg/ijab") {
         std::cout << "Output does not match expected output" << std::endl;
         return 1;
     }
     decimal = Decimal::from_double_with_round_trip_precision(123451234567.8901).ok().value();
-    out = fdf->format(*decimal.get());
+    out = formatter->format(*decimal.get());
     std::cout << "Formatted float value for custom numeric system is " << out << std::endl;
     if (out != "bc_de_fb_cd_efgh/ijab") {
         std::cout << "Output does not match expected output" << std::endl;
@@ -103,11 +103,11 @@ int main() {
 
     locale = Locale::from_string("th-u-nu-thai").ok().value();
     std::cout << "Running test for locale " << locale->to_string() << std::endl;
-    fdf = DecimalFormatter::create_with_grouping_strategy(
+    formatter = DecimalFormatter::create_with_grouping_strategy(
         *locale.get(), DecimalGroupingStrategy::Auto).ok().value();
 
     decimal = Decimal::from_double_with_round_trip_precision(123456.8901).ok().value();
-    out = fdf->format(*decimal.get());
+    out = formatter->format(*decimal.get());
     std::cout << "Formatted value is " << out << std::endl;
     if (out != "๑๒๓,๔๕๖.๘๙๐๑") {
         std::cout << "Output does not match expected output" << std::endl;


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->