### PR TITLE
Fix to_field_set_builder for times

### DIFF
--- a/components/datetime/src/neo.rs
+++ b/components/datetime/src/neo.rs
@@ -954,6 +954,7 @@ impl<C: CldrCalendar, FSet: DateTimeMarkers> FixedCalendarDateTimeFormatter<C, F
     /// equivalent_builder.date_fields = Some(DateFields::YMD);
     /// equivalent_builder.time_precision = Some(TimePrecision::Minute);
     /// equivalent_builder.alignment = Some(Alignment::Column);
+    /// equivalent_builder.year_style = None;
     /// assert_eq!(
     ///     builder,
     ///     equivalent_builder,
@@ -1127,7 +1128,7 @@ impl<FSet: DateTimeMarkers> DateTimeFormatter<FSet> {
     /// // Create a simple YMDT formatter:
     /// let formatter = DateTimeFormatter::try_new(
     ///     locale!("und").into(),
-    ///     YMDT::long().hm().with_alignment(Alignment::Column)
+    ///     YMDT::long().with_alignment(Alignment::Column)
     /// )
     /// .unwrap();
     ///
@@ -1138,8 +1139,9 @@ impl<FSet: DateTimeMarkers> DateTimeFormatter<FSet> {
     /// let mut equivalent_builder = FieldSetBuilder::default();
     /// equivalent_builder.length = Some(Length::Long);
     /// equivalent_builder.date_fields = Some(DateFields::YMD);
-    /// equivalent_builder.time_precision = Some(TimePrecision::Minute);
+    /// equivalent_builder.time_precision = Some(TimePrecision::Second); // set automatically
     /// equivalent_builder.alignment = Some(Alignment::Column);
+    /// equivalent_builder.year_style = None;
     /// assert_eq!(
     ///     builder,
     ///     equivalent_builder,

--- a/components/datetime/src/raw/neo.rs
+++ b/components/datetime/src/raw/neo.rs
@@ -643,6 +643,11 @@ impl DateTimeZonePatternSelectionData {
 
     /// Converts one of these into a corresponding [`builder::FieldSetBuilder`]
     pub(crate) fn to_builder(&self) -> builder::FieldSetBuilder {
+        let time_precision = if self.time.payload.is_payload() {
+            Some(self.options.time_precision.unwrap_or_default())
+        } else {
+            None
+        };
         let zone_style = self.zone.as_ref().map(|zone| {
             let ZonePatternSelectionData::SinglePatternItem(field_set, _) = zone;
             field_set.to_zone_style()
@@ -650,7 +655,7 @@ impl DateTimeZonePatternSelectionData {
         builder::FieldSetBuilder {
             length: self.options.length,
             date_fields: self.options.date_fields,
-            time_precision: self.options.time_precision,
+            time_precision,
             zone_style,
             alignment: self.options.alignment,
             year_style: self.options.year_style,


### PR DESCRIPTION
WDYT?

I need to set the `time_precision` field in order to make the FieldSetBuilder know to round-trip this to a formatter that has time. I wish there were a better place to do this. Maybe there is but I can't think of one. I'm also not super excited that `time_precision` (and also `zone_style`) are special-cased here. But this fixes the bug, which is exercised by the test.