### PR TITLE
Remove excessive `ZeroFrom` usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1293,7 +1293,6 @@ dependencies = [
  "smallvec",
  "tinystr",
  "writeable",
- "zerofrom",
  "zerotrie",
  "zerovec",
 ]
@@ -1447,7 +1446,6 @@ dependencies = [
  "serde_json",
  "writeable",
  "yoke",
- "zerofrom",
  "zerovec",
 ]
 
@@ -1492,6 +1490,7 @@ dependencies = [
  "potential_utf",
  "serde",
  "unicode-bidi",
+ "zerofrom",
  "zerotrie",
  "zerovec",
 ]

--- a/components/calendar/src/provider.rs
+++ b/components/calendar/src/provider.rs
@@ -103,9 +103,7 @@ pub const MARKERS: &[DataMarkerInfo] = &[
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
 #[zerovec::make_ule(EraStartDateULE)]
-#[derive(
-    Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Debug, yoke::Yokeable, zerofrom::ZeroFrom,
-)]
+#[derive(Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Debug, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_calendar::provider))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -126,7 +124,7 @@ pub struct EraStartDate {
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_calendar::provider))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -149,7 +147,7 @@ icu_provider::data_struct!(
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Clone, Copy, Debug, PartialEq, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Clone, Copy, Debug, PartialEq, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_calendar::provider))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]

--- a/components/calendar/src/provider/chinese_based.rs
+++ b/components/calendar/src/provider/chinese_based.rs
@@ -40,7 +40,7 @@ icu_provider::data_marker!(
 /// Cached/precompiled data for a certain range of years for a chinese-based
 /// calendar. Avoids the need to perform lunar calendar arithmetic for most calendrical
 /// operations.
-#[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_calendar::provider::chinese_based))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]

--- a/components/calendar/src/provider/islamic.rs
+++ b/components/calendar/src/provider/islamic.rs
@@ -39,7 +39,7 @@ icu_provider::data_marker!(
 /// Cached/precompiled data for a certain range of years for a chinese-based
 /// calendar. Avoids the need to perform lunar calendar arithmetic for most calendrical
 /// operations.
-#[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_calendar::provider::islamic))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]

--- a/components/casemap/src/provider/exceptions.rs
+++ b/components/casemap/src/provider/exceptions.rs
@@ -36,7 +36,7 @@ const SURROGATES_LEN: u32 = 0xDFFF - SURROGATES_START + 1;
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_casemap::provider::exceptions))]
-#[derive(Debug, Eq, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, Eq, PartialEq, Clone, yoke::Yokeable)]
 pub struct CaseMapExceptions<'data> {
     #[cfg_attr(feature = "serde", serde(borrow))]
     /// The list of exceptions

--- a/components/casemap/src/provider/mod.rs
+++ b/components/casemap/src/provider/mod.rs
@@ -87,7 +87,7 @@ pub use self::unfold::CaseMapUnfold;
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_casemap::provider))]
 #[yoke(prove_covariance_manually)]

--- a/components/casemap/src/provider/unfold.rs
+++ b/components/casemap/src/provider/unfold.rs
@@ -21,7 +21,7 @@ use zerovec::ZeroMap;
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_casemap::provider))]
-#[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, yoke::Yokeable)]
 #[yoke(prove_covariance_manually)]
 pub struct CaseMapUnfold<'data> {
     #[cfg_attr(feature = "serde", serde(borrow))]

--- a/components/collator/src/provider.rs
+++ b/components/collator/src/provider.rs
@@ -180,7 +180,7 @@ fn data_ce_to_primary(data_ce: u64, c: char) -> u32 {
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_collator::provider))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -295,7 +295,7 @@ impl<'data> CollationData<'data> {
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_collator::provider))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -320,7 +320,7 @@ icu_provider::data_struct!(
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_collator::provider))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -343,7 +343,7 @@ icu_provider::data_struct!(
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_collator::provider))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -432,7 +432,7 @@ impl CollationReordering<'_> {
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Debug, PartialEq, Clone, Copy, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, Copy, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_collator::provider))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -528,7 +528,7 @@ impl CollationMetadata {
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_collator::provider))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]

--- a/components/collections/src/char16trie/trie.rs
+++ b/components/collections/src/char16trie/trie.rs
@@ -2,7 +2,6 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use zerofrom::ZeroFrom;
 use zerovec::{ZeroSlice, ZeroVec};
 
 // Match-node lead unit values, after masking off intermediate-value bits:
@@ -78,7 +77,7 @@ fn skip_node_value(pos: usize, lead: u16) -> usize {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "databake", derive(databake::Bake))]
 #[cfg_attr(feature = "databake", databake(path = icu_collections::char16trie))]
-#[derive(Clone, Debug, PartialEq, Eq, ZeroFrom)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Char16Trie<'data> {
     /// An array of u16 containing the trie data.
     #[cfg_attr(feature = "serde", serde(borrow))]

--- a/components/datetime/src/provider/calendar/mod.rs
+++ b/components/datetime/src/provider/calendar/mod.rs
@@ -91,7 +91,7 @@ icu_provider::data_marker!(
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Debug, PartialEq, Clone, Default, zerofrom::ZeroFrom, yoke::Yokeable)]
+#[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_datetime::provider::calendar))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -126,7 +126,7 @@ size_test!(TimeLengths, time_lengths_v1_size, 264);
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_datetime::provider::calendar))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -176,7 +176,7 @@ pub mod patterns {
     /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
     /// to be stable, their Rust representation might not be. Use with caution.
     /// </div>
-    #[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]
+    #[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable)]
     #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
     #[cfg_attr(feature = "datagen", databake(path = icu_datetime::provider::calendar::patterns))]
     #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -202,7 +202,7 @@ pub mod patterns {
     /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
     /// to be stable, their Rust representation might not be. Use with caution.
     /// </div>
-    #[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]
+    #[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable)]
     #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
     #[cfg_attr(feature = "datagen", databake(path = icu_datetime::provider::calendar::patterns))]
     #[cfg_attr(feature = "serde", derive(serde::Deserialize))]

--- a/components/datetime/src/provider/calendar/symbols.rs
+++ b/components/datetime/src/provider/calendar/symbols.rs
@@ -91,7 +91,7 @@ size_test!(DateSymbols, date_symbols_v1_size, 3792);
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_datetime::provider::calendar))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -131,7 +131,7 @@ size_test!(TimeSymbols, time_symbols_v1_size, 768);
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_datetime::provider::calendar))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -163,7 +163,7 @@ icu_provider::data_struct!(
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_datetime::provider::calendar))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -201,7 +201,7 @@ macro_rules! symbols {
         pub mod $name {
             use super::*;
 
-            #[derive(Debug, PartialEq, Clone, zerofrom::ZeroFrom, yoke::Yokeable)]
+            #[derive(Debug, PartialEq, Clone, yoke::Yokeable)]
             #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
             #[cfg_attr(feature = "datagen", databake(path = icu_datetime::provider::calendar::$name))]
             #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -217,7 +217,7 @@ macro_rules! symbols {
 
             // UTS 35 specifies that `format` widths are mandatory,
             // except for `short`.
-            #[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]
+            #[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable)]
             #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
             #[cfg_attr(feature = "datagen", databake(path = icu_datetime::provider::calendar::$name))]
             #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -247,7 +247,7 @@ macro_rules! symbols {
             }
 
             // UTS 35 specifies that `stand_alone` widths are optional
-            #[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]
+            #[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable)]
             #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
             #[cfg_attr(feature = "datagen", databake(path = icu_datetime::provider::calendar::$name))]
             #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -275,7 +275,7 @@ macro_rules! symbols {
                 pub wide: Option<Symbols<'data>>,
             }
 
-            #[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]
+            #[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable)]
             #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
             #[cfg_attr(feature = "datagen", databake(path = icu_datetime::provider::calendar::$name))]
             #[cfg_attr(feature = "serde", derive(serde::Deserialize))]

--- a/components/datetime/src/provider/fields/symbols.rs
+++ b/components/datetime/src/provider/fields/symbols.rs
@@ -396,7 +396,7 @@ macro_rules! field_type {
         }
     );
     ($(#[$enum_attr:meta])* $i:ident; { $( $(#[$variant_attr:meta])* $key:literal => $val:ident = $idx:expr,)* }; $($ule_name:ident)?) => (
-        #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Clone, Copy, yoke::Yokeable, zerofrom::ZeroFrom)]
+        #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Clone, Copy, yoke::Yokeable)]
         // FIXME: This should be replaced with a custom derive.
         // See: https://github.com/unicode-org/icu4x/issues/1044
         #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
@@ -771,9 +771,7 @@ impl LengthType for TimeZone {
 }
 
 /// A second field with fractional digits.
-#[derive(
-    Debug, Eq, PartialEq, Ord, PartialOrd, Clone, Copy, yoke::Yokeable, zerofrom::ZeroFrom,
-)]
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Clone, Copy, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_datetime::fields))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]

--- a/components/datetime/src/provider/neo/mod.rs
+++ b/components/datetime/src/provider/neo/mod.rs
@@ -547,7 +547,7 @@ size_test!(YearNames, year_names_v1_size, 32);
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_datetime::provider::neo))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -595,7 +595,7 @@ size_test!(MonthNames, month_names_v1_size, 32);
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_datetime::provider::neo))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -651,7 +651,7 @@ size_test!(LinearNames, linear_names_v1_size, 24);
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_datetime::provider::neo))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -705,7 +705,7 @@ size_test!(GluePattern, glue_pattern_v1_size, 24);
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_datetime::provider::neo))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -721,7 +721,7 @@ icu_provider::data_struct!(
     #[cfg(feature = "datagen")]
 );
 
-#[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_datetime::provider::neo))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]

--- a/components/datetime/src/provider/packed_pattern.rs
+++ b/components/datetime/src/provider/packed_pattern.rs
@@ -181,7 +181,7 @@ icu_provider::data_marker!(
 /// postcard and other size-optimized serialization formats.
 ///
 /// [`YearStyle::Auto`]: crate::options::YearStyle::Auto
-#[derive(Debug, PartialEq, Eq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Eq, Clone, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_datetime::provider))]
 pub struct PackedPatterns<'data> {

--- a/components/datetime/src/provider/pattern/hour_cycle.rs
+++ b/components/datetime/src/provider/pattern/hour_cycle.rs
@@ -14,7 +14,7 @@ use icu_provider::prelude::*;
 
 /// Used to represent either H11/H12, or H23/H24. Skeletons only store these
 /// hour cycles as H12 or H23.
-#[derive(Debug, PartialEq, Clone, Copy, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, Copy, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_datetime::provider::pattern))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]

--- a/components/datetime/src/provider/pattern/mod.rs
+++ b/components/datetime/src/provider/pattern/mod.rs
@@ -27,9 +27,7 @@ pub use item::{GenericPatternItem, PatternItem};
 
 /// The granularity of time represented in a [`Pattern`](runtime::Pattern).
 /// Ordered from least granular to most granular for comparison.
-#[derive(
-    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, yoke::Yokeable, zerofrom::ZeroFrom,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_datetime::provider::pattern))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]

--- a/components/datetime/src/provider/pattern/runtime/generic.rs
+++ b/components/datetime/src/provider/pattern/runtime/generic.rs
@@ -23,7 +23,7 @@ use zerovec::ZeroVec;
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Debug, PartialEq, Eq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Eq, Clone, yoke::Yokeable)]
 #[allow(clippy::exhaustive_structs)] // this type is stable
 #[cfg_attr(feature = "datagen", derive(databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_datetime::provider::pattern::runtime))]

--- a/components/datetime/src/provider/pattern/runtime/pattern.rs
+++ b/components/datetime/src/provider/pattern/runtime/pattern.rs
@@ -21,7 +21,7 @@ use zerovec::{ZeroSlice, ZeroVec};
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Debug, PartialEq, Eq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Eq, Clone, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_datetime::provider::pattern::runtime))]
 #[zerovec::make_varule(PatternULE)]

--- a/components/datetime/src/provider/skeleton/plural.rs
+++ b/components/datetime/src/provider/skeleton/plural.rs
@@ -9,7 +9,7 @@ use icu_plurals::PluralCategory;
 use icu_provider::prelude::*;
 
 /// A collection of plural variants of a pattern.
-#[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, yoke::Yokeable)]
 #[allow(missing_docs)]
 pub struct PluralPattern<'data> {
     /// The field that 'variants' are predicated on.
@@ -109,7 +109,7 @@ impl<'data> PluralPattern<'data> {
 /// patterns when there are plural variants.
 ///
 /// Currently, the plural forms are only based on the week number.
-#[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, yoke::Yokeable)]
 #[allow(clippy::large_enum_variant)]
 pub enum PatternPlurals<'data> {
     /// A collection of pattern variants for when plurals differ.

--- a/components/datetime/src/provider/time_zones.rs
+++ b/components/datetime/src/provider/time_zones.rs
@@ -115,7 +115,7 @@ icu_provider::data_marker!(
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(PartialEq, Debug, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(PartialEq, Debug, Clone, Default, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_datetime::provider::time_zones))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -154,7 +154,7 @@ icu_provider::data_struct!(
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(PartialEq, Debug, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(PartialEq, Debug, Clone, Default, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_datetime::provider::time_zones))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -214,7 +214,7 @@ icu_provider::data_struct!(
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(PartialEq, Debug, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(PartialEq, Debug, Clone, Default, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_datetime::provider::time_zones))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -239,7 +239,7 @@ icu_provider::data_struct!(
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(PartialEq, Debug, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(PartialEq, Debug, Clone, Default, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_datetime::provider::time_zones))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -269,7 +269,7 @@ icu_provider::data_struct!(
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(PartialEq, Debug, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(PartialEq, Debug, Clone, Default, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_datetime::provider::time_zones))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -308,7 +308,7 @@ pub type MetazoneId = core::num::NonZeroU8;
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(PartialEq, Debug, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(PartialEq, Debug, Clone, Default, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_datetime::provider::time_zones))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]

--- a/components/decimal/src/provider.rs
+++ b/components/decimal/src/provider.rs
@@ -138,7 +138,7 @@ pub const MARKERS: &[DataMarkerInfo] = &[DecimalSymbolsV2::INFO, DecimalDigitsV1
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Debug, PartialEq, Clone, yoke::Yokeable, Copy, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, yoke::Yokeable, Copy)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_decimal::provider))]
@@ -167,7 +167,7 @@ pub struct GroupingSizes {
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, yoke::Yokeable)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize))]
 #[zerovec::make_varule(DecimalSymbolsStrs)]
@@ -223,7 +223,7 @@ impl DecimalSymbolStrsBuilder<'_> {
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, yoke::Yokeable)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_decimal::provider))]

--- a/components/experimental/Cargo.toml
+++ b/components/experimental/Cargo.toml
@@ -43,9 +43,8 @@ litemap = { workspace = true }
 tinystr = { workspace = true, features = ["alloc", "zerovec"] }
 potential_utf = { workspace = true, features = ["zerovec"] }
 writeable = { workspace = true }
-zerotrie = { workspace = true, features = ["yoke", "zerofrom"] }
+zerotrie = { workspace = true, features = ["yoke"] }
 zerovec = { workspace = true, features = ["derive", "yoke"] }
-zerofrom = { workspace = true }
 
 displaydoc = { workspace = true }
 log = { workspace = true, optional = true }

--- a/components/experimental/src/compactdecimal/provider.rs
+++ b/components/experimental/src/compactdecimal/provider.rs
@@ -63,7 +63,7 @@ icu_provider::data_marker!(
 ///
 /// Finally, the pattern indicating noncompact notation for the first few powers
 /// of ten is omitted; that is, there is an implicit (1, other) ↦ 0.
-#[derive(Debug, Clone, Default, PartialEq, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, Clone, Default, PartialEq, yoke::Yokeable)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_experimental::compactdecimal::provider))]
@@ -120,9 +120,7 @@ impl From<PluralCategory> for Count {
 
 /// A compact decimal pattern, representing some literal text with an optional
 /// placeholder, and the power of 10 expressed by the text.
-#[derive(
-    Debug, Clone, Default, PartialEq, yoke::Yokeable, zerofrom::ZeroFrom, Ord, PartialOrd, Eq,
-)]
+#[derive(Debug, Clone, Default, PartialEq, yoke::Yokeable, Ord, PartialOrd, Eq)]
 #[zerovec::make_varule(PatternULE)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]

--- a/components/experimental/src/dimension/provider/currency.rs
+++ b/components/experimental/src/dimension/provider/currency.rs
@@ -41,7 +41,7 @@ icu_provider::data_marker!(
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Clone, PartialEq, Debug, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Clone, PartialEq, Debug, yoke::Yokeable)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_experimental::dimension::provider::currency))]

--- a/components/experimental/src/dimension/provider/currency_compact.rs
+++ b/components/experimental/src/dimension/provider/currency_compact.rs
@@ -20,7 +20,7 @@ icu_provider::data_marker!(
 );
 
 /// Currency Compact  data struct.
-#[derive(Debug, Clone, Default, PartialEq, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, Clone, Default, PartialEq, yoke::Yokeable)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_experimental::dimension::provider::currency_compact))]

--- a/components/experimental/src/dimension/provider/currency_displayname.rs
+++ b/components/experimental/src/dimension/provider/currency_displayname.rs
@@ -31,7 +31,7 @@ icu_provider::data_marker!(
 );
 
 /// Currency Extended  data struct.
-#[derive(Debug, Clone, Default, PartialEq, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, Clone, Default, PartialEq, yoke::Yokeable)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_experimental::dimension::provider::currency_displayname))]

--- a/components/experimental/src/dimension/provider/currency_patterns.rs
+++ b/components/experimental/src/dimension/provider/currency_patterns.rs
@@ -20,7 +20,7 @@ icu_provider::data_marker!(
 );
 
 /// Currency Extended data struct.
-#[derive(Debug, Clone, PartialEq, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, Clone, PartialEq, yoke::Yokeable)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_experimental::dimension::provider::currency_patterns))]

--- a/components/experimental/src/dimension/provider/extended_currency.rs
+++ b/components/experimental/src/dimension/provider/extended_currency.rs
@@ -31,7 +31,7 @@ icu_provider::data_marker!(
 );
 
 /// Currency Extended  data struct.
-#[derive(Debug, Clone, PartialEq, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, Clone, PartialEq, yoke::Yokeable)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize))]
 #[yoke(prove_covariance_manually)]

--- a/components/experimental/src/dimension/provider/percent.rs
+++ b/components/experimental/src/dimension/provider/percent.rs
@@ -32,7 +32,7 @@ icu_provider::data_marker!(
    PercentEssentials<'static>
 );
 
-#[derive(Clone, PartialEq, Debug, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Clone, PartialEq, Debug, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_experimental::dimension::provider::percent))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]

--- a/components/experimental/src/dimension/provider/units.rs
+++ b/components/experimental/src/dimension/provider/units.rs
@@ -21,7 +21,7 @@ icu_provider::data_marker!(
     attributes_domain = "units"
 );
 
-#[derive(Clone, PartialEq, Debug, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Clone, PartialEq, Debug, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[yoke(prove_covariance_manually)]

--- a/components/experimental/src/dimension/provider/units_essentials.rs
+++ b/components/experimental/src/dimension/provider/units_essentials.rs
@@ -44,7 +44,7 @@ icu_provider::data_marker!(
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Clone, PartialEq, Debug, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Clone, PartialEq, Debug, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_experimental::dimension::provider::units_essentials))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]

--- a/components/experimental/src/displaynames/provider.rs
+++ b/components/experimental/src/displaynames/provider.rs
@@ -60,7 +60,7 @@ icu_provider::data_marker!(
     RegionDisplayNames<'static>
 );
 
-#[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_experimental::displaynames::provider))]
@@ -77,7 +77,7 @@ pub struct RegionDisplayNames<'data> {
 
 icu_provider::data_struct!(RegionDisplayNames<'_>, #[cfg(feature = "datagen")]);
 
-#[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_experimental::displaynames::provider))]
@@ -100,7 +100,7 @@ pub struct LanguageDisplayNames<'data> {
 
 icu_provider::data_struct!(LanguageDisplayNames<'_>, #[cfg(feature = "datagen")]);
 
-#[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_experimental::displaynames::provider))]
@@ -117,7 +117,7 @@ pub struct ScriptDisplayNames<'data> {
 
 icu_provider::data_struct!(ScriptDisplayNames<'_>, #[cfg(feature = "datagen")]);
 
-#[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_experimental::displaynames::provider))]
@@ -140,7 +140,7 @@ pub struct LocaleDisplayNames<'data> {
 
 icu_provider::data_struct!(LocaleDisplayNames<'_>, #[cfg(feature = "datagen")]);
 
-#[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, Default, yoke::Yokeable)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_experimental::displaynames::provider))]

--- a/components/experimental/src/duration/provider.rs
+++ b/components/experimental/src/duration/provider.rs
@@ -16,7 +16,7 @@ icu_provider::data_marker!(
     DigitalDurationData<'static>,
 );
 
-#[derive(Debug, Clone, PartialEq, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, Clone, PartialEq, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_experimental::duration::provider))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]

--- a/components/experimental/src/measure/provider/trie.rs
+++ b/components/experimental/src/measure/provider/trie.rs
@@ -37,7 +37,7 @@ icu_provider::data_marker!(
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Clone, PartialEq, Debug, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Clone, PartialEq, Debug, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_experimental::measure::provider::trie))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]

--- a/components/experimental/src/personnames/formatter.rs
+++ b/components/experimental/src/personnames/formatter.rs
@@ -20,7 +20,7 @@ use super::provider::{
 use super::specifications;
 use icu_locale_core::Locale;
 use icu_provider::prelude::*;
-use zerofrom::ZeroFrom;
+use zerovec::ule::ZeroFrom;
 
 pub struct PersonNamesFormatter {
     pub(crate) default_options: PersonNamesFormatterOptions,

--- a/components/experimental/src/personnames/provider.rs
+++ b/components/experimental/src/personnames/provider.rs
@@ -47,7 +47,7 @@ icu_provider::data_marker!(
 /// e.g. : initialPattern has no upper bound, DTD allows for the element to be specified any number
 /// of times, while in this implementation we are restraining it to the 2 documented types
 /// (`initial`, `initialSequence`).
-#[derive(PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(PartialEq, Clone, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_experimental::personnames::provider))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]

--- a/components/experimental/src/relativetime/provider.rs
+++ b/components/experimental/src/relativetime/provider.rs
@@ -148,7 +148,7 @@ icu_provider::data_marker!(
 );
 
 /// Relative time format  data struct.
-#[derive(Debug, Clone, PartialEq, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, Clone, PartialEq, yoke::Yokeable)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_experimental::relativetime::provider))]

--- a/components/experimental/src/transliterate/provider.rs
+++ b/components/experimental/src/transliterate/provider.rs
@@ -36,7 +36,7 @@ icu_provider::data_marker!(
 );
 
 /// The data struct representing [UTS #35 transform rules](https://unicode.org/reports/tr35/tr35-general.html#Transforms).
-#[derive(Debug, Clone, PartialEq, Eq, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, Clone, PartialEq, Eq, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_experimental::transliterate::provider))]
 pub struct RuleBasedTransliterator<'a> {
@@ -103,7 +103,7 @@ impl RuleBasedTransliterator<'_> {
     ///
     /// Note that this may contain duplicate entries.
     pub fn deps(&self) -> impl Iterator<Item = Cow<str>> {
-        use zerofrom::ZeroFrom;
+        use zerovec::ule::ZeroFrom;
         self.id_group_list
             .iter()
             .flat_map(|id_group| id_group.iter().map(|s| SimpleId::zero_from(s).id))
@@ -173,7 +173,7 @@ pub struct Rule<'a> {
 }
 
 /// The special matchers and replacers used by this transliterator.
-#[derive(Debug, Clone, zerofrom::ZeroFrom, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_experimental::transliterate::provider))]

--- a/components/experimental/src/transliterate/transliterator/mod.rs
+++ b/components/experimental/src/transliterate/transliterator/mod.rs
@@ -23,7 +23,7 @@ use icu_normalizer::{ComposingNormalizer, DecomposingNormalizer};
 use icu_provider::prelude::*;
 use litemap::LiteMap;
 use replaceable::*;
-use zerofrom::ZeroFrom;
+use zerovec::ule::ZeroFrom;
 use zerovec::vecs::Index32;
 use zerovec::VarZeroSlice;
 

--- a/components/experimental/src/units/provider.rs
+++ b/components/experimental/src/units/provider.rs
@@ -36,7 +36,7 @@ icu_provider::data_marker!(UnitsInfoV1, UnitsInfo<'static>, is_singleton = true)
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Clone, PartialEq, Debug, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Clone, PartialEq, Debug, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_experimental::units::provider))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]

--- a/components/list/src/provider/mod.rs
+++ b/components/list/src/provider/mod.rs
@@ -81,7 +81,7 @@ icu_provider::data_struct!(
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Clone, Debug, PartialEq, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Clone, Debug, PartialEq, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_list::provider))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -123,7 +123,7 @@ impl ListFormatterPatterns<'_> {
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Clone, Debug, PartialEq, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Clone, Debug, PartialEq, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_list::provider))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -146,7 +146,7 @@ pub struct ConditionalListJoinerPattern<'data> {
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Clone, Debug, PartialEq, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Clone, Debug, PartialEq, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_list::provider))]
 pub struct SpecialCasePattern<'data> {
@@ -195,7 +195,7 @@ impl<'data> SpecialCasePattern<'data> {
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Clone, Debug, PartialEq, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Clone, Debug, PartialEq, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize))]
 pub struct ListJoinerPattern<'data> {
     /// The pattern string without the placeholders

--- a/components/list/src/provider/serde_dfa.rs
+++ b/components/list/src/provider/serde_dfa.rs
@@ -17,7 +17,7 @@ use zerovec::VarZeroCow;
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Clone, Debug, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Clone, Debug, yoke::Yokeable)]
 pub struct SerdeDFA<'data> {
     // Safety: These always represent a valid DFA (DFA::from_bytes(dfa_bytes).is_ok())
     dfa_bytes: VarZeroCow<'data, [u8]>,

--- a/components/list/src/provider/serde_dfa.rs
+++ b/components/list/src/provider/serde_dfa.rs
@@ -21,7 +21,7 @@ use zerovec::VarZeroCow;
 pub struct SerdeDFA<'data> {
     // Safety: These always represent a valid DFA (DFA::from_bytes(dfa_bytes).is_ok())
     dfa_bytes: VarZeroCow<'data, [u8]>,
-    #[cfg(feature = "serde_human")]
+    #[cfg(feature = "datagen")]
     pattern: Option<alloc::borrow::Cow<'data, str>>,
 }
 
@@ -116,7 +116,7 @@ impl<'data> SerdeDFA<'data> {
 
         Ok(Some(SerdeDFA {
             dfa_bytes,
-            #[cfg(feature = "serde_human")]
+            #[cfg(feature = "datagen")]
             pattern: None,
         }))
     }
@@ -132,13 +132,13 @@ impl<'data> SerdeDFA<'data> {
         Self {
             // SAFETY: safe for VarZeroCow<[u8]>
             dfa_bytes: unsafe { VarZeroCow::from_bytes_unchecked(dfa_bytes) },
-            #[cfg(feature = "serde_human")]
+            #[cfg(feature = "datagen")]
             pattern: None,
         }
     }
 
     /// Creates a `SerdeDFA` from a regex.
-    #[cfg(any(feature = "datagen", feature = "serde_human",))]
+    #[cfg(any(feature = "datagen", feature = "serde_human"))]
     pub fn new(pattern: alloc::borrow::Cow<'data, str>) -> Result<Self, icu_provider::DataError> {
         use regex_automata::dfa::dense::{Builder, Config};
 
@@ -171,6 +171,7 @@ impl<'data> SerdeDFA<'data> {
 
         Ok(Self {
             dfa_bytes: VarZeroCow::new_owned(dfa.to_bytes_native_endian().into_boxed_slice()),
+            #[cfg(feature = "datagen")]
             pattern: Some(pattern),
         })
     }

--- a/components/locale/src/canonicalizer.rs
+++ b/components/locale/src/canonicalizer.rs
@@ -511,7 +511,7 @@ impl<Expander: AsRef<LocaleExpander>> LocaleCanonicalizer<Expander> {
             .get()
             .language_variants
             .iter()
-            .map(zerofrom::ZeroFrom::zero_from)
+            .map(zerovec::ule::ZeroFrom::zero_from)
         {
             let raw_variants = raw_variants.split('-');
             // if is_iter_sorted(raw_variants.clone()) { // can we sort at construction?
@@ -538,7 +538,7 @@ impl<Expander: AsRef<LocaleExpander>> LocaleCanonicalizer<Expander> {
             .get()
             .language
             .iter()
-            .map(zerofrom::ZeroFrom::zero_from)
+            .map(zerovec::ule::ZeroFrom::zero_from)
         {
             if let Ok(from) = raw_from.parse::<LanguageIdentifier>() {
                 if uts35_rule_matches(

--- a/components/locale/src/provider.rs
+++ b/components/locale/src/provider.rs
@@ -212,7 +212,7 @@ pub struct LanguageStrStrPair<'a>(
     #[cfg_attr(feature = "serde", serde(borrow))] pub Cow<'a, str>,
 );
 
-#[derive(PartialEq, Clone, Default, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(PartialEq, Clone, Default, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_locale::provider))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -289,7 +289,7 @@ icu_provider::data_struct!(
     #[cfg(feature = "datagen")]
 );
 
-#[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_locale::provider))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -335,7 +335,7 @@ icu_provider::data_struct!(
     #[cfg(feature = "datagen")]
 );
 
-#[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_locale::provider))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -379,7 +379,7 @@ icu_provider::data_struct!(
     #[cfg(feature = "datagen")]
 );
 
-#[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_locale::provider))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -419,7 +419,7 @@ icu_provider::data_struct!(
 );
 
 /// Locale fallback rules derived from CLDR parent locales data.
-#[derive(Default, Clone, PartialEq, Debug, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Default, Clone, PartialEq, Debug, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_locale::provider))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -436,7 +436,7 @@ icu_provider::data_struct!(
     #[cfg(feature = "datagen")]
 );
 
-#[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_locale::provider))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -469,7 +469,7 @@ icu_provider::data_struct!(
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Debug, Eq, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, Eq, PartialEq, Clone, yoke::Yokeable)]
 #[cfg_attr(
     feature = "datagen", 
     derive(serde::Serialize, databake::Bake),

--- a/components/normalizer/src/provider.rs
+++ b/components/normalizer/src/provider.rs
@@ -118,7 +118,7 @@ pub const MARKERS: &[DataMarkerInfo] = &[
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_normalizer::provider))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -145,7 +145,7 @@ icu_provider::data_struct!(
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_normalizer::provider))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -171,7 +171,7 @@ icu_provider::data_struct!(
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_normalizer::provider))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -196,7 +196,7 @@ icu_provider::data_struct!(
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_normalizer::provider))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]

--- a/components/normalizer/tests/tests.rs
+++ b/components/normalizer/tests/tests.rs
@@ -984,7 +984,7 @@ fn test_conformance() {
 // #[test]
 // fn test_hangul() {
 //     use icu_collections::codepointinvlist::{CodePointSet, CodePointSetBuilder};
-//     use zerofrom::ZeroFrom;
+//     use zerovec::ule::ZeroFrom;
 //     let builder = CodePointSetBuilder::new();
 //     let set: CodePointSet = builder.build();
 

--- a/components/pattern/Cargo.toml
+++ b/components/pattern/Cargo.toml
@@ -31,7 +31,6 @@ yoke = { workspace = true, features = ["derive"], optional = true }
 zerovec = { workspace = true, default-features = false, optional = true }
 
 [dev-dependencies]
-zerofrom = { workspace = true, features = ["alloc"] }
 zerovec = { workspace = true, features = ["databake", "serde"] }
 rmp-serde = { workspace = true }
 serde_json = { workspace = true }

--- a/components/plurals/src/provider.rs
+++ b/components/plurals/src/provider.rs
@@ -24,7 +24,6 @@ use core::fmt;
 use core::marker::PhantomData;
 use icu_provider::prelude::*;
 use yoke::Yokeable;
-use zerofrom::ZeroFrom;
 use zerovec::ule::vartuple::VarTuple;
 use zerovec::ule::vartuple::VarTupleULE;
 use zerovec::ule::AsULE;
@@ -104,7 +103,7 @@ pub const MARKERS: &[DataMarkerInfo] = &[
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Default, Clone, PartialEq, Debug, Yokeable, ZeroFrom)]
+#[derive(Default, Clone, PartialEq, Debug, Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_plurals::provider))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -336,7 +335,7 @@ mod ranges {
     /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
     /// to be stable, their Rust representation might not be. Use with caution.
     /// </div>
-    #[derive(Clone, PartialEq, Debug, Yokeable, ZeroFrom)]
+    #[derive(Clone, PartialEq, Debug, Yokeable)]
     #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
     #[cfg_attr(feature = "datagen", databake(path = icu_plurals::provider))]
     #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -366,7 +365,7 @@ mod ranges {
 /// 3. It always serializes the [`FourBitMetadata`] as 0
 ///
 /// Use [`PluralElementsPackedULE`] directly if you need these additional features.
-#[derive(Debug, PartialEq, Yokeable, ZeroFrom)]
+#[derive(Debug, PartialEq, Yokeable)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_plurals::provider))]

--- a/components/plurals/src/provider/rules/runtime/ast.rs
+++ b/components/plurals/src/provider/rules/runtime/ast.rs
@@ -18,7 +18,7 @@ use zerovec::{
 /// including in SemVer minor releases. In particular, the `DataProvider` implementations are only
 /// guaranteed to match with this version's `*_unstable` providers. Use with caution.
 /// </div>
-#[derive(yoke::Yokeable, zerofrom::ZeroFrom, Clone, PartialEq, Debug)]
+#[derive(yoke::Yokeable, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "datagen", derive(databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_plurals::provider::rules::runtime::ast))]
 #[allow(clippy::exhaustive_structs)] // Reference AST is non-public and this type is stable
@@ -282,7 +282,7 @@ impl RelationULE {
     /// Convert to a Relation
     #[inline]
     pub fn as_relation(&self) -> Relation {
-        zerofrom::ZeroFrom::zero_from(self)
+        zerovec::ule::ZeroFrom::zero_from(self)
     }
 }
 

--- a/components/properties/Cargo.toml
+++ b/components/properties/Cargo.toml
@@ -24,11 +24,12 @@ displaydoc = { workspace = true }
 icu_collections = { workspace = true }
 icu_provider = { workspace = true }
 zerovec = { workspace = true, features = ["derive", "yoke"] }
-zerotrie = { workspace = true, features = ["yoke", "zerofrom"] }
+zerotrie = { workspace = true, features = ["yoke"] }
 databake = { workspace = true, features = ["derive"], optional = true}
 serde = { workspace = true, features = ["derive", "alloc"], optional = true }
 icu_locale_core = { workspace = true, features = ["zerovec"] }
 potential_utf = { workspace = true, features = ["zerovec"]}
+zerofrom = { workspace = true, features = ["derive"] }
 
 unicode-bidi = { workspace = true, optional = true }
 

--- a/components/properties/src/provider.rs
+++ b/components/properties/src/provider.rs
@@ -44,8 +44,7 @@ use icu_collections::codepointinvlist::CodePointInversionList;
 use icu_collections::codepointinvliststringlist::CodePointInversionListAndStringList;
 use icu_collections::codepointtrie::{CodePointMapRange, CodePointTrie, TrieValue};
 use icu_provider::prelude::*;
-use zerofrom::ZeroFrom;
-use zerovec::{VarZeroVec, ZeroSlice};
+use zerovec::{ule::ZeroFrom, VarZeroVec, ZeroSlice};
 
 #[cfg(feature = "compiled_data")]
 #[derive(Debug)]
@@ -799,7 +798,7 @@ pub const MARKERS: &[DataMarkerInfo] = &[
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Debug, Eq, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, Eq, PartialEq, Clone, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_properties::provider))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -976,7 +975,7 @@ impl<'data, T: TrieValue> PropertyCodePointMap<'data, T> {
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Debug, Eq, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, Eq, PartialEq, Clone, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_properties::provider))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -1052,7 +1051,7 @@ impl<'data> PropertyUnicodeSet<'data> {
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Debug, Eq, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, Eq, PartialEq, Clone, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_properties::provider))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]

--- a/components/properties/src/provider/names.rs
+++ b/components/properties/src/provider/names.rs
@@ -249,7 +249,7 @@ icu_provider::data_marker!(
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Debug, Clone, PartialEq, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, Clone, PartialEq, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_properties::provider::names))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -272,7 +272,7 @@ icu_provider::data_struct!(
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Debug, Clone, PartialEq, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, Clone, PartialEq, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_properties::provider::names))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -296,7 +296,7 @@ icu_provider::data_struct!(
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Debug, Clone, PartialEq, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, Clone, PartialEq, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_properties::provider::names))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -321,7 +321,7 @@ icu_provider::data_struct!(
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Debug, Clone, PartialEq, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, Clone, PartialEq, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_properties::provider::names))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]

--- a/components/segmenter/src/provider/lstm.rs
+++ b/components/segmenter/src/provider/lstm.rs
@@ -11,7 +11,7 @@ use icu_provider::prelude::*;
 use potential_utf::PotentialUtf8;
 use zerovec::{ZeroMap, ZeroVec};
 
-// We do this instead of const generics because ZeroFrom and Yokeable derives, as well as serde
+// We do this instead of const generics because Yokeable derive, as well as serde
 // don't support them
 macro_rules! lstm_matrix {
     ($name:ident, $generic:literal) => {
@@ -22,7 +22,7 @@ macro_rules! lstm_matrix {
         /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
         /// to be stable, their Rust representation might not be. Use with caution.
         /// </div>
-        #[derive(PartialEq, Debug, Clone, zerofrom::ZeroFrom, yoke::Yokeable)]
+        #[derive(PartialEq, Debug, Clone, yoke::Yokeable)]
         #[cfg_attr(feature = "datagen", derive(serde::Serialize))]
         pub struct $name<'data> {
             // Invariant: dims.product() == data.len()
@@ -125,7 +125,7 @@ pub enum ModelType {
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(PartialEq, Debug, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(PartialEq, Debug, Clone, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize))]
 #[yoke(prove_covariance_manually)]
 pub struct LstmDataFloat32<'data> {
@@ -355,7 +355,7 @@ impl databake::BakeSize for LstmDataFloat32<'_> {
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_segmenter::provider))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]

--- a/components/segmenter/src/provider/mod.rs
+++ b/components/segmenter/src/provider/mod.rs
@@ -133,7 +133,7 @@ pub const MARKERS: &[DataMarkerInfo] = &[
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_segmenter::provider))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -180,7 +180,7 @@ icu_provider::data_struct!(
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_segmenter::provider))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -202,7 +202,7 @@ impl DynamicDataMarker for UCharDictionaryBreakDataV1 {
 }
 
 /// codepoint trie data that the difference by specific locale
-#[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, yoke::Yokeable)]
 #[cfg_attr(
     feature = "datagen",
     derive(serde::Serialize,databake::Bake),

--- a/components/time/Cargo.toml
+++ b/components/time/Cargo.toml
@@ -26,7 +26,7 @@ icu_calendar = { workspace = true }
 icu_provider = { workspace = true }
 ixdtf = { workspace = true, optional = true }
 tinystr = { workspace = true, features = ["zerovec"] }
-zerotrie = { workspace = true, features = ["yoke", "zerofrom"] }
+zerotrie = { workspace = true, features = ["yoke"] }
 zerovec = { workspace = true, features = ["derive", "yoke"] }
 writeable = { workspace = true }
 

--- a/components/time/src/provider/iana.rs
+++ b/components/time/src/provider/iana.rs
@@ -57,7 +57,7 @@ icu_provider::data_marker!(
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Debug, Clone, PartialEq, zerofrom::ZeroFrom, yoke::Yokeable)]
+#[derive(Debug, Clone, PartialEq, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_time::provider::iana))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
@@ -95,7 +95,7 @@ icu_provider::data_struct!(
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Debug, Clone, PartialEq, zerofrom::ZeroFrom, yoke::Yokeable)]
+#[derive(Debug, Clone, PartialEq, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_time::provider::iana))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]

--- a/components/time/src/provider/windows.rs
+++ b/components/time/src/provider/windows.rs
@@ -33,7 +33,7 @@ icu_provider::data_marker!(
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(PartialEq, Debug, Clone, zerofrom::ZeroFrom, yoke::Yokeable)]
+#[derive(PartialEq, Debug, Clone, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_time::provider::windows))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]

--- a/documents/design/data_pipeline.md
+++ b/documents/design/data_pipeline.md
@@ -96,7 +96,7 @@ icu_provider::data_marker!(
 );
 
 /// This is a sample data struct.
-#[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, yoke::Yokeable)]
 #[cfg_attr(feature = "serde", derive(Deserialize))]
 #[cfg_attr(feature = "datagen", derive(Serialize))]
 pub struct SampleDataStruct<'data> {

--- a/documents/process/writing_a_new_data_struct.md
+++ b/documents/process/writing_a_new_data_struct.md
@@ -101,7 +101,7 @@ icu_provider::data_marker!(
     DecimalSymbols<'static>,
 );
 
-#[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[derive(Debug, PartialEq, Clone, yoke::Yokeable)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_decimal::provider))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]

--- a/provider/baked/src/zerotrie.rs
+++ b/provider/baked/src/zerotrie.rs
@@ -8,12 +8,9 @@
 const ID_SEPARATOR: u8 = 0x1E;
 
 pub use icu_provider::DynamicDataMarker;
-use icu_provider::{
-    prelude::{zerofrom::ZeroFrom, *},
-    ule::MaybeAsVarULE,
-};
+use icu_provider::{prelude::*, ule::MaybeAsVarULE};
 pub use zerotrie::ZeroTrieSimpleAscii;
-use zerovec::VarZeroSlice;
+use zerovec::{ule::ZeroFrom, VarZeroSlice};
 
 #[cfg(feature = "export")]
 use icu_provider::export::ExportMarker;

--- a/provider/blob/benches/auxkey_bench.rs
+++ b/provider/blob/benches/auxkey_bench.rs
@@ -21,14 +21,7 @@ icu_provider::data_marker!(MarkerV3, Empty);
 icu_provider::data_marker!(MarkerV4, Empty);
 
 #[derive(
-    serde::Serialize,
-    serde::Deserialize,
-    Clone,
-    Copy,
-    databake::Bake,
-    PartialEq,
-    yoke::Yokeable,
-    zerofrom::ZeroFrom,
+    serde::Serialize, serde::Deserialize, Clone, Copy, databake::Bake, PartialEq, yoke::Yokeable,
 )]
 #[databake(path = crate)]
 pub struct Empty;

--- a/provider/blob/src/blob_data_provider.rs
+++ b/provider/blob/src/blob_data_provider.rs
@@ -169,7 +169,7 @@ mod test {
     use icu_provider::hello_world::*;
 
     icu_provider::data_marker!(HelloSingletonV1, HelloSingleton, is_singleton = true);
-    #[derive(Clone, Copy, yoke::Yokeable, zerofrom::ZeroFrom)]
+    #[derive(Clone, Copy, yoke::Yokeable)]
     pub struct HelloSingleton;
 
     #[test]

--- a/provider/core/Cargo.toml
+++ b/provider/core/Cargo.toml
@@ -26,7 +26,7 @@ stable_deref_trait = { workspace = true }
 writeable = { workspace = true }
 tinystr = { workspace = true }
 yoke = { workspace = true, features = ["alloc", "derive"] }
-zerofrom = { workspace = true, features = ["alloc", "derive"] }
+zerofrom = { workspace = true, features = ["alloc"] }
 zerovec = { workspace = true, features = ["derive"]}
 
 # log

--- a/provider/core/src/lib.rs
+++ b/provider/core/src/lib.rs
@@ -177,8 +177,6 @@ pub mod prelude {
     pub use icu_locale_core;
     #[doc(no_inline)]
     pub use yoke;
-    #[doc(no_inline)]
-    pub use zerofrom;
 }
 
 #[doc(hidden)] // internal

--- a/provider/core/src/marker.rs
+++ b/provider/core/src/marker.rs
@@ -29,7 +29,7 @@ use zerovec::ule::*;
 /// use icu_provider::prelude::*;
 /// use std::borrow::Cow;
 ///
-/// #[derive(yoke::Yokeable, zerofrom::ZeroFrom)]
+/// #[derive(yoke::Yokeable)]
 /// struct MyDataStruct<'data> {
 ///     message: Cow<'data, str>,
 /// }

--- a/provider/source/src/decimal/compact.rs
+++ b/provider/source/src/decimal/compact.rs
@@ -117,8 +117,7 @@ mod tests {
     use super::*;
     use icu::locale::langid;
     use std::borrow::Cow;
-    use zerofrom::ZeroFrom;
-    use zerovec::ule::AsULE;
+    use zerovec::ule::{AsULE, ZeroFrom};
 
     #[test]
 

--- a/provider/source/src/decimal/compact_decimal_pattern.rs
+++ b/provider/source/src/decimal/compact_decimal_pattern.rs
@@ -371,9 +371,7 @@ impl TryFrom<&DecimalFormat> for CompactDecimalPatternData<'static> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use icu_provider::prelude::*;
-    use zerofrom::ZeroFrom;
-    use zerovec::ule::AsULE;
+    use zerovec::ule::{AsULE, ZeroFrom};
 
     #[test]
     fn test_french_compressibility() {

--- a/provider/source/src/personnames/person_names_format_data_providers.rs
+++ b/provider/source/src/personnames/person_names_format_data_providers.rs
@@ -150,7 +150,7 @@ impl TryFrom<&'_ Resource> for PersonNamesFormat<'_> {
 #[cfg(test)]
 mod tests {
     use icu::locale::langid;
-    use zerofrom::ZeroFrom;
+    use zerovec::ule::ZeroFrom;
 
     use super::*;
 

--- a/provider/source/src/units/info.rs
+++ b/provider/source/src/units/info.rs
@@ -107,8 +107,8 @@ fn test_basic() {
     use icu_provider::prelude::*;
     use num_bigint::BigUint;
     use num_rational::Ratio;
-    use zerofrom::ZeroFrom;
     use zerovec::maps::ZeroVecLike;
+    use zerovec::ule::ZeroFrom;
     use zerovec::ZeroVec;
 
     let provider = SourceDataProvider::new_testing();

--- a/utils/zerovec/src/ule/mod.rs
+++ b/utils/zerovec/src/ule/mod.rs
@@ -34,6 +34,8 @@ pub use multi::MultiFieldsULE;
 pub use niche::{NicheBytes, NichedOption, NichedOptionULE};
 pub use option::{OptionULE, OptionVarULE};
 pub use plain::RawBytesULE;
+#[doc(no_inline)]
+pub use zerofrom::ZeroFrom;
 
 use core::{any, fmt, mem, slice};
 
@@ -253,7 +255,7 @@ where
 /// If deserialization with `VarZeroVec` is desired is recommended to implement `Deserialize` for
 /// `Box<T>` (serde does not do this automatically for unsized `T`).
 ///
-/// For convenience it is typically desired to implement [`EncodeAsVarULE`] and [`ZeroFrom`](zerofrom::ZeroFrom)
+/// For convenience it is typically desired to implement [`EncodeAsVarULE`] and [`ZeroFrom`]
 /// on some stack type to convert to and from the ULE type efficiently when necessary.
 ///
 /// # Safety


### PR DESCRIPTION
We currently derive `ZeroFrom` for every single data struct. However, it is not required for a data struct to be `ZeroFrom`, it's only required to use `DataPayload::map_project`, `DataPayload::try_map_project`, and `DataPayload::with_mut`, which have a total of *one* usage in all of ICU4X. So it suffices to derive `ZeroFrom` for the one data struct, and remove all the other derives.

This also exposes the `ZeroFrom` trait (not derive macro) through `zerovec::ule::ZeroFrom`. This is because `VarZeroVec` fundamentally requires this trait, so it should be imported from there, not from `icu_provider::prelude` (where I've removed it, because it's not needed).