### PR TITLE
Unify day-of-week calculation

### DIFF
--- a/components/calendar/src/cal/coptic.rs
+++ b/components/calendar/src/cal/coptic.rs
@@ -131,10 +131,6 @@ impl Calendar for Coptic {
         date.0.days_in_month()
     }
 
-    fn day_of_week(&self, date: &Self::DateInner) -> types::Weekday {
-        Iso.day_of_week(Coptic.date_to_iso(date).inner())
-    }
-
     fn offset_date(&self, date: &mut Self::DateInner, offset: DateDuration<Self>) {
         date.0.offset_date(offset, &());
     }

--- a/components/calendar/src/cal/dangi.rs
+++ b/components/calendar/src/cal/dangi.rs
@@ -242,10 +242,6 @@ impl Calendar for Dangi {
         date.0 .0.day_of_year()
     }
 
-    fn day_of_week(&self, date: &Self::DateInner) -> crate::types::Weekday {
-        self.date_to_iso(date).day_of_week()
-    }
-
     fn any_calendar_kind(&self) -> Option<crate::AnyCalendarKind> {
         Some(crate::any_calendar::IntoAnyCalendar::kind(self))
     }

--- a/components/calendar/src/cal/ethiopian.rs
+++ b/components/calendar/src/cal/ethiopian.rs
@@ -158,10 +158,6 @@ impl Calendar for Ethiopian {
         date.0.days_in_month()
     }
 
-    fn day_of_week(&self, date: &Self::DateInner) -> types::Weekday {
-        Iso.day_of_week(self.date_to_iso(date).inner())
-    }
-
     fn offset_date(&self, date: &mut Self::DateInner, offset: DateDuration<Self>) {
         date.0.offset_date(offset, &());
     }

--- a/components/calendar/src/cal/hebrew.rs
+++ b/components/calendar/src/cal/hebrew.rs
@@ -497,10 +497,10 @@ mod tests {
         let cal = Hebrew::new();
         let era = "am";
         let month_code = MonthCode(tinystr!(4, "M01"));
-        let dt = cal.date_from_codes(Some(era), 3760, month_code, 1).unwrap();
+        let dt = Date::try_new_from_codes(Some(era), 3760, month_code, 1, cal).unwrap();
 
         // Should be Saturday per:
         // https://www.hebcal.com/converter?hd=1&hm=Tishrei&hy=3760&h2g=1
-        assert_eq!(6, cal.day_of_week(&dt) as usize);
+        assert_eq!(6, dt.day_of_week() as usize);
     }
 }

--- a/components/calendar/src/cal/hijri.rs
+++ b/components/calendar/src/cal/hijri.rs
@@ -484,10 +484,6 @@ impl Calendar for HijriObservational {
         date.0.days_in_month()
     }
 
-    fn day_of_week(&self, date: &Self::DateInner) -> types::Weekday {
-        Iso.day_of_week(self.date_to_iso(date).inner())
-    }
-
     fn offset_date(&self, date: &mut Self::DateInner, offset: DateDuration<Self>) {
         date.0.offset_date(offset, &self.precomputed_data())
     }
@@ -839,10 +835,6 @@ impl Calendar for HijriCivil {
         date.0.days_in_month()
     }
 
-    fn day_of_week(&self, date: &Self::DateInner) -> types::Weekday {
-        Iso.day_of_week(self.date_to_iso(date).inner())
-    }
-
     fn offset_date(&self, date: &mut Self::DateInner, offset: DateDuration<Self>) {
         date.0.offset_date(offset, &())
     }
@@ -1018,10 +1010,6 @@ impl Calendar for HijriTabular {
 
     fn days_in_month(&self, date: &Self::DateInner) -> u8 {
         date.0.days_in_month()
-    }
-
-    fn day_of_week(&self, date: &Self::DateInner) -> types::Weekday {
-        Iso.day_of_week(self.date_to_iso(date).inner())
     }
 
     fn offset_date(&self, date: &mut Self::DateInner, offset: DateDuration<Self>) {

--- a/components/calendar/src/cal/indian.rs
+++ b/components/calendar/src/cal/indian.rs
@@ -156,10 +156,6 @@ impl Calendar for Indian {
         date.0.days_in_month()
     }
 
-    fn day_of_week(&self, date: &Self::DateInner) -> types::Weekday {
-        Iso.day_of_week(Indian.date_to_iso(date).inner())
-    }
-
     fn offset_date(&self, date: &mut Self::DateInner, offset: DateDuration<Self>) {
         date.0.offset_date(offset, &());
     }

--- a/components/calendar/src/cal/julian.rs
+++ b/components/calendar/src/cal/julian.rs
@@ -122,10 +122,6 @@ impl Calendar for Julian {
         date.0.days_in_month()
     }
 
-    fn day_of_week(&self, date: &Self::DateInner) -> types::Weekday {
-        Iso.day_of_week(Julian.date_to_iso(date).inner())
-    }
-
     fn offset_date(&self, date: &mut Self::DateInner, offset: DateDuration<Self>) {
         date.0.offset_date(offset, &());
     }

--- a/components/calendar/src/cal/persian.rs
+++ b/components/calendar/src/cal/persian.rs
@@ -123,10 +123,6 @@ impl Calendar for Persian {
         date.0.days_in_month()
     }
 
-    fn day_of_week(&self, date: &Self::DateInner) -> types::Weekday {
-        Iso.day_of_week(self.date_to_iso(date).inner())
-    }
-
     fn offset_date(&self, date: &mut Self::DateInner, offset: DateDuration<Self>) {
         date.0.offset_date(offset, &())
     }

--- a/components/calendar/src/calendar.rs
+++ b/components/calendar/src/calendar.rs
@@ -47,10 +47,6 @@ pub trait Calendar {
     /// Count the number of days in a given month, specified by providing a date
     /// from that year/month
     fn days_in_month(&self, date: &Self::DateInner) -> u8;
-    /// Calculate the day of the week and return it
-    fn day_of_week(&self, date: &Self::DateInner) -> types::Weekday {
-        self.date_to_iso(date).day_of_week()
-    }
     // fn week_of_year(&self, date: &Self::DateInner) -> u8;
 
     #[doc(hidden)] // unstable

--- a/components/calendar/src/date.rs
+++ b/components/calendar/src/date.rs
@@ -11,6 +11,7 @@ use crate::{types, Calendar, DateDuration, DateDurationUnit, Iso};
 use alloc::rc::Rc;
 #[cfg(feature = "alloc")]
 use alloc::sync::Arc;
+use calendrical_calculations::rata_die::RataDie;
 use core::fmt;
 use core::ops::Deref;
 
@@ -168,11 +169,21 @@ impl<A: AsCalendar> Date<A> {
     }
 
     /// The day of the week for this date
-    ///
-    /// Monday is 1, Sunday is 7, according to ISO
     #[inline]
     pub fn day_of_week(&self) -> types::Weekday {
-        self.calendar.as_calendar().day_of_week(self.inner())
+        // RD 1 happens to be a Monday
+        const MONDAY: RataDie = RataDie::new(1);
+
+        match (Iso::to_fixed(self.to_iso()) - MONDAY).rem_euclid(7) {
+            0 => types::Weekday::Monday,
+            1 => types::Weekday::Tuesday,
+            2 => types::Weekday::Wednesday,
+            3 => types::Weekday::Thursday,
+            4 => types::Weekday::Friday,
+            5 => types::Weekday::Saturday,
+            6 => types::Weekday::Sunday,
+            _ => unreachable!(),
+        }
     }
 
     /// Add a `duration` to this date, mutating it

--- a/components/calendar/src/date.rs
+++ b/components/calendar/src/date.rs
@@ -460,6 +460,7 @@ impl<A> Copy for Date<A> where A: AsCalendar + Copy {}
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::Weekday;
 
     #[test]
     fn test_ord() {
@@ -488,5 +489,24 @@ mod tests {
                 assert_eq!(i.cmp(&j), i_date.cmp(j_date));
             }
         }
+    }
+
+    #[test]
+    fn test_day_of_week() {
+        // June 23, 2021 is a Wednesday
+        assert_eq!(
+            Date::try_new_iso(2021, 6, 23).unwrap().day_of_week(),
+            Weekday::Wednesday,
+        );
+        // Feb 2, 1983 was a Wednesday
+        assert_eq!(
+            Date::try_new_iso(1983, 2, 2).unwrap().day_of_week(),
+            Weekday::Wednesday,
+        );
+        // Jan 21, 2021 was a Tuesday
+        assert_eq!(
+            Date::try_new_iso(2020, 1, 21).unwrap().day_of_week(),
+            Weekday::Tuesday,
+        );
     }
 }

--- a/components/calendar/src/date.rs
+++ b/components/calendar/src/date.rs
@@ -11,7 +11,6 @@ use crate::{types, Calendar, DateDuration, DateDurationUnit, Iso};
 use alloc::rc::Rc;
 #[cfg(feature = "alloc")]
 use alloc::sync::Arc;
-use calendrical_calculations::rata_die::RataDie;
 use core::fmt;
 use core::ops::Deref;
 
@@ -171,19 +170,7 @@ impl<A: AsCalendar> Date<A> {
     /// The day of the week for this date
     #[inline]
     pub fn day_of_week(&self) -> types::Weekday {
-        // RD 1 happens to be a Monday
-        const MONDAY: RataDie = RataDie::new(1);
-
-        match (Iso::to_fixed(self.to_iso()) - MONDAY).rem_euclid(7) {
-            0 => types::Weekday::Monday,
-            1 => types::Weekday::Tuesday,
-            2 => types::Weekday::Wednesday,
-            3 => types::Weekday::Thursday,
-            4 => types::Weekday::Friday,
-            5 => types::Weekday::Saturday,
-            6 => types::Weekday::Sunday,
-            _ => unreachable!(),
-        }
+        Iso::to_fixed(self.to_iso()).into()
     }
 
     /// Add a `duration` to this date, mutating it

--- a/components/calendar/src/week.rs
+++ b/components/calendar/src/week.rs
@@ -126,7 +126,7 @@ impl WeekCalculator {
 /// Returns the weekday that's `num_days` after `weekday`.
 fn add_to_weekday(weekday: Weekday, num_days: i32) -> Weekday {
     let new_weekday = (7 + (weekday as i32) + (num_days % 7)) % 7;
-    Weekday::from(new_weekday as usize)
+    Weekday::from_days_since_sunday(new_weekday as isize)
 }
 
 /// Which year or month that a calendar assigns a week to relative to the year/month
@@ -409,13 +409,16 @@ mod tests {
         for min_week_days in 1..7 {
             for start_of_week in 1..7 {
                 let calendar = WeekCalculator {
-                    first_weekday: Weekday::from(start_of_week),
+                    first_weekday: Weekday::from_days_since_sunday(start_of_week),
                     min_week_days,
                 };
                 for unit_duration in super::MIN_UNIT_DAYS..400 {
                     for start_of_unit in 1..7 {
-                        let unit =
-                            UnitInfo::new(Weekday::from(start_of_unit), unit_duration).unwrap();
+                        let unit = UnitInfo::new(
+                            Weekday::from_days_since_sunday(start_of_unit),
+                            unit_duration,
+                        )
+                        .unwrap();
                         let expected = classify_days_of_unit(calendar, &unit);
                         for (index, expected_week_of) in expected.iter().enumerate() {
                             let day = index + 1;


### PR DESCRIPTION
Weekdays are not calender-specific, and the current code is overly complex.