### PR TITLE
Remove Hijri scaffolding from semver

### DIFF
--- a/components/calendar/Cargo.toml
+++ b/components/calendar/Cargo.toml
@@ -36,6 +36,7 @@ icu_calendar_data = { workspace = true, optional = true }
 icu_locale = { workspace = true, optional = true }
 
 [dev-dependencies]
+icu_provider = { path = "../../provider/core", features = ["logging"] }
 icu = { path = "../../components/icu", default-features = false }
 icu_benchmark_macros = { path = "../../tools/benchmark/macros" }
 serde = { workspace = true, features = ["derive", "alloc"] }

--- a/components/calendar/src/cal/hijri.rs
+++ b/components/calendar/src/cal/hijri.rs
@@ -67,7 +67,7 @@ pub(crate) enum HijriObservationalLocation {
 }
 
 impl HijriObservationalLocation {
-    fn location(self) -> calendrical_calculations::astronomy::Location {
+    fn location(self) -> calendrical_calculations::islamic::Location {
         match self {
             Self::Mecca => calendrical_calculations::islamic::MECCA,
         }
@@ -401,8 +401,7 @@ impl<IB: CacheableHijri> HijriYearInfo<IB> {
         // truncating instead of flooring does not matter, as this is well-defined for
         // positive years only
         IB::EPOCH
-            + ((extended_year - 1) as f64
-                * (calendrical_calculations::astronomy::MEAN_SYNODIC_MONTH * 12.))
+            + ((extended_year - 1) as f64 * calendrical_calculations::islamic::MEAN_YEAR_LENGTH)
                 as i64
     }
 
@@ -474,7 +473,7 @@ impl<'b, IB: CacheableHijri> HijriPrecomputedData<'b, IB> {
                 // truncating instead of flooring does not matter, as this is well-defined for
                 // positive years only
                 let extended_year = ((fixed - IB::EPOCH) as f64
-                    / (calendrical_calculations::astronomy::MEAN_SYNODIC_MONTH * 12.))
+                    / calendrical_calculations::islamic::MEAN_YEAR_LENGTH)
                     as i32
                     + 1;
 

--- a/components/calendar/src/cal/hijri.rs
+++ b/components/calendar/src/cal/hijri.rs
@@ -28,7 +28,6 @@ use crate::provider::hijri::{
 };
 use crate::{types, Calendar, Date, DateDuration, DateDurationUnit};
 use crate::{AsCalendar, RangeError};
-use calendrical_calculations::islamic::{IslamicBased, ObservationalIslamic, SaudiIslamic};
 use calendrical_calculations::rata_die::RataDie;
 use icu_provider::marker::ErasedMarker;
 use icu_provider::prelude::*;
@@ -67,6 +66,14 @@ pub(crate) enum HijriObservationalLocation {
     Mecca,
 }
 
+impl HijriObservationalLocation {
+    fn location(self) -> calendrical_calculations::astronomy::Location {
+        match self {
+            Self::Mecca => calendrical_calculations::islamic::MECCA,
+        }
+    }
+}
+
 /// The [tabular Hijri Calendar](https://en.wikipedia.org/wiki/Tabular_Islamic_calendar) (civil epoch)
 ///
 /// This is a tabular/arithmetic Hijri calendar with leap years (1-based) 2, 5, 7, 10,
@@ -103,6 +110,9 @@ pub struct HijriCivil;
 pub struct HijriUmmAlQura {
     data: Option<DataPayload<CalendarHijriUmmalquraV1>>,
 }
+
+#[derive(Debug, Clone, Copy)]
+pub struct HijriUmmAlQuraMarker;
 
 /// The [tabular Hijri Calendar](https://en.wikipedia.org/wiki/Tabular_Islamic_calendar) (astronomical epoch)
 ///
@@ -166,6 +176,12 @@ impl HijriObservational {
             data: None,
         }
     }
+
+    /// Compute a cache for this calendar
+    #[cfg(feature = "datagen")]
+    pub fn build_cache(&self, extended_years: core::ops::Range<i32>) -> HijriCache<'static> {
+        HijriCache::compute_for(extended_years, self.location)
+    }
 }
 
 impl HijriCivil {
@@ -211,6 +227,12 @@ impl HijriUmmAlQura {
     pub fn new_always_calculating() -> Self {
         Self { data: None }
     }
+
+    /// Compute a cache for this calendar
+    #[cfg(feature = "datagen")]
+    pub fn build_cache(&self, extended_years: core::ops::Range<i32>) -> HijriCache<'static> {
+        HijriCache::compute_for(extended_years, HijriUmmAlQuraMarker)
+    }
 }
 
 impl HijriTabular {
@@ -220,39 +242,116 @@ impl HijriTabular {
     }
 }
 
+pub trait CacheableHijri: Copy {
+    /// The epoch of the calendar. Different calendars use a different epoch (Thu or Fri) due to disagreement on the exact date of Mohammed's migration to Mecca.
+    const EPOCH: RataDie;
+    /// The name of the calendar for debugging.
+    const DEBUG_NAME: &'static str;
+    /// Convert a Hijri date in this calendar to a R.D.
+    fn fixed_from_hijri(&self, year: i32, month: u8, day: u8) -> RataDie;
+    /// Convert an R.D. to a Hijri date in this calendar
+    fn hijri_from_fixed(&self, date: RataDie) -> (i32, u8, u8);
+}
+
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub(crate) struct HijriYearInfo<IB: IslamicBased> {
+pub(crate) struct HijriYearInfo<IB: CacheableHijri> {
     pub(crate) packed_data: PackedHijriYearInfo,
     model: IB,
     value: i32,
 }
 
-impl<IB: IslamicBased> From<HijriYearInfo<IB>> for i32 {
+impl<IB: CacheableHijri> From<HijriYearInfo<IB>> for i32 {
     fn from(value: HijriYearInfo<IB>) -> Self {
         value.value
+    }
+}
+
+impl HijriCache<'_> {
+    #[cfg(feature = "datagen")]
+    fn compute_for<IB: CacheableHijri>(extended_years: core::ops::Range<i32>, model: IB) -> Self {
+        let data = extended_years
+            .clone()
+            .map(|year| HijriYearInfo::compute_for_year(year, model).packed_data)
+            .collect();
+        HijriCache {
+            first_extended_year: extended_years.start,
+            data,
+        }
+    }
+
+    /// Get the cached data for a given extended year
+    fn get<IB: CacheableHijri>(&self, extended_year: i32, model: IB) -> Option<HijriYearInfo<IB>> {
+        let packed_data = self
+            .data
+            .get(usize::try_from(extended_year - self.first_extended_year).ok()?)?;
+
+        Some(HijriYearInfo {
+            packed_data,
+            model,
+            value: extended_year,
+        })
     }
 }
 
 const LONG_YEAR_LEN: u16 = 355;
 const SHORT_YEAR_LEN: u16 = 354;
 
-impl<IB: IslamicBased> HijriYearInfo<IB> {
-    pub(crate) fn from_packed(
-        packed_data: PackedHijriYearInfo,
-        extended_year: i32,
-        model: IB,
-    ) -> Self {
-        Self {
-            packed_data,
-            model,
-            value: extended_year,
-        }
-    }
+impl<IB: CacheableHijri> HijriYearInfo<IB> {
+    fn compute_for_year(extended_year: i32, model: IB) -> Self {
+        let ny = model.fixed_from_hijri(extended_year, 1, 1);
 
-    pub(crate) fn compute_for_year(extended_year: i32, model: IB) -> Self {
-        let ny = model.fixed_from_islamic(extended_year, 1, 1);
-        let month_lengths = model.month_lengths_for_year(extended_year, ny);
-        let ny_offset = ny - IB::mean_synodic_ny(extended_year);
+        let ny_offset = ny - Self::mean_synodic_ny(extended_year);
+
+        let month_lengths = {
+            let mut excess_days = 0;
+            let mut start_of_month = ny;
+            let mut month_lengths = core::array::from_fn(|month_idx| {
+                let end_of_month = if month_idx < 11 {
+                    model.fixed_from_hijri(extended_year, month_idx as u8 + 2, 1)
+                } else {
+                    model.fixed_from_hijri(extended_year + 1, 1, 1)
+                };
+                let days_in_month = end_of_month - start_of_month;
+                start_of_month = end_of_month;
+                match days_in_month {
+                    29 => false,
+                    30 => true,
+                    31 => {
+                        icu_provider::log::trace!(
+                            "({}) Found year {extended_year} AH with month length {days_in_month} for month {}.",
+                            IB::DEBUG_NAME,
+                            month_idx + 1
+                        );
+                        excess_days += 1;
+                        true
+                    }
+                    _ => {
+                        core::debug_assert!(
+                            false,
+                            "({}) Found year {extended_year} AH with month length {days_in_month} for month {}!",
+                            IB::DEBUG_NAME,
+                            month_idx + 1
+                        );
+                        false
+                    }
+                }
+            });
+            // To maintain invariants for calendar arithmetic, if astronomy finds
+            // a 31-day month, "move" the day to the first 29-day month in the
+            // same year to maintain all months at 29 or 30 days.
+            if excess_days != 0 {
+                core::debug_assert_eq!(
+                    excess_days,
+                    1,
+                    "({}) Found year {extended_year} AH with more than one excess day!",
+                    IB::DEBUG_NAME
+                );
+                if let Some(l) = month_lengths.iter_mut().find(|l| !(**l)) {
+                    *l = true;
+                }
+            }
+            month_lengths
+        };
         let r = Self {
             packed_data: PackedHijriYearInfo::new(month_lengths, ny_offset),
             model,
@@ -266,12 +365,12 @@ impl<IB: IslamicBased> HijriYearInfo<IB> {
     }
 
     fn compute_for_fixed(fixed: RataDie, model: IB) -> Self {
-        let (y, _m, _d) = model.islamic_from_fixed(fixed);
+        let (y, _m, _d) = model.hijri_from_fixed(fixed);
         Self::compute_for_year(y, model)
     }
 
     /// The number of days in a given 1-indexed month
-    pub(crate) fn days_in_month(self, month: u8) -> u8 {
+    fn days_in_month(self, month: u8) -> u8 {
         if self.packed_data.month_has_30_days(month) {
             30
         } else {
@@ -279,13 +378,23 @@ impl<IB: IslamicBased> HijriYearInfo<IB> {
         }
     }
 
-    pub(crate) fn days_in_year(self) -> u16 {
+    fn days_in_year(self) -> u16 {
         self.packed_data.last_day_of_month(12)
     }
 
+    fn mean_synodic_ny(extended_year: i32) -> RataDie {
+        // -1 because the epoch is new year of year 1
+        // truncating instead of flooring does not matter, as this is well-defined for
+        // positive years only
+        IB::EPOCH
+            + ((extended_year - 1) as f64
+                * (calendrical_calculations::astronomy::MEAN_SYNODIC_MONTH * 12.))
+                as i64
+    }
+
     /// Get the new year R.D. given the extended year that this yearinfo is for    
-    pub(crate) fn new_year(self) -> RataDie {
-        IB::mean_synodic_ny(self.value) + self.packed_data.ny_offset()
+    fn new_year(self) -> RataDie {
+        Self::mean_synodic_ny(self.value) + self.packed_data.ny_offset()
     }
 
     /// Get the date's R.D. given (m, d) in this info's year
@@ -333,28 +442,49 @@ impl<IB: IslamicBased> HijriYearInfo<IB> {
 /// Contains any loaded precomputed data. If constructed with Default, will
 /// *not* contain any extra data and will always compute stuff from scratch
 #[derive(Default)]
-pub(crate) struct HijriPrecomputedData<'a, IB: IslamicBased> {
+struct HijriPrecomputedData<'a, IB: CacheableHijri> {
     data: Option<&'a HijriCache<'a>>,
     model: IB,
 }
 
-impl<'b, IB: IslamicBased> HijriPrecomputedData<'b, IB> {
-    pub(crate) fn new(data: Option<&'b HijriCache<'b>>, model: IB) -> Self {
+impl<'b, IB: CacheableHijri> HijriPrecomputedData<'b, IB> {
+    fn new(data: Option<&'b HijriCache<'b>>, model: IB) -> Self {
         Self { data, model }
     }
 
     /// Returns the [`HijriYearInfo`] loading from cache or computing.
     fn load_or_compute_info_for_fixed(&self, fixed: RataDie) -> HijriYearInfo<IB> {
         self.data
-            .and_then(|d| d.get_for_fixed(fixed, self.model))
+            .and_then(|d| {
+                // +1 because the epoch is new year of year 1
+                // truncating instead of flooring does not matter, as this is well-defined for
+                // positive years only
+                let extended_year = ((fixed - IB::EPOCH) as f64
+                    / (calendrical_calculations::astronomy::MEAN_SYNODIC_MONTH * 12.))
+                    as i32
+                    + 1;
+
+                let year = d.get(extended_year, self.model)?;
+
+                if fixed < year.new_year() {
+                    d.get(extended_year - 1, self.model)
+                } else {
+                    let next_year = d.get(extended_year + 1, self.model)?;
+                    Some(if fixed < next_year.new_year() {
+                        year
+                    } else {
+                        next_year
+                    })
+                }
+            })
             .unwrap_or_else(|| HijriYearInfo::compute_for_fixed(fixed, self.model))
     }
 }
 
-impl<IB: IslamicBased> PrecomputedDataSource<HijriYearInfo<IB>> for HijriPrecomputedData<'_, IB> {
+impl<IB: CacheableHijri> PrecomputedDataSource<HijriYearInfo<IB>> for HijriPrecomputedData<'_, IB> {
     fn load_or_compute_info(&self, extended_year: i32) -> HijriYearInfo<IB> {
         self.data
-            .and_then(|d| d.get_for_extended_year(extended_year, self.model))
+            .and_then(|d| d.get(extended_year, self.model))
             .unwrap_or_else(|| HijriYearInfo::compute_for_year(extended_year, self.model))
     }
 }
@@ -365,7 +495,7 @@ impl<IB: IslamicBased> PrecomputedDataSource<HijriYearInfo<IB>> for HijriPrecomp
 pub struct HijriDateInner(ArithmeticDate<HijriObservational>);
 
 impl CalendarArithmetic for HijriObservational {
-    type YearInfo = HijriYearInfo<ObservationalIslamic>;
+    type YearInfo = HijriYearInfo<HijriObservationalLocation>;
 
     fn days_in_provided_month(year: Self::YearInfo, month: u8) -> u8 {
         year.days_in_month(month)
@@ -485,12 +615,30 @@ impl Calendar for HijriObservational {
     }
 }
 
+impl CacheableHijri for HijriObservationalLocation {
+    const EPOCH: RataDie = calendrical_calculations::islamic::ISLAMIC_EPOCH_FRIDAY;
+
+    const DEBUG_NAME: &'static str = HijriObservational::DEBUG_NAME;
+
+    fn fixed_from_hijri(&self, year: i32, month: u8, day: u8) -> RataDie {
+        calendrical_calculations::islamic::fixed_from_observational_islamic(
+            year,
+            month,
+            day,
+            self.location(),
+        )
+    }
+    fn hijri_from_fixed(&self, date: RataDie) -> (i32, u8, u8) {
+        calendrical_calculations::islamic::observational_islamic_from_fixed(date, self.location())
+    }
+}
+
 impl HijriObservational {
-    fn precomputed_data(&self) -> HijriPrecomputedData<ObservationalIslamic> {
+    fn precomputed_data(&self) -> HijriPrecomputedData<HijriObservationalLocation> {
         match self.location {
             HijriObservationalLocation::Mecca => HijriPrecomputedData::new(
                 self.data.as_ref().map(|x| x.get()),
-                ObservationalIslamic::mecca(),
+                HijriObservationalLocation::Mecca,
             ),
         }
     }
@@ -538,13 +686,13 @@ impl<A: AsCalendar<Calendar = HijriObservational>> Date<A> {
 pub struct HijriUmmAlQuraDateInner(ArithmeticDate<HijriUmmAlQura>);
 
 impl CalendarArithmetic for HijriUmmAlQura {
-    type YearInfo = HijriYearInfo<SaudiIslamic>;
+    type YearInfo = HijriYearInfo<HijriUmmAlQuraMarker>;
 
     fn days_in_provided_month(year: Self::YearInfo, month: u8) -> u8 {
         year.days_in_month(month)
     }
 
-    fn months_in_provided_year(_year: HijriYearInfo<SaudiIslamic>) -> u8 {
+    fn months_in_provided_year(_year: HijriYearInfo<HijriUmmAlQuraMarker>) -> u8 {
         12
     }
 
@@ -557,7 +705,7 @@ impl CalendarArithmetic for HijriUmmAlQura {
         year.days_in_year() != SHORT_YEAR_LEN
     }
 
-    fn last_month_day_in_provided_year(year: HijriYearInfo<SaudiIslamic>) -> (u8, u8) {
+    fn last_month_day_in_provided_year(year: HijriYearInfo<HijriUmmAlQuraMarker>) -> (u8, u8) {
         let days = Self::days_in_provided_month(year, 12);
 
         (12, days)
@@ -658,9 +806,20 @@ impl Calendar for HijriUmmAlQura {
     }
 }
 
+impl CacheableHijri for HijriUmmAlQuraMarker {
+    const EPOCH: RataDie = calendrical_calculations::islamic::ISLAMIC_EPOCH_FRIDAY;
+    const DEBUG_NAME: &'static str = HijriUmmAlQura::DEBUG_NAME;
+    fn fixed_from_hijri(&self, year: i32, month: u8, day: u8) -> RataDie {
+        calendrical_calculations::islamic::fixed_from_saudi_islamic(year, month, day)
+    }
+    fn hijri_from_fixed(&self, date: RataDie) -> (i32, u8, u8) {
+        calendrical_calculations::islamic::saudi_islamic_from_fixed(date)
+    }
+}
+
 impl HijriUmmAlQura {
-    fn precomputed_data(&self) -> HijriPrecomputedData<SaudiIslamic> {
-        HijriPrecomputedData::new(self.data.as_ref().map(|x| x.get()), SaudiIslamic)
+    fn precomputed_data(&self) -> HijriPrecomputedData<HijriUmmAlQuraMarker> {
+        HijriPrecomputedData::new(self.data.as_ref().map(|x| x.get()), HijriUmmAlQuraMarker)
     }
 
     pub(crate) const DEBUG_NAME: &'static str = "Hijri (Umm al-Qura)";
@@ -1889,7 +2048,7 @@ mod test {
             .map(|year| {
                 HijriObservational::days_in_provided_year(HijriYearInfo::compute_for_year(
                     year,
-                    ObservationalIslamic::mecca(),
+                    HijriObservationalLocation::Mecca,
                 )) as i64
             })
             .sum();
@@ -1919,7 +2078,7 @@ mod test {
             .map(|year| {
                 HijriUmmAlQura::days_in_provided_year(HijriYearInfo::compute_for_year(
                     year,
-                    SaudiIslamic,
+                    HijriUmmAlQuraMarker,
                 )) as i64
             })
             .sum();

--- a/components/calendar/src/provider/hijri.rs
+++ b/components/calendar/src/provider/hijri.rs
@@ -12,9 +12,6 @@
 //!
 //! Read more about data providers: [`icu_provider`]
 
-use crate::cal::hijri::HijriYearInfo;
-use calendrical_calculations::islamic::IslamicBased;
-use calendrical_calculations::rata_die::RataDie;
 use core::fmt;
 use icu_provider::prelude::*;
 use zerovec::ule::{AsULE, ULE};
@@ -55,61 +52,6 @@ icu_provider::data_struct!(
     HijriCache<'_>,
     #[cfg(feature = "datagen")]
 );
-
-impl HijriCache<'_> {
-    /// Compute this data for a range of years
-    #[cfg(feature = "datagen")]
-    pub fn compute_for<IB: IslamicBased>(extended_years: core::ops::Range<i32>, model: IB) -> Self {
-        let data = extended_years
-            .clone()
-            .map(|year| HijriYearInfo::compute_for_year(year, model).packed_data)
-            .collect();
-        HijriCache {
-            first_extended_year: extended_years.start,
-            data,
-        }
-    }
-
-    /// Get the cached data for a given extended year
-    pub(crate) fn get_for_extended_year<IB: IslamicBased>(
-        &self,
-        extended_year: i32,
-        model: IB,
-    ) -> Option<HijriYearInfo<IB>> {
-        let packed_data = self
-            .data
-            .get(usize::try_from(extended_year - self.first_extended_year).ok()?)?;
-
-        Some(HijriYearInfo::from_packed(
-            packed_data,
-            extended_year,
-            model,
-        ))
-    }
-    /// Get the cached data for the Hijri Year corresponding to a given day.
-    ///
-    /// Also returns the corresponding extended year.
-    pub(crate) fn get_for_fixed<IB: IslamicBased>(
-        &self,
-        fixed: RataDie,
-        model: IB,
-    ) -> Option<HijriYearInfo<IB>> {
-        let extended_year = IB::approximate_islamic_from_fixed(fixed);
-
-        let year = self.get_for_extended_year(extended_year, model)?;
-
-        if fixed < year.new_year() {
-            self.get_for_extended_year(extended_year - 1, model)
-        } else {
-            let next_year = self.get_for_extended_year(extended_year + 1, model)?;
-            Some(if fixed < next_year.new_year() {
-                year
-            } else {
-                next_year
-            })
-        }
-    }
-}
 
 /// The struct containing compiled Hijri YearInfo
 ///

--- a/provider/source/src/calendar/hijri.rs
+++ b/provider/source/src/calendar/hijri.rs
@@ -5,19 +5,9 @@
 use std::collections::HashSet;
 
 use crate::SourceDataProvider;
-use calendrical_calculations::islamic::{IslamicBased, ObservationalIslamic, SaudiIslamic};
-use calendrical_calculations::iso;
+use icu::calendar::cal::{HijriObservational, HijriUmmAlQura};
 use icu::calendar::provider::hijri::*;
 use icu_provider::prelude::*;
-
-const YEARS: i32 = 250;
-const ISO_START: i32 = 1900;
-
-fn load<IB: IslamicBased>(model: IB) -> HijriCache<'static> {
-    let extended_start = IB::approximate_islamic_from_fixed(iso::fixed_from_iso(ISO_START, 1, 1));
-    let extended_end = extended_start + YEARS;
-    HijriCache::compute_for(extended_start..extended_end, model)
-}
 
 impl DataProvider<CalendarHijriObservationalMeccaV1> for SourceDataProvider {
     fn load(
@@ -25,7 +15,7 @@ impl DataProvider<CalendarHijriObservationalMeccaV1> for SourceDataProvider {
         req: DataRequest,
     ) -> Result<DataResponse<CalendarHijriObservationalMeccaV1>, DataError> {
         self.check_req::<CalendarHijriObservationalMeccaV1>(req)?;
-        let cache = load(ObservationalIslamic::mecca());
+        let cache = HijriObservational::new_mecca_always_calculating().build_cache(1317..1567);
         Ok(DataResponse {
             metadata: Default::default(),
             payload: DataPayload::from_owned(cache),
@@ -42,7 +32,7 @@ impl crate::IterableDataProviderCached<CalendarHijriObservationalMeccaV1> for So
 impl DataProvider<CalendarHijriUmmalquraV1> for crate::SourceDataProvider {
     fn load(&self, req: DataRequest) -> Result<DataResponse<CalendarHijriUmmalquraV1>, DataError> {
         self.check_req::<CalendarHijriUmmalquraV1>(req)?;
-        let cache = load(SaudiIslamic);
+        let cache = HijriUmmAlQura::new_always_calculating().build_cache(1317..1567);
         Ok(DataResponse {
             metadata: Default::default(),
             payload: DataPayload::from_owned(cache),

--- a/utils/calendrical_calculations/src/astronomy.rs
+++ b/utils/calendrical_calculations/src/astronomy.rs
@@ -80,7 +80,7 @@ impl Location {
     /// Create a location; latitude is from -90 to 90, and longitude is from -180 to 180;
     /// attempting to create a location outside of these bounds will result in a LocationOutOfBoundsError.
     #[allow(dead_code)] // TODO: Remove dead_code tag after use
-    pub fn try_new(
+    pub(crate) fn try_new(
         latitude: f64,
         longitude: f64,
         elevation: f64,
@@ -109,25 +109,25 @@ impl Location {
 
     /// Get the longitude of a Location
     #[allow(dead_code)]
-    pub fn longitude(&self) -> f64 {
+    pub(crate) fn longitude(&self) -> f64 {
         self.longitude
     }
 
     /// Get the latitude of a Location
     #[allow(dead_code)]
-    pub fn latitude(&self) -> f64 {
+    pub(crate) fn latitude(&self) -> f64 {
         self.latitude
     }
 
     /// Get the elevation of a Location
     #[allow(dead_code)]
-    pub fn elevation(&self) -> f64 {
+    pub(crate) fn elevation(&self) -> f64 {
         self.elevation
     }
 
     /// Get the utc-offset of a Location
     #[allow(dead_code)]
-    pub fn zone(&self) -> f64 {
+    pub(crate) fn zone(&self) -> f64 {
         self.utc_offset
     }
 
@@ -135,7 +135,7 @@ impl Location {
     /// this yields the difference in Moment given a longitude
     /// e.g. a longitude of 90 degrees is 0.25 (90 / 360) days ahead
     /// of a location with a longitude of 0 degrees.
-    pub fn zone_from_longitude(longitude: f64) -> f64 {
+    pub(crate) fn zone_from_longitude(longitude: f64) -> f64 {
         longitude / (360.0)
     }
 
@@ -144,7 +144,7 @@ impl Location {
     /// Based on functions from _Calendrical Calculations_ by Reingold & Dershowitz.
     /// Reference lisp code: <https://github.com/EdReingold/calendar-code2/blob/9afc1f3/calendar.l#L3501-L3506>
     #[allow(dead_code)]
-    pub fn standard_from_local(standard_time: Moment, location: Location) -> Moment {
+    pub(crate) fn standard_from_local(standard_time: Moment, location: Location) -> Moment {
         Self::standard_from_universal(
             Self::universal_from_local(standard_time, location),
             location,
@@ -155,7 +155,7 @@ impl Location {
     ///
     /// Based on functions from _Calendrical Calculations_ by Reingold & Dershowitz.
     /// Reference lisp code: <https://github.com/EdReingold/calendar-code2/blob/9afc1f3/calendar.l#L3496-L3499>
-    pub fn universal_from_local(local_time: Moment, location: Location) -> Moment {
+    pub(crate) fn universal_from_local(local_time: Moment, location: Location) -> Moment {
         local_time - Self::zone_from_longitude(location.longitude)
     }
 
@@ -164,7 +164,7 @@ impl Location {
     /// Based on functions from _Calendrical Calculations_ by Reingold & Dershowitz.
     /// Reference lisp code: <https://github.com/EdReingold/calendar-code2/blob/9afc1f3/calendar.l#L3491-L3494>
     #[allow(dead_code)] // TODO: Remove dead_code tag after use
-    pub fn local_from_universal(universal_time: Moment, location: Location) -> Moment {
+    pub(crate) fn local_from_universal(universal_time: Moment, location: Location) -> Moment {
         universal_time + Self::zone_from_longitude(location.longitude)
     }
 
@@ -175,7 +175,7 @@ impl Location {
     ///
     /// Based on functions from _Calendrical Calculations_ by Reingold & Dershowitz.
     /// Reference lisp code: <https://github.com/EdReingold/calendar-code2/blob/9afc1f3/calendar.l#L3479-L3483>
-    pub fn universal_from_standard(standard_moment: Moment, location: Location) -> Moment {
+    pub(crate) fn universal_from_standard(standard_moment: Moment, location: Location) -> Moment {
         debug_assert!(location.utc_offset > MIN_UTC_OFFSET && location.utc_offset < MAX_UTC_OFFSET, "UTC offset {0} was not within the possible range of offsets (see astronomy::MIN_UTC_OFFSET and astronomy::MAX_UTC_OFFSET)", location.utc_offset);
         standard_moment - location.utc_offset
     }
@@ -187,7 +187,7 @@ impl Location {
     /// Based on functions from _Calendrical Calculations_ by Reingold & Dershowitz.
     /// Reference lisp code: <https://github.com/EdReingold/calendar-code2/blob/9afc1f3/calendar.l#L3473-L3477>
     #[allow(dead_code)]
-    pub fn standard_from_universal(standard_time: Moment, location: Location) -> Moment {
+    pub(crate) fn standard_from_universal(standard_time: Moment, location: Location) -> Moment {
         debug_assert!(location.utc_offset > MIN_UTC_OFFSET && location.utc_offset < MAX_UTC_OFFSET, "UTC offset {0} was not within the possible range of offsets (see astronomy::MIN_UTC_OFFSET and astronomy::MAX_UTC_OFFSET)", location.utc_offset);
         standard_time + location.utc_offset
     }

--- a/utils/calendrical_calculations/src/islamic.rs
+++ b/utils/calendrical_calculations/src/islamic.rs
@@ -1,17 +1,19 @@
 use crate::astronomy::*;
-use crate::error::LocationOutOfBoundsError;
 use crate::helpers::{i64_to_saturated_i32, next};
 use crate::rata_die::{Moment, RataDie};
 #[allow(unused_imports)]
 use core_maths::*;
 
-// Different islamic calendars use different epochs (Thursday vs Friday) due to disagreement on the exact date of Mohammed's migration to Mecca.
+/// Different islamic calendars use different epochs (Thursday vs Friday) due to disagreement on the exact date of Mohammed's migration to Mecca.
 /// Lisp code reference: <https://github.com/EdReingold/calendar-code2/blob/main/calendar.l#L2066>
-const FIXED_ISLAMIC_EPOCH_FRIDAY: RataDie = crate::julian::fixed_from_julian(622, 7, 16);
-const FIXED_ISLAMIC_EPOCH_THURSDAY: RataDie = crate::julian::fixed_from_julian(622, 7, 15);
+pub const ISLAMIC_EPOCH_FRIDAY: RataDie = crate::julian::fixed_from_julian(622, 7, 16);
+
+/// Different islamic calendars use different epochs (Thursday vs Friday) due to disagreement on the exact date of Mohammed's migration to Mecca.
+/// Lisp code reference: <https://github.com/EdReingold/calendar-code2/blob/main/calendar.l#L2066>
+pub const ISLAMIC_EPOCH_THURSDAY: RataDie = crate::julian::fixed_from_julian(622, 7, 15);
 
 /// Lisp code reference: <https://github.com/EdReingold/calendar-code2/blob/main/calendar.l#L6898>
-pub(crate) const CAIRO: Location = Location {
+pub const CAIRO: Location = Location {
     latitude: 30.1,
     longitude: 31.3,
     elevation: 200.0,
@@ -19,207 +21,15 @@ pub(crate) const CAIRO: Location = Location {
 };
 
 /// The location of Mecca; used for Islamic calendar calculations.
-pub(crate) const MECCA: Location = Location {
+pub const MECCA: Location = Location {
     latitude: 6427.0 / 300.0,
     longitude: 11947.0 / 300.0,
     elevation: 298.0,
     utc_offset: (1_f64 / 8_f64),
 };
 
-/// Common abstraction over islamic-style calendars
-pub trait IslamicBased: Copy {
-    /// The epoch of the calendar. Different calendars use a different epoch (Thu or Fri) due to disagreement on the exact date of Mohammed's migration to Mecca.
-    const EPOCH: RataDie;
-    /// The name of the calendar for debugging.
-    const DEBUG_NAME: &'static str;
-    /// Whether this calendar is known to have 353-day years.
-    /// This is probably a bug; see <https://github.com/unicode-org/icu4x/issues/4930>
-    const HAS_353_DAY_YEARS: bool;
-    /// Given the extended year, calculate the approximate new year using the mean synodic month
-    fn mean_synodic_ny(extended_year: i32) -> RataDie {
-        Self::EPOCH + (f64::from((extended_year - 1) * 12) * MEAN_SYNODIC_MONTH).floor() as i64
-    }
-    /// Given an iso date, calculate the *approximate* islamic year it corresponds to (for quick cache lookup)
-    fn approximate_islamic_from_fixed(date: RataDie) -> i32 {
-        let diff = date - Self::EPOCH;
-        let months = diff as f64 / MEAN_SYNODIC_MONTH;
-        let years = months / 12.;
-        (years + 1.).floor() as i32
-    }
-    /// Convert an islamic date in this calendar to a R.D.
-    fn fixed_from_islamic(&self, year: i32, month: u8, day: u8) -> RataDie;
-    /// Convert an R.D. To an islamic date in this calendar
-    fn islamic_from_fixed(&self, date: RataDie) -> (i32, u8, u8);
-
-    /// Given an extended year, calculate whether each month is 29 or 30 days long
-    fn month_lengths_for_year(&self, extended_year: i32, ny: RataDie) -> [bool; 12] {
-        let next_ny = self.fixed_from_islamic(extended_year + 1, 1, 1);
-        match next_ny - ny {
-            355 | 354 => (),
-            353 if Self::HAS_353_DAY_YEARS => {
-                #[cfg(feature = "logging")]
-                log::trace!(
-                    "({}) Found year {extended_year} AH with length {}. See <https://github.com/unicode-org/icu4x/issues/4930>",
-                    Self::DEBUG_NAME,
-                    next_ny - ny
-                );
-            }
-            other => {
-                debug_assert!(
-                    false,
-                    "({}) Found year {extended_year} AH with length {}!",
-                    Self::DEBUG_NAME,
-                    other
-                )
-            }
-        }
-        let mut prev_rd = ny;
-        let mut excess_days = 0;
-        let mut lengths = core::array::from_fn(|month_idx| {
-            let month_idx = month_idx as u8;
-            let new_rd = if month_idx < 11 {
-                self.fixed_from_islamic(extended_year, month_idx + 2, 1)
-            } else {
-                next_ny
-            };
-            let diff = new_rd - prev_rd;
-            prev_rd = new_rd;
-            match diff {
-                29 => false,
-                30 => true,
-                31 => {
-                    #[cfg(feature = "logging")]
-                    log::trace!(
-                        "({}) Found year {extended_year} AH with month length {diff} for month {}.",
-                        Self::DEBUG_NAME,
-                        month_idx + 1
-                    );
-                    excess_days += 1;
-                    true
-                }
-                _ => {
-                    debug_assert!(
-                        false,
-                        "({}) Found year {extended_year} AH with month length {diff} for month {}!",
-                        Self::DEBUG_NAME,
-                        month_idx + 1
-                    );
-                    false
-                }
-            }
-        });
-        // To maintain invariants for calendar arithmetic, if astronomy finds
-        // a 31-day month, "move" the day to the first 29-day month in the
-        // same year to maintain all months at 29 or 30 days.
-        if excess_days != 0 {
-            debug_assert_eq!(
-                excess_days,
-                1,
-                "({}) Found year {extended_year} AH with more than one excess day!",
-                Self::DEBUG_NAME
-            );
-            if let Some(l) = lengths.iter_mut().find(|l| !(**l)) {
-                *l = true;
-            }
-        }
-        lengths
-    }
-}
-
-/// Observational islamic calendar for a particular location
-#[derive(Clone, Copy, Debug, PartialEq)]
-#[allow(clippy::exhaustive_structs)]
-pub struct ObservationalIslamic(Location);
-
-impl ObservationalIslamic {
-    /// Creates a new [`ObservationalIslamic`] for the Cairo, Egypt location
-    ///
-    /// Warning: These calculations do not take DST changes into account.
-    pub const fn cairo() -> Self {
-        Self(CAIRO)
-    }
-
-    /// Creates a new [`ObservationalIslamic`] for the Mecca, Saudi Arabia location
-    pub const fn mecca() -> Self {
-        Self(MECCA)
-    }
-
-    /// Creates a new [`ObservationalIslamic`] for an arbitrary location
-    pub fn for_location(
-        latitude: f64,
-        longitude: f64,
-        elevation: f64,
-        utc_offset_days: f64,
-    ) -> Result<Self, LocationOutOfBoundsError> {
-        Location::try_new(latitude, longitude, elevation, utc_offset_days).map(Self)
-    }
-}
-
-/// Saudi islamic calendar
-#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
-#[allow(clippy::exhaustive_structs)]
-pub struct SaudiIslamic;
-
-/// Civil-era tabular islamic calendar
-#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
-#[allow(clippy::exhaustive_structs)]
-pub struct CivilIslamic;
-
-/// Astronomical-era tabular islamic calendar
-#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
-#[allow(clippy::exhaustive_structs)]
-pub struct TabularIslamic;
-
-impl IslamicBased for ObservationalIslamic {
-    const EPOCH: RataDie = FIXED_ISLAMIC_EPOCH_FRIDAY;
-    const DEBUG_NAME: &'static str = "ObservationalIslamic";
-    const HAS_353_DAY_YEARS: bool = true;
-    fn fixed_from_islamic(&self, year: i32, month: u8, day: u8) -> RataDie {
-        fixed_from_islamic_observational(year, month, day, self.0)
-    }
-    fn islamic_from_fixed(&self, date: RataDie) -> (i32, u8, u8) {
-        observational_islamic_from_fixed(date, self.0)
-    }
-}
-
-impl IslamicBased for SaudiIslamic {
-    const EPOCH: RataDie = FIXED_ISLAMIC_EPOCH_FRIDAY;
-    const DEBUG_NAME: &'static str = "SaudiIslamic";
-    const HAS_353_DAY_YEARS: bool = true;
-    fn fixed_from_islamic(&self, year: i32, month: u8, day: u8) -> RataDie {
-        fixed_from_saudi_islamic(year, month, day)
-    }
-    fn islamic_from_fixed(&self, date: RataDie) -> (i32, u8, u8) {
-        saudi_islamic_from_fixed(date)
-    }
-}
-
-impl IslamicBased for CivilIslamic {
-    const EPOCH: RataDie = FIXED_ISLAMIC_EPOCH_FRIDAY;
-    const DEBUG_NAME: &'static str = "CivilIslamic";
-    const HAS_353_DAY_YEARS: bool = false;
-    fn fixed_from_islamic(&self, year: i32, month: u8, day: u8) -> RataDie {
-        fixed_from_islamic_civil(year, month, day)
-    }
-    fn islamic_from_fixed(&self, date: RataDie) -> (i32, u8, u8) {
-        islamic_civil_from_fixed(date)
-    }
-}
-
-impl IslamicBased for TabularIslamic {
-    const EPOCH: RataDie = FIXED_ISLAMIC_EPOCH_THURSDAY;
-    const DEBUG_NAME: &'static str = "TabularIslamic";
-    const HAS_353_DAY_YEARS: bool = false;
-    fn fixed_from_islamic(&self, year: i32, month: u8, day: u8) -> RataDie {
-        fixed_from_islamic_tabular(year, month, day)
-    }
-    fn islamic_from_fixed(&self, date: RataDie) -> (i32, u8, u8) {
-        islamic_tabular_from_fixed(date)
-    }
-}
-
 /// Lisp code reference: <https://github.com/EdReingold/calendar-code2/blob/main/calendar.l#L6904>
-pub fn fixed_from_islamic_observational(
+pub fn fixed_from_observational_islamic(
     year: i32,
     month: u8,
     day: u8,
@@ -228,7 +38,7 @@ pub fn fixed_from_islamic_observational(
     let year = i64::from(year);
     let month = i64::from(month);
     let day = i64::from(day);
-    let midmonth = FIXED_ISLAMIC_EPOCH_FRIDAY.to_f64_date()
+    let midmonth = ISLAMIC_EPOCH_FRIDAY.to_f64_date()
         + (((year - 1) as f64) * 12.0 + month as f64 - 0.5) * MEAN_SYNODIC_MONTH;
     let lunar_phase = Astronomical::calculate_new_moon_at_or_before(RataDie::new(midmonth as i64));
     Astronomical::phasis_on_or_before(RataDie::new(midmonth as i64), location, Some(lunar_phase))
@@ -241,7 +51,7 @@ pub fn observational_islamic_from_fixed(date: RataDie, location: Location) -> (i
     let lunar_phase = Astronomical::calculate_new_moon_at_or_before(date);
     let crescent = Astronomical::phasis_on_or_before(date, location, Some(lunar_phase));
     let elapsed_months =
-        ((crescent - FIXED_ISLAMIC_EPOCH_FRIDAY) as f64 / MEAN_SYNODIC_MONTH).round() as i32;
+        ((crescent - ISLAMIC_EPOCH_FRIDAY) as f64 / MEAN_SYNODIC_MONTH).round() as i32;
     let year = elapsed_months.div_euclid(12) + 1;
     let month = elapsed_months.rem_euclid(12) + 1;
     let day = (date - crescent + 1) as u8;
@@ -262,7 +72,7 @@ fn saudi_criterion(date: RataDie) -> Option<bool> {
     Some(phase > 0.0 && phase < 90.0 && moonlag > 0.0)
 }
 
-pub(crate) fn adjusted_saudi_criterion(date: RataDie) -> bool {
+fn adjusted_saudi_criterion(date: RataDie) -> bool {
     saudi_criterion(date).unwrap_or_default()
 }
 
@@ -288,7 +98,7 @@ pub fn saudi_new_month_on_or_before(date: RataDie) -> RataDie {
 pub fn saudi_islamic_from_fixed(date: RataDie) -> (i32, u8, u8) {
     let crescent = saudi_new_month_on_or_before(date);
     let elapsed_months =
-        ((crescent - FIXED_ISLAMIC_EPOCH_FRIDAY) as f64 / MEAN_SYNODIC_MONTH).round() as i64;
+        ((crescent - ISLAMIC_EPOCH_FRIDAY) as f64 / MEAN_SYNODIC_MONTH).round() as i64;
     let year = i64_to_saturated_i32(elapsed_months.div_euclid(12) + 1);
     let month = (elapsed_months.rem_euclid(12) + 1) as u8;
     let day = ((date - crescent) + 1) as u8;
@@ -299,7 +109,7 @@ pub fn saudi_islamic_from_fixed(date: RataDie) -> (i32, u8, u8) {
 /// Lisp code reference: <https://github.com/EdReingold/calendar-code2/blob/main/calendar.l#L6981>
 pub fn fixed_from_saudi_islamic(year: i32, month: u8, day: u8) -> RataDie {
     let midmonth = RataDie::new(
-        FIXED_ISLAMIC_EPOCH_FRIDAY.to_i64_date()
+        ISLAMIC_EPOCH_FRIDAY.to_i64_date()
             + (((year as f64 - 1.0) * 12.0 + month as f64 - 0.5) * MEAN_SYNODIC_MONTH).floor()
                 as i64,
     );
@@ -315,7 +125,7 @@ pub fn fixed_from_islamic_civil(year: i32, month: u8, day: u8) -> RataDie {
     let day = i64::from(day);
 
     RataDie::new(
-        (FIXED_ISLAMIC_EPOCH_FRIDAY.to_i64_date() - 1)
+        (ISLAMIC_EPOCH_FRIDAY.to_i64_date() - 1)
             + (year - 1) * 354
             + (3 + year * 11).div_euclid(30)
             + 29 * (month - 1)
@@ -325,8 +135,7 @@ pub fn fixed_from_islamic_civil(year: i32, month: u8, day: u8) -> RataDie {
 }
 /// Lisp code reference: <https://github.com/EdReingold/calendar-code2/blob/main/calendar.l#L2090>
 pub fn islamic_civil_from_fixed(date: RataDie) -> (i32, u8, u8) {
-    let year =
-        i64_to_saturated_i32(((date - FIXED_ISLAMIC_EPOCH_FRIDAY) * 30 + 10646).div_euclid(10631));
+    let year = i64_to_saturated_i32(((date - ISLAMIC_EPOCH_FRIDAY) * 30 + 10646).div_euclid(10631));
     let prior_days = date.to_f64_date() - fixed_from_islamic_civil(year, 1, 1).to_f64_date();
     debug_assert!(prior_days >= 0.0);
     debug_assert!(prior_days <= 354.);
@@ -344,7 +153,7 @@ pub fn fixed_from_islamic_tabular(year: i32, month: u8, day: u8) -> RataDie {
     let month = i64::from(month);
     let day = i64::from(day);
     RataDie::new(
-        (FIXED_ISLAMIC_EPOCH_THURSDAY.to_i64_date() - 1)
+        (ISLAMIC_EPOCH_THURSDAY.to_i64_date() - 1)
             + (year - 1) * 354
             + (3 + year * 11).div_euclid(30)
             + 29 * (month - 1)
@@ -354,9 +163,8 @@ pub fn fixed_from_islamic_tabular(year: i32, month: u8, day: u8) -> RataDie {
 }
 /// Lisp code reference: <https://github.com/EdReingold/calendar-code2/blob/main/calendar.l#L2090>
 pub fn islamic_tabular_from_fixed(date: RataDie) -> (i32, u8, u8) {
-    let year = i64_to_saturated_i32(
-        ((date - FIXED_ISLAMIC_EPOCH_THURSDAY) * 30 + 10646).div_euclid(10631),
-    );
+    let year =
+        i64_to_saturated_i32(((date - ISLAMIC_EPOCH_THURSDAY) * 30 + 10646).div_euclid(10631));
     let prior_days = date.to_f64_date() - fixed_from_islamic_tabular(year, 1, 1).to_f64_date();
     debug_assert!(prior_days >= 0.0);
     debug_assert!(prior_days <= 354.);
@@ -370,7 +178,7 @@ pub fn islamic_tabular_from_fixed(date: RataDie) -> (i32, u8, u8) {
 
 /// The number of days in a month for the observational islamic calendar
 pub fn observational_islamic_month_days(year: i32, month: u8, location: Location) -> u8 {
-    let midmonth = FIXED_ISLAMIC_EPOCH_FRIDAY.to_f64_date()
+    let midmonth = ISLAMIC_EPOCH_FRIDAY.to_f64_date()
         + (((year - 1) as f64) * 12.0 + month as f64 - 0.5) * MEAN_SYNODIC_MONTH;
 
     let lunar_phase: f64 =
@@ -390,7 +198,7 @@ pub fn saudi_islamic_month_days(year: i32, month: u8) -> u8 {
     //
     // Instead we subtract the two new months calculated using the saudi criterion
     let midmonth = Moment::new(
-        FIXED_ISLAMIC_EPOCH_FRIDAY.to_f64_date()
+        ISLAMIC_EPOCH_FRIDAY.to_f64_date()
             + (((year - 1) as f64) * 12.0 + month as f64 - 0.5) * MEAN_SYNODIC_MONTH,
     );
     let midmonth_next = midmonth + MEAN_SYNODIC_MONTH;
@@ -436,7 +244,7 @@ mod tests {
     ];
     #[test]
     fn test_islamic_epoch_friday() {
-        let epoch = FIXED_ISLAMIC_EPOCH_FRIDAY.to_i64_date();
+        let epoch = ISLAMIC_EPOCH_FRIDAY.to_i64_date();
         // Iso year of Islamic Epoch
         let epoch_year_from_fixed = crate::iso::iso_year_from_fixed(RataDie::new(epoch));
         // 622 is the correct ISO year for the Islamic Epoch
@@ -445,7 +253,7 @@ mod tests {
 
     #[test]
     fn test_islamic_epoch_thursday() {
-        let epoch = FIXED_ISLAMIC_EPOCH_THURSDAY.to_i64_date();
+        let epoch = ISLAMIC_EPOCH_THURSDAY.to_i64_date();
         // Iso year of Islamic Epoch
         let epoch_year_from_fixed = crate::iso::iso_year_from_fixed(RataDie::new(epoch));
         // 622 is the correct ISO year for the Islamic Epoch

--- a/utils/calendrical_calculations/src/islamic.rs
+++ b/utils/calendrical_calculations/src/islamic.rs
@@ -4,6 +4,11 @@ use crate::rata_die::{Moment, RataDie};
 #[allow(unused_imports)]
 use core_maths::*;
 
+pub use crate::astronomy::Location;
+
+/// The average length of an Islamic year, equal to 12 moon cycles
+pub const MEAN_YEAR_LENGTH: f64 = MEAN_SYNODIC_MONTH * 12.;
+
 /// Different islamic calendars use different epochs (Thursday vs Friday) due to disagreement on the exact date of Mohammed's migration to Mecca.
 /// Lisp code reference: <https://github.com/EdReingold/calendar-code2/blob/main/calendar.l#L2066>
 pub const ISLAMIC_EPOCH_FRIDAY: RataDie = crate::julian::fixed_from_julian(622, 7, 16);

--- a/utils/calendrical_calculations/src/lib.rs
+++ b/utils/calendrical_calculations/src/lib.rs
@@ -35,13 +35,13 @@
 )]
 #![warn(missing_docs)]
 
-mod astronomy;
+pub mod astronomy;
 /// Chinese-like lunar calendars (Chinese, Dangi)
 pub mod chinese_based;
 /// The Coptic calendar
 pub mod coptic;
 /// Error handling
-mod error;
+pub mod error;
 /// The ethiopian calendar
 pub mod ethiopian;
 /// The Hebrew calendar

--- a/utils/calendrical_calculations/src/lib.rs
+++ b/utils/calendrical_calculations/src/lib.rs
@@ -35,13 +35,13 @@
 )]
 #![warn(missing_docs)]
 
-pub mod astronomy;
+mod astronomy;
 /// Chinese-like lunar calendars (Chinese, Dangi)
 pub mod chinese_based;
 /// The Coptic calendar
 pub mod coptic;
 /// Error handling
-pub mod error;
+mod error;
 /// The ethiopian calendar
 pub mod ethiopian;
 /// The Hebrew calendar


### PR DESCRIPTION
This removes scaffolding and data-provider-specific code from `calendrical_calculations` and moves it into the `icu_calendar` crate. This allows us to iterate on this without breaking semver between `icu_calendar`, `calendrical_calculations`, and `icu_provider_source`. This code should also move because it's not from the book.