### PR TITLE
Re-enable ZonedDTF in demogen

### DIFF
--- a/ffi/capi/src/neo_datetime.rs
+++ b/ffi/capi/src/neo_datetime.rs
@@ -527,7 +527,6 @@ pub mod ffi {
     #[diplomat::rust_link(icu::datetime::fieldsets::MDET::zone, FnInStruct, hidden)]
     #[diplomat::rust_link(icu::datetime::fieldsets::YMDET::zone, FnInStruct, hidden)]
     #[diplomat::rust_link(icu::datetime::fieldsets::ET::zone, FnInStruct, hidden)]
-    #[diplomat::attr(demo_gen, disable)] // constructors are on a different type :(
     pub struct ZonedDateTimeFormatter(
         pub icu_datetime::DateTimeFormatter<icu_datetime::fieldsets::enums::CompositeFieldSet>,
     );
@@ -1345,7 +1344,6 @@ pub mod ffi {
     #[diplomat::rust_link(icu::datetime::fieldsets::MDET::zone, FnInStruct, hidden)]
     #[diplomat::rust_link(icu::datetime::fieldsets::YMDET::zone, FnInStruct, hidden)]
     #[diplomat::rust_link(icu::datetime::fieldsets::ET::zone, FnInStruct, hidden)]
-    #[diplomat::attr(demo_gen, disable)] // constructors are on a different type :(
     pub struct ZonedDateTimeFormatterGregorian(
         pub  icu_datetime::FixedCalendarDateTimeFormatter<
             Gregorian,


### PR DESCRIPTION
Should have been unhidden after https://github.com/unicode-org/icu4x/commit/a92720cb5de20dc5fde0baf7145557300dc2de3d (#6286)