### PR TITLE
Add test illustrating mismatched time zone time and zoned datetime

### DIFF
--- a/components/datetime/src/combo.rs
+++ b/components/datetime/src/combo.rs
@@ -203,3 +203,60 @@ where
     type Z = Z::Z;
     type GluePatternV1 = datetime_marker_helper!(@glue, yes);
 }
+
+#[cfg(test)]
+mod tests {
+    use icu_calendar::Iso;
+    use icu_locale_core::locale;
+    use icu_time::{
+        zone::{IanaParser, UtcOffset, UtcOffsetCalculator},
+        DateTime, ZonedDateTime,
+    };
+    use writeable::assert_writeable_eq;
+
+    use crate::{
+        fieldsets::{zone::SpecificLong, YMDT},
+        DateTimeFormatter,
+    };
+
+    #[test]
+    fn please_dont_do_this() {
+        let mapper = IanaParser::new();
+        let calculator = UtcOffsetCalculator::new();
+        let formatter =
+            DateTimeFormatter::try_new(locale!("en").into(), YMDT::medium().zone(SpecificLong))
+                .unwrap();
+
+        let good_zdt = ZonedDateTime::try_from_str(
+            "2020-01-01T12:00:00-0100[America/Scoresbysund]",
+            Iso,
+            mapper,
+            &calculator,
+        )
+        .unwrap();
+
+        let dt_2020 = DateTime::try_from_str("2020-01-01T12:00", Iso).unwrap();
+        let dt_2025 = DateTime::try_from_str("2025-01-01T12:00", Iso).unwrap();
+
+        let time_zone = IanaParser::new()
+            .parse("America/Scoresbysund")
+            .with_offset(Some(UtcOffset::try_from_str("-0100").unwrap()))
+            .at_time((dt_2025.date, dt_2025.time))
+            .infer_zone_variant(&calculator);
+
+        let bad_zdt = ZonedDateTime {
+            date: dt_2020.date,
+            time: dt_2020.time,
+            zone: time_zone,
+        };
+
+        assert_writeable_eq!(
+            formatter.format(&good_zdt),
+            "Jan 1, 2020, 12:00:00 PM East Greenland Standard Time"
+        );
+        assert_writeable_eq!(
+            formatter.format(&bad_zdt),
+            "Jan 1, 2020, 12:00:00 PM Greenland Summer Time"
+        );
+    }
+}


### PR DESCRIPTION
I realized that ZonedDateTime can contain two different datetimes: the "main" datetime and the reference datetime for the time zone.

It's fairly easy to get into this state. For example, someone might pick "Unix epoch" or "current datetime" to put into the fairly obscure `at_time` function when constructing their TimeZoneInfo, which is almost always wrong.

This might be partially mitigated if we change the reference datetime to be an absolute time (https://github.com/unicode-org/icu4x/issues/6238) so that there isn't a categorical mismatch, but it can still happen.

Maybe fine to ignore. If people use `infer_zone_offsets`, they won't get a specific non-location zone name that is _wrong_, only not applicable at the given time, which is confusing but not _wrong_. (However, if they pull the zone variant from `isdst`, maybe things could go wrong.)

@robertbastian 