### PR TITLE
Update more deps to latest major version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
 ]
@@ -94,6 +94,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arraystring"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -154,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "atoi"
-version = "1.0.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c57d12312ff59c811c0643f4d80830505833c9ffaebd193d819392b265be8e"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
 dependencies = [
  "num-traits",
 ]
@@ -188,7 +197,7 @@ version = "0.0.0"
 dependencies = [
  "crlify",
  "icu",
- "icu_provider 2.0.0-beta2",
+ "icu_provider",
  "icu_provider_export",
  "icu_provider_source",
  "log",
@@ -225,11 +234,11 @@ version = "0.2.3"
 dependencies = [
  "itertools 0.14.0",
  "partial-min-max",
- "rand",
+ "rand 0.9.0",
  "rand_distr",
  "rand_pcg",
  "strum",
- "writeable 0.6.1",
+ "writeable",
 ]
 
 [[package]]
@@ -614,6 +623,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "detone"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,7 +712,7 @@ dependencies = [
  "serde",
  "syn 2.0.98",
  "syn-inline-mod",
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -747,7 +767,7 @@ dependencies = [
  "eyre",
  "flate2",
  "icu_locale_core",
- "icu_provider 2.0.0-beta2",
+ "icu_provider",
  "icu_provider_source",
  "log",
  "simple_logger",
@@ -817,11 +837,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "erased-serde"
-version = "0.3.31"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
+checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
 dependencies = [
  "serde",
+ "typeid",
 ]
 
 [[package]]
@@ -852,14 +873,14 @@ version = "0.7.0"
 dependencies = [
  "criterion",
  "displaydoc",
- "getrandom",
+ "getrandom 0.3.1",
  "icu_benchmark_macros",
- "rand",
+ "rand 0.9.0",
  "rand_distr",
  "rand_pcg",
  "ryu",
  "smallvec",
- "writeable 0.6.1",
+ "writeable",
 ]
 
 [[package]]
@@ -873,13 +894,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "form_urlencoded"
-version = "1.2.1"
+name = "fnv"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
-dependencies = [
- "percent-encoding",
-]
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 
 [[package]]
 name = "freertos-rust"
@@ -909,10 +933,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.13.3+wasi-0.2.2",
  "wasm-bindgen",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -951,6 +987,9 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -969,6 +1008,23 @@ name = "hermit-abi"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+
+[[package]]
+name = "http"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "humansize"
@@ -994,17 +1050,17 @@ dependencies = [
  "icu_calendar",
  "icu_casemap",
  "icu_collator",
- "icu_collections 2.0.0-beta2",
+ "icu_collections",
  "icu_datetime",
  "icu_decimal",
  "icu_experimental",
  "icu_list",
  "icu_locale",
- "icu_normalizer 2.0.0-beta2",
+ "icu_normalizer",
  "icu_pattern",
  "icu_plurals",
- "icu_properties 2.0.0-beta2",
- "icu_provider 2.0.0-beta2",
+ "icu_properties",
+ "icu_provider",
  "icu_provider_adapters",
  "icu_provider_blob",
  "icu_provider_registry",
@@ -1012,7 +1068,7 @@ dependencies = [
  "icu_time",
  "jiff",
  "memchr",
- "writeable 0.6.1",
+ "writeable",
 ]
 
 [[package]]
@@ -1022,7 +1078,7 @@ dependencies = [
  "clap",
  "eyre",
  "icu",
- "icu_provider 2.0.0-beta2",
+ "icu_provider",
  "icu_provider_blob",
  "icu_provider_export",
  "icu_provider_registry",
@@ -1038,8 +1094,8 @@ dependencies = [
  "ecma402_traits",
  "fixed_decimal",
  "icu",
- "icu_provider 2.0.0-beta2",
- "writeable 0.6.1",
+ "icu_provider",
+ "writeable",
 ]
 
 [[package]]
@@ -1075,14 +1131,14 @@ dependencies = [
  "icu_benchmark_macros",
  "icu_calendar_data",
  "icu_locale_core",
- "icu_provider 2.0.0-beta2",
+ "icu_provider",
  "ixdtf",
  "serde",
  "serde_json",
  "simple_logger",
- "tinystr 0.8.1",
- "writeable 0.6.1",
- "zerovec 0.11.1",
+ "tinystr",
+ "writeable",
+ "zerovec",
 ]
 
 [[package]]
@@ -1103,17 +1159,17 @@ dependencies = [
  "icu_calendar",
  "icu_casemap",
  "icu_collator",
- "icu_collections 2.0.0-beta2",
+ "icu_collections",
  "icu_datetime",
  "icu_decimal",
  "icu_experimental",
  "icu_list",
  "icu_locale",
  "icu_locale_core",
- "icu_normalizer 2.0.0-beta2",
+ "icu_normalizer",
  "icu_plurals",
- "icu_properties 2.0.0-beta2",
- "icu_provider 2.0.0-beta2",
+ "icu_properties",
+ "icu_provider",
  "icu_provider_adapters",
  "icu_provider_blob",
  "icu_provider_fs",
@@ -1124,10 +1180,10 @@ dependencies = [
  "potential_utf",
  "serde",
  "simple_logger",
- "tinystr 0.8.1",
+ "tinystr",
  "unicode-bidi",
- "writeable 0.6.1",
- "zerovec 0.11.1",
+ "writeable",
+ "zerovec",
 ]
 
 [[package]]
@@ -1140,15 +1196,15 @@ dependencies = [
  "icu",
  "icu_benchmark_macros",
  "icu_casemap_data",
- "icu_collections 2.0.0-beta2",
+ "icu_collections",
  "icu_locale_core",
- "icu_normalizer 2.0.0-beta2",
- "icu_properties 2.0.0-beta2",
- "icu_provider 2.0.0-beta2",
+ "icu_normalizer",
+ "icu_properties",
+ "icu_provider",
  "potential_utf",
  "serde",
- "writeable 0.6.1",
- "zerovec 0.11.1",
+ "writeable",
+ "zerovec",
 ]
 
 [[package]]
@@ -1163,10 +1219,10 @@ name = "icu_codepointtrie_builder"
 version = "0.4.0"
 dependencies = [
  "icu",
- "icu_collections 2.0.0-beta2",
+ "icu_collections",
  "wasmi",
  "wat",
- "zerovec 0.11.1",
+ "zerovec",
 ]
 
 [[package]]
@@ -1180,18 +1236,18 @@ dependencies = [
  "displaydoc",
  "icu",
  "icu_collator_data",
- "icu_collections 2.0.0-beta2",
+ "icu_collections",
  "icu_locale_core",
- "icu_normalizer 2.0.0-beta2",
- "icu_normalizer_data 2.0.0-beta2",
- "icu_properties 2.0.0-beta2",
- "icu_provider 2.0.0-beta2",
+ "icu_normalizer",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
  "icu_provider_adapters",
  "serde",
  "smallvec",
  "utf16_iter",
  "utf8_iter",
- "zerovec 0.11.1",
+ "zerovec",
 ]
 
 [[package]]
@@ -1204,18 +1260,6 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
-dependencies = [
- "displaydoc",
- "yoke 0.7.5",
- "zerofrom 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "zerovec 0.10.4",
-]
-
-[[package]]
-name = "icu_collections"
 version = "2.0.0-beta2"
 dependencies = [
  "criterion",
@@ -1224,15 +1268,15 @@ dependencies = [
  "iai",
  "icu",
  "icu_benchmark_macros",
- "icu_properties 2.0.0-beta2",
+ "icu_properties",
  "postcard",
  "potential_utf",
  "serde",
  "serde_json",
- "toml",
- "yoke 0.8.0",
- "zerofrom 0.1.6",
- "zerovec 0.11.1",
+ "toml 0.8.20",
+ "yoke",
+ "zerofrom",
+ "zerovec",
 ]
 
 [[package]]
@@ -1253,18 +1297,18 @@ dependencies = [
  "icu_locale_core",
  "icu_pattern",
  "icu_plurals",
- "icu_provider 2.0.0-beta2",
+ "icu_provider",
  "icu_provider_adapters",
  "icu_provider_blob",
  "icu_time",
- "litemap 0.7.5",
+ "litemap",
  "potential_utf",
  "serde",
  "serde_json",
  "smallvec",
- "tinystr 0.8.1",
- "writeable 0.6.1",
- "zerovec 0.11.1",
+ "tinystr",
+ "writeable",
+ "zerovec",
 ]
 
 [[package]]
@@ -1283,20 +1327,20 @@ dependencies = [
  "databake",
  "displaydoc",
  "fixed_decimal",
- "getrandom",
+ "getrandom 0.3.1",
  "icu",
  "icu_benchmark_macros",
  "icu_decimal_data",
  "icu_locale_core",
- "icu_provider 2.0.0-beta2",
+ "icu_provider",
  "icu_provider_adapters",
- "rand",
+ "rand 0.9.0",
  "rand_distr",
  "rand_pcg",
  "serde",
- "tinystr 0.8.1",
- "writeable 0.6.1",
- "zerovec 0.11.1",
+ "tinystr",
+ "writeable",
+ "zerovec",
 ]
 
 [[package]]
@@ -1318,21 +1362,21 @@ dependencies = [
  "fixed_decimal",
  "icu",
  "icu_casemap",
- "icu_collections 2.0.0-beta2",
+ "icu_collections",
  "icu_decimal",
  "icu_experimental_data",
  "icu_list",
  "icu_locale",
  "icu_locale_core",
  "icu_locale_data",
- "icu_normalizer 2.0.0-beta2",
- "icu_normalizer_data 2.0.0-beta2",
+ "icu_normalizer",
+ "icu_normalizer_data",
  "icu_pattern",
  "icu_plurals",
- "icu_properties 2.0.0-beta2",
- "icu_properties_data 2.0.0-beta2",
- "icu_provider 2.0.0-beta2",
- "litemap 0.7.5",
+ "icu_properties",
+ "icu_properties_data",
+ "icu_provider",
+ "litemap",
  "log",
  "num-bigint",
  "num-rational",
@@ -1340,11 +1384,11 @@ dependencies = [
  "potential_utf",
  "serde",
  "smallvec",
- "tinystr 0.8.1",
- "writeable 0.6.1",
- "zerofrom 0.1.6",
+ "tinystr",
+ "writeable",
+ "zerofrom",
  "zerotrie",
- "zerovec 0.11.1",
+ "zerovec",
 ]
 
 [[package]]
@@ -1371,9 +1415,9 @@ version = "0.2.0"
 dependencies = [
  "displaydoc",
  "harfbuzz-traits",
- "icu_normalizer 2.0.0-beta2",
- "icu_properties 2.0.0-beta2",
- "icu_provider 2.0.0-beta2",
+ "icu_normalizer",
+ "icu_properties",
+ "icu_provider",
 ]
 
 [[package]]
@@ -1385,14 +1429,14 @@ dependencies = [
  "icu",
  "icu_benchmark_macros",
  "icu_list_data",
- "icu_provider 2.0.0-beta2",
+ "icu_provider",
  "postcard",
  "regex-automata",
  "rmp-serde",
  "serde",
  "serde_json",
- "writeable 0.6.1",
- "zerovec 0.11.1",
+ "writeable",
+ "zerovec",
 ]
 
 [[package]]
@@ -1411,16 +1455,16 @@ dependencies = [
  "databake",
  "displaydoc",
  "icu",
- "icu_collections 2.0.0-beta2",
+ "icu_collections",
  "icu_locale_core",
  "icu_locale_data",
- "icu_provider 2.0.0-beta2",
+ "icu_provider",
  "potential_utf",
  "serde",
  "serde_json",
- "tinystr 0.8.1",
- "writeable 0.6.1",
- "zerovec 0.11.1",
+ "tinystr",
+ "writeable",
+ "zerovec",
 ]
 
 [[package]]
@@ -1433,15 +1477,15 @@ dependencies = [
  "iai",
  "icu",
  "icu_benchmark_macros",
- "icu_provider 2.0.0-beta2",
- "litemap 0.7.5",
+ "icu_provider",
+ "litemap",
  "postcard",
  "potential_utf",
  "serde",
  "serde_json",
- "tinystr 0.8.1",
- "writeable 0.6.1",
- "zerovec 0.11.1",
+ "tinystr",
+ "writeable",
+ "zerovec",
 ]
 
 [[package]]
@@ -1449,57 +1493,6 @@ name = "icu_locale_data"
 version = "2.0.0-beta2"
 dependencies = [
  "icu_provider_baked",
-]
-
-[[package]]
-name = "icu_locid"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
-dependencies = [
- "displaydoc",
- "litemap 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "tinystr 0.7.6",
- "writeable 0.5.5",
- "zerovec 0.10.4",
-]
-
-[[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider 1.5.0",
- "tinystr 0.7.6",
- "zerovec 0.10.4",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
-
-[[package]]
-name = "icu_normalizer"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
-dependencies = [
- "displaydoc",
- "icu_collections 1.5.0",
- "icu_normalizer_data 1.5.0",
- "icu_properties 1.5.1",
- "icu_provider 1.5.0",
- "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
- "zerovec 0.10.4",
 ]
 
 [[package]]
@@ -1514,23 +1507,17 @@ dependencies = [
  "detone",
  "displaydoc",
  "icu",
- "icu_collections 2.0.0-beta2",
- "icu_normalizer_data 2.0.0-beta2",
- "icu_properties 2.0.0-beta2",
- "icu_provider 2.0.0-beta2",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
  "serde",
  "smallvec",
  "utf16_iter",
  "utf8_iter",
  "write16",
- "zerovec 0.11.1",
+ "zerovec",
 ]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
 
 [[package]]
 name = "icu_normalizer_data"
@@ -1546,15 +1533,15 @@ dependencies = [
  "databake",
  "displaydoc",
  "either",
- "litemap 0.7.5",
+ "litemap",
  "postcard",
  "rmp-serde",
  "serde",
  "serde_json",
- "writeable 0.6.1",
- "yoke 0.8.0",
- "zerofrom 0.1.6",
- "zerovec 0.11.1",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
 ]
 
 [[package]]
@@ -1569,11 +1556,11 @@ dependencies = [
  "icu_benchmark_macros",
  "icu_locale_core",
  "icu_plurals_data",
- "icu_provider 2.0.0-beta2",
+ "icu_provider",
  "postcard",
  "serde",
  "serde_json",
- "zerovec 0.11.1",
+ "zerovec",
 ]
 
 [[package]]
@@ -1586,65 +1573,27 @@ dependencies = [
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
-dependencies = [
- "displaydoc",
- "icu_collections 1.5.0",
- "icu_locid_transform",
- "icu_properties_data 1.5.0",
- "icu_provider 1.5.0",
- "tinystr 0.7.6",
- "zerovec 0.10.4",
-]
-
-[[package]]
-name = "icu_properties"
 version = "2.0.0-beta2"
 dependencies = [
  "databake",
  "displaydoc",
  "icu",
- "icu_collections 2.0.0-beta2",
+ "icu_collections",
  "icu_locale_core",
- "icu_properties_data 2.0.0-beta2",
- "icu_provider 2.0.0-beta2",
+ "icu_properties_data",
+ "icu_provider",
  "potential_utf",
  "serde",
  "unicode-bidi",
  "zerotrie",
- "zerovec 0.11.1",
+ "zerovec",
 ]
-
-[[package]]
-name = "icu_properties_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
 
 [[package]]
 name = "icu_properties_data"
 version = "2.0.0-beta2"
 dependencies = [
  "icu_provider_baked",
-]
-
-[[package]]
-name = "icu_provider"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_provider_macros",
- "stable_deref_trait",
- "tinystr 0.7.6",
- "writeable 0.5.5",
- "yoke 0.7.5",
- "zerofrom 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "zerovec 0.10.4",
 ]
 
 [[package]]
@@ -1665,11 +1614,11 @@ dependencies = [
  "serde",
  "serde_json",
  "stable_deref_trait",
- "tinystr 0.8.1",
- "writeable 0.6.1",
- "yoke 0.8.0",
- "zerofrom 0.1.6",
- "zerovec 0.11.1",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
 ]
 
 [[package]]
@@ -1678,11 +1627,11 @@ version = "2.0.0-beta2"
 dependencies = [
  "databake",
  "icu_locale",
- "icu_provider 2.0.0-beta2",
+ "icu_provider",
  "serde",
- "tinystr 0.8.1",
- "writeable 0.6.1",
- "zerovec 0.11.1",
+ "tinystr",
+ "writeable",
+ "zerovec",
 ]
 
 [[package]]
@@ -1692,14 +1641,14 @@ dependencies = [
  "crlify",
  "databake",
  "heck 0.5.0",
- "icu_provider 2.0.0-beta2",
+ "icu_provider",
  "icu_provider_export",
  "icu_provider_registry",
  "log",
  "proc-macro2",
- "writeable 0.6.1",
+ "writeable",
  "zerotrie",
- "zerovec 0.11.1",
+ "zerovec",
 ]
 
 [[package]]
@@ -1710,16 +1659,16 @@ dependencies = [
  "databake",
  "icu_locale",
  "icu_locale_core",
- "icu_provider 2.0.0-beta2",
+ "icu_provider",
  "icu_provider_adapters",
  "icu_provider_export",
  "log",
  "postcard",
  "serde",
  "twox-hash",
- "writeable 0.6.1",
+ "writeable",
  "zerotrie",
- "zerovec 0.11.1",
+ "zerovec",
 ]
 
 [[package]]
@@ -1730,7 +1679,7 @@ dependencies = [
  "elsa",
  "icu",
  "icu_locale",
- "icu_provider 2.0.0-beta2",
+ "icu_provider",
  "icu_provider_baked",
  "icu_provider_blob",
  "icu_provider_fs",
@@ -1739,7 +1688,7 @@ dependencies = [
  "postcard",
  "rayon",
  "simple_logger",
- "writeable 0.6.1",
+ "writeable",
 ]
 
 [[package]]
@@ -1752,7 +1701,7 @@ dependencies = [
  "displaydoc",
  "icu_benchmark_macros",
  "icu_locale_core",
- "icu_provider 2.0.0-beta2",
+ "icu_provider",
  "icu_provider_export",
  "icu_provider_registry",
  "log",
@@ -1760,18 +1709,7 @@ dependencies = [
  "serde",
  "serde-json-core",
  "serde_json",
- "writeable 0.6.1",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
+ "writeable",
 ]
 
 [[package]]
@@ -1779,7 +1717,7 @@ name = "icu_provider_registry"
 version = "2.0.0-beta2"
 dependencies = [
  "icu",
- "icu_provider 2.0.0-beta2",
+ "icu_provider",
 ]
 
 [[package]]
@@ -1793,16 +1731,16 @@ dependencies = [
  "flate2",
  "icu",
  "icu_codepointtrie_builder",
- "icu_collections 2.0.0-beta2",
+ "icu_collections",
  "icu_experimental",
  "icu_pattern",
- "icu_provider 2.0.0-beta2",
+ "icu_provider",
  "icu_provider_adapters",
  "icu_provider_export",
  "icu_provider_registry",
  "icu_segmenter",
  "itertools 0.14.0",
- "litemap 0.7.5",
+ "litemap",
  "log",
  "ndarray",
  "num-bigint",
@@ -1816,13 +1754,13 @@ dependencies = [
  "serde_json",
  "simple_logger",
  "tar",
- "tinystr 0.8.1",
- "toml",
+ "tinystr",
+ "toml 0.8.20",
  "twox-hash",
  "ureq",
- "writeable 0.6.1",
+ "writeable",
  "zerotrie",
- "zerovec 0.11.1",
+ "zerovec",
  "zip",
 ]
 
@@ -1835,17 +1773,17 @@ dependencies = [
  "databake",
  "displaydoc",
  "icu",
- "icu_collections 2.0.0-beta2",
+ "icu_collections",
  "icu_locale_core",
- "icu_properties 2.0.0-beta2",
- "icu_provider 2.0.0-beta2",
+ "icu_properties",
+ "icu_provider",
  "icu_segmenter_data",
  "itertools 0.14.0",
  "potential_utf",
  "serde",
  "serde_json",
  "utf8_iter",
- "zerovec 0.11.1",
+ "zerovec",
 ]
 
 [[package]]
@@ -1865,14 +1803,14 @@ dependencies = [
  "displaydoc",
  "icu",
  "icu_calendar",
- "icu_provider 2.0.0-beta2",
+ "icu_provider",
  "icu_time_data",
  "ixdtf",
  "serde",
- "tinystr 0.8.1",
- "writeable 0.6.1",
+ "tinystr",
+ "writeable",
  "zerotrie",
- "zerovec 0.11.1",
+ "zerovec",
 ]
 
 [[package]]
@@ -1883,41 +1821,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "idna"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
-dependencies = [
- "idna_adapter",
- "smallvec",
- "utf8_iter",
-]
-
-[[package]]
-name = "idna_adapter"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
-dependencies = [
- "icu_normalizer 1.5.0",
- "icu_properties 1.5.1",
-]
-
-[[package]]
 name = "indenter"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
-
-[[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
 
 [[package]]
 name = "indexmap"
@@ -1928,12 +1835,6 @@ dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
 ]
-
-[[package]]
-name = "indexmap-nostd"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
 
 [[package]]
 name = "is-terminal"
@@ -2068,14 +1969,8 @@ dependencies = [
  "rkyv",
  "serde",
  "serde_json",
- "yoke 0.8.0",
+ "yoke",
 ]
-
-[[package]]
-name = "litemap"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "lock_api"
@@ -2086,6 +1981,12 @@ dependencies = [
  "autocfg",
  "scopeguard",
 ]
+
+[[package]]
+name = "lockfree-object-pool"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
 
 [[package]]
 name = "log"
@@ -2119,21 +2020,21 @@ dependencies = [
  "databake",
  "displaydoc",
  "icu",
- "icu_provider 2.0.0-beta2",
+ "icu_provider",
  "icu_provider_adapters",
  "icu_provider_blob",
  "icu_provider_export",
  "icu_provider_fs",
  "icu_provider_source",
  "itertools 0.14.0",
- "litemap 0.7.5",
+ "litemap",
  "lru",
  "serde",
  "serde-aux",
  "time",
- "tinystr 0.8.1",
- "writeable 0.6.1",
- "zerovec 0.11.1",
+ "tinystr",
+ "writeable",
+ "zerovec",
 ]
 
 [[package]]
@@ -2180,6 +2081,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bec4598fddb13cc7b528819e697852653252b760f1228b7642679bf2ff2cd07"
 
 [[package]]
+name = "multi-stash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685a9ac4b61f4e728e1d2c6a7844609c16527aeb5e6c865915c08e619c16410f"
+
+[[package]]
 name = "nb"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2196,14 +2103,16 @@ checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
 name = "ndarray"
-version = "0.15.6"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
+checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
 dependencies = [
  "matrixmultiply",
  "num-complex",
  "num-integer",
  "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
  "rawpointer",
 ]
 
@@ -2212,19 +2121,19 @@ name = "noalloctest"
 version = "2.0.0-beta2"
 dependencies = [
  "icu_calendar",
- "icu_collections 2.0.0-beta2",
+ "icu_collections",
  "icu_locale_core",
- "icu_properties 2.0.0-beta2",
- "icu_provider 2.0.0-beta2",
+ "icu_properties",
+ "icu_provider",
  "icu_provider_baked",
  "icu_time",
- "litemap 0.7.5",
+ "litemap",
  "potential_utf",
- "tinystr 0.8.1",
- "yoke 0.8.0",
- "zerofrom 0.1.6",
+ "tinystr",
+ "yoke",
+ "zerofrom",
  "zerotrie",
- "zerovec 0.11.1",
+ "zerovec",
 ]
 
 [[package]]
@@ -2407,7 +2316,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2482,8 +2391,8 @@ dependencies = [
  "databake",
  "serde",
  "serde_json",
- "writeable 0.6.1",
- "zerovec 0.11.1",
+ "writeable",
+ "zerovec",
 ]
 
 [[package]]
@@ -2498,7 +2407,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -2570,19 +2479,28 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "libc",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.3",
+ "zerocopy 0.8.23",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2590,27 +2508,33 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.1",
 ]
 
 [[package]]
 name = "rand_distr"
-version = "0.4.3"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.9.0",
 ]
 
 [[package]]
 name = "rand_pcg"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
+checksum = "b48ac3f7ffaab7fac4d2376632268aa5f89abdb55f7ebf8f4d11fffccb2320f7"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2690,11 +2614,11 @@ dependencies = [
 name = "resb"
 version = "0.1.0"
 dependencies = [
- "indexmap 1.9.3",
+ "indexmap",
  "log",
  "nom",
  "serde",
- "zerovec 0.11.1",
+ "zerovec",
 ]
 
 [[package]]
@@ -2705,7 +2629,7 @@ checksum = "da5349ae27d3887ca812fb375b45a4fbb36d8d12d2df394968cd86e35683fe73"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -2817,6 +2741,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2909,9 +2842,9 @@ dependencies = [
 
 [[package]]
 name = "serde-json-core"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8014aeea272bca0f0779778d43253f2f3375b414185b30e6ecc4d3e4a9994781"
+checksum = "5b81787e655bd59cecadc91f7b6b8651330b2be6c33246039a65e5cd6f4e0828"
 dependencies = [
  "ryu",
  "serde",
@@ -2951,10 +2884,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "simdutf8"
@@ -2964,9 +2912,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simple_logger"
-version = "4.3.3"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e7e46c8c90251d47d08b28b8a419ffb4aede0f87c2eea95e17d1d5bacbf3ef1"
+checksum = "e8c5dfa5e08767553704aa0ffd9d9794d527103c736aba9854773851fd7497eb"
 dependencies = [
  "colored",
  "log",
@@ -3008,6 +2956,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42316e70da376f3d113a68d138a60d8a9883c604fe97942721ec2068dab13a9f"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "string-interner"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a3275464d7a9f2d4cac57c89c2ef96a8524dba2864c8d6f82e3980baf136f9b"
+dependencies = [
+ "hashbrown 0.15.2",
+ "serde",
 ]
 
 [[package]]
@@ -3104,6 +3062,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "thousands"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3144,16 +3122,6 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
-dependencies = [
- "displaydoc",
- "zerovec 0.10.4",
-]
-
-[[package]]
-name = "tinystr"
 version = "0.8.1"
 dependencies = [
  "bincode",
@@ -3161,10 +3129,10 @@ dependencies = [
  "databake",
  "displaydoc",
  "postcard",
- "rand",
+ "rand 0.9.0",
  "serde",
  "serde_json",
- "zerovec 0.11.1",
+ "zerovec",
 ]
 
 [[package]]
@@ -3202,10 +3170,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "twox-hash"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7b17f197b3050ba473acf9181f7b1d3b66d1cf7356c6cc57886662276e65908"
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
@@ -3259,30 +3267,39 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.12.1"
+version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+checksum = "06f78313c985f2fba11100dd06d60dd402d0cabb458af4d94791b8e09c025323"
 dependencies = [
  "base64",
  "flate2",
  "log",
- "once_cell",
+ "percent-encoding",
  "rustls",
+ "rustls-pemfile",
  "rustls-pki-types",
- "url",
+ "ureq-proto",
+ "utf-8",
  "webpki-roots",
 ]
 
 [[package]]
-name = "url"
-version = "2.5.4"
+name = "ureq-proto"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "64adb55464bad1ab1aa9229133d0d59d2f679180f4d15f0d9debe616f541f25e"
 dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
+ "base64",
+ "http",
+ "httparse",
+ "log",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf16_iter"
@@ -3352,6 +3369,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3416,38 +3442,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d81b727619aec227dce83e7f7420d4e56c79acd044642a356ea045b98d4e13"
 dependencies = [
  "leb128fmt",
- "wasmparser",
+ "wasmparser 0.226.0",
 ]
 
 [[package]]
 name = "wasmi"
-version = "0.31.2"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8281d1d660cdf54c76a3efa9ddd0c270cada1383a995db3ccb43d166456c7"
+checksum = "a19af97fcb96045dd1d6b4d23e2b4abdbbe81723dbc5c9f016eb52145b320063"
 dependencies = [
+ "arrayvec",
+ "multi-stash",
  "smallvec",
  "spin",
- "wasmi_arena",
+ "wasmi_collections",
  "wasmi_core",
- "wasmparser-nostd",
+ "wasmi_ir",
+ "wasmparser 0.221.3",
 ]
 
 [[package]]
-name = "wasmi_arena"
-version = "0.4.1"
+name = "wasmi_collections"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "104a7f73be44570cac297b3035d76b169d6599637631cf37a1703326a0727073"
+checksum = "e80d6b275b1c922021939d561574bf376613493ae2b61c6963b15db0e8813562"
+dependencies = [
+ "string-interner",
+]
 
 [[package]]
 name = "wasmi_core"
-version = "0.13.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf1a7db34bff95b85c261002720c00c3a6168256dcb93041d3fa2054d19856a"
+checksum = "3a8c51482cc32d31c2c7ff211cd2bedd73c5bd057ba16a2ed0110e7a96097c33"
 dependencies = [
  "downcast-rs",
  "libm",
- "num-traits",
- "paste",
+]
+
+[[package]]
+name = "wasmi_ir"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e431a14c186db59212a88516788bd68ed51f87aa1e08d1df742522867b5289a"
+dependencies = [
+ "wasmi_core",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.221.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d06bfa36ab3ac2be0dee563380147a5b81ba10dd8885d7fbbc9eb574be67d185"
+dependencies = [
+ "bitflags",
+ "indexmap",
 ]
 
 [[package]]
@@ -3457,17 +3506,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc28600dcb2ba68d7e5f1c3ba4195c2bddc918c0243fd702d0b6dbd05689b681"
 dependencies = [
  "bitflags",
- "indexmap 2.7.1",
+ "indexmap",
  "semver 1.0.25",
-]
-
-[[package]]
-name = "wasmparser-nostd"
-version = "0.100.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5a015fe95f3504a94bb1462c717aae75253e39b9dd6c3fb1062c934535c64aa"
-dependencies = [
- "indexmap-nostd",
 ]
 
 [[package]]
@@ -3722,6 +3762,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7f4ea97f6f78012141bcdb6a216b2609f0979ada50b20ca5b52dde2eac2bb1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3732,18 +3790,12 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
-
-[[package]]
-name = "writeable"
 version = "0.6.1"
 dependencies = [
  "criterion",
  "either",
  "icu_benchmark_macros",
- "rand",
+ "rand 0.9.0",
 ]
 
 [[package]]
@@ -3757,38 +3809,14 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
-dependencies = [
- "serde",
- "stable_deref_trait",
- "yoke-derive 0.7.5",
- "zerofrom 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "yoke"
 version = "0.8.0"
 dependencies = [
  "bincode",
  "postcard",
  "serde",
  "stable_deref_trait",
- "yoke-derive 0.8.0",
- "zerofrom 0.1.6",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
- "synstructure",
+ "yoke-derive",
+ "zerofrom",
 ]
 
 [[package]]
@@ -3799,8 +3827,8 @@ dependencies = [
  "quote",
  "syn 2.0.98",
  "synstructure",
- "yoke 0.8.0",
- "zerovec 0.11.1",
+ "yoke",
+ "zerovec",
 ]
 
 [[package]]
@@ -3810,7 +3838,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
+dependencies = [
+ "zerocopy-derive 0.8.23",
 ]
 
 [[package]]
@@ -3825,19 +3862,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerofrom"
-version = "0.1.6"
+name = "zerocopy-derive"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
 dependencies = [
- "zerofrom-derive 0.1.6",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "zerofrom"
 version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
- "zerofrom-derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zerofrom-derive",
 ]
 
 [[package]]
@@ -3848,20 +3887,8 @@ dependencies = [
  "quote",
  "syn 2.0.98",
  "synstructure",
- "zerofrom 0.1.6",
- "zerovec 0.11.1",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
- "synstructure",
+ "zerofrom",
+ "zerovec",
 ]
 
 [[package]]
@@ -3880,28 +3907,17 @@ dependencies = [
  "displaydoc",
  "icu_benchmark_macros",
  "icu_locale_core",
- "litemap 0.7.5",
+ "litemap",
  "postcard",
- "rand",
+ "rand 0.9.0",
  "rand_pcg",
  "rmp-serde",
  "serde",
  "serde_json",
- "writeable 0.6.1",
- "yoke 0.8.0",
- "zerofrom 0.1.6",
- "zerovec 0.11.1",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
-dependencies = [
- "yoke 0.7.5",
- "zerofrom 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "zerovec-derive 0.10.3",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
 ]
 
 [[package]]
@@ -3911,32 +3927,21 @@ dependencies = [
  "bincode",
  "criterion",
  "databake",
- "getrandom",
+ "getrandom 0.3.1",
  "iai",
  "icu_benchmark_macros",
  "postcard",
  "potential_utf",
- "rand",
+ "rand 0.9.0",
  "rand_distr",
  "rand_pcg",
  "rmp-serde",
  "serde",
  "serde_json",
  "twox-hash",
- "yoke 0.8.0",
- "zerofrom 0.1.6",
- "zerovec-derive 0.11.1",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
 ]
 
 [[package]]
@@ -3949,18 +3954,37 @@ dependencies = [
  "serde",
  "serde_json",
  "syn 2.0.98",
- "zerofrom 0.1.6",
- "zerovec 0.11.1",
+ "zerofrom",
+ "zerovec",
 ]
 
 [[package]]
 name = "zip"
-version = "0.6.6"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+checksum = "b280484c454e74e5fff658bbf7df8fdbe7a07c6b2de4a53def232c15ef138f3a"
 dependencies = [
- "byteorder",
+ "arbitrary",
  "crc32fast",
  "crossbeam-utils",
+ "displaydoc",
  "flate2",
+ "indexmap",
+ "memchr",
+ "thiserror",
+ "zopfli",
+]
+
+[[package]]
+name = "zopfli"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5019f391bac5cf252e93bbcc53d039ffd62c7bfb7c150414d61369afe57e946"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "lockfree-object-pool",
+ "log",
+ "once_cell",
+ "simd-adler32",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -252,7 +252,7 @@ postcard = { version = "1.0.3", default-features = false }
 regex-automata = { version = "0.4.7", default-features = false }
 ryu = { version = "1.0.5", default-features = false }
 serde = { version = "1.0.110", default-features = false }
-serde-json-core = { version = "0.4.0", default-features = false }
+serde-json-core = { version = "0.6.0", default-features = false }
 smallvec = { version = "1.10.0", default-features = false }
 stable_deref_trait = { version = "1.2.0", default-features = false }
 twox-hash = { version = "2.0.0", default-features = false, features = ["xxhash64"] }
@@ -262,46 +262,46 @@ utf8_iter = { version = "1.0.2", default-features = false }
 write16 = { version = "1.0.0", default-features = false }
 
 ## External Deps Group 2: Heavy Dev and Datagen deps. No default features.
-zip = { version = "0.6.0", default-features = false }
+zip = { version = "2", default-features = false }
 tar = { version = "0.4.43", default-features = false }
 flate2 = { version = "1.0.35", default-features = false }
 serde-aux = { version = "4.0.0", default-features = false }
 
 ## External Deps Group 3: Dev and Datagen deps. Include default features.
 arraystring = "0.3.0"
-atoi = "1.0.0"
-bincode = "1.3.1"
+atoi = "2.0.0"
+bincode = "1.3.1" # Can be updated to 2.0 after MSRV 1.85
 clap = "4.2.0"
 combine = "4.3.1"
 criterion = "0.5.0"
 detone = "1.0.0"
 elsa = "1.10.0"
-erased-serde = "0.3.11"
+erased-serde = "0.4.0"
 eyre = "0.6.0"
-getrandom = "0.2"
+getrandom = "0.3"
 heck = "0.5"
 iai = "0.1.1"
-indexmap = "1.0.0"
+indexmap = "2.0.0"
 itertools = "0.14.0"
-ndarray = "0.15.0"
+ndarray = "0.16.0"
 nom = "7.0.0"
 parse-zoneinfo = "0.3.1"
 proc-macro2 = "1.0.61"
 quote = "1.0.28"
-rand = "0.8"
-rand_distr = "0.4"
-rand_pcg = "0.3"
+rand = "0.9"
+rand_distr = "0.5"
+rand_pcg = "0.9"
 rayon = "1.3.0"
 rkyv = "0.7"
 rmp-serde = "1.2.0"
 serde_json = "1.0.45"
-simple_logger = "4.0.0"
+simple_logger = "5.0.0"
 syn = "2.0.21"
 synstructure = "0.13.0"
-toml = "0.5.8"
-ureq = "2.3.0"
+toml = "0.8.0"
+ureq = "3.0.0"
 walkdir = "2.3.2"
-wasmi = "0.31.2"
+wasmi = "0.40.0"
 wat = "1"
 
 # Size optimized builds

--- a/components/decimal/Cargo.toml
+++ b/components/decimal/Cargo.toml
@@ -39,7 +39,7 @@ icu_provider_adapters = { path = "../../provider/adapters" }
 rand = { workspace = true }
 rand_pcg = { workspace = true }
 rand_distr = { workspace = true }
-getrandom = { workspace = true, features = ["js"] }
+getrandom = { workspace = true, features = ["wasm_js"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 criterion = { workspace = true }

--- a/provider/source/src/segmenter/lstm.rs
+++ b/provider/source/src/segmenter/lstm.rs
@@ -92,13 +92,13 @@ impl RawLstmData {
             return Err(DIMENSION_MISMATCH_ERROR);
         }
         // Unwraps okay: dimensions checked above
-        let mut fw_w = fw_w.into_shape((embedd_dim, 4, hunits)).unwrap();
-        let mut fw_u = fw_u.into_shape((hunits, 4, hunits)).unwrap();
-        let fw_b = fw_b.into_shape((4, hunits)).unwrap();
-        let mut bw_w = bw_w.into_shape((embedd_dim, 4, hunits)).unwrap();
-        let mut bw_u = bw_u.into_shape((hunits, 4, hunits)).unwrap();
-        let bw_b = bw_b.into_shape((4, hunits)).unwrap();
-        let mut time_w = time_w.into_shape((2, hunits, 4)).unwrap();
+        let mut fw_w = fw_w.into_shape_with_order((embedd_dim, 4, hunits)).unwrap();
+        let mut fw_u = fw_u.into_shape_with_order((hunits, 4, hunits)).unwrap();
+        let fw_b = fw_b.into_shape_with_order((4, hunits)).unwrap();
+        let mut bw_w = bw_w.into_shape_with_order((embedd_dim, 4, hunits)).unwrap();
+        let mut bw_u = bw_u.into_shape_with_order((hunits, 4, hunits)).unwrap();
+        let bw_b = bw_b.into_shape_with_order((4, hunits)).unwrap();
+        let mut time_w = time_w.into_shape_with_order((2, hunits, 4)).unwrap();
         fw_w.swap_axes(0, 2);
         fw_w.swap_axes(0, 1);
         fw_u.swap_axes(0, 2);

--- a/tools/make/depcheck/src/allowlist.rs
+++ b/tools/make/depcheck/src/allowlist.rs
@@ -156,10 +156,13 @@ pub const EXTRA_SOURCE_DEPS: &[&str] = &[
     "databake-derive",
     "elsa",
     "erased-serde",
+    "equivalent",
     "filetime",
+    "hashbrown",
     "icu_codepointtrie_builder",
     "icu_provider_adapters",
     "icu_provider_registry",
+    "indexmap",
     "itertools",
     "itoa",
     "libc",
@@ -173,10 +176,17 @@ pub const EXTRA_SOURCE_DEPS: &[&str] = &[
     "ryu",
     "serde-aux",
     "serde_json",
+    "serde_spanned",
     "static_assertions",
     "tar",
+    "toml_edit",
+    "toml_datetime",
+    "thiserror",
+    "thiserror-impl",
+    "typeid",
     "toml",
     "twox-hash",
+    "winnow",
 ];
 
 /// Dependencies needed by datagen (not counting `log` and `rayon` deps)
@@ -187,6 +197,7 @@ pub const EXTRA_EXPORT_DEPS: &[&str] = &[
     "databake-derive",
     "erased-serde",
     "postcard",
+    "typeid",
 ];
 
 /// Dependencies needed by the `log` crate
@@ -199,13 +210,19 @@ pub const EXTRA_LOGGING_DEPS: &[&str] = &["cfg-if", "log"];
 /// This should rarely change, and if it does consider toggling features until it doesn't
 pub const EXTRA_ZIP_DEPS: &[&str] = &[
     "adler2",
+    "bumpalo",
     "byteorder",
     "crc32fast",
     "flate2",
+    "lockfree-object-pool",
     "miniz_oxide",
+    "once_cell",
     "ordered-float",
+    "serde-spanned",
     "serde-value",
+    "simd-adler32",
     "zip",
+    "zopfli",
 ];
 
 /// Dependencies needed by the `rayon` crate

--- a/tools/make/download-repo-sources/src/main.rs
+++ b/tools/make/download-repo-sources/src/main.rs
@@ -67,6 +67,7 @@ fn main() -> eyre::Result<()> {
                 &mut ureq::get(resource)
                     .call()
                     .map_err(|e| DataError::custom("Download").with_display_context(&e))?
+                    .into_body()
                     .into_reader(),
                 &mut BufWriter::new(File::create(&root)?),
             )?;

--- a/utils/bies/tests/from_bies_matrix.rs
+++ b/utils/bies/tests/from_bies_matrix.rs
@@ -107,8 +107,10 @@ impl<R: Rng> TestDataGenerator<R> {
 
     /// Returns a BIES vector weighted at the given cell (b, i, e, s)
     fn bies_vector_for_char(&mut self, ch: char, noise: f32) -> BiesVector<f32> {
-        let cell = if self.rng.gen::<f32>() < noise {
-            Uniform::new(0, 4).sample(&mut self.rng)
+        let cell = if self.rng.random::<f32>() < noise {
+            Uniform::new(0, 4)
+                .expect("Uniform out of bounds")
+                .sample(&mut self.rng)
         } else {
             match ch {
                 'b' => 0,
@@ -123,7 +125,9 @@ impl<R: Rng> TestDataGenerator<R> {
 
     /// Returns a random BIES vector.
     fn rand_bies_vector(&mut self) -> BiesVector<f32> {
-        let cell = Uniform::new(0, 4).sample(&mut self.rng);
+        let cell = Uniform::new(0, 4)
+            .expect("Uniform out of bounds")
+            .sample(&mut self.rng);
         self.bies_vector_for_cell(cell)
     }
 
@@ -146,7 +150,7 @@ impl<R: Rng> TestDataGenerator<R> {
     /// Returns a random instance of Breakpoints with the given concentration (higher = more breakpoints)
     fn rand_breakpoints(&mut self, len: usize, concentr: f32) -> Breakpoints {
         let breakpoints = (1..len - 1)
-            .filter(|_| self.rng.gen::<f32>() < concentr)
+            .filter(|_| self.rng.random::<f32>() < concentr)
             .collect();
         Breakpoints {
             breakpoints,
@@ -161,7 +165,7 @@ impl<R: Rng> TestDataGenerator<R> {
     ) -> Vec<usize> {
         let mut breakpoints = vec![];
         for i in 1..true_breakpoints.length {
-            if true_breakpoints.breakpoints.contains(&i) || self.rng.gen::<f32>() < concentr {
+            if true_breakpoints.breakpoints.contains(&i) || self.rng.random::<f32>() < concentr {
                 breakpoints.push(i);
             }
         }

--- a/utils/fixed_decimal/Cargo.toml
+++ b/utils/fixed_decimal/Cargo.toml
@@ -29,7 +29,7 @@ writeable = { workspace = true }
 ryu = { workspace = true, features = ["small"], optional = true }
 
 [dev-dependencies]
-getrandom = { workspace = true, features = ["js"] }
+getrandom = { workspace = true, features = ["wasm_js"] }
 icu_benchmark_macros = { path = "../../tools/benchmark/macros" }
 rand = { workspace = true }
 rand_distr = { workspace = true }

--- a/utils/tinystr/src/ascii.rs
+++ b/utils/tinystr/src/ascii.rs
@@ -819,10 +819,9 @@ impl<const N: usize> PartialEq<TinyAsciiStr<N>> for alloc::string::String {
 #[cfg(test)]
 mod test {
     use super::*;
-    use rand::distributions::Distribution;
-    use rand::distributions::Standard;
+    use rand::distr::Distribution;
+    use rand::distr::StandardUniform;
     use rand::rngs::SmallRng;
-    use rand::seq::SliceRandom;
     use rand::SeedableRng;
 
     const STRINGS: [&str; 26] = [
@@ -855,6 +854,7 @@ mod test {
     ];
 
     fn gen_strings(num_strings: usize, allowed_lengths: &[usize]) -> Vec<String> {
+        use rand::seq::IndexedRandom;
         let mut rng = SmallRng::seed_from_u64(2022);
         // Need to do this in 2 steps since the RNG is needed twice
         let string_lengths = core::iter::repeat_with(|| *allowed_lengths.choose(&mut rng).unwrap())
@@ -863,7 +863,7 @@ mod test {
         string_lengths
             .iter()
             .map(|len| {
-                Standard
+                StandardUniform
                     .sample_iter(&mut rng)
                     .filter(|b: &u8| *b > 0 && *b < 0x80)
                     .take(*len)

--- a/utils/writeable/src/impls.rs
+++ b/utils/writeable/src/impls.rs
@@ -6,7 +6,8 @@ use crate::*;
 use core::fmt;
 
 macro_rules! impl_write_num {
-    ($u:ty, $i:ty, $test:ident) => {
+    // random_call exists since usize doesn't have a rand impl. Should always be `random` or empty
+    ($u:ty, $i:ty, $test:ident $(,$random_call:ident)?) => {
         impl $crate::Writeable for $u {
             fn write_to<W: core::fmt::Write + ?Sized>(&self, sink: &mut W) -> core::fmt::Result {
                 const MAX_LEN: usize = <$u>::MAX.ilog10() as usize + 1;
@@ -71,22 +72,25 @@ macro_rules! impl_write_num {
             assert_writeable_eq!(&<$i>::MAX, <$i>::MAX.to_string());
             assert_writeable_eq!(&<$i>::MIN, <$i>::MIN.to_string());
 
-            use rand::{rngs::SmallRng, Rng, SeedableRng};
-            let mut rng = SmallRng::seed_from_u64(4); // chosen by fair dice roll.
-                                                      // guaranteed to be random.
-            for _ in 0..1000 {
-                let rand = rng.gen::<$u>();
-                assert_writeable_eq!(rand, rand.to_string());
-            }
+            $(
+
+                use rand::{rngs::SmallRng, Rng, SeedableRng};
+                let mut rng = SmallRng::seed_from_u64(4); // chosen by fair dice roll.
+                                                          // guaranteed to be random.
+                for _ in 0..1000 {
+                    let rand = rng.$random_call::<$u>();
+                    assert_writeable_eq!(rand, rand.to_string());
+                }
+            )?
         }
     };
 }
 
-impl_write_num!(u8, i8, test_u8);
-impl_write_num!(u16, i16, test_u16);
-impl_write_num!(u32, i32, test_u32);
-impl_write_num!(u64, i64, test_u64);
-impl_write_num!(u128, i128, test_u128);
+impl_write_num!(u8, i8, test_u8, random);
+impl_write_num!(u16, i16, test_u16, random);
+impl_write_num!(u32, i32, test_u32, random);
+impl_write_num!(u64, i64, test_u64, random);
+impl_write_num!(u128, i128, test_u128, random);
 impl_write_num!(usize, isize, test_usize);
 
 impl Writeable for str {

--- a/utils/zerotrie/Cargo.toml
+++ b/utils/zerotrie/Cargo.toml
@@ -39,7 +39,7 @@ rmp-serde = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 zerovec = { path = "../../utils/zerovec", features = ["serde", "hashmap"] }
-icu_locale_core = { path = "../../components/locale_core" }
+icu_locale_core = { workspace = true, features = ["alloc"]  }
 writeable = { path = "../../utils/writeable" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/utils/zerotrie/src/byte_phf/builder.rs
+++ b/utils/zerotrie/src/byte_phf/builder.rs
@@ -156,9 +156,10 @@ mod tests {
     fn random_alphanums(seed: u64, len: usize) -> Vec<u8> {
         use rand::seq::SliceRandom;
         use rand::SeedableRng;
-        const BYTES: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+        let mut bytes: Vec<u8> =
+            b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789".into();
         let mut rng = rand_pcg::Lcg64Xsh32::seed_from_u64(seed);
-        BYTES.choose_multiple(&mut rng, len).copied().collect()
+        bytes.partial_shuffle(&mut rng, len).0.into()
     }
 
     #[test]
@@ -185,8 +186,8 @@ mod tests {
 
         assert_eq!(2500, fast_p);
         assert_eq!(0, slow_p);
-        assert_eq!(61247, fast_q);
-        assert_eq!(3, slow_q);
+        assert_eq!(61243, fast_q);
+        assert_eq!(7, slow_q);
 
         let bytes = random_alphanums(0, 16);
 

--- a/utils/zerotrie/src/byte_phf/mod.rs
+++ b/utils/zerotrie/src/byte_phf/mod.rs
@@ -289,9 +289,11 @@ mod tests {
     fn random_alphanums(seed: u64, len: usize) -> Vec<u8> {
         use rand::seq::SliceRandom;
         use rand::SeedableRng;
-        const BYTES: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+        let mut bytes: Vec<u8> =
+            b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789".into();
         let mut rng = rand_pcg::Lcg64Xsh32::seed_from_u64(seed);
-        BYTES.choose_multiple(&mut rng, len).copied().collect()
+        bytes.partial_shuffle(&mut rng, len).0.into()
     }
 
     #[test]

--- a/utils/zerovec/Cargo.toml
+++ b/utils/zerovec/Cargo.toml
@@ -35,7 +35,7 @@ twox-hash = { workspace = true, optional = true }
 
 [dev-dependencies]
 bincode = { workspace = true }
-getrandom = { workspace = true, features = ["js"] }
+getrandom = { workspace = true, features = ["wasm_js"] }
 iai = { workspace = true }
 icu_benchmark_macros = { path = "../../tools/benchmark/macros" }
 postcard = { workspace = true, features = ["use-std"] }

--- a/utils/zerovec/benches/vzv.rs
+++ b/utils/zerovec/benches/vzv.rs
@@ -20,9 +20,9 @@ use zerovec::VarZeroVec;
 fn random_alphanums(lengths: RangeInclusive<usize>, count: usize, seed: u64) -> (Vec<String>, u64) {
     // Lcg64Xsh32 is a small, fast PRNG for reproducible benchmarks.
     let mut rng1 = Lcg64Xsh32::seed_from_u64(seed);
-    let mut rng2 = Lcg64Xsh32::seed_from_u64(rand::Rng::gen(&mut rng1));
+    let mut rng2 = Lcg64Xsh32::seed_from_u64(rand::Rng::random(&mut rng1));
     let alpha_dist = Alphanumeric;
-    let len_dist = Uniform::from(lengths);
+    let len_dist = Uniform::try_from(lengths).expect("range out of bounds");
     let string_vec = len_dist
         .sample_iter(&mut rng1)
         .take(count)
@@ -34,7 +34,7 @@ fn random_alphanums(lengths: RangeInclusive<usize>, count: usize, seed: u64) -> 
                 .collect::<String>()
         })
         .collect();
-    (string_vec, rand::Rng::gen(&mut rng1))
+    (string_vec, rand::Rng::random(&mut rng1))
 }
 
 fn overview_bench(c: &mut Criterion) {

--- a/utils/zerovec/src/hashmap/mod.rs
+++ b/utils/zerovec/src/hashmap/mod.rs
@@ -218,7 +218,7 @@ where
 mod tests {
     use super::*;
     use crate::ule::AsULE;
-    use rand::{distributions::Standard, Rng, SeedableRng};
+    use rand::{distr::StandardUniform, Rng, SeedableRng};
     use rand_pcg::Lcg64Xsh32;
 
     #[test]
@@ -226,7 +226,7 @@ mod tests {
         const N: usize = 65530;
         let seed = u64::from_le_bytes(*b"testseed");
         let rng = Lcg64Xsh32::seed_from_u64(seed);
-        let kv: Vec<(u64, u64)> = rng.sample_iter(&Standard).take(N).collect();
+        let kv: Vec<(u64, u64)> = rng.sample_iter(&StandardUniform).take(N).collect();
         let hashmap: ZeroHashMap<u64, u64> =
             ZeroHashMap::from_iter(kv.iter().map(|e| (&e.0, &e.1)));
         for (k, v) in kv {


### PR DESCRIPTION
Fixes #6265

I didn't update nom, it's complicated and it's test only.

I _did_ update toml: this is a major change to the deps allowlist because `toml` upstream merged with `toml_edit`. This is an inevitable deps change that we'll have to handle eventually, better now rather than later.

zip also expanded to support zopfli, it's not something that can be disabled. I think that's fine overall

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->