### PR TITLE
Refactor buffer data constructors to align formatting for `try_new_with_buffer_provider`

### DIFF
--- a/components/calendar/src/cal/hijri.rs
+++ b/components/calendar/src/cal/hijri.rs
@@ -184,7 +184,7 @@ impl HijriUmmAlQura {
     icu_provider::gen_buffer_data_constructors!(() -> error: DataError,
         functions: [
             new: skip,
-                        try_new_with_buffer_provider,
+            try_new_with_buffer_provider,
             try_new_unstable,
             Self,
     ]);

--- a/components/calendar/src/cal/japanese.rs
+++ b/components/calendar/src/cal/japanese.rs
@@ -116,7 +116,7 @@ impl Japanese {
     icu_provider::gen_buffer_data_constructors!(() -> error: DataError,
         functions: [
             new: skip,
-                        try_new_with_buffer_provider,
+            try_new_with_buffer_provider,
             try_new_unstable,
             Self,
     ]);
@@ -169,7 +169,7 @@ impl JapaneseExtended {
     icu_provider::gen_buffer_data_constructors!(() -> error: DataError,
         functions: [
             new: skip,
-                        try_new_with_buffer_provider,
+            try_new_with_buffer_provider,
             try_new_unstable,
             Self,
     ]);

--- a/components/casemap/src/titlecase.rs
+++ b/components/casemap/src/titlecase.rs
@@ -215,7 +215,7 @@ impl TitlecaseMapper<CaseMapper> {
     icu_provider::gen_buffer_data_constructors!(() -> error: DataError,
     functions: [
         new: skip,
-                try_new_with_buffer_provider,
+        try_new_with_buffer_provider,
         try_new_unstable,
         Self,
     ]);

--- a/components/collator/src/comparison.rs
+++ b/components/collator/src/comparison.rs
@@ -280,7 +280,7 @@ impl Collator {
         (prefs: CollatorPreferences, options: CollatorOptions) -> error: DataError,
         functions: [
             try_new: skip,
-                        try_new_with_buffer_provider,
+            try_new_with_buffer_provider,
             try_new_unstable,
             Self
         ]

--- a/components/experimental/src/dimension/currency/compact_formatter.rs
+++ b/components/experimental/src/dimension/currency/compact_formatter.rs
@@ -71,7 +71,7 @@ impl CompactCurrencyFormatter {
         (prefs: CompactCurrencyFormatterPreferences, options: CompactCurrencyFormatterOptions) -> error: DataError,
         functions: [
             try_new: skip,
-                        try_new_with_buffer_provider,
+            try_new_with_buffer_provider,
             try_new_unstable,
             Self
         ]

--- a/components/experimental/src/dimension/currency/formatter.rs
+++ b/components/experimental/src/dimension/currency/formatter.rs
@@ -60,7 +60,7 @@ impl CurrencyFormatter {
         (prefs: CurrencyFormatterPreferences, options: super::options::CurrencyFormatterOptions) -> error: DataError,
         functions: [
             try_new: skip,
-                        try_new_with_buffer_provider,
+            try_new_with_buffer_provider,
             try_new_unstable,
             Self
         ]

--- a/components/experimental/src/dimension/currency/long_compact_formatter.rs
+++ b/components/experimental/src/dimension/currency/long_compact_formatter.rs
@@ -68,7 +68,7 @@ impl LongCompactCurrencyFormatter {
         ) -> error: DataError,
         functions: [
             try_new: skip,
-                        try_new_with_buffer_provider,
+            try_new_with_buffer_provider,
             try_new_unstable,
             Self
         ]

--- a/components/experimental/src/dimension/currency/long_formatter.rs
+++ b/components/experimental/src/dimension/currency/long_formatter.rs
@@ -45,7 +45,7 @@ impl LongCurrencyFormatter {
         (prefs: CurrencyFormatterPreferences, currency_code: &CurrencyCode) -> error: DataError,
         functions: [
             try_new: skip,
-                        try_new_with_buffer_provider,
+            try_new_with_buffer_provider,
             try_new_unstable,
             Self
         ]

--- a/components/experimental/src/dimension/percent/formatter.rs
+++ b/components/experimental/src/dimension/percent/formatter.rs
@@ -53,7 +53,7 @@ impl PercentFormatter<DecimalFormatter> {
         (prefs: PercentFormatterPreferences, options: PercentFormatterOptions) -> error: DataError,
         functions: [
             try_new: skip,
-                        try_new_with_buffer_provider,
+            try_new_with_buffer_provider,
             try_new_unstable,
             Self
         ]

--- a/components/experimental/src/dimension/units/formatter.rs
+++ b/components/experimental/src/dimension/units/formatter.rs
@@ -64,7 +64,7 @@ impl UnitsFormatter {
         (prefs: UnitsFormatterPreferences, unit: &str, options: super::options::UnitsFormatterOptions) -> error: DataError,
         functions: [
             try_new: skip,
-                        try_new_with_buffer_provider,
+            try_new_with_buffer_provider,
             try_new_unstable,
             Self
         ]

--- a/components/experimental/src/displaynames/displaynames.rs
+++ b/components/experimental/src/displaynames/displaynames.rs
@@ -52,7 +52,7 @@ impl RegionDisplayNames {
         /// Creates a new [`RegionDisplayNames`] from locale data and an options bag using compiled data.
         functions: [
             try_new,
-                        try_new_with_buffer_provider,
+            try_new_with_buffer_provider,
             try_new_unstable,
             Self
         ]
@@ -119,7 +119,7 @@ impl ScriptDisplayNames {
         /// Creates a new [`ScriptDisplayNames`] from locale data and an options bag using compiled data.
         functions: [
             try_new,
-                        try_new_with_buffer_provider,
+            try_new_with_buffer_provider,
             try_new_unstable,
             Self
         ]
@@ -187,7 +187,7 @@ impl VariantDisplayNames {
         /// Creates a new [`VariantDisplayNames`] from locale data and an options bag using compiled data.
         functions: [
             try_new,
-                        try_new_with_buffer_provider,
+            try_new_with_buffer_provider,
             try_new_unstable,
             Self
         ]
@@ -250,7 +250,7 @@ impl LanguageDisplayNames {
         /// Creates a new [`LanguageDisplayNames`] from locale data and an options bag using compiled data.
         functions: [
             try_new,
-                        try_new_with_buffer_provider,
+            try_new_with_buffer_provider,
             try_new_unstable,
             Self
         ]
@@ -334,7 +334,7 @@ impl LocaleDisplayNamesFormatter {
         /// Creates a new [`LocaleDisplayNamesFormatter`] from locale data and an options bag using compiled data.
         functions: [
             try_new,
-                        try_new_with_buffer_provider,
+            try_new_with_buffer_provider,
             try_new_unstable,
             Self
         ]

--- a/components/experimental/src/duration/formatter.rs
+++ b/components/experimental/src/duration/formatter.rs
@@ -195,7 +195,7 @@ impl DurationFormatter {
         (prefs: DurationFormatterPreferences, options: ValidatedDurationFormatterOptions) -> error: DataError,
         functions: [
             try_new: skip,
-                        try_new_with_buffer_provider,
+            try_new_with_buffer_provider,
             try_new_unstable,
             Self
         ]

--- a/components/experimental/src/units/converter_factory.rs
+++ b/components/experimental/src/units/converter_factory.rs
@@ -43,7 +43,7 @@ impl ConverterFactory {
         () -> error: DataError,
         functions: [
             new: skip,
-                        try_new_with_buffer_provider,
+            try_new_with_buffer_provider,
             try_new_unstable,
             Self,
         ]

--- a/components/locale/src/fallback/mod.rs
+++ b/components/locale/src/fallback/mod.rs
@@ -118,7 +118,7 @@ impl LocaleFallbacker {
     icu_provider::gen_buffer_data_constructors!(() -> error: DataError,
         functions: [
             new: skip,
-                        try_new_with_buffer_provider,
+            try_new_with_buffer_provider,
             try_new_unstable,
             Self
     ]);

--- a/components/normalizer/src/properties.rs
+++ b/components/normalizer/src/properties.rs
@@ -148,7 +148,7 @@ impl CanonicalComposition {
     icu_provider::gen_buffer_data_constructors!(() -> error: DataError,
         functions: [
             new: skip,
-                        try_new_with_buffer_provider,
+            try_new_with_buffer_provider,
             try_new_unstable,
             Self,
         ]
@@ -475,7 +475,7 @@ impl CanonicalDecomposition {
     icu_provider::gen_buffer_data_constructors!(() -> error: DataError,
         functions: [
             new: skip,
-                        try_new_with_buffer_provider,
+            try_new_with_buffer_provider,
             try_new_unstable,
             Self,
         ]
@@ -646,7 +646,7 @@ impl CanonicalCombiningClassMap {
     icu_provider::gen_buffer_data_constructors!(() -> error: DataError,
         functions: [
             new: skip,
-                        try_new_with_buffer_provider,
+            try_new_with_buffer_provider,
             try_new_unstable,
             Self,
     ]);

--- a/components/properties/src/script.rs
+++ b/components/properties/src/script.rs
@@ -319,7 +319,7 @@ impl ScriptWithExtensions {
         () -> result: Result<ScriptWithExtensions, DataError>,
         functions: [
             new: skip,
-                        try_new_with_buffer_provider,
+            try_new_with_buffer_provider,
             try_new_unstable,
             Self,
         ]

--- a/components/segmenter/src/grapheme.rs
+++ b/components/segmenter/src/grapheme.rs
@@ -150,7 +150,7 @@ impl GraphemeClusterSegmenter {
     icu_provider::gen_buffer_data_constructors!(() -> error: DataError,
         functions: [
             new: skip,
-                        try_new_with_buffer_provider,
+            try_new_with_buffer_provider,
             try_new_unstable,
             Self,
     ]);

--- a/components/segmenter/src/sentence.rs
+++ b/components/segmenter/src/sentence.rs
@@ -148,7 +148,7 @@ impl SentenceSegmenter {
         /// Constructs a [`SentenceSegmenter`] for a given options and using compiled data.
         functions: [
             try_new,
-                        try_new_with_buffer_provider,
+            try_new_with_buffer_provider,
             try_new_unstable,
             Self
         ]

--- a/components/time/src/zone/iana.rs
+++ b/components/time/src/zone/iana.rs
@@ -107,7 +107,7 @@ impl IanaParser {
     icu_provider::gen_buffer_data_constructors!(() -> error: DataError,
         functions: [
             new: skip,
-                        try_new_with_buffer_provider,
+            try_new_with_buffer_provider,
             try_new_unstable,
             Self,
         ]
@@ -303,7 +303,7 @@ impl IanaParserExtended<IanaParser> {
     icu_provider::gen_buffer_data_constructors!(() -> error: DataError,
         functions: [
             new: skip,
-                        try_new_with_buffer_provider,
+            try_new_with_buffer_provider,
             try_new_unstable,
             Self,
         ]

--- a/components/time/src/zone/offset.rs
+++ b/components/time/src/zone/offset.rs
@@ -228,7 +228,7 @@ impl VariantOffsetsCalculator {
     icu_provider::gen_buffer_data_constructors!(() -> error: DataError,
         functions: [
             new: skip,
-                        try_new_with_buffer_provider,
+            try_new_with_buffer_provider,
             try_new_unstable,
             Self,
         ]

--- a/components/time/src/zone/windows.rs
+++ b/components/time/src/zone/windows.rs
@@ -52,7 +52,7 @@ impl WindowsParser {
     icu_provider::gen_buffer_data_constructors!(() -> error: DataError,
         functions: [
             new: skip,
-                        try_new_with_buffer_provider,
+            try_new_with_buffer_provider,
             try_new_unstable,
             Self,
         ]


### PR DESCRIPTION

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->