### PR TITLE
Remove support for U+2212 from `ixdtf`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1959,7 +1959,6 @@ dependencies = [
  "criterion",
  "displaydoc",
  "serde-json-core",
- "utf8_iter",
 ]
 
 [[package]]

--- a/utils/ixdtf/Cargo.toml
+++ b/utils/ixdtf/Cargo.toml
@@ -28,7 +28,6 @@ duration = []
 
 [dependencies]
 displaydoc = { workspace = true }
-utf8_iter.workspace = true
 
 [dev-dependencies]
 serde-json-core = { workspace = true, features = ["std"] }

--- a/utils/ixdtf/src/parsers/datetime.rs
+++ b/utils/ixdtf/src/parsers/datetime.rs
@@ -8,9 +8,7 @@ use crate::{
     assert_syntax,
     parsers::{
         annotations,
-        grammar::{
-            is_annotation_open, is_date_time_separator, is_hyphen, is_sign, is_utc_designator,
-        },
+        grammar::{is_annotation_open, is_date_time_separator, is_hyphen, is_utc_designator},
         records::{DateRecord, TimeRecord},
         time::parse_time_record,
         timezone, Cursor, IxdtfParseRecord,
@@ -18,7 +16,10 @@ use crate::{
     ParseError, ParserResult,
 };
 
-use super::records::{Annotation, UtcOffsetRecordOrZ};
+use super::{
+    grammar::is_ascii_sign,
+    records::{Annotation, UtcOffsetRecordOrZ},
+};
 
 #[derive(Debug, Default, Clone)]
 /// A `DateTime` Parse Node that contains the date, time, and offset info.
@@ -157,7 +158,7 @@ fn parse_date_time(cursor: &mut Cursor) -> ParserResult<DateTimeRecord> {
 
     let time = parse_time_record(cursor)?;
 
-    let time_zone = if cursor.check_or(false, |ch| is_sign(ch) || is_utc_designator(ch)) {
+    let time_zone = if cursor.check_or(false, |ch| is_ascii_sign(ch) || is_utc_designator(ch)) {
         Some(timezone::parse_date_time_utc(cursor)?)
     } else {
         None
@@ -229,8 +230,8 @@ pub(crate) fn parse_month_day(cursor: &mut Cursor) -> ParserResult<DateRecord> {
 
 #[inline]
 fn parse_date_year(cursor: &mut Cursor) -> ParserResult<i32> {
-    if cursor.check_or(false, is_sign) {
-        let sign = if cursor.next_or(ParseError::ImplAssert)? == '+' {
+    if cursor.check_or(false, is_ascii_sign) {
+        let sign = if cursor.next_or(ParseError::ImplAssert)? == b'+' {
             1
         } else {
             -1

--- a/utils/ixdtf/src/parsers/duration.rs
+++ b/utils/ixdtf/src/parsers/duration.rs
@@ -8,8 +8,8 @@ use crate::{
     assert_syntax,
     parsers::{
         grammar::{
-            is_day_designator, is_duration_designator, is_hour_designator, is_minute_designator,
-            is_month_designator, is_second_designator, is_sign, is_time_designator,
+            is_ascii_sign, is_day_designator, is_duration_designator, is_hour_designator,
+            is_minute_designator, is_month_designator, is_second_designator, is_time_designator,
             is_week_designator, is_year_designator,
         },
         records::{DateDurationRecord, DurationParseRecord, Fraction, TimeDurationRecord},
@@ -21,10 +21,10 @@ use crate::{
 
 pub(crate) fn parse_duration(cursor: &mut Cursor) -> ParserResult<DurationParseRecord> {
     let sign = if cursor
-        .check(is_sign)
+        .check(is_ascii_sign)
         .ok_or_else(|| ParseError::abrupt_end("DurationStart"))?
     {
-        cursor.next_or(ParseError::ImplAssert)? == '+'
+        cursor.next_or(ParseError::ImplAssert)? == b'+'
     } else {
         true
     };

--- a/utils/ixdtf/src/parsers/grammar.rs
+++ b/utils/ixdtf/src/parsers/grammar.rs
@@ -4,172 +4,166 @@
 
 //! ISO8601 specific grammar checks.
 
-/// Checks if char is a `AKeyLeadingChar`.
+/// Checks if ascii char is a `AKeyLeadingChar`.
 #[inline]
-pub(crate) const fn is_a_key_leading_char(ch: char) -> bool {
-    ch.is_ascii_lowercase() || ch == '_'
+pub(crate) const fn is_a_key_leading_char(ch: u8) -> bool {
+    ch.is_ascii_lowercase() || ch == b'_'
 }
 
-/// Checks if char is an `AKeyChar`.
+/// Checks if ascii char is an `AKeyChar`.
 #[inline]
-pub(crate) const fn is_a_key_char(ch: char) -> bool {
-    is_a_key_leading_char(ch) || ch.is_ascii_digit() || ch == '-'
+pub(crate) const fn is_a_key_char(ch: u8) -> bool {
+    is_a_key_leading_char(ch) || ch.is_ascii_digit() || ch == b'-'
 }
 
-/// Checks if char is an `AnnotationValueComponent`.
-pub(crate) const fn is_annotation_value_component(ch: char) -> bool {
+/// Checks if ascii char is an `AnnotationValueComponent`.
+pub(crate) const fn is_annotation_value_component(ch: u8) -> bool {
     ch.is_ascii_digit() || ch.is_ascii_alphabetic()
 }
 
-/// Checks if char is a `TZLeadingChar`.
+/// Checks if ascii char is a `TZLeadingChar`.
 #[inline]
-pub(crate) const fn is_tz_leading_char(ch: char) -> bool {
-    ch.is_ascii_alphabetic() || ch == '_' || ch == '.'
+pub(crate) const fn is_tz_leading_char(ch: u8) -> bool {
+    ch.is_ascii_alphabetic() || ch == b'_' || ch == b'.'
 }
 
-/// Checks if char is a `TZChar`.
+/// Checks if ascii char is a `TZChar`.
 #[inline]
-pub(crate) const fn is_tz_char(ch: char) -> bool {
-    is_tz_leading_char(ch) || ch.is_ascii_digit() || ch == '-' || ch == '+'
+pub(crate) const fn is_tz_char(ch: u8) -> bool {
+    is_tz_leading_char(ch) || ch.is_ascii_digit() || ch == b'-' || ch == b'+'
 }
 
-/// Checks if char is a `TimeZoneIANAName` Separator.
+/// Checks if ascii char is a `TimeZoneIANAName` Separator.
 #[inline]
-pub(crate) const fn is_tz_name_separator(ch: char) -> bool {
-    ch == '/'
+pub(crate) const fn is_tz_name_separator(ch: u8) -> bool {
+    ch == b'/'
 }
 
-/// Checks if char is an ascii sign.
+/// Checks if ascii char is an ascii sign.
 #[inline]
-pub(crate) const fn is_ascii_sign(ch: char) -> bool {
-    ch == '+' || ch == '-'
+pub(crate) const fn is_ascii_sign(ch: u8) -> bool {
+    ch == b'+' || ch == b'-'
 }
 
-/// Checks if char is an ascii sign or U+2212
+/// Checks if ascii char is a `TimeSeparator`.
 #[inline]
-pub(crate) const fn is_sign(ch: char) -> bool {
-    is_ascii_sign(ch) || ch == '\u{2212}'
+pub(crate) const fn is_time_separator(ch: u8) -> bool {
+    ch == b':'
 }
 
-/// Checks if char is a `TimeSeparator`.
+/// Checks if ascii char is a `TimeDesignator`.
 #[inline]
-pub(crate) const fn is_time_separator(ch: char) -> bool {
-    ch == ':'
-}
-
-/// Checks if char is a `TimeDesignator`.
-#[inline]
-pub(crate) const fn is_time_designator(ch: char) -> bool {
-    ch == 'T' || ch == 't'
+pub(crate) const fn is_time_designator(ch: u8) -> bool {
+    ch == b'T' || ch == b't'
 }
 
 #[inline]
-/// Checks if char is a space.
-pub(crate) const fn is_space(ch: char) -> bool {
-    ch == ' '
+/// Checks if ascii char is a space.
+pub(crate) const fn is_space(ch: u8) -> bool {
+    ch == b' '
 }
 
-/// Checks if char is a `DateTimeSeparator`.
+/// Checks if ascii char is a `DateTimeSeparator`.
 #[inline]
-pub(crate) const fn is_date_time_separator(ch: char) -> bool {
+pub(crate) const fn is_date_time_separator(ch: u8) -> bool {
     is_time_designator(ch) || is_space(ch)
 }
 
-/// Checks if char is a `UtcDesignator`.
+/// Checks if ascii char is a `UtcDesignator`.
 #[inline]
-pub(crate) const fn is_utc_designator(ch: char) -> bool {
-    ch == 'Z' || ch == 'z'
+pub(crate) const fn is_utc_designator(ch: u8) -> bool {
+    ch == b'Z' || ch == b'z'
 }
 
-/// Checks if char is a `DurationDesignator`.
+/// Checks if ascii char is a `DurationDesignator`.
 #[inline]
 #[cfg(feature = "duration")]
-pub(crate) const fn is_duration_designator(ch: char) -> bool {
-    ch == 'P' || ch == 'p'
+pub(crate) const fn is_duration_designator(ch: u8) -> bool {
+    ch == b'P' || ch == b'p'
 }
 
-/// Checks if char is a `YearDesignator`.
+/// Checks if ascii char is a `YearDesignator`.
 #[inline]
 #[cfg(feature = "duration")]
-pub(crate) const fn is_year_designator(ch: char) -> bool {
-    ch == 'Y' || ch == 'y'
+pub(crate) const fn is_year_designator(ch: u8) -> bool {
+    ch == b'Y' || ch == b'y'
 }
 
-/// Checks if char is a `MonthsDesignator`.
+/// Checks if ascii char is a `MonthsDesignator`.
 #[inline]
 #[cfg(feature = "duration")]
-pub(crate) const fn is_month_designator(ch: char) -> bool {
-    ch == 'M' || ch == 'm'
+pub(crate) const fn is_month_designator(ch: u8) -> bool {
+    ch == b'M' || ch == b'm'
 }
 
-/// Checks if char is a `WeekDesignator`.
+/// Checks if ascii char is a `WeekDesignator`.
 #[inline]
 #[cfg(feature = "duration")]
-pub(crate) const fn is_week_designator(ch: char) -> bool {
-    ch == 'W' || ch == 'w'
+pub(crate) const fn is_week_designator(ch: u8) -> bool {
+    ch == b'W' || ch == b'w'
 }
 
-/// Checks if char is a `DayDesignator`.
+/// Checks if ascii char is a `DayDesignator`.
 #[inline]
 #[cfg(feature = "duration")]
-pub(crate) const fn is_day_designator(ch: char) -> bool {
-    ch == 'D' || ch == 'd'
+pub(crate) const fn is_day_designator(ch: u8) -> bool {
+    ch == b'D' || ch == b'd'
 }
 
-/// checks if char is a `DayDesignator`.
+/// checks if ascii char is a `DayDesignator`.
 #[inline]
 #[cfg(feature = "duration")]
-pub(crate) const fn is_hour_designator(ch: char) -> bool {
-    ch == 'H' || ch == 'h'
+pub(crate) const fn is_hour_designator(ch: u8) -> bool {
+    ch == b'H' || ch == b'h'
 }
 
-/// Checks if char is a `MinuteDesignator`.
+/// Checks if ascii char is a `MinuteDesignator`.
 #[inline]
 #[cfg(feature = "duration")]
-pub(crate) const fn is_minute_designator(ch: char) -> bool {
+pub(crate) const fn is_minute_designator(ch: u8) -> bool {
     is_month_designator(ch)
 }
 
-/// checks if char is a `SecondDesignator`.
+/// checks if ascii char is a `SecondDesignator`.
 #[inline]
 #[cfg(feature = "duration")]
-pub(crate) const fn is_second_designator(ch: char) -> bool {
-    ch == 'S' || ch == 's'
+pub(crate) const fn is_second_designator(ch: u8) -> bool {
+    ch == b'S' || ch == b's'
 }
 
-/// Checks if char is a `DecimalSeparator`.
+/// Checks if ascii char is a `DecimalSeparator`.
 #[inline]
-pub(crate) const fn is_decimal_separator(ch: char) -> bool {
-    ch == '.' || ch == ','
+pub(crate) const fn is_decimal_separator(ch: u8) -> bool {
+    ch == b'.' || ch == b','
 }
 
-/// Checks if char is an `AnnotationOpen`.
+/// Checks if ascii char is an `AnnotationOpen`.
 #[inline]
-pub(crate) const fn is_annotation_open(ch: char) -> bool {
-    ch == '['
+pub(crate) const fn is_annotation_open(ch: u8) -> bool {
+    ch == b'['
 }
 
-/// Checks if char is an `AnnotationClose`.
+/// Checks if ascii char is an `AnnotationClose`.
 #[inline]
-pub(crate) const fn is_annotation_close(ch: char) -> bool {
-    ch == ']'
+pub(crate) const fn is_annotation_close(ch: u8) -> bool {
+    ch == b']'
 }
 
-/// Checks if char is an `CriticalFlag`.
+/// Checks if ascii char is an `CriticalFlag`.
 #[inline]
-pub(crate) const fn is_critical_flag(ch: char) -> bool {
-    ch == '!'
+pub(crate) const fn is_critical_flag(ch: u8) -> bool {
+    ch == b'!'
 }
 
-/// Checks if char is the `AnnotationKeyValueSeparator`.
+/// Checks if ascii char is the `AnnotationKeyValueSeparator`.
 #[inline]
-pub(crate) const fn is_annotation_key_value_separator(ch: char) -> bool {
-    ch == '='
+pub(crate) const fn is_annotation_key_value_separator(ch: u8) -> bool {
+    ch == b'='
 }
 
-/// Checks if char is a hyphen. Hyphens are used as a Date separator
+/// Checks if ascii char is a hyphen. Hyphens are used as a Date separator
 /// and as a `AttributeValueComponent` separator.
 #[inline]
-pub(crate) const fn is_hyphen(ch: char) -> bool {
-    ch == '-'
+pub(crate) const fn is_hyphen(ch: u8) -> bool {
+    ch == b'-'
 }

--- a/utils/ixdtf/src/parsers/time.rs
+++ b/utils/ixdtf/src/parsers/time.rs
@@ -10,8 +10,8 @@ use crate::{
     assert_syntax,
     parsers::{
         grammar::{
-            is_annotation_open, is_decimal_separator, is_sign, is_time_designator,
-            is_time_separator, is_utc_designator,
+            is_annotation_open, is_decimal_separator, is_time_designator, is_time_separator,
+            is_utc_designator,
         },
         records::{Annotation, TimeRecord},
         timezone::parse_date_time_utc,
@@ -22,6 +22,7 @@ use crate::{
 
 use super::{
     annotations,
+    grammar::is_ascii_sign,
     records::{Fraction, IxdtfParseRecord},
 };
 
@@ -39,7 +40,7 @@ pub(crate) fn parse_annotated_time_record<'a>(
     // If Time was successfully parsed, assume from this point that this IS a
     // valid AnnotatedTimeRecord.
 
-    let offset = if cursor.check_or(false, |ch| is_sign(ch) || is_utc_designator(ch)) {
+    let offset = if cursor.check_or(false, |ch| is_ascii_sign(ch) || is_utc_designator(ch)) {
         Some(parse_date_time_utc(cursor)?)
     } else {
         None

--- a/utils/ixdtf/src/parsers/timezone.rs
+++ b/utils/ixdtf/src/parsers/timezone.rs
@@ -7,7 +7,7 @@
 use super::{
     grammar::{
         is_a_key_char, is_a_key_leading_char, is_annotation_close,
-        is_annotation_key_value_separator, is_annotation_open, is_critical_flag, is_sign,
+        is_annotation_key_value_separator, is_annotation_open, is_ascii_sign, is_critical_flag,
         is_time_separator, is_tz_char, is_tz_leading_char, is_tz_name_separator, is_utc_designator,
     },
     records::{Sign, TimeZoneAnnotation, TimeZoneRecord, UtcOffsetRecord, UtcOffsetRecordOrZ},
@@ -39,7 +39,7 @@ pub(crate) fn parse_ambiguous_tz_annotation<'a>(
         .peek_n(current_peek)
         .ok_or(ParseError::abrupt_end("AmbiguousAnnotation"))?;
 
-    if is_tz_leading_char(leading_char) || is_sign(leading_char) {
+    if is_tz_leading_char(leading_char) || is_ascii_sign(leading_char) {
         // Ambigious start values when lowercase alpha that is shared between `TzLeadingChar` and `KeyLeadingChar`.
         if is_a_key_leading_char(leading_char) {
             let mut peek_pos = current_peek + 1;
@@ -96,7 +96,7 @@ pub(crate) fn parse_time_zone<'a>(cursor: &mut Cursor<'a>) -> ParserResult<TimeZ
     let is_iana = cursor
         .check(is_tz_leading_char)
         .ok_or(ParseError::abrupt_end("TimeZoneAnnotation"))?;
-    let is_offset = cursor.check_or(false, is_sign);
+    let is_offset = cursor.check_or(false, is_ascii_sign);
 
     if is_iana {
         return parse_tz_iana_name(cursor);
@@ -169,9 +169,9 @@ pub(crate) fn parse_date_time_utc(cursor: &mut Cursor) -> ParserResult<UtcOffset
 pub(crate) fn parse_utc_offset_minute_precision(
     cursor: &mut Cursor,
 ) -> ParserResult<(UtcOffsetRecord, bool)> {
-    let sign = if cursor.check_or(false, is_sign) {
+    let sign = if cursor.check_or(false, is_ascii_sign) {
         let sign = cursor.next_or(ParseError::ImplAssert)?;
-        Sign::from(sign == '+')
+        Sign::from(sign == b'+')
     } else {
         Sign::Positive
     };


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->

This PR removes support for U+2212 from `ixdtf` to bring it up to date with the Temporal specification.

This also removes the dependency on `utf8_iter` as all parsed values should be ASCII.