### PR TITLE
Use regions, not languages, for calendar algorithm defaults

### DIFF
--- a/components/calendar/src/any_calendar.rs
+++ b/components/calendar/src/any_calendar.rs
@@ -14,7 +14,7 @@ use crate::{types, AsCalendar, Calendar, Date, DateDuration, DateDurationUnit, R
 
 use crate::preferences::{CalendarAlgorithm, HijriCalendarAlgorithm};
 use icu_locale_core::preferences::define_preferences;
-use icu_locale_core::subtags::language;
+use icu_locale_core::subtags::region;
 use icu_provider::prelude::*;
 
 use core::fmt;
@@ -731,12 +731,10 @@ impl AnyCalendar {
     {
         // This will eventually need fallback data from the provider
         let algo = prefs.calendar_algorithm.unwrap_or_else(|| {
-            let lang = prefs.locale_preferences.language();
-            if lang == language!("th") {
+            let reg = prefs.locale_preferences.region();
+            if reg == Some(region!("th")) {
                 CalendarAlgorithm::Buddhist
-            } else if lang == language!("sa") {
-                CalendarAlgorithm::Hijri(Some(HijriCalendarAlgorithm::Umalqura))
-            } else if lang == language!("af") || lang == language!("ir") {
+            } else if reg == Some(region!("af")) || reg == Some(region!("ir")) {
                 CalendarAlgorithm::Persian
             } else {
                 CalendarAlgorithm::Gregory

--- a/components/datetime/src/neo.rs
+++ b/components/datetime/src/neo.rs
@@ -804,7 +804,7 @@ impl<FSet: DateTimeNamesMarker> DateTimeFormatter<FSet> {
     /// use writeable::assert_try_writeable_eq;
     ///
     /// let formatter = DateTimeFormatter::try_new(
-    ///     locale!("th").into(),
+    ///     locale!("th-TH").into(),
     ///     YMD::long(),
     /// )
     /// .unwrap()
@@ -1097,7 +1097,7 @@ impl<FSet: DateTimeMarkers> DateTimeFormatter<FSet> {
     /// use writeable::assert_writeable_eq;
     ///
     /// let formatter =
-    ///     DateTimeFormatter::try_new(locale!("th").into(), YMD::long()).unwrap();
+    ///     DateTimeFormatter::try_new(locale!("th-TH").into(), YMD::long()).unwrap();
     ///
     /// assert_writeable_eq!(
     ///     formatter.format(&Date::try_new_iso(2024, 12, 16).unwrap()),

--- a/components/locale_core/src/preferences/locale.rs
+++ b/components/locale_core/src/preferences/locale.rs
@@ -156,7 +156,6 @@ impl LocalePreferences {
         self.region
     }
 
-
     /// Extends the preferences with the values from another set of preferences.
     pub fn extend(&mut self, other: LocalePreferences) {
         if !other.language.is_default() {

--- a/components/locale_core/src/preferences/locale.rs
+++ b/components/locale_core/src/preferences/locale.rs
@@ -151,6 +151,12 @@ impl LocalePreferences {
         self.language
     }
 
+    /// Preference of Region
+    pub const fn region(&self) -> Option<Region> {
+        self.region
+    }
+
+
     /// Extends the preferences with the values from another set of preferences.
     pub fn extend(&mut self, other: LocalePreferences) {
         if !other.language.is_default() {


### PR DESCRIPTION
Depends on #6302

Matching on languages is incorrect here, these are region codes (treating `"sa"` as a language code gives us the obviously incorrect result of mapping Sanskrit to the Islamic calendar). Calendar choice is corellated with the region, not the language.

This does not start using fallback (though we really should). This also removes the sa/umalqura mapping entirely since @sffc said it is not in the latest CLDR.





<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->