### PR TITLE
Clean up datetime tests

### DIFF
--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -124,6 +124,9 @@ pub mod preferences {
     pub use icu_locale_core::preferences::extensions::unicode::keywords::CalendarAlgorithm;
     /// **This is a reexport of a type in [`icu::locale`](icu_locale_core::preferences::extensions::unicode::keywords)**.
     #[doc = "\n"] // prevent autoformatting
+    pub use icu_locale_core::preferences::extensions::unicode::keywords::HijriCalendarAlgorithm;
+    /// **This is a reexport of a type in [`icu::locale`](icu_locale_core::preferences::extensions::unicode::keywords)**.
+    #[doc = "\n"] // prevent autoformatting
     pub use icu_locale_core::preferences::extensions::unicode::keywords::HourCycle;
     /// **This is a reexport of a type in [`icu::locale`](icu_locale_core::preferences::extensions::unicode::keywords)**.
     #[doc = "\n"] // prevent autoformatting

--- a/components/datetime/tests/fixtures/mod.rs
+++ b/components/datetime/tests/fixtures/mod.rs
@@ -6,7 +6,6 @@
 
 use icu_datetime::fieldsets::builder::FieldSetBuilder;
 use icu_datetime::provider::fields::components;
-use icu_locale_core::preferences::extensions::unicode::keywords::HourCycle;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -31,8 +30,6 @@ pub struct TestOptions {
     pub length: Option<TestOptionsLength>,
     pub components: Option<TestComponentsBag>,
     pub semantic: Option<FieldSetBuilder>,
-    #[serde(rename = "hourCycle")]
-    pub hour_cycle: Option<TestHourCycle>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -68,26 +65,6 @@ pub struct TestComponentsBag {
     pub subsecond: Option<u8>,
 
     pub time_zone_name: Option<components::TimeZoneName>,
-}
-
-#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum TestHourCycle {
-    H11,
-    H12,
-    H23,
-    H24,
-}
-
-impl From<TestHourCycle> for HourCycle {
-    fn from(value: TestHourCycle) -> Self {
-        match value {
-            TestHourCycle::H11 => HourCycle::H11,
-            TestHourCycle::H12 => HourCycle::H12,
-            TestHourCycle::H23 => HourCycle::H23,
-            TestHourCycle::H24 => HourCycle::H24,
-        }
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/components/datetime/tests/fixtures/mod.rs
+++ b/components/datetime/tests/fixtures/mod.rs
@@ -5,7 +5,6 @@
 #![cfg(feature = "serde")]
 
 use icu_datetime::fieldsets::builder::FieldSetBuilder;
-use icu_datetime::provider::fields::components;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -27,44 +26,7 @@ pub struct TestInput {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TestOptions {
-    pub length: Option<TestOptionsLength>,
-    pub components: Option<TestComponentsBag>,
     pub semantic: Option<FieldSetBuilder>,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct TestOptionsLength {
-    pub date: Option<TestLength>,
-    pub time: Option<TestLength>,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub enum TestLength {
-    #[serde(rename = "short")]
-    Short,
-    #[serde(rename = "medium")]
-    Medium,
-    #[serde(rename = "long")]
-    Long,
-    #[serde(rename = "full")]
-    Full,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct TestComponentsBag {
-    pub era: Option<components::Text>,
-    pub year: Option<components::Year>,
-    pub month: Option<components::Month>,
-    pub week: Option<components::Week>,
-    pub day: Option<components::Day>,
-    pub weekday: Option<components::Text>,
-
-    pub hour: Option<components::Numeric>,
-    pub minute: Option<components::Numeric>,
-    pub second: Option<components::Numeric>,
-    pub subsecond: Option<u8>,
-
-    pub time_zone_name: Option<components::TimeZoneName>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/components/datetime/tests/fixtures/mod.rs
+++ b/components/datetime/tests/fixtures/mod.rs
@@ -5,6 +5,7 @@
 #![cfg(feature = "serde")]
 
 use icu_datetime::fieldsets::builder::FieldSetBuilder;
+use icu_datetime::provider::fields::components;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -26,7 +27,44 @@ pub struct TestInput {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TestOptions {
+    pub length: Option<TestOptionsLength>,
+    pub components: Option<TestComponentsBag>,
     pub semantic: Option<FieldSetBuilder>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TestOptionsLength {
+    pub date: Option<TestLength>,
+    pub time: Option<TestLength>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum TestLength {
+    #[serde(rename = "short")]
+    Short,
+    #[serde(rename = "medium")]
+    Medium,
+    #[serde(rename = "long")]
+    Long,
+    #[serde(rename = "full")]
+    Full,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TestComponentsBag {
+    pub era: Option<components::Text>,
+    pub year: Option<components::Year>,
+    pub month: Option<components::Month>,
+    pub week: Option<components::Week>,
+    pub day: Option<components::Day>,
+    pub weekday: Option<components::Text>,
+
+    pub hour: Option<components::Numeric>,
+    pub minute: Option<components::Numeric>,
+    pub second: Option<components::Numeric>,
+    pub subsecond: Option<u8>,
+
+    pub time_zone_name: Option<components::TimeZoneName>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/components/datetime/tests/fixtures/tests/components-combine-datetime.json
+++ b/components/datetime/tests/fixtures/tests/components-combine-datetime.json
@@ -17,13 +17,12 @@
                     "dateFields": "YMDE",
                     "length": "medium",
                     "timePrecision": "minute"
-                },
-                "hourCycle": "h12"
+                }
             }
         },
         "output": {
             "values": {
-                "en": {
+                "en-u-hc-h12": {
                     "formatted": "Tue, Jan 7, 2020, 8:25\u202fAM",
                     "pattern": "E, MMM d, y, h:mm\u202fa"
                 }
@@ -48,13 +47,12 @@
                     "dateFields": "YMDE",
                     "length": "long",
                     "timePrecision": "minute"
-                },
-                "hourCycle": "h12"
+                }
             }
         },
         "output": {
             "values": {
-                "en": {
+                "en-u-hc-h12": {
                     "formatted": "Tuesday, January 7, 2020, 8:25\u202fAM",
                     "pattern": "EEEE, MMMM d, y, h:mm\u202fa"
                 }

--- a/components/datetime/tests/fixtures/tests/components-exact-matches.json
+++ b/components/datetime/tests/fixtures/tests/components-exact-matches.json
@@ -445,13 +445,12 @@
                     "dateFields": "E",
                     "length": "medium",
                     "timePrecision": "minute"
-                },
-                "hourCycle": "h23"
+                }
             }
         },
         "output": {
             "values": {
-                "en": "Tue, 08:25"
+                "en-u-hc-h23": "Tue, 08:25"
             }
         }
     },
@@ -470,13 +469,12 @@
                     "dateFields": "E",
                     "length": "medium",
                     "timePrecision": "second"
-                },
-                "hourCycle": "h23"
+                }
             }
         },
         "output": {
             "values": {
-                "en": "Tue, 08:25:07"
+                "en-u-hc-h23": "Tue, 08:25:07"
             }
         }
     },
@@ -491,13 +489,12 @@
                 "semantic": {
                     "length": "short",
                     "timePrecision": "hour"
-                },
-                "hourCycle": "h12"
+                }
             }
         },
         "output": {
             "values": {
-                "en": "8\u202fAM"
+                "en-u-hc-h12": "8\u202fAM"
             }
         }
     },
@@ -513,13 +510,12 @@
                 "semantic": {
                     "length": "short",
                     "timePrecision": "minute"
-                },
-                "hourCycle": "h12"
+                }
             }
         },
         "output": {
             "values": {
-                "en": "8:25\u202fAM"
+                "en-u-hc-h12": "8:25\u202fAM"
             }
         }
     },
@@ -536,13 +532,12 @@
                 "semantic": {
                     "length": "short",
                     "timePrecision": "second"
-                },
-                "hourCycle": "h12"
+                }
             }
         },
         "output": {
             "values": {
-                "en": "8:25:07\u202fAM"
+                "en-u-hc-h12": "8:25:07\u202fAM"
             }
         }
     },
@@ -557,13 +552,12 @@
                 "semantic": {
                     "length": "short",
                     "timePrecision": "hour"
-                },
-                "hourCycle": "h23"
+                }
             }
         },
         "output": {
             "values": {
-                "en": "08"
+                "en-u-hc-h23": "08"
             }
         }
     },
@@ -579,13 +573,12 @@
                 "semantic": {
                     "length": "short",
                     "timePrecision": "minute"
-                },
-                "hourCycle": "h23"
+                }
             }
         },
         "output": {
             "values": {
-                "en": "08:25"
+                "en-u-hc-h23": "08:25"
             }
         }
     },
@@ -602,13 +595,12 @@
                 "semantic": {
                     "length": "short",
                     "timePrecision": "second"
-                },
-                "hourCycle": "h23"
+                }
             }
         },
         "output": {
             "values": {
-                "en": "08:25:07"
+                "en-u-hc-h23": "08:25:07"
             }
         }
     },

--- a/components/datetime/tests/fixtures/tests/components.json
+++ b/components/datetime/tests/fixtures/tests/components.json
@@ -18,42 +18,41 @@
                     "length": "long",
                     "timePrecision": "second",
                     "yearStyle": "withEra"
-                },
-                "hourCycle": "h23"
+                }
             }
         },
         "output": {
             "values": {
-                "en": "Tuesday, January 21, 2020 AD, 08:25:07",
-                "en-u-ca-buddhist": "Tuesday, January 21, 2563 BE, 08:25:07",
-                "en-u-ca-chinese": "Tuesday, Twelfth Month 27, 2019(ji-hai), 08:25:07",
-                "zh-u-ca-chinese": "2019己亥年腊月27星期二 08:25:07",
-                "en-u-ca-japanese": "Tuesday, January 21, 2 Reiwa, 08:25:07",
-                "ja-u-ca-japanese": "令和2年1月21日火曜日 8:25:07",
-                "en-u-ca-coptic": "Tuesday, Toba 12, 1736 ERA1, 08:25:07",
-                "fr-u-ca-coptic": "mardi 12 toubah 1736 ap. D., 08:25:07",
-                "en-u-ca-dangi": "Tuesday, Twelfth Month 27, 2019(ji-hai), 08:25:07",
-                "fr-u-ca-dangi": "2019(ji-hai) shí’èryuè 27, mardi, 08:25:07",
-                "ko-u-ca-dangi": "2019년(기해년) 12월 27일 화요일 08:25:07",
-                "en-u-ca-indian": "Tuesday, Magha 1, 1941 Saka, 08:25:07",
-                "en-u-ca-islamic": "Tuesday, Jumada I 25, 1441 AH, 08:25:07",
-                "fr-u-ca-islamic": "mardi 25 joumada al oula 1441 AH, 08:25:07",
-                "en-u-ca-islamic-civil": "Tuesday, Jumada I 25, 1441 AH, 08:25:07",
-                "fr-u-ca-islamic-civil": "mardi 25 joumada al oula 1441 AH, 08:25:07",
-                "en-u-ca-islamic-umalqura": "Tuesday, Jumada I 26, 1441 AH, 08:25:07",
-                "fr-u-ca-islamic-umalqura": "mardi 26 joumada al oula 1441 AH, 08:25:07",
-                "en-u-ca-islamic-tbla": "Tuesday, Jumada I 26, 1441 AH, 08:25:07",
-                "fr-u-ca-islamic-tbla": "mardi 26 joumada al oula 1441 AH, 08:25:07",
-                "en-u-ca-persian": "Tuesday, Bahman 1, 1398 AP, 08:25:07",
-                "fr-u-ca-persian": "mardi 1 bahman 1398 A. P., 08:25:07",
-                "en-u-ca-hebrew": "Tuesday, 24 Tevet 5780 AM, 08:25:07",
-                "fr-u-ca-hebrew": "mardi 24 téveth 5780 A. M., 08:25:07",
-                "en-u-ca-ethiopic": "Tuesday, Ter 12, 2012 ERA1, 08:25:07",
-                "fr-u-ca-ethiopic": "mardi 12 ter 2012 ap. Inc., 08:25:07",
-                "fr-u-ca-ethioaa": "mardi 12 ter 7512 av. Inc., 08:25:07",
-                "en-u-ca-roc": "Tuesday, January 21, 109 Minguo, 08:25:07",
-                "fr-u-ca-roc": "mardi 21 janvier 109 RdC, 08:25:07",
-                "zh-u-ca-roc": "民国109年1月21日星期二 08:25:07"
+                "en-u-hc-h23": "Tuesday, January 21, 2020 AD, 08:25:07",
+                "en-u-ca-buddhist-hc-h23": "Tuesday, January 21, 2563 BE, 08:25:07",
+                "en-u-ca-chinese-hc-h23": "Tuesday, Twelfth Month 27, 2019(ji-hai), 08:25:07",
+                "zh-u-ca-chinese-hc-h23": "2019己亥年腊月27星期二 08:25:07",
+                "en-u-ca-japanese-hc-h23": "Tuesday, January 21, 2 Reiwa, 08:25:07",
+                "ja-u-ca-japanese-hc-h23": "令和2年1月21日火曜日 8:25:07",
+                "en-u-ca-coptic-hc-h23": "Tuesday, Toba 12, 1736 ERA1, 08:25:07",
+                "fr-u-ca-coptic-hc-h23": "mardi 12 toubah 1736 ap. D., 08:25:07",
+                "en-u-ca-dangi-hc-h23": "Tuesday, Twelfth Month 27, 2019(ji-hai), 08:25:07",
+                "fr-u-ca-dangi-hc-h23": "2019(ji-hai) shí’èryuè 27, mardi, 08:25:07",
+                "ko-u-ca-dangi-hc-h23": "2019년(기해년) 12월 27일 화요일 08:25:07",
+                "en-u-ca-indian-hc-h23": "Tuesday, Magha 1, 1941 Saka, 08:25:07",
+                "en-u-ca-islamic-hc-h23": "Tuesday, Jumada I 25, 1441 AH, 08:25:07",
+                "fr-u-ca-islamic-hc-h23": "mardi 25 joumada al oula 1441 AH, 08:25:07",
+                "en-u-ca-islamic-civil-hc-h23": "Tuesday, Jumada I 25, 1441 AH, 08:25:07",
+                "fr-u-ca-islamic-civil-hc-h23": "mardi 25 joumada al oula 1441 AH, 08:25:07",
+                "en-u-ca-islamic-umalqura-hc-h23": "Tuesday, Jumada I 26, 1441 AH, 08:25:07",
+                "fr-u-ca-islamic-umalqura-hc-h23": "mardi 26 joumada al oula 1441 AH, 08:25:07",
+                "en-u-ca-islamic-tbla-hc-h23": "Tuesday, Jumada I 26, 1441 AH, 08:25:07",
+                "fr-u-ca-islamic-tbla-hc-h23": "mardi 26 joumada al oula 1441 AH, 08:25:07",
+                "en-u-ca-persian-hc-h23": "Tuesday, Bahman 1, 1398 AP, 08:25:07",
+                "fr-u-ca-persian-hc-h23": "mardi 1 bahman 1398 A. P., 08:25:07",
+                "en-u-ca-hebrew-hc-h23": "Tuesday, 24 Tevet 5780 AM, 08:25:07",
+                "fr-u-ca-hebrew-hc-h23": "mardi 24 téveth 5780 A. M., 08:25:07",
+                "en-u-ca-ethiopic-hc-h23": "Tuesday, Ter 12, 2012 ERA1, 08:25:07",
+                "fr-u-ca-ethiopic-hc-h23": "mardi 12 ter 2012 ap. Inc., 08:25:07",
+                "fr-u-ca-ethioaa-hc-h23": "mardi 12 ter 7512 av. Inc., 08:25:07",
+                "en-u-ca-roc-hc-h23": "Tuesday, January 21, 109 Minguo, 08:25:07",
+                "fr-u-ca-roc-hc-h23": "mardi 21 janvier 109 RdC, 08:25:07",
+                "zh-u-ca-roc-hc-h23": "民国109年1月21日星期二 08:25:07"
             }
         }
     },
@@ -76,14 +75,13 @@
                     "length": "long",
                     "timePrecision": "second",
                     "yearStyle": "withEra"
-                },
-                "hourCycle": "h23"
+                }
             }
         },
         "output": {
             "values": {
-                "en-u-ca-chinese": "Thursday, Second Monthbis 2, 2023(gui-mao), 14:15:07",
-                "zh-u-ca-chinese": "2023癸卯年闰二月2星期四 14:15:07"
+                "en-u-ca-chinese-hc-h23": "Thursday, Second Monthbis 2, 2023(gui-mao), 14:15:07",
+                "zh-u-ca-chinese-hc-h23": "2023癸卯年闰二月2星期四 14:15:07"
             }
         }
     },
@@ -106,14 +104,13 @@
                     "length": "long",
                     "timePrecision": "second",
                     "yearStyle": "withEra"
-                },
-                "hourCycle": "h23"
+                }
             }
         },
         "output": {
             "values": {
-                "en-u-ca-hebrew": "Sunday, 28 Adar II 5771 AM, 14:15:07",
-                "fr-u-ca-hebrew": "dimanche 28 adar II 5771 A. M., 14:15:07"
+                "en-u-ca-hebrew-hc-h23": "Sunday, 28 Adar II 5771 AM, 14:15:07",
+                "fr-u-ca-hebrew-hc-h23": "dimanche 28 adar II 5771 A. M., 14:15:07"
             }
         }
     },
@@ -129,13 +126,12 @@
                 },
                 "semantic": {
                     "timePrecision": "second"
-                },
-                "hourCycle": "h23"
+                }
             }
         },
         "output": {
             "values": {
-                "en": "14:15:07"
+                "en-u-hc-h23": "14:15:07"
             }
         }
     },
@@ -151,13 +147,12 @@
                 },
                 "semantic": {
                     "timePrecision": "subsecond9"
-                },
-                "hourCycle": "h23"
+                }
             }
         },
         "output": {
             "values": {
-                "en": {
+                "en-u-hc-h23": {
                     "formatted": "14:15:07.012300000",
                     "pattern": "HH:mm:ss.SSSSSSSSS"
                 }

--- a/components/datetime/tests/fixtures/tests/components_hour_cycle.json
+++ b/components/datetime/tests/fixtures/tests/components_hour_cycle.json
@@ -11,13 +11,12 @@
                 "semantic": {
                     "length": "short",
                     "timePrecision": "minute"
-                },
-                "hourCycle": "h11"
+                }
             }
         },
         "output": {
             "values": {
-                "en": {
+                "en-u-hc-h11": {
                     "formatted": "0:25\u202fAM",
                     "pattern": "K:mm\u202fa"
                 }
@@ -36,13 +35,12 @@
                 "semantic": {
                     "length": "short",
                     "timePrecision": "minute"
-                },
-                "hourCycle": "h12"
+                }
             }
         },
         "output": {
             "values": {
-                "en": {
+                "en-u-hc-h12": {
                     "formatted": "12:25\u202fAM",
                     "pattern": "h:mm\u202fa"
                 }
@@ -61,13 +59,12 @@
                 "semantic": {
                     "length": "short",
                     "timePrecision": "minute"
-                },
-                "hourCycle": "h23"
+                }
             }
         },
         "output": {
             "values": {
-                "en": {
+                "en-u-hc-h23": {
                     "formatted": "00:25",
                     "pattern": "HH:mm"
                 }
@@ -86,13 +83,12 @@
                 "semantic": {
                     "length": "short",
                     "timePrecision": "minute"
-                },
-                "hourCycle": "h24"
+                }
             }
         },
         "output": {
             "values": {
-                "en": {
+                "en-u-hc-h24": {
                     "formatted": "24:25",
                     "pattern": "kk:mm"
                 }
@@ -112,13 +108,12 @@
                 "semantic": {
                     "length": "short",
                     "timePrecision": "minute"
-                },
-                "hourCycle": "h11"
+                }
             }
         },
         "output": {
             "values": {
-                "ar-EG": "٠:٢٥ ص"
+                "ar-EG-u-hc-h11": "٠:٢٥ ص"
             }
         }
     },
@@ -134,13 +129,12 @@
                 "semantic": {
                     "length": "short",
                     "timePrecision": "minute"
-                },
-                "hourCycle": "h12"
+                }
             }
         },
         "output": {
             "values": {
-                "ar-EG": "١٢:٢٥ ص"
+                "ar-EG-u-hc-h12": "١٢:٢٥ ص"
             }
         }
     },
@@ -156,13 +150,12 @@
                 "semantic": {
                     "length": "short",
                     "timePrecision": "minute"
-                },
-                "hourCycle": "h23"
+                }
             }
         },
         "output": {
             "values": {
-                "ar-EG": "٠٠:٢٥"
+                "ar-EG-u-hc-h23": "٠٠:٢٥"
             }
         }
     },
@@ -178,13 +171,12 @@
                 "semantic": {
                     "length": "short",
                     "timePrecision": "minute"
-                },
-                "hourCycle": "h24"
+                }
             }
         },
         "output": {
             "values": {
-                "ar-EG": "٢٤:٢٥"
+                "ar-EG-u-hc-h24": "٢٤:٢٥"
             }
         }
     },
@@ -199,13 +191,12 @@
                 "semantic": {
                     "length": "short",
                     "timePrecision": "hour"
-                },
-                "hourCycle": "h11"
+                }
             }
         },
         "output": {
             "values": {
-                "en": "0\u202fAM"
+                "en-u-hc-h11": "0\u202fAM"
             }
         }
     },
@@ -220,13 +211,12 @@
                 "semantic": {
                     "length": "short",
                     "timePrecision": "hour"
-                },
-                "hourCycle": "h12"
+                }
             }
         },
         "output": {
             "values": {
-                "en": "12\u202fAM"
+                "en-u-hc-h12": "12\u202fAM"
             }
         }
     },
@@ -241,13 +231,12 @@
                 "semantic": {
                     "length": "short",
                     "timePrecision": "hour"
-                },
-                "hourCycle": "h23"
+                }
             }
         },
         "output": {
             "values": {
-                "en": "00"
+                "en-u-hc-h23": "00"
             }
         }
     },
@@ -262,13 +251,12 @@
                 "semantic": {
                     "length": "short",
                     "timePrecision": "hour"
-                },
-                "hourCycle": "h24"
+                }
             }
         },
         "output": {
             "values": {
-                "en": "24"
+                "en-u-hc-h24": "24"
             }
         }
     }

--- a/components/datetime/tests/fixtures/tests/components_with_zones.json
+++ b/components/datetime/tests/fixtures/tests/components_with_zones.json
@@ -19,13 +19,12 @@
                     "length": "long",
                     "zoneStyle": "GenericShort",
                     "timePrecision": "second"
-                },
-                "hourCycle": "h23"
+                }
             }
         },
         "output": {
             "values": {
-                "en": "Tuesday, January 21, 2020, 08:25:07 GMT+5"
+                "en-u-hc-h23": "Tuesday, January 21, 2020, 08:25:07 GMT+5"
             }
         }
     },
@@ -49,13 +48,12 @@
                     "length": "long",
                     "zoneStyle": "GenericShort",
                     "timePrecision": "second"
-                },
-                "hourCycle": "h23"
+                }
             }
         },
         "output": {
             "values": {
-                "en": "Tuesday, January 21, 2020, 08:25:07 GMT+5"
+                "en-u-hc-h23": "Tuesday, January 21, 2020, 08:25:07 GMT+5"
             }
         }
     },
@@ -79,13 +77,12 @@
                     "length": "long",
                     "zoneStyle": "GenericShort",
                     "timePrecision": "second"
-                },
-                "hourCycle": "h23"
+                }
             }
         },
         "output": {
             "values": {
-                "en": "Tuesday, January 21, 2020, 08:25:07 GMT+5"
+                "en-u-hc-h23": "Tuesday, January 21, 2020, 08:25:07 GMT+5"
             }
         }
     },
@@ -109,13 +106,12 @@
                     "length": "long",
                     "zoneStyle": "GenericShort",
                     "timePrecision": "second"
-                },
-                "hourCycle": "h23"
+                }
             }
         },
         "output": {
             "values": {
-                "en": "Tuesday, January 21, 2020, 08:25:07 GMT+5"
+                "en-u-hc-h23": "Tuesday, January 21, 2020, 08:25:07 GMT+5"
             }
         }
     },
@@ -139,13 +135,12 @@
                     "length": "long",
                     "zoneStyle": "LocalizedOffsetShort",
                     "timePrecision": "second"
-                },
-                "hourCycle": "h23"
+                }
             }
         },
         "output": {
             "values": {
-                "en": "Tuesday, January 21, 2020, 08:25:07 GMT+5"
+                "en-u-hc-h23": "Tuesday, January 21, 2020, 08:25:07 GMT+5"
             }
         }
     },

--- a/components/datetime/tests/fixtures/tests/japanese.json
+++ b/components/datetime/tests/fixtures/tests/japanese.json
@@ -108,7 +108,7 @@
         "output": {
             "values": {
                 "en-u-ca-japanese": "1800 Anno Domini",
-                "en-u-ca-japanext": "12 Kansei (1789–1801)"
+                "en-u-ca-japanese-x-extended": "12 Kansei (1789–1801)"
             }
         }
     },
@@ -125,7 +125,7 @@
         "output": {
             "values": {
                 "en-u-ca-japanese": "1600 Anno Domini",
-                "en-u-ca-japanext": "5 Keichō (1596–1615)"
+                "en-u-ca-japanese-x-extended": "5 Keichō (1596–1615)"
             }
         }
     }


### PR DESCRIPTION
* Removes the `hourCycle` fixture field in favour of using `-u-hc`
* ~Removes dead code for legacy fixture format~
* Removes usage of `AnyCalendarKind`, instead uses `CalendarAlgorithm` 