### PR TITLE
Create icu4x-tc_2025-02-05.md

### DIFF
--- a/documents/minutes/icu4x-tc_2025-02-05.md
+++ b/documents/minutes/icu4x-tc_2025-02-05.md
@@ -1,0 +1,17 @@
+# ICU4X TC Meeting 2025-02-05
+
+Attendees:
+
+- Shane Carr (Google)
+- Robert Bastian (Google)
+- Manish Goregaokar (Google)
+- Elango Cheran (Google)
+- Zibi Braniecki (Amazon)
+- Henri Sivonen (Mozilla)
+
+Minutes:
+
+- Mapping from BCP47 extensions to collator options is inconsistent: https://github.com/unicode-org/icu4x/issues/6033#issuecomment-2639553087
+- ICU4X will not contain data for time zone transitions: https://github.com/unicode-org/icu4x/issues/533#issuecomment-2639549795
+- Be more consistent about options modules: https://github.com/unicode-org/icu4x/issues/5991#issuecomment-2639552097
+- Consider having private fields for DataLocale: https://github.com/unicode-org/icu4x/issues/5989#issuecomment-2639551190


### PR DESCRIPTION
Minutes from the TC meeting on 2025-02-05.

Wanted to have a paper trail about our decision not to include time zone transitions especially.