### PR TITLE
Internal refactor of DateTimeFormatter

### DIFF
--- a/components/datetime/src/neo.rs
+++ b/components/datetime/src/neo.rs
@@ -128,7 +128,7 @@ macro_rules! gen_buffer_constructors_with_external_loader {
     };
 }
 
-size_test!(FixedCalendarDateTimeFormatter<icu_calendar::Gregorian, crate::fieldsets::YMD>, typed_neo_year_month_day_formatter_size, 384);
+size_test!(FixedCalendarDateTimeFormatter<icu_calendar::Gregorian, crate::fieldsets::YMD>, typed_neo_year_month_day_formatter_size, 336);
 
 /// [`FixedCalendarDateTimeFormatter`] is a formatter capable of formatting dates and/or times from
 /// a calendar selected at compile time.

--- a/components/datetime/src/neo.rs
+++ b/components/datetime/src/neo.rs
@@ -128,7 +128,7 @@ macro_rules! gen_buffer_constructors_with_external_loader {
     };
 }
 
-size_test!(FixedCalendarDateTimeFormatter<icu_calendar::Gregorian, crate::fieldsets::YMD>, typed_neo_year_month_day_formatter_size, 344);
+size_test!(FixedCalendarDateTimeFormatter<icu_calendar::Gregorian, crate::fieldsets::YMD>, typed_neo_year_month_day_formatter_size, 328);
 
 /// [`FixedCalendarDateTimeFormatter`] is a formatter capable of formatting dates and/or times from
 /// a calendar selected at compile time.

--- a/components/datetime/src/neo.rs
+++ b/components/datetime/src/neo.rs
@@ -128,7 +128,7 @@ macro_rules! gen_buffer_constructors_with_external_loader {
     };
 }
 
-size_test!(FixedCalendarDateTimeFormatter<icu_calendar::Gregorian, crate::fieldsets::YMD>, typed_neo_year_month_day_formatter_size, 336);
+size_test!(FixedCalendarDateTimeFormatter<icu_calendar::Gregorian, crate::fieldsets::YMD>, typed_neo_year_month_day_formatter_size, 344);
 
 /// [`FixedCalendarDateTimeFormatter`] is a formatter capable of formatting dates and/or times from
 /// a calendar selected at compile time.

--- a/components/datetime/src/neo.rs
+++ b/components/datetime/src/neo.rs
@@ -128,7 +128,7 @@ macro_rules! gen_buffer_constructors_with_external_loader {
     };
 }
 
-size_test!(FixedCalendarDateTimeFormatter<icu_calendar::Gregorian, crate::fieldsets::YMD>, typed_neo_year_month_day_formatter_size, 328);
+size_test!(FixedCalendarDateTimeFormatter<icu_calendar::Gregorian, crate::fieldsets::YMD>, typed_neo_year_month_day_formatter_size, 384);
 
 /// [`FixedCalendarDateTimeFormatter`] is a formatter capable of formatting dates and/or times from
 /// a calendar selected at compile time.

--- a/components/datetime/src/provider/packed_pattern.rs
+++ b/components/datetime/src/provider/packed_pattern.rs
@@ -120,9 +120,15 @@ icu_provider::data_marker!(
 /// This supports a set of "standard" patterns plus up to two "variants".
 /// The variants are currently used by year formatting:
 ///
-/// - Standard: Year, which could be partial precision (2-digit Gregorain)
+/// - Standard: Year, which could be partial precision (2-digit Gregorian)
 /// - Variant 0: Full Year, which is always full precision
 /// - Variant 1: Year With Era
+/// 
+/// And by time formatting:
+/// 
+/// - Standard: Hour only
+/// - Variant 0: Hour and minute
+/// - Variant 1: Hour, minute, and second
 ///
 /// Variants should be used when the pattern could depend on the value being
 /// formatted. For example, with [`YearStyle::Auto`], any of these three
@@ -457,9 +463,13 @@ impl PackedPatternsBuilder<'_> {
     }
 }
 
+/// Which pattern to select. For details, see [`PackedPatterns`].
 pub(crate) enum PackedSkeletonVariant {
+    /// Default-precision year OR hours only
     Standard,
+    /// Full-precision year OR hours and minutes
     Variant0,
+    /// Year with era OR hours, minutes, and seconds
     Variant1,
 }
 

--- a/components/datetime/src/provider/packed_pattern.rs
+++ b/components/datetime/src/provider/packed_pattern.rs
@@ -123,9 +123,9 @@ icu_provider::data_marker!(
 /// - Standard: Year, which could be partial precision (2-digit Gregorian)
 /// - Variant 0: Full Year, which is always full precision
 /// - Variant 1: Year With Era
-/// 
+///
 /// And by time formatting:
-/// 
+///
 /// - Standard: Hour only
 /// - Variant 0: Hour and minute
 /// - Variant 1: Hour, minute, and second

--- a/components/datetime/src/raw/neo.rs
+++ b/components/datetime/src/raw/neo.rs
@@ -145,13 +145,13 @@ impl DatePatternSelectionData {
 
     /// Borrows a pattern containing all of the fields that need to be loaded.
     #[inline]
-    pub(crate) fn pattern_items_for_data_loading(&self, options: &RawOptions) -> Option<impl Iterator<Item = PatternItem> + '_> {
+    pub(crate) fn pattern_items_for_data_loading(&self, options: RawOptions) -> Option<impl Iterator<Item = PatternItem> + '_> {
         let payload = self.payload.get_option()?;
         Some(payload.get(options.length, PackedSkeletonVariant::Variant1).items.iter())
     }
 
     /// Borrows a resolved pattern based on the given datetime
-    pub(crate) fn select(&self, input: &ExtractedInput, options: &RawOptions) -> Option<DatePatternDataBorrowed> {
+    pub(crate) fn select(&self, input: &ExtractedInput, options: RawOptions) -> Option<DatePatternDataBorrowed> {
         let payload = self.payload.get_option()?;
         let year_style = options.year_style.unwrap_or_default();
         let variant = match (
@@ -284,13 +284,13 @@ impl TimePatternSelectionData {
 
     /// Borrows a pattern containing all of the fields that need to be loaded.
     #[inline]
-    pub(crate) fn pattern_items_for_data_loading(&self, options: &RawOptions) -> Option<impl Iterator<Item = PatternItem> + '_> {
+    pub(crate) fn pattern_items_for_data_loading(&self, options: RawOptions) -> Option<impl Iterator<Item = PatternItem> + '_> {
         let payload = self.payload.get_option()?;
         Some(payload.get(options.length, PackedSkeletonVariant::Variant1).items.iter())
     }
 
     /// Borrows a resolved pattern based on the given datetime
-    pub(crate) fn select(&self, input: &ExtractedInput, options: &RawOptions, prefs: &RawPreferences) -> Option<TimePatternDataBorrowed> {
+    pub(crate) fn select(&self, input: &ExtractedInput, options: RawOptions, prefs: RawPreferences) -> Option<TimePatternDataBorrowed> {
         let payload = self.payload.get_option()?;
         let time_precision = options.time_precision.unwrap_or_default();
         let (variant, subsecond_digits) = input.resolve_time_precision(time_precision);
@@ -469,8 +469,8 @@ impl DateTimeZonePatternSelectionData {
                 Ok(Self {
                     options,
                     prefs,
-                    date: date,
-                    time: time,
+                    date,
+                    time,
                     zone: None,
                     glue: Some(glue),
                 })
@@ -487,7 +487,7 @@ impl DateTimeZonePatternSelectionData {
                 Ok(Self {
                     options,
                     prefs: Default::default(), // not used: no time
-                    date: date,
+                    date,
                     time: TimePatternSelectionData::none(),
                     zone: Some(zone),
                     glue: Some(glue),
@@ -507,7 +507,7 @@ impl DateTimeZonePatternSelectionData {
                     options,
                     prefs,
                     date: DatePatternSelectionData::none(),
-                    time: time,
+                    time,
                     zone: Some(zone),
                     glue: Some(glue),
                 })
@@ -530,8 +530,8 @@ impl DateTimeZonePatternSelectionData {
                 Ok(Self {
                     options,
                     prefs,
-                    date: date,
-                    time: time,
+                    date,
+                    time,
                     zone: Some(zone),
                     glue: Some(glue),
                 })
@@ -574,10 +574,10 @@ impl DateTimeZonePatternSelectionData {
         let Self {
             date, time, zone, ..
         } = self;
-        let date_items = date.pattern_items_for_data_loading(&self.options).into_iter().flatten();
-        let time_items = time.pattern_items_for_data_loading(&self.options).into_iter().flatten();
+        let date_items = date.pattern_items_for_data_loading(self.options).into_iter().flatten();
+        let time_items = time.pattern_items_for_data_loading(self.options).into_iter().flatten();
         let zone_items = zone
-            .into_iter()
+            .iter()
             .flat_map(|x| x.pattern_items_for_data_loading());
         date_items.chain(time_items).chain(zone_items)
     }
@@ -585,8 +585,8 @@ impl DateTimeZonePatternSelectionData {
     /// Borrows a resolved pattern based on the given datetime
     pub(crate) fn select(&self, input: &ExtractedInput) -> DateTimeZonePatternDataBorrowed {
         DateTimeZonePatternDataBorrowed {
-            date: self.date.select(input, &self.options),
-            time: self.time.select(input, &self.options, &self.prefs),
+            date: self.date.select(input, self.options),
+            time: self.time.select(input, self.options, self.prefs),
             zone: self.zone.as_ref().map(|zone| zone.select(input)),
             glue: self.glue.as_ref().map(|glue| glue.get()),
         }

--- a/components/datetime/src/raw/neo.rs
+++ b/components/datetime/src/raw/neo.rs
@@ -42,10 +42,8 @@ impl RawPreferences {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) enum DatePatternSelectionData {
-    SkeletonDate {
-        payload: DataPayload<ErasedPackedPatterns>,
-    },
+pub(crate) struct DatePatternSelectionData {
+    payload: DataPayload<ErasedPackedPatterns>,
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -58,10 +56,8 @@ pub(crate) enum DatePatternDataBorrowed<'a> {
 /// TODO: Consider reducing data size by filtering out explicit overlap patterns when they are
 /// the same as their individual patterns with glue.
 #[derive(Debug, Clone)]
-pub(crate) enum TimePatternSelectionData {
-    SkeletonTime {
-        payload: DataPayload<ErasedPackedPatterns>,
-    },
+pub(crate) struct TimePatternSelectionData {
+    payload: DataPayload<ErasedPackedPatterns>,
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -139,14 +135,14 @@ impl DatePatternSelectionData {
                 ..Default::default()
             })?
             .payload;
-        Ok(Self::SkeletonDate { payload })
+        Ok(Self { payload })
     }
 
     /// Borrows a pattern containing all of the fields that need to be loaded.
     #[inline]
     pub(crate) fn pattern_items_for_data_loading(&self, options: &RawOptions) -> impl Iterator<Item = PatternItem> + '_ {
         let items: &ZeroSlice<PatternItem> = match self {
-            DatePatternSelectionData::SkeletonDate { payload } => {
+            DatePatternSelectionData { payload } => {
                 payload
                     .get()
                     .get(options.length, PackedSkeletonVariant::Variant1)
@@ -159,7 +155,7 @@ impl DatePatternSelectionData {
     /// Borrows a resolved pattern based on the given datetime
     pub(crate) fn select(&self, input: &ExtractedInput, options: &RawOptions) -> DatePatternDataBorrowed {
         match self {
-            DatePatternSelectionData::SkeletonDate { payload } => {
+            DatePatternSelectionData { payload } => {
                 let year_style = options.year_style.unwrap_or_default();
                 let variant = match (
                     year_style,
@@ -259,7 +255,7 @@ impl TimePatternSelectionData {
                     .payload
             }
         };
-        Ok(Self::SkeletonTime {
+        Ok(Self {
             payload,
         })
     }
@@ -286,7 +282,7 @@ impl TimePatternSelectionData {
                 ..Default::default()
             })?
             .payload;
-        Ok(Self::SkeletonTime {
+        Ok(Self {
             payload,
         })
     }
@@ -295,7 +291,7 @@ impl TimePatternSelectionData {
     #[inline]
     pub(crate) fn pattern_items_for_data_loading(&self, options: &RawOptions) -> impl Iterator<Item = PatternItem> + '_ {
         let items: &ZeroSlice<PatternItem> = match self {
-            TimePatternSelectionData::SkeletonTime {
+            TimePatternSelectionData {
                 payload, ..
             } => {
                 payload
@@ -310,7 +306,7 @@ impl TimePatternSelectionData {
     /// Borrows a resolved pattern based on the given datetime
     pub(crate) fn select(&self, input: &ExtractedInput, options: &RawOptions, prefs: &RawPreferences) -> TimePatternDataBorrowed {
         match self {
-            TimePatternSelectionData::SkeletonTime {
+            TimePatternSelectionData {
                 payload,
             } => {
                 let time_precision = options.time_precision.unwrap_or_default();

--- a/components/datetime/src/raw/neo.rs
+++ b/components/datetime/src/raw/neo.rs
@@ -46,7 +46,6 @@ pub(crate) enum DatePatternSelectionData {
     SkeletonDate {
         payload: DataPayload<ErasedPackedPatterns>,
     },
-    // TODO(#4478): add support for optional eras
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/components/datetime/src/raw/neo.rs
+++ b/components/datetime/src/raw/neo.rs
@@ -123,7 +123,9 @@ pub(crate) struct DateTimeZonePatternDataBorrowed<'a> {
 
 impl DatePatternSelectionData {
     pub(crate) fn none() -> Self {
-        Self { payload: DataPayloadOr::none() }
+        Self {
+            payload: DataPayloadOr::none(),
+        }
     }
 
     pub(crate) fn try_new_with_skeleton(
@@ -140,18 +142,32 @@ impl DatePatternSelectionData {
                 ..Default::default()
             })?
             .payload;
-        Ok(Self { payload: DataPayloadOr::from_payload(payload) })
+        Ok(Self {
+            payload: DataPayloadOr::from_payload(payload),
+        })
     }
 
     /// Borrows a pattern containing all of the fields that need to be loaded.
     #[inline]
-    pub(crate) fn pattern_items_for_data_loading(&self, options: RawOptions) -> Option<impl Iterator<Item = PatternItem> + '_> {
+    pub(crate) fn pattern_items_for_data_loading(
+        &self,
+        options: RawOptions,
+    ) -> Option<impl Iterator<Item = PatternItem> + '_> {
         let payload = self.payload.get_option()?;
-        Some(payload.get(options.length, PackedSkeletonVariant::Variant1).items.iter())
+        Some(
+            payload
+                .get(options.length, PackedSkeletonVariant::Variant1)
+                .items
+                .iter(),
+        )
     }
 
     /// Borrows a resolved pattern based on the given datetime
-    pub(crate) fn select(&self, input: &ExtractedInput, options: RawOptions) -> Option<DatePatternDataBorrowed> {
+    pub(crate) fn select(
+        &self,
+        input: &ExtractedInput,
+        options: RawOptions,
+    ) -> Option<DatePatternDataBorrowed> {
         let payload = self.payload.get_option()?;
         let year_style = options.year_style.unwrap_or_default();
         let variant = match (
@@ -213,7 +229,9 @@ impl<'a> DatePatternDataBorrowed<'a> {
 
 impl TimePatternSelectionData {
     pub(crate) fn none() -> Self {
-        Self { payload: DataPayloadOr::none() }
+        Self {
+            payload: DataPayloadOr::none(),
+        }
     }
 
     pub(crate) fn try_new_with_skeleton(
@@ -254,7 +272,9 @@ impl TimePatternSelectionData {
                     .payload
             }
         };
-        Ok(Self { payload: DataPayloadOr::from_payload(payload) })
+        Ok(Self {
+            payload: DataPayloadOr::from_payload(payload),
+        })
     }
 
     pub(crate) fn try_new_overlap_with_skeleton(
@@ -279,18 +299,33 @@ impl TimePatternSelectionData {
                 ..Default::default()
             })?
             .payload;
-        Ok(Self { payload: DataPayloadOr::from_payload(payload) })
+        Ok(Self {
+            payload: DataPayloadOr::from_payload(payload),
+        })
     }
 
     /// Borrows a pattern containing all of the fields that need to be loaded.
     #[inline]
-    pub(crate) fn pattern_items_for_data_loading(&self, options: RawOptions) -> Option<impl Iterator<Item = PatternItem> + '_> {
+    pub(crate) fn pattern_items_for_data_loading(
+        &self,
+        options: RawOptions,
+    ) -> Option<impl Iterator<Item = PatternItem> + '_> {
         let payload = self.payload.get_option()?;
-        Some(payload.get(options.length, PackedSkeletonVariant::Variant1).items.iter())
+        Some(
+            payload
+                .get(options.length, PackedSkeletonVariant::Variant1)
+                .items
+                .iter(),
+        )
     }
 
     /// Borrows a resolved pattern based on the given datetime
-    pub(crate) fn select(&self, input: &ExtractedInput, options: RawOptions, prefs: RawPreferences) -> Option<TimePatternDataBorrowed> {
+    pub(crate) fn select(
+        &self,
+        input: &ExtractedInput,
+        options: RawOptions,
+        prefs: RawPreferences,
+    ) -> Option<TimePatternDataBorrowed> {
         let payload = self.payload.get_option()?;
         let time_precision = options.time_precision.unwrap_or_default();
         let (variant, subsecond_digits) = input.resolve_time_precision(time_precision);
@@ -574,11 +609,15 @@ impl DateTimeZonePatternSelectionData {
         let Self {
             date, time, zone, ..
         } = self;
-        let date_items = date.pattern_items_for_data_loading(self.options).into_iter().flatten();
-        let time_items = time.pattern_items_for_data_loading(self.options).into_iter().flatten();
-        let zone_items = zone
-            .iter()
-            .flat_map(|x| x.pattern_items_for_data_loading());
+        let date_items = date
+            .pattern_items_for_data_loading(self.options)
+            .into_iter()
+            .flatten();
+        let time_items = time
+            .pattern_items_for_data_loading(self.options)
+            .into_iter()
+            .flatten();
+        let zone_items = zone.iter().flat_map(|x| x.pattern_items_for_data_loading());
         date_items.chain(time_items).chain(zone_items)
     }
 


### PR DESCRIPTION
Organizes the inner workings without impacting stack size. I've wanted to do this for a while and #6243 was the impetus.