### PR TITLE
Add additional docs on ZeroFrom, EncodeAsVarULE

### DIFF
--- a/utils/zerofrom/src/zero_from.rs
+++ b/utils/zerofrom/src/zero_from.rs
@@ -24,12 +24,6 @@ use alloc::string::String;
 /// One can use the [`#[derive(ZeroFrom)]`](zerofrom_derive::ZeroFrom) custom derive to automatically
 /// implement this trait.
 ///
-/// # Reverse-encoding VarULE
-///
-/// In the zero-copy universe defined by this crate and `zerovec`, the trait `EncodeAsVarULE`
-/// maps a struct to its bytes representation ("serialization"), and [`ZeroFrom`] takes those
-/// bytes and creates a struct from them ("deserialization").
-///
 /// # Examples
 ///
 /// Implementing `ZeroFrom` on a custom data struct:

--- a/utils/zerofrom/src/zero_from.rs
+++ b/utils/zerofrom/src/zero_from.rs
@@ -24,6 +24,12 @@ use alloc::string::String;
 /// One can use the [`#[derive(ZeroFrom)]`](zerofrom_derive::ZeroFrom) custom derive to automatically
 /// implement this trait.
 ///
+/// # Reverse-encoding VarULE
+///
+/// In the zero-copy universe defined by this crate and `zerovec`, the trait `EncodeAsVarULE`
+/// maps a struct to its bytes representation ("serialization"), and [`ZeroFrom`] takes those
+/// bytes and creates a struct from them ("deserialization").
+///
 /// # Examples
 ///
 /// Implementing `ZeroFrom` on a custom data struct:

--- a/utils/zerovec/src/ule/encode.rs
+++ b/utils/zerovec/src/ule/encode.rs
@@ -39,6 +39,12 @@ use core::mem;
 /// implementation will add up the sizes of each field on the [`VarULE`] type and then add in the byte length of the
 /// dynamically-sized part.
 ///
+/// # Reverse-encoding VarULE
+///
+/// This trait maps a struct to its bytes representation ("serialization"), and [`ZeroFrom`]
+/// performs the opposite operation, taking those bytes and creating a struct
+/// from them ("deserialization").
+///
 /// # Safety
 ///
 /// The safety invariants of [`Self::encode_var_ule_as_slices()`] are:

--- a/utils/zerovec/src/ule/encode.rs
+++ b/utils/zerovec/src/ule/encode.rs
@@ -41,9 +41,9 @@ use core::mem;
 ///
 /// # Reverse-encoding VarULE
 ///
-/// This trait maps a struct to its bytes representation ("serialization"), and [`ZeroFrom`]
-/// performs the opposite operation, taking those bytes and creating a struct
-/// from them ("deserialization").
+/// This trait maps a struct to its bytes representation ("serialization"), and
+/// [`ZeroFrom`](zerofrom::ZeroFrom) performs the opposite operation, taking those bytes and
+/// creating a struct from them ("deserialization").
 ///
 /// # Safety
 ///


### PR DESCRIPTION
Follow-up from #6133

Originally discussed in #1180

We already say this in the `VarULE` docs. I am adding additional docs about the EncodeAsVarULE/ZeroFrom parallelism in the zerovec universe on the docs of those specific traits, too.