### PR TITLE
OPTION B: Add format_unchecked functions to DateTimeFormatter via DateTimeInputUnchecked

### DIFF
--- a/components/datetime/src/format/datetime.rs
+++ b/components/datetime/src/format/datetime.rs
@@ -4,7 +4,7 @@
 
 use super::time_zone::{FormatTimeZone, FormatTimeZoneError, Iso8601Format, TimeZoneFormatterUnit};
 use crate::error::{DateTimeWriteError, ErrorField};
-use crate::format::ExtractedInput;
+use crate::format::DateTimeInputUnchecked;
 use crate::provider::fields::{self, FieldLength, FieldSymbol, Second, Year};
 use crate::provider::pattern::runtime::PatternMetadata;
 use crate::provider::pattern::PatternItem;
@@ -66,7 +66,7 @@ where
 pub(crate) fn try_write_pattern_items<W>(
     pattern_metadata: PatternMetadata,
     pattern_items: impl Iterator<Item = PatternItem>,
-    input: &ExtractedInput,
+    input: &DateTimeInputUnchecked,
     datetime_names: &RawDateTimeNamesBorrowed,
     decimal_formatter: Option<&DecimalFormatter>,
     w: &mut W,
@@ -101,7 +101,7 @@ where
 fn try_write_field<W>(
     field: fields::Field,
     pattern_metadata: PatternMetadata,
-    input: &ExtractedInput,
+    input: &DateTimeInputUnchecked,
     datetime_names: &RawDateTimeNamesBorrowed,
     decimal_formatter: Option<&DecimalFormatter>,
     w: &mut W,
@@ -537,7 +537,7 @@ fn write_value_missing(
 
 fn perform_timezone_fallback(
     w: &mut (impl writeable::PartsWrite + ?Sized),
-    input: &ExtractedInput,
+    input: &DateTimeInputUnchecked,
     datetime_names: &RawDateTimeNamesBorrowed,
     fdf: Option<&DecimalFormatter>,
     field: fields::Field,

--- a/components/datetime/src/format/input.rs
+++ b/components/datetime/src/format/input.rs
@@ -5,6 +5,7 @@
 //! A collection of utilities for representing and working with dates as an input to
 //! formatting operations.
 
+use crate::fieldsets::enums::DateFieldSet;
 use crate::scaffold::{DateInputMarkers, GetField, TimeMarkers, ZoneMarkers};
 use icu_calendar::types::DayOfYearInfo;
 use icu_calendar::Iso;
@@ -16,6 +17,9 @@ use icu_time::{zone::UtcOffset, Time, TimeZone};
 
 // TODO(#2630) fix up imports to directly import from icu_calendar
 pub(crate) use icu_calendar::types::{DayOfMonth, MonthInfo, Weekday, YearInfo};
+
+#[cfg(doc)]
+use crate::input::*;
 
 /// An input bag with all possible datetime input fields.
 ///
@@ -57,6 +61,32 @@ pub struct DateTimeInputUnchecked {
 }
 
 impl DateTimeInputUnchecked {
+    /// Sets all date fields from an input.
+    ///
+    /// Example inputs: [`Date`], [`DateTime`]
+    pub fn set_date_fields<I>(&mut self, input: &I)
+    where
+        I: ?Sized
+            + GetField<<DateFieldSet as DateInputMarkers>::YearInput>
+            + GetField<<DateFieldSet as DateInputMarkers>::MonthInput>
+            + GetField<<DateFieldSet as DateInputMarkers>::DayOfMonthInput>
+            + GetField<<DateFieldSet as DateInputMarkers>::DayOfWeekInput>
+            + GetField<<DateFieldSet as DateInputMarkers>::DayOfYearInput>,
+    {
+        let fields = (
+            GetField::<<DateFieldSet as DateInputMarkers>::YearInput>::get_field(input),
+            GetField::<<DateFieldSet as DateInputMarkers>::MonthInput>::get_field(input),
+            GetField::<<DateFieldSet as DateInputMarkers>::DayOfMonthInput>::get_field(input),
+            GetField::<<DateFieldSet as DateInputMarkers>::DayOfWeekInput>::get_field(input),
+            GetField::<<DateFieldSet as DateInputMarkers>::DayOfYearInput>::get_field(input),
+        );
+        self.year = fields.0.into_option();
+        self.month = fields.1.into_option();
+        self.day_of_month = fields.2.into_option();
+        self.iso_weekday = fields.3.into_option();
+        self.day_of_year = fields.4.into_option();
+    }
+
     /// Construct given neo date input instances.
     pub(crate) fn extract_from_neo_input<D, T, Z, I>(input: &I) -> Self
     where

--- a/components/datetime/src/format/input.rs
+++ b/components/datetime/src/format/input.rs
@@ -5,7 +5,6 @@
 //! A collection of utilities for representing and working with dates as an input to
 //! formatting operations.
 
-use crate::fieldsets::enums::*;
 use crate::scaffold::*;
 use icu_calendar::types::DayOfYearInfo;
 use icu_calendar::{AsCalendar, Calendar, Iso};
@@ -60,42 +59,22 @@ pub struct DateTimeInputUnchecked {
     pub(crate) local_time: Option<(Date<Iso>, Time)>,
 }
 
-macro_rules! set_field {
-    ($type:ident as $trait:ident, $receiver:expr, $assoc_type:ident, $input:expr) => {
-        $receiver = GetField::<<$type as $trait>::$assoc_type>::get_field($input).into_option()
-    };
-    (@date, $receiver:expr, $assoc_type:ident, $input:expr) => {
-        set_field!(
-            DateFieldSet as DateInputMarkers,
-            $receiver,
-            $assoc_type,
-            $input
-        )
-    };
-    (@time, $receiver:expr, $assoc_type:ident, $input:expr) => {
-        set_field!(TimeFieldSet as TimeMarkers, $receiver, $assoc_type, $input)
-    };
-    (@zone, $receiver:expr, $assoc_type:ident, $input:expr) => {
-        set_field!(ZoneFieldSet as ZoneMarkers, $receiver, $assoc_type, $input)
-    };
-}
-
 impl DateTimeInputUnchecked {
     /// Sets all fields from a [`Date`] input.
     pub fn set_date_fields<C: Calendar, A: AsCalendar<Calendar = C>>(&mut self, input: Date<A>) {
-        set_field!(@date, self.year, YearInput, &input);
-        set_field!(@date, self.month, MonthInput, &input);
-        set_field!(@date, self.day_of_month, DayOfMonthInput, &input);
-        set_field!(@date, self.iso_weekday, DayOfWeekInput, &input);
-        set_field!(@date, self.day_of_year, DayOfYearInput, &input);
+        self.year = Some(input.year());
+        self.month = Some(input.month());
+        self.day_of_month = Some(input.day_of_month());
+        self.iso_weekday = Some(input.day_of_week());
+        self.day_of_year = Some(input.day_of_year_info());
     }
 
     /// Sets all fields from a [`Time`] input.
     pub fn set_time_fields(&mut self, input: Time) {
-        set_field!(@time, self.hour, HourInput, &input);
-        set_field!(@time, self.minute, MinuteInput, &input);
-        set_field!(@time, self.second, SecondInput, &input);
-        set_field!(@time, self.subsecond, NanosecondInput, &input);
+        self.hour = Some(input.hour);
+        self.minute = Some(input.minute);
+        self.second = Some(input.second);
+        self.subsecond = Some(input.subsecond);
     }
 
     /// Sets the time zone UTC offset.

--- a/components/datetime/src/format/input.rs
+++ b/components/datetime/src/format/input.rs
@@ -18,21 +18,41 @@ use icu_time::{zone::UtcOffset, Time, TimeZone};
 pub(crate) use icu_calendar::types::{DayOfMonth, MonthInfo, Weekday, YearInfo};
 
 /// An input bag with all possible datetime input fields.
+/// 
+/// Each input field may or may not be required, depending on the field set
+/// and the options.
 #[derive(Debug, Copy, Clone, Default)]
 #[non_exhaustive]
 pub struct DateTimeInputUnchecked {
+    /// The year, required for field sets with years (`Y`).
     pub year: Option<YearInfo>,
+    /// The month, required for field sets with months (`M`)
     pub month: Option<MonthInfo>,
+    /// The day-of-month, required for field sets with days (`D`).
     pub day_of_month: Option<DayOfMonth>,
+    /// The weekday, required for field sets with weekdays (`E`).
     pub iso_weekday: Option<Weekday>,
+    /// The day-of-year, required for field sets with weeks.
     pub day_of_year: Option<DayOfYearInfo>,
+    /// The hour, required for field sets with times (`T`).
     pub hour: Option<Hour>,
+    /// The minute, required for field sets with times (`T`).
     pub minute: Option<Minute>,
+    /// The second, required for field sets with times (`T`).
     pub second: Option<Second>,
+    /// The subsecond, required for field sets with times (`T`).
     pub subsecond: Option<Nanosecond>,
+    /// The time zone ID, required for field sets with
+    /// certain time zone styles.
     pub time_zone_id: Option<TimeZone>,
+    /// The time zone UTC offset, required for field sets with
+    /// certain time zone styles.
     pub offset: Option<UtcOffset>,
+    /// The time zone variant, required for field sets with
+    /// certain time zone styles.
     pub zone_variant: Option<TimeZoneVariant>,
+    /// The local ISO time, required for field sets with
+    /// certain time zone styles.
     pub local_time: Option<(Date<Iso>, Time)>,
 }
 

--- a/components/datetime/src/format/input.rs
+++ b/components/datetime/src/format/input.rs
@@ -17,21 +17,23 @@ use icu_time::{zone::UtcOffset, Time, TimeZone};
 // TODO(#2630) fix up imports to directly import from icu_calendar
 pub(crate) use icu_calendar::types::{DayOfMonth, MonthInfo, Weekday, YearInfo};
 
-#[derive(Debug, Copy, Clone)]
-pub(crate) struct DateTimeInputUnchecked {
-    pub(crate) year: Option<YearInfo>,
-    pub(crate) month: Option<MonthInfo>,
-    pub(crate) day_of_month: Option<DayOfMonth>,
-    pub(crate) iso_weekday: Option<Weekday>,
-    pub(crate) day_of_year: Option<DayOfYearInfo>,
-    pub(crate) hour: Option<Hour>,
-    pub(crate) minute: Option<Minute>,
-    pub(crate) second: Option<Second>,
-    pub(crate) subsecond: Option<Nanosecond>,
-    pub(crate) time_zone_id: Option<TimeZone>,
-    pub(crate) offset: Option<UtcOffset>,
-    pub(crate) zone_variant: Option<TimeZoneVariant>,
-    pub(crate) local_time: Option<(Date<Iso>, Time)>,
+/// An input bag with all possible datetime input fields.
+#[derive(Debug, Copy, Clone, Default)]
+#[non_exhaustive]
+pub struct DateTimeInputUnchecked {
+    pub year: Option<YearInfo>,
+    pub month: Option<MonthInfo>,
+    pub day_of_month: Option<DayOfMonth>,
+    pub iso_weekday: Option<Weekday>,
+    pub day_of_year: Option<DayOfYearInfo>,
+    pub hour: Option<Hour>,
+    pub minute: Option<Minute>,
+    pub second: Option<Second>,
+    pub subsecond: Option<Nanosecond>,
+    pub time_zone_id: Option<TimeZone>,
+    pub offset: Option<UtcOffset>,
+    pub zone_variant: Option<TimeZoneVariant>,
+    pub local_time: Option<(Date<Iso>, Time)>,
 }
 
 impl DateTimeInputUnchecked {

--- a/components/datetime/src/format/input.rs
+++ b/components/datetime/src/format/input.rs
@@ -10,8 +10,6 @@ use crate::scaffold::*;
 use icu_calendar::types::DayOfYearInfo;
 use icu_calendar::{AsCalendar, Calendar, Iso};
 use icu_time::scaffold::IntoOption;
-use icu_time::zone::models;
-use icu_time::TimeZoneInfo;
 use icu_time::{zone::TimeZoneVariant, Hour, Minute, Nanosecond, Second};
 
 use icu_calendar::Date;
@@ -100,30 +98,24 @@ impl DateTimeInputUnchecked {
         set_field!(@time, self.subsecond, NanosecondInput, &input);
     }
 
-    /// Sets all fields from a [`UtcOffset`] input.
-    pub fn set_zone_fields_utc_offset(&mut self, input: UtcOffset) {
-        set_field!(@zone, self.offset, TimeZoneOffsetInput, &input);
+    /// Sets the time zone UTC offset.
+    pub fn set_time_zone_utc_offset(&mut self, offset: UtcOffset) {
+        self.offset = Some(offset);
     }
 
-    /// Sets all fields from a [`TimeZoneInfo<Base>`] input.
-    pub fn set_zone_fields_base(&mut self, input: TimeZoneInfo<models::Base>) {
-        set_field!(@zone, self.time_zone_id, TimeZoneIdInput, &input);
-        set_field!(@zone, self.offset, TimeZoneOffsetInput, &input);
+    /// Sets the time zone ID.
+    pub fn set_time_zone_id(&mut self, id: TimeZone) {
+        self.time_zone_id = Some(id);
     }
 
-    /// Sets all fields from a [`TimeZoneInfo<AtTime>`] input.
-    pub fn set_zone_fields_at_time(&mut self, input: TimeZoneInfo<models::AtTime>) {
-        set_field!(@zone, self.time_zone_id, TimeZoneIdInput, &input);
-        set_field!(@zone, self.offset, TimeZoneOffsetInput, &input);
-        set_field!(@zone, self.local_time, TimeZoneLocalTimeInput, &input);
+    /// Sets the local time for time zone name resolution.
+    pub fn set_time_zone_local_time(&mut self, local_time: (Date<Iso>, Time)) {
+        self.local_time = Some(local_time);
     }
 
-    /// Sets all fields from a [`TimeZoneInfo<Full>`] input.
-    pub fn set_zone_fields_full(&mut self, input: TimeZoneInfo<models::Full>) {
-        set_field!(@zone, self.time_zone_id, TimeZoneIdInput, &input);
-        set_field!(@zone, self.offset, TimeZoneOffsetInput, &input);
-        set_field!(@zone, self.zone_variant, TimeZoneVariantInput, &input);
-        set_field!(@zone, self.local_time, TimeZoneLocalTimeInput, &input);
+    /// Sets the time zone variant.
+    pub fn set_time_zone_variant(&mut self, zone_variant: TimeZoneVariant) {
+        self.zone_variant = Some(zone_variant);
     }
 
     /// Construct given neo date input instances.

--- a/components/datetime/src/format/input.rs
+++ b/components/datetime/src/format/input.rs
@@ -18,7 +18,7 @@ use icu_time::{zone::UtcOffset, Time, TimeZone};
 pub(crate) use icu_calendar::types::{DayOfMonth, MonthInfo, Weekday, YearInfo};
 
 /// An input bag with all possible datetime input fields.
-/// 
+///
 /// Each input field may or may not be required, depending on the field set
 /// and the options.
 #[derive(Debug, Copy, Clone, Default)]

--- a/components/datetime/src/format/input.rs
+++ b/components/datetime/src/format/input.rs
@@ -18,7 +18,7 @@ use icu_time::{zone::UtcOffset, Time, TimeZone};
 pub(crate) use icu_calendar::types::{DayOfMonth, MonthInfo, Weekday, YearInfo};
 
 #[derive(Debug, Copy, Clone)]
-pub(crate) struct ExtractedInput {
+pub(crate) struct DateTimeInputUnchecked {
     pub(crate) year: Option<YearInfo>,
     pub(crate) month: Option<MonthInfo>,
     pub(crate) day_of_month: Option<DayOfMonth>,
@@ -34,7 +34,7 @@ pub(crate) struct ExtractedInput {
     pub(crate) local_time: Option<(Date<Iso>, Time)>,
 }
 
-impl ExtractedInput {
+impl DateTimeInputUnchecked {
     /// Construct given neo date input instances.
     pub(crate) fn extract_from_neo_input<D, T, Z, I>(input: &I) -> Self
     where

--- a/components/datetime/src/format/mod.rs
+++ b/components/datetime/src/format/mod.rs
@@ -5,4 +5,4 @@
 pub(crate) mod datetime;
 mod input;
 pub(crate) mod time_zone;
-pub(crate) use input::ExtractedInput;
+pub(crate) use input::DateTimeInputUnchecked;

--- a/components/datetime/src/format/mod.rs
+++ b/components/datetime/src/format/mod.rs
@@ -5,4 +5,4 @@
 pub(crate) mod datetime;
 mod input;
 pub(crate) mod time_zone;
-pub(crate) use input::DateTimeInputUnchecked;
+pub use input::DateTimeInputUnchecked;

--- a/components/datetime/src/format/time_zone.rs
+++ b/components/datetime/src/format/time_zone.rs
@@ -6,7 +6,7 @@
 
 use crate::pattern::TimeZoneDataPayloadsBorrowed;
 use crate::provider::time_zones::MetazoneId;
-use crate::{format::ExtractedInput, provider::fields::FieldLength};
+use crate::{format::DateTimeInputUnchecked, provider::fields::FieldLength};
 use core::fmt;
 use fixed_decimal::Decimal;
 use icu_calendar::{Date, Iso};
@@ -64,7 +64,7 @@ pub(super) trait FormatTimeZone {
     fn format<W: writeable::PartsWrite + ?Sized>(
         &self,
         sink: &mut W,
-        input: &ExtractedInput,
+        input: &DateTimeInputUnchecked,
         data_payloads: TimeZoneDataPayloadsBorrowed,
         fdf: Option<&DecimalFormatter>,
     ) -> Result<Result<(), FormatTimeZoneError>, fmt::Error>;
@@ -74,7 +74,7 @@ impl FormatTimeZone for TimeZoneFormatterUnit {
     fn format<W: writeable::PartsWrite + ?Sized>(
         &self,
         sink: &mut W,
-        input: &ExtractedInput,
+        input: &DateTimeInputUnchecked,
         data_payloads: TimeZoneDataPayloadsBorrowed,
         fdf: Option<&DecimalFormatter>,
     ) -> Result<Result<(), FormatTimeZoneError>, fmt::Error> {
@@ -111,7 +111,7 @@ impl FormatTimeZone for GenericNonLocationFormat {
     fn format<W: writeable::PartsWrite + ?Sized>(
         &self,
         sink: &mut W,
-        input: &ExtractedInput,
+        input: &DateTimeInputUnchecked,
         data_payloads: TimeZoneDataPayloadsBorrowed,
         _fdf: Option<&DecimalFormatter>,
     ) -> Result<Result<(), FormatTimeZoneError>, fmt::Error> {
@@ -167,7 +167,7 @@ impl FormatTimeZone for SpecificNonLocationFormat {
     fn format<W: writeable::PartsWrite + ?Sized>(
         &self,
         sink: &mut W,
-        input: &ExtractedInput,
+        input: &DateTimeInputUnchecked,
         data_payloads: TimeZoneDataPayloadsBorrowed,
         _fdf: Option<&DecimalFormatter>,
     ) -> Result<Result<(), FormatTimeZoneError>, fmt::Error> {
@@ -251,7 +251,7 @@ impl FormatTimeZone for LocalizedOffsetFormat {
     fn format<W: writeable::PartsWrite + ?Sized>(
         &self,
         sink: &mut W,
-        input: &ExtractedInput,
+        input: &DateTimeInputUnchecked,
         data_payloads: TimeZoneDataPayloadsBorrowed,
         formatter: Option<&DecimalFormatter>,
     ) -> Result<Result<(), FormatTimeZoneError>, fmt::Error> {
@@ -340,7 +340,7 @@ impl FormatTimeZone for GenericLocationFormat {
     fn format<W: writeable::PartsWrite + ?Sized>(
         &self,
         sink: &mut W,
-        input: &ExtractedInput,
+        input: &DateTimeInputUnchecked,
         data_payloads: TimeZoneDataPayloadsBorrowed,
         _decimal_formatter: Option<&DecimalFormatter>,
     ) -> Result<Result<(), FormatTimeZoneError>, fmt::Error> {
@@ -383,7 +383,7 @@ impl FormatTimeZone for SpecificLocationFormat {
     fn format<W: writeable::PartsWrite + ?Sized>(
         &self,
         sink: &mut W,
-        input: &ExtractedInput,
+        input: &DateTimeInputUnchecked,
         data_payloads: TimeZoneDataPayloadsBorrowed,
         _decimal_formatter: Option<&DecimalFormatter>,
     ) -> Result<Result<(), FormatTimeZoneError>, fmt::Error> {
@@ -431,7 +431,7 @@ impl FormatTimeZone for ExemplarCityFormat {
     fn format<W: writeable::PartsWrite + ?Sized>(
         &self,
         sink: &mut W,
-        input: &ExtractedInput,
+        input: &DateTimeInputUnchecked,
         data_payloads: TimeZoneDataPayloadsBorrowed,
         _fdf: Option<&DecimalFormatter>,
     ) -> Result<Result<(), FormatTimeZoneError>, fmt::Error> {
@@ -478,7 +478,7 @@ impl FormatTimeZone for GenericPartialLocationFormat {
     fn format<W: writeable::PartsWrite + ?Sized>(
         &self,
         sink: &mut W,
-        input: &ExtractedInput,
+        input: &DateTimeInputUnchecked,
         data_payloads: TimeZoneDataPayloadsBorrowed,
         _fdf: Option<&DecimalFormatter>,
     ) -> Result<Result<(), FormatTimeZoneError>, fmt::Error> {
@@ -645,7 +645,7 @@ impl FormatTimeZone for Iso8601Format {
     fn format<W: writeable::PartsWrite + ?Sized>(
         &self,
         sink: &mut W,
-        input: &ExtractedInput,
+        input: &DateTimeInputUnchecked,
         _data_payloads: TimeZoneDataPayloadsBorrowed,
         _fdf: Option<&DecimalFormatter>,
     ) -> Result<Result<(), FormatTimeZoneError>, fmt::Error> {
@@ -713,7 +713,7 @@ impl FormatTimeZone for Bcp47IdFormat {
     fn format<W: writeable::PartsWrite + ?Sized>(
         &self,
         sink: &mut W,
-        input: &ExtractedInput,
+        input: &DateTimeInputUnchecked,
         _data_payloads: TimeZoneDataPayloadsBorrowed,
         _fdf: Option<&DecimalFormatter>,
     ) -> Result<Result<(), FormatTimeZoneError>, fmt::Error> {

--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -108,6 +108,7 @@ pub(crate) mod size_test_macro;
 
 pub use error::{DateTimeFormatterLoadError, DateTimeWriteError, MismatchedCalendarError};
 
+pub use format::DateTimeInputUnchecked;
 pub use neo::DateTimeFormatter;
 pub use neo::DateTimeFormatterPreferences;
 pub use neo::FixedCalendarDateTimeFormatter;

--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -113,6 +113,7 @@ pub use neo::DateTimeFormatter;
 pub use neo::DateTimeFormatterPreferences;
 pub use neo::FixedCalendarDateTimeFormatter;
 pub use neo::FormattedDateTime;
+pub use neo::FormattedDateTimeTry;
 pub use neo::NoCalendarFormatter;
 pub use options::Length;
 

--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -113,7 +113,7 @@ pub use neo::DateTimeFormatter;
 pub use neo::DateTimeFormatterPreferences;
 pub use neo::FixedCalendarDateTimeFormatter;
 pub use neo::FormattedDateTime;
-pub use neo::FormattedDateTimeTry;
+pub use neo::FormattedDateTimeUnchecked;
 pub use neo::NoCalendarFormatter;
 pub use options::Length;
 

--- a/components/datetime/src/neo.rs
+++ b/components/datetime/src/neo.rs
@@ -764,10 +764,7 @@ impl<FSet: DateTimeNamesMarker> DateTimeFormatter<FSet> {
     /// [`ZonedDateTime`]: crate::input::ZonedDateTime
     /// [`YMD`]: crate::fieldsets::YMD
     /// [`format_unchecked`]: Self::format_unchecked
-    pub fn format_unchecked(
-        &self,
-        datetime: DateTimeInputUnchecked,
-    ) -> FormattedDateTimeTry {
+    pub fn format_unchecked(&self, datetime: DateTimeInputUnchecked) -> FormattedDateTimeTry {
         FormattedDateTimeTry {
             pattern: self.selection.select(&datetime),
             input: datetime,

--- a/components/datetime/src/neo.rs
+++ b/components/datetime/src/neo.rs
@@ -5,7 +5,6 @@
 //! High-level entrypoints for Neo DateTime Formatter
 
 use crate::error::DateTimeFormatterLoadError;
-use crate::external_loaders::*;
 use crate::fieldsets::builder::FieldSetBuilder;
 use crate::fieldsets::enums::CompositeFieldSet;
 use crate::format::datetime::try_write_pattern_items;
@@ -20,6 +19,7 @@ use crate::scaffold::{
 };
 use crate::size_test_macro::size_test;
 use crate::MismatchedCalendarError;
+use crate::{external_loaders::*, DateTimeWriteError};
 use core::fmt;
 use core::marker::PhantomData;
 use icu_calendar::any_calendar::IntoAnyCalendar;
@@ -27,7 +27,7 @@ use icu_calendar::{AnyCalendar, AnyCalendarPreferences};
 use icu_decimal::DecimalFormatterPreferences;
 use icu_locale_core::preferences::{define_preferences, prefs_convert};
 use icu_provider::prelude::*;
-use writeable::{impl_display_with_writeable, Writeable};
+use writeable::{impl_display_with_writeable, TryWriteable, Writeable};
 
 define_preferences!(
     /// The user locale preferences for datetime formatting.
@@ -356,7 +356,8 @@ where
     where
         I: ?Sized + InFixedCalendar<C> + AllInputMarkers<FSet>,
     {
-        let input = DateTimeInputUnchecked::extract_from_neo_input::<FSet::D, FSet::T, FSet::Z, I>(input);
+        let input =
+            DateTimeInputUnchecked::extract_from_neo_input::<FSet::D, FSet::T, FSet::Z, I>(input);
         FormattedDateTime {
             pattern: self.selection.select(&input),
             input,
@@ -622,8 +623,9 @@ where
         I: ?Sized + InSameCalendar + AllInputMarkers<FSet>,
     {
         datetime.check_any_calendar_kind(self.calendar.kind())?;
-        let datetime =
-            DateTimeInputUnchecked::extract_from_neo_input::<FSet::D, FSet::T, FSet::Z, I>(datetime);
+        let datetime = DateTimeInputUnchecked::extract_from_neo_input::<FSet::D, FSet::T, FSet::Z, I>(
+            datetime,
+        );
         Ok(FormattedDateTime {
             pattern: self.selection.select(&datetime),
             input: datetime,
@@ -680,11 +682,93 @@ where
         I::Converted<'a>: Sized + AllInputMarkers<FSet>,
     {
         let datetime = datetime.to_calendar(&self.calendar);
-        let datetime =
-            DateTimeInputUnchecked::extract_from_neo_input::<FSet::D, FSet::T, FSet::Z, I::Converted<'a>>(
-                &datetime,
-            );
+        let datetime = DateTimeInputUnchecked::extract_from_neo_input::<
+            FSet::D,
+            FSet::T,
+            FSet::Z,
+            I::Converted<'a>,
+        >(&datetime);
         FormattedDateTime {
+            pattern: self.selection.select(&datetime),
+            input: datetime,
+            names: self.names.as_borrowed(),
+        }
+    }
+}
+
+impl<FSet: DateTimeNamesMarker> DateTimeFormatter<FSet> {
+    /// Formats a datetime without enforcing either the field set or the calendar.
+    ///
+    /// This function is useful when the caller knows something about the field set that the
+    /// type system is unaware of. For example, if the formatter is represented with a
+    /// [dynamic field set](crate::fieldsets::enums), the caller may be able to provide a
+    /// narrower type for formatting.
+    ///
+    /// ❗ The caller must ensure that:
+    ///
+    /// 1. The calendar of the input matches the calendar of the formatter
+    /// 2. The fields of the input are a superset of the fields of the formatter
+    ///
+    /// Returns a [`FormattedDateTimeTry`] to surface errors when they occur,
+    /// but not every invariant will result in an error. Use with caution!
+    ///
+    /// # Examples
+    ///
+    /// In the following example, we know that the formatter's field set is [`YMD`], but the
+    /// type system thinks we are a [`CompositeFieldSet`], which requires a [`ZonedDateTime`]
+    /// as input. However, since [`Date`] contains all the fields required by [`YMD`], we can
+    /// successfully pass it into [`format_unchecked`].
+    ///
+    /// ```
+    /// use icu::datetime::fieldsets::{T, YMD};
+    /// use icu::datetime::fieldsets::enums::CompositeFieldSet;
+    /// use icu::datetime::input::{Date, Time};
+    /// use icu::datetime::DateTimeFormatter;
+    /// use icu::datetime::DateTimeWriteError;
+    /// use icu::datetime::DateTimeInputUnchecked;
+    /// use icu::locale::locale;
+    /// use writeable::assert_try_writeable_eq;
+    ///
+    /// let formatter = DateTimeFormatter::try_new(
+    ///     locale!("th").into(),
+    ///     YMD::long(),
+    /// )
+    /// .unwrap()
+    /// .cast_into_fset::<CompositeFieldSet>();
+    ///
+    /// // Create a date and convert it to the correct calendar:
+    /// let date = Date::try_new_iso(2025, 3, 7).unwrap().to_calendar(formatter.calendar());
+    ///
+    /// // Extract the fields and use it with format_unchecked:
+    /// let mut input = DateTimeInputUnchecked::default();
+    /// input.year = Some(date.year());
+    /// input.month = Some(date.month());
+    /// input.day_of_month = Some(date.day_of_month());
+    /// let result = formatter.format_unchecked(input);
+    ///
+    /// assert_try_writeable_eq!(result, "7 มีนาคม 2568");
+    ///
+    /// // If we don't give all needed fields, we will get an error!
+    /// let mut input = DateTimeInputUnchecked::default();
+    /// input.year = Some(date.year());
+    /// input.month = Some(date.month());
+    /// let result = formatter.format_unchecked(input);
+    /// assert_try_writeable_eq!(
+    ///     result,
+    ///     "{d} มีนาคม 2568",
+    ///     Err(DateTimeWriteError::MissingInputField("day_of_month"))
+    /// );
+    /// ```
+    ///
+    /// [`Date`]: crate::input::Date
+    /// [`ZonedDateTime`]: crate::input::ZonedDateTime
+    /// [`YMD`]: crate::fieldsets::YMD
+    /// [`format_unchecked`]: Self::format_unchecked
+    pub fn format_unchecked<'a>(
+        &'a self,
+        datetime: DateTimeInputUnchecked,
+    ) -> FormattedDateTimeTry<'a> {
+        FormattedDateTimeTry {
             pattern: self.selection.select(&datetime),
             input: datetime,
             names: self.names.as_borrowed(),
@@ -1089,6 +1173,47 @@ impl Writeable for FormattedDateTime<'_> {
 impl_display_with_writeable!(FormattedDateTime<'_>);
 
 impl FormattedDateTime<'_> {
+    /// Gets the pattern used in this formatted value.
+    ///
+    /// From the pattern, one can check the properties of the included components, such as
+    /// the hour cycle being used for formatting. See [`DateTimePattern`].
+    pub fn pattern(&self) -> DateTimePattern {
+        self.pattern.to_pattern()
+    }
+}
+
+/// An intermediate type during a datetime formatting operation with dynamic input.
+///
+/// Unlike [`FormattedDateTime`], converting this to a string could fail.
+///
+/// Not intended to be stored: convert to a string first.
+#[derive(Debug)]
+pub struct FormattedDateTimeTry<'a> {
+    pattern: DateTimeZonePatternDataBorrowed<'a>,
+    input: DateTimeInputUnchecked,
+    names: RawDateTimeNamesBorrowed<'a>,
+}
+
+impl TryWriteable for FormattedDateTimeTry<'_> {
+    type Error = DateTimeWriteError;
+    fn try_write_to_parts<S: writeable::PartsWrite + ?Sized>(
+        &self,
+        sink: &mut S,
+    ) -> Result<Result<(), Self::Error>, fmt::Error> {
+        try_write_pattern_items(
+            self.pattern.metadata(),
+            self.pattern.iter_items(),
+            &self.input,
+            &self.names,
+            self.names.decimal_formatter,
+            sink,
+        )
+    }
+
+    // TODO(#489): Implement writeable_length_hint
+}
+
+impl FormattedDateTimeTry<'_> {
     /// Gets the pattern used in this formatted value.
     ///
     /// From the pattern, one can check the properties of the included components, such as

--- a/components/datetime/src/neo.rs
+++ b/components/datetime/src/neo.rs
@@ -379,7 +379,7 @@ impl<C: CldrCalendar, FSet: DateTimeNamesMarker> FixedCalendarDateTimeFormatter<
     /// 1. The calendar of the input matches the calendar of the formatter
     /// 2. The fields of the input are a superset of the fields of the formatter
     ///
-    /// Returns a [`FormattedDateTimeTry`] to surface errors when they occur,
+    /// Returns a [`FormattedDateTimeUnchecked`] to surface errors when they occur,
     /// but not every invariant will result in an error. Use with caution!
     ///
     /// # Examples
@@ -431,8 +431,8 @@ impl<C: CldrCalendar, FSet: DateTimeNamesMarker> FixedCalendarDateTimeFormatter<
     /// [`ZonedDateTime`]: crate::input::ZonedDateTime
     /// [`YMD`]: crate::fieldsets::YMD
     /// [`format_unchecked`]: Self::format_unchecked
-    pub fn format_unchecked(&self, datetime: DateTimeInputUnchecked) -> FormattedDateTimeTry {
-        FormattedDateTimeTry {
+    pub fn format_unchecked(&self, datetime: DateTimeInputUnchecked) -> FormattedDateTimeUnchecked {
+        FormattedDateTimeUnchecked {
             pattern: self.selection.select(&datetime),
             input: datetime,
             names: self.names.as_borrowed(),
@@ -783,7 +783,7 @@ impl<FSet: DateTimeNamesMarker> DateTimeFormatter<FSet> {
     /// 1. The calendar of the input matches the calendar of the formatter
     /// 2. The fields of the input are a superset of the fields of the formatter
     ///
-    /// Returns a [`FormattedDateTimeTry`] to surface errors when they occur,
+    /// Returns a [`FormattedDateTimeUnchecked`] to surface errors when they occur,
     /// but not every invariant will result in an error. Use with caution!
     ///
     /// # Examples
@@ -834,8 +834,8 @@ impl<FSet: DateTimeNamesMarker> DateTimeFormatter<FSet> {
     /// [`ZonedDateTime`]: crate::input::ZonedDateTime
     /// [`YMD`]: crate::fieldsets::YMD
     /// [`format_unchecked`]: Self::format_unchecked
-    pub fn format_unchecked(&self, datetime: DateTimeInputUnchecked) -> FormattedDateTimeTry {
-        FormattedDateTimeTry {
+    pub fn format_unchecked(&self, datetime: DateTimeInputUnchecked) -> FormattedDateTimeUnchecked {
+        FormattedDateTimeUnchecked {
             pattern: self.selection.select(&datetime),
             input: datetime,
             names: self.names.as_borrowed(),
@@ -1255,13 +1255,13 @@ impl FormattedDateTime<'_> {
 ///
 /// Not intended to be stored: convert to a string first.
 #[derive(Debug)]
-pub struct FormattedDateTimeTry<'a> {
+pub struct FormattedDateTimeUnchecked<'a> {
     pattern: DateTimeZonePatternDataBorrowed<'a>,
     input: DateTimeInputUnchecked,
     names: RawDateTimeNamesBorrowed<'a>,
 }
 
-impl TryWriteable for FormattedDateTimeTry<'_> {
+impl TryWriteable for FormattedDateTimeUnchecked<'_> {
     type Error = DateTimeWriteError;
     fn try_write_to_parts<S: writeable::PartsWrite + ?Sized>(
         &self,
@@ -1280,7 +1280,7 @@ impl TryWriteable for FormattedDateTimeTry<'_> {
     // TODO(#489): Implement writeable_length_hint
 }
 
-impl FormattedDateTimeTry<'_> {
+impl FormattedDateTimeUnchecked<'_> {
     /// Gets the pattern used in this formatted value.
     ///
     /// From the pattern, one can check the properties of the included components, such as

--- a/components/datetime/src/neo.rs
+++ b/components/datetime/src/neo.rs
@@ -764,10 +764,10 @@ impl<FSet: DateTimeNamesMarker> DateTimeFormatter<FSet> {
     /// [`ZonedDateTime`]: crate::input::ZonedDateTime
     /// [`YMD`]: crate::fieldsets::YMD
     /// [`format_unchecked`]: Self::format_unchecked
-    pub fn format_unchecked<'a>(
-        &'a self,
+    pub fn format_unchecked(
+        &self,
         datetime: DateTimeInputUnchecked,
-    ) -> FormattedDateTimeTry<'a> {
+    ) -> FormattedDateTimeTry {
         FormattedDateTimeTry {
             pattern: self.selection.select(&datetime),
             input: datetime,

--- a/components/datetime/src/neo.rs
+++ b/components/datetime/src/neo.rs
@@ -412,21 +412,17 @@ impl<C: CldrCalendar, FSet: DateTimeNamesMarker> FixedCalendarDateTimeFormatter<
     ///
     /// // Extract the fields and use it with format_unchecked:
     /// let mut input = DateTimeInputUnchecked::default();
-    /// input.year = Some(date.year());
-    /// input.month = Some(date.month());
-    /// input.day_of_month = Some(date.day_of_month());
+    /// input.set_date_fields(date);
     /// let result = formatter.format_unchecked(input);
     ///
     /// assert_try_writeable_eq!(result, "7 มีนาคม 2568");
     ///
     /// // If we don't give all needed fields, we will get an error!
     /// let mut input = DateTimeInputUnchecked::default();
-    /// input.year = Some(date.year());
-    /// input.month = Some(date.month());
     /// let result = formatter.format_unchecked(input);
     /// assert_try_writeable_eq!(
     ///     result,
-    ///     "{d} มีนาคม 2568",
+    ///     "{d} {M} {G} {y}",
     ///     Err(DateTimeWriteError::MissingInputField("day_of_month"))
     /// );
     /// ```
@@ -819,21 +815,17 @@ impl<FSet: DateTimeNamesMarker> DateTimeFormatter<FSet> {
     ///
     /// // Extract the fields and use it with format_unchecked:
     /// let mut input = DateTimeInputUnchecked::default();
-    /// input.year = Some(date.year());
-    /// input.month = Some(date.month());
-    /// input.day_of_month = Some(date.day_of_month());
+    /// input.set_date_fields(date);
     /// let result = formatter.format_unchecked(input);
     ///
     /// assert_try_writeable_eq!(result, "7 มีนาคม 2568");
     ///
     /// // If we don't give all needed fields, we will get an error!
     /// let mut input = DateTimeInputUnchecked::default();
-    /// input.year = Some(date.year());
-    /// input.month = Some(date.month());
     /// let result = formatter.format_unchecked(input);
     /// assert_try_writeable_eq!(
     ///     result,
-    ///     "{d} มีนาคม 2568",
+    ///     "{d} {M} {G} {y}",
     ///     Err(DateTimeWriteError::MissingInputField("day_of_month"))
     /// );
     /// ```

--- a/components/datetime/src/neo.rs
+++ b/components/datetime/src/neo.rs
@@ -9,7 +9,7 @@ use crate::external_loaders::*;
 use crate::fieldsets::builder::FieldSetBuilder;
 use crate::fieldsets::enums::CompositeFieldSet;
 use crate::format::datetime::try_write_pattern_items;
-use crate::format::ExtractedInput;
+use crate::format::DateTimeInputUnchecked;
 use crate::pattern::*;
 use crate::preferences::{CalendarAlgorithm, HourCycle, NumberingSystem};
 use crate::raw::neo::*;
@@ -356,7 +356,7 @@ where
     where
         I: ?Sized + InFixedCalendar<C> + AllInputMarkers<FSet>,
     {
-        let input = ExtractedInput::extract_from_neo_input::<FSet::D, FSet::T, FSet::Z, I>(input);
+        let input = DateTimeInputUnchecked::extract_from_neo_input::<FSet::D, FSet::T, FSet::Z, I>(input);
         FormattedDateTime {
             pattern: self.selection.select(&input),
             input,
@@ -623,7 +623,7 @@ where
     {
         datetime.check_any_calendar_kind(self.calendar.kind())?;
         let datetime =
-            ExtractedInput::extract_from_neo_input::<FSet::D, FSet::T, FSet::Z, I>(datetime);
+            DateTimeInputUnchecked::extract_from_neo_input::<FSet::D, FSet::T, FSet::Z, I>(datetime);
         Ok(FormattedDateTime {
             pattern: self.selection.select(&datetime),
             input: datetime,
@@ -681,7 +681,7 @@ where
     {
         let datetime = datetime.to_calendar(&self.calendar);
         let datetime =
-            ExtractedInput::extract_from_neo_input::<FSet::D, FSet::T, FSet::Z, I::Converted<'a>>(
+            DateTimeInputUnchecked::extract_from_neo_input::<FSet::D, FSet::T, FSet::Z, I::Converted<'a>>(
                 &datetime,
             );
         FormattedDateTime {
@@ -1052,7 +1052,7 @@ pub type NoCalendarFormatter<FSet> = FixedCalendarDateTimeFormatter<(), FSet>;
 #[derive(Debug)]
 pub struct FormattedDateTime<'a> {
     pattern: DateTimeZonePatternDataBorrowed<'a>,
-    input: ExtractedInput,
+    input: DateTimeInputUnchecked,
     names: RawDateTimeNamesBorrowed<'a>,
 }
 

--- a/components/datetime/src/pattern/formatter.rs
+++ b/components/datetime/src/pattern/formatter.rs
@@ -210,7 +210,9 @@ where
     {
         FormattedDateTimePattern {
             pattern: self.inner.pattern,
-            input: DateTimeInputUnchecked::extract_from_neo_input::<FSet::D, FSet::T, FSet::Z, I>(datetime),
+            input: DateTimeInputUnchecked::extract_from_neo_input::<FSet::D, FSet::T, FSet::Z, I>(
+                datetime,
+            ),
             names: self.inner.names,
         }
     }

--- a/components/datetime/src/pattern/formatter.rs
+++ b/components/datetime/src/pattern/formatter.rs
@@ -5,7 +5,7 @@
 use super::names::RawDateTimeNamesBorrowed;
 use super::pattern::DateTimePatternBorrowed;
 use crate::format::datetime::try_write_pattern_items;
-use crate::format::ExtractedInput;
+use crate::format::DateTimeInputUnchecked;
 use crate::scaffold::*;
 use crate::scaffold::{
     AllInputMarkers, DateInputMarkers, DateTimeMarkers, InFixedCalendar, TimeMarkers,
@@ -210,7 +210,7 @@ where
     {
         FormattedDateTimePattern {
             pattern: self.inner.pattern,
-            input: ExtractedInput::extract_from_neo_input::<FSet::D, FSet::T, FSet::Z, I>(datetime),
+            input: DateTimeInputUnchecked::extract_from_neo_input::<FSet::D, FSet::T, FSet::Z, I>(datetime),
             names: self.inner.names,
         }
     }
@@ -220,7 +220,7 @@ where
 #[derive(Debug)]
 pub struct FormattedDateTimePattern<'a> {
     pattern: DateTimePatternBorrowed<'a>,
-    input: ExtractedInput,
+    input: DateTimeInputUnchecked,
     names: RawDateTimeNamesBorrowed<'a>,
 }
 

--- a/components/datetime/src/raw/neo.rs
+++ b/components/datetime/src/raw/neo.rs
@@ -4,7 +4,7 @@
 
 use crate::fieldsets::builder;
 use crate::fieldsets::enums::{CompositeFieldSet, TimeFieldSet, ZoneFieldSet};
-use crate::format::ExtractedInput;
+use crate::format::DateTimeInputUnchecked;
 use crate::options::*;
 use crate::pattern::DateTimePattern;
 use crate::provider::fields::{self, Field, FieldLength, FieldSymbol};
@@ -177,7 +177,7 @@ impl DatePatternSelectionData {
     /// Borrows a resolved pattern based on the given datetime
     pub(crate) fn select(
         &self,
-        input: &ExtractedInput,
+        input: &DateTimeInputUnchecked,
         options: RawOptions,
     ) -> Option<DatePatternDataBorrowed> {
         let payload = self.payload.get_option()?;
@@ -206,7 +206,7 @@ impl DatePatternSelectionData {
     }
 }
 
-impl ExtractedInput {
+impl DateTimeInputUnchecked {
     fn resolve_time_precision(
         &self,
         time_precision: TimePrecision,
@@ -334,7 +334,7 @@ impl TimePatternSelectionData {
     /// Borrows a resolved pattern based on the given datetime
     pub(crate) fn select(
         &self,
-        input: &ExtractedInput,
+        input: &DateTimeInputUnchecked,
         options: RawOptions,
         prefs: RawPreferences,
     ) -> Option<TimePatternDataBorrowed> {
@@ -381,7 +381,7 @@ impl ZonePatternSelectionData {
     }
 
     /// Borrows a resolved pattern based on the given datetime
-    pub(crate) fn select(&self, _input: &ExtractedInput) -> ZonePatternDataBorrowed {
+    pub(crate) fn select(&self, _input: &DateTimeInputUnchecked) -> ZonePatternDataBorrowed {
         let Self::SinglePatternItem(_, pattern_item) = self;
         ZonePatternDataBorrowed::SinglePatternItem(pattern_item)
     }
@@ -632,7 +632,7 @@ impl DateTimeZonePatternSelectionData {
     }
 
     /// Borrows a resolved pattern based on the given datetime
-    pub(crate) fn select(&self, input: &ExtractedInput) -> DateTimeZonePatternDataBorrowed {
+    pub(crate) fn select(&self, input: &DateTimeInputUnchecked) -> DateTimeZonePatternDataBorrowed {
         DateTimeZonePatternDataBorrowed {
             date: self.date.select(input, self.options),
             time: self.time.select(input, self.options, self.prefs),

--- a/ffi/capi/tests/missing_apis.txt
+++ b/ffi/capi/tests/missing_apis.txt
@@ -14,7 +14,9 @@
 # Please check in with @Manishearth, @robertbastian, or @sffc if you have questions
 
 
+icu::datetime::DateTimeFormatter::format_unchecked#FnInStruct
 icu::datetime::DateTimeFormatter::to_field_set_builder#FnInStruct
+icu::datetime::DateTimeInputUnchecked#Struct
 icu::datetime::FixedCalendarDateTimeFormatter::to_field_set_builder#FnInStruct
 icu::datetime::fieldsets::Combo#Struct
 icu::datetime::fieldsets::Combo::into_enums#FnInStruct

--- a/ffi/capi/tests/missing_apis.txt
+++ b/ffi/capi/tests/missing_apis.txt
@@ -17,6 +17,12 @@
 icu::datetime::DateTimeFormatter::format_unchecked#FnInStruct
 icu::datetime::DateTimeFormatter::to_field_set_builder#FnInStruct
 icu::datetime::DateTimeInputUnchecked#Struct
+icu::datetime::DateTimeInputUnchecked::set_date_fields#FnInStruct
+icu::datetime::DateTimeInputUnchecked::set_time_fields#FnInStruct
+icu::datetime::DateTimeInputUnchecked::set_time_zone_id#FnInStruct
+icu::datetime::DateTimeInputUnchecked::set_time_zone_local_time#FnInStruct
+icu::datetime::DateTimeInputUnchecked::set_time_zone_utc_offset#FnInStruct
+icu::datetime::DateTimeInputUnchecked::set_time_zone_variant#FnInStruct
 icu::datetime::FixedCalendarDateTimeFormatter::format_unchecked#FnInStruct
 icu::datetime::FixedCalendarDateTimeFormatter::to_field_set_builder#FnInStruct
 icu::datetime::FormattedDateTimeTry#Struct

--- a/ffi/capi/tests/missing_apis.txt
+++ b/ffi/capi/tests/missing_apis.txt
@@ -17,7 +17,11 @@
 icu::datetime::DateTimeFormatter::format_unchecked#FnInStruct
 icu::datetime::DateTimeFormatter::to_field_set_builder#FnInStruct
 icu::datetime::DateTimeInputUnchecked#Struct
+icu::datetime::FixedCalendarDateTimeFormatter::format_unchecked#FnInStruct
 icu::datetime::FixedCalendarDateTimeFormatter::to_field_set_builder#FnInStruct
+icu::datetime::FormattedDateTimeTry#Struct
+icu::datetime::FormattedDateTimeTry::pattern#FnInStruct
+icu::datetime::FormattedDateTimeTry::try_write_to_parts#FnInStruct
 icu::datetime::fieldsets::Combo#Struct
 icu::datetime::fieldsets::Combo::into_enums#FnInStruct
 icu::datetime::fieldsets::D#Struct

--- a/ffi/capi/tests/missing_apis.txt
+++ b/ffi/capi/tests/missing_apis.txt
@@ -25,9 +25,9 @@ icu::datetime::DateTimeInputUnchecked::set_time_zone_utc_offset#FnInStruct
 icu::datetime::DateTimeInputUnchecked::set_time_zone_variant#FnInStruct
 icu::datetime::FixedCalendarDateTimeFormatter::format_unchecked#FnInStruct
 icu::datetime::FixedCalendarDateTimeFormatter::to_field_set_builder#FnInStruct
-icu::datetime::FormattedDateTimeTry#Struct
-icu::datetime::FormattedDateTimeTry::pattern#FnInStruct
-icu::datetime::FormattedDateTimeTry::try_write_to_parts#FnInStruct
+icu::datetime::FormattedDateTimeUnchecked#Struct
+icu::datetime::FormattedDateTimeUnchecked::pattern#FnInStruct
+icu::datetime::FormattedDateTimeUnchecked::try_write_to_parts#FnInStruct
 icu::datetime::fieldsets::Combo#Struct
 icu::datetime::fieldsets::Combo::into_enums#FnInStruct
 icu::datetime::fieldsets::D#Struct


### PR DESCRIPTION
Toward https://github.com/unicode-org/icu4x/issues/5940

Alternative to #6255

In hindsight, this is a pretty obviously useful function. It took some experimentation until I arrived at it. I have two signatures: this one and the one in #6255. Please express an opinion on which one to move forward with.

How this approach works: it adds a single plain input type named `DateTimeInputUnchecked`. This type cannot be passed into `format` because it can't implement the required traits, so it gets its own format function with fallible behavior.

Pros and cons:

- Pro: No weird trait bounds on this function
- Pro: Can construct this type manually without having to implement ICU4X traits or go through ICU4X input types
- Con: Adds a new struct type to the API that we need to bikeshed (where does it live, what is it named, what are its fields named, ...)