### PR TITLE
Add format_unchecked functions to DateTimeFormatter

### DIFF
--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -112,6 +112,7 @@ pub use neo::DateTimeFormatter;
 pub use neo::DateTimeFormatterPreferences;
 pub use neo::FixedCalendarDateTimeFormatter;
 pub use neo::FormattedDateTime;
+pub use neo::FormattedDateTimeTry;
 pub use neo::NoCalendarFormatter;
 pub use options::Length;
 

--- a/components/datetime/src/neo.rs
+++ b/components/datetime/src/neo.rs
@@ -365,6 +365,90 @@ where
     }
 }
 
+impl<C: CldrCalendar, FSet: DateTimeNamesMarker> FixedCalendarDateTimeFormatter<C, FSet> {
+    /// Formats a datetime without enforcing either the field set or the calendar.
+    ///
+    /// This function is useful when the caller knows something about the field set that the
+    /// type system is unaware of. For example, if the formatter is represented with a
+    /// [dynamic field set](crate::fieldsets::enums), the caller may be able to provide a
+    /// narrower type for formatting.
+    ///
+    /// ❗ The caller must ensure that:
+    ///
+    /// 1. The calendar of the input matches the calendar of the formatter
+    /// 2. The fields of the input are a superset of the fields of the formatter
+    ///
+    /// Returns a [`FormattedDateTimeTry`] to surface errors when they occur,
+    /// but not every invariant will result in an error. Use with caution!
+    ///
+    /// # Examples
+    ///
+    /// In the following example, we know that the formatter's field set is [`YMD`], but the
+    /// type system thinks we are a [`CompositeFieldSet`], which requires a [`ZonedDateTime`]
+    /// as input. However, since [`Date`] contains all the fields required by [`YMD`], we can
+    /// successfully pass it into [`format_unchecked`].
+    ///
+    /// ```
+    /// use icu::calendar::cal::Buddhist;
+    /// use icu::datetime::fieldsets::{T, YMD};
+    /// use icu::datetime::fieldsets::enums::CompositeFieldSet;
+    /// use icu::datetime::input::{Date, Time};
+    /// use icu::datetime::FixedCalendarDateTimeFormatter;
+    /// use icu::datetime::DateTimeWriteError;
+    /// use icu::locale::locale;
+    /// use writeable::assert_try_writeable_eq;
+    ///
+    /// let formatter = FixedCalendarDateTimeFormatter::<Buddhist, YMD>::try_new(
+    ///     locale!("th").into(),
+    ///     YMD::long(),
+    /// )
+    /// .unwrap()
+    /// .cast_into_fset::<CompositeFieldSet>();
+    ///
+    /// // Create a date and convert it to the correct calendar:
+    /// let date = Date::try_new_iso(2025, 3, 7).unwrap().to_calendar(Buddhist);
+    ///
+    /// // Use it with format_unchecked:
+    /// let result = formatter.format_unchecked::<YMD, _>(&date);
+    ///
+    /// assert_try_writeable_eq!(result, "7 มีนาคม 2568");
+    ///
+    /// // We can try formatting a time, but it won't work!
+    /// let time = Time::try_new(17, 40, 0, 0).unwrap();
+    /// let result = formatter.format_unchecked::<T, _>(&time);
+    ///
+    /// // Note: The exact error is not guaranteed to be stable.
+    /// assert_try_writeable_eq!(
+    ///     result,
+    ///     "{d} {M} {G} {y}",
+    ///     Err(DateTimeWriteError::MissingInputField("day_of_month"))
+    /// );
+    /// ```
+    ///
+    /// [`Date`]: crate::input::Date
+    /// [`ZonedDateTime`]: crate::input::ZonedDateTime
+    /// [`YMD`]: crate::fieldsets::YMD
+    /// [`format_unchecked`]: Self::format_unchecked
+    pub fn format_unchecked<'a, InputFSet, I>(&'a self, datetime: &I) -> FormattedDateTimeTry<'a>
+    where
+        I: ?Sized + AllInputMarkers<InputFSet>,
+        InputFSet: DateTimeMarkers,
+        InputFSet::D: DateInputMarkers,
+        InputFSet::T: TimeMarkers,
+        InputFSet::Z: ZoneMarkers,
+    {
+        let datetime =
+            ExtractedInput::extract_from_neo_input::<InputFSet::D, InputFSet::T, InputFSet::Z, I>(
+                &datetime,
+            );
+        FormattedDateTimeTry {
+            pattern: self.selection.select(&datetime),
+            input: datetime,
+            names: self.names.as_borrowed(),
+        }
+    }
+}
+
 size_test!(
     DateTimeFormatter<crate::fieldsets::YMD>,
     neo_year_month_day_formatter_size,


### PR DESCRIPTION
Toward #5940 

In hindsight, this is a pretty obviously useful function. It took some experimentation until I arrived at it.