### PR TITLE
Refactor MeasureUnit to use `single_units` instead of `contained_units`

### DIFF
--- a/components/experimental/src/measure/measureunit.rs
+++ b/components/experimental/src/measure/measureunit.rs
@@ -13,7 +13,13 @@ use super::provider::single_unit::SingleUnit;
 ///   - To construct a MeasureUnit from a cldr unit identifier, use the `MeasureUnitParser`.
 #[derive(Debug)]
 pub struct MeasureUnit {
-    // TODO: make this field private and add functions to use it.
     /// Contains the processed units.
-    pub contained_units: SmallVec<[SingleUnit; 8]>,
+    pub(crate) single_units: SmallVec<[SingleUnit; 8]>,
+}
+
+impl MeasureUnit {
+    /// Returns a reference to the single units of the measure unit.
+    pub fn get_single_units(&self) -> &SmallVec<[SingleUnit; 8]> {
+        &self.single_units
+    }
 }

--- a/components/experimental/src/measure/measureunit.rs
+++ b/components/experimental/src/measure/measureunit.rs
@@ -7,10 +7,15 @@ use smallvec::SmallVec;
 use super::provider::single_unit::SingleUnit;
 
 // TODO NOTE: the MeasureUnitParser takes the trie and the ConverterFactory takes the full payload and an instance of MeasureUnitParser.
-/// MeasureUnit is a struct that contains a processed CLDR unit.
-///     For example, "meter-per-second".
-/// NOTE:
-///   - To construct a MeasureUnit from a cldr unit identifier, use the `MeasureUnitParser`.
+/// The [`MeasureUnit`] struct represents a processed CLDR compound unit.
+/// Examples include:
+///  1. `meter-per-second`
+///  2. `square-meter`
+///  3. `liter-per-100-kilometer`
+///  4. `portion-per-1e9`
+///  5. `square-meter` (Note: a single unit is a special case of a compound unit containing only one single unit.)
+///
+/// To construct a [`MeasureUnit`] from a CLDR unit identifier, use the [`crate::measure::parser::MeasureUnitParser`].
 #[derive(Debug)]
 pub struct MeasureUnit {
     /// Contains the processed units.
@@ -18,7 +23,7 @@ pub struct MeasureUnit {
 }
 
 impl MeasureUnit {
-    /// Returns a reference to the single units of the measure unit.
+    /// Returns a reference to the single units contained within this measure unit.
     pub fn get_single_units(&self) -> &SmallVec<[SingleUnit; 8]> {
         &self.single_units
     }

--- a/components/experimental/src/measure/parser.rs
+++ b/components/experimental/src/measure/parser.rs
@@ -153,7 +153,7 @@ impl<'data> MeasureUnitParser<'data> {
         }
 
         Ok(MeasureUnit {
-            contained_units: measure_unit_items.into(),
+            single_units: measure_unit_items.into(),
         })
     }
 }

--- a/components/experimental/src/units/converter_factory.rs
+++ b/components/experimental/src/units/converter_factory.rs
@@ -103,12 +103,12 @@ impl ConverterFactory {
         input_unit: &MeasureUnit,
         output_unit: &MeasureUnit,
     ) -> Option<IcuRatio> {
-        if !(input_unit.contained_units.len() == 1
-            && output_unit.contained_units.len() == 1
-            && input_unit.contained_units[0].power == 1
-            && output_unit.contained_units[0].power == 1
-            && input_unit.contained_units[0].si_prefix.power == 0
-            && output_unit.contained_units[0].si_prefix.power == 0)
+        if !(input_unit.single_units.len() == 1
+            && output_unit.single_units.len() == 1
+            && input_unit.single_units[0].power == 1
+            && output_unit.single_units[0].power == 1
+            && input_unit.single_units[0].si_prefix.power == 0
+            && output_unit.single_units[0].si_prefix.power == 0)
         {
             return Some(IcuRatio::zero());
         }
@@ -117,7 +117,7 @@ impl ConverterFactory {
             .payload
             .get()
             .convert_infos
-            .get(input_unit.contained_units[0].unit_id as usize);
+            .get(input_unit.single_units[0].unit_id as usize);
         debug_assert!(
             input_conversion_info.is_some(),
             "Failed to get input conversion info"
@@ -128,7 +128,7 @@ impl ConverterFactory {
             .payload
             .get()
             .convert_infos
-            .get(output_unit.contained_units[0].unit_id as usize);
+            .get(output_unit.single_units[0].unit_id as usize);
         debug_assert!(
             output_conversion_info.is_some(),
             "Failed to get output conversion info"
@@ -221,8 +221,8 @@ impl ConverterFactory {
             }
         }
 
-        let unit1 = &unit1.contained_units;
-        let unit2 = &unit2.contained_units;
+        let unit1 = &unit1.single_units;
+        let unit2 = &unit2.single_units;
 
         let mut map = LiteMap::new();
         insert_non_basic_units(self, unit1, 1, &mut map)?;
@@ -282,11 +282,11 @@ impl ConverterFactory {
         let root_to_unit2_direction_sign = if is_reciprocal { 1 } else { -1 };
 
         let mut conversion_rate = IcuRatio::one();
-        for input_item in input_unit.contained_units.iter() {
+        for input_item in input_unit.single_units.iter() {
             conversion_rate *= Self::compute_conversion_term(self, input_item, 1)?;
         }
 
-        for output_item in output_unit.contained_units.iter() {
+        for output_item in output_unit.single_units.iter() {
             conversion_rate *=
                 Self::compute_conversion_term(self, output_item, root_to_unit2_direction_sign)?;
         }

--- a/provider/source/src/units/helpers.rs
+++ b/provider/source/src/units/helpers.rs
@@ -164,7 +164,7 @@ pub(crate) fn extract_conversion_info<'data>(
         .map_err(|_| DataError::custom("the base unit is not valid"))?;
 
     Ok(ConversionInfo {
-        basic_units: ZeroVec::from_iter(base_unit.contained_units),
+        basic_units: ZeroVec::from_iter(base_unit.get_single_units().iter().map(|su| *su)),
         factor_num: factor_num.into(),
         factor_den: factor_den.into(),
         factor_sign,

--- a/provider/source/src/units/helpers.rs
+++ b/provider/source/src/units/helpers.rs
@@ -164,7 +164,7 @@ pub(crate) fn extract_conversion_info<'data>(
         .map_err(|_| DataError::custom("the base unit is not valid"))?;
 
     Ok(ConversionInfo {
-        basic_units: ZeroVec::from_iter(base_unit.get_single_units().iter().map(|su| *su)),
+        basic_units: ZeroVec::from_iter(base_unit.get_single_units().iter().copied()),
         factor_num: factor_num.into(),
         factor_den: factor_den.into(),
         factor_sign,


### PR DESCRIPTION
# Description

- Rename the internal field.
- Add a getter method to improve encapsulation while maintaining existing functionality across multiple components.
- Fix the documentation to better represent the `MeasureUnit` struct.

Related issue: #6161


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->