### PR TITLE
Expose Date to/from RataDie

### DIFF
--- a/components/calendar/src/any_calendar.rs
+++ b/components/calendar/src/any_calendar.rs
@@ -5,6 +5,7 @@
 //! Module for working with multiple calendars at once
 
 use crate::cal::hijri::HijriObservationalLocation;
+use crate::cal::iso::IsoDateInner;
 use crate::cal::{
     Buddhist, Chinese, Coptic, Dangi, Ethiopian, EthiopianEraStyle, Gregorian, Hebrew, HijriCivil,
     HijriObservational, HijriTabular, HijriUmmAlQura, Indian, Iso, Japanese, JapaneseExtended,
@@ -194,92 +195,56 @@ macro_rules! match_cal_and_date {
     };
 }
 
+macro_rules! match_cal {
+    (match $cal:ident: ($cal_matched:ident) => $e:expr) => {
+        match $cal {
+            &Self::Buddhist(ref $cal_matched) => AnyDateInner::Buddhist($e),
+            &Self::Chinese(ref $cal_matched) => AnyDateInner::Chinese($e),
+            &Self::Coptic(ref $cal_matched) => AnyDateInner::Coptic($e),
+            &Self::Dangi(ref $cal_matched) => AnyDateInner::Dangi($e),
+            &Self::Ethiopian(ref $cal_matched) => AnyDateInner::Ethiopian($e),
+            &Self::Gregorian(ref $cal_matched) => AnyDateInner::Gregorian($e),
+            &Self::Hebrew(ref $cal_matched) => AnyDateInner::Hebrew($e),
+            &Self::Indian(ref $cal_matched) => AnyDateInner::Indian($e),
+            &Self::HijriCivil(ref $cal_matched) => AnyDateInner::HijriCivil($e),
+            &Self::HijriObservational(ref $cal_matched) => AnyDateInner::HijriObservational($e),
+            &Self::HijriTabular(ref $cal_matched) => AnyDateInner::HijriTabular($e),
+            &Self::HijriUmmAlQura(ref $cal_matched) => AnyDateInner::HijriUmmAlQura($e),
+            &Self::Iso(ref $cal_matched) => AnyDateInner::Iso($e),
+            &Self::Japanese(ref $cal_matched) => AnyDateInner::Japanese($e),
+            &Self::JapaneseExtended(ref $cal_matched) => AnyDateInner::JapaneseExtended($e),
+            &Self::Persian(ref $cal_matched) => AnyDateInner::Persian($e),
+            &Self::Roc(ref $cal_matched) => AnyDateInner::Roc($e),
+        }
+    };
+}
+
 impl Calendar for AnyCalendar {
     type DateInner = AnyDateInner;
-    fn date_from_codes(
+    fn from_codes(
         &self,
         era: Option<&str>,
         year: i32,
         month_code: types::MonthCode,
         day: u8,
     ) -> Result<Self::DateInner, DateError> {
-        let ret = match *self {
-            Self::Buddhist(ref c) => {
-                AnyDateInner::Buddhist(c.date_from_codes(era, year, month_code, day)?)
-            }
-            Self::Chinese(ref c) => {
-                AnyDateInner::Chinese(c.date_from_codes(era, year, month_code, day)?)
-            }
-            Self::Coptic(ref c) => {
-                AnyDateInner::Coptic(c.date_from_codes(era, year, month_code, day)?)
-            }
-            Self::Dangi(ref c) => {
-                AnyDateInner::Dangi(c.date_from_codes(era, year, month_code, day)?)
-            }
-            Self::Ethiopian(ref c) => {
-                AnyDateInner::Ethiopian(c.date_from_codes(era, year, month_code, day)?)
-            }
-            Self::Gregorian(ref c) => {
-                AnyDateInner::Gregorian(c.date_from_codes(era, year, month_code, day)?)
-            }
-            Self::Hebrew(ref c) => {
-                AnyDateInner::Hebrew(c.date_from_codes(era, year, month_code, day)?)
-            }
-            Self::Indian(ref c) => {
-                AnyDateInner::Indian(c.date_from_codes(era, year, month_code, day)?)
-            }
-            Self::HijriCivil(ref c) => {
-                AnyDateInner::HijriCivil(c.date_from_codes(era, year, month_code, day)?)
-            }
-            Self::HijriObservational(ref c) => {
-                AnyDateInner::HijriObservational(c.date_from_codes(era, year, month_code, day)?)
-            }
-            Self::HijriTabular(ref c) => {
-                AnyDateInner::HijriTabular(c.date_from_codes(era, year, month_code, day)?)
-            }
-            Self::HijriUmmAlQura(ref c) => {
-                AnyDateInner::HijriUmmAlQura(c.date_from_codes(era, year, month_code, day)?)
-            }
-            Self::Iso(ref c) => AnyDateInner::Iso(c.date_from_codes(era, year, month_code, day)?),
-            Self::Japanese(ref c) => {
-                AnyDateInner::Japanese(c.date_from_codes(era, year, month_code, day)?)
-            }
-            Self::JapaneseExtended(ref c) => {
-                AnyDateInner::JapaneseExtended(c.date_from_codes(era, year, month_code, day)?)
-            }
-            Self::Persian(ref c) => {
-                AnyDateInner::Persian(c.date_from_codes(era, year, month_code, day)?)
-            }
-            Self::Roc(ref c) => AnyDateInner::Roc(c.date_from_codes(era, year, month_code, day)?),
-        };
-        Ok(ret)
-    }
-    fn date_from_iso(&self, iso: Date<Iso>) -> AnyDateInner {
-        match *self {
-            Self::Buddhist(ref c) => AnyDateInner::Buddhist(c.date_from_iso(iso)),
-            Self::Chinese(ref c) => AnyDateInner::Chinese(c.date_from_iso(iso)),
-            Self::Coptic(ref c) => AnyDateInner::Coptic(c.date_from_iso(iso)),
-            Self::Dangi(ref c) => AnyDateInner::Dangi(c.date_from_iso(iso)),
-            Self::Ethiopian(ref c) => AnyDateInner::Ethiopian(c.date_from_iso(iso)),
-            Self::Gregorian(ref c) => AnyDateInner::Gregorian(c.date_from_iso(iso)),
-            Self::Hebrew(ref c) => AnyDateInner::Hebrew(c.date_from_iso(iso)),
-            Self::Indian(ref c) => AnyDateInner::Indian(c.date_from_iso(iso)),
-            Self::HijriCivil(ref c) => AnyDateInner::HijriCivil(c.date_from_iso(iso)),
-            Self::HijriObservational(ref c) => {
-                AnyDateInner::HijriObservational(c.date_from_iso(iso))
-            }
-            Self::HijriTabular(ref c) => AnyDateInner::HijriTabular(c.date_from_iso(iso)),
-            Self::HijriUmmAlQura(ref c) => AnyDateInner::HijriUmmAlQura(c.date_from_iso(iso)),
-            Self::Iso(ref c) => AnyDateInner::Iso(c.date_from_iso(iso)),
-            Self::Japanese(ref c) => AnyDateInner::Japanese(c.date_from_iso(iso)),
-            Self::JapaneseExtended(ref c) => AnyDateInner::JapaneseExtended(c.date_from_iso(iso)),
-            Self::Persian(ref c) => AnyDateInner::Persian(c.date_from_iso(iso)),
-            Self::Roc(ref c) => AnyDateInner::Roc(c.date_from_iso(iso)),
-        }
+        Ok(match_cal!(match self: (c) => c.from_codes(era, year, month_code, day)?))
     }
 
-    fn date_to_iso(&self, date: &Self::DateInner) -> Date<Iso> {
-        match_cal_and_date!(match (self, date): (c, d) => c.date_to_iso(d))
+    fn from_iso(&self, iso: IsoDateInner) -> AnyDateInner {
+        match_cal!(match self: (c) => c.from_iso(iso))
+    }
+
+    fn from_fixed(&self, fixed: calendrical_calculations::rata_die::RataDie) -> Self::DateInner {
+        match_cal!(match self: (c) => c.from_fixed(fixed))
+    }
+
+    fn to_fixed(&self, date: &Self::DateInner) -> calendrical_calculations::rata_die::RataDie {
+        match_cal_and_date!(match (self, date): (c, d) => c.to_fixed(d))
+    }
+
+    fn to_iso(&self, date: &Self::DateInner) -> IsoDateInner {
+        match_cal_and_date!(match (self, date): (c, d) => c.to_iso(d))
     }
 
     fn months_in_year(&self, date: &Self::DateInner) -> u8 {
@@ -296,57 +261,53 @@ impl Calendar for AnyCalendar {
 
     fn offset_date(&self, date: &mut Self::DateInner, offset: DateDuration<Self>) {
         match (self, date) {
-            (Self::Buddhist(c), &mut AnyDateInner::Buddhist(ref mut d)) => {
+            (Self::Buddhist(c), AnyDateInner::Buddhist(ref mut d)) => {
                 c.offset_date(d, offset.cast_unit())
             }
-            (Self::Chinese(c), &mut AnyDateInner::Chinese(ref mut d)) => {
+            (Self::Chinese(c), AnyDateInner::Chinese(ref mut d)) => {
                 c.offset_date(d, offset.cast_unit())
             }
-            (Self::Coptic(c), &mut AnyDateInner::Coptic(ref mut d)) => {
+            (Self::Coptic(c), AnyDateInner::Coptic(ref mut d)) => {
                 c.offset_date(d, offset.cast_unit())
             }
-            (Self::Dangi(c), &mut AnyDateInner::Dangi(ref mut d)) => {
+            (Self::Dangi(c), AnyDateInner::Dangi(ref mut d)) => {
                 c.offset_date(d, offset.cast_unit())
             }
-            (Self::Ethiopian(c), &mut AnyDateInner::Ethiopian(ref mut d)) => {
+            (Self::Ethiopian(c), AnyDateInner::Ethiopian(ref mut d)) => {
                 c.offset_date(d, offset.cast_unit())
             }
-            (Self::Gregorian(c), &mut AnyDateInner::Gregorian(ref mut d)) => {
+            (Self::Gregorian(c), AnyDateInner::Gregorian(ref mut d)) => {
                 c.offset_date(d, offset.cast_unit())
             }
-            (Self::Hebrew(c), &mut AnyDateInner::Hebrew(ref mut d)) => {
+            (Self::Hebrew(c), AnyDateInner::Hebrew(ref mut d)) => {
                 c.offset_date(d, offset.cast_unit())
             }
-            (Self::Indian(c), &mut AnyDateInner::Indian(ref mut d)) => {
+            (Self::Indian(c), AnyDateInner::Indian(ref mut d)) => {
                 c.offset_date(d, offset.cast_unit())
             }
-            (Self::HijriCivil(c), &mut AnyDateInner::HijriCivil(ref mut d)) => {
+            (Self::HijriCivil(c), AnyDateInner::HijriCivil(ref mut d)) => {
                 c.offset_date(d, offset.cast_unit())
             }
-            (Self::HijriObservational(c), &mut AnyDateInner::HijriObservational(ref mut d)) => {
+            (Self::HijriObservational(c), AnyDateInner::HijriObservational(ref mut d)) => {
                 c.offset_date(d, offset.cast_unit())
             }
-            (Self::HijriTabular(c), &mut AnyDateInner::HijriTabular(ref mut d)) => {
+            (Self::HijriTabular(c), AnyDateInner::HijriTabular(ref mut d)) => {
                 c.offset_date(d, offset.cast_unit())
             }
-            (Self::HijriUmmAlQura(c), &mut AnyDateInner::HijriUmmAlQura(ref mut d)) => {
+            (Self::HijriUmmAlQura(c), AnyDateInner::HijriUmmAlQura(ref mut d)) => {
                 c.offset_date(d, offset.cast_unit())
             }
-            (Self::Iso(c), &mut AnyDateInner::Iso(ref mut d)) => {
+            (Self::Iso(c), AnyDateInner::Iso(ref mut d)) => c.offset_date(d, offset.cast_unit()),
+            (Self::Japanese(c), AnyDateInner::Japanese(ref mut d)) => {
                 c.offset_date(d, offset.cast_unit())
             }
-            (Self::Japanese(c), &mut AnyDateInner::Japanese(ref mut d)) => {
+            (Self::JapaneseExtended(c), AnyDateInner::JapaneseExtended(ref mut d)) => {
                 c.offset_date(d, offset.cast_unit())
             }
-            (Self::JapaneseExtended(c), &mut AnyDateInner::JapaneseExtended(ref mut d)) => {
+            (Self::Persian(c), AnyDateInner::Persian(ref mut d)) => {
                 c.offset_date(d, offset.cast_unit())
             }
-            (Self::Persian(c), &mut AnyDateInner::Persian(ref mut d)) => {
-                c.offset_date(d, offset.cast_unit())
-            }
-            (Self::Roc(c), &mut AnyDateInner::Roc(ref mut d)) => {
-                c.offset_date(d, offset.cast_unit())
-            }
+            (Self::Roc(c), AnyDateInner::Roc(ref mut d)) => c.offset_date(d, offset.cast_unit()),
             // This is only reached from misuse of from_raw, a semi-internal api
             #[allow(clippy::panic)]
             (_, d) => panic!(
@@ -494,11 +455,11 @@ impl Calendar for AnyCalendar {
                 .cast_unit(),
             _ => {
                 // attempt to convert
-                let iso = calendar2.date_to_iso(date2);
+                let iso = calendar2.to_iso(date2);
 
                 match_cal_and_date!(match (self, date1):
                     (c1, d1) => {
-                        let d2 = c1.date_from_iso(iso);
+                        let d2 = c1.from_iso(iso);
                         let until = c1.until(d1, &d2, c1, largest_unit, smallest_unit);
                         until.cast_unit::<AnyCalendar>()
                     }
@@ -709,19 +670,17 @@ impl AnyCalendar {
             Self::Roc(_) => AnyCalendarKind::Roc,
         }
     }
+}
 
-    /// Given an AnyCalendar date, convert that date to another AnyCalendar date in this calendar,
-    /// if conversion is needed
-    pub fn convert_any_date<'a>(
-        &'a self,
-        date: &Date<impl AsCalendar<Calendar = AnyCalendar>>,
-    ) -> Date<Ref<'a, AnyCalendar>> {
-        if self.kind() != date.calendar.as_calendar().kind() {
-            Date::new_from_iso(date.to_iso(), Ref(self))
+impl<C: AsCalendar<Calendar = AnyCalendar>> Date<C> {
+    /// Convert this `Date<AnyCalendar>` to another `AnyCalendar`, if conversion is needed
+    pub fn convert_any<'a>(&self, calendar: &'a AnyCalendar) -> Date<Ref<'a, AnyCalendar>> {
+        if calendar.kind() != self.calendar.as_calendar().kind() {
+            Date::new_from_iso(self.to_iso(), Ref(calendar))
         } else {
             Date {
-                inner: date.inner,
-                calendar: Ref(self),
+                inner: self.inner,
+                calendar: Ref(calendar),
             }
         }
     }

--- a/components/calendar/src/any_calendar.rs
+++ b/components/calendar/src/any_calendar.rs
@@ -235,12 +235,12 @@ impl Calendar for AnyCalendar {
         match_cal!(match self: (c) => c.from_iso(iso))
     }
 
-    fn from_fixed(&self, fixed: calendrical_calculations::rata_die::RataDie) -> Self::DateInner {
-        match_cal!(match self: (c) => c.from_fixed(fixed))
+    fn from_rata_die(&self, rd: calendrical_calculations::rata_die::RataDie) -> Self::DateInner {
+        match_cal!(match self: (c) => c.from_rata_die(rd))
     }
 
-    fn to_fixed(&self, date: &Self::DateInner) -> calendrical_calculations::rata_die::RataDie {
-        match_cal_and_date!(match (self, date): (c, d) => c.to_fixed(d))
+    fn to_rata_die(&self, date: &Self::DateInner) -> calendrical_calculations::rata_die::RataDie {
+        match_cal_and_date!(match (self, date): (c, d) => c.to_rata_die(d))
     }
 
     fn to_iso(&self, date: &Self::DateInner) -> IsoDateInner {

--- a/components/calendar/src/cal/buddhist.rs
+++ b/components/calendar/src/cal/buddhist.rs
@@ -21,6 +21,7 @@ use crate::cal::iso::{Iso, IsoDateInner};
 use crate::calendar_arithmetic::ArithmeticDate;
 use crate::error::DateError;
 use crate::{types, Calendar, Date, DateDuration, DateDurationUnit, RangeError};
+use calendrical_calculations::rata_die::RataDie;
 use tinystr::tinystr;
 
 /// The number of years the Buddhist Era is ahead of C.E. by
@@ -52,7 +53,7 @@ pub struct Buddhist;
 impl Calendar for Buddhist {
     type DateInner = IsoDateInner;
 
-    fn date_from_codes(
+    fn from_codes(
         &self,
         era: Option<&str>,
         year: i32,
@@ -67,12 +68,21 @@ impl Calendar for Buddhist {
 
         ArithmeticDate::new_from_codes(self, year, month_code, day).map(IsoDateInner)
     }
-    fn date_from_iso(&self, iso: Date<Iso>) -> IsoDateInner {
-        *iso.inner()
+
+    fn from_iso(&self, iso: IsoDateInner) -> Self::DateInner {
+        iso
     }
 
-    fn date_to_iso(&self, date: &Self::DateInner) -> Date<Iso> {
-        Date::from_raw(*date, Iso)
+    fn to_iso(&self, date: &Self::DateInner) -> IsoDateInner {
+        *date
+    }
+
+    fn from_fixed(&self, fixed: RataDie) -> Self::DateInner {
+        Iso.from_fixed(fixed)
+    }
+
+    fn to_fixed(&self, date: &Self::DateInner) -> RataDie {
+        Iso.to_fixed(date)
     }
 
     fn months_in_year(&self, date: &Self::DateInner) -> u8 {
@@ -177,10 +187,10 @@ mod test {
     fn test_buddhist_roundtrip_near_rd_zero() {
         for i in -10000..=10000 {
             let rd = RataDie::new(i);
-            let iso1 = Iso::from_fixed(rd);
+            let iso1 = Date::from_fixed(rd, Iso);
             let buddhist = iso1.to_calendar(Buddhist);
             let iso2 = buddhist.to_calendar(Iso);
-            let result = Iso::to_fixed(iso2);
+            let result = iso2.to_fixed();
             assert_eq!(rd, result);
         }
     }
@@ -190,10 +200,10 @@ mod test {
         // Buddhist epoch start RD: -198326
         for i in -208326..=-188326 {
             let rd = RataDie::new(i);
-            let iso1 = Iso::from_fixed(rd);
+            let iso1 = Date::from_fixed(rd, Iso);
             let buddhist = iso1.to_calendar(Buddhist);
             let iso2 = buddhist.to_calendar(Iso);
-            let result = Iso::to_fixed(iso2);
+            let result = iso2.to_fixed();
             assert_eq!(rd, result);
         }
     }
@@ -202,8 +212,8 @@ mod test {
     fn test_buddhist_directionality_near_rd_zero() {
         for i in -100..=100 {
             for j in -100..=100 {
-                let iso_i = Iso::from_fixed(RataDie::new(i));
-                let iso_j = Iso::from_fixed(RataDie::new(j));
+                let iso_i = Date::from_fixed(RataDie::new(i), Iso);
+                let iso_j = Date::from_fixed(RataDie::new(j), Iso);
 
                 let buddhist_i = Date::new_from_iso(iso_i, Buddhist);
                 let buddhist_j = Date::new_from_iso(iso_j, Buddhist);
@@ -228,8 +238,8 @@ mod test {
         // Buddhist epoch start RD: -198326
         for i in -198426..=-198226 {
             for j in -198426..=-198226 {
-                let iso_i = Iso::from_fixed(RataDie::new(i));
-                let iso_j = Iso::from_fixed(RataDie::new(j));
+                let iso_i = Date::from_fixed(RataDie::new(i), Iso);
+                let iso_j = Date::from_fixed(RataDie::new(j), Iso);
 
                 let buddhist_i = Date::new_from_iso(iso_i, Buddhist);
                 let buddhist_j = Date::new_from_iso(iso_j, Buddhist);

--- a/components/calendar/src/cal/buddhist.rs
+++ b/components/calendar/src/cal/buddhist.rs
@@ -77,12 +77,12 @@ impl Calendar for Buddhist {
         *date
     }
 
-    fn from_fixed(&self, fixed: RataDie) -> Self::DateInner {
-        Iso.from_fixed(fixed)
+    fn from_rata_die(&self, rd: RataDie) -> Self::DateInner {
+        Iso.from_rata_die(rd)
     }
 
-    fn to_fixed(&self, date: &Self::DateInner) -> RataDie {
-        Iso.to_fixed(date)
+    fn to_rata_die(&self, date: &Self::DateInner) -> RataDie {
+        Iso.to_rata_die(date)
     }
 
     fn months_in_year(&self, date: &Self::DateInner) -> u8 {
@@ -187,10 +187,10 @@ mod test {
     fn test_buddhist_roundtrip_near_rd_zero() {
         for i in -10000..=10000 {
             let rd = RataDie::new(i);
-            let iso1 = Date::from_fixed(rd, Iso);
+            let iso1 = Date::from_rata_die(rd, Iso);
             let buddhist = iso1.to_calendar(Buddhist);
             let iso2 = buddhist.to_calendar(Iso);
-            let result = iso2.to_fixed();
+            let result = iso2.to_rata_die();
             assert_eq!(rd, result);
         }
     }
@@ -200,10 +200,10 @@ mod test {
         // Buddhist epoch start RD: -198326
         for i in -208326..=-188326 {
             let rd = RataDie::new(i);
-            let iso1 = Date::from_fixed(rd, Iso);
+            let iso1 = Date::from_rata_die(rd, Iso);
             let buddhist = iso1.to_calendar(Buddhist);
             let iso2 = buddhist.to_calendar(Iso);
-            let result = iso2.to_fixed();
+            let result = iso2.to_rata_die();
             assert_eq!(rd, result);
         }
     }
@@ -212,8 +212,8 @@ mod test {
     fn test_buddhist_directionality_near_rd_zero() {
         for i in -100..=100 {
             for j in -100..=100 {
-                let iso_i = Date::from_fixed(RataDie::new(i), Iso);
-                let iso_j = Date::from_fixed(RataDie::new(j), Iso);
+                let iso_i = Date::from_rata_die(RataDie::new(i), Iso);
+                let iso_j = Date::from_rata_die(RataDie::new(j), Iso);
 
                 let buddhist_i = Date::new_from_iso(iso_i, Buddhist);
                 let buddhist_j = Date::new_from_iso(iso_j, Buddhist);
@@ -238,8 +238,8 @@ mod test {
         // Buddhist epoch start RD: -198326
         for i in -198426..=-198226 {
             for j in -198426..=-198226 {
-                let iso_i = Date::from_fixed(RataDie::new(i), Iso);
-                let iso_j = Date::from_fixed(RataDie::new(j), Iso);
+                let iso_i = Date::from_rata_die(RataDie::new(i), Iso);
+                let iso_j = Date::from_rata_die(RataDie::new(j), Iso);
 
                 let buddhist_i = Date::new_from_iso(iso_i, Buddhist);
                 let buddhist_j = Date::new_from_iso(iso_j, Buddhist);

--- a/components/calendar/src/cal/chinese_based.rs
+++ b/components/calendar/src/cal/chinese_based.rs
@@ -150,7 +150,7 @@ impl<'b, CB: ChineseBased> ChineseBasedPrecomputedData<'b, CB> {
     /// from cache or computing.
     fn load_or_compute_info_for_iso(
         &self,
-        fixed: RataDie,
+        rd: RataDie,
         iso: ArithmeticDate<Iso>,
     ) -> ChineseBasedYearInfo {
         if let Some(cached) = self.data.and_then(|d| d.get_for_iso::<CB>(iso)) {
@@ -162,7 +162,7 @@ impl<'b, CB: ChineseBased> ChineseBasedPrecomputedData<'b, CB> {
         let mid_year = chinese_based::fixed_mid_year_from_year::<CB>(extended_year);
         let year_bounds = YearBounds::compute::<CB>(mid_year);
         let YearBounds { new_year, .. } = year_bounds;
-        if fixed >= new_year {
+        if rd >= new_year {
             compute_cache_with_yb::<CB>(extended_year, year_bounds)
         } else {
             compute_cache::<CB>(extended_year - 1)
@@ -263,7 +263,7 @@ impl ChineseBasedYearInfo {
 impl<C: ChineseBasedWithDataLoading + CalendarArithmetic<YearInfo = ChineseBasedYearInfo>>
     ChineseBasedDateInner<C>
 {
-    /// Get a ChineseBasedDateInner from a fixed date and the cache/extended year associated with it
+    /// Get a ChineseBasedDateInner from a RD and the cache/extended year associated with it
     fn chinese_based_date_from_info(
         date: RataDie,
         year: ChineseBasedYearInfo,
@@ -304,18 +304,18 @@ impl<C: ChineseBasedWithDataLoading + CalendarArithmetic<YearInfo = ChineseBased
         ChineseBasedDateInner(ArithmeticDate::new_unchecked(year, month, day_of_month))
     }
 
-    /// Get a ChineseBasedDateInner from a fixed date, with the related ISO date
+    /// Get a ChineseBasedDateInner from a RD, with the related ISO date
     /// (passed in to avoid recomputing)
-    pub(crate) fn chinese_based_date_from_fixed(
+    pub(crate) fn chinese_based_date_from_rd(
         cal: &C,
-        fixed: RataDie,
+        rd: RataDie,
         iso: ArithmeticDate<Iso>,
     ) -> ChineseBasedDateInner<C> {
         let data = cal.get_precomputed_data();
 
-        let year = data.load_or_compute_info_for_iso(fixed, iso);
+        let year = data.load_or_compute_info_for_iso(rd, iso);
 
-        Self::chinese_based_date_from_info(fixed, year)
+        Self::chinese_based_date_from_info(rd, year)
     }
 
     pub(crate) fn new_year(self) -> RataDie {
@@ -326,7 +326,7 @@ impl<C: ChineseBasedWithDataLoading + CalendarArithmetic<YearInfo = ChineseBased
     ///
     /// This finds the RataDie of the new year of the year given, then finds the RataDie of the new moon
     /// (beginning of the month) of the month given, then adds the necessary number of days.
-    pub(crate) fn fixed_from_chinese_based_date_inner(date: ChineseBasedDateInner<C>) -> RataDie {
+    pub(crate) fn rd_from_chinese_based_date_inner(date: ChineseBasedDateInner<C>) -> RataDie {
         let first_day_of_year = date.new_year();
         let day_of_year = date.day_of_year(); // 1 indexed
         first_day_of_year + i64::from(day_of_year) - 1

--- a/components/calendar/src/cal/coptic.rs
+++ b/components/calendar/src/cal/coptic.rs
@@ -16,7 +16,7 @@
 //! assert_eq!(date_coptic.day_of_month().0, 24);
 //! ```
 
-use crate::cal::iso::Iso;
+use crate::cal::iso::{Iso, IsoDateInner};
 use crate::calendar_arithmetic::{ArithmeticDate, CalendarArithmetic};
 use crate::error::{year_check, DateError};
 use crate::{types, Calendar, Date, DateDuration, DateDurationUnit, RangeError};
@@ -94,7 +94,7 @@ impl CalendarArithmetic for Coptic {
 
 impl Calendar for Coptic {
     type DateInner = CopticDateInner;
-    fn date_from_codes(
+    fn from_codes(
         &self,
         era: Option<&str>,
         year: i32,
@@ -109,14 +109,27 @@ impl Calendar for Coptic {
 
         ArithmeticDate::new_from_codes(self, year, month_code, day).map(CopticDateInner)
     }
-    fn date_from_iso(&self, iso: Date<Iso>) -> CopticDateInner {
-        let fixed_iso = Iso::to_fixed(iso);
-        Self::coptic_from_fixed(fixed_iso)
+
+    fn from_fixed(&self, fixed: RataDie) -> Self::DateInner {
+        CopticDateInner(
+            match calendrical_calculations::coptic::coptic_from_fixed(fixed) {
+                Err(I32CastError::BelowMin) => ArithmeticDate::min_date(),
+                Err(I32CastError::AboveMax) => ArithmeticDate::max_date(),
+                Ok((year, month, day)) => ArithmeticDate::new_unchecked(year, month, day),
+            },
+        )
     }
 
-    fn date_to_iso(&self, date: &Self::DateInner) -> Date<Iso> {
-        let fixed_coptic = Coptic::fixed_from_coptic(date.0);
-        Iso::from_fixed(fixed_coptic)
+    fn to_fixed(&self, date: &Self::DateInner) -> RataDie {
+        calendrical_calculations::coptic::fixed_from_coptic(date.0.year, date.0.month, date.0.day)
+    }
+
+    fn from_iso(&self, iso: IsoDateInner) -> CopticDateInner {
+        self.from_fixed(Iso.to_fixed(&iso))
+    }
+
+    fn to_iso(&self, date: &Self::DateInner) -> IsoDateInner {
+        Iso.from_fixed(self.to_fixed(date))
     }
 
     fn months_in_year(&self, date: &Self::DateInner) -> u8 {
@@ -194,22 +207,6 @@ impl Calendar for Coptic {
 
     fn any_calendar_kind(&self) -> Option<crate::AnyCalendarKind> {
         Some(crate::any_calendar::IntoAnyCalendar::kind(self))
-    }
-}
-
-impl Coptic {
-    fn fixed_from_coptic(date: ArithmeticDate<Coptic>) -> RataDie {
-        calendrical_calculations::coptic::fixed_from_coptic(date.year, date.month, date.day)
-    }
-
-    pub(crate) fn coptic_from_fixed(date: RataDie) -> CopticDateInner {
-        let (year, month, day) = match calendrical_calculations::coptic::coptic_from_fixed(date) {
-            Err(I32CastError::BelowMin) => return CopticDateInner(ArithmeticDate::min_date()),
-            Err(I32CastError::AboveMax) => return CopticDateInner(ArithmeticDate::max_date()),
-            Ok(ymd) => ymd,
-        };
-
-        CopticDateInner(ArithmeticDate::new_unchecked(year, month, day))
     }
 }
 

--- a/components/calendar/src/cal/coptic.rs
+++ b/components/calendar/src/cal/coptic.rs
@@ -110,9 +110,9 @@ impl Calendar for Coptic {
         ArithmeticDate::new_from_codes(self, year, month_code, day).map(CopticDateInner)
     }
 
-    fn from_fixed(&self, fixed: RataDie) -> Self::DateInner {
+    fn from_rata_die(&self, rd: RataDie) -> Self::DateInner {
         CopticDateInner(
-            match calendrical_calculations::coptic::coptic_from_fixed(fixed) {
+            match calendrical_calculations::coptic::coptic_from_fixed(rd) {
                 Err(I32CastError::BelowMin) => ArithmeticDate::min_date(),
                 Err(I32CastError::AboveMax) => ArithmeticDate::max_date(),
                 Ok((year, month, day)) => ArithmeticDate::new_unchecked(year, month, day),
@@ -120,16 +120,16 @@ impl Calendar for Coptic {
         )
     }
 
-    fn to_fixed(&self, date: &Self::DateInner) -> RataDie {
+    fn to_rata_die(&self, date: &Self::DateInner) -> RataDie {
         calendrical_calculations::coptic::fixed_from_coptic(date.0.year, date.0.month, date.0.day)
     }
 
     fn from_iso(&self, iso: IsoDateInner) -> CopticDateInner {
-        self.from_fixed(Iso.to_fixed(&iso))
+        self.from_rata_die(Iso.to_rata_die(&iso))
     }
 
     fn to_iso(&self, date: &Self::DateInner) -> IsoDateInner {
-        Iso.from_fixed(self.to_fixed(date))
+        Iso.from_rata_die(self.to_rata_die(date))
     }
 
     fn months_in_year(&self, date: &Self::DateInner) -> u8 {

--- a/components/calendar/src/cal/dangi.rs
+++ b/components/calendar/src/cal/dangi.rs
@@ -179,22 +179,25 @@ impl Calendar for Dangi {
             .map(DangiDateInner)
     }
 
-    fn from_fixed(&self, fixed: RataDie) -> Self::DateInner {
-        let iso = Iso.from_fixed(fixed);
-        DangiDateInner(Inner::chinese_based_date_from_fixed(self, fixed, iso.0))
+    fn from_rata_die(&self, rd: RataDie) -> Self::DateInner {
+        let iso = Iso.from_rata_die(rd);
+        DangiDateInner(Inner::chinese_based_date_from_rd(self, rd, iso.0))
     }
 
-    fn to_fixed(&self, date: &Self::DateInner) -> RataDie {
-        Inner::fixed_from_chinese_based_date_inner(date.0)
+    fn to_rata_die(&self, date: &Self::DateInner) -> RataDie {
+        Inner::rd_from_chinese_based_date_inner(date.0)
     }
 
     fn from_iso(&self, iso: IsoDateInner) -> Self::DateInner {
-        let fixed = Iso.to_fixed(&iso);
-        DangiDateInner(Inner::chinese_based_date_from_fixed(self, fixed, iso.0))
+        DangiDateInner(Inner::chinese_based_date_from_rd(
+            self,
+            Iso.to_rata_die(&iso),
+            iso.0,
+        ))
     }
 
     fn to_iso(&self, date: &Self::DateInner) -> IsoDateInner {
-        Iso.from_fixed(self.to_fixed(date))
+        Iso.from_rata_die(self.to_rata_die(date))
     }
 
     fn months_in_year(&self, date: &Self::DateInner) -> u8 {
@@ -234,7 +237,7 @@ impl Calendar for Dangi {
         let cyclic = (year.value as i64 - 1 + 364).rem_euclid(60) as u8;
         let cyclic = NonZeroU8::new(cyclic + 1).unwrap_or(NonZeroU8::MIN); // 1-indexed
         let rata_die_in_year = date.0 .0.year.new_year::<DangiCB>();
-        let related_iso = Iso.from_fixed(rata_die_in_year).0.year;
+        let related_iso = Iso.from_rata_die(rata_die_in_year).0.year;
         types::YearInfo::new_cyclic(year.value, cyclic, related_iso)
     }
 
@@ -360,25 +363,25 @@ mod test {
 
     #[test]
     fn test_iso_to_dangi_roundtrip() {
-        let mut fixed = -1963020;
-        let max_fixed = 1963020;
+        let mut rd = -1963020;
+        let max_rd = 1963020;
         let mut iters = 0;
         let max_iters = 560;
         let dangi_calculating = Dangi::new_always_calculating();
         let dangi_cached = Dangi::new();
-        while fixed < max_fixed && iters < max_iters {
-            let rata_die = RataDie::new(fixed);
-            let iso = Date::from_fixed(rata_die, Iso);
+        while rd < max_rd && iters < max_iters {
+            let rata_die = RataDie::new(rd);
+            let iso = Date::from_rata_die(rata_die, Iso);
             do_twice(&dangi_calculating, &dangi_cached, |dangi, calendar_type| {
                 let korean = iso.to_calendar(dangi);
                 let result = korean.to_calendar(Iso);
                 assert_eq!(
                     iso, result,
-                    "[{calendar_type}] Failed roundtrip ISO -> Dangi -> ISO for fixed: {fixed}"
+                    "[{calendar_type}] Failed roundtrip ISO -> Dangi -> ISO for RD: {rd}"
                 );
             });
 
-            fixed += 7043;
+            rd += 7043;
             iters += 1;
         }
     }

--- a/components/calendar/src/cal/ethiopian.rs
+++ b/components/calendar/src/cal/ethiopian.rs
@@ -137,9 +137,9 @@ impl Calendar for Ethiopian {
         ArithmeticDate::new_from_codes(self, year, month_code, day).map(EthiopianDateInner)
     }
 
-    fn from_fixed(&self, fixed: RataDie) -> Self::DateInner {
+    fn from_rata_die(&self, rd: RataDie) -> Self::DateInner {
         EthiopianDateInner(
-            match calendrical_calculations::ethiopian::ethiopian_from_fixed(fixed) {
+            match calendrical_calculations::ethiopian::ethiopian_from_fixed(rd) {
                 Err(I32CastError::BelowMin) => ArithmeticDate::min_date(),
                 Err(I32CastError::AboveMax) => ArithmeticDate::max_date(),
                 Ok((year, month, day)) => ArithmeticDate::new_unchecked(
@@ -152,7 +152,7 @@ impl Calendar for Ethiopian {
         )
     }
 
-    fn to_fixed(&self, date: &Self::DateInner) -> RataDie {
+    fn to_rata_die(&self, date: &Self::DateInner) -> RataDie {
         // calendrical calculations expects years in the Incarnation era
         calendrical_calculations::ethiopian::fixed_from_ethiopian(
             date.0.year - INCARNATION_OFFSET,
@@ -162,11 +162,11 @@ impl Calendar for Ethiopian {
     }
 
     fn from_iso(&self, iso: IsoDateInner) -> EthiopianDateInner {
-        self.from_fixed(Iso.to_fixed(&iso))
+        self.from_rata_die(Iso.to_rata_die(&iso))
     }
 
     fn to_iso(&self, date: &Self::DateInner) -> IsoDateInner {
-        Iso.from_fixed(self.to_fixed(date))
+        Iso.from_rata_die(self.to_rata_die(date))
     }
 
     fn months_in_year(&self, date: &Self::DateInner) -> u8 {

--- a/components/calendar/src/cal/gregorian.rs
+++ b/components/calendar/src/cal/gregorian.rs
@@ -60,12 +60,12 @@ impl Calendar for Gregorian {
             .map(GregorianDateInner)
     }
 
-    fn from_fixed(&self, fixed: RataDie) -> Self::DateInner {
-        GregorianDateInner(Iso.from_fixed(fixed))
+    fn from_rata_die(&self, rd: RataDie) -> Self::DateInner {
+        GregorianDateInner(Iso.from_rata_die(rd))
     }
 
-    fn to_fixed(&self, date: &Self::DateInner) -> RataDie {
-        Iso.to_fixed(&date.0)
+    fn to_rata_die(&self, date: &Self::DateInner) -> RataDie {
+        Iso.to_rata_die(&date.0)
     }
 
     fn from_iso(&self, iso: IsoDateInner) -> GregorianDateInner {
@@ -193,7 +193,7 @@ mod test {
 
     #[derive(Debug)]
     struct TestCase {
-        fixed_date: RataDie,
+        rd: RataDie,
         iso_year: i32,
         iso_month: u8,
         iso_day: u8,
@@ -204,25 +204,31 @@ mod test {
     }
 
     fn check_test_case(case: TestCase) {
-        let iso_from_fixed = Date::from_fixed(case.fixed_date, Iso);
-        let greg_date_from_fixed = Date::from_fixed(case.fixed_date, Gregorian);
-        assert_eq!(greg_date_from_fixed.year().era_year_or_extended(), case.expected_year,
-            "Failed year check from fixed: {case:?}\nISO: {iso_from_fixed:?}\nGreg: {greg_date_from_fixed:?}");
-        assert_eq!(greg_date_from_fixed.year().standard_era().unwrap(), case.expected_era,
-            "Failed era check from fixed: {case:?}\nISO: {iso_from_fixed:?}\nGreg: {greg_date_from_fixed:?}");
-        assert_eq!(greg_date_from_fixed.month().ordinal, case.expected_month,
-            "Failed month check from fixed: {case:?}\nISO: {iso_from_fixed:?}\nGreg: {greg_date_from_fixed:?}");
-        assert_eq!(greg_date_from_fixed.day_of_month().0, case.expected_day,
-            "Failed day check from fixed: {case:?}\nISO: {iso_from_fixed:?}\nGreg: {greg_date_from_fixed:?}");
+        let iso_from_rd = Date::from_rata_die(case.rd, Iso);
+        let greg_date_from_rd = Date::from_rata_die(case.rd, Gregorian);
+        assert_eq!(greg_date_from_rd.year().era_year_or_extended(), case.expected_year,
+            "Failed year check from RD: {case:?}\nISO: {iso_from_rd:?}\nGreg: {greg_date_from_rd:?}");
+        assert_eq!(
+            greg_date_from_rd.year().standard_era().unwrap(),
+            case.expected_era,
+            "Failed era check from RD: {case:?}\nISO: {iso_from_rd:?}\nGreg: {greg_date_from_rd:?}"
+        );
+        assert_eq!(greg_date_from_rd.month().ordinal, case.expected_month,
+            "Failed month check from RD: {case:?}\nISO: {iso_from_rd:?}\nGreg: {greg_date_from_rd:?}");
+        assert_eq!(
+            greg_date_from_rd.day_of_month().0,
+            case.expected_day,
+            "Failed day check from RD: {case:?}\nISO: {iso_from_rd:?}\nGreg: {greg_date_from_rd:?}"
+        );
 
         let iso_date_man: Date<Iso> =
             Date::try_new_iso(case.iso_year, case.iso_month, case.iso_day)
                 .expect("Failed to initialize ISO date for {case:?}");
         let greg_date_man: Date<Gregorian> = Date::new_from_iso(iso_date_man, Gregorian);
-        assert_eq!(iso_from_fixed, iso_date_man,
-            "ISO from fixed not equal to ISO generated from manually-input ymd\nCase: {case:?}\nFixed: {iso_from_fixed:?}\nMan: {iso_date_man:?}");
-        assert_eq!(greg_date_from_fixed, greg_date_man,
-            "Greg. date from fixed not equal to Greg. generated from manually-input ymd\nCase: {case:?}\nFixed: {greg_date_from_fixed:?}\nMan: {greg_date_man:?}");
+        assert_eq!(iso_from_rd, iso_date_man,
+            "ISO from RD not equal to ISO generated from manually-input ymd\nCase: {case:?}\nRD: {iso_from_rd:?}\nMan: {iso_date_man:?}");
+        assert_eq!(greg_date_from_rd, greg_date_man,
+            "Greg. date from RD not equal to Greg. generated from manually-input ymd\nCase: {case:?}\nRD: {greg_date_from_rd:?}\nMan: {greg_date_man:?}");
     }
 
     #[test]
@@ -232,7 +238,7 @@ mod test {
 
         let cases = [
             TestCase {
-                fixed_date: RataDie::new(1),
+                rd: RataDie::new(1),
                 iso_year: 1,
                 iso_month: 1,
                 iso_day: 1,
@@ -242,7 +248,7 @@ mod test {
                 expected_day: 1,
             },
             TestCase {
-                fixed_date: RataDie::new(181),
+                rd: RataDie::new(181),
                 iso_year: 1,
                 iso_month: 6,
                 iso_day: 30,
@@ -252,7 +258,7 @@ mod test {
                 expected_day: 30,
             },
             TestCase {
-                fixed_date: RataDie::new(1155),
+                rd: RataDie::new(1155),
                 iso_year: 4,
                 iso_month: 2,
                 iso_day: 29,
@@ -262,7 +268,7 @@ mod test {
                 expected_day: 29,
             },
             TestCase {
-                fixed_date: RataDie::new(1344),
+                rd: RataDie::new(1344),
                 iso_year: 4,
                 iso_month: 9,
                 iso_day: 5,
@@ -272,7 +278,7 @@ mod test {
                 expected_day: 5,
             },
             TestCase {
-                fixed_date: RataDie::new(36219),
+                rd: RataDie::new(36219),
                 iso_year: 100,
                 iso_month: 3,
                 iso_day: 1,
@@ -295,7 +301,7 @@ mod test {
 
         let cases = [
             TestCase {
-                fixed_date: RataDie::new(0),
+                rd: RataDie::new(0),
                 iso_year: 0,
                 iso_month: 12,
                 iso_day: 31,
@@ -305,7 +311,7 @@ mod test {
                 expected_day: 31,
             },
             TestCase {
-                fixed_date: RataDie::new(-365), // This is a leap year
+                rd: RataDie::new(-365), // This is a leap year
                 iso_year: 0,
                 iso_month: 1,
                 iso_day: 1,
@@ -315,7 +321,7 @@ mod test {
                 expected_day: 1,
             },
             TestCase {
-                fixed_date: RataDie::new(-366),
+                rd: RataDie::new(-366),
                 iso_year: -1,
                 iso_month: 12,
                 iso_day: 31,
@@ -325,7 +331,7 @@ mod test {
                 expected_day: 31,
             },
             TestCase {
-                fixed_date: RataDie::new(-1461),
+                rd: RataDie::new(-1461),
                 iso_year: -4,
                 iso_month: 12,
                 iso_day: 31,
@@ -335,7 +341,7 @@ mod test {
                 expected_day: 31,
             },
             TestCase {
-                fixed_date: RataDie::new(-1826),
+                rd: RataDie::new(-1826),
                 iso_year: -4,
                 iso_month: 1,
                 iso_day: 1,
@@ -353,13 +359,13 @@ mod test {
 
     #[test]
     fn check_gregorian_directionality() {
-        // Tests that for a large range of fixed dates, if a fixed date
+        // Tests that for a large range of RDs, if a RD
         // is less than another, the corresponding YMD should also be less
         // than the other, without exception.
         for i in -100..100 {
             for j in -100..100 {
-                let iso_i = Date::from_fixed(RataDie::new(i), Iso);
-                let iso_j = Date::from_fixed(RataDie::new(j), Iso);
+                let iso_i = Date::from_rata_die(RataDie::new(i), Iso);
+                let iso_j = Date::from_rata_die(RataDie::new(j), Iso);
 
                 let greg_i = iso_i.to_calendar(Gregorian);
                 let greg_j = iso_j.to_calendar(Gregorian);

--- a/components/calendar/src/cal/hebrew.rs
+++ b/components/calendar/src/cal/hebrew.rs
@@ -15,14 +15,16 @@
 //! assert_eq!(hebrew_date.day_of_month().0, 11);
 //! ```
 
+use crate::cal::iso::{Iso, IsoDateInner};
 use crate::calendar_arithmetic::PrecomputedDataSource;
 use crate::calendar_arithmetic::{ArithmeticDate, CalendarArithmetic};
 use crate::error::DateError;
 use crate::types::MonthInfo;
+use crate::RangeError;
 use crate::{types, Calendar, Date, DateDuration, DateDurationUnit};
-use crate::{Iso, RangeError};
 use ::tinystr::tinystr;
 use calendrical_calculations::hebrew_keviyah::{Keviyah, YearInfo};
+use calendrical_calculations::rata_die::RataDie;
 
 /// The [Hebrew Calendar](https://en.wikipedia.org/wiki/Hebrew_calendar)
 ///
@@ -131,7 +133,7 @@ impl PrecomputedDataSource<HebrewYearInfo> for () {
 impl Calendar for Hebrew {
     type DateInner = HebrewDateInner;
 
-    fn date_from_codes(
+    fn from_codes(
         &self,
         era: Option<&str>,
         year: i32,
@@ -196,11 +198,10 @@ impl Calendar for Hebrew {
         )?))
     }
 
-    fn date_from_iso(&self, iso: Date<Iso>) -> Self::DateInner {
-        let fixed_iso = Iso::to_fixed(iso);
-        let (year, h_year) = YearInfo::year_containing_rd(fixed_iso);
+    fn from_fixed(&self, fixed: RataDie) -> Self::DateInner {
+        let (year, h_year) = YearInfo::year_containing_rd(fixed);
         // Obtaining a 1-indexed day-in-year value
-        let day = fixed_iso - year.new_year() + 1;
+        let day = fixed - year.new_year() + 1;
         let day = u16::try_from(day).unwrap_or(u16::MAX);
 
         let year = HebrewYearInfo::compute_with_keviyah(year.keviyah, h_year);
@@ -208,14 +209,22 @@ impl Calendar for Hebrew {
         HebrewDateInner(ArithmeticDate::new_unchecked(year, month, day))
     }
 
-    fn date_to_iso(&self, date: &Self::DateInner) -> Date<Iso> {
+    fn to_fixed(&self, date: &Self::DateInner) -> RataDie {
         let year = date.0.year.keviyah.year_info(date.0.year.value);
 
         let ny = year.new_year();
         let days_preceding = year.keviyah.days_preceding(date.0.month);
 
         // Need to subtract 1 since the new year is itself in this year
-        Iso::from_fixed(ny + i64::from(days_preceding) + i64::from(date.0.day) - 1)
+        ny + i64::from(days_preceding) + i64::from(date.0.day) - 1
+    }
+
+    fn from_iso(&self, iso: IsoDateInner) -> Self::DateInner {
+        self.from_fixed(Iso.to_fixed(&iso))
+    }
+
+    fn to_iso(&self, date: &Self::DateInner) -> IsoDateInner {
+        Iso.from_fixed(self.to_fixed(date))
     }
 
     fn months_in_year(&self, date: &Self::DateInner) -> u8 {

--- a/components/calendar/src/cal/hebrew.rs
+++ b/components/calendar/src/cal/hebrew.rs
@@ -198,10 +198,10 @@ impl Calendar for Hebrew {
         )?))
     }
 
-    fn from_fixed(&self, fixed: RataDie) -> Self::DateInner {
-        let (year, h_year) = YearInfo::year_containing_rd(fixed);
+    fn from_rata_die(&self, rd: RataDie) -> Self::DateInner {
+        let (year, h_year) = YearInfo::year_containing_rd(rd);
         // Obtaining a 1-indexed day-in-year value
-        let day = fixed - year.new_year() + 1;
+        let day = rd - year.new_year() + 1;
         let day = u16::try_from(day).unwrap_or(u16::MAX);
 
         let year = HebrewYearInfo::compute_with_keviyah(year.keviyah, h_year);
@@ -209,7 +209,7 @@ impl Calendar for Hebrew {
         HebrewDateInner(ArithmeticDate::new_unchecked(year, month, day))
     }
 
-    fn to_fixed(&self, date: &Self::DateInner) -> RataDie {
+    fn to_rata_die(&self, date: &Self::DateInner) -> RataDie {
         let year = date.0.year.keviyah.year_info(date.0.year.value);
 
         let ny = year.new_year();
@@ -220,11 +220,11 @@ impl Calendar for Hebrew {
     }
 
     fn from_iso(&self, iso: IsoDateInner) -> Self::DateInner {
-        self.from_fixed(Iso.to_fixed(&iso))
+        self.from_rata_die(Iso.to_rata_die(&iso))
     }
 
     fn to_iso(&self, date: &Self::DateInner) -> IsoDateInner {
-        Iso.from_fixed(self.to_fixed(date))
+        Iso.from_rata_die(self.to_rata_die(date))
     }
 
     fn months_in_year(&self, date: &Self::DateInner) -> u8 {

--- a/components/calendar/src/cal/indian.rs
+++ b/components/calendar/src/cal/indian.rs
@@ -106,12 +106,12 @@ impl Calendar for Indian {
         ArithmeticDate::new_from_codes(self, year, month_code, day).map(IndianDateInner)
     }
 
-    fn from_fixed(&self, fixed: RataDie) -> Self::DateInner {
-        self.from_iso(Iso.from_fixed(fixed))
+    fn from_rata_die(&self, rd: RataDie) -> Self::DateInner {
+        self.from_iso(Iso.from_rata_die(rd))
     }
 
-    fn to_fixed(&self, date: &Self::DateInner) -> RataDie {
-        Iso.to_fixed(&self.to_iso(date))
+    fn to_rata_die(&self, date: &Self::DateInner) -> RataDie {
+        Iso.to_rata_die(&self.to_iso(date))
     }
 
     // Algorithms directly implemented in icu_calendar since they're not from the book
@@ -447,10 +447,10 @@ mod tests {
     fn test_roundtrip_near_rd_zero() {
         for i in -1000..=1000 {
             let initial = RataDie::new(i);
-            let result = Date::from_fixed(initial, Iso)
+            let result = Date::from_rata_die(initial, Iso)
                 .to_calendar(Indian)
                 .to_iso()
-                .to_fixed();
+                .to_rata_die();
             assert_eq!(
                 initial, result,
                 "Roundtrip failed for initial: {initial:?}, result: {result:?}"
@@ -463,10 +463,10 @@ mod tests {
         // Epoch start: RD 28570
         for i in 27570..=29570 {
             let initial = RataDie::new(i);
-            let result = Date::from_fixed(initial, Iso)
+            let result = Date::from_rata_die(initial, Iso)
                 .to_calendar(Indian)
                 .to_iso()
-                .to_fixed();
+                .to_rata_die();
             assert_eq!(
                 initial, result,
                 "Roundtrip failed for initial: {initial:?}, result: {result:?}"
@@ -481,8 +481,8 @@ mod tests {
                 let rd_i = RataDie::new(i);
                 let rd_j = RataDie::new(j);
 
-                let indian_i = Date::from_fixed(rd_i, Indian);
-                let indian_j = Date::from_fixed(rd_j, Indian);
+                let indian_i = Date::from_rata_die(rd_i, Indian);
+                let indian_j = Date::from_rata_die(rd_j, Indian);
 
                 assert_eq!(i.cmp(&j), indian_i.cmp(&indian_j), "Directionality test failed for i: {i}, j: {j}, indian_i: {indian_i:?}, indian_j: {indian_j:?}");
             }
@@ -494,8 +494,8 @@ mod tests {
         // Epoch start: RD 28570
         for i in 28470..=28670 {
             for j in 28470..=28670 {
-                let indian_i = Date::from_fixed(RataDie::new(i), Indian);
-                let indian_j = Date::from_fixed(RataDie::new(j), Indian);
+                let indian_i = Date::from_rata_die(RataDie::new(i), Indian);
+                let indian_j = Date::from_rata_die(RataDie::new(j), Indian);
 
                 assert_eq!(i.cmp(&j), indian_i.cmp(&indian_j), "Directionality test failed for i: {i}, j: {j}, indian_i: {indian_i:?}, indian_j: {indian_j:?}");
             }

--- a/components/calendar/src/cal/indian.rs
+++ b/components/calendar/src/cal/indian.rs
@@ -16,10 +16,11 @@
 //! assert_eq!(date_indian.day_of_month().0, 12);
 //! ```
 
-use crate::cal::iso::Iso;
+use crate::cal::iso::{Iso, IsoDateInner};
 use crate::calendar_arithmetic::{ArithmeticDate, CalendarArithmetic};
 use crate::error::DateError;
 use crate::{types, Calendar, Date, DateDuration, DateDurationUnit, RangeError};
+use calendrical_calculations::rata_die::RataDie;
 use tinystr::tinystr;
 
 /// The [Indian National (Śaka) Calendar](https://en.wikipedia.org/wiki/Indian_national_calendar)
@@ -91,7 +92,7 @@ const YEAR_OFFSET: i32 = 78;
 
 impl Calendar for Indian {
     type DateInner = IndianDateInner;
-    fn date_from_codes(
+    fn from_codes(
         &self,
         era: Option<&str>,
         year: i32,
@@ -105,12 +106,20 @@ impl Calendar for Indian {
         ArithmeticDate::new_from_codes(self, year, month_code, day).map(IndianDateInner)
     }
 
+    fn from_fixed(&self, fixed: RataDie) -> Self::DateInner {
+        self.from_iso(Iso.from_fixed(fixed))
+    }
+
+    fn to_fixed(&self, date: &Self::DateInner) -> RataDie {
+        Iso.to_fixed(&self.to_iso(date))
+    }
+
     // Algorithms directly implemented in icu_calendar since they're not from the book
-    fn date_from_iso(&self, iso: Date<Iso>) -> IndianDateInner {
+    fn from_iso(&self, iso: IsoDateInner) -> IndianDateInner {
         // Get day number in year (1 indexed)
-        let day_of_year_iso = Iso::day_of_year(*iso.inner());
+        let day_of_year_iso = Iso::day_of_year(iso);
         // Convert to Saka year
-        let mut year = iso.inner().0.year - YEAR_OFFSET;
+        let mut year = iso.0.year - YEAR_OFFSET;
         // This is in the previous Indian year
         let day_of_year_indian = if day_of_year_iso <= DAY_OFFSET {
             year -= 1;
@@ -128,7 +137,7 @@ impl Calendar for Indian {
     }
 
     // Algorithms directly implemented in icu_calendar since they're not from the book
-    fn date_to_iso(&self, date: &Self::DateInner) -> Date<Iso> {
+    fn to_iso(&self, date: &Self::DateInner) -> IsoDateInner {
         let day_of_year_indian = date.0.day_of_year().0; // 1-indexed
         let days_in_year = date.0.days_in_year();
 
@@ -438,11 +447,10 @@ mod tests {
     fn test_roundtrip_near_rd_zero() {
         for i in -1000..=1000 {
             let initial = RataDie::new(i);
-            let result = Iso::to_fixed(
-                Iso::from_fixed(initial)
-                    .to_calendar(Indian)
-                    .to_calendar(Iso),
-            );
+            let result = Date::from_fixed(initial, Iso)
+                .to_calendar(Indian)
+                .to_iso()
+                .to_fixed();
             assert_eq!(
                 initial, result,
                 "Roundtrip failed for initial: {initial:?}, result: {result:?}"
@@ -455,11 +463,10 @@ mod tests {
         // Epoch start: RD 28570
         for i in 27570..=29570 {
             let initial = RataDie::new(i);
-            let result = Iso::to_fixed(
-                Iso::from_fixed(initial)
-                    .to_calendar(Indian)
-                    .to_calendar(Iso),
-            );
+            let result = Date::from_fixed(initial, Iso)
+                .to_calendar(Indian)
+                .to_iso()
+                .to_fixed();
             assert_eq!(
                 initial, result,
                 "Roundtrip failed for initial: {initial:?}, result: {result:?}"
@@ -474,8 +481,8 @@ mod tests {
                 let rd_i = RataDie::new(i);
                 let rd_j = RataDie::new(j);
 
-                let indian_i = Iso::from_fixed(rd_i).to_calendar(Indian);
-                let indian_j = Iso::from_fixed(rd_j).to_calendar(Indian);
+                let indian_i = Date::from_fixed(rd_i, Indian);
+                let indian_j = Date::from_fixed(rd_j, Indian);
 
                 assert_eq!(i.cmp(&j), indian_i.cmp(&indian_j), "Directionality test failed for i: {i}, j: {j}, indian_i: {indian_i:?}, indian_j: {indian_j:?}");
             }
@@ -487,8 +494,8 @@ mod tests {
         // Epoch start: RD 28570
         for i in 28470..=28670 {
             for j in 28470..=28670 {
-                let indian_i = Iso::from_fixed(RataDie::new(i)).to_calendar(Indian);
-                let indian_j = Iso::from_fixed(RataDie::new(j)).to_calendar(Indian);
+                let indian_i = Date::from_fixed(RataDie::new(i), Indian);
+                let indian_j = Date::from_fixed(RataDie::new(j), Indian);
 
                 assert_eq!(i.cmp(&j), indian_i.cmp(&indian_j), "Directionality test failed for i: {i}, j: {j}, indian_i: {indian_i:?}, indian_j: {indian_j:?}");
             }

--- a/components/calendar/src/cal/iso.rs
+++ b/components/calendar/src/cal/iso.rs
@@ -94,7 +94,7 @@ impl Calendar for Iso {
         ArithmeticDate::new_from_codes(self, year, month_code, day).map(IsoDateInner)
     }
 
-    fn from_fixed(&self, date: RataDie) -> IsoDateInner {
+    fn from_rata_die(&self, date: RataDie) -> IsoDateInner {
         IsoDateInner(match calendrical_calculations::iso::iso_from_fixed(date) {
             Err(I32CastError::BelowMin) => ArithmeticDate::min_date(),
             Err(I32CastError::AboveMax) => ArithmeticDate::max_date(),
@@ -102,7 +102,7 @@ impl Calendar for Iso {
         })
     }
 
-    fn to_fixed(&self, date: &IsoDateInner) -> RataDie {
+    fn to_rata_die(&self, date: &IsoDateInner) -> RataDie {
         calendrical_calculations::iso::fixed_from_iso(date.0.year, date.0.month, date.0.day)
     }
 
@@ -254,13 +254,13 @@ mod test {
             year: i32,
             month: u8,
             day: u8,
-            fixed: RataDie,
+            rd: RataDie,
             saturating: bool,
         }
-        // Calculates the max possible year representable using i32::MAX as the fixed date
-        let max_year = Iso.from_fixed(RataDie::new(i32::MAX as i64)).0.year;
+        // Calculates the max possible year representable using i32::MAX as the RD
+        let max_year = Iso.from_rata_die(RataDie::new(i32::MAX as i64)).0.year;
 
-        // Calculates the minimum possible year representable using i32::MIN as the fixed date
+        // Calculates the minimum possible year representable using i32::MIN as the RD
         // *Cannot be tested yet due to hard coded date not being available yet (see line 436)
         let min_year = -5879610;
 
@@ -270,56 +270,56 @@ mod test {
                 year: min_year,
                 month: 6,
                 day: 22,
-                fixed: RataDie::new(i32::MIN as i64),
+                rd: RataDie::new(i32::MIN as i64),
                 saturating: false,
             },
             TestCase {
                 year: min_year,
                 month: 6,
                 day: 23,
-                fixed: RataDie::new(i32::MIN as i64 + 1),
+                rd: RataDie::new(i32::MIN as i64 + 1),
                 saturating: false,
             },
             TestCase {
                 year: min_year,
                 month: 6,
                 day: 21,
-                fixed: RataDie::new(i32::MIN as i64 - 1),
+                rd: RataDie::new(i32::MIN as i64 - 1),
                 saturating: false,
             },
             TestCase {
                 year: min_year,
                 month: 12,
                 day: 31,
-                fixed: RataDie::new(-2147483456),
+                rd: RataDie::new(-2147483456),
                 saturating: false,
             },
             TestCase {
                 year: min_year + 1,
                 month: 1,
                 day: 1,
-                fixed: RataDie::new(-2147483455),
+                rd: RataDie::new(-2147483455),
                 saturating: false,
             },
             TestCase {
                 year: max_year,
                 month: 6,
                 day: 11,
-                fixed: RataDie::new(i32::MAX as i64 - 30),
+                rd: RataDie::new(i32::MAX as i64 - 30),
                 saturating: false,
             },
             TestCase {
                 year: max_year,
                 month: 7,
                 day: 9,
-                fixed: RataDie::new(i32::MAX as i64 - 2),
+                rd: RataDie::new(i32::MAX as i64 - 2),
                 saturating: false,
             },
             TestCase {
                 year: max_year,
                 month: 7,
                 day: 10,
-                fixed: RataDie::new(i32::MAX as i64 - 1),
+                rd: RataDie::new(i32::MAX as i64 - 1),
                 saturating: false,
             },
             TestCase {
@@ -327,56 +327,56 @@ mod test {
                 year: max_year,
                 month: 7,
                 day: 11,
-                fixed: RataDie::new(i32::MAX as i64),
+                rd: RataDie::new(i32::MAX as i64),
                 saturating: false,
             },
             TestCase {
                 year: max_year,
                 month: 7,
                 day: 12,
-                fixed: RataDie::new(i32::MAX as i64 + 1),
+                rd: RataDie::new(i32::MAX as i64 + 1),
                 saturating: false,
             },
             TestCase {
                 year: i32::MIN,
                 month: 1,
                 day: 2,
-                fixed: RataDie::new(-784352296669),
+                rd: RataDie::new(-784352296669),
                 saturating: false,
             },
             TestCase {
                 year: i32::MIN,
                 month: 1,
                 day: 1,
-                fixed: RataDie::new(-784352296670),
+                rd: RataDie::new(-784352296670),
                 saturating: false,
             },
             TestCase {
                 year: i32::MIN,
                 month: 1,
                 day: 1,
-                fixed: RataDie::new(-784352296671),
+                rd: RataDie::new(-784352296671),
                 saturating: true,
             },
             TestCase {
                 year: i32::MAX,
                 month: 12,
                 day: 30,
-                fixed: RataDie::new(784352295938),
+                rd: RataDie::new(784352295938),
                 saturating: false,
             },
             TestCase {
                 year: i32::MAX,
                 month: 12,
                 day: 31,
-                fixed: RataDie::new(784352295939),
+                rd: RataDie::new(784352295939),
                 saturating: false,
             },
             TestCase {
                 year: i32::MAX,
                 month: 12,
                 day: 31,
-                fixed: RataDie::new(784352295940),
+                rd: RataDie::new(784352295940),
                 saturating: true,
             },
         ];
@@ -384,9 +384,9 @@ mod test {
         for case in cases {
             let date = Date::try_new_iso(case.year, case.month, case.day).unwrap();
             if !case.saturating {
-                assert_eq!(date.to_fixed(), case.fixed, "{case:?}");
+                assert_eq!(date.to_rata_die(), case.rd, "{case:?}");
             }
-            assert_eq!(Date::from_fixed(case.fixed, Iso), date, "{case:?}");
+            assert_eq!(Date::from_rata_die(case.rd, Iso), date, "{case:?}");
         }
     }
 
@@ -394,7 +394,7 @@ mod test {
     #[test]
     fn min_year() {
         assert_eq!(
-            Date::from_fixed(RataDie::big_negative(), Iso)
+            Date::from_rata_die(RataDie::big_negative(), Iso)
                 .year()
                 .era_year_or_extended(),
             i32::MIN
@@ -530,16 +530,16 @@ mod test {
     }
 
     #[test]
-    fn test_iso_to_from_fixed() {
+    fn test_iso_to_from_rd() {
         // Reminder: ISO year 0 is Gregorian year 1 BCE.
         // Year 0 is a leap year due to the 400-year rule.
-        fn check(fixed: i64, year: i32, month: u8, day: u8) {
-            let fixed = RataDie::new(fixed);
+        fn check(rd: i64, year: i32, month: u8, day: u8) {
+            let rd = RataDie::new(rd);
 
             assert_eq!(
-                Date::from_fixed(fixed, Iso),
+                Date::from_rata_die(rd, Iso),
                 Date::try_new_iso(year, month, day).unwrap(),
-                "fixed: {fixed:?}"
+                "RD: {rd:?}"
             );
         }
         check(-1828, -5, 12, 30);

--- a/components/calendar/src/cal/japanese.rs
+++ b/components/calendar/src/cal/japanese.rs
@@ -190,12 +190,12 @@ impl Calendar for Japanese {
         self.new_japanese_date_inner(era.unwrap_or("gregory"), year, month, day)
     }
 
-    fn from_fixed(&self, fixed: RataDie) -> Self::DateInner {
-        self.from_iso(Iso.from_fixed(fixed))
+    fn from_rata_die(&self, rd: RataDie) -> Self::DateInner {
+        self.from_iso(Iso.from_rata_die(rd))
     }
 
-    fn to_fixed(&self, date: &Self::DateInner) -> RataDie {
-        Iso.to_fixed(&self.to_iso(date))
+    fn to_rata_die(&self, date: &Self::DateInner) -> RataDie {
+        Iso.to_rata_die(&self.to_iso(date))
     }
 
     fn from_iso(&self, iso: IsoDateInner) -> JapaneseDateInner {
@@ -300,12 +300,12 @@ impl Calendar for JapaneseExtended {
         self.0.from_codes(era, year, month_code, day)
     }
 
-    fn from_fixed(&self, fixed: RataDie) -> Self::DateInner {
-        Japanese::from_fixed(&self.0, fixed)
+    fn from_rata_die(&self, rd: RataDie) -> Self::DateInner {
+        Japanese::from_rata_die(&self.0, rd)
     }
 
-    fn to_fixed(&self, date: &Self::DateInner) -> RataDie {
-        Japanese::to_fixed(&self.0, date)
+    fn to_rata_die(&self, date: &Self::DateInner) -> RataDie {
+        Japanese::to_rata_die(&self.0, date)
     }
 
     fn from_iso(&self, iso: IsoDateInner) -> JapaneseDateInner {

--- a/components/calendar/src/cal/julian.rs
+++ b/components/calendar/src/cal/julian.rs
@@ -101,9 +101,9 @@ impl Calendar for Julian {
         ArithmeticDate::new_from_codes(self, year, month_code, day).map(JulianDateInner)
     }
 
-    fn from_fixed(&self, fixed: RataDie) -> Self::DateInner {
+    fn from_rata_die(&self, rd: RataDie) -> Self::DateInner {
         JulianDateInner(
-            match calendrical_calculations::julian::julian_from_fixed(fixed) {
+            match calendrical_calculations::julian::julian_from_fixed(rd) {
                 Err(I32CastError::BelowMin) => ArithmeticDate::min_date(),
                 Err(I32CastError::AboveMax) => ArithmeticDate::max_date(),
                 Ok((year, month, day)) => ArithmeticDate::new_unchecked(year, month, day),
@@ -111,16 +111,16 @@ impl Calendar for Julian {
         )
     }
 
-    fn to_fixed(&self, date: &Self::DateInner) -> RataDie {
+    fn to_rata_die(&self, date: &Self::DateInner) -> RataDie {
         calendrical_calculations::julian::fixed_from_julian(date.0.year, date.0.month, date.0.day)
     }
 
     fn from_iso(&self, iso: IsoDateInner) -> JulianDateInner {
-        self.from_fixed(Iso.to_fixed(&iso))
+        self.from_rata_die(Iso.to_rata_die(&iso))
     }
 
     fn to_iso(&self, date: &Self::DateInner) -> IsoDateInner {
-        Iso.from_fixed(self.to_fixed(date))
+        Iso.from_rata_die(self.to_rata_die(date))
     }
 
     fn months_in_year(&self, date: &Self::DateInner) -> u8 {
@@ -319,7 +319,7 @@ mod test {
 
         #[derive(Debug)]
         struct TestCase {
-            fixed_date: i64,
+            rd: i64,
             iso_year: i32,
             iso_month: u8,
             iso_day: u8,
@@ -331,7 +331,7 @@ mod test {
 
         let cases = [
             TestCase {
-                fixed_date: 1,
+                rd: 1,
                 iso_year: 1,
                 iso_month: 1,
                 iso_day: 1,
@@ -341,7 +341,7 @@ mod test {
                 expected_day: 3,
             },
             TestCase {
-                fixed_date: 0,
+                rd: 0,
                 iso_year: 0,
                 iso_month: 12,
                 iso_day: 31,
@@ -351,7 +351,7 @@ mod test {
                 expected_day: 2,
             },
             TestCase {
-                fixed_date: -1,
+                rd: -1,
                 iso_year: 0,
                 iso_month: 12,
                 iso_day: 30,
@@ -361,7 +361,7 @@ mod test {
                 expected_day: 1,
             },
             TestCase {
-                fixed_date: -2,
+                rd: -2,
                 iso_year: 0,
                 iso_month: 12,
                 iso_day: 29,
@@ -371,7 +371,7 @@ mod test {
                 expected_day: 31,
             },
             TestCase {
-                fixed_date: -3,
+                rd: -3,
                 iso_year: 0,
                 iso_month: 12,
                 iso_day: 28,
@@ -381,7 +381,7 @@ mod test {
                 expected_day: 30,
             },
             TestCase {
-                fixed_date: -367,
+                rd: -367,
                 iso_year: -1,
                 iso_month: 12,
                 iso_day: 30,
@@ -391,7 +391,7 @@ mod test {
                 expected_day: 1,
             },
             TestCase {
-                fixed_date: -368,
+                rd: -368,
                 iso_year: -1,
                 iso_month: 12,
                 iso_day: 29,
@@ -401,7 +401,7 @@ mod test {
                 expected_day: 31,
             },
             TestCase {
-                fixed_date: -1462,
+                rd: -1462,
                 iso_year: -4,
                 iso_month: 12,
                 iso_day: 30,
@@ -411,7 +411,7 @@ mod test {
                 expected_day: 1,
             },
             TestCase {
-                fixed_date: -1463,
+                rd: -1463,
                 iso_year: -4,
                 iso_month: 12,
                 iso_day: 29,
@@ -423,48 +423,48 @@ mod test {
         ];
 
         for case in cases {
-            let iso_from_fixed = Date::from_fixed(RataDie::new(case.fixed_date), crate::Iso);
-            let julian_from_fixed = Date::from_fixed(RataDie::new(case.fixed_date), Julian);
-            assert_eq!(julian_from_fixed.year().era_year().unwrap(), case.expected_year,
-                "Failed year check from fixed: {case:?}\nISO: {iso_from_fixed:?}\nJulian: {julian_from_fixed:?}");
-            assert_eq!(julian_from_fixed.year().standard_era().unwrap(), case.expected_era,
-                "Failed era check from fixed: {case:?}\nISO: {iso_from_fixed:?}\nJulian: {julian_from_fixed:?}");
-            assert_eq!(julian_from_fixed.month().ordinal, case.expected_month,
-                "Failed month check from fixed: {case:?}\nISO: {iso_from_fixed:?}\nJulian: {julian_from_fixed:?}");
-            assert_eq!(julian_from_fixed.day_of_month().0, case.expected_day,
-                "Failed day check from fixed: {case:?}\nISO: {iso_from_fixed:?}\nJulian: {julian_from_fixed:?}");
+            let iso_from_rd = Date::from_rata_die(RataDie::new(case.rd), crate::Iso);
+            let julian_from_rd = Date::from_rata_die(RataDie::new(case.rd), Julian);
+            assert_eq!(julian_from_rd.year().era_year().unwrap(), case.expected_year,
+                "Failed year check from RD: {case:?}\nISO: {iso_from_rd:?}\nJulian: {julian_from_rd:?}");
+            assert_eq!(julian_from_rd.year().standard_era().unwrap(), case.expected_era,
+                "Failed era check from RD: {case:?}\nISO: {iso_from_rd:?}\nJulian: {julian_from_rd:?}");
+            assert_eq!(julian_from_rd.month().ordinal, case.expected_month,
+                "Failed month check from RD: {case:?}\nISO: {iso_from_rd:?}\nJulian: {julian_from_rd:?}");
+            assert_eq!(julian_from_rd.day_of_month().0, case.expected_day,
+                "Failed day check from RD: {case:?}\nISO: {iso_from_rd:?}\nJulian: {julian_from_rd:?}");
 
             let iso_date_man = Date::try_new_iso(case.iso_year, case.iso_month, case.iso_day)
                 .expect("Failed to initialize ISO date for {case:?}");
             let julian_date_man = Date::new_from_iso(iso_date_man, Julian);
-            assert_eq!(iso_from_fixed, iso_date_man,
-                "ISO from fixed not equal to ISO generated from manually-input ymd\nCase: {case:?}\nFixed: {iso_from_fixed:?}\nMan: {iso_date_man:?}");
-            assert_eq!(julian_from_fixed, julian_date_man,
-                "Julian from fixed not equal to Julian generated from manually-input ymd\nCase: {case:?}\nFixed: {julian_from_fixed:?}\nMan: {julian_date_man:?}");
+            assert_eq!(iso_from_rd, iso_date_man,
+                "ISO from RD not equal to ISO generated from manually-input ymd\nCase: {case:?}\nRD: {iso_from_rd:?}\nMan: {iso_date_man:?}");
+            assert_eq!(julian_from_rd, julian_date_man,
+                "Julian from RD not equal to Julian generated from manually-input ymd\nCase: {case:?}\nRD: {julian_from_rd:?}\nMan: {julian_date_man:?}");
         }
     }
 
     #[test]
-    fn test_julian_fixed_date_conversion() {
-        // Tests that converting from fixed date to Julian then
-        // back to fixed date yields the same fixed date
+    fn test_julian_rd_date_conversion() {
+        // Tests that converting from RD to Julian then
+        // back to RD yields the same RD
         for i in -10000..=10000 {
-            let fixed = RataDie::new(i);
-            let julian = Date::from_fixed(fixed, Julian);
-            let new_fixed = julian.to_fixed();
-            assert_eq!(fixed, new_fixed);
+            let rd = RataDie::new(i);
+            let julian = Date::from_rata_die(rd, Julian);
+            let new_rd = julian.to_rata_die();
+            assert_eq!(rd, new_rd);
         }
     }
 
     #[test]
     fn test_julian_directionality() {
-        // Tests that for a large range of fixed dates, if a fixed date
+        // Tests that for a large range of RDs, if a RD
         // is less than another, the corresponding YMD should also be less
         // than the other, without exception.
         for i in -100..=100 {
             for j in -100..=100 {
-                let julian_i = Date::from_fixed(RataDie::new(i), Julian);
-                let julian_j = Date::from_fixed(RataDie::new(j), Julian);
+                let julian_i = Date::from_rata_die(RataDie::new(i), Julian);
+                let julian_j = Date::from_rata_die(RataDie::new(j), Julian);
 
                 assert_eq!(
                     i.cmp(&j),

--- a/components/calendar/src/cal/persian.rs
+++ b/components/calendar/src/cal/persian.rs
@@ -101,9 +101,9 @@ impl Calendar for Persian {
         ArithmeticDate::new_from_codes(self, year, month_code, day).map(PersianDateInner)
     }
 
-    fn from_fixed(&self, fixed: RataDie) -> Self::DateInner {
+    fn from_rata_die(&self, rd: RataDie) -> Self::DateInner {
         PersianDateInner(
-            match calendrical_calculations::persian::fast_persian_from_fixed(fixed) {
+            match calendrical_calculations::persian::fast_persian_from_fixed(rd) {
                 Err(I32CastError::BelowMin) => ArithmeticDate::min_date(),
                 Err(I32CastError::AboveMax) => ArithmeticDate::max_date(),
                 Ok((year, month, day)) => ArithmeticDate::new_unchecked(year, month, day),
@@ -111,7 +111,7 @@ impl Calendar for Persian {
         )
     }
 
-    fn to_fixed(&self, date: &Self::DateInner) -> RataDie {
+    fn to_rata_die(&self, date: &Self::DateInner) -> RataDie {
         calendrical_calculations::persian::fixed_from_fast_persian(
             date.0.year,
             date.0.month,
@@ -120,11 +120,11 @@ impl Calendar for Persian {
     }
 
     fn from_iso(&self, iso: IsoDateInner) -> PersianDateInner {
-        self.from_fixed(Iso.to_fixed(&iso))
+        self.from_rata_die(Iso.to_rata_die(&iso))
     }
 
     fn to_iso(&self, date: &Self::DateInner) -> IsoDateInner {
-        Iso.from_fixed(self.to_fixed(date))
+        Iso.from_rata_die(self.to_rata_die(date))
     }
 
     fn months_in_year(&self, date: &Self::DateInner) -> u8 {
@@ -231,7 +231,7 @@ mod tests {
         day: u8,
     }
 
-    static TEST_FIXED_DATE: [i64; 21] = [
+    static TEST_RD: [i64; 21] = [
         656786, 664224, 671401, 694799, 702806, 704424, 708842, 709409, 709580, 727274, 728714,
         739330, 739331, 744313, 763436, 763437, 764652, 775123, 775488, 775489, 1317874,
     ];
@@ -355,13 +355,12 @@ mod tests {
     ];
 
     fn days_in_provided_year_core(year: i32) -> u16 {
-        let fixed_year =
+        let ny =
             calendrical_calculations::persian::fixed_from_fast_persian(year, 1, 1).to_i64_date();
-        let next_fixed_year =
-            calendrical_calculations::persian::fixed_from_fast_persian(year + 1, 1, 1)
-                .to_i64_date();
+        let next_ny = calendrical_calculations::persian::fixed_from_fast_persian(year + 1, 1, 1)
+            .to_i64_date();
 
-        (next_fixed_year - fixed_year) as u16
+        (next_ny - ny) as u16
     }
 
     #[test]
@@ -392,19 +391,19 @@ mod tests {
     }
 
     #[test]
-    fn test_fixed_from_persian() {
-        for (case, f_date) in CASES.iter().zip(TEST_FIXED_DATE.iter()) {
+    fn test_rd_from_persian() {
+        for (case, f_date) in CASES.iter().zip(TEST_RD.iter()) {
             let date = Date::try_new_persian(case.year, case.month, case.day).unwrap();
 
-            assert_eq!(date.to_fixed().to_i64_date(), *f_date, "{case:?}");
+            assert_eq!(date.to_rata_die().to_i64_date(), *f_date, "{case:?}");
         }
     }
     #[test]
-    fn test_persian_from_fixed() {
-        for (case, f_date) in CASES.iter().zip(TEST_FIXED_DATE.iter()) {
+    fn test_persian_from_rd() {
+        for (case, f_date) in CASES.iter().zip(TEST_RD.iter()) {
             let date = Date::try_new_persian(case.year, case.month, case.day).unwrap();
             assert_eq!(
-                Persian.from_fixed(RataDie::new(*f_date)),
+                Persian.from_rata_die(RataDie::new(*f_date)),
                 date.inner,
                 "{case:?}"
             );

--- a/components/calendar/src/cal/roc.rs
+++ b/components/calendar/src/cal/roc.rs
@@ -75,12 +75,12 @@ impl Calendar for Roc {
             .map(RocDateInner)
     }
 
-    fn from_fixed(&self, fixed: RataDie) -> Self::DateInner {
-        RocDateInner(Iso.from_fixed(fixed))
+    fn from_rata_die(&self, rd: RataDie) -> Self::DateInner {
+        RocDateInner(Iso.from_rata_die(rd))
     }
 
-    fn to_fixed(&self, date: &Self::DateInner) -> RataDie {
-        Iso.to_fixed(&date.0)
+    fn to_rata_die(&self, date: &Self::DateInner) -> RataDie {
+        Iso.to_rata_die(&date.0)
     }
 
     fn from_iso(&self, iso: IsoDateInner) -> Self::DateInner {
@@ -210,7 +210,7 @@ mod test {
 
     #[derive(Debug)]
     struct TestCase {
-        fixed_date: RataDie,
+        rd: RataDie,
         iso_year: i32,
         iso_month: u8,
         iso_day: u8,
@@ -221,24 +221,33 @@ mod test {
     }
 
     fn check_test_case(case: TestCase) {
-        let iso_from_fixed = Date::from_fixed(case.fixed_date, Iso);
-        let roc_from_fixed = Date::from_fixed(case.fixed_date, Roc);
-        assert_eq!(roc_from_fixed.year().era_year().unwrap(), case.expected_year,
-            "Failed year check from fixed: {case:?}\nISO: {iso_from_fixed:?}\nROC: {roc_from_fixed:?}");
-        assert_eq!(roc_from_fixed.year().standard_era().unwrap(), case.expected_era,
-            "Failed era check from fixed: {case:?}\nISO: {iso_from_fixed:?}\nROC: {roc_from_fixed:?}");
-        assert_eq!(roc_from_fixed.month().ordinal, case.expected_month,
-            "Failed month check from fixed: {case:?}\nISO: {iso_from_fixed:?}\nROC: {roc_from_fixed:?}");
-        assert_eq!(roc_from_fixed.day_of_month().0, case.expected_day,
-            "Failed day_of_month check from fixed: {case:?}\nISO: {iso_from_fixed:?}\nROC: {roc_from_fixed:?}");
+        let iso_from_rd = Date::from_rata_die(case.rd, Iso);
+        let roc_from_rd = Date::from_rata_die(case.rd, Roc);
+        assert_eq!(
+            roc_from_rd.year().era_year().unwrap(),
+            case.expected_year,
+            "Failed year check from RD: {case:?}\nISO: {iso_from_rd:?}\nROC: {roc_from_rd:?}"
+        );
+        assert_eq!(
+            roc_from_rd.year().standard_era().unwrap(),
+            case.expected_era,
+            "Failed era check from RD: {case:?}\nISO: {iso_from_rd:?}\nROC: {roc_from_rd:?}"
+        );
+        assert_eq!(
+            roc_from_rd.month().ordinal,
+            case.expected_month,
+            "Failed month check from RD: {case:?}\nISO: {iso_from_rd:?}\nROC: {roc_from_rd:?}"
+        );
+        assert_eq!(roc_from_rd.day_of_month().0, case.expected_day,
+            "Failed day_of_month check from RD: {case:?}\nISO: {iso_from_rd:?}\nROC: {roc_from_rd:?}");
 
         let iso_from_case = Date::try_new_iso(case.iso_year, case.iso_month, case.iso_day)
             .expect("Failed to initialize ISO date for {case:?}");
         let roc_from_case = Date::new_from_iso(iso_from_case, Roc);
-        assert_eq!(iso_from_fixed, iso_from_case,
-            "ISO from fixed not equal to ISO generated from manually-input ymd\nCase: {case:?}\nFixed: {iso_from_fixed:?}\nManual: {iso_from_case:?}");
-        assert_eq!(roc_from_fixed, roc_from_case,
-            "ROC date from fixed not equal to ROC generated from manually-input ymd\nCase: {case:?}\nFixed: {roc_from_fixed:?}\nManual: {roc_from_case:?}");
+        assert_eq!(iso_from_rd, iso_from_case,
+            "ISO from RD not equal to ISO generated from manually-input ymd\nCase: {case:?}\nRD: {iso_from_rd:?}\nManual: {iso_from_case:?}");
+        assert_eq!(roc_from_rd, roc_from_case,
+            "ROC date from RD not equal to ROC generated from manually-input ymd\nCase: {case:?}\nRD: {roc_from_rd:?}\nManual: {roc_from_case:?}");
     }
 
     #[test]
@@ -250,7 +259,7 @@ mod test {
 
         let cases = [
             TestCase {
-                fixed_date: RataDie::new(697978),
+                rd: RataDie::new(697978),
                 iso_year: 1912,
                 iso_month: 1,
                 iso_day: 1,
@@ -260,7 +269,7 @@ mod test {
                 expected_day: 1,
             },
             TestCase {
-                fixed_date: RataDie::new(698037),
+                rd: RataDie::new(698037),
                 iso_year: 1912,
                 iso_month: 2,
                 iso_day: 29,
@@ -270,7 +279,7 @@ mod test {
                 expected_day: 29,
             },
             TestCase {
-                fixed_date: RataDie::new(698524),
+                rd: RataDie::new(698524),
                 iso_year: 1913,
                 iso_month: 6,
                 iso_day: 30,
@@ -280,7 +289,7 @@ mod test {
                 expected_day: 30,
             },
             TestCase {
-                fixed_date: RataDie::new(738714),
+                rd: RataDie::new(738714),
                 iso_year: 2023,
                 iso_month: 7,
                 iso_day: 13,
@@ -304,7 +313,7 @@ mod test {
         // Jan 1. 1912 CE = RD 697978
         let cases = [
             TestCase {
-                fixed_date: RataDie::new(697977),
+                rd: RataDie::new(697977),
                 iso_year: 1911,
                 iso_month: 12,
                 iso_day: 31,
@@ -314,7 +323,7 @@ mod test {
                 expected_day: 31,
             },
             TestCase {
-                fixed_date: RataDie::new(697613),
+                rd: RataDie::new(697613),
                 iso_year: 1911,
                 iso_month: 1,
                 iso_day: 1,
@@ -324,7 +333,7 @@ mod test {
                 expected_day: 1,
             },
             TestCase {
-                fixed_date: RataDie::new(697612),
+                rd: RataDie::new(697612),
                 iso_year: 1910,
                 iso_month: 12,
                 iso_day: 31,
@@ -334,7 +343,7 @@ mod test {
                 expected_day: 31,
             },
             TestCase {
-                fixed_date: RataDie::new(696576),
+                rd: RataDie::new(696576),
                 iso_year: 1908,
                 iso_month: 2,
                 iso_day: 29,
@@ -344,7 +353,7 @@ mod test {
                 expected_day: 29,
             },
             TestCase {
-                fixed_date: RataDie::new(1),
+                rd: RataDie::new(1),
                 iso_year: 1,
                 iso_month: 1,
                 iso_day: 1,
@@ -354,7 +363,7 @@ mod test {
                 expected_day: 1,
             },
             TestCase {
-                fixed_date: RataDie::new(0),
+                rd: RataDie::new(0),
                 iso_year: 0,
                 iso_month: 12,
                 iso_day: 31,
@@ -372,17 +381,17 @@ mod test {
 
     #[test]
     fn test_roc_directionality_near_epoch() {
-        // Tests that for a large range of fixed dates near the beginning of the minguo era (CE 1912),
-        // the comparison between those two fixed dates should be equal to the comparison between their
+        // Tests that for a large range of RDs near the beginning of the minguo era (CE 1912),
+        // the comparison between those two RDs should be equal to the comparison between their
         // corresponding YMD.
         let rd_epoch_start = 697978;
         for i in (rd_epoch_start - 100)..=(rd_epoch_start + 100) {
             for j in (rd_epoch_start - 100)..=(rd_epoch_start + 100) {
-                let iso_i = Date::from_fixed(RataDie::new(i), Iso);
-                let iso_j = Date::from_fixed(RataDie::new(j), Iso);
+                let iso_i = Date::from_rata_die(RataDie::new(i), Iso);
+                let iso_j = Date::from_rata_die(RataDie::new(j), Iso);
 
-                let roc_i = Date::from_fixed(RataDie::new(i), Roc);
-                let roc_j = Date::from_fixed(RataDie::new(j), Roc);
+                let roc_i = Date::from_rata_die(RataDie::new(i), Roc);
+                let roc_j = Date::from_rata_die(RataDie::new(j), Roc);
 
                 assert_eq!(
                     i.cmp(&j),
@@ -403,11 +412,11 @@ mod test {
         // Same as `test_directionality_near_epoch`, but with a focus around RD 0
         for i in -100..=100 {
             for j in -100..100 {
-                let iso_i = Date::from_fixed(RataDie::new(i), Iso);
-                let iso_j = Date::from_fixed(RataDie::new(j), Iso);
+                let iso_i = Date::from_rata_die(RataDie::new(i), Iso);
+                let iso_j = Date::from_rata_die(RataDie::new(j), Iso);
 
-                let roc_i = Date::from_fixed(RataDie::new(i), Roc);
-                let roc_j = Date::from_fixed(RataDie::new(j), Roc);
+                let roc_i = Date::from_rata_die(RataDie::new(i), Roc);
+                let roc_j = Date::from_rata_die(RataDie::new(j), Roc);
 
                 assert_eq!(
                     i.cmp(&j),

--- a/components/calendar/src/calendar.rs
+++ b/components/calendar/src/calendar.rs
@@ -2,15 +2,18 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use calendrical_calculations::rata_die::RataDie;
+
 use crate::any_calendar::AnyCalendarKind;
+use crate::cal::iso::IsoDateInner;
 use crate::error::DateError;
-use crate::{types, Date, DateDuration, DateDurationUnit, Iso};
+use crate::{types, DateDuration, DateDurationUnit};
 use core::fmt;
 
 /// A calendar implementation
 ///
 /// Only implementors of [`Calendar`] should care about these methods, in general users of
-/// these calendars should use the methods on [`Date`] instead.
+/// these calendars should use the methods on [`Date`](crate::Date) instead.
 ///
 /// Individual [`Calendar`] implementations may have inherent utility methods
 /// allowing for direct construction, etc.
@@ -23,7 +26,8 @@ pub trait Calendar {
     /// Construct a date from era/month codes and fields
     ///
     /// The year is extended_year if no era is provided
-    fn date_from_codes(
+    #[allow(clippy::wrong_self_convention)]
+    fn from_codes(
         &self,
         era: Option<&str>,
         year: i32,
@@ -32,9 +36,16 @@ pub trait Calendar {
     ) -> Result<Self::DateInner, DateError>;
 
     /// Construct the date from an ISO date
-    fn date_from_iso(&self, iso: Date<Iso>) -> Self::DateInner;
+    #[allow(clippy::wrong_self_convention)]
+    fn from_iso(&self, iso: IsoDateInner) -> Self::DateInner;
     /// Obtain an ISO date from this date
-    fn date_to_iso(&self, date: &Self::DateInner) -> Date<Iso>;
+    fn to_iso(&self, date: &Self::DateInner) -> IsoDateInner;
+
+    /// Construct the date from a fixed day
+    #[allow(clippy::wrong_self_convention)]
+    fn from_fixed(&self, fixed: RataDie) -> Self::DateInner;
+    /// Obtain a fixed day from this date
+    fn to_fixed(&self, date: &Self::DateInner) -> RataDie;
 
     /// Count the number of months in a given year, specified by providing a date
     /// from that year

--- a/components/calendar/src/calendar.rs
+++ b/components/calendar/src/calendar.rs
@@ -41,11 +41,11 @@ pub trait Calendar {
     /// Obtain an ISO date from this date
     fn to_iso(&self, date: &Self::DateInner) -> IsoDateInner;
 
-    /// Construct the date from a fixed day
+    /// Construct the date from a [`RataDie`]
     #[allow(clippy::wrong_self_convention)]
-    fn from_fixed(&self, fixed: RataDie) -> Self::DateInner;
-    /// Obtain a fixed day from this date
-    fn to_fixed(&self, date: &Self::DateInner) -> RataDie;
+    fn from_rata_die(&self, rd: RataDie) -> Self::DateInner;
+    /// Obtain a [`RataDie`] from this date
+    fn to_rata_die(&self, date: &Self::DateInner) -> RataDie;
 
     /// Count the number of months in a given year, specified by providing a date
     /// from that year

--- a/components/calendar/src/date.rs
+++ b/components/calendar/src/date.rs
@@ -134,23 +134,19 @@ impl<A: AsCalendar> Date<A> {
         Ok(Date { inner, calendar })
     }
 
-    /// Construct a date from a fixed day and some calendar representation.
-    ///
-    /// See [`RataDie`] for more information on fixed day numbers.
+    /// Construct a date from a [`RataDie`] and some calendar representation
     #[inline]
-    pub fn from_fixed(fixed: RataDie, calendar: A) -> Self {
+    pub fn from_rata_die(rd: RataDie, calendar: A) -> Self {
         Date {
-            inner: calendar.as_calendar().from_fixed(fixed),
+            inner: calendar.as_calendar().from_rata_die(rd),
             calendar,
         }
     }
 
-    /// Convert the Date to a fixed day.
-    ///
-    /// See [`RataDie`] for more information on fixed day numbers.
+    /// Convert the date to a [`RataDie`]
     #[inline]
-    pub fn to_fixed(&self) -> RataDie {
-        self.calendar.as_calendar().to_fixed(self.inner())
+    pub fn to_rata_die(&self) -> RataDie {
+        self.calendar.as_calendar().to_rata_die(self.inner())
     }
 
     /// Construct a date from an ISO date and some calendar representation
@@ -193,7 +189,7 @@ impl<A: AsCalendar> Date<A> {
     /// The day of the week for this date
     #[inline]
     pub fn day_of_week(&self) -> types::Weekday {
-        self.to_fixed().into()
+        self.to_rata_die().into()
     }
 
     /// Add a `duration` to this date, mutating it

--- a/components/calendar/src/date.rs
+++ b/components/calendar/src/date.rs
@@ -134,7 +134,9 @@ impl<A: AsCalendar> Date<A> {
         Ok(Date { inner, calendar })
     }
 
-    /// Construct a date from a fixed day and some calendar representation
+    /// Construct a date from a fixed day and some calendar representation.
+    ///
+    /// See [`RataDie`] for more information on fixed day numbers.
     #[inline]
     pub fn from_fixed(fixed: RataDie, calendar: A) -> Self {
         Date {
@@ -143,7 +145,9 @@ impl<A: AsCalendar> Date<A> {
         }
     }
 
-    /// Convert the Date to a fixed day
+    /// Convert the Date to a fixed day.
+    ///
+    /// See [`RataDie`] for more information on fixed day numbers.
     #[inline]
     pub fn to_fixed(&self) -> RataDie {
         self.calendar.as_calendar().to_fixed(self.inner())

--- a/components/calendar/src/provider/hijri.rs
+++ b/components/calendar/src/provider/hijri.rs
@@ -89,20 +89,20 @@ impl HijriCache<'_> {
     /// Get the cached data for the Hijri Year corresponding to a given day.
     ///
     /// Also returns the corresponding extended year.
-    pub(crate) fn get_for_fixed<IB: IslamicBased>(
+    pub(crate) fn get_for_rd<IB: IslamicBased>(
         &self,
-        fixed: RataDie,
+        rd: RataDie,
         model: IB,
     ) -> Option<HijriYearInfo<IB>> {
-        let extended_year = IB::approximate_islamic_from_fixed(fixed);
+        let extended_year = IB::approximate_islamic_from_fixed(rd);
 
         let year = self.get_for_extended_year(extended_year, model)?;
 
-        if fixed < year.new_year() {
+        if rd < year.new_year() {
             self.get_for_extended_year(extended_year - 1, model)
         } else {
             let next_year = self.get_for_extended_year(extended_year + 1, model)?;
-            Some(if fixed < next_year.new_year() {
+            Some(if rd < next_year.new_year() {
                 year
             } else {
                 next_year

--- a/components/calendar/src/tests/continuity_test.rs
+++ b/components/calendar/src/tests/continuity_test.rs
@@ -14,14 +14,14 @@ fn check_continuity<A: AsCalendar>(mut date: Date<A>) {
         marker: PhantomData,
     };
 
-    let mut rata_die = Iso::to_fixed(date.to_iso());
+    let mut rata_die = date.to_fixed();
     let mut weekday = date.day_of_week();
     let mut year = date.year();
     let mut is_in_leap_year = date.is_in_leap_year();
 
     for _ in 0..(366 * 20) {
         let next_date = date.added(one_day_duration);
-        let next_rata_die = Iso::to_fixed(next_date.to_iso());
+        let next_rata_die = next_date.to_iso().to_fixed();
         assert_eq!(next_rata_die, rata_die + 1, "{next_date:?}");
         let next_weekday = next_date.day_of_week();
         let next_year = next_date.year();
@@ -51,12 +51,12 @@ fn check_every_250_days<A: AsCalendar>(mut date: Date<A>) {
         marker: PhantomData,
     };
 
-    let mut rata_die = Iso::to_fixed(date.to_iso());
+    let mut rata_die = date.to_fixed();
 
     for _ in 0..2000 {
         let next_date = date.added(one_thousand_days_duration);
         let next_iso = next_date.to_iso();
-        let next_rata_die = Iso::to_fixed(next_iso.to_iso());
+        let next_rata_die = next_iso.to_fixed();
         assert_eq!(next_rata_die, rata_die + 250, "{next_date:?}");
         let next_date_roundtrip = next_iso.to_calendar(Ref(next_date.calendar()));
         assert_eq!(next_date, next_date_roundtrip, "{next_date:?}");

--- a/components/calendar/src/tests/continuity_test.rs
+++ b/components/calendar/src/tests/continuity_test.rs
@@ -14,14 +14,14 @@ fn check_continuity<A: AsCalendar>(mut date: Date<A>) {
         marker: PhantomData,
     };
 
-    let mut rata_die = date.to_fixed();
+    let mut rata_die = date.to_rata_die();
     let mut weekday = date.day_of_week();
     let mut year = date.year();
     let mut is_in_leap_year = date.is_in_leap_year();
 
     for _ in 0..(366 * 20) {
         let next_date = date.added(one_day_duration);
-        let next_rata_die = next_date.to_iso().to_fixed();
+        let next_rata_die = next_date.to_iso().to_rata_die();
         assert_eq!(next_rata_die, rata_die + 1, "{next_date:?}");
         let next_weekday = next_date.day_of_week();
         let next_year = next_date.year();
@@ -51,12 +51,12 @@ fn check_every_250_days<A: AsCalendar>(mut date: Date<A>) {
         marker: PhantomData,
     };
 
-    let mut rata_die = date.to_fixed();
+    let mut rata_die = date.to_rata_die();
 
     for _ in 0..2000 {
         let next_date = date.added(one_thousand_days_duration);
         let next_iso = next_date.to_iso();
-        let next_rata_die = next_iso.to_fixed();
+        let next_rata_die = next_iso.to_rata_die();
         assert_eq!(next_rata_die, rata_die + 250, "{next_date:?}");
         let next_date_roundtrip = next_iso.to_calendar(Ref(next_date.calendar()));
         assert_eq!(next_date, next_date_roundtrip, "{next_date:?}");

--- a/components/calendar/src/types.rs
+++ b/components/calendar/src/types.rs
@@ -4,7 +4,7 @@
 
 //! This module contains various types used by `icu_calendar` and `icu::datetime`
 
-use calendrical_calculations::rata_die::RataDie;
+pub use calendrical_calculations::rata_die::RataDie;
 use core::fmt;
 use core::num::NonZeroU8;
 use tinystr::TinyAsciiStr;

--- a/components/time/src/provider/mod.rs
+++ b/components/time/src/provider/mod.rs
@@ -72,7 +72,7 @@ pub struct MinutesSinceEpoch(pub i32);
 impl From<(Date<Iso>, Time)> for MinutesSinceEpoch {
     fn from((d, t): (Date<Iso>, Time)) -> MinutesSinceEpoch {
         Self(
-            ((Iso::to_fixed(d) - Self::EPOCH) as i32 * 24 + t.hour.number() as i32) * 60
+            ((d.to_fixed() - Self::EPOCH) as i32 * 24 + t.hour.number() as i32) * 60
                 + t.minute.number() as i32,
         )
     }
@@ -113,7 +113,7 @@ impl serde::Serialize for MinutesSinceEpoch {
             let minute = self.0 % 60;
             let hour = self.0 / 60 % 24;
             let days = self.0 / 60 / 24;
-            let date = Iso::from_fixed(Self::EPOCH + days as i64);
+            let date = Date::from_fixed(Self::EPOCH + days as i64, Iso);
             let year = date.year().extended_year;
             let month = date.month().month_number();
             let day = date.day_of_month().0;

--- a/components/time/src/provider/mod.rs
+++ b/components/time/src/provider/mod.rs
@@ -72,7 +72,7 @@ pub struct MinutesSinceEpoch(pub i32);
 impl From<(Date<Iso>, Time)> for MinutesSinceEpoch {
     fn from((d, t): (Date<Iso>, Time)) -> MinutesSinceEpoch {
         Self(
-            ((d.to_fixed() - Self::EPOCH) as i32 * 24 + t.hour.number() as i32) * 60
+            ((d.to_rata_die() - Self::EPOCH) as i32 * 24 + t.hour.number() as i32) * 60
                 + t.minute.number() as i32,
         )
     }
@@ -113,7 +113,7 @@ impl serde::Serialize for MinutesSinceEpoch {
             let minute = self.0 % 60;
             let hour = self.0 / 60 % 24;
             let days = self.0 / 60 / 24;
-            let date = Date::from_fixed(Self::EPOCH + days as i64, Iso);
+            let date = Date::from_rata_die(Self::EPOCH + days as i64, Iso);
             let year = date.year().extended_year;
             let month = date.month().month_number();
             let day = date.day_of_month().0;

--- a/ffi/capi/bindings/c/Date.h
+++ b/ffi/capi/bindings/c/Date.h
@@ -26,12 +26,17 @@ icu4x_Date_from_iso_in_calendar_mv1_result icu4x_Date_from_iso_in_calendar_mv1(i
 typedef struct icu4x_Date_from_codes_in_calendar_mv1_result {union {Date* ok; CalendarError err;}; bool is_ok;} icu4x_Date_from_codes_in_calendar_mv1_result;
 icu4x_Date_from_codes_in_calendar_mv1_result icu4x_Date_from_codes_in_calendar_mv1(DiplomatStringView era_code, int32_t year, DiplomatStringView month_code, uint8_t day, const Calendar* calendar);
 
+typedef struct icu4x_Date_from_rata_die_mv1_result {union {Date* ok; CalendarError err;}; bool is_ok;} icu4x_Date_from_rata_die_mv1_result;
+icu4x_Date_from_rata_die_mv1_result icu4x_Date_from_rata_die_mv1(int64_t rd, const Calendar* calendar);
+
 typedef struct icu4x_Date_from_string_mv1_result {union {Date* ok; CalendarParseError err;}; bool is_ok;} icu4x_Date_from_string_mv1_result;
 icu4x_Date_from_string_mv1_result icu4x_Date_from_string_mv1(DiplomatStringView v, const Calendar* calendar);
 
 Date* icu4x_Date_to_calendar_mv1(const Date* self, const Calendar* calendar);
 
 IsoDate* icu4x_Date_to_iso_mv1(const Date* self);
+
+int64_t icu4x_Date_to_rata_die_mv1(const Date* self);
 
 uint16_t icu4x_Date_day_of_year_mv1(const Date* self);
 

--- a/ffi/capi/bindings/c/IsoDate.h
+++ b/ffi/capi/bindings/c/IsoDate.h
@@ -24,12 +24,16 @@
 typedef struct icu4x_IsoDate_create_mv1_result {union {IsoDate* ok; CalendarError err;}; bool is_ok;} icu4x_IsoDate_create_mv1_result;
 icu4x_IsoDate_create_mv1_result icu4x_IsoDate_create_mv1(int32_t year, uint8_t month, uint8_t day);
 
+IsoDate* icu4x_IsoDate_from_rata_die_mv1(int64_t rd);
+
 typedef struct icu4x_IsoDate_from_string_mv1_result {union {IsoDate* ok; CalendarParseError err;}; bool is_ok;} icu4x_IsoDate_from_string_mv1_result;
 icu4x_IsoDate_from_string_mv1_result icu4x_IsoDate_from_string_mv1(DiplomatStringView v);
 
 Date* icu4x_IsoDate_to_calendar_mv1(const IsoDate* self, const Calendar* calendar);
 
 Date* icu4x_IsoDate_to_any_mv1(const IsoDate* self);
+
+int64_t icu4x_IsoDate_to_rata_die_mv1(const IsoDate* self);
 
 uint16_t icu4x_IsoDate_day_of_year_mv1(const IsoDate* self);
 

--- a/ffi/capi/bindings/cpp/icu4x/Date.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/Date.d.hpp
@@ -31,7 +31,7 @@ namespace capi {
 
 namespace icu4x {
 /**
- * An ICU4X Date object capable of containing a date and time for any calendar.
+ * An ICU4X Date object capable of containing a date for any calendar.
  *
  * See the [Rust documentation for `Date`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html) for more information.
  */
@@ -39,7 +39,7 @@ class Date {
 public:
 
   /**
-   * Creates a new [`Date`] representing the ISO date and time
+   * Creates a new [`Date`] representing the ISO date
    * given but in a given calendar
    *
    * See the [Rust documentation for `new_from_iso`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.new_from_iso) for more information.
@@ -54,6 +54,13 @@ public:
    * See the [Rust documentation for `try_new_from_codes`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.try_new_from_codes) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::Date>, icu4x::CalendarError> from_codes_in_calendar(std::string_view era_code, int32_t year, std::string_view month_code, uint8_t day, const icu4x::Calendar& calendar);
+
+  /**
+   * Creates a new [`Date`] from the given Rata Die
+   *
+   * See the [Rust documentation for `from_rata_die`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.from_rata_die) for more information.
+   */
+  inline static diplomat::result<std::unique_ptr<icu4x::Date>, icu4x::CalendarError> from_rata_die(int64_t rd, const icu4x::Calendar& calendar);
 
   /**
    * Creates a new [`Date`] from an IXDTF string.
@@ -75,6 +82,13 @@ public:
    * See the [Rust documentation for `to_iso`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.to_iso) for more information.
    */
   inline std::unique_ptr<icu4x::IsoDate> to_iso() const;
+
+  /**
+   * Returns this date's Rata Die
+   *
+   * See the [Rust documentation for `to_rata_die`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.to_rata_die) for more information.
+   */
+  inline int64_t to_rata_die() const;
 
   /**
    * Returns the 1-indexed day in the year for this date

--- a/ffi/capi/bindings/cpp/icu4x/Date.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/Date.hpp
@@ -28,12 +28,17 @@ namespace capi {
     typedef struct icu4x_Date_from_codes_in_calendar_mv1_result {union {icu4x::capi::Date* ok; icu4x::capi::CalendarError err;}; bool is_ok;} icu4x_Date_from_codes_in_calendar_mv1_result;
     icu4x_Date_from_codes_in_calendar_mv1_result icu4x_Date_from_codes_in_calendar_mv1(diplomat::capi::DiplomatStringView era_code, int32_t year, diplomat::capi::DiplomatStringView month_code, uint8_t day, const icu4x::capi::Calendar* calendar);
     
+    typedef struct icu4x_Date_from_rata_die_mv1_result {union {icu4x::capi::Date* ok; icu4x::capi::CalendarError err;}; bool is_ok;} icu4x_Date_from_rata_die_mv1_result;
+    icu4x_Date_from_rata_die_mv1_result icu4x_Date_from_rata_die_mv1(int64_t rd, const icu4x::capi::Calendar* calendar);
+    
     typedef struct icu4x_Date_from_string_mv1_result {union {icu4x::capi::Date* ok; icu4x::capi::CalendarParseError err;}; bool is_ok;} icu4x_Date_from_string_mv1_result;
     icu4x_Date_from_string_mv1_result icu4x_Date_from_string_mv1(diplomat::capi::DiplomatStringView v, const icu4x::capi::Calendar* calendar);
     
     icu4x::capi::Date* icu4x_Date_to_calendar_mv1(const icu4x::capi::Date* self, const icu4x::capi::Calendar* calendar);
     
     icu4x::capi::IsoDate* icu4x_Date_to_iso_mv1(const icu4x::capi::Date* self);
+    
+    int64_t icu4x_Date_to_rata_die_mv1(const icu4x::capi::Date* self);
     
     uint16_t icu4x_Date_day_of_year_mv1(const icu4x::capi::Date* self);
     
@@ -87,6 +92,12 @@ inline diplomat::result<std::unique_ptr<icu4x::Date>, icu4x::CalendarError> icu4
   return result.is_ok ? diplomat::result<std::unique_ptr<icu4x::Date>, icu4x::CalendarError>(diplomat::Ok<std::unique_ptr<icu4x::Date>>(std::unique_ptr<icu4x::Date>(icu4x::Date::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<icu4x::Date>, icu4x::CalendarError>(diplomat::Err<icu4x::CalendarError>(icu4x::CalendarError::FromFFI(result.err)));
 }
 
+inline diplomat::result<std::unique_ptr<icu4x::Date>, icu4x::CalendarError> icu4x::Date::from_rata_die(int64_t rd, const icu4x::Calendar& calendar) {
+  auto result = icu4x::capi::icu4x_Date_from_rata_die_mv1(rd,
+    calendar.AsFFI());
+  return result.is_ok ? diplomat::result<std::unique_ptr<icu4x::Date>, icu4x::CalendarError>(diplomat::Ok<std::unique_ptr<icu4x::Date>>(std::unique_ptr<icu4x::Date>(icu4x::Date::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<icu4x::Date>, icu4x::CalendarError>(diplomat::Err<icu4x::CalendarError>(icu4x::CalendarError::FromFFI(result.err)));
+}
+
 inline diplomat::result<std::unique_ptr<icu4x::Date>, icu4x::CalendarParseError> icu4x::Date::from_string(std::string_view v, const icu4x::Calendar& calendar) {
   auto result = icu4x::capi::icu4x_Date_from_string_mv1({v.data(), v.size()},
     calendar.AsFFI());
@@ -102,6 +113,11 @@ inline std::unique_ptr<icu4x::Date> icu4x::Date::to_calendar(const icu4x::Calend
 inline std::unique_ptr<icu4x::IsoDate> icu4x::Date::to_iso() const {
   auto result = icu4x::capi::icu4x_Date_to_iso_mv1(this->AsFFI());
   return std::unique_ptr<icu4x::IsoDate>(icu4x::IsoDate::FromFFI(result));
+}
+
+inline int64_t icu4x::Date::to_rata_die() const {
+  auto result = icu4x::capi::icu4x_Date_to_rata_die_mv1(this->AsFFI());
+  return result;
 }
 
 inline uint16_t icu4x::Date::day_of_year() const {

--- a/ffi/capi/bindings/cpp/icu4x/IsoDate.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/IsoDate.d.hpp
@@ -40,11 +40,18 @@ class IsoDate {
 public:
 
   /**
-   * Creates a new [`IsoDate`] from the specified date and time.
+   * Creates a new [`IsoDate`] from the specified date.
    *
    * See the [Rust documentation for `try_new_iso`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.try_new_iso) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::IsoDate>, icu4x::CalendarError> create(int32_t year, uint8_t month, uint8_t day);
+
+  /**
+   * Creates a new [`IsoDate`] from the given Rata Die
+   *
+   * See the [Rust documentation for `from_rata_die`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.from_rata_die) for more information.
+   */
+  inline static std::unique_ptr<icu4x::IsoDate> from_rata_die(int64_t rd);
 
   /**
    * Creates a new [`IsoDate`] from an IXDTF string.
@@ -64,6 +71,13 @@ public:
    * See the [Rust documentation for `to_any`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.to_any) for more information.
    */
   inline std::unique_ptr<icu4x::Date> to_any() const;
+
+  /**
+   * Returns this date's Rata Die
+   *
+   * See the [Rust documentation for `to_rata_die`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.to_rata_die) for more information.
+   */
+  inline int64_t to_rata_die() const;
 
   /**
    * Returns the 1-indexed day in the year for this date

--- a/ffi/capi/bindings/cpp/icu4x/IsoDate.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/IsoDate.hpp
@@ -26,12 +26,16 @@ namespace capi {
     typedef struct icu4x_IsoDate_create_mv1_result {union {icu4x::capi::IsoDate* ok; icu4x::capi::CalendarError err;}; bool is_ok;} icu4x_IsoDate_create_mv1_result;
     icu4x_IsoDate_create_mv1_result icu4x_IsoDate_create_mv1(int32_t year, uint8_t month, uint8_t day);
     
+    icu4x::capi::IsoDate* icu4x_IsoDate_from_rata_die_mv1(int64_t rd);
+    
     typedef struct icu4x_IsoDate_from_string_mv1_result {union {icu4x::capi::IsoDate* ok; icu4x::capi::CalendarParseError err;}; bool is_ok;} icu4x_IsoDate_from_string_mv1_result;
     icu4x_IsoDate_from_string_mv1_result icu4x_IsoDate_from_string_mv1(diplomat::capi::DiplomatStringView v);
     
     icu4x::capi::Date* icu4x_IsoDate_to_calendar_mv1(const icu4x::capi::IsoDate* self, const icu4x::capi::Calendar* calendar);
     
     icu4x::capi::Date* icu4x_IsoDate_to_any_mv1(const icu4x::capi::IsoDate* self);
+    
+    int64_t icu4x_IsoDate_to_rata_die_mv1(const icu4x::capi::IsoDate* self);
     
     uint16_t icu4x_IsoDate_day_of_year_mv1(const icu4x::capi::IsoDate* self);
     
@@ -67,6 +71,11 @@ inline diplomat::result<std::unique_ptr<icu4x::IsoDate>, icu4x::CalendarError> i
   return result.is_ok ? diplomat::result<std::unique_ptr<icu4x::IsoDate>, icu4x::CalendarError>(diplomat::Ok<std::unique_ptr<icu4x::IsoDate>>(std::unique_ptr<icu4x::IsoDate>(icu4x::IsoDate::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<icu4x::IsoDate>, icu4x::CalendarError>(diplomat::Err<icu4x::CalendarError>(icu4x::CalendarError::FromFFI(result.err)));
 }
 
+inline std::unique_ptr<icu4x::IsoDate> icu4x::IsoDate::from_rata_die(int64_t rd) {
+  auto result = icu4x::capi::icu4x_IsoDate_from_rata_die_mv1(rd);
+  return std::unique_ptr<icu4x::IsoDate>(icu4x::IsoDate::FromFFI(result));
+}
+
 inline diplomat::result<std::unique_ptr<icu4x::IsoDate>, icu4x::CalendarParseError> icu4x::IsoDate::from_string(std::string_view v) {
   auto result = icu4x::capi::icu4x_IsoDate_from_string_mv1({v.data(), v.size()});
   return result.is_ok ? diplomat::result<std::unique_ptr<icu4x::IsoDate>, icu4x::CalendarParseError>(diplomat::Ok<std::unique_ptr<icu4x::IsoDate>>(std::unique_ptr<icu4x::IsoDate>(icu4x::IsoDate::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<icu4x::IsoDate>, icu4x::CalendarParseError>(diplomat::Err<icu4x::CalendarParseError>(icu4x::CalendarParseError::FromFFI(result.err)));
@@ -81,6 +90,11 @@ inline std::unique_ptr<icu4x::Date> icu4x::IsoDate::to_calendar(const icu4x::Cal
 inline std::unique_ptr<icu4x::Date> icu4x::IsoDate::to_any() const {
   auto result = icu4x::capi::icu4x_IsoDate_to_any_mv1(this->AsFFI());
   return std::unique_ptr<icu4x::Date>(icu4x::Date::FromFFI(result));
+}
+
+inline int64_t icu4x::IsoDate::to_rata_die() const {
+  auto result = icu4x::capi::icu4x_IsoDate_to_rata_die_mv1(this->AsFFI());
+  return result;
 }
 
 inline uint16_t icu4x::IsoDate::day_of_year() const {

--- a/ffi/capi/bindings/dart/Date.g.dart
+++ b/ffi/capi/bindings/dart/Date.g.dart
@@ -3,7 +3,7 @@
 
 part of 'lib.g.dart';
 
-/// An ICU4X Date object capable of containing a date and time for any calendar.
+/// An ICU4X Date object capable of containing a date for any calendar.
 ///
 /// See the [Rust documentation for `Date`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html) for more information.
 final class Date implements ffi.Finalizable {
@@ -25,7 +25,7 @@ final class Date implements ffi.Finalizable {
 
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_Date_destroy_mv1));
 
-  /// Creates a new [`Date`] representing the ISO date and time
+  /// Creates a new [`Date`] representing the ISO date
   /// given but in a given calendar
   ///
   /// See the [Rust documentation for `new_from_iso`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.new_from_iso) for more information.
@@ -49,6 +49,19 @@ final class Date implements ffi.Finalizable {
   factory Date.fromCodesInCalendar(String eraCode, int year, String monthCode, int day, Calendar calendar) {
     final temp = _FinalizedArena();
     final result = _icu4x_Date_from_codes_in_calendar_mv1(eraCode._utf8AllocIn(temp.arena), year, monthCode._utf8AllocIn(temp.arena), day, calendar._ffi);
+    if (!result.isOk) {
+      throw CalendarError.values[result.union.err];
+    }
+    return Date._fromFfi(result.union.ok, []);
+  }
+
+  /// Creates a new [`Date`] from the given Rata Die
+  ///
+  /// See the [Rust documentation for `from_rata_die`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.from_rata_die) for more information.
+  ///
+  /// Throws [CalendarError] on failure.
+  factory Date.fromRataDie(int rd, Calendar calendar) {
+    final result = _icu4x_Date_from_rata_die_mv1(rd, calendar._ffi);
     if (!result.isOk) {
       throw CalendarError.values[result.union.err];
     }
@@ -83,6 +96,14 @@ final class Date implements ffi.Finalizable {
   IsoDate toIso() {
     final result = _icu4x_Date_to_iso_mv1(_ffi);
     return IsoDate._fromFfi(result, []);
+  }
+
+  /// Returns this date's Rata Die
+  ///
+  /// See the [Rust documentation for `to_rata_die`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.to_rata_die) for more information.
+  int get rataDie {
+    final result = _icu4x_Date_to_rata_die_mv1(_ffi);
+    return result;
   }
 
   /// Returns the 1-indexed day in the year for this date
@@ -230,6 +251,11 @@ external _ResultOpaqueInt32 _icu4x_Date_from_iso_in_calendar_mv1(int year, int m
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_Date_from_codes_in_calendar_mv1(_SliceUtf8 eraCode, int year, _SliceUtf8 monthCode, int day, ffi.Pointer<ffi.Opaque> calendar);
 
+@_DiplomatFfiUse('icu4x_Date_from_rata_die_mv1')
+@ffi.Native<_ResultOpaqueInt32 Function(ffi.Int64, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Date_from_rata_die_mv1')
+// ignore: non_constant_identifier_names
+external _ResultOpaqueInt32 _icu4x_Date_from_rata_die_mv1(int rd, ffi.Pointer<ffi.Opaque> calendar);
+
 @_DiplomatFfiUse('icu4x_Date_from_string_mv1')
 @ffi.Native<_ResultOpaqueInt32 Function(_SliceUtf8, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Date_from_string_mv1')
 // ignore: non_constant_identifier_names
@@ -244,6 +270,11 @@ external ffi.Pointer<ffi.Opaque> _icu4x_Date_to_calendar_mv1(ffi.Pointer<ffi.Opa
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Date_to_iso_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_Date_to_iso_mv1(ffi.Pointer<ffi.Opaque> self);
+
+@_DiplomatFfiUse('icu4x_Date_to_rata_die_mv1')
+@ffi.Native<ffi.Int64 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Date_to_rata_die_mv1')
+// ignore: non_constant_identifier_names
+external int _icu4x_Date_to_rata_die_mv1(ffi.Pointer<ffi.Opaque> self);
 
 @_DiplomatFfiUse('icu4x_Date_day_of_year_mv1')
 @ffi.Native<ffi.Uint16 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Date_day_of_year_mv1')

--- a/ffi/capi/bindings/dart/IsoDate.g.dart
+++ b/ffi/capi/bindings/dart/IsoDate.g.dart
@@ -25,7 +25,7 @@ final class IsoDate implements ffi.Finalizable {
 
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_IsoDate_destroy_mv1));
 
-  /// Creates a new [`IsoDate`] from the specified date and time.
+  /// Creates a new [`IsoDate`] from the specified date.
   ///
   /// See the [Rust documentation for `try_new_iso`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.try_new_iso) for more information.
   ///
@@ -36,6 +36,14 @@ final class IsoDate implements ffi.Finalizable {
       throw CalendarError.values[result.union.err];
     }
     return IsoDate._fromFfi(result.union.ok, []);
+  }
+
+  /// Creates a new [`IsoDate`] from the given Rata Die
+  ///
+  /// See the [Rust documentation for `from_rata_die`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.from_rata_die) for more information.
+  factory IsoDate.fromRataDie(int rd) {
+    final result = _icu4x_IsoDate_from_rata_die_mv1(rd);
+    return IsoDate._fromFfi(result, []);
   }
 
   /// Creates a new [`IsoDate`] from an IXDTF string.
@@ -64,6 +72,14 @@ final class IsoDate implements ffi.Finalizable {
   Date toAny() {
     final result = _icu4x_IsoDate_to_any_mv1(_ffi);
     return Date._fromFfi(result, []);
+  }
+
+  /// Returns this date's Rata Die
+  ///
+  /// See the [Rust documentation for `to_rata_die`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.to_rata_die) for more information.
+  int get rataDie {
+    final result = _icu4x_IsoDate_to_rata_die_mv1(_ffi);
+    return result;
   }
 
   /// Returns the 1-indexed day in the year for this date
@@ -161,6 +177,11 @@ external void _icu4x_IsoDate_destroy_mv1(ffi.Pointer<ffi.Void> self);
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_IsoDate_create_mv1(int year, int month, int day);
 
+@_DiplomatFfiUse('icu4x_IsoDate_from_rata_die_mv1')
+@ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Int64)>(isLeaf: true, symbol: 'icu4x_IsoDate_from_rata_die_mv1')
+// ignore: non_constant_identifier_names
+external ffi.Pointer<ffi.Opaque> _icu4x_IsoDate_from_rata_die_mv1(int rd);
+
 @_DiplomatFfiUse('icu4x_IsoDate_from_string_mv1')
 @ffi.Native<_ResultOpaqueInt32 Function(_SliceUtf8)>(isLeaf: true, symbol: 'icu4x_IsoDate_from_string_mv1')
 // ignore: non_constant_identifier_names
@@ -175,6 +196,11 @@ external ffi.Pointer<ffi.Opaque> _icu4x_IsoDate_to_calendar_mv1(ffi.Pointer<ffi.
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_IsoDate_to_any_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_IsoDate_to_any_mv1(ffi.Pointer<ffi.Opaque> self);
+
+@_DiplomatFfiUse('icu4x_IsoDate_to_rata_die_mv1')
+@ffi.Native<ffi.Int64 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_IsoDate_to_rata_die_mv1')
+// ignore: non_constant_identifier_names
+external int _icu4x_IsoDate_to_rata_die_mv1(ffi.Pointer<ffi.Opaque> self);
 
 @_DiplomatFfiUse('icu4x_IsoDate_day_of_year_mv1')
 @ffi.Native<ffi.Uint16 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_IsoDate_day_of_year_mv1')

--- a/ffi/capi/bindings/js/Date.d.ts
+++ b/ffi/capi/bindings/js/Date.d.ts
@@ -8,7 +8,7 @@ import type { pointer, codepoint } from "./diplomat-runtime.d.ts";
 
 
 /** 
- * An ICU4X Date object capable of containing a date and time for any calendar.
+ * An ICU4X Date object capable of containing a date for any calendar.
  *
  * See the [Rust documentation for `Date`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html) for more information.
  */
@@ -19,7 +19,7 @@ export class Date {
     get ffiValue(): pointer;
 
     /** 
-     * Creates a new [`Date`] representing the ISO date and time
+     * Creates a new [`Date`] representing the ISO date
      * given but in a given calendar
      *
      * See the [Rust documentation for `new_from_iso`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.new_from_iso) for more information.
@@ -34,6 +34,13 @@ export class Date {
      * See the [Rust documentation for `try_new_from_codes`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.try_new_from_codes) for more information.
      */
     static fromCodesInCalendar(eraCode: string, year: number, monthCode: string, day: number, calendar: Calendar): Date;
+
+    /** 
+     * Creates a new [`Date`] from the given Rata Die
+     *
+     * See the [Rust documentation for `from_rata_die`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.from_rata_die) for more information.
+     */
+    static fromRataDie(rd: bigint, calendar: Calendar): Date;
 
     /** 
      * Creates a new [`Date`] from an IXDTF string.
@@ -55,6 +62,13 @@ export class Date {
      * See the [Rust documentation for `to_iso`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.to_iso) for more information.
      */
     toIso(): IsoDate;
+
+    /** 
+     * Returns this date's Rata Die
+     *
+     * See the [Rust documentation for `to_rata_die`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.to_rata_die) for more information.
+     */
+    get rataDie(): bigint;
 
     /** 
      * Returns the 1-indexed day in the year for this date

--- a/ffi/capi/bindings/js/Date.mjs
+++ b/ffi/capi/bindings/js/Date.mjs
@@ -9,7 +9,7 @@ import * as diplomatRuntime from "./diplomat-runtime.mjs";
 
 
 /** 
- * An ICU4X Date object capable of containing a date and time for any calendar.
+ * An ICU4X Date object capable of containing a date for any calendar.
  *
  * See the [Rust documentation for `Date`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html) for more information.
  */
@@ -47,7 +47,7 @@ export class Date {
     }
 
     /** 
-     * Creates a new [`Date`] representing the ISO date and time
+     * Creates a new [`Date`] representing the ISO date
      * given but in a given calendar
      *
      * See the [Rust documentation for `new_from_iso`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.new_from_iso) for more information.
@@ -99,6 +99,29 @@ export class Date {
         finally {
             functionCleanupArena.free();
         
+            diplomatReceive.free();
+        }
+    }
+
+    /** 
+     * Creates a new [`Date`] from the given Rata Die
+     *
+     * See the [Rust documentation for `from_rata_die`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.from_rata_die) for more information.
+     */
+    static fromRataDie(rd, calendar) {
+        const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
+        
+        const result = wasm.icu4x_Date_from_rata_die_mv1(diplomatReceive.buffer, rd, calendar.ffiValue);
+    
+        try {
+            if (!diplomatReceive.resultFlag) {
+                const cause = new CalendarError(diplomatRuntime.internalConstructor, diplomatRuntime.enumDiscriminant(wasm, diplomatReceive.buffer));
+                throw new globalThis.Error('CalendarError: ' + cause.value, { cause });
+            }
+            return new Date(diplomatRuntime.internalConstructor, diplomatRuntime.ptrRead(wasm, diplomatReceive.buffer), []);
+        }
+        
+        finally {
             diplomatReceive.free();
         }
     }
@@ -157,6 +180,21 @@ export class Date {
     
         try {
             return new IsoDate(diplomatRuntime.internalConstructor, result, []);
+        }
+        
+        finally {}
+    }
+
+    /** 
+     * Returns this date's Rata Die
+     *
+     * See the [Rust documentation for `to_rata_die`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.to_rata_die) for more information.
+     */
+    get rataDie() {
+        const result = wasm.icu4x_Date_to_rata_die_mv1(this.ffiValue);
+    
+        try {
+            return result;
         }
         
         finally {}

--- a/ffi/capi/bindings/js/IsoDate.d.ts
+++ b/ffi/capi/bindings/js/IsoDate.d.ts
@@ -20,6 +20,13 @@ export class IsoDate {
     get ffiValue(): pointer;
 
     /** 
+     * Creates a new [`IsoDate`] from the given Rata Die
+     *
+     * See the [Rust documentation for `from_rata_die`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.from_rata_die) for more information.
+     */
+    static fromRataDie(rd: bigint): IsoDate;
+
+    /** 
      * Creates a new [`IsoDate`] from an IXDTF string.
      *
      * See the [Rust documentation for `try_iso_from_str`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.try_iso_from_str) for more information.
@@ -37,6 +44,13 @@ export class IsoDate {
      * See the [Rust documentation for `to_any`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.to_any) for more information.
      */
     toAny(): Date;
+
+    /** 
+     * Returns this date's Rata Die
+     *
+     * See the [Rust documentation for `to_rata_die`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.to_rata_die) for more information.
+     */
+    get rataDie(): bigint;
 
     /** 
      * Returns the 1-indexed day in the year for this date

--- a/ffi/capi/bindings/js/IsoDate.mjs
+++ b/ffi/capi/bindings/js/IsoDate.mjs
@@ -48,7 +48,7 @@ export class IsoDate {
     }
 
     /** 
-     * Creates a new [`IsoDate`] from the specified date and time.
+     * Creates a new [`IsoDate`] from the specified date.
      *
      * See the [Rust documentation for `try_new_iso`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.try_new_iso) for more information.
      */
@@ -68,6 +68,21 @@ export class IsoDate {
         finally {
             diplomatReceive.free();
         }
+    }
+
+    /** 
+     * Creates a new [`IsoDate`] from the given Rata Die
+     *
+     * See the [Rust documentation for `from_rata_die`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.from_rata_die) for more information.
+     */
+    static fromRataDie(rd) {
+        const result = wasm.icu4x_IsoDate_from_rata_die_mv1(rd);
+    
+        try {
+            return new IsoDate(diplomatRuntime.internalConstructor, result, []);
+        }
+        
+        finally {}
     }
 
     /** 
@@ -122,6 +137,21 @@ export class IsoDate {
     
         try {
             return new Date(diplomatRuntime.internalConstructor, result, []);
+        }
+        
+        finally {}
+    }
+
+    /** 
+     * Returns this date's Rata Die
+     *
+     * See the [Rust documentation for `to_rata_die`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.to_rata_die) for more information.
+     */
+    get rataDie() {
+        const result = wasm.icu4x_IsoDate_to_rata_die_mv1(this.ffiValue);
+    
+        try {
+            return result;
         }
         
         finally {}

--- a/ffi/capi/src/date.rs
+++ b/ffi/capi/src/date.rs
@@ -35,13 +35,24 @@ pub mod ffi {
     pub struct IsoDate(pub icu_calendar::Date<icu_calendar::Iso>);
 
     impl IsoDate {
-        /// Creates a new [`IsoDate`] from the specified date and time.
+        /// Creates a new [`IsoDate`] from the specified date.
         #[diplomat::rust_link(icu::calendar::Date::try_new_iso, FnInStruct)]
         #[diplomat::attr(supports = fallible_constructors, constructor)]
         pub fn create(year: i32, month: u8, day: u8) -> Result<Box<IsoDate>, CalendarError> {
             Ok(Box::new(IsoDate(icu_calendar::Date::try_new_iso(
                 year, month, day,
             )?)))
+        }
+
+        /// Creates a new [`IsoDate`] from the given Rata Die
+        #[diplomat::rust_link(icu::calendar::Date::from_rata_die, FnInStruct)]
+        #[diplomat::attr(all(supports = named_constructors), named_constructor)]
+        #[diplomat::demo(default_constructor)]
+        pub fn from_rata_die(rd: i64) -> Box<IsoDate> {
+            Box::new(IsoDate(icu_calendar::Date::from_rata_die(
+                icu_calendar::types::RataDie::new(rd),
+                Iso,
+            )))
         }
 
         /// Creates a new [`IsoDate`] from an IXDTF string.
@@ -64,6 +75,13 @@ pub mod ffi {
         #[diplomat::rust_link(icu::calendar::Date::to_any, FnInStruct)]
         pub fn to_any(&self) -> Box<Date> {
             Box::new(Date(self.0.to_any().wrap_calendar_in_arc()))
+        }
+
+        /// Returns this date's Rata Die
+        #[diplomat::rust_link(icu::calendar::Date::to_rata_die, FnInStruct)]
+        #[diplomat::attr(auto, getter = "rata_die")]
+        pub fn to_rata_die(&self) -> i64 {
+            self.0.to_rata_die().to_i64_date()
         }
 
         /// Returns the 1-indexed day in the year for this date
@@ -142,12 +160,12 @@ pub mod ffi {
 
     #[diplomat::opaque]
     #[diplomat::transparent_convert]
-    /// An ICU4X Date object capable of containing a date and time for any calendar.
+    /// An ICU4X Date object capable of containing a date for any calendar.
     #[diplomat::rust_link(icu::calendar::Date, Struct)]
     pub struct Date(pub icu_calendar::Date<Arc<icu_calendar::AnyCalendar>>);
 
     impl Date {
-        /// Creates a new [`Date`] representing the ISO date and time
+        /// Creates a new [`Date`] representing the ISO date
         /// given but in a given calendar
         #[diplomat::rust_link(icu::calendar::Date::new_from_iso, FnInStruct)]
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor)]
@@ -191,6 +209,18 @@ pub mod ffi {
             )?)))
         }
 
+        /// Creates a new [`Date`] from the given Rata Die
+        #[diplomat::rust_link(icu::calendar::Date::from_rata_die, FnInStruct)]
+        #[diplomat::attr(all(supports = named_constructors), named_constructor)]
+        #[diplomat::demo(default_constructor)]
+        pub fn from_rata_die(rd: i64, calendar: &Calendar) -> Result<Box<Date>, CalendarError> {
+            let cal = calendar.0.clone();
+            Ok(Box::new(Date(icu_calendar::Date::from_rata_die(
+                icu_calendar::types::RataDie::new(rd),
+                cal,
+            ))))
+        }
+
         /// Creates a new [`Date`] from an IXDTF string.
         #[diplomat::rust_link(icu::calendar::Date::try_from_str, FnInStruct)]
         #[diplomat::rust_link(icu::calendar::Date::try_from_utf8, FnInStruct, hidden)]
@@ -217,6 +247,13 @@ pub mod ffi {
         #[diplomat::rust_link(icu::calendar::Date::to_iso, FnInStruct)]
         pub fn to_iso(&self) -> Box<IsoDate> {
             Box::new(IsoDate(self.0.to_iso()))
+        }
+
+        /// Returns this date's Rata Die
+        #[diplomat::rust_link(icu::calendar::Date::to_rata_die, FnInStruct)]
+        #[diplomat::attr(auto, getter = "rata_die")]
+        pub fn to_rata_die(&self) -> i64 {
+            self.0.to_rata_die().to_i64_date()
         }
 
         /// Returns the 1-indexed day in the year for this date

--- a/ffi/capi/src/date.rs
+++ b/ffi/capi/src/date.rs
@@ -208,7 +208,7 @@ pub mod ffi {
 
         /// Convert this date to one in a different calendar
         #[diplomat::rust_link(icu::calendar::Date::to_calendar, FnInStruct)]
-        #[diplomat::rust_link(icu::calendar::AnyCalendar::convert_any_date, FnInEnum, hidden)]
+        #[diplomat::rust_link(icu::calendar::Date::convert_any, FnInStruct, hidden)]
         pub fn to_calendar(&self, calendar: &Calendar) -> Box<Date> {
             Box::new(Date(self.0.to_calendar(calendar.0.clone())))
         }

--- a/ffi/capi/tests/missing_apis.txt
+++ b/ffi/capi/tests/missing_apis.txt
@@ -14,8 +14,6 @@
 # Please check in with @Manishearth, @robertbastian, or @sffc if you have questions
 
 
-icu::calendar::Date::from_fixed#FnInStruct
-icu::calendar::Date::to_fixed#FnInStruct
 icu::datetime::DateTimeFormatter#Struct
 icu::datetime::DateTimeFormatter::calendar#FnInStruct
 icu::datetime::DateTimeFormatter::format_unchecked#FnInStruct

--- a/ffi/capi/tests/missing_apis.txt
+++ b/ffi/capi/tests/missing_apis.txt
@@ -14,6 +14,8 @@
 # Please check in with @Manishearth, @robertbastian, or @sffc if you have questions
 
 
+icu::calendar::Date::from_fixed#FnInStruct
+icu::calendar::Date::to_fixed#FnInStruct
 icu::datetime::DateTimeFormatter#Struct
 icu::datetime::DateTimeFormatter::calendar#FnInStruct
 icu::datetime::DateTimeFormatter::format_unchecked#FnInStruct

--- a/provider/source/src/calendar/eras.rs
+++ b/provider/source/src/calendar/eras.rs
@@ -483,11 +483,11 @@ fn test_calendar_eras() {
             let (in_era_iso, not_in_era_iso) = match (era.start, era.end) {
                 (Some(start), None) => {
                     let start = Date::try_new_iso(start.year, start.month, start.day).unwrap();
-                    (start, Iso::from_fixed(Iso::to_fixed(start) - 1))
+                    (start, Date::from_fixed(start.to_fixed() - 1, Iso))
                 }
                 (None, Some(end)) => {
                     let end = Date::try_new_iso(end.year, end.month, end.day).unwrap();
-                    (end, Iso::from_fixed(Iso::to_fixed(end) + 1))
+                    (end, Date::from_fixed(end.to_fixed() + 1, Iso))
                 }
                 _ => unreachable!(),
             };

--- a/provider/source/src/calendar/eras.rs
+++ b/provider/source/src/calendar/eras.rs
@@ -483,11 +483,11 @@ fn test_calendar_eras() {
             let (in_era_iso, not_in_era_iso) = match (era.start, era.end) {
                 (Some(start), None) => {
                     let start = Date::try_new_iso(start.year, start.month, start.day).unwrap();
-                    (start, Date::from_fixed(start.to_fixed() - 1, Iso))
+                    (start, Date::from_rata_die(start.to_rata_die() - 1, Iso))
                 }
                 (None, Some(end)) => {
                     let end = Date::try_new_iso(end.year, end.month, end.day).unwrap();
-                    (end, Date::from_fixed(end.to_fixed() + 1, Iso))
+                    (end, Date::from_rata_die(end.to_rata_die() + 1, Iso))
                 }
                 _ => unreachable!(),
             };

--- a/tools/make/diplomat-coverage/src/allowlist.rs
+++ b/tools/make/diplomat-coverage/src/allowlist.rs
@@ -151,6 +151,7 @@ lazy_static::lazy_static! {
         "icu::calendar::Date::formattable_year",
         "icu::calendar::types::FormattableYear",
         "icu::calendar::types::FormattableYearKind",
+        "icu::calendar::types::RataDie",
 
         // Not planned for 2.0: Temporal doesn't yet want this.
         "icu::calendar::types::CyclicYear",


### PR DESCRIPTION
Currently we use ISO dates as the "exchange format". For example, when converting between calendars, we convert through ISO. Most calendars implement ISO conversion through Rata Die, so we should skip that step.

It's also useful to expose this publicly. Right now we expose to/from fixed for ISO only, but the code is there to do this for every calendar.