### PR TITLE
Remove broken unused intra-doc links

### DIFF
--- a/components/plurals/src/provider/rules/reference/serializer.rs
+++ b/components/plurals/src/provider/rules/reference/serializer.rs
@@ -34,14 +34,7 @@ use core::ops::RangeInclusive;
 /// assert_eq!(input, result);
 /// ```
 ///
-/// [`AST`]: super::ast
-/// [`resolver`]: super::rules::resolver
-/// [`PluralOperands`]: super::PluralOperands
-/// [`PluralCategory`]: super::PluralCategory
-/// [`Rule`]: super::rules::ast::Rule
-/// [`Samples`]: super::rules::ast::Samples
-/// [`Condition`]:  super::rules::ast::Condition
-/// [`parse_condition`]: parse_condition()
+/// [`AST`]: crate::provider::rules::reference::ast
 pub fn serialize(rule: &ast::Rule, w: &mut impl fmt::Write) -> fmt::Result {
     serialize_condition(&rule.condition, w)?;
     if let Some(samples) = &rule.samples {


### PR DESCRIPTION
Looks like rustc started checking these as well

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->