### PR TITLE
Seal AbstractSerializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
         - ...
     - `icu_provider`
         - Put `MaybeEncodeAsVarULE` behind the `"export"` feature (unicode-org#6221)
+    - `icu_provider_fs`
+        - `AbstractSerializer` is now a sealed trait (unicode-org#6263)
 - Utils
     - General
         - ...

--- a/provider/fs/src/export/serializers/bincode.rs
+++ b/provider/fs/src/export/serializers/bincode.rs
@@ -39,6 +39,8 @@ pub struct Serializer;
 #[derive(Clone, Debug, PartialEq, Default)]
 pub struct Options;
 
+impl super::seal::Sealed for Serializer {}
+
 impl AbstractSerializer for Serializer {
     fn serialize(
         &self,

--- a/provider/fs/src/export/serializers/json.rs
+++ b/provider/fs/src/export/serializers/json.rs
@@ -53,6 +53,8 @@ pub struct Options {
     pub style: StyleOption,
 }
 
+impl super::seal::Sealed for Serializer {}
+
 impl AbstractSerializer for Serializer {
     fn serialize(
         &self,

--- a/provider/fs/src/export/serializers/mod.rs
+++ b/provider/fs/src/export/serializers/mod.rs
@@ -25,8 +25,9 @@ use std::io;
 /// A simple serializer trait that works on whole objects.
 ///
 /// This trait is not meant to be implemented by clients.
-pub trait AbstractSerializer: core::fmt::Debug {
+pub trait AbstractSerializer: core::fmt::Debug + seal::Sealed {
     /// Serializes an object to a sink.
+    #[doc(hidden)]
     fn serialize(
         &self,
         obj: &DataPayload<ExportMarker>,
@@ -34,10 +35,16 @@ pub trait AbstractSerializer: core::fmt::Debug {
     ) -> Result<(), DataError>;
 
     /// Gets the buffer format currently being serialized.
+    #[doc(hidden)]
     fn get_buffer_format(&self) -> BufferFormat;
 
     /// This can be set to get correct CRLF on Windows.
+    #[doc(hidden)]
     fn is_text_format(&self) -> bool {
         false
     }
+}
+
+pub(crate) mod seal {
+    pub trait Sealed {}
 }

--- a/provider/fs/src/export/serializers/mod.rs
+++ b/provider/fs/src/export/serializers/mod.rs
@@ -27,7 +27,7 @@ use std::io;
 /// This trait is not meant to be implemented by clients.
 pub trait AbstractSerializer: core::fmt::Debug + seal::Sealed {
     /// Serializes an object to a sink.
-    #[doc(hidden)]
+    #[doc(hidden)] // sealed trait
     fn serialize(
         &self,
         obj: &DataPayload<ExportMarker>,
@@ -35,11 +35,11 @@ pub trait AbstractSerializer: core::fmt::Debug + seal::Sealed {
     ) -> Result<(), DataError>;
 
     /// Gets the buffer format currently being serialized.
-    #[doc(hidden)]
+    #[doc(hidden)] // sealed trait
     fn get_buffer_format(&self) -> BufferFormat;
 
     /// This can be set to get correct CRLF on Windows.
-    #[doc(hidden)]
+    #[doc(hidden)] // sealed trait
     fn is_text_format(&self) -> bool {
         false
     }

--- a/provider/fs/src/export/serializers/postcard.rs
+++ b/provider/fs/src/export/serializers/postcard.rs
@@ -39,6 +39,8 @@ pub struct Serializer;
 #[derive(Clone, Debug, PartialEq, Default)]
 pub struct Options;
 
+impl super::seal::Sealed for Serializer {}
+
 impl AbstractSerializer for Serializer {
     fn serialize(
         &self,


### PR DESCRIPTION
Supersedes https://github.com/unicode-org/icu4x/pull/6025

Can't be private, it's used in FilesystemExporter::try_new

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->