### PR TITLE
Add lower-level datetime benches

### DIFF
--- a/components/datetime/benches/datetime.rs
+++ b/components/datetime/benches/datetime.rs
@@ -170,6 +170,21 @@ fn datetime_benches(c: &mut Criterion) {
         });
     });
 
+    group.bench_function("fixed/format_to_string/ymd_numeric/10_cases", |b| {
+        let formatter = construct_fixed_ymd_numeric();
+        b.iter(|| {
+            let mut counter = 0usize; // make sure the loop is not DCE'd
+            for datetime in black_box(&ten_cases).iter() {
+                let n = black_box(&formatter)
+                    .format(datetime)
+                    .write_to_string()
+                    .len();
+                counter = counter.wrapping_add(n);
+            }
+            counter
+        });
+    });
+
     group.finish();
 }
 

--- a/components/datetime/benches/datetime.rs
+++ b/components/datetime/benches/datetime.rs
@@ -110,29 +110,35 @@ fn datetime_benches(c: &mut Criterion) {
     .map(|s| DateTime::try_from_str(s, Gregorian).unwrap());
 
     #[inline]
-    fn construct_any_ymd_numeric() -> DateTimeFormatter<fieldsets::YMD> {
+    fn construct_any_ymd_short() -> DateTimeFormatter<fieldsets::YMD> {
         DateTimeFormatter::try_new(locale!("fr").into(), fieldsets::YMD::short()).unwrap()
     }
 
     #[inline]
-    fn construct_fixed_ymd_numeric() -> FixedCalendarDateTimeFormatter<Gregorian, fieldsets::YMD> {
+    fn construct_fixed_ymd_short() -> FixedCalendarDateTimeFormatter<Gregorian, fieldsets::YMD> {
         FixedCalendarDateTimeFormatter::try_new(locale!("fr").into(), fieldsets::YMD::short())
             .unwrap()
     }
 
-    group.bench_function("any/construct_and_format/ymd_numeric/10_cases", |b| {
+    #[inline]
+    fn construct_fixed_ymd_long() -> FixedCalendarDateTimeFormatter<Gregorian, fieldsets::YMD> {
+        FixedCalendarDateTimeFormatter::try_new(locale!("fr").into(), fieldsets::YMD::long())
+            .unwrap()
+    }
+
+    group.bench_function("any/construct_and_format/ymd_short/10_cases", |b| {
         let mut buffer = String::with_capacity(1000);
         b.iter(|| {
             for datetime in black_box(&ten_cases).iter() {
                 buffer.clear();
-                let formatter = construct_any_ymd_numeric();
+                let formatter = construct_any_ymd_short();
                 formatter.format(datetime).write_to(&mut buffer).unwrap();
             }
         });
     });
 
-    group.bench_function("any/format_only/ymd_numeric/10_cases", |b| {
-        let formatter = construct_any_ymd_numeric();
+    group.bench_function("any/format_only/ymd_short/10_cases", |b| {
+        let formatter = construct_any_ymd_short();
         let mut buffer = String::with_capacity(1000);
         b.iter(|| {
             for datetime in black_box(&ten_cases).iter() {
@@ -145,19 +151,34 @@ fn datetime_benches(c: &mut Criterion) {
         });
     });
 
-    group.bench_function("fixed/construct_and_format/ymd_numeric/10_cases", |b| {
+    group.bench_function("any/format_to_string/ymd_short/10_cases", |b| {
+        let formatter = construct_any_ymd_short();
+        b.iter(|| {
+            let mut counter = 0usize; // make sure the loop is not DCE'd
+            for datetime in black_box(&ten_cases).iter() {
+                let n = black_box(&formatter)
+                    .format(datetime)
+                    .write_to_string()
+                    .len();
+                counter = counter.wrapping_add(n);
+            }
+            counter
+        });
+    });
+
+    group.bench_function("fixed/construct_and_format/ymd_short/10_cases", |b| {
         let mut buffer = String::with_capacity(1000);
         b.iter(|| {
             for datetime in black_box(&ten_cases).iter() {
                 buffer.clear();
-                let formatter = construct_fixed_ymd_numeric();
+                let formatter = construct_fixed_ymd_short();
                 formatter.format(datetime).write_to(&mut buffer).unwrap();
             }
         });
     });
 
-    group.bench_function("fixed/format_only/ymd_numeric/10_cases", |b| {
-        let formatter = construct_fixed_ymd_numeric();
+    group.bench_function("fixed/format_only/ymd_short/10_cases", |b| {
+        let formatter = construct_fixed_ymd_short();
         let mut buffer = String::with_capacity(1000);
         b.iter(|| {
             for datetime in black_box(&ten_cases).iter() {
@@ -170,8 +191,48 @@ fn datetime_benches(c: &mut Criterion) {
         });
     });
 
-    group.bench_function("fixed/format_to_string/ymd_numeric/10_cases", |b| {
-        let formatter = construct_fixed_ymd_numeric();
+    group.bench_function("fixed/format_to_string/ymd_short/10_cases", |b| {
+        let formatter = construct_fixed_ymd_short();
+        b.iter(|| {
+            let mut counter = 0usize; // make sure the loop is not DCE'd
+            for datetime in black_box(&ten_cases).iter() {
+                let n = black_box(&formatter)
+                    .format(datetime)
+                    .write_to_string()
+                    .len();
+                counter = counter.wrapping_add(n);
+            }
+            counter
+        });
+    });
+
+    group.bench_function("fixed/construct_and_format/ymd_long/10_cases", |b| {
+        let mut buffer = String::with_capacity(1000);
+        b.iter(|| {
+            for datetime in black_box(&ten_cases).iter() {
+                buffer.clear();
+                let formatter = construct_fixed_ymd_long();
+                formatter.format(datetime).write_to(&mut buffer).unwrap();
+            }
+        });
+    });
+
+    group.bench_function("fixed/format_only/ymd_long/10_cases", |b| {
+        let formatter = construct_fixed_ymd_long();
+        let mut buffer = String::with_capacity(1000);
+        b.iter(|| {
+            for datetime in black_box(&ten_cases).iter() {
+                buffer.clear();
+                black_box(&formatter)
+                    .format(datetime)
+                    .write_to(&mut buffer)
+                    .unwrap();
+            }
+        });
+    });
+
+    group.bench_function("fixed/format_to_string/ymd_long/10_cases", |b| {
+        let formatter = construct_fixed_ymd_long();
         b.iter(|| {
             let mut counter = 0usize; // make sure the loop is not DCE'd
             for datetime in black_box(&ten_cases).iter() {

--- a/components/datetime/benches/datetime.rs
+++ b/components/datetime/benches/datetime.rs
@@ -126,7 +126,7 @@ fn datetime_benches(c: &mut Criterion) {
             .unwrap()
     }
 
-    group.bench_function("any/construct_and_format/ymd_short/10_cases", |b| {
+    group.bench_function("ymd_short/any/construct_and_format/10_cases", |b| {
         let mut buffer = String::with_capacity(1000);
         b.iter(|| {
             for datetime in black_box(&ten_cases).iter() {
@@ -137,7 +137,7 @@ fn datetime_benches(c: &mut Criterion) {
         });
     });
 
-    group.bench_function("any/format_only/ymd_short/10_cases", |b| {
+    group.bench_function("ymd_short/any/format_only/10_cases", |b| {
         let formatter = construct_any_ymd_short();
         let mut buffer = String::with_capacity(1000);
         b.iter(|| {
@@ -151,7 +151,7 @@ fn datetime_benches(c: &mut Criterion) {
         });
     });
 
-    group.bench_function("any/format_to_string/ymd_short/10_cases", |b| {
+    group.bench_function("ymd_short/any/format_to_string/10_cases", |b| {
         let formatter = construct_any_ymd_short();
         b.iter(|| {
             let mut counter = 0usize; // make sure the loop is not DCE'd
@@ -166,7 +166,7 @@ fn datetime_benches(c: &mut Criterion) {
         });
     });
 
-    group.bench_function("fixed/construct_and_format/ymd_short/10_cases", |b| {
+    group.bench_function("ymd_short/fixed/construct_and_format/10_cases", |b| {
         let mut buffer = String::with_capacity(1000);
         b.iter(|| {
             for datetime in black_box(&ten_cases).iter() {
@@ -177,7 +177,7 @@ fn datetime_benches(c: &mut Criterion) {
         });
     });
 
-    group.bench_function("fixed/format_only/ymd_short/10_cases", |b| {
+    group.bench_function("ymd_short/fixed/format_only/10_cases", |b| {
         let formatter = construct_fixed_ymd_short();
         let mut buffer = String::with_capacity(1000);
         b.iter(|| {
@@ -191,7 +191,7 @@ fn datetime_benches(c: &mut Criterion) {
         });
     });
 
-    group.bench_function("fixed/format_to_string/ymd_short/10_cases", |b| {
+    group.bench_function("ymd_short/fixed/format_to_string/10_cases", |b| {
         let formatter = construct_fixed_ymd_short();
         b.iter(|| {
             let mut counter = 0usize; // make sure the loop is not DCE'd
@@ -206,7 +206,7 @@ fn datetime_benches(c: &mut Criterion) {
         });
     });
 
-    group.bench_function("fixed/construct_and_format/ymd_long/10_cases", |b| {
+    group.bench_function("ymd_long/fixed/construct_and_format/10_cases", |b| {
         let mut buffer = String::with_capacity(1000);
         b.iter(|| {
             for datetime in black_box(&ten_cases).iter() {
@@ -217,7 +217,7 @@ fn datetime_benches(c: &mut Criterion) {
         });
     });
 
-    group.bench_function("fixed/format_only/ymd_long/10_cases", |b| {
+    group.bench_function("ymd_long/fixed/format_only/10_cases", |b| {
         let formatter = construct_fixed_ymd_long();
         let mut buffer = String::with_capacity(1000);
         b.iter(|| {
@@ -231,7 +231,7 @@ fn datetime_benches(c: &mut Criterion) {
         });
     });
 
-    group.bench_function("fixed/format_to_string/ymd_long/10_cases", |b| {
+    group.bench_function("ymd_long/fixed/format_to_string/10_cases", |b| {
         let formatter = construct_fixed_ymd_long();
         b.iter(|| {
             let mut counter = 0usize; // make sure the loop is not DCE'd


### PR DESCRIPTION
Related: #5849

On my machine I'm getting

```
Benchmarking datetime/construct_and_format/ymd_numeric/10_cases: Collecting 100 samples in edatetime/construct_and_format/ymd_numeric/10_cases
                        time:   [14.854 µs 15.007 µs 15.177 µs]
Found 6 outliers among 100 measurements (6.00%)
  6 (6.00%) high mild
Benchmarking datetime/format_only/ymd_numeric/10_cases: Collecting 100 samples in estimated datetime/format_only/ymd_numeric/10_cases
                        time:   [3.9147 µs 3.9524 µs 3.9974 µs]
Found 10 outliers among 100 measurements (10.00%)
  6 (6.00%) high mild
  4 (4.00%) high severe
```

which is on the higher end of what my estimated ballpark would be, but still in the ballpark.