### PR TITLE
Change LocalTime associated type to a type called LocalTime

### DIFF
--- a/components/datetime/benches/datetime.rs
+++ b/components/datetime/benches/datetime.rs
@@ -37,10 +37,13 @@ fn datetime_benches(c: &mut Criterion) {
                                     time,
                                     // zone is unused but we need to make the types match
                                     zone: TimeZoneInfo::utc()
-                                        .at_time((
-                                            Date::try_new_iso(2024, 1, 1).unwrap(),
-                                            Time::midnight(),
-                                        ))
+                                        .at_time(
+                                            (
+                                                Date::try_new_iso(2024, 1, 1).unwrap(),
+                                                Time::midnight(),
+                                            )
+                                                .into(),
+                                        )
                                         .with_zone_variant(TimeZoneVariant::Standard),
                                 }
                             }

--- a/components/datetime/examples/timezone_picker.rs
+++ b/components/datetime/examples/timezone_picker.rs
@@ -8,6 +8,8 @@ use icu::calendar::Date;
 use icu::datetime::{fieldsets, NoCalendarFormatter};
 use icu::locale::locale;
 use icu::time::Time;
+use icu_time::zone::models::LocalTime;
+use icu_time::DateTime;
 
 fn main() {
     let parser = icu::time::zone::IanaParser::new();
@@ -22,7 +24,10 @@ fn main() {
     let city_formatter =
         NoCalendarFormatter::try_new(prefs, fieldsets::zone::ExemplarCity).unwrap();
 
-    let reference_date = (Date::try_new_iso(2025, 1, 1).unwrap(), Time::midnight());
+    let reference_date = LocalTime::from(DateTime {
+        date: Date::try_new_iso(2025, 1, 1).unwrap(),
+        time: Time::midnight(),
+    });
 
     let mut grouped_tzs = BTreeMap::<_, Vec<_>>::new();
 

--- a/components/datetime/src/fieldsets.rs
+++ b/components/datetime/src/fieldsets.rs
@@ -63,14 +63,11 @@ use crate::{
     scaffold::*,
 };
 use enums::*;
-use icu_calendar::{
-    types::{DayOfMonth, MonthInfo, Weekday, YearInfo},
-    Date, Iso,
-};
+use icu_calendar::types::{DayOfMonth, MonthInfo, Weekday, YearInfo};
 use icu_provider::marker::NeverMarker;
 use icu_time::{
-    zone::{TimeZoneVariant, UtcOffset},
-    Hour, Minute, Nanosecond, Second, Time, TimeZone,
+    zone::{models::LocalTime, TimeZoneVariant, UtcOffset},
+    Hour, Minute, Nanosecond, Second, TimeZone,
 };
 
 #[cfg(doc)]

--- a/components/datetime/src/format/input.rs
+++ b/components/datetime/src/format/input.rs
@@ -7,8 +7,9 @@
 
 use crate::scaffold::*;
 use icu_calendar::types::DayOfYearInfo;
-use icu_calendar::{AsCalendar, Calendar, Iso};
+use icu_calendar::{AsCalendar, Calendar};
 use icu_time::scaffold::IntoOption;
+use icu_time::zone::models::LocalTime;
 use icu_time::{zone::TimeZoneVariant, Hour, Minute, Nanosecond, Second};
 
 use icu_calendar::Date;
@@ -56,7 +57,7 @@ pub struct DateTimeInputUnchecked {
     pub(crate) zone_variant: Option<TimeZoneVariant>,
     /// The local ISO time, required for field sets with
     /// certain time zone styles.
-    pub(crate) local_time: Option<(Date<Iso>, Time)>,
+    pub(crate) local_time: Option<LocalTime>,
 }
 
 impl DateTimeInputUnchecked {
@@ -88,7 +89,7 @@ impl DateTimeInputUnchecked {
     }
 
     /// Sets the local time for time zone name resolution.
-    pub fn set_time_zone_local_time(&mut self, local_time: (Date<Iso>, Time)) {
+    pub fn set_time_zone_local_time(&mut self, local_time: LocalTime) {
         self.local_time = Some(local_time);
     }
 

--- a/components/datetime/src/format/time_zone.rs
+++ b/components/datetime/src/format/time_zone.rs
@@ -9,17 +9,17 @@ use crate::provider::time_zones::MetazoneId;
 use crate::{format::DateTimeInputUnchecked, provider::fields::FieldLength};
 use core::fmt;
 use fixed_decimal::Decimal;
-use icu_calendar::{Date, Iso};
 use icu_decimal::DecimalFormatter;
 use icu_time::provider::MinutesSinceEpoch;
+use icu_time::zone::models::LocalTime;
 use icu_time::{
     zone::{TimeZoneVariant, UtcOffset},
-    Time, TimeZone,
+    TimeZone,
 };
 use writeable::Writeable;
 
 impl crate::provider::time_zones::MetazonePeriod<'_> {
-    fn resolve(&self, time_zone_id: TimeZone, dt: (Date<Iso>, Time)) -> Option<MetazoneId> {
+    fn resolve(&self, time_zone_id: TimeZone, dt: LocalTime) -> Option<MetazoneId> {
         use zerovec::ule::AsULE;
         let cursor = self.list.get0(&time_zone_id)?;
         let mut metazone_id = None;

--- a/components/datetime/src/scaffold/dynamic_impls.rs
+++ b/components/datetime/src/scaffold/dynamic_impls.rs
@@ -5,14 +5,11 @@
 use super::*;
 use crate::fieldsets::enums::*;
 use crate::provider::{neo::*, time_zones::tz, *};
-use icu_calendar::{
-    types::{DayOfMonth, DayOfYearInfo, MonthInfo, Weekday, YearInfo},
-    Date, Iso,
-};
+use icu_calendar::types::{DayOfMonth, DayOfYearInfo, MonthInfo, Weekday, YearInfo};
 use icu_provider::marker::NeverMarker;
 use icu_time::{
-    zone::{TimeZoneVariant, UtcOffset},
-    Hour, Minute, Nanosecond, Second, Time, TimeZone,
+    zone::{models::LocalTime, TimeZoneVariant, UtcOffset},
+    Hour, Minute, Nanosecond, Second, TimeZone,
 };
 
 impl UnstableSealed for DateFieldSet {}

--- a/components/datetime/src/scaffold/fieldset_traits.rs
+++ b/components/datetime/src/scaffold/fieldset_traits.rs
@@ -12,14 +12,13 @@ use icu_calendar::{
         CalendarJapaneseExtendedV1, CalendarJapaneseModernV1,
     },
     types::{DayOfMonth, DayOfYearInfo, MonthInfo, Weekday, YearInfo},
-    Date, Iso,
 };
 use icu_decimal::provider::{DecimalDigitsV1, DecimalSymbolsV1};
 use icu_provider::{marker::NeverMarker, prelude::*};
 use icu_time::scaffold::IntoOption;
 use icu_time::{
-    zone::{TimeZoneVariant, UtcOffset},
-    Hour, Minute, Nanosecond, Second, Time, TimeZone,
+    zone::{models::LocalTime, TimeZoneVariant, UtcOffset},
+    Hour, Minute, Nanosecond, Second, TimeZone,
 };
 
 // TODO: Add WeekCalculator and DecimalFormatter optional bindings here
@@ -127,7 +126,7 @@ pub trait ZoneMarkers: UnstableSealed {
     /// Marker for resolving the time zone variant input field.
     type TimeZoneVariantInput: IntoOption<TimeZoneVariant>;
     /// Marker for resolving the time zone non-location display names, which depend on the datetime.
-    type TimeZoneLocalTimeInput: IntoOption<(Date<Iso>, Time)>;
+    type TimeZoneLocalTimeInput: IntoOption<LocalTime>;
     /// Marker for loading core time zone data.
     type EssentialsV1: DataMarker<DataStruct = tz::Essentials<'static>>;
     /// Marker for loading location names for time zone formatting
@@ -182,7 +181,7 @@ pub trait DateTimeMarkers: UnstableSealed + DateTimeNamesMarker {
 ///
 /// This trait allows for only those types compatible with a particular field set to be passed
 /// as arguments to the formatting function for that field set. For example, this trait prevents
-/// [`Time`] from being passed to a formatter parameterized with [`fieldsets::YMD`].
+/// [`Time`](icu_time::Time) from being passed to a formatter parameterized with [`fieldsets::YMD`].
 ///
 /// The following types implement this trait:
 ///
@@ -719,7 +718,7 @@ macro_rules! datetime_marker_helper {
         TimeZoneVariant
     };
     (@input/timezone/local_time, yes) => {
-        (Date<Iso>, Time)
+        LocalTime
     };
     (@input/timezone/$any:ident,) => {
         ()

--- a/components/datetime/src/scaffold/get_field.rs
+++ b/components/datetime/src/scaffold/get_field.rs
@@ -4,10 +4,13 @@
 
 use icu_calendar::{
     types::{DayOfMonth, DayOfYearInfo, MonthInfo, Weekday, YearInfo},
-    AsCalendar, Calendar, Date, Iso,
+    AsCalendar, Calendar, Date,
 };
 use icu_time::{
-    zone::{models::TimeZoneModel, TimeZoneVariant, UtcOffset},
+    zone::{
+        models::{LocalTime, TimeZoneModel},
+        TimeZoneVariant, UtcOffset,
+    },
     DateTime, Hour, Minute, Nanosecond, Second, Time, TimeZone, TimeZoneInfo, ZonedDateTime,
 };
 
@@ -264,13 +267,12 @@ where
     }
 }
 
-impl<C: Calendar, A: AsCalendar<Calendar = C>, Z> GetField<(Date<Iso>, Time)>
-    for ZonedDateTime<A, Z>
+impl<C: Calendar, A: AsCalendar<Calendar = C>, Z> GetField<LocalTime> for ZonedDateTime<A, Z>
 where
-    Z: GetField<(Date<Iso>, Time)>,
+    Z: GetField<LocalTime>,
 {
     #[inline]
-    fn get_field(&self) -> (Date<Iso>, Time) {
+    fn get_field(&self) -> LocalTime {
         self.zone.get_field()
     }
 }
@@ -316,12 +318,12 @@ where
     }
 }
 
-impl<O> GetField<(Date<Iso>, Time)> for TimeZoneInfo<O>
+impl<O> GetField<LocalTime> for TimeZoneInfo<O>
 where
-    O: TimeZoneModel<LocalTime = (Date<Iso>, Time)>,
+    O: TimeZoneModel<LocalTime = LocalTime>,
 {
     #[inline]
-    fn get_field(&self) -> (Date<Iso>, Time) {
+    fn get_field(&self) -> LocalTime {
         self.local_time()
     }
 }

--- a/components/icu/examples/chrono_jiff.rs
+++ b/components/icu/examples/chrono_jiff.rs
@@ -68,7 +68,7 @@ fn jiff_to_icu(jiff: &jiff::Zoned) -> ZonedDateTime<Iso, TimeZoneInfo<Full>> {
         .with_offset(UtcOffset::try_from_seconds(jiff.offset().seconds()).ok())
         // Display names might change over time for a given zone (e.g. it might change from Eastern Time to
         // Central Time), so the ICU timezone needs a reference date and time.
-        .at_time((date, time))
+        .at_time((date, time).into())
         // And finally, the zone variant is also required for formatting
         // TODO(jiff#258): Jiff does not currently guarantee rearguard semantics
         .with_zone_variant(TimeZoneVariant::from_rearguard_isdst(jiff.time_zone().to_offset_info(jiff.timestamp()).dst().is_dst()));
@@ -100,7 +100,7 @@ fn chrono_to_icu(
         .with_offset(UtcOffset::try_from_seconds((chrono.offset().base_utc_offset() + chrono.offset().dst_offset()).num_seconds() as i32).ok())
         // Display names might change over time for a given zone (e.g. it might change from Eastern Time to
         // Central Time), so the ICU timezone needs a reference date and time.
-        .at_time((date, time))
+        .at_time((date, time).into())
         // And finally, the zone variant is also required for formatting
         // TODO: chrono_tz does not use rearguard semantics
         .with_zone_variant(TimeZoneVariant::from_rearguard_isdst(!chrono.offset().dst_offset().is_zero()));

--- a/components/time/src/ixdtf.rs
+++ b/components/time/src/ixdtf.rs
@@ -285,7 +285,9 @@ impl<'a> Intermediate<'a> {
             "utc" | "gmt" => Some(UtcOffset::zero()),
             _ => None,
         };
-        Ok(time_zone_id.with_offset(offset).at_time((date, time)))
+        Ok(time_zone_id
+            .with_offset(offset)
+            .at_time((date, time).into()))
     }
 
     fn loose(
@@ -317,7 +319,9 @@ impl<'a> Intermediate<'a> {
         };
         let date = Date::<Iso>::try_new_iso(self.date.year, self.date.month, self.date.day)?;
         let time = Time::try_from_time_record(&self.time)?;
-        Ok(time_zone_id.with_offset(offset).at_time((date, time)))
+        Ok(time_zone_id
+            .with_offset(offset)
+            .at_time((date, time).into()))
     }
 
     fn full(
@@ -337,7 +341,7 @@ impl<'a> Intermediate<'a> {
         let offset = UtcOffset::try_from_utc_offset_record(offset)?;
         Ok(time_zone_id
             .with_offset(Some(offset))
-            .at_time((date, time))
+            .at_time((date, time).into())
             .infer_zone_variant(offset_calculator))
     }
 }
@@ -480,7 +484,7 @@ impl<A: AsCalendar> ZonedDateTime<A, TimeZoneInfo<models::Full>> {
     ///     Some(UtcOffset::try_from_seconds(-18000).unwrap())
     /// );
     /// assert_eq!(zoneddatetime.zone.zone_variant(), TimeZoneVariant::Daylight);
-    /// let (_, _) = zoneddatetime.zone.local_time();
+    /// let _ = zoneddatetime.zone.local_time();
     /// ```
     ///
     /// An IXDTF string can provide a time zone in two parts: the DateTime UTC Offset or the Time Zone
@@ -565,7 +569,7 @@ impl<A: AsCalendar> ZonedDateTime<A, TimeZoneInfo<models::Full>> {
     /// assert_eq!(consistent_tz_from_both.zone.time_zone_id(), TimeZone(tinystr!(8, "uschi")));
     /// assert_eq!(consistent_tz_from_both.zone.offset(), Some(UtcOffset::try_from_seconds(-18000).unwrap()));
     /// assert_eq!(consistent_tz_from_both.zone.zone_variant(), TimeZoneVariant::Daylight);
-    /// let (_, _) = consistent_tz_from_both.zone.local_time();
+    /// let _ = consistent_tz_from_both.zone.local_time();
     ///
     /// // There is no name for America/Los_Angeles never at -05:00 (at least in 2024), so either the
     /// // time zone or the offset are wrong.

--- a/components/time/src/scaffold/into_option.rs
+++ b/components/time/src/scaffold/into_option.rs
@@ -3,10 +3,10 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::{
-    zone::{TimeZoneVariant, UtcOffset},
-    Hour, Minute, Nanosecond, Second, Time, TimeZone,
+    zone::{models::LocalTime, TimeZoneVariant, UtcOffset},
+    Hour, Minute, Nanosecond, Second, TimeZone,
 };
-use icu_calendar::{types::*, AnyCalendarKind, Date, Iso};
+use icu_calendar::{types::*, AnyCalendarKind};
 
 /// Converts Self to an `Option<T>`, either `Some(T)` if able or `None`
 pub trait IntoOption<T> {
@@ -119,7 +119,7 @@ impl IntoOption<TimeZoneVariant> for TimeZoneVariant {
     }
 }
 
-impl IntoOption<(Date<Iso>, Time)> for (Date<Iso>, Time) {
+impl IntoOption<LocalTime> for LocalTime {
     #[inline]
     fn into_option(self) -> Option<Self> {
         Some(self)

--- a/components/time/src/types.rs
+++ b/components/time/src/types.rs
@@ -168,7 +168,7 @@ impl Time {
 }
 
 /// A date and time for a given calendar.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 #[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct DateTime<A: AsCalendar> {
     /// The date
@@ -177,8 +177,10 @@ pub struct DateTime<A: AsCalendar> {
     pub time: Time,
 }
 
+impl<A> Copy for DateTime<A> where A: AsCalendar + Copy {}
+
 /// A date and time for a given calendar, local to a specified time zone.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 #[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct ZonedDateTime<A: AsCalendar, Z> {
     /// The date, local to the time zone
@@ -187,4 +189,11 @@ pub struct ZonedDateTime<A: AsCalendar, Z> {
     pub time: Time,
     /// The time zone
     pub zone: Z,
+}
+
+impl<A, Z> Copy for ZonedDateTime<A, Z>
+where
+    A: AsCalendar + Copy,
+    Z: Copy,
+{
 }

--- a/components/time/src/zone/offset.rs
+++ b/components/time/src/zone/offset.rs
@@ -5,9 +5,7 @@
 use core::str::FromStr;
 
 use crate::provider::{EighthsOfHourOffset, MinutesSinceEpoch, TimeZoneOffsetsV1};
-use crate::{Time, TimeZone};
-use icu_calendar::Date;
-use icu_calendar::Iso;
+use crate::TimeZone;
 use icu_provider::prelude::*;
 
 use displaydoc::Display;
@@ -298,7 +296,7 @@ impl VariantOffsetsCalculatorBorrowed<'_> {
     /// let offsets = zoc
     ///     .compute_offsets_from_time_zone(
     ///         TimeZone(tinystr!(8, "usden")),
-    ///         (Date::try_new_iso(2024, 1, 1).unwrap(), Time::midnight()),
+    ///         (Date::try_new_iso(2024, 1, 1).unwrap(), Time::midnight()).into(),
     ///     )
     ///     .unwrap();
     /// assert_eq!(
@@ -314,7 +312,7 @@ impl VariantOffsetsCalculatorBorrowed<'_> {
     /// let offsets = zoc
     ///     .compute_offsets_from_time_zone(
     ///         TimeZone(tinystr!(8, "usphx")),
-    ///         (Date::try_new_iso(2024, 1, 1).unwrap(), Time::midnight()),
+    ///         (Date::try_new_iso(2024, 1, 1).unwrap(), Time::midnight()).into(),
     ///     )
     ///     .unwrap();
     /// assert_eq!(
@@ -326,7 +324,7 @@ impl VariantOffsetsCalculatorBorrowed<'_> {
     pub fn compute_offsets_from_time_zone(
         &self,
         time_zone_id: TimeZone,
-        dt: (Date<Iso>, Time),
+        dt: super::models::LocalTime,
     ) -> Option<VariantOffsets> {
         use zerovec::ule::AsULE;
         match self.offset_period.get0(&time_zone_id) {

--- a/ffi/capi/src/neo_datetime.rs
+++ b/ffi/capi/src/neo_datetime.rs
@@ -840,7 +840,7 @@ pub mod ffi {
                 input.set_time_zone_utc_offset(offset);
             }
             if let Some(local_time) = zone.local_time {
-                input.set_time_zone_local_time(local_time);
+                input.set_time_zone_local_time(local_time.into());
             }
             if let Some(zone_variant) = zone.zone_variant {
                 input.set_time_zone_variant(zone_variant);
@@ -1637,7 +1637,7 @@ pub mod ffi {
                 input.set_time_zone_utc_offset(offset);
             }
             if let Some(local_time) = zone.local_time {
-                input.set_time_zone_local_time(local_time);
+                input.set_time_zone_local_time(local_time.into());
             }
             if let Some(zone_variant) = zone.zone_variant {
                 input.set_time_zone_variant(zone_variant);

--- a/ffi/capi/src/timezone.rs
+++ b/ffi/capi/src/timezone.rs
@@ -151,7 +151,7 @@ pub mod ffi {
             let info = self
                 .time_zone_id
                 .with_offset(self.offset)
-                .at_time(self.local_time?)
+                .at_time(self.local_time?.into())
                 .infer_zone_variant(offset_calculator.0.as_borrowed());
 
             self.time_zone_id = info.time_zone_id();
@@ -194,7 +194,7 @@ impl From<icu_time::TimeZoneInfo<icu_time::zone::models::AtTime>> for TimeZoneIn
             time_zone_id: other.time_zone_id(),
             offset: other.offset(),
             zone_variant: None,
-            local_time: Some(other.local_time()),
+            local_time: Some(other.local_time().into()),
         }
     }
 }
@@ -205,7 +205,7 @@ impl From<icu_time::TimeZoneInfo<icu_time::zone::models::Full>> for TimeZoneInfo
             time_zone_id: other.time_zone_id(),
             offset: other.offset(),
             zone_variant: Some(other.zone_variant()),
-            local_time: Some(other.local_time()),
+            local_time: Some(other.local_time().into()),
         }
     }
 }

--- a/ffi/capi/src/variant_offset.rs
+++ b/ffi/capi/src/variant_offset.rs
@@ -175,7 +175,7 @@ pub mod ffi {
             } = self
                 .0
                 .as_borrowed()
-                .compute_offsets_from_time_zone(time_zone.0, (local_date.0, local_time.0))?;
+                .compute_offsets_from_time_zone(time_zone.0, (local_date.0, local_time.0).into())?;
 
             Some(VariantOffsets {
                 standard: Box::new(UtcOffset(standard)),


### PR DESCRIPTION
Fixes #6235

No conclusion was written down there. I think this concept is weird enough that we should make a type for it. Currently it is just a thin wrapper around `DateTime<Iso>` but this could change in the future (e.g. merge it with MinutesSinceLocalEpoch).