### PR TITLE
Audit era identifiers

### DIFF
--- a/components/calendar/src/any_calendar.rs
+++ b/components/calendar/src/any_calendar.rs
@@ -56,7 +56,7 @@ define_preferences!(
 ///
 /// // construct from era code, year, month code, day, and a calendar
 /// // This is March 28, 15 Heisei
-/// let manual_date = Date::try_new_from_codes(Some(Era(tinystr!(16, "heisei"))), 15, MonthCode(tinystr!(4, "M03")), 28, calendar.clone())
+/// let manual_date = Date::try_new_from_codes(Some(Era::HEISEI, 15, MonthCode(tinystr!(4, "M03")), 28, calendar.clone())
 ///                     .expect("Failed to construct Date manually");
 ///
 ///
@@ -67,7 +67,7 @@ define_preferences!(
 ///
 /// // Construct a date in the appropriate typed calendar and convert
 /// let japanese_calendar = Japanese::new();
-/// let japanese_date = Date::try_new_japanese_with_calendar(Era(tinystr!(16, "heisei")), 15, 3, 28,
+/// let japanese_date = Date::try_new_japanese_with_calendar(Era::HEISEI, 15, 3, 28,
 ///                                                         japanese_calendar).unwrap();
 /// // This is a Date<AnyCalendar>
 /// let any_japanese_date = japanese_date.to_any();

--- a/components/calendar/src/any_calendar.rs
+++ b/components/calendar/src/any_calendar.rs
@@ -56,7 +56,7 @@ define_preferences!(
 ///
 /// // construct from era code, year, month code, day, and a calendar
 /// // This is March 28, 15 Heisei
-/// let manual_date = Date::try_new_from_codes(Some(Era::HEISEI, 15, MonthCode(tinystr!(4, "M03")), 28, calendar.clone())
+/// let manual_date = Date::try_new_from_codes(Some(Era::HEISEI), 15, MonthCode(tinystr!(4, "M03")), 28, calendar.clone())
 ///                     .expect("Failed to construct Date manually");
 ///
 ///

--- a/components/calendar/src/cal/buddhist.rs
+++ b/components/calendar/src/cal/buddhist.rs
@@ -20,6 +20,7 @@ use crate::any_calendar::AnyCalendarKind;
 use crate::cal::iso::{Iso, IsoDateInner};
 use crate::calendar_arithmetic::ArithmeticDate;
 use crate::error::DateError;
+use crate::types::Era;
 use crate::{types, Calendar, Date, DateDuration, DateDurationUnit, RangeError};
 use tinystr::tinystr;
 
@@ -41,7 +42,7 @@ const BUDDHIST_ERA_OFFSET: i32 = 543;
 ///
 /// # Era codes
 ///
-/// This calendar supports one era, `"be"`, with 1 B.E. being 543 BCE.
+/// This calendar supports one era, [`Era::BE`], with 1 B.E. being 543 BCE.
 ///
 /// # Month codes
 ///
@@ -59,12 +60,10 @@ impl Calendar for Buddhist {
         month_code: types::MonthCode,
         day: u8,
     ) -> Result<Self::DateInner, DateError> {
-        if let Some(era) = era {
-            if era.0 != tinystr!(16, "be") {
-                return Err(DateError::UnknownEra(era));
-            }
-        }
-        let year = year - BUDDHIST_ERA_OFFSET;
+        let year = match era {
+            Some(Era::BE) | None => year - BUDDHIST_ERA_OFFSET,
+            Some(e) => return Err(DateError::UnknownEra(e)),
+        };
 
         ArithmeticDate::new_from_codes(self, year, month_code, day).map(IsoDateInner)
     }
@@ -172,7 +171,7 @@ fn iso_year_as_buddhist(year: i32) -> types::YearInfo {
     types::YearInfo::new(
         buddhist_year,
         types::EraYear {
-            standard_era: tinystr!(16, "buddhist").into(),
+            standard_era: Era::BUDDHIST,
             formatting_era: types::FormattingEra::Index(0, tinystr!(16, "BE")),
             era_year: buddhist_year,
             ambiguity: types::YearAmbiguity::CenturyRequired,

--- a/components/calendar/src/cal/coptic.rs
+++ b/components/calendar/src/cal/coptic.rs
@@ -19,6 +19,7 @@
 use crate::cal::iso::Iso;
 use crate::calendar_arithmetic::{ArithmeticDate, CalendarArithmetic};
 use crate::error::DateError;
+use crate::types::Era;
 use crate::{types, Calendar, Date, DateDuration, DateDurationUnit, RangeError};
 use calendrical_calculations::helpers::I32CastError;
 use calendrical_calculations::rata_die::RataDie;
@@ -35,8 +36,10 @@ use tinystr::tinystr;
 ///
 /// # Era codes
 ///
-/// This calendar supports two era codes: `"bd"`, and `"ad"`, corresponding to the Before Diocletian and After Diocletian/Anno Martyrum
+/// This calendar supports two era codes: [`Era::BD`], and [`Era::AD`], corresponding to the Before Diocletian and After Diocletian/Anno Martyrum
 /// eras. 1 A.M. is equivalent to 284 C.E.
+///
+/// [`Era::COPTIC_INVERSE`] and [`Era::COPTIC`] are accepted as aliases.
 ///
 /// # Month codes
 ///
@@ -101,32 +104,18 @@ impl Calendar for Coptic {
         month_code: types::MonthCode,
         day: u8,
     ) -> Result<Self::DateInner, DateError> {
-        let year = if let Some(era) = era {
-            if era.0 == tinystr!(16, "ad") || era.0 == tinystr!(16, "coptic") {
-                if year <= 0 {
-                    return Err(DateError::Range {
-                        field: "year",
-                        value: year,
-                        min: 1,
-                        max: i32::MAX,
-                    });
-                }
-                year
-            } else if era.0 == tinystr!(16, "bd") || era.0 == tinystr!(16, "coptic-inverse") {
-                if year <= 0 {
-                    return Err(DateError::Range {
-                        field: "year",
-                        value: year,
-                        min: 1,
-                        max: i32::MAX,
-                    });
-                }
-                1 - year
-            } else {
-                return Err(DateError::UnknownEra(era));
-            }
-        } else {
-            year
+        if year <= 0 {
+            return Err(DateError::Range {
+                field: "year",
+                value: year,
+                min: 1,
+                max: i32::MAX,
+            });
+        }
+        let year = match era {
+            Some(Era::AD | Era::COPTIC) | None => year,
+            Some(Era::BD | Era::COPTIC_INVERSE) => 1 - year,
+            Some(e) => return Err(DateError::UnknownEra(e)),
         };
 
         ArithmeticDate::new_from_codes(self, year, month_code, day).map(CopticDateInner)
@@ -261,7 +250,7 @@ fn year_as_coptic(year: i32) -> types::YearInfo {
         types::YearInfo::new(
             year,
             types::EraYear {
-                standard_era: tinystr!(16, "coptic").into(),
+                standard_era: Era::COPTIC,
                 formatting_era: types::FormattingEra::Index(1, tinystr!(16, "AD")),
                 era_year: year,
                 ambiguity: types::YearAmbiguity::CenturyRequired,
@@ -271,7 +260,7 @@ fn year_as_coptic(year: i32) -> types::YearInfo {
         types::YearInfo::new(
             year,
             types::EraYear {
-                standard_era: tinystr!(16, "coptic-inverse").into(),
+                standard_era: Era::COPTIC_INVERSE,
                 formatting_era: types::FormattingEra::Index(0, tinystr!(16, "BD")),
                 era_year: 1 - year,
                 ambiguity: types::YearAmbiguity::EraAndCenturyRequired,

--- a/components/calendar/src/cal/hebrew.rs
+++ b/components/calendar/src/cal/hebrew.rs
@@ -33,7 +33,7 @@ use calendrical_calculations::hebrew_keviyah::{Keviyah, YearInfo};
 ///
 /// # Era codes
 ///
-/// This calendar supports a single era code, Anno Mundi, with code [`Era::AM`].
+/// This calendar supports a single era, Anno Mundi, [`Era::AM`].
 ///
 /// [`Era::HEBREW`] is accepted as an alias.
 ///

--- a/components/calendar/src/cal/indian.rs
+++ b/components/calendar/src/cal/indian.rs
@@ -19,6 +19,7 @@
 use crate::cal::iso::Iso;
 use crate::calendar_arithmetic::{ArithmeticDate, CalendarArithmetic};
 use crate::error::DateError;
+use crate::types::Era;
 use crate::{types, Calendar, Date, DateDuration, DateDurationUnit, RangeError};
 use tinystr::tinystr;
 
@@ -30,7 +31,9 @@ use tinystr::tinystr;
 ///
 /// # Era codes
 ///
-/// This calendar has a single era: `"saka"`, with Saka 0 being 78 CE. Dates before this era use negative years.
+/// This calendar has a single era: [`Era::SAKA`], with Saka 0 being 78 CE. Dates before this era use negative years.
+///
+/// [`Era::INDIAN`] is supported as an alias.
 ///
 /// # Month codes
 ///
@@ -98,12 +101,10 @@ impl Calendar for Indian {
         month_code: types::MonthCode,
         day: u8,
     ) -> Result<Self::DateInner, DateError> {
-        if let Some(era) = era {
-            if era.0 != tinystr!(16, "saka") && era.0 != tinystr!(16, "indian") {
-                return Err(DateError::UnknownEra(era));
-            }
-        }
-
+        let year = match era {
+            Some(Era::SAKA | Era::INDIAN) | None => year,
+            Some(e) => return Err(DateError::UnknownEra(e)),
+        };
         ArithmeticDate::new_from_codes(self, year, month_code, day).map(IndianDateInner)
     }
 
@@ -220,8 +221,8 @@ fn year_as_saka(year: i32) -> types::YearInfo {
     types::YearInfo::new(
         year,
         types::EraYear {
+            standard_era: Era::SAKA,
             formatting_era: types::FormattingEra::Index(0, tinystr!(16, "Saka")),
-            standard_era: tinystr!(16, "saka").into(),
             era_year: year,
             ambiguity: types::YearAmbiguity::CenturyRequired,
         },

--- a/components/calendar/src/cal/iso.rs
+++ b/components/calendar/src/cal/iso.rs
@@ -17,6 +17,7 @@
 
 use crate::calendar_arithmetic::{ArithmeticDate, CalendarArithmetic};
 use crate::error::DateError;
+use crate::types::Era;
 use crate::{types, Calendar, Date, DateDuration, DateDurationUnit, RangeError};
 use calendrical_calculations::helpers::I32CastError;
 use calendrical_calculations::rata_die::RataDie;
@@ -32,7 +33,7 @@ use tinystr::tinystr;
 ///
 /// # Era codes
 ///
-/// This calendar supports one era, `"default"`
+/// This calendar supports one era, [`Era::DEFAULT`]
 
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[allow(clippy::exhaustive_structs)] // this type is stable
@@ -86,11 +87,10 @@ impl Calendar for Iso {
         month_code: types::MonthCode,
         day: u8,
     ) -> Result<Self::DateInner, DateError> {
-        if let Some(era) = era {
-            if era.0 != tinystr!(16, "default") {
-                return Err(DateError::UnknownEra(era));
-            }
-        }
+        let year = match era {
+            Some(Era::DEFAULT) | None => year,
+            Some(e) => return Err(DateError::UnknownEra(e)),
+        };
 
         ArithmeticDate::new_from_codes(self, year, month_code, day).map(IsoDateInner)
     }
@@ -326,8 +326,8 @@ impl Iso {
         types::YearInfo::new(
             year,
             types::EraYear {
+                standard_era: Era::DEFAULT,
                 formatting_era: types::FormattingEra::Index(0, tinystr!(16, "")),
-                standard_era: tinystr!(16, "default").into(),
                 era_year: year,
                 ambiguity: types::YearAmbiguity::Unambiguous,
             },

--- a/components/calendar/src/cal/persian.rs
+++ b/components/calendar/src/cal/persian.rs
@@ -18,6 +18,7 @@
 use crate::cal::iso::Iso;
 use crate::calendar_arithmetic::{ArithmeticDate, CalendarArithmetic};
 use crate::error::DateError;
+use crate::types::Era;
 use crate::{types, Calendar, Date, DateDuration, DateDurationUnit, RangeError};
 use ::tinystr::tinystr;
 use calendrical_calculations::helpers::I32CastError;
@@ -32,7 +33,9 @@ use calendrical_calculations::rata_die::RataDie;
 ///
 /// # Era codes
 ///
-/// This calendar supports only one era code, which starts from the year of the Hijra, designated as "ah".
+/// This calendar supports only one era code, [`Era::AH`].
+///
+/// [`Era::PERSIAN`] is accepted as an alias.
 ///
 /// # Month codes
 ///
@@ -93,11 +96,10 @@ impl Calendar for Persian {
         month_code: types::MonthCode,
         day: u8,
     ) -> Result<Self::DateInner, DateError> {
-        if let Some(era) = era {
-            if era.0 != tinystr!(16, "ah") && era.0 != tinystr!(16, "persian") {
-                return Err(DateError::UnknownEra(era));
-            }
-        }
+        let year = match era {
+            Some(Era::AH | Era::PERSIAN) | None => year,
+            Some(e) => return Err(DateError::UnknownEra(e)),
+        };
 
         ArithmeticDate::new_from_codes(self, year, month_code, day).map(PersianDateInner)
     }
@@ -208,7 +210,7 @@ impl Persian {
         types::YearInfo::new(
             year,
             types::EraYear {
-                standard_era: tinystr!(16, "persian").into(),
+                standard_era: Era::PERSIAN,
                 formatting_era: types::FormattingEra::Index(0, tinystr!(16, "AH")),
                 era_year: year,
                 ambiguity: types::YearAmbiguity::CenturyRequired,

--- a/components/calendar/src/cal/roc.rs
+++ b/components/calendar/src/cal/roc.rs
@@ -74,8 +74,8 @@ impl Calendar for Roc {
         }
 
         let year = match era {
-            Some(Era::ROC) | None => year,
-            Some(Era::ROC_INVERSE) => 1 - year,
+            Some(Era::ROC) | None => year + ROC_ERA_OFFSET,
+            Some(Era::ROC_INVERSE) => 1 + ROC_ERA_OFFSET - year,
             Some(e) => return Err(DateError::UnknownEra(e)),
         };
 

--- a/components/calendar/src/provider.rs
+++ b/components/calendar/src/provider.rs
@@ -20,10 +20,9 @@ pub mod hijri;
 pub use chinese_based::{CalendarChineseV1, CalendarDangiV1};
 pub use hijri::{CalendarHijriObservationalV1, CalendarHijriUmmalquraV1};
 
-use crate::types::Weekday;
+use crate::types::{Era, Weekday};
 use icu_provider::fallback::{LocaleFallbackConfig, LocaleFallbackPriority};
 use icu_provider::prelude::*;
-use tinystr::TinyStr16;
 use zerovec::ZeroVec;
 
 #[cfg(feature = "compiled_data")]
@@ -133,7 +132,7 @@ pub struct EraStartDate {
 pub struct JapaneseEras<'data> {
     /// A map from era start dates to their era codes
     #[cfg_attr(feature = "serde", serde(borrow))]
-    pub dates_to_eras: ZeroVec<'data, (EraStartDate, TinyStr16)>,
+    pub dates_to_eras: ZeroVec<'data, (EraStartDate, Era)>,
 }
 
 icu_provider::data_struct!(

--- a/components/calendar/src/tests/continuity_test.rs
+++ b/components/calendar/src/tests/continuity_test.rs
@@ -200,26 +200,22 @@ fn test_iso_continuity() {
 #[test]
 fn test_japanese_continuity() {
     use crate::types::Era;
-    use tinystr::tinystr;
     let cal = crate::cal::Japanese::new();
     let cal = Ref(&cal);
-    let date = Date::try_new_japanese_with_calendar(Era(tinystr!(16, "heisei")), 20, 1, 1, cal);
+    let date = Date::try_new_japanese_with_calendar(Era::HEISEI, 20, 1, 1, cal);
     check_continuity(date.unwrap());
-    let date = Date::try_new_japanese_with_calendar(Era(tinystr!(16, "bce")), 500, 1, 1, cal);
+    let date = Date::try_new_japanese_with_calendar(Era::BCE, 500, 1, 1, cal);
     check_every_250_days(date.unwrap());
 }
 
 #[test]
 fn test_japanese_extended_continuity() {
     use crate::types::Era;
-    use tinystr::tinystr;
     let cal = crate::cal::JapaneseExtended::new();
     let cal = Ref(&cal);
-    let date =
-        Date::try_new_japanese_extended_with_calendar(Era(tinystr!(16, "heisei")), 20, 1, 1, cal);
+    let date = Date::try_new_japanese_extended_with_calendar(Era::HEISEI, 20, 1, 1, cal);
     check_continuity(date.unwrap());
-    let date =
-        Date::try_new_japanese_extended_with_calendar(Era(tinystr!(16, "bce")), 500, 1, 1, cal);
+    let date = Date::try_new_japanese_extended_with_calendar(Era::BCE, 500, 1, 1, cal);
     check_every_250_days(date.unwrap());
 }
 

--- a/components/calendar/src/types.rs
+++ b/components/calendar/src/types.rs
@@ -55,7 +55,7 @@ impl Era {
     pub const INCARNATION: Era = Era(tinystr!(16, "incar"));
     /// Pre-Incarnation (Ethiopian)
     pub const PRE_INCARNATION: Era = Era(tinystr!(16, "pre-incar"));
-    /// Anno Mundi (Coptic)
+    /// Anno Mundi (Ethiopian)
     pub const MUNDI: Era = Era(tinystr!(16, "mundi"));
     /// Anno Mundi (Hebrew)
     pub const AM: Era = Era(tinystr!(16, "am"));

--- a/provider/source/src/datetime/neo.rs
+++ b/provider/source/src/datetime/neo.rs
@@ -6,6 +6,7 @@ use super::supported_cals;
 use crate::cldr_serde::ca;
 use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
+use icu::calendar::types::Era;
 use icu::datetime::provider::pattern;
 
 use icu::datetime::provider::neo::marker_attrs::GlueType;
@@ -319,7 +320,7 @@ fn eras_convert(
 
         let mut out_eras: BTreeMap<TinyAsciiStr<16>, &str> = BTreeMap::new();
 
-        for (cldr, code) in map {
+        for (cldr, Era(code)) in map {
             if let Some(name) = eras.get(cldr) {
                 if let Some(modern_japanese_eras) = modern_japanese_eras {
                     if !modern_japanese_eras.contains(cldr) {


### PR DESCRIPTION
We're pretty inconsistent in what we accept, and what we return as era codes.

This PR does not change behaviour. It documents current behaviour and moves era identifiers into constants.