### PR TITLE
Make zoned formatters have more efficient storage

### DIFF
--- a/ffi/capi/src/datetime_helpers.rs
+++ b/ffi/capi/src/datetime_helpers.rs
@@ -43,7 +43,7 @@ where
     Zone: DateTimeMarkers + ZoneMarkers,
     <Zone as DateTimeMarkers>::Z: ZoneMarkers,
     Combo<DateFieldSet, Zone>: DateTimeNamesFrom<DateFieldSet>,
-    CompositeFieldSet: DateTimeNamesFrom<Combo<DateFieldSet, Zone>>,
+    Combo<DateFieldSet, ZoneFieldSet>: DateTimeNamesFrom<Combo<DateFieldSet, Zone>>,
 {
     let prefs = (&locale.0).into();
     let mut names = DateTimeNames::from_formatter(prefs, formatter.clone())
@@ -151,7 +151,7 @@ where
     Zone: DateTimeMarkers + ZoneMarkers,
     <Zone as DateTimeMarkers>::Z: ZoneMarkers,
     Combo<DateFieldSet, Zone>: DateTimeNamesFrom<DateFieldSet>,
-    CompositeFieldSet: DateTimeNamesFrom<Combo<DateFieldSet, Zone>>,
+    Combo<DateFieldSet, ZoneFieldSet>: DateTimeNamesFrom<Combo<DateFieldSet, Zone>>,
 {
     let prefs = (&locale.0).into();
     let mut names = FixedCalendarDateTimeNames::from_formatter(prefs, formatter.clone())

--- a/ffi/capi/src/zoned_date_formatter.rs
+++ b/ffi/capi/src/zoned_date_formatter.rs
@@ -36,7 +36,10 @@ pub mod ffi {
     #[diplomat::rust_link(icu::datetime::DateTimeFormatter, Typedef)]
     pub struct ZonedDateFormatter(
         pub  icu_datetime::DateTimeFormatter<
-            icu_datetime::fieldsets::enums::CompositeFieldSet,
+            icu_datetime::fieldsets::Combo<
+                icu_datetime::fieldsets::enums::DateFieldSet,
+                icu_datetime::fieldsets::enums::ZoneFieldSet,
+            >
         >,
     );
 
@@ -512,7 +515,10 @@ pub mod ffi {
     pub struct ZonedDateFormatterGregorian(
         pub  icu_datetime::FixedCalendarDateTimeFormatter<
             Gregorian,
-            icu_datetime::fieldsets::enums::CompositeFieldSet,
+            icu_datetime::fieldsets::Combo<
+                icu_datetime::fieldsets::enums::DateFieldSet,
+                icu_datetime::fieldsets::enums::ZoneFieldSet,
+            >
         >,
     );
 

--- a/ffi/capi/src/zoned_time_formatter.rs
+++ b/ffi/capi/src/zoned_time_formatter.rs
@@ -36,7 +36,10 @@ pub mod ffi {
     pub struct ZonedTimeFormatter(
         pub  icu_datetime::FixedCalendarDateTimeFormatter<
             (),
-            icu_datetime::fieldsets::enums::CompositeFieldSet,
+            icu_datetime::fieldsets::Combo<
+                icu_datetime::fieldsets::enums::TimeFieldSet,
+                icu_datetime::fieldsets::enums::ZoneFieldSet,
+            >
         >,
     );
 

--- a/tools/make/codegen/templates/zoned_formatter.rs.jinja
+++ b/tools/make/codegen/templates/zoned_formatter.rs.jinja
@@ -67,8 +67,21 @@ pub mod ffi {
             {%- endif %}
             {%- if flavor.is_zone_only() %}
             icu_datetime::fieldsets::enums::ZoneFieldSet,
+            {%- else if flavor.has_date() && flavor.has_time() %}
+            icu_datetime::fieldsets::Combo<
+                icu_datetime::fieldsets::enums::DateAndTimeFieldSet,
+                icu_datetime::fieldsets::enums::ZoneFieldSet,
+            >
+            {%- else if flavor.has_date() %}
+            icu_datetime::fieldsets::Combo<
+                icu_datetime::fieldsets::enums::DateFieldSet,
+                icu_datetime::fieldsets::enums::ZoneFieldSet,
+            >
             {%- else %}
-            icu_datetime::fieldsets::enums::CompositeFieldSet,
+            icu_datetime::fieldsets::Combo<
+                icu_datetime::fieldsets::enums::TimeFieldSet,
+                icu_datetime::fieldsets::enums::ZoneFieldSet,
+            >
             {%- endif %}
         >,
     );


### PR DESCRIPTION
https://github.com/unicode-org/icu4x/issues/5940#issuecomment-2749648906

What this actually means:

- ZonedDateFormatter does not need a slot for day periods
- ZonedTimeFormatter does not need a slot for month names, era names, or weekdays
- Both of them get a slightly more efficient Drop impl that doesn't need to traverse CompositeFieldSet