### PR TITLE
Add borrowed versions of segmenter types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1748,7 +1748,6 @@ dependencies = [
  "criterion",
  "databake",
  "displaydoc",
- "either",
  "icu",
  "icu_collections",
  "icu_locale",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1748,6 +1748,7 @@ dependencies = [
  "criterion",
  "databake",
  "displaydoc",
+ "either",
  "icu",
  "icu_collections",
  "icu_locale",

--- a/components/segmenter/Cargo.toml
+++ b/components/segmenter/Cargo.toml
@@ -25,6 +25,7 @@ icu_collections = { workspace = true }
 icu_locale_core = { workspace = true }
 icu_provider = { workspace = true }
 utf8_iter = { workspace = true }
+either = { workspace = true }
 zerovec = { workspace = true, features = ["alloc", "yoke"] }
 
 databake = { workspace = true, optional = true, features = ["derive"] }

--- a/components/segmenter/Cargo.toml
+++ b/components/segmenter/Cargo.toml
@@ -25,7 +25,6 @@ icu_collections = { workspace = true }
 icu_locale_core = { workspace = true }
 icu_provider = { workspace = true }
 utf8_iter = { workspace = true }
-either = { workspace = true }
 zerovec = { workspace = true, features = ["alloc", "yoke"] }
 
 databake = { workspace = true, optional = true, features = ["derive"] }

--- a/components/segmenter/src/complex/dictionary.rs
+++ b/components/segmenter/src/complex/dictionary.rs
@@ -152,7 +152,8 @@ impl<'l> DictionarySegmenter<'l> {
 
     /// Create a dictionary based break iterator for an `str` (a UTF-8 string).
     pub(super) fn segment_str(&'l self, input: &'l str) -> impl Iterator<Item = usize> + 'l {
-        let grapheme_iter = GraphemeClusterSegmenter::new_and_segment_str(input, self.grapheme);
+        let grapheme_iter =
+            GraphemeClusterSegmenterBorrowed::new_and_segment_str(input, self.grapheme);
         DictionaryBreakIterator::<char, GraphemeClusterBreakIteratorUtf8> {
             trie: Char16Trie::new(self.dict.trie_data.clone()),
             iter: input.char_indices(),
@@ -163,7 +164,8 @@ impl<'l> DictionarySegmenter<'l> {
 
     /// Create a dictionary based break iterator for a UTF-16 string.
     pub(super) fn segment_utf16(&'l self, input: &'l [u16]) -> impl Iterator<Item = usize> + 'l {
-        let grapheme_iter = GraphemeClusterSegmenter::new_and_segment_utf16(input, self.grapheme);
+        let grapheme_iter =
+            GraphemeClusterSegmenterBorrowed::new_and_segment_utf16(input, self.grapheme);
         DictionaryBreakIterator::<u32, GraphemeClusterBreakIteratorUtf16> {
             trie: Char16Trie::new(self.dict.trie_data.clone()),
             iter: Utf16Indices::new(input),

--- a/components/segmenter/src/complex/dictionary.rs
+++ b/components/segmenter/src/complex/dictionary.rs
@@ -138,13 +138,13 @@ impl<'s> DictionaryType<'_, 's> for char {
 
 pub(super) struct DictionarySegmenter<'l> {
     dict: &'l UCharDictionaryBreakData<'l>,
-    grapheme: &'l RuleBreakData<'l>,
+    grapheme: GraphemeClusterSegmenterBorrowed<'l>,
 }
 
 impl<'l> DictionarySegmenter<'l> {
     pub(super) fn new(
         dict: &'l UCharDictionaryBreakData<'l>,
-        grapheme: &'l RuleBreakData<'l>,
+        grapheme: GraphemeClusterSegmenterBorrowed<'l>,
     ) -> Self {
         // TODO: no way to verify trie data
         Self { dict, grapheme }
@@ -152,8 +152,7 @@ impl<'l> DictionarySegmenter<'l> {
 
     /// Create a dictionary based break iterator for an `str` (a UTF-8 string).
     pub(super) fn segment_str(&'l self, input: &'l str) -> impl Iterator<Item = usize> + 'l {
-        let grapheme_iter =
-            GraphemeClusterSegmenterBorrowed::new_and_segment_str(input, self.grapheme);
+        let grapheme_iter = self.grapheme.new_and_segment_str(input);
         DictionaryBreakIterator::<char, GraphemeClusterBreakIteratorUtf8> {
             trie: Char16Trie::new(self.dict.trie_data.clone()),
             iter: input.char_indices(),
@@ -164,8 +163,7 @@ impl<'l> DictionarySegmenter<'l> {
 
     /// Create a dictionary based break iterator for a UTF-16 string.
     pub(super) fn segment_utf16(&'l self, input: &'l [u16]) -> impl Iterator<Item = usize> + 'l {
-        let grapheme_iter =
-            GraphemeClusterSegmenterBorrowed::new_and_segment_utf16(input, self.grapheme);
+        let grapheme_iter = self.grapheme.new_and_segment_utf16(input);
         DictionaryBreakIterator::<u32, GraphemeClusterBreakIteratorUtf16> {
             trie: Char16Trie::new(self.dict.trie_data.clone()),
             iter: Utf16Indices::new(input),
@@ -179,7 +177,7 @@ impl<'l> DictionarySegmenter<'l> {
 #[cfg(feature = "serde")]
 mod tests {
     use super::*;
-    use crate::{LineSegmenter, WordSegmenter};
+    use crate::{GraphemeClusterSegmenter, LineSegmenter, WordSegmenter};
     use icu_provider::prelude::*;
 
     #[test]
@@ -206,10 +204,8 @@ mod tests {
             })
             .unwrap();
         let word_segmenter = WordSegmenter::new_dictionary(Default::default());
-        let dict_segmenter = DictionarySegmenter::new(
-            response.payload.get(),
-            crate::provider::Baked::SINGLETON_SEGMENTER_BREAK_GRAPHEME_CLUSTER_V1,
-        );
+        let dict_segmenter =
+            DictionarySegmenter::new(response.payload.get(), GraphemeClusterSegmenter::new());
 
         // Match case
         let s = "龟山岛龟山岛";

--- a/components/segmenter/src/complex/dictionary.rs
+++ b/components/segmenter/src/complex/dictionary.rs
@@ -152,7 +152,7 @@ impl<'l> DictionarySegmenter<'l> {
 
     /// Create a dictionary based break iterator for an `str` (a UTF-8 string).
     pub(super) fn segment_str(&'l self, input: &'l str) -> impl Iterator<Item = usize> + 'l {
-        let grapheme_iter = self.grapheme.new_and_segment_str(input);
+        let grapheme_iter = self.grapheme.segment_str(input);
         DictionaryBreakIterator::<char, GraphemeClusterBreakIteratorUtf8> {
             trie: Char16Trie::new(self.dict.trie_data.clone()),
             iter: input.char_indices(),
@@ -163,7 +163,7 @@ impl<'l> DictionarySegmenter<'l> {
 
     /// Create a dictionary based break iterator for a UTF-16 string.
     pub(super) fn segment_utf16(&'l self, input: &'l [u16]) -> impl Iterator<Item = usize> + 'l {
-        let grapheme_iter = self.grapheme.new_and_segment_utf16(input);
+        let grapheme_iter = self.grapheme.segment_utf16(input);
         DictionaryBreakIterator::<u32, GraphemeClusterBreakIteratorUtf16> {
             trie: Char16Trie::new(self.dict.trie_data.clone()),
             iter: Utf16Indices::new(input),

--- a/components/segmenter/src/complex/lstm/mod.rs
+++ b/components/segmenter/src/complex/lstm/mod.rs
@@ -93,7 +93,6 @@ impl<'data> LstmSegmenter<'data> {
         }
     }
 
-    
     /// Create an LSTM based break iterator for an `str` (a UTF-8 string).
     pub(super) fn segment_str<'a>(&'a self, input: &'a str) -> LstmSegmenterIterator<'a, 'data> {
         let input_seq = if let Some(grapheme) = self.grapheme {

--- a/components/segmenter/src/complex/lstm/mod.rs
+++ b/components/segmenter/src/complex/lstm/mod.rs
@@ -14,13 +14,13 @@ use matrix::*;
 
 // A word break iterator using LSTM model. Input string have to be same language.
 
-struct LstmSegmenterIterator<'s> {
+pub(super) struct LstmSegmenterIterator<'s, 'data> {
     input: &'s str,
     pos_utf8: usize,
-    bies: BiesIterator<'s>,
+    bies: BiesIterator<'s, 'data>,
 }
 
-impl Iterator for LstmSegmenterIterator<'_> {
+impl Iterator for LstmSegmenterIterator<'_, '_> {
     type Item = usize;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -35,12 +35,12 @@ impl Iterator for LstmSegmenterIterator<'_> {
     }
 }
 
-struct LstmSegmenterIteratorUtf16<'s> {
-    bies: BiesIterator<'s>,
+pub(super) struct LstmSegmenterIteratorUtf16<'s, 'data> {
+    bies: BiesIterator<'s, 'data>,
     pos: usize,
 }
 
-impl Iterator for LstmSegmenterIteratorUtf16<'_> {
+impl Iterator for LstmSegmenterIteratorUtf16<'_, '_> {
     type Item = usize;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -53,24 +53,24 @@ impl Iterator for LstmSegmenterIteratorUtf16<'_> {
     }
 }
 
-pub(super) struct LstmSegmenter<'l> {
-    dic: ZeroMapBorrowed<'l, PotentialUtf8, u16>,
-    embedding: MatrixZero<'l, 2>,
-    fw_w: MatrixZero<'l, 3>,
-    fw_u: MatrixZero<'l, 3>,
-    fw_b: MatrixZero<'l, 2>,
-    bw_w: MatrixZero<'l, 3>,
-    bw_u: MatrixZero<'l, 3>,
-    bw_b: MatrixZero<'l, 2>,
-    timew_fw: MatrixZero<'l, 2>,
-    timew_bw: MatrixZero<'l, 2>,
-    time_b: MatrixZero<'l, 1>,
-    grapheme: Option<&'l RuleBreakData<'l>>,
+pub(super) struct LstmSegmenter<'data> {
+    dic: ZeroMapBorrowed<'data, PotentialUtf8, u16>,
+    embedding: MatrixZero<'data, 2>,
+    fw_w: MatrixZero<'data, 3>,
+    fw_u: MatrixZero<'data, 3>,
+    fw_b: MatrixZero<'data, 2>,
+    bw_w: MatrixZero<'data, 3>,
+    bw_u: MatrixZero<'data, 3>,
+    bw_b: MatrixZero<'data, 2>,
+    timew_fw: MatrixZero<'data, 2>,
+    timew_bw: MatrixZero<'data, 2>,
+    time_b: MatrixZero<'data, 1>,
+    grapheme: Option<&'data RuleBreakData<'data>>,
 }
 
-impl<'l> LstmSegmenter<'l> {
+impl<'data> LstmSegmenter<'data> {
     /// Returns `Err` if grapheme data is required but not present
-    pub(super) fn new(lstm: &'l LstmData<'l>, grapheme: &'l RuleBreakData<'l>) -> Self {
+    pub(super) fn new(lstm: &'data LstmData<'data>, grapheme: &'data RuleBreakData<'data>) -> Self {
         let LstmData::Float32(lstm) = lstm;
         let time_w = MatrixZero::from(&lstm.time_w);
         #[allow(clippy::unwrap_used)] // shape (2, 4, hunits)
@@ -93,13 +93,9 @@ impl<'l> LstmSegmenter<'l> {
         }
     }
 
+    
     /// Create an LSTM based break iterator for an `str` (a UTF-8 string).
-    pub(super) fn segment_str(&'l self, input: &'l str) -> impl Iterator<Item = usize> + 'l {
-        self.segment_str_p(input)
-    }
-
-    // For unit testing as we cannot inspect the opaque type's bies
-    fn segment_str_p(&'l self, input: &'l str) -> LstmSegmenterIterator<'l> {
+    pub(super) fn segment_str<'a>(&'a self, input: &'a str) -> LstmSegmenterIterator<'a, 'data> {
         let input_seq = if let Some(grapheme) = self.grapheme {
             GraphemeClusterSegmenterBorrowed::new_and_segment_str(input, grapheme)
                 .collect::<Vec<usize>>()
@@ -139,7 +135,10 @@ impl<'l> LstmSegmenter<'l> {
     }
 
     /// Create an LSTM based break iterator for a UTF-16 string.
-    pub(super) fn segment_utf16(&'l self, input: &[u16]) -> impl Iterator<Item = usize> + 'l {
+    pub(super) fn segment_utf16<'a>(
+        &'a self,
+        input: &[u16],
+    ) -> LstmSegmenterIteratorUtf16<'a, 'data> {
         let input_seq = if let Some(grapheme) = self.grapheme {
             GraphemeClusterSegmenterBorrowed::new_and_segment_utf16(input, grapheme)
                 .collect::<Vec<usize>>()
@@ -189,18 +188,18 @@ impl<'l> LstmSegmenter<'l> {
     }
 }
 
-struct BiesIterator<'l> {
-    segmenter: &'l LstmSegmenter<'l>,
+struct BiesIterator<'l, 'data> {
+    segmenter: &'l LstmSegmenter<'data>,
     input_seq: core::iter::Enumerate<alloc::vec::IntoIter<u16>>,
     h_bw: MatrixOwned<2>,
     curr_fw: MatrixOwned<1>,
     c_fw: MatrixOwned<1>,
 }
 
-impl<'l> BiesIterator<'l> {
+impl<'l, 'data> BiesIterator<'l, 'data> {
     // input_seq is a sequence of id numbers that represents grapheme clusters or code points in the input line. These ids are used later
     // in the embedding layer of the model.
-    fn new(segmenter: &'l LstmSegmenter<'l>, input_seq: Vec<u16>) -> Self {
+    fn new(segmenter: &'l LstmSegmenter<'data>, input_seq: Vec<u16>) -> Self {
         let hunits = segmenter.fw_u.dim().1;
 
         // Backward LSTM
@@ -231,13 +230,13 @@ impl<'l> BiesIterator<'l> {
     }
 }
 
-impl ExactSizeIterator for BiesIterator<'_> {
+impl ExactSizeIterator for BiesIterator<'_, '_> {
     fn len(&self) -> usize {
         self.input_seq.len()
     }
 }
 
-impl Iterator for BiesIterator<'_> {
+impl Iterator for BiesIterator<'_, '_> {
     type Item = bool;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -376,7 +375,7 @@ mod tests {
         // Testing
         for test_case in &test_text.data.testcases {
             let lstm_output = lstm
-                .segment_str_p(&test_case.unseg)
+                .segment_str(&test_case.unseg)
                 .bies
                 .map(|is_e| if is_e { 'e' } else { '?' })
                 .collect::<String>();

--- a/components/segmenter/src/complex/lstm/mod.rs
+++ b/components/segmenter/src/complex/lstm/mod.rs
@@ -100,7 +100,7 @@ impl<'data> LstmSegmenter<'data> {
     pub(super) fn segment_str<'a>(&'a self, input: &'a str) -> LstmSegmenterIterator<'a, 'data> {
         let input_seq = if let Some(grapheme) = self.grapheme {
             grapheme
-                .new_and_segment_str(input)
+                .segment_str(input)
                 .collect::<Vec<usize>>()
                 .windows(2)
                 .map(|chunk| {
@@ -144,7 +144,7 @@ impl<'data> LstmSegmenter<'data> {
     ) -> LstmSegmenterIteratorUtf16<'a, 'data> {
         let input_seq = if let Some(grapheme) = self.grapheme {
             grapheme
-                .new_and_segment_utf16(input)
+                .segment_utf16(input)
                 .collect::<Vec<usize>>()
                 .windows(2)
                 .map(|chunk| {

--- a/components/segmenter/src/complex/lstm/mod.rs
+++ b/components/segmenter/src/complex/lstm/mod.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use crate::grapheme::GraphemeClusterSegmenter;
+use crate::grapheme::GraphemeClusterSegmenterBorrowed;
 use crate::provider::*;
 use alloc::vec::Vec;
 use core::char::{decode_utf16, REPLACEMENT_CHARACTER};
@@ -101,7 +101,7 @@ impl<'l> LstmSegmenter<'l> {
     // For unit testing as we cannot inspect the opaque type's bies
     fn segment_str_p(&'l self, input: &'l str) -> LstmSegmenterIterator<'l> {
         let input_seq = if let Some(grapheme) = self.grapheme {
-            GraphemeClusterSegmenter::new_and_segment_str(input, grapheme)
+            GraphemeClusterSegmenterBorrowed::new_and_segment_str(input, grapheme)
                 .collect::<Vec<usize>>()
                 .windows(2)
                 .map(|chunk| {
@@ -141,7 +141,7 @@ impl<'l> LstmSegmenter<'l> {
     /// Create an LSTM based break iterator for a UTF-16 string.
     pub(super) fn segment_utf16(&'l self, input: &[u16]) -> impl Iterator<Item = usize> + 'l {
         let input_seq = if let Some(grapheme) = self.grapheme {
-            GraphemeClusterSegmenter::new_and_segment_utf16(input, grapheme)
+            GraphemeClusterSegmenterBorrowed::new_and_segment_utf16(input, grapheme)
                 .collect::<Vec<usize>>()
                 .windows(2)
                 .map(|chunk| {

--- a/components/segmenter/src/complex/mod.rs
+++ b/components/segmenter/src/complex/mod.rs
@@ -3,6 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::provider::*;
+use crate::{GraphemeClusterSegmenter, GraphemeClusterSegmenterBorrowed};
 use alloc::vec::Vec;
 use either::Either;
 use icu_provider::prelude::*;
@@ -48,7 +49,7 @@ fn fromstatic_dictor(dict_or: DictOrLstmBorrowed<'static>) -> DictOrLstm {
 
 #[derive(Debug)]
 pub(crate) struct ComplexPayloads {
-    grapheme: DataPayload<SegmenterBreakGraphemeClusterV1>,
+    grapheme: GraphemeClusterSegmenter,
     my: Option<DictOrLstm>,
     km: Option<DictOrLstm>,
     lo: Option<DictOrLstm>,
@@ -58,7 +59,7 @@ pub(crate) struct ComplexPayloads {
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct ComplexPayloadsBorrowed<'data> {
-    grapheme: &'data RuleBreakData<'data>,
+    grapheme: GraphemeClusterSegmenterBorrowed<'data>,
     my: Option<DictOrLstmBorrowed<'data>>,
     km: Option<DictOrLstmBorrowed<'data>>,
     lo: Option<DictOrLstmBorrowed<'data>>,
@@ -165,7 +166,7 @@ impl ComplexPayloadsBorrowed<'static> {
         #[allow(clippy::unwrap_used)]
         // try_load is infallible if the provider only returns `MissingLocale`.
         Self {
-            grapheme: crate::provider::Baked::SINGLETON_SEGMENTER_BREAK_GRAPHEME_CLUSTER_V1,
+            grapheme: GraphemeClusterSegmenter::new(),
             my: try_load_static::<SegmenterLstmAutoV1, _>(&crate::provider::Baked, MY_LSTM)
                 .unwrap()
                 .map(Either::Right),
@@ -195,7 +196,7 @@ impl ComplexPayloadsBorrowed<'static> {
         #[allow(clippy::unwrap_used)]
         // try_load is infallible if the provider only returns `MissingLocale`.
         Self {
-            grapheme: crate::provider::Baked::SINGLETON_SEGMENTER_BREAK_GRAPHEME_CLUSTER_V1,
+            grapheme: GraphemeClusterSegmenter::new(),
             my: try_load_static::<SegmenterDictionaryExtendedV1, _>(
                 &crate::provider::Baked,
                 MY_DICT,
@@ -230,7 +231,7 @@ impl ComplexPayloadsBorrowed<'static> {
         #[allow(clippy::unwrap_used)]
         // try_load is infallible if the provider only returns `MissingLocale`.
         Self {
-            grapheme: crate::provider::Baked::SINGLETON_SEGMENTER_BREAK_GRAPHEME_CLUSTER_V1,
+            grapheme: GraphemeClusterSegmenter::new(),
             my: try_load_static::<SegmenterDictionaryExtendedV1, _>(
                 &crate::provider::Baked,
                 MY_DICT,
@@ -261,7 +262,7 @@ impl ComplexPayloadsBorrowed<'static> {
 
     pub(crate) fn static_to_owned(self) -> ComplexPayloads {
         ComplexPayloads {
-            grapheme: DataPayload::from_static_ref(self.grapheme),
+            grapheme: self.grapheme.static_to_owned(),
             my: self.my.map(fromstatic_dictor),
             km: self.km.map(fromstatic_dictor),
             lo: self.lo.map(fromstatic_dictor),
@@ -274,7 +275,7 @@ impl ComplexPayloadsBorrowed<'static> {
 impl ComplexPayloads {
     pub(crate) fn as_borrowed(&self) -> ComplexPayloadsBorrowed<'_> {
         ComplexPayloadsBorrowed {
-            grapheme: self.grapheme.get(),
+            grapheme: self.grapheme.as_borrowed(),
             my: self.my.as_ref().map(borrow_dictor),
             km: self.km.as_ref().map(borrow_dictor),
             lo: self.lo.as_ref().map(borrow_dictor),
@@ -291,7 +292,7 @@ impl ComplexPayloads {
             + ?Sized,
     {
         Ok(Self {
-            grapheme: provider.load(Default::default())?.payload,
+            grapheme: GraphemeClusterSegmenter::try_new_unstable(provider)?,
             my: try_load::<SegmenterLstmAutoV1, D>(provider, MY_LSTM)?
                 .map(DataPayload::cast)
                 .map(Either::Right),
@@ -316,7 +317,7 @@ impl ComplexPayloads {
             + ?Sized,
     {
         Ok(Self {
-            grapheme: provider.load(Default::default())?.payload,
+            grapheme: GraphemeClusterSegmenter::try_new_unstable(provider)?,
             my: try_load::<SegmenterDictionaryExtendedV1, D>(provider, MY_DICT)?
                 .map(DataPayload::cast)
                 .map(Either::Left),
@@ -342,7 +343,7 @@ impl ComplexPayloads {
             + ?Sized,
     {
         Ok(Self {
-            grapheme: provider.load(Default::default())?.payload,
+            grapheme: GraphemeClusterSegmenter::try_new_unstable(provider)?,
             my: try_load::<SegmenterLstmAutoV1, D>(provider, MY_LSTM)?
                 .map(DataPayload::cast)
                 .map(Either::Right),
@@ -366,7 +367,7 @@ impl ComplexPayloads {
             + ?Sized,
     {
         Ok(Self {
-            grapheme: provider.load(Default::default())?.payload,
+            grapheme: GraphemeClusterSegmenter::try_new_unstable(provider)?,
             my: try_load::<SegmenterDictionaryExtendedV1, _>(provider, MY_DICT)?
                 .map(DataPayload::cast)
                 .map(Either::Left),

--- a/components/segmenter/src/complex/mod.rs
+++ b/components/segmenter/src/complex/mod.rs
@@ -224,6 +224,41 @@ impl ComplexPayloadsBorrowed<'static> {
         }
     }
 
+
+    #[cfg(feature = "compiled_data")]
+    pub(crate) fn new_southeast_asian() -> Self {
+        #[allow(clippy::unwrap_used)]
+        // try_load is infallible if the provider only returns `MissingLocale`.
+        Self {
+            grapheme: crate::provider::Baked::SINGLETON_SEGMENTER_BREAK_GRAPHEME_CLUSTER_V1,
+            my: try_load_static::<SegmenterDictionaryExtendedV1, _>(
+                &crate::provider::Baked,
+                MY_DICT,
+            )
+            .unwrap()
+            .map(Ok),
+            km: try_load_static::<SegmenterDictionaryExtendedV1, _>(
+                &crate::provider::Baked,
+                KM_DICT,
+            )
+            .unwrap()
+            .map(Ok),
+            lo: try_load_static::<SegmenterDictionaryExtendedV1, _>(
+                &crate::provider::Baked,
+                LO_DICT,
+            )
+            .unwrap()
+            .map(Ok),
+            th: try_load_static::<SegmenterDictionaryExtendedV1, _>(
+                &crate::provider::Baked,
+                TH_DICT,
+            )
+            .unwrap()
+            .map(Ok),
+            ja: None,
+        }
+    }
+
     pub(crate) fn static_to_owned(self) -> ComplexPayloads {
         ComplexPayloads {
             grapheme: DataPayload::from_static_ref(self.grapheme),
@@ -245,35 +280,6 @@ impl ComplexPayloads {
             lo: self.lo.as_ref().map(borrow_dictor),
             th: self.th.as_ref().map(borrow_dictor),
             ja: self.ja.as_ref().map(|p| p.get()),
-        }
-    }
-
-    #[cfg(feature = "lstm")]
-    #[cfg(feature = "compiled_data")]
-    pub(crate) fn new_lstm() -> Self {
-        #[allow(clippy::unwrap_used)]
-        // try_load is infallible if the provider only returns `MissingLocale`.
-        Self {
-            grapheme: DataPayload::from_static_ref(
-                crate::provider::Baked::SINGLETON_SEGMENTER_BREAK_GRAPHEME_CLUSTER_V1,
-            ),
-            my: try_load::<SegmenterLstmAutoV1, _>(&crate::provider::Baked, MY_LSTM)
-                .unwrap()
-                .map(DataPayload::cast)
-                .map(Err),
-            km: try_load::<SegmenterLstmAutoV1, _>(&crate::provider::Baked, KM_LSTM)
-                .unwrap()
-                .map(DataPayload::cast)
-                .map(Err),
-            lo: try_load::<SegmenterLstmAutoV1, _>(&crate::provider::Baked, LO_LSTM)
-                .unwrap()
-                .map(DataPayload::cast)
-                .map(Err),
-            th: try_load::<SegmenterLstmAutoV1, _>(&crate::provider::Baked, TH_LSTM)
-                .unwrap()
-                .map(DataPayload::cast)
-                .map(Err),
-            ja: None,
         }
     }
 
@@ -353,33 +359,6 @@ impl ComplexPayloads {
         })
     }
 
-    #[cfg(feature = "compiled_data")]
-    pub(crate) fn new_southeast_asian() -> Self {
-        #[allow(clippy::unwrap_used)]
-        // try_load is infallible if the provider only returns `MissingLocale`.
-        Self {
-            grapheme: DataPayload::from_static_ref(
-                crate::provider::Baked::SINGLETON_SEGMENTER_BREAK_GRAPHEME_CLUSTER_V1,
-            ),
-            my: try_load::<SegmenterDictionaryExtendedV1, _>(&crate::provider::Baked, MY_DICT)
-                .unwrap()
-                .map(DataPayload::cast)
-                .map(Ok),
-            km: try_load::<SegmenterDictionaryExtendedV1, _>(&crate::provider::Baked, KM_DICT)
-                .unwrap()
-                .map(DataPayload::cast)
-                .map(Ok),
-            lo: try_load::<SegmenterDictionaryExtendedV1, _>(&crate::provider::Baked, LO_DICT)
-                .unwrap()
-                .map(DataPayload::cast)
-                .map(Ok),
-            th: try_load::<SegmenterDictionaryExtendedV1, _>(&crate::provider::Baked, TH_DICT)
-                .unwrap()
-                .map(DataPayload::cast)
-                .map(Ok),
-            ja: None,
-        }
-    }
 
     pub(crate) fn try_new_southeast_asian<D>(provider: &D) -> Result<Self, DataError>
     where

--- a/components/segmenter/src/complex/mod.rs
+++ b/components/segmenter/src/complex/mod.rs
@@ -25,7 +25,7 @@ type DictOrLstm = Result<DataPayload<UCharDictionaryBreakDataV1>, DataPayload<Se
 #[cfg(feature = "lstm")]
 type DictOrLstmBorrowed<'a> = Result<&'a UCharDictionaryBreakData<'a>, &'a LstmData<'a>>;
 
-fn borrow_dictor<'data>(dict_or: &'data DictOrLstm) -> DictOrLstmBorrowed<'data> {
+fn borrow_dictor(dict_or: &DictOrLstm) -> DictOrLstmBorrowed<'_> {
     match dict_or {
         Ok(dict) => Ok(dict.get()),
         #[cfg(feature = "lstm")]
@@ -164,7 +164,7 @@ impl ComplexPayloadsBorrowed<'static> {
         #[allow(clippy::unwrap_used)]
         // try_load is infallible if the provider only returns `MissingLocale`.
         Self {
-            grapheme: &crate::provider::Baked::SINGLETON_SEGMENTER_BREAK_GRAPHEME_CLUSTER_V1,
+            grapheme: crate::provider::Baked::SINGLETON_SEGMENTER_BREAK_GRAPHEME_CLUSTER_V1,
             my: try_load_static::<SegmenterLstmAutoV1, _>(&crate::provider::Baked, MY_LSTM)
                 .unwrap()
                 .map(Err),
@@ -271,7 +271,7 @@ impl ComplexPayloadsBorrowed<'static> {
 }
 
 impl ComplexPayloads {
-    pub(crate) fn as_borrowed<'data>(&'data self) -> ComplexPayloadsBorrowed<'data> {
+    pub(crate) fn as_borrowed(&self) -> ComplexPayloadsBorrowed<'_> {
         ComplexPayloadsBorrowed {
             grapheme: self.grapheme.get(),
             my: self.my.as_ref().map(borrow_dictor),

--- a/components/segmenter/src/complex/mod.rs
+++ b/components/segmenter/src/complex/mod.rs
@@ -181,7 +181,7 @@ impl ComplexPayloadsBorrowed<'static> {
             ja: None,
         }
     }
-    #[cfg(feature = "lstm")]
+    #[cfg(feature = "auto")]
     #[cfg(feature = "compiled_data")]
     #[allow(clippy::unwrap_used)]
     pub(crate) fn new_auto() -> Self {
@@ -401,6 +401,7 @@ fn try_load<M: DataMarker, P: DataProvider<M> + ?Sized>(
         .map(|r| r.map(|r| r.payload))
 }
 
+#[cfg(feature = "compiled_data")]
 fn try_load_static<M: DataMarker, P: DataProvider<M> + ?Sized>(
     provider: &P,
     model: &'static DataMarkerAttributes,

--- a/components/segmenter/src/complex/mod.rs
+++ b/components/segmenter/src/complex/mod.rs
@@ -41,7 +41,7 @@ fn fromstatic_dictor(dict_or: DictOrLstmBorrowed<'static>) -> DictOrLstm {
         #[cfg(feature = "lstm")]
         Err(lstm) => Err(DataPayload::from_static_ref(lstm)),
         #[cfg(not(feature = "lstm"))]
-        Err(infallible) => Err(*infallible),
+        Err(infallible) => Err(infallible),
     }
 }
 
@@ -224,7 +224,6 @@ impl ComplexPayloadsBorrowed<'static> {
         }
     }
 
-
     #[cfg(feature = "compiled_data")]
     pub(crate) fn new_southeast_asian() -> Self {
         #[allow(clippy::unwrap_used)]
@@ -358,7 +357,6 @@ impl ComplexPayloads {
             ja: try_load::<SegmenterDictionaryAutoV1, D>(provider, CJ_DICT)?.map(DataPayload::cast),
         })
     }
-
 
     pub(crate) fn try_new_southeast_asian<D>(provider: &D) -> Result<Self, DataError>
     where

--- a/components/segmenter/src/grapheme.rs
+++ b/components/segmenter/src/grapheme.rs
@@ -24,7 +24,7 @@ use utf8_iter::Utf8CharIndices;
 ///
 /// For examples of use, see [`GraphemeClusterSegmenter`].
 #[derive(Debug)]
-pub struct GraphemeClusterBreakIterator<'l, 's, Y: RuleBreakType<'l, 's> + ?Sized>(
+pub struct GraphemeClusterBreakIterator<'l, 's, Y: RuleBreakType<'s> + ?Sized>(
     RuleBreakIterator<'l, 's, Y>,
 );
 

--- a/components/segmenter/src/grapheme.rs
+++ b/components/segmenter/src/grapheme.rs
@@ -25,7 +25,7 @@ use utf8_iter::Utf8CharIndices;
 /// For examples of use, see [`GraphemeClusterSegmenter`].
 #[derive(Debug)]
 pub struct GraphemeClusterBreakIterator<'l, 's, Y: RuleBreakType<'s> + ?Sized>(
-    RuleBreakIterator<'l, 's, Y>,
+    RuleBreakIterator<'l, 'l, 's, Y>,
 );
 
 derive_usize_iterator_with_type!(GraphemeClusterBreakIterator);

--- a/components/segmenter/src/grapheme.rs
+++ b/components/segmenter/src/grapheme.rs
@@ -186,7 +186,7 @@ impl GraphemeClusterSegmenter {
 impl<'data> GraphemeClusterSegmenterBorrowed<'data> {
     /// Creates a grapheme cluster break iterator for an `str` (a UTF-8 string).
     pub fn segment_str<'s>(self, input: &'s str) -> GraphemeClusterBreakIteratorUtf8<'data, 's> {
-        Self::new_and_segment_str(input, self.data)
+        self.new_and_segment_str(input)
     }
 
     /// Creates a grapheme cluster break iterator for a potentially ill-formed UTF8 string
@@ -235,22 +235,22 @@ impl<'data> GraphemeClusterSegmenterBorrowed<'data> {
         self,
         input: &'s [u16],
     ) -> GraphemeClusterBreakIteratorUtf16<'data, 's> {
-        Self::new_and_segment_utf16(input, self.data)
+        self.new_and_segment_utf16(input)
     }
 
     /// Creates a grapheme cluster break iterator from grapheme cluster rule payload.
     ///
     /// There are always breakpoints at 0 and the string length, or only at 0 for the empty string.
     pub(crate) fn new_and_segment_str<'s>(
+        self,
         input: &'s str,
-        payload: &'data RuleBreakData<'data>,
     ) -> GraphemeClusterBreakIteratorUtf8<'data, 's> {
         GraphemeClusterBreakIterator(RuleBreakIterator {
             iter: input.char_indices(),
             len: input.len(),
             current_pos_data: None,
             result_cache: Vec::new(),
-            data: payload,
+            data: self.data,
             complex: None,
             boundary_property: 0,
             locale_override: None,
@@ -259,15 +259,15 @@ impl<'data> GraphemeClusterSegmenterBorrowed<'data> {
 
     /// Creates a grapheme cluster break iterator from grapheme cluster rule payload.
     pub(crate) fn new_and_segment_utf16<'s>(
+        self,
         input: &'s [u16],
-        payload: &'data RuleBreakData<'data>,
     ) -> GraphemeClusterBreakIteratorUtf16<'data, 's> {
         GraphemeClusterBreakIterator(RuleBreakIterator {
             iter: Utf16Indices::new(input),
             len: input.len(),
             current_pos_data: None,
             result_cache: Vec::new(),
-            data: payload,
+            data: self.data,
             complex: None,
             boundary_property: 0,
             locale_override: None,

--- a/components/segmenter/src/grapheme.rs
+++ b/components/segmenter/src/grapheme.rs
@@ -186,9 +186,17 @@ impl GraphemeClusterSegmenter {
 impl<'data> GraphemeClusterSegmenterBorrowed<'data> {
     /// Creates a grapheme cluster break iterator for an `str` (a UTF-8 string).
     pub fn segment_str<'s>(self, input: &'s str) -> GraphemeClusterBreakIteratorUtf8<'data, 's> {
-        self.new_and_segment_str(input)
+        GraphemeClusterBreakIterator(RuleBreakIterator {
+            iter: input.char_indices(),
+            len: input.len(),
+            current_pos_data: None,
+            result_cache: Vec::new(),
+            data: self.data,
+            complex: None,
+            boundary_property: 0,
+            locale_override: None,
+        })
     }
-
     /// Creates a grapheme cluster break iterator for a potentially ill-formed UTF8 string
     ///
     /// Invalid characters are treated as REPLACEMENT CHARACTER
@@ -232,33 +240,6 @@ impl<'data> GraphemeClusterSegmenterBorrowed<'data> {
     ///
     /// There are always breakpoints at 0 and the string length, or only at 0 for the empty string.
     pub fn segment_utf16<'s>(
-        self,
-        input: &'s [u16],
-    ) -> GraphemeClusterBreakIteratorUtf16<'data, 's> {
-        self.new_and_segment_utf16(input)
-    }
-
-    /// Creates a grapheme cluster break iterator from grapheme cluster rule payload.
-    ///
-    /// There are always breakpoints at 0 and the string length, or only at 0 for the empty string.
-    pub(crate) fn new_and_segment_str<'s>(
-        self,
-        input: &'s str,
-    ) -> GraphemeClusterBreakIteratorUtf8<'data, 's> {
-        GraphemeClusterBreakIterator(RuleBreakIterator {
-            iter: input.char_indices(),
-            len: input.len(),
-            current_pos_data: None,
-            result_cache: Vec::new(),
-            data: self.data,
-            complex: None,
-            boundary_property: 0,
-            locale_override: None,
-        })
-    }
-
-    /// Creates a grapheme cluster break iterator from grapheme cluster rule payload.
-    pub(crate) fn new_and_segment_utf16<'s>(
         self,
         input: &'s [u16],
     ) -> GraphemeClusterBreakIteratorUtf16<'data, 's> {

--- a/components/segmenter/src/grapheme.rs
+++ b/components/segmenter/src/grapheme.rs
@@ -149,7 +149,7 @@ impl GraphemeClusterSegmenter {
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
-    #[allow(clippy::new_without_default)] // Deliberate choice, see #5554
+    #[allow(clippy::new_ret_no_self)] // Deliberate choice, see #5554
     pub const fn new() -> GraphemeClusterSegmenterBorrowed<'static> {
         GraphemeClusterSegmenterBorrowed {
             data: crate::provider::Baked::SINGLETON_SEGMENTER_BREAK_GRAPHEME_CLUSTER_V1,

--- a/components/segmenter/src/grapheme.rs
+++ b/components/segmenter/src/grapheme.rs
@@ -15,7 +15,7 @@ use utf8_iter::Utf8CharIndices;
 ///
 /// Lifetimes:
 ///
-/// - `'l` = lifetime of the segmenter object from which this iterator was created
+/// - `'data` = lifetime of the segmenter object from which this iterator was created
 /// - `'s` = lifetime of the string being segmented
 ///
 /// The [`Iterator::Item`] is an [`usize`] representing index of a code unit
@@ -24,35 +24,35 @@ use utf8_iter::Utf8CharIndices;
 ///
 /// For examples of use, see [`GraphemeClusterSegmenter`].
 #[derive(Debug)]
-pub struct GraphemeClusterBreakIterator<'l, 's, Y: RuleBreakType<'s> + ?Sized>(
-    RuleBreakIterator<'l, 'l, 's, Y>,
+pub struct GraphemeClusterBreakIterator<'data, 's, Y: RuleBreakType<'s> + ?Sized>(
+    RuleBreakIterator<'data, 's, Y>,
 );
 
-derive_usize_iterator_with_type!(GraphemeClusterBreakIterator);
+derive_usize_iterator_with_type!(GraphemeClusterBreakIterator, 'data);
 
 /// Grapheme cluster break iterator for an `str` (a UTF-8 string).
 ///
 /// For examples of use, see [`GraphemeClusterSegmenter`].
-pub type GraphemeClusterBreakIteratorUtf8<'l, 's> =
-    GraphemeClusterBreakIterator<'l, 's, RuleBreakTypeUtf8>;
+pub type GraphemeClusterBreakIteratorUtf8<'data, 's> =
+    GraphemeClusterBreakIterator<'data, 's, RuleBreakTypeUtf8>;
 
 /// Grapheme cluster break iterator for a potentially invalid UTF-8 string.
 ///
 /// For examples of use, see [`GraphemeClusterSegmenter`].
-pub type GraphemeClusterBreakIteratorPotentiallyIllFormedUtf8<'l, 's> =
-    GraphemeClusterBreakIterator<'l, 's, RuleBreakTypePotentiallyIllFormedUtf8>;
+pub type GraphemeClusterBreakIteratorPotentiallyIllFormedUtf8<'data, 's> =
+    GraphemeClusterBreakIterator<'data, 's, RuleBreakTypePotentiallyIllFormedUtf8>;
 
 /// Grapheme cluster break iterator for a Latin-1 (8-bit) string.
 ///
 /// For examples of use, see [`GraphemeClusterSegmenter`].
-pub type GraphemeClusterBreakIteratorLatin1<'l, 's> =
-    GraphemeClusterBreakIterator<'l, 's, RuleBreakTypeLatin1>;
+pub type GraphemeClusterBreakIteratorLatin1<'data, 's> =
+    GraphemeClusterBreakIterator<'data, 's, RuleBreakTypeLatin1>;
 
 /// Grapheme cluster break iterator for a UTF-16 string.
 ///
 /// For examples of use, see [`GraphemeClusterSegmenter`].
-pub type GraphemeClusterBreakIteratorUtf16<'l, 's> =
-    GraphemeClusterBreakIterator<'l, 's, RuleBreakTypeUtf16>;
+pub type GraphemeClusterBreakIteratorUtf16<'data, 's> =
+    GraphemeClusterBreakIterator<'data, 's, RuleBreakTypeUtf16>;
 
 /// Segments a string into grapheme clusters.
 ///

--- a/components/segmenter/src/iterator_helpers.rs
+++ b/components/segmenter/src/iterator_helpers.rs
@@ -6,7 +6,7 @@
 
 macro_rules! derive_usize_iterator_with_type {
     ($ty:tt) => {
-        impl<'l, 's, Y: RuleBreakType<'l, 's> + ?Sized> Iterator for $ty<'l, 's, Y> {
+        impl<'l, 's, Y: RuleBreakType<'s> + ?Sized> Iterator for $ty<'l, 's, Y> {
             type Item = usize;
             #[inline]
             fn next(&mut self) -> Option<Self::Item> {

--- a/components/segmenter/src/iterator_helpers.rs
+++ b/components/segmenter/src/iterator_helpers.rs
@@ -5,8 +5,8 @@
 //! Macros and utilities to help implement the various iterator types.
 
 macro_rules! derive_usize_iterator_with_type {
-    ($ty:tt) => {
-        impl<'l, 's, Y: RuleBreakType<'s> + ?Sized> Iterator for $ty<'l, 's, Y> {
+    ($ty:tt, $($lt:lifetime),* ) => {
+        impl<$($lt,)* 's, Y: RuleBreakType<'s> + ?Sized> Iterator for $ty<$($lt,)* 's, Y> {
             type Item = usize;
             #[inline]
             fn next(&mut self) -> Option<Self::Item> {

--- a/components/segmenter/src/lib.rs
+++ b/components/segmenter/src/lib.rs
@@ -145,6 +145,7 @@ pub use crate::sentence::SentenceSegmenter;
 pub use crate::sentence::SentenceSegmenterBorrowed;
 pub use crate::word::WordBreakIterator;
 pub use crate::word::WordSegmenter;
+pub use crate::word::WordSegmenterBorrowed;
 
 /// Options structs and enums
 pub mod options {
@@ -175,6 +176,7 @@ pub use crate::word::WordBreakIteratorLatin1;
 pub use crate::word::WordBreakIteratorPotentiallyIllFormedUtf8;
 pub use crate::word::WordBreakIteratorUtf16;
 pub use crate::word::WordBreakIteratorUtf8;
+pub use crate::word::WordBreakIteratorWithWordType;
 
 pub(crate) mod private {
     /// Trait marking other traits that are considered unstable and should not generally be

--- a/components/segmenter/src/lib.rs
+++ b/components/segmenter/src/lib.rs
@@ -140,6 +140,7 @@ pub use crate::grapheme::GraphemeClusterSegmenter;
 pub use crate::grapheme::GraphemeClusterSegmenterBorrowed;
 pub use crate::line::LineBreakIterator;
 pub use crate::line::LineSegmenter;
+pub use crate::line::LineSegmenterBorrowed;
 pub use crate::sentence::SentenceBreakIterator;
 pub use crate::sentence::SentenceSegmenter;
 pub use crate::sentence::SentenceSegmenterBorrowed;

--- a/components/segmenter/src/lib.rs
+++ b/components/segmenter/src/lib.rs
@@ -137,6 +137,7 @@ pub mod provider;
 // Main Segmenter and BreakIterator public types
 pub use crate::grapheme::GraphemeClusterBreakIterator;
 pub use crate::grapheme::GraphemeClusterSegmenter;
+pub use crate::grapheme::GraphemeClusterSegmenterBorrowed;
 pub use crate::line::LineBreakIterator;
 pub use crate::line::LineSegmenter;
 pub use crate::sentence::SentenceBreakIterator;

--- a/components/segmenter/src/lib.rs
+++ b/components/segmenter/src/lib.rs
@@ -142,6 +142,7 @@ pub use crate::line::LineBreakIterator;
 pub use crate::line::LineSegmenter;
 pub use crate::sentence::SentenceBreakIterator;
 pub use crate::sentence::SentenceSegmenter;
+pub use crate::sentence::SentenceSegmenterBorrowed;
 pub use crate::word::WordBreakIterator;
 pub use crate::word::WordSegmenter;
 

--- a/components/segmenter/src/line.rs
+++ b/components/segmenter/src/line.rs
@@ -1306,9 +1306,7 @@ impl<'s> LineBreakType<'s> for LineBreakTypeUtf16 {
         // Restore iterator to move to head of complex string
         iterator.iter = start_iter;
         iterator.current_pos_data = start_point;
-        let breaks = iterator
-            .complex
-            .complex_language_segment_utf16(&s);
+        let breaks = iterator.complex.complex_language_segment_utf16(&s);
         iterator.result_cache = breaks;
         // result_cache vector is utf-16 index that is in BMP.
         let first_pos = *iterator.result_cache.first()?;

--- a/components/segmenter/src/line.rs
+++ b/components/segmenter/src/line.rs
@@ -208,7 +208,7 @@ pub struct LineBreakOptions<'a> {
     pub content_locale: Option<&'a LanguageIdentifier>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 struct ResolvedLineBreakOptions {
     strictness: LineBreakStrictness,
     word_option: LineBreakWordOption,
@@ -253,6 +253,9 @@ pub type LineBreakIteratorUtf16<'l, 's> = LineBreakIterator<'l, 's, LineBreakTyp
 
 /// Supports loading line break data, and creating line break iterators for different string
 /// encodings.
+///
+/// Most segmentation methods live on [`LineSegmenterBorrowed`], which can be obtained via
+/// [`LineSegmenter::new()`] or [`LineSegmenter::as_borrowed()`].
 ///
 /// The segmenter returns mandatory breaks (as defined by [definition LD7][LD7] of
 /// Unicode Standard Annex #14, _Unicode Line Breaking Algorithm_) as well as
@@ -377,6 +380,16 @@ pub struct LineSegmenter {
     complex: ComplexPayloads,
 }
 
+/// Segments a string into lines (borrowed version).
+///
+/// See [`LineSegmenter`] for examples.
+#[derive(Clone, Debug, Copy)]
+pub struct LineSegmenterBorrowed<'data> {
+    options: ResolvedLineBreakOptions,
+    data: &'data RuleBreakData<'data>,
+    complex: ComplexPayloadsBorrowed<'data>,
+}
+
 impl LineSegmenter {
     /// Constructs a [`LineSegmenter`] with an invariant locale, custom [`LineBreakOptions`], and
     /// the best available compiled data for complex scripts (Khmer, Lao, Myanmar, and Thai).
@@ -390,7 +403,7 @@ impl LineSegmenter {
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "auto")]
     #[cfg(feature = "compiled_data")]
-    pub fn new_auto(options: LineBreakOptions) -> Self {
+    pub fn new_auto(options: LineBreakOptions) -> LineSegmenterBorrowed<'static> {
         Self::new_lstm(options)
     }
 
@@ -433,13 +446,11 @@ impl LineSegmenter {
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "lstm")]
     #[cfg(feature = "compiled_data")]
-    pub fn new_lstm(options: LineBreakOptions) -> Self {
-        Self {
+    pub fn new_lstm(options: LineBreakOptions) -> LineSegmenterBorrowed<'static> {
+        LineSegmenterBorrowed {
             options: options.into(),
-            payload: DataPayload::from_static_ref(
-                crate::provider::Baked::SINGLETON_SEGMENTER_BREAK_LINE_V1,
-            ),
-            complex: ComplexPayloads::new_lstm(),
+            data: crate::provider::Baked::SINGLETON_SEGMENTER_BREAK_LINE_V1,
+            complex: ComplexPayloadsBorrowed::new_lstm(),
         }
     }
 
@@ -485,19 +496,17 @@ impl LineSegmenter {
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
-    pub fn new_dictionary(options: LineBreakOptions) -> Self {
-        Self {
+    pub fn new_dictionary(options: LineBreakOptions) -> LineSegmenterBorrowed<'static> {
+        LineSegmenterBorrowed {
             options: options.into(),
-            payload: DataPayload::from_static_ref(
-                crate::provider::Baked::SINGLETON_SEGMENTER_BREAK_LINE_V1,
-            ),
+            data: crate::provider::Baked::SINGLETON_SEGMENTER_BREAK_LINE_V1,
             // Line segmenter doesn't need to load CJ dictionary because UAX 14 rules handles CJK
             // characters [1]. Southeast Asian languages however require complex context analysis
             // [2].
             //
             // [1]: https://www.unicode.org/reports/tr14/#ID
             // [2]: https://www.unicode.org/reports/tr14/#SA
-            complex: ComplexPayloads::new_southeast_asian(),
+            complex: ComplexPayloadsBorrowed::new_southeast_asian(),
         }
     }
 
@@ -535,18 +544,31 @@ impl LineSegmenter {
         })
     }
 
+    /// Constructs a borrowed version of this type for more efficient querying.
+    ///
+    /// Most useful methods for segmentation are on this type.
+    pub fn as_borrowed(&self) -> LineSegmenterBorrowed<'_> {
+        LineSegmenterBorrowed {
+            options: self.options,
+            data: self.payload.get(),
+            complex: self.complex.as_borrowed(),
+        }
+    }
+}
+
+impl<'data> LineSegmenterBorrowed<'data> {
     /// Creates a line break iterator for an `str` (a UTF-8 string).
     ///
     /// There are always breakpoints at 0 and the string length, or only at 0 for the empty string.
-    pub fn segment_str<'l, 's>(&'l self, input: &'s str) -> LineBreakIteratorUtf8<'l, 's> {
+    pub fn segment_str<'s>(self, input: &'s str) -> LineBreakIteratorUtf8<'data, 's> {
         LineBreakIterator {
             iter: input.char_indices(),
             len: input.len(),
             current_pos_data: None,
             result_cache: Vec::new(),
-            data: self.payload.get(),
-            options: &self.options,
-            complex: &self.complex,
+            data: self.data,
+            options: self.options,
+            complex: self.complex,
         }
     }
     /// Creates a line break iterator for a potentially ill-formed UTF8 string
@@ -554,47 +576,61 @@ impl LineSegmenter {
     /// Invalid characters are treated as REPLACEMENT CHARACTER
     ///
     /// There are always breakpoints at 0 and the string length, or only at 0 for the empty string.
-    pub fn segment_utf8<'l, 's>(
-        &'l self,
+    pub fn segment_utf8<'s>(
+        self,
         input: &'s [u8],
-    ) -> LineBreakIteratorPotentiallyIllFormedUtf8<'l, 's> {
+    ) -> LineBreakIteratorPotentiallyIllFormedUtf8<'data, 's> {
         LineBreakIterator {
             iter: Utf8CharIndices::new(input),
             len: input.len(),
             current_pos_data: None,
             result_cache: Vec::new(),
-            data: self.payload.get(),
-            options: &self.options,
-            complex: &self.complex,
+            data: self.data,
+            options: self.options,
+            complex: self.complex,
         }
     }
     /// Creates a line break iterator for a Latin-1 (8-bit) string.
     ///
     /// There are always breakpoints at 0 and the string length, or only at 0 for the empty string.
-    pub fn segment_latin1<'l, 's>(&'l self, input: &'s [u8]) -> LineBreakIteratorLatin1<'l, 's> {
+    pub fn segment_latin1<'s>(self, input: &'s [u8]) -> LineBreakIteratorLatin1<'data, 's> {
         LineBreakIterator {
             iter: Latin1Indices::new(input),
             len: input.len(),
             current_pos_data: None,
             result_cache: Vec::new(),
-            data: self.payload.get(),
-            options: &self.options,
-            complex: &self.complex,
+            data: self.data,
+            options: self.options,
+            complex: self.complex,
         }
     }
 
     /// Creates a line break iterator for a UTF-16 string.
     ///
     /// There are always breakpoints at 0 and the string length, or only at 0 for the empty string.
-    pub fn segment_utf16<'l, 's>(&'l self, input: &'s [u16]) -> LineBreakIteratorUtf16<'l, 's> {
+    pub fn segment_utf16<'s>(self, input: &'s [u16]) -> LineBreakIteratorUtf16<'data, 's> {
         LineBreakIterator {
             iter: Utf16Indices::new(input),
             len: input.len(),
             current_pos_data: None,
             result_cache: Vec::new(),
-            data: self.payload.get(),
-            options: &self.options,
-            complex: &self.complex,
+            data: self.data,
+            options: self.options,
+            complex: self.complex,
+        }
+    }
+}
+
+impl LineSegmenterBorrowed<'static> {
+    /// Cheaply converts a [`LineSegmenterBorrowed<'static>`] into a [`LineSegmenter`].
+    ///
+    /// Note: Due to branching and indirection, using [`LineSegmenter`] might inhibit some
+    /// compile-time optimizations that are possible with [`LineSegmenterBorrowed`].
+    pub fn static_to_owned(self) -> LineSegmenter {
+        LineSegmenter {
+            payload: DataPayload::from_static_ref(self.data),
+            complex: self.complex.static_to_owned(),
+            options: self.options,
         }
     }
 }
@@ -713,7 +749,7 @@ fn is_break_utf32_by_loose(
 /// 🚫 This trait is sealed; it cannot be implemented by user code. If an API requests an item that implements this
 /// trait, please consider using a type from the implementors listed below.
 /// </div>
-pub trait LineBreakType<'l, 's>: crate::private::Sealed {
+pub trait LineBreakType<'s>: crate::private::Sealed {
     /// The iterator over characters.
     type IterAttr: Iterator<Item = (usize, Self::CharType)> + Clone;
 
@@ -721,20 +757,20 @@ pub trait LineBreakType<'l, 's>: crate::private::Sealed {
     type CharType: Copy + Into<u32>;
 
     #[doc(hidden)]
-    fn use_complex_breaking(iterator: &LineBreakIterator<'l, 's, Self>, c: Self::CharType) -> bool;
+    fn use_complex_breaking(iterator: &LineBreakIterator<'_, 's, Self>, c: Self::CharType) -> bool;
 
     #[doc(hidden)]
     fn get_linebreak_property_with_rule(
-        iterator: &LineBreakIterator<'l, 's, Self>,
+        iterator: &LineBreakIterator<'_, 's, Self>,
         c: Self::CharType,
     ) -> u8;
 
     #[doc(hidden)]
-    fn get_current_position_character_len(iterator: &LineBreakIterator<'l, 's, Self>) -> usize;
+    fn get_current_position_character_len(iterator: &LineBreakIterator<'_, 's, Self>) -> usize;
 
     #[doc(hidden)]
     fn handle_complex_language(
-        iterator: &mut LineBreakIterator<'l, 's, Self>,
+        iterator: &mut LineBreakIterator<'_, 's, Self>,
         left_codepoint: Self::CharType,
     ) -> Option<usize>;
 }
@@ -752,17 +788,17 @@ pub trait LineBreakType<'l, 's>: crate::private::Sealed {
 ///
 /// For examples of use, see [`LineSegmenter`].
 #[derive(Debug)]
-pub struct LineBreakIterator<'l, 's, Y: LineBreakType<'l, 's> + ?Sized> {
+pub struct LineBreakIterator<'data, 's, Y: LineBreakType<'s> + ?Sized> {
     iter: Y::IterAttr,
     len: usize,
     current_pos_data: Option<(usize, Y::CharType)>,
     result_cache: Vec<usize>,
-    data: &'l RuleBreakData<'l>,
-    options: &'l ResolvedLineBreakOptions,
-    complex: &'l ComplexPayloads,
+    data: &'data RuleBreakData<'data>,
+    options: ResolvedLineBreakOptions,
+    complex: ComplexPayloadsBorrowed<'data>,
 }
 
-impl<'l, 's, Y: LineBreakType<'l, 's>> Iterator for LineBreakIterator<'l, 's, Y> {
+impl<'data, 's, Y: LineBreakType<'s>> Iterator for LineBreakIterator<'data, 's, Y> {
     type Item = usize;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -1008,7 +1044,7 @@ enum StringBoundaryPosType {
     End,
 }
 
-impl<'l, 's, Y: LineBreakType<'l, 's>> LineBreakIterator<'l, 's, Y> {
+impl<'data, 's, Y: LineBreakType<'s>> LineBreakIterator<'data, 's, Y> {
     fn advance_iter(&mut self) {
         self.current_pos_data = self.iter.next();
     }
@@ -1069,7 +1105,7 @@ pub struct LineBreakTypeUtf8;
 
 impl crate::private::Sealed for LineBreakTypeUtf8 {}
 
-impl<'l, 's> LineBreakType<'l, 's> for LineBreakTypeUtf8 {
+impl<'s> LineBreakType<'s> for LineBreakTypeUtf8 {
     type IterAttr = CharIndices<'s>;
     type CharType = char;
 
@@ -1091,7 +1127,7 @@ impl<'l, 's> LineBreakType<'l, 's> for LineBreakTypeUtf8 {
     }
 
     fn handle_complex_language(
-        iter: &mut LineBreakIterator<'l, 's, Self>,
+        iter: &mut LineBreakIterator<'_, 's, Self>,
         left_codepoint: char,
     ) -> Option<usize> {
         handle_complex_language_utf8(iter, left_codepoint)
@@ -1103,7 +1139,7 @@ pub struct LineBreakTypePotentiallyIllFormedUtf8;
 
 impl crate::private::Sealed for LineBreakTypePotentiallyIllFormedUtf8 {}
 
-impl<'l, 's> LineBreakType<'l, 's> for LineBreakTypePotentiallyIllFormedUtf8 {
+impl<'s> LineBreakType<'s> for LineBreakTypePotentiallyIllFormedUtf8 {
     type IterAttr = Utf8CharIndices<'s>;
     type CharType = char;
 
@@ -1125,19 +1161,19 @@ impl<'l, 's> LineBreakType<'l, 's> for LineBreakTypePotentiallyIllFormedUtf8 {
     }
 
     fn handle_complex_language(
-        iter: &mut LineBreakIterator<'l, 's, Self>,
+        iter: &mut LineBreakIterator<'_, 's, Self>,
         left_codepoint: char,
     ) -> Option<usize> {
         handle_complex_language_utf8(iter, left_codepoint)
     }
 }
 /// handle_complex_language impl for UTF8 iterators
-fn handle_complex_language_utf8<'l, 's, T>(
-    iter: &mut LineBreakIterator<'l, 's, T>,
+fn handle_complex_language_utf8<'data, 's, T>(
+    iter: &mut LineBreakIterator<'data, 's, T>,
     left_codepoint: char,
 ) -> Option<usize>
 where
-    T: LineBreakType<'l, 's, CharType = char>,
+    T: LineBreakType<'s, CharType = char>,
 {
     // word segmenter doesn't define break rules for some languages such as Thai.
     let start_iter = iter.iter.clone();
@@ -1161,7 +1197,7 @@ where
     // Restore iterator to move to head of complex string
     iter.iter = start_iter;
     iter.current_pos_data = start_point;
-    let breaks = iter.complex.as_borrowed().complex_language_segment_str(&s);
+    let breaks = iter.complex.complex_language_segment_str(&s);
     iter.result_cache = breaks;
     let first_pos = *iter.result_cache.first()?;
     let mut i = left_codepoint.len_utf8();
@@ -1189,7 +1225,7 @@ where
 pub struct LineBreakTypeLatin1;
 impl crate::private::Sealed for LineBreakTypeLatin1 {}
 
-impl<'s> LineBreakType<'_, 's> for LineBreakTypeLatin1 {
+impl<'s> LineBreakType<'s> for LineBreakTypeLatin1 {
     type IterAttr = Latin1Indices<'s>;
     type CharType = u8;
 
@@ -1220,7 +1256,7 @@ impl<'s> LineBreakType<'_, 's> for LineBreakTypeLatin1 {
 pub struct LineBreakTypeUtf16;
 impl crate::private::Sealed for LineBreakTypeUtf16 {}
 
-impl<'s> LineBreakType<'_, 's> for LineBreakTypeUtf16 {
+impl<'s> LineBreakType<'s> for LineBreakTypeUtf16 {
     type IterAttr = Utf16Indices<'s>;
     type CharType = u32;
 
@@ -1272,7 +1308,6 @@ impl<'s> LineBreakType<'_, 's> for LineBreakTypeUtf16 {
         iterator.current_pos_data = start_point;
         let breaks = iterator
             .complex
-            .as_borrowed()
             .complex_language_segment_utf16(&s);
         iterator.result_cache = breaks;
         // result_cache vector is utf-16 index that is in BMP.

--- a/components/segmenter/src/line.rs
+++ b/components/segmenter/src/line.rs
@@ -1481,6 +1481,7 @@ mod tests {
         let segmenter =
             LineSegmenter::try_new_dictionary_unstable(&crate::provider::Baked, Default::default())
                 .expect("Data exists");
+        let segmenter = segmenter.as_borrowed();
 
         let mut iter = segmenter.segment_str("hello world");
         assert_eq!(Some(0), iter.next());

--- a/components/segmenter/src/line.rs
+++ b/components/segmenter/src/line.rs
@@ -1161,7 +1161,7 @@ where
     // Restore iterator to move to head of complex string
     iter.iter = start_iter;
     iter.current_pos_data = start_point;
-    let breaks = complex_language_segment_str(iter.complex, &s);
+    let breaks = iter.complex.as_borrowed().complex_language_segment_str(&s);
     iter.result_cache = breaks;
     let first_pos = *iter.result_cache.first()?;
     let mut i = left_codepoint.len_utf8();
@@ -1270,7 +1270,10 @@ impl<'s> LineBreakType<'_, 's> for LineBreakTypeUtf16 {
         // Restore iterator to move to head of complex string
         iterator.iter = start_iter;
         iterator.current_pos_data = start_point;
-        let breaks = complex_language_segment_utf16(iterator.complex, &s);
+        let breaks = iterator
+            .complex
+            .as_borrowed()
+            .complex_language_segment_utf16(&s);
         iterator.result_cache = breaks;
         // result_cache vector is utf-16 index that is in BMP.
         let first_pos = *iterator.result_cache.first()?;

--- a/components/segmenter/src/line.rs
+++ b/components/segmenter/src/line.rs
@@ -798,7 +798,7 @@ pub struct LineBreakIterator<'data, 's, Y: LineBreakType<'s> + ?Sized> {
     complex: ComplexPayloadsBorrowed<'data>,
 }
 
-impl<'data, 's, Y: LineBreakType<'s>> Iterator for LineBreakIterator<'data, 's, Y> {
+impl<'s, Y: LineBreakType<'s>> Iterator for LineBreakIterator<'_, 's, Y> {
     type Item = usize;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -1044,7 +1044,7 @@ enum StringBoundaryPosType {
     End,
 }
 
-impl<'data, 's, Y: LineBreakType<'s>> LineBreakIterator<'data, 's, Y> {
+impl<'s, Y: LineBreakType<'s>> LineBreakIterator<'_, 's, Y> {
     fn advance_iter(&mut self) {
         self.current_pos_data = self.iter.next();
     }

--- a/components/segmenter/src/line.rs
+++ b/components/segmenter/src/line.rs
@@ -255,7 +255,7 @@ pub type LineBreakIteratorUtf16<'l, 's> = LineBreakIterator<'l, 's, LineBreakTyp
 /// encodings.
 ///
 /// Most segmentation methods live on [`LineSegmenterBorrowed`], which can be obtained via
-/// [`LineSegmenter::new()`] or [`LineSegmenter::as_borrowed()`].
+/// [`LineSegmenter::new_auto()`] (etc) or [`LineSegmenter::as_borrowed()`].
 ///
 /// The segmenter returns mandatory breaks (as defined by [definition LD7][LD7] of
 /// Unicode Standard Annex #14, _Unicode Line Breaking Algorithm_) as well as

--- a/components/segmenter/src/rule_segmenter.rs
+++ b/components/segmenter/src/rule_segmenter.rs
@@ -24,13 +24,13 @@ pub trait RuleBreakType<'s>: crate::private::Sealed {
     type CharType: Copy + Into<u32> + core::fmt::Debug;
 
     #[doc(hidden)]
-    fn get_current_position_character_len<'l, 'data>(
-        iter: &RuleBreakIterator<'l, 'data, 's, Self>,
+    fn get_current_position_character_len<'data>(
+        iter: &RuleBreakIterator<'data, 's, Self>,
     ) -> usize;
 
     #[doc(hidden)]
-    fn handle_complex_language<'l, 'data>(
-        iter: &mut RuleBreakIterator<'l, 'data, 's, Self>,
+    fn handle_complex_language<'data>(
+        iter: &mut RuleBreakIterator<'data, 's, Self>,
         left_codepoint: Self::CharType,
     ) -> Option<usize>;
 }
@@ -49,20 +49,18 @@ pub trait RuleBreakType<'s>: crate::private::Sealed {
 /// _after_ the boundary (for a boundary at the end of text, this index is the length
 /// of the [`str`] or array of code units).
 #[derive(Debug)]
-pub struct RuleBreakIterator<'l, 'data, 's, Y: RuleBreakType<'s> + ?Sized> {
+pub struct RuleBreakIterator<'data, 's, Y: RuleBreakType<'s> + ?Sized> {
     pub(crate) iter: Y::IterAttr,
     pub(crate) len: usize,
     pub(crate) current_pos_data: Option<(usize, Y::CharType)>,
     pub(crate) result_cache: alloc::vec::Vec<usize>,
-    pub(crate) data: &'l RuleBreakData<'data>,
+    pub(crate) data: &'data RuleBreakData<'data>,
     pub(crate) complex: Option<ComplexPayloadsBorrowed<'data>>,
     pub(crate) boundary_property: u8,
-    pub(crate) locale_override: Option<&'l RuleBreakDataOverride<'data>>,
+    pub(crate) locale_override: Option<&'data RuleBreakDataOverride<'data>>,
 }
 
-impl<'l, 'data, 's, Y: RuleBreakType<'s> + ?Sized> Iterator
-    for RuleBreakIterator<'l, 'data, 's, Y>
-{
+impl<'data, 's, Y: RuleBreakType<'s> + ?Sized> Iterator for RuleBreakIterator<'data, 's, Y> {
     type Item = usize;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -201,7 +199,7 @@ impl<'l, 'data, 's, Y: RuleBreakType<'s> + ?Sized> Iterator
     }
 }
 
-impl<'l, 'data, 's, Y: RuleBreakType<'s> + ?Sized> RuleBreakIterator<'l, 'data, 's, Y> {
+impl<'data, 's, Y: RuleBreakType<'s> + ?Sized> RuleBreakIterator<'data, 's, Y> {
     pub(crate) fn advance_iter(&mut self) {
         self.current_pos_data = self.iter.next();
     }

--- a/components/segmenter/src/rule_segmenter.rs
+++ b/components/segmenter/src/rule_segmenter.rs
@@ -16,7 +16,7 @@ use utf8_iter::Utf8CharIndices;
 /// 🚫 This trait is sealed; it cannot be implemented by user code. If an API requests an item that implements this
 /// trait, please consider using a type from the implementors listed below.
 /// </div>
-pub trait RuleBreakType<'l, 's>: crate::private::Sealed {
+pub trait RuleBreakType<'s>: crate::private::Sealed {
     /// The iterator over characters.
     type IterAttr: Iterator<Item = (usize, Self::CharType)> + Clone + core::fmt::Debug;
 
@@ -24,10 +24,10 @@ pub trait RuleBreakType<'l, 's>: crate::private::Sealed {
     type CharType: Copy + Into<u32> + core::fmt::Debug;
 
     #[doc(hidden)]
-    fn get_current_position_character_len(iter: &RuleBreakIterator<'l, 's, Self>) -> usize;
+    fn get_current_position_character_len<'l>(iter: &RuleBreakIterator<'l, 's, Self>) -> usize;
 
     #[doc(hidden)]
-    fn handle_complex_language(
+    fn handle_complex_language<'l>(
         iter: &mut RuleBreakIterator<'l, 's, Self>,
         left_codepoint: Self::CharType,
     ) -> Option<usize>;
@@ -44,7 +44,7 @@ pub trait RuleBreakType<'l, 's>: crate::private::Sealed {
 /// _after_ the boundary (for a boundary at the end of text, this index is the length
 /// of the [`str`] or array of code units).
 #[derive(Debug)]
-pub struct RuleBreakIterator<'l, 's, Y: RuleBreakType<'l, 's> + ?Sized> {
+pub struct RuleBreakIterator<'l, 's, Y: RuleBreakType<'s> + ?Sized> {
     pub(crate) iter: Y::IterAttr,
     pub(crate) len: usize,
     pub(crate) current_pos_data: Option<(usize, Y::CharType)>,
@@ -55,7 +55,7 @@ pub struct RuleBreakIterator<'l, 's, Y: RuleBreakType<'l, 's> + ?Sized> {
     pub(crate) locale_override: Option<&'l RuleBreakDataOverride<'l>>,
 }
 
-impl<'l, 's, Y: RuleBreakType<'l, 's> + ?Sized> Iterator for RuleBreakIterator<'l, 's, Y> {
+impl<'l, 's, Y: RuleBreakType<'s> + ?Sized> Iterator for RuleBreakIterator<'l, 's, Y> {
     type Item = usize;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -194,7 +194,7 @@ impl<'l, 's, Y: RuleBreakType<'l, 's> + ?Sized> Iterator for RuleBreakIterator<'
     }
 }
 
-impl<'l, 's, Y: RuleBreakType<'l, 's> + ?Sized> RuleBreakIterator<'l, 's, Y> {
+impl<'l, 's, Y: RuleBreakType<'s> + ?Sized> RuleBreakIterator<'l, 's, Y> {
     pub(crate) fn advance_iter(&mut self) {
         self.current_pos_data = self.iter.next();
     }
@@ -267,7 +267,7 @@ pub struct RuleBreakTypeUtf8;
 
 impl crate::private::Sealed for RuleBreakTypeUtf8 {}
 
-impl<'s> RuleBreakType<'_, 's> for RuleBreakTypeUtf8 {
+impl<'s> RuleBreakType<'s> for RuleBreakTypeUtf8 {
     type IterAttr = CharIndices<'s>;
     type CharType = char;
 
@@ -288,7 +288,7 @@ pub struct RuleBreakTypePotentiallyIllFormedUtf8;
 
 impl crate::private::Sealed for RuleBreakTypePotentiallyIllFormedUtf8 {}
 
-impl<'s> RuleBreakType<'_, 's> for RuleBreakTypePotentiallyIllFormedUtf8 {
+impl<'s> RuleBreakType<'s> for RuleBreakTypePotentiallyIllFormedUtf8 {
     type IterAttr = Utf8CharIndices<'s>;
     type CharType = char;
 
@@ -309,7 +309,7 @@ pub struct RuleBreakTypeLatin1;
 
 impl crate::private::Sealed for RuleBreakTypeLatin1 {}
 
-impl<'s> RuleBreakType<'_, 's> for RuleBreakTypeLatin1 {
+impl<'s> RuleBreakType<'s> for RuleBreakTypeLatin1 {
     type IterAttr = Latin1Indices<'s>;
     type CharType = u8;
 
@@ -330,7 +330,7 @@ pub struct RuleBreakTypeUtf16;
 
 impl crate::private::Sealed for RuleBreakTypeUtf16 {}
 
-impl<'s> RuleBreakType<'_, 's> for RuleBreakTypeUtf16 {
+impl<'s> RuleBreakType<'s> for RuleBreakTypeUtf16 {
     type IterAttr = Utf16Indices<'s>;
     type CharType = u32;
 

--- a/components/segmenter/src/rule_segmenter.rs
+++ b/components/segmenter/src/rule_segmenter.rs
@@ -60,7 +60,7 @@ pub struct RuleBreakIterator<'data, 's, Y: RuleBreakType<'s> + ?Sized> {
     pub(crate) locale_override: Option<&'data RuleBreakDataOverride<'data>>,
 }
 
-impl<'data, 's, Y: RuleBreakType<'s> + ?Sized> Iterator for RuleBreakIterator<'data, 's, Y> {
+impl<'s, Y: RuleBreakType<'s> + ?Sized> Iterator for RuleBreakIterator<'_, 's, Y> {
     type Item = usize;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -199,7 +199,7 @@ impl<'data, 's, Y: RuleBreakType<'s> + ?Sized> Iterator for RuleBreakIterator<'d
     }
 }
 
-impl<'data, 's, Y: RuleBreakType<'s> + ?Sized> RuleBreakIterator<'data, 's, Y> {
+impl<'s, Y: RuleBreakType<'s> + ?Sized> RuleBreakIterator<'_, 's, Y> {
     pub(crate) fn advance_iter(&mut self) {
         self.current_pos_data = self.iter.next();
     }

--- a/components/segmenter/src/rule_segmenter.rs
+++ b/components/segmenter/src/rule_segmenter.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use crate::complex::ComplexPayloads;
+use crate::complex::ComplexPayloadsBorrowed;
 use crate::indices::{Latin1Indices, Utf16Indices};
 use crate::options::WordType;
 use crate::provider::*;
@@ -50,7 +50,7 @@ pub struct RuleBreakIterator<'l, 's, Y: RuleBreakType<'s> + ?Sized> {
     pub(crate) current_pos_data: Option<(usize, Y::CharType)>,
     pub(crate) result_cache: alloc::vec::Vec<usize>,
     pub(crate) data: &'l RuleBreakData<'l>,
-    pub(crate) complex: Option<&'l ComplexPayloads>,
+    pub(crate) complex: Option<ComplexPayloadsBorrowed<'l>>,
     pub(crate) boundary_property: u8,
     pub(crate) locale_override: Option<&'l RuleBreakDataOverride<'l>>,
 }

--- a/components/segmenter/src/sentence.rs
+++ b/components/segmenter/src/sentence.rs
@@ -43,7 +43,7 @@ pub struct SentenceBreakInvariantOptions {}
 /// For examples of use, see [`SentenceSegmenter`].
 #[derive(Debug)]
 pub struct SentenceBreakIterator<'l, 's, Y: RuleBreakType<'s> + ?Sized>(
-    RuleBreakIterator<'l, 's, Y>,
+    RuleBreakIterator<'l, 'l, 's, Y>,
 );
 
 derive_usize_iterator_with_type!(SentenceBreakIterator);

--- a/components/segmenter/src/sentence.rs
+++ b/components/segmenter/src/sentence.rs
@@ -146,7 +146,9 @@ impl SentenceSegmenter {
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
-    pub const fn new(_options: SentenceBreakInvariantOptions) -> SentenceSegmenterBorrowed<'static> {
+    pub const fn new(
+        _options: SentenceBreakInvariantOptions,
+    ) -> SentenceSegmenterBorrowed<'static> {
         SentenceSegmenterBorrowed {
             data: crate::provider::Baked::SINGLETON_SEGMENTER_BREAK_SENTENCE_V1,
             locale_override: None,

--- a/components/segmenter/src/sentence.rs
+++ b/components/segmenter/src/sentence.rs
@@ -42,7 +42,7 @@ pub struct SentenceBreakInvariantOptions {}
 ///
 /// For examples of use, see [`SentenceSegmenter`].
 #[derive(Debug)]
-pub struct SentenceBreakIterator<'l, 's, Y: RuleBreakType<'l, 's> + ?Sized>(
+pub struct SentenceBreakIterator<'l, 's, Y: RuleBreakType<'s> + ?Sized>(
     RuleBreakIterator<'l, 's, Y>,
 );
 

--- a/components/segmenter/src/sentence.rs
+++ b/components/segmenter/src/sentence.rs
@@ -33,7 +33,7 @@ pub struct SentenceBreakInvariantOptions {}
 ///
 /// Lifetimes:
 ///
-/// - `'l` = lifetime of the segmenter object from which this iterator was created
+/// - `'data` = lifetime of the segmenter object from which this iterator was created
 /// - `'s` = lifetime of the string being segmented
 ///
 /// The [`Iterator::Item`] is an [`usize`] representing index of a code unit
@@ -42,32 +42,34 @@ pub struct SentenceBreakInvariantOptions {}
 ///
 /// For examples of use, see [`SentenceSegmenter`].
 #[derive(Debug)]
-pub struct SentenceBreakIterator<'l, 's, Y: RuleBreakType<'s> + ?Sized>(
-    RuleBreakIterator<'l, 'l, 's, Y>,
+pub struct SentenceBreakIterator<'data, 's, Y: RuleBreakType<'s> + ?Sized>(
+    RuleBreakIterator<'data, 's, Y>,
 );
 
-derive_usize_iterator_with_type!(SentenceBreakIterator);
+derive_usize_iterator_with_type!(SentenceBreakIterator, 'data);
 
 /// Sentence break iterator for an `str` (a UTF-8 string).
 ///
 /// For examples of use, see [`SentenceSegmenter`].
-pub type SentenceBreakIteratorUtf8<'l, 's> = SentenceBreakIterator<'l, 's, RuleBreakTypeUtf8>;
+pub type SentenceBreakIteratorUtf8<'data, 's> = SentenceBreakIterator<'data, 's, RuleBreakTypeUtf8>;
 
 /// Sentence break iterator for a potentially invalid UTF-8 string.
 ///
 /// For examples of use, see [`SentenceSegmenter`].
-pub type SentenceBreakIteratorPotentiallyIllFormedUtf8<'l, 's> =
-    SentenceBreakIterator<'l, 's, RuleBreakTypePotentiallyIllFormedUtf8>;
+pub type SentenceBreakIteratorPotentiallyIllFormedUtf8<'data, 's> =
+    SentenceBreakIterator<'data, 's, RuleBreakTypePotentiallyIllFormedUtf8>;
 
 /// Sentence break iterator for a Latin-1 (8-bit) string.
 ///
 /// For examples of use, see [`SentenceSegmenter`].
-pub type SentenceBreakIteratorLatin1<'l, 's> = SentenceBreakIterator<'l, 's, RuleBreakTypeLatin1>;
+pub type SentenceBreakIteratorLatin1<'data, 's> =
+    SentenceBreakIterator<'data, 's, RuleBreakTypeLatin1>;
 
 /// Sentence break iterator for a UTF-16 string.
 ///
 /// For examples of use, see [`SentenceSegmenter`].
-pub type SentenceBreakIteratorUtf16<'l, 's> = SentenceBreakIterator<'l, 's, RuleBreakTypeUtf16>;
+pub type SentenceBreakIteratorUtf16<'data, 's> =
+    SentenceBreakIterator<'data, 's, RuleBreakTypeUtf16>;
 
 /// Supports loading sentence break data, and creating sentence break iterators for different string
 /// encodings.

--- a/components/segmenter/src/sentence.rs
+++ b/components/segmenter/src/sentence.rs
@@ -148,6 +148,7 @@ impl SentenceSegmenter {
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
+    #[allow(clippy::new_ret_no_self)]
     pub const fn new(
         _options: SentenceBreakInvariantOptions,
     ) -> SentenceSegmenterBorrowed<'static> {

--- a/components/segmenter/src/word.rs
+++ b/components/segmenter/src/word.rs
@@ -45,7 +45,9 @@ pub struct WordBreakInvariantOptions {}
 ///
 /// For examples of use, see [`WordSegmenter`].
 #[derive(Debug)]
-pub struct WordBreakIterator<'l, 's, Y: RuleBreakType<'s> + ?Sized>(RuleBreakIterator<'l, 's, Y>);
+pub struct WordBreakIterator<'l, 's, Y: RuleBreakType<'s> + ?Sized>(
+    RuleBreakIterator<'l, 'l, 's, Y>,
+);
 
 derive_usize_iterator_with_type!(WordBreakIterator);
 
@@ -558,7 +560,7 @@ impl<'l, 's> RuleBreakType<'s> for WordBreakTypeUtf8 {
     }
 
     fn handle_complex_language(
-        iter: &mut RuleBreakIterator<'_, 's, Self>,
+        iter: &mut RuleBreakIterator<'_, '_, 's, Self>,
         left_codepoint: Self::CharType,
     ) -> Option<usize> {
         handle_complex_language_utf8(iter, left_codepoint)
@@ -578,7 +580,7 @@ impl<'l, 's> RuleBreakType<'s> for WordBreakTypePotentiallyIllFormedUtf8 {
     }
 
     fn handle_complex_language(
-        iter: &mut RuleBreakIterator<'_, 's, Self>,
+        iter: &mut RuleBreakIterator<'_, '_, 's, Self>,
         left_codepoint: Self::CharType,
     ) -> Option<usize> {
         handle_complex_language_utf8(iter, left_codepoint)
@@ -586,8 +588,8 @@ impl<'l, 's> RuleBreakType<'s> for WordBreakTypePotentiallyIllFormedUtf8 {
 }
 
 /// handle_complex_language impl for UTF8 iterators
-fn handle_complex_language_utf8<'l, 's, T>(
-    iter: &mut RuleBreakIterator<'l, 's, T>,
+fn handle_complex_language_utf8<'l, 'data, 's, T>(
+    iter: &mut RuleBreakIterator<'l, 'data, 's, T>,
     left_codepoint: T::CharType,
 ) -> Option<usize>
 where

--- a/components/segmenter/src/word.rs
+++ b/components/segmenter/src/word.rs
@@ -103,9 +103,7 @@ pub struct WordBreakIteratorWithWordType<'data, 's, Y: RuleBreakType<'s> + ?Size
 impl<'s, Y: RuleBreakType<'s> + ?Sized> Iterator for WordBreakIteratorWithWordType<'_, 's, Y> {
     type Item = (usize, WordType);
     fn next(&mut self) -> Option<Self::Item> {
-        let Some(ret) = self.0.next() else {
-            return None;
-        };
+        let ret = self.0.next()?;
         Some((ret, self.0 .0.word_type()))
     }
 }
@@ -573,7 +571,7 @@ impl WordSegmenterBorrowed<'static> {
     pub fn static_to_owned(self) -> WordSegmenter {
         let payload_locale_override = self
             .locale_override
-            .map(|d| DataPayload::from_static_ref(d));
+            .map(DataPayload::from_static_ref);
         WordSegmenter {
             payload: DataPayload::from_static_ref(self.data),
             complex: self.complex.static_to_owned(),
@@ -586,7 +584,7 @@ impl WordSegmenterBorrowed<'static> {
 pub struct WordBreakTypeUtf8;
 impl crate::private::Sealed for WordBreakTypeUtf8 {}
 
-impl<'l, 's> RuleBreakType<'s> for WordBreakTypeUtf8 {
+impl<'s> RuleBreakType<'s> for WordBreakTypeUtf8 {
     type IterAttr = CharIndices<'s>;
     type CharType = char;
 
@@ -606,7 +604,7 @@ impl<'l, 's> RuleBreakType<'s> for WordBreakTypeUtf8 {
 pub struct WordBreakTypePotentiallyIllFormedUtf8;
 impl crate::private::Sealed for WordBreakTypePotentiallyIllFormedUtf8 {}
 
-impl<'l, 's> RuleBreakType<'s> for WordBreakTypePotentiallyIllFormedUtf8 {
+impl<'s> RuleBreakType<'s> for WordBreakTypePotentiallyIllFormedUtf8 {
     type IterAttr = Utf8CharIndices<'s>;
     type CharType = char;
 

--- a/components/segmenter/src/word.rs
+++ b/components/segmenter/src/word.rs
@@ -45,7 +45,7 @@ pub struct WordBreakInvariantOptions {}
 ///
 /// For examples of use, see [`WordSegmenter`].
 #[derive(Debug)]
-pub struct WordBreakIterator<'l, 's, Y: RuleBreakType<'l, 's> + ?Sized>(
+pub struct WordBreakIterator<'l, 's, Y: RuleBreakType<'s> + ?Sized>(
     RuleBreakIterator<'l, 's, Y>,
 );
 
@@ -73,7 +73,7 @@ impl WordType {
     }
 }
 
-impl<'l, 's, Y: RuleBreakType<'l, 's> + ?Sized> WordBreakIterator<'l, 's, Y> {
+impl<'l, 's, Y: RuleBreakType<'s> + ?Sized> WordBreakIterator<'l, 's, Y> {
     /// Returns the word type of the segment preceding the current boundary.
     #[inline]
     pub fn word_type(&self) -> WordType {
@@ -551,7 +551,7 @@ impl WordSegmenter {
 pub struct WordBreakTypeUtf8;
 impl crate::private::Sealed for WordBreakTypeUtf8 {}
 
-impl<'l, 's> RuleBreakType<'l, 's> for WordBreakTypeUtf8 {
+impl<'l, 's> RuleBreakType<'s> for WordBreakTypeUtf8 {
     type IterAttr = CharIndices<'s>;
     type CharType = char;
 
@@ -560,7 +560,7 @@ impl<'l, 's> RuleBreakType<'l, 's> for WordBreakTypeUtf8 {
     }
 
     fn handle_complex_language(
-        iter: &mut RuleBreakIterator<'l, 's, Self>,
+        iter: &mut RuleBreakIterator<'_, 's, Self>,
         left_codepoint: Self::CharType,
     ) -> Option<usize> {
         handle_complex_language_utf8(iter, left_codepoint)
@@ -571,7 +571,7 @@ impl<'l, 's> RuleBreakType<'l, 's> for WordBreakTypeUtf8 {
 pub struct WordBreakTypePotentiallyIllFormedUtf8;
 impl crate::private::Sealed for WordBreakTypePotentiallyIllFormedUtf8 {}
 
-impl<'l, 's> RuleBreakType<'l, 's> for WordBreakTypePotentiallyIllFormedUtf8 {
+impl<'l, 's> RuleBreakType<'s> for WordBreakTypePotentiallyIllFormedUtf8 {
     type IterAttr = Utf8CharIndices<'s>;
     type CharType = char;
 
@@ -580,7 +580,7 @@ impl<'l, 's> RuleBreakType<'l, 's> for WordBreakTypePotentiallyIllFormedUtf8 {
     }
 
     fn handle_complex_language(
-        iter: &mut RuleBreakIterator<'l, 's, Self>,
+        iter: &mut RuleBreakIterator<'_, 's, Self>,
         left_codepoint: Self::CharType,
     ) -> Option<usize> {
         handle_complex_language_utf8(iter, left_codepoint)
@@ -593,7 +593,7 @@ fn handle_complex_language_utf8<'l, 's, T>(
     left_codepoint: T::CharType,
 ) -> Option<usize>
 where
-    T: RuleBreakType<'l, 's, CharType = char>,
+    T: RuleBreakType<'s, CharType = char>,
 {
     // word segmenter doesn't define break rules for some languages such as Thai.
     let start_iter = iter.iter.clone();
@@ -651,7 +651,7 @@ pub struct WordBreakTypeUtf16;
 
 impl crate::private::Sealed for WordBreakTypeUtf16 {}
 
-impl<'s> RuleBreakType<'_, 's> for WordBreakTypeUtf16 {
+impl<'s> RuleBreakType<'s> for WordBreakTypeUtf16 {
     type IterAttr = Utf16Indices<'s>;
     type CharType = u32;
 

--- a/components/segmenter/src/word.rs
+++ b/components/segmenter/src/word.rs
@@ -45,11 +45,11 @@ pub struct WordBreakInvariantOptions {}
 ///
 /// For examples of use, see [`WordSegmenter`].
 #[derive(Debug)]
-pub struct WordBreakIterator<'l, 's, Y: RuleBreakType<'s> + ?Sized>(
-    RuleBreakIterator<'l, 'l, 's, Y>,
+pub struct WordBreakIterator<'data, 's, Y: RuleBreakType<'s> + ?Sized>(
+    RuleBreakIterator<'data, 's, Y>,
 );
 
-derive_usize_iterator_with_type!(WordBreakIterator);
+derive_usize_iterator_with_type!(WordBreakIterator, 'data);
 
 /// The word type tag that is returned by [`WordBreakIterator::word_type()`].
 #[non_exhaustive]
@@ -73,7 +73,7 @@ impl WordType {
     }
 }
 
-impl<'l, 's, Y: RuleBreakType<'s> + ?Sized> WordBreakIterator<'l, 's, Y> {
+impl<'data, 's, Y: RuleBreakType<'s> + ?Sized> WordBreakIterator<'data, 's, Y> {
     /// Returns the word type of the segment preceding the current boundary.
     #[inline]
     pub fn word_type(&self) -> WordType {
@@ -81,10 +81,8 @@ impl<'l, 's, Y: RuleBreakType<'s> + ?Sized> WordBreakIterator<'l, 's, Y> {
     }
 
     /// Returns an iterator over pairs of boundary position and word type.
-    pub fn iter_with_word_type<'i: 'l + 's>(
-        &'i mut self,
-    ) -> impl Iterator<Item = (usize, WordType)> + 'i {
-        core::iter::from_fn(move || self.next().map(|i| (i, self.word_type())))
+    pub fn iter_with_word_type(self) -> WordBreakIteratorWithWordType<'data, 's, Y> {
+        WordBreakIteratorWithWordType(self)
     }
 
     /// Returns `true` when the segment preceding the current boundary is word-like,
@@ -95,29 +93,51 @@ impl<'l, 's, Y: RuleBreakType<'s> + ?Sized> WordBreakIterator<'l, 's, Y> {
     }
 }
 
+/// Word break iterator that also returns the word type
+// We can use impl Trait here once `use<..>` syntax is available, see https://github.com/rust-lang/rust/issues/61756
+#[derive(Debug)]
+pub struct WordBreakIteratorWithWordType<'data, 's, Y: RuleBreakType<'s> + ?Sized>(
+    WordBreakIterator<'data, 's, Y>,
+);
+
+impl<'data, 's, Y: RuleBreakType<'s> + ?Sized> Iterator
+    for WordBreakIteratorWithWordType<'data, 's, Y>
+{
+    type Item = (usize, WordType);
+    fn next(&mut self) -> Option<Self::Item> {
+        let Some(ret) = self.0.next() else {
+            return None;
+        };
+        Some((ret, self.0 .0.word_type()))
+    }
+}
+
 /// Word break iterator for an `str` (a UTF-8 string).
 ///
 /// For examples of use, see [`WordSegmenter`].
-pub type WordBreakIteratorUtf8<'l, 's> = WordBreakIterator<'l, 's, WordBreakTypeUtf8>;
+pub type WordBreakIteratorUtf8<'data, 's> = WordBreakIterator<'data, 's, WordBreakTypeUtf8>;
 
 /// Word break iterator for a potentially invalid UTF-8 string.
 ///
 /// For examples of use, see [`WordSegmenter`].
-pub type WordBreakIteratorPotentiallyIllFormedUtf8<'l, 's> =
-    WordBreakIterator<'l, 's, WordBreakTypePotentiallyIllFormedUtf8>;
+pub type WordBreakIteratorPotentiallyIllFormedUtf8<'data, 's> =
+    WordBreakIterator<'data, 's, WordBreakTypePotentiallyIllFormedUtf8>;
 
 /// Word break iterator for a Latin-1 (8-bit) string.
 ///
 /// For examples of use, see [`WordSegmenter`].
-pub type WordBreakIteratorLatin1<'l, 's> = WordBreakIterator<'l, 's, RuleBreakTypeLatin1>;
+pub type WordBreakIteratorLatin1<'data, 's> = WordBreakIterator<'data, 's, RuleBreakTypeLatin1>;
 
 /// Word break iterator for a UTF-16 string.
 ///
 /// For examples of use, see [`WordSegmenter`].
-pub type WordBreakIteratorUtf16<'l, 's> = WordBreakIterator<'l, 's, WordBreakTypeUtf16>;
+pub type WordBreakIteratorUtf16<'data, 's> = WordBreakIterator<'data, 's, WordBreakTypeUtf16>;
 
 /// Supports loading word break data, and creating word break iterators for different string
 /// encodings.
+///
+/// Most segmentation methods live on [`WordSegmenterBorrowed`], which can be obtained via
+/// [`WordSegmenter::new()`] or [`WordSegmenter::as_borrowed()`].
 ///
 /// # Examples
 ///
@@ -192,6 +212,16 @@ pub struct WordSegmenter {
     payload_locale_override: Option<DataPayload<SegmenterBreakWordOverrideV1>>,
 }
 
+/// Segments a string into words (borrowed version).
+///
+/// See [`WordSegmenter`] for examples.
+#[derive(Clone, Debug, Copy)]
+pub struct WordSegmenterBorrowed<'data> {
+    data: &'data RuleBreakData<'data>,
+    complex: ComplexPayloadsBorrowed<'data>,
+    locale_override: Option<&'data RuleBreakDataOverride<'data>>,
+}
+
 impl WordSegmenter {
     /// Constructs a [`WordSegmenter`] with an invariant locale and the best available compiled data for
     /// complex scripts (Chinese, Japanese, Khmer, Lao, Myanmar, and Thai).
@@ -224,13 +254,11 @@ impl WordSegmenter {
     /// ```
     #[cfg(feature = "compiled_data")]
     #[cfg(feature = "auto")]
-    pub fn new_auto(_options: WordBreakInvariantOptions) -> Self {
-        Self {
-            payload: DataPayload::from_static_ref(
-                crate::provider::Baked::SINGLETON_SEGMENTER_BREAK_WORD_V1,
-            ),
-            complex: ComplexPayloads::new_auto(),
-            payload_locale_override: None,
+    pub fn new_auto(_options: WordBreakInvariantOptions) -> WordSegmenterBorrowed<'static> {
+        WordSegmenterBorrowed {
+            data: crate::provider::Baked::SINGLETON_SEGMENTER_BREAK_WORD_V1,
+            complex: ComplexPayloadsBorrowed::new_auto(),
+            locale_override: None,
         }
     }
 
@@ -318,13 +346,11 @@ impl WordSegmenter {
     /// ```
     #[cfg(feature = "compiled_data")]
     #[cfg(feature = "lstm")]
-    pub fn new_lstm(_options: WordBreakInvariantOptions) -> Self {
-        Self {
-            payload: DataPayload::from_static_ref(
-                crate::provider::Baked::SINGLETON_SEGMENTER_BREAK_WORD_V1,
-            ),
-            complex: ComplexPayloads::new_lstm(),
-            payload_locale_override: None,
+    pub fn new_lstm(_options: WordBreakInvariantOptions) -> WordSegmenterBorrowed<'static> {
+        WordSegmenterBorrowed {
+            data: crate::provider::Baked::SINGLETON_SEGMENTER_BREAK_WORD_V1,
+            complex: ComplexPayloadsBorrowed::new_lstm(),
+            locale_override: None,
         }
     }
 
@@ -405,13 +431,11 @@ impl WordSegmenter {
     /// assert_eq!(ja_bps, [0, 15, 21]);
     /// ```
     #[cfg(feature = "compiled_data")]
-    pub fn new_dictionary(_options: WordBreakInvariantOptions) -> Self {
-        Self {
-            payload: DataPayload::from_static_ref(
-                crate::provider::Baked::SINGLETON_SEGMENTER_BREAK_WORD_V1,
-            ),
-            complex: ComplexPayloads::new_dict(),
-            payload_locale_override: None,
+    pub fn new_dictionary(_options: WordBreakInvariantOptions) -> WordSegmenterBorrowed<'static> {
+        WordSegmenterBorrowed {
+            data: crate::provider::Baked::SINGLETON_SEGMENTER_BREAK_WORD_V1,
+            complex: ComplexPayloadsBorrowed::new_dict(),
+            locale_override: None,
         }
     }
 
@@ -460,24 +484,32 @@ impl WordSegmenter {
             },
         })
     }
+    /// Constructs a borrowed version of this type for more efficient querying.
+    ///
+    /// Most useful methods for segmentation are on this type.
+    pub fn as_borrowed(&self) -> WordSegmenterBorrowed<'_> {
+        WordSegmenterBorrowed {
+            data: self.payload.get(),
+            complex: self.complex.as_borrowed(),
+            locale_override: self.payload_locale_override.as_ref().map(|p| p.get()),
+        }
+    }
+}
 
+impl<'data> WordSegmenterBorrowed<'data> {
     /// Creates a word break iterator for an `str` (a UTF-8 string).
     ///
     /// There are always breakpoints at 0 and the string length, or only at 0 for the empty string.
-    pub fn segment_str<'l, 's>(&'l self, input: &'s str) -> WordBreakIteratorUtf8<'l, 's> {
-        let locale_override = self
-            .payload_locale_override
-            .as_ref()
-            .map(|payload| payload.get());
+    pub fn segment_str<'s>(self, input: &'s str) -> WordBreakIteratorUtf8<'data, 's> {
         WordBreakIterator(RuleBreakIterator {
             iter: input.char_indices(),
             len: input.len(),
             current_pos_data: None,
             result_cache: Vec::new(),
-            data: self.payload.get(),
-            complex: Some(self.complex.as_borrowed()),
+            data: self.data,
+            complex: Some(self.complex),
             boundary_property: 0,
-            locale_override,
+            locale_override: self.locale_override,
         })
     }
 
@@ -486,64 +518,71 @@ impl WordSegmenter {
     /// Invalid characters are treated as REPLACEMENT CHARACTER
     ///
     /// There are always breakpoints at 0 and the string length, or only at 0 for the empty string.
-    pub fn segment_utf8<'l, 's>(
-        &'l self,
+    pub fn segment_utf8<'s>(
+        self,
         input: &'s [u8],
-    ) -> WordBreakIteratorPotentiallyIllFormedUtf8<'l, 's> {
-        let locale_override = self
-            .payload_locale_override
-            .as_ref()
-            .map(|payload| payload.get());
+    ) -> WordBreakIteratorPotentiallyIllFormedUtf8<'data, 's> {
         WordBreakIterator(RuleBreakIterator {
             iter: Utf8CharIndices::new(input),
             len: input.len(),
             current_pos_data: None,
             result_cache: Vec::new(),
-            data: self.payload.get(),
-            complex: Some(self.complex.as_borrowed()),
+            data: self.data,
+            complex: Some(self.complex),
             boundary_property: 0,
-            locale_override,
+            locale_override: self.locale_override,
         })
     }
 
     /// Creates a word break iterator for a Latin-1 (8-bit) string.
     ///
     /// There are always breakpoints at 0 and the string length, or only at 0 for the empty string.
-    pub fn segment_latin1<'l, 's>(&'l self, input: &'s [u8]) -> WordBreakIteratorLatin1<'l, 's> {
-        let locale_override = self
-            .payload_locale_override
-            .as_ref()
-            .map(|payload| payload.get());
+    pub fn segment_latin1<'s>(self, input: &'s [u8]) -> WordBreakIteratorLatin1<'data, 's> {
         WordBreakIterator(RuleBreakIterator {
             iter: Latin1Indices::new(input),
             len: input.len(),
             current_pos_data: None,
             result_cache: Vec::new(),
-            data: self.payload.get(),
-            complex: Some(self.complex.as_borrowed()),
+            data: self.data,
+            complex: Some(self.complex),
             boundary_property: 0,
-            locale_override,
+            locale_override: self.locale_override,
         })
     }
 
     /// Creates a word break iterator for a UTF-16 string.
     ///
     /// There are always breakpoints at 0 and the string length, or only at 0 for the empty string.
-    pub fn segment_utf16<'l, 's>(&'l self, input: &'s [u16]) -> WordBreakIteratorUtf16<'l, 's> {
-        let locale_override = self
-            .payload_locale_override
-            .as_ref()
-            .map(|payload| payload.get());
+    pub fn segment_utf16<'s>(self, input: &'s [u16]) -> WordBreakIteratorUtf16<'data, 's> {
         WordBreakIterator(RuleBreakIterator {
             iter: Utf16Indices::new(input),
             len: input.len(),
             current_pos_data: None,
             result_cache: Vec::new(),
-            data: self.payload.get(),
-            complex: Some(self.complex.as_borrowed()),
+            data: self.data,
+            complex: Some(self.complex),
             boundary_property: 0,
-            locale_override,
+            locale_override: self.locale_override,
         })
+    }
+}
+
+impl WordSegmenterBorrowed<'static> {
+    /// Cheaply converts a [`WordSegmenterBorrowed<'static>`] into a [`WordSegmenter`].
+    ///
+    /// Note: Due to branching and indirection, using [`WordSegmenter`] might inhibit some
+    /// compile-time optimizations that are possible with [`WordSegmenterBorrowed`].
+    pub fn static_to_owned(self) -> WordSegmenter {
+        let payload_locale_override = if let Some(d) = self.locale_override {
+            Some(DataPayload::from_static_ref(d))
+        } else {
+            None
+        };
+        WordSegmenter {
+            payload: DataPayload::from_static_ref(self.data),
+            complex: self.complex.static_to_owned(),
+            payload_locale_override,
+        }
     }
 }
 
@@ -560,7 +599,7 @@ impl<'l, 's> RuleBreakType<'s> for WordBreakTypeUtf8 {
     }
 
     fn handle_complex_language(
-        iter: &mut RuleBreakIterator<'_, '_, 's, Self>,
+        iter: &mut RuleBreakIterator<'_, 's, Self>,
         left_codepoint: Self::CharType,
     ) -> Option<usize> {
         handle_complex_language_utf8(iter, left_codepoint)
@@ -580,7 +619,7 @@ impl<'l, 's> RuleBreakType<'s> for WordBreakTypePotentiallyIllFormedUtf8 {
     }
 
     fn handle_complex_language(
-        iter: &mut RuleBreakIterator<'_, '_, 's, Self>,
+        iter: &mut RuleBreakIterator<'_, 's, Self>,
         left_codepoint: Self::CharType,
     ) -> Option<usize> {
         handle_complex_language_utf8(iter, left_codepoint)
@@ -588,8 +627,8 @@ impl<'l, 's> RuleBreakType<'s> for WordBreakTypePotentiallyIllFormedUtf8 {
 }
 
 /// handle_complex_language impl for UTF8 iterators
-fn handle_complex_language_utf8<'l, 'data, 's, T>(
-    iter: &mut RuleBreakIterator<'l, 'data, 's, T>,
+fn handle_complex_language_utf8<'data, 's, T>(
+    iter: &mut RuleBreakIterator<'data, 's, T>,
     left_codepoint: T::CharType,
 ) -> Option<usize>
 where

--- a/components/segmenter/src/word.rs
+++ b/components/segmenter/src/word.rs
@@ -100,8 +100,8 @@ pub struct WordBreakIteratorWithWordType<'data, 's, Y: RuleBreakType<'s> + ?Size
     WordBreakIterator<'data, 's, Y>,
 );
 
-impl<'data, 's, Y: RuleBreakType<'s> + ?Sized> Iterator
-    for WordBreakIteratorWithWordType<'data, 's, Y>
+impl<'s, Y: RuleBreakType<'s> + ?Sized> Iterator
+    for WordBreakIteratorWithWordType<'_, 's, Y>
 {
     type Item = (usize, WordType);
     fn next(&mut self) -> Option<Self::Item> {
@@ -573,11 +573,7 @@ impl WordSegmenterBorrowed<'static> {
     /// Note: Due to branching and indirection, using [`WordSegmenter`] might inhibit some
     /// compile-time optimizations that are possible with [`WordSegmenterBorrowed`].
     pub fn static_to_owned(self) -> WordSegmenter {
-        let payload_locale_override = if let Some(d) = self.locale_override {
-            Some(DataPayload::from_static_ref(d))
-        } else {
-            None
-        };
+        let payload_locale_override = self.locale_override.map(|d| DataPayload::from_static_ref(d));
         WordSegmenter {
             payload: DataPayload::from_static_ref(self.data),
             complex: self.complex.static_to_owned(),

--- a/components/segmenter/src/word.rs
+++ b/components/segmenter/src/word.rs
@@ -133,7 +133,7 @@ pub type WordBreakIteratorUtf16<'data, 's> = WordBreakIterator<'data, 's, WordBr
 /// encodings.
 ///
 /// Most segmentation methods live on [`WordSegmenterBorrowed`], which can be obtained via
-/// [`WordSegmenter::new()`] or [`WordSegmenter::as_borrowed()`].
+/// [`WordSegmenter::new_auto()`] (etc) or [`WordSegmenter::as_borrowed()`].
 ///
 /// # Examples
 ///

--- a/components/segmenter/src/word.rs
+++ b/components/segmenter/src/word.rs
@@ -100,9 +100,7 @@ pub struct WordBreakIteratorWithWordType<'data, 's, Y: RuleBreakType<'s> + ?Size
     WordBreakIterator<'data, 's, Y>,
 );
 
-impl<'s, Y: RuleBreakType<'s> + ?Sized> Iterator
-    for WordBreakIteratorWithWordType<'_, 's, Y>
-{
+impl<'s, Y: RuleBreakType<'s> + ?Sized> Iterator for WordBreakIteratorWithWordType<'_, 's, Y> {
     type Item = (usize, WordType);
     fn next(&mut self) -> Option<Self::Item> {
         let Some(ret) = self.0.next() else {
@@ -573,7 +571,9 @@ impl WordSegmenterBorrowed<'static> {
     /// Note: Due to branching and indirection, using [`WordSegmenter`] might inhibit some
     /// compile-time optimizations that are possible with [`WordSegmenterBorrowed`].
     pub fn static_to_owned(self) -> WordSegmenter {
-        let payload_locale_override = self.locale_override.map(|d| DataPayload::from_static_ref(d));
+        let payload_locale_override = self
+            .locale_override
+            .map(|d| DataPayload::from_static_ref(d));
         WordSegmenter {
             payload: DataPayload::from_static_ref(self.data),
             complex: self.complex.static_to_owned(),

--- a/components/segmenter/src/word.rs
+++ b/components/segmenter/src/word.rs
@@ -618,7 +618,11 @@ where
     iter.iter = start_iter;
     iter.current_pos_data = start_point;
     #[allow(clippy::unwrap_used)] // iter.complex present for word segmenter
-    let breaks = complex_language_segment_str(iter.complex.unwrap(), &s);
+    let breaks = iter
+        .complex
+        .unwrap()
+        .as_borrowed()
+        .complex_language_segment_str(&s);
     iter.result_cache = breaks;
     let first_pos = *iter.result_cache.first()?;
     let mut i = left_codepoint.len_utf8();
@@ -685,7 +689,11 @@ impl<'s> RuleBreakType<'_, 's> for WordBreakTypeUtf16 {
         iter.iter = start_iter;
         iter.current_pos_data = start_point;
         #[allow(clippy::unwrap_used)] // iter.complex present for word segmenter
-        let breaks = complex_language_segment_utf16(iter.complex.unwrap(), &s);
+        let breaks = iter
+            .complex
+            .unwrap()
+            .as_borrowed()
+            .complex_language_segment_utf16(&s);
         iter.result_cache = breaks;
         // result_cache vector is utf-16 index that is in BMP.
         let first_pos = *iter.result_cache.first()?;

--- a/components/segmenter/src/word.rs
+++ b/components/segmenter/src/word.rs
@@ -569,9 +569,7 @@ impl WordSegmenterBorrowed<'static> {
     /// Note: Due to branching and indirection, using [`WordSegmenter`] might inhibit some
     /// compile-time optimizations that are possible with [`WordSegmenterBorrowed`].
     pub fn static_to_owned(self) -> WordSegmenter {
-        let payload_locale_override = self
-            .locale_override
-            .map(DataPayload::from_static_ref);
+        let payload_locale_override = self.locale_override.map(DataPayload::from_static_ref);
         WordSegmenter {
             payload: DataPayload::from_static_ref(self.data),
             complex: self.complex.static_to_owned(),

--- a/components/segmenter/src/word.rs
+++ b/components/segmenter/src/word.rs
@@ -45,9 +45,7 @@ pub struct WordBreakInvariantOptions {}
 ///
 /// For examples of use, see [`WordSegmenter`].
 #[derive(Debug)]
-pub struct WordBreakIterator<'l, 's, Y: RuleBreakType<'s> + ?Sized>(
-    RuleBreakIterator<'l, 's, Y>,
-);
+pub struct WordBreakIterator<'l, 's, Y: RuleBreakType<'s> + ?Sized>(RuleBreakIterator<'l, 's, Y>);
 
 derive_usize_iterator_with_type!(WordBreakIterator);
 
@@ -475,7 +473,7 @@ impl WordSegmenter {
             current_pos_data: None,
             result_cache: Vec::new(),
             data: self.payload.get(),
-            complex: Some(&self.complex),
+            complex: Some(self.complex.as_borrowed()),
             boundary_property: 0,
             locale_override,
         })
@@ -500,7 +498,7 @@ impl WordSegmenter {
             current_pos_data: None,
             result_cache: Vec::new(),
             data: self.payload.get(),
-            complex: Some(&self.complex),
+            complex: Some(self.complex.as_borrowed()),
             boundary_property: 0,
             locale_override,
         })
@@ -520,7 +518,7 @@ impl WordSegmenter {
             current_pos_data: None,
             result_cache: Vec::new(),
             data: self.payload.get(),
-            complex: Some(&self.complex),
+            complex: Some(self.complex.as_borrowed()),
             boundary_property: 0,
             locale_override,
         })
@@ -540,7 +538,7 @@ impl WordSegmenter {
             current_pos_data: None,
             result_cache: Vec::new(),
             data: self.payload.get(),
-            complex: Some(&self.complex),
+            complex: Some(self.complex.as_borrowed()),
             boundary_property: 0,
             locale_override,
         })
@@ -618,11 +616,7 @@ where
     iter.iter = start_iter;
     iter.current_pos_data = start_point;
     #[allow(clippy::unwrap_used)] // iter.complex present for word segmenter
-    let breaks = iter
-        .complex
-        .unwrap()
-        .as_borrowed()
-        .complex_language_segment_str(&s);
+    let breaks = iter.complex.unwrap().complex_language_segment_str(&s);
     iter.result_cache = breaks;
     let first_pos = *iter.result_cache.first()?;
     let mut i = left_codepoint.len_utf8();
@@ -689,11 +683,7 @@ impl<'s> RuleBreakType<'s> for WordBreakTypeUtf16 {
         iter.iter = start_iter;
         iter.current_pos_data = start_point;
         #[allow(clippy::unwrap_used)] // iter.complex present for word segmenter
-        let breaks = iter
-            .complex
-            .unwrap()
-            .as_borrowed()
-            .complex_language_segment_utf16(&s);
+        let breaks = iter.complex.unwrap().complex_language_segment_utf16(&s);
         iter.result_cache = breaks;
         // result_cache vector is utf-16 index that is in BMP.
         let first_pos = *iter.result_cache.first()?;

--- a/components/segmenter/tests/locale.rs
+++ b/components/segmenter/tests/locale.rs
@@ -16,6 +16,7 @@ fn word_break_with_locale() {
     let langid = langid!("sv");
     options_sv.content_locale = Some(&langid);
     let segmenter = WordSegmenter::try_new_auto(options_sv).expect("Loading should succeed!");
+    let segmenter = segmenter.as_borrowed();
     let iter = segmenter.segment_str(s);
     assert_eq!(
         iter.collect::<Vec<usize>>(),
@@ -27,6 +28,7 @@ fn word_break_with_locale() {
     let langid = langid!("en");
     options_en.content_locale = Some(&langid);
     let segmenter = WordSegmenter::try_new_auto(options_en).expect("Loading should succeed!");
+    let segmenter = segmenter.as_borrowed();
     let iter = segmenter.segment_str(s);
     assert_eq!(
         iter.collect::<Vec<usize>>(),
@@ -43,7 +45,8 @@ fn sentence_break_with_locale() {
     let langid = langid!("el");
     options_el.content_locale = Some(&langid);
     let segmenter = SentenceSegmenter::try_new(options_el).expect("Loading should succeed!");
-    let iter = segmenter.as_borrowed().segment_str(s);
+    let segmenter = segmenter.as_borrowed();
+    let iter = segmenter.segment_str(s);
     assert_eq!(
         iter.collect::<Vec<usize>>(),
         vec![0, 7, 12],
@@ -54,7 +57,8 @@ fn sentence_break_with_locale() {
     let langid = langid!("en");
     options_en.content_locale = Some(&langid);
     let segmenter = SentenceSegmenter::try_new(options_en).expect("Loading should succeed!");
-    let iter = segmenter.as_borrowed().segment_str(s);
+    let segmenter = segmenter.as_borrowed();
+    let iter = segmenter.segment_str(s);
     assert_eq!(
         iter.collect::<Vec<usize>>(),
         vec![0, 12],

--- a/components/segmenter/tests/locale.rs
+++ b/components/segmenter/tests/locale.rs
@@ -43,7 +43,7 @@ fn sentence_break_with_locale() {
     let langid = langid!("el");
     options_el.content_locale = Some(&langid);
     let segmenter = SentenceSegmenter::try_new(options_el).expect("Loading should succeed!");
-    let iter = segmenter.segment_str(s);
+    let iter = segmenter.as_borrowed().segment_str(s);
     assert_eq!(
         iter.collect::<Vec<usize>>(),
         vec![0, 7, 12],
@@ -54,7 +54,7 @@ fn sentence_break_with_locale() {
     let langid = langid!("en");
     options_en.content_locale = Some(&langid);
     let segmenter = SentenceSegmenter::try_new(options_en).expect("Loading should succeed!");
-    let iter = segmenter.segment_str(s);
+    let iter = segmenter.as_borrowed().segment_str(s);
     assert_eq!(
         iter.collect::<Vec<usize>>(),
         vec![0, 12],

--- a/components/segmenter/tests/spec_test.rs
+++ b/components/segmenter/tests/spec_test.rs
@@ -207,6 +207,7 @@ fn word_break_test(file: &'static str) {
     let langid = langid!("sv");
     options.content_locale = Some(&langid);
     let segmenter = WordSegmenter::try_new_dictionary(options).expect("Loading should succeed!");
+    let segmenter = segmenter.as_borrowed();
     for (i, test) in test_iter.enumerate() {
         let s: String = test.utf8_vec.into_iter().collect();
         let iter = segmenter.segment_str(&s);

--- a/ffi/capi/bindings/cpp/icu4x/GraphemeClusterSegmenter.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/GraphemeClusterSegmenter.d.hpp
@@ -61,7 +61,7 @@ public:
    * Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
    * to the WHATWG Encoding Standard.
    *
-   * See the [Rust documentation for `segment_utf8`](https://docs.rs/icu/latest/icu/segmenter/struct.GraphemeClusterSegmenter.html#method.segment_utf8) for more information.
+   * See the [Rust documentation for `segment_utf8`](https://docs.rs/icu/latest/icu/segmenter/struct.GraphemeClusterSegmenterBorrowed.html#method.segment_utf8) for more information.
    */
   inline std::unique_ptr<icu4x::GraphemeClusterBreakIteratorUtf8> segment(std::string_view input) const;
 
@@ -71,14 +71,14 @@ public:
    * Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
    * to the WHATWG Encoding Standard.
    *
-   * See the [Rust documentation for `segment_utf16`](https://docs.rs/icu/latest/icu/segmenter/struct.GraphemeClusterSegmenter.html#method.segment_utf16) for more information.
+   * See the [Rust documentation for `segment_utf16`](https://docs.rs/icu/latest/icu/segmenter/struct.GraphemeClusterSegmenterBorrowed.html#method.segment_utf16) for more information.
    */
   inline std::unique_ptr<icu4x::GraphemeClusterBreakIteratorUtf16> segment16(std::u16string_view input) const;
 
   /**
    * Segments a Latin-1 string.
    *
-   * See the [Rust documentation for `segment_latin1`](https://docs.rs/icu/latest/icu/segmenter/struct.GraphemeClusterSegmenter.html#method.segment_latin1) for more information.
+   * See the [Rust documentation for `segment_latin1`](https://docs.rs/icu/latest/icu/segmenter/struct.GraphemeClusterSegmenterBorrowed.html#method.segment_latin1) for more information.
    */
   inline std::unique_ptr<icu4x::GraphemeClusterBreakIteratorLatin1> segment_latin1(diplomat::span<const uint8_t> input) const;
 

--- a/ffi/capi/bindings/cpp/icu4x/LineSegmenter.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/LineSegmenter.d.hpp
@@ -121,7 +121,7 @@ public:
    * Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
    * to the WHATWG Encoding Standard.
    *
-   * See the [Rust documentation for `segment_utf8`](https://docs.rs/icu/latest/icu/segmenter/struct.LineSegmenter.html#method.segment_utf8) for more information.
+   * See the [Rust documentation for `segment_utf8`](https://docs.rs/icu/latest/icu/segmenter/struct.LineSegmenterBorrowed.html#method.segment_utf8) for more information.
    */
   inline std::unique_ptr<icu4x::LineBreakIteratorUtf8> segment(std::string_view input) const;
 
@@ -131,14 +131,14 @@ public:
    * Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
    * to the WHATWG Encoding Standard.
    *
-   * See the [Rust documentation for `segment_utf16`](https://docs.rs/icu/latest/icu/segmenter/struct.LineSegmenter.html#method.segment_utf16) for more information.
+   * See the [Rust documentation for `segment_utf16`](https://docs.rs/icu/latest/icu/segmenter/struct.LineSegmenterBorrowed.html#method.segment_utf16) for more information.
    */
   inline std::unique_ptr<icu4x::LineBreakIteratorUtf16> segment16(std::u16string_view input) const;
 
   /**
    * Segments a Latin-1 string.
    *
-   * See the [Rust documentation for `segment_latin1`](https://docs.rs/icu/latest/icu/segmenter/struct.LineSegmenter.html#method.segment_latin1) for more information.
+   * See the [Rust documentation for `segment_latin1`](https://docs.rs/icu/latest/icu/segmenter/struct.LineSegmenterBorrowed.html#method.segment_latin1) for more information.
    */
   inline std::unique_ptr<icu4x::LineBreakIteratorLatin1> segment_latin1(diplomat::span<const uint8_t> input) const;
 

--- a/ffi/capi/bindings/cpp/icu4x/SentenceSegmenter.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/SentenceSegmenter.d.hpp
@@ -65,7 +65,7 @@ public:
    * Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
    * to the WHATWG Encoding Standard.
    *
-   * See the [Rust documentation for `segment_utf8`](https://docs.rs/icu/latest/icu/segmenter/struct.SentenceSegmenter.html#method.segment_utf8) for more information.
+   * See the [Rust documentation for `segment_utf8`](https://docs.rs/icu/latest/icu/segmenter/struct.SentenceSegmenterBorrowed.html#method.segment_utf8) for more information.
    */
   inline std::unique_ptr<icu4x::SentenceBreakIteratorUtf8> segment(std::string_view input) const;
 
@@ -75,14 +75,14 @@ public:
    * Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
    * to the WHATWG Encoding Standard.
    *
-   * See the [Rust documentation for `segment_utf16`](https://docs.rs/icu/latest/icu/segmenter/struct.SentenceSegmenter.html#method.segment_utf16) for more information.
+   * See the [Rust documentation for `segment_utf16`](https://docs.rs/icu/latest/icu/segmenter/struct.SentenceSegmenterBorrowed.html#method.segment_utf16) for more information.
    */
   inline std::unique_ptr<icu4x::SentenceBreakIteratorUtf16> segment16(std::u16string_view input) const;
 
   /**
    * Segments a Latin-1 string.
    *
-   * See the [Rust documentation for `segment_latin1`](https://docs.rs/icu/latest/icu/segmenter/struct.SentenceSegmenter.html#method.segment_latin1) for more information.
+   * See the [Rust documentation for `segment_latin1`](https://docs.rs/icu/latest/icu/segmenter/struct.SentenceSegmenterBorrowed.html#method.segment_latin1) for more information.
    */
   inline std::unique_ptr<icu4x::SentenceBreakIteratorLatin1> segment_latin1(diplomat::span<const uint8_t> input) const;
 

--- a/ffi/capi/bindings/cpp/icu4x/WordSegmenter.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/WordSegmenter.d.hpp
@@ -147,7 +147,7 @@ public:
    * Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
    * to the WHATWG Encoding Standard.
    *
-   * See the [Rust documentation for `segment_utf8`](https://docs.rs/icu/latest/icu/segmenter/struct.WordSegmenter.html#method.segment_utf8) for more information.
+   * See the [Rust documentation for `segment_utf8`](https://docs.rs/icu/latest/icu/segmenter/struct.WordSegmenterBorrowed.html#method.segment_utf8) for more information.
    */
   inline std::unique_ptr<icu4x::WordBreakIteratorUtf8> segment(std::string_view input) const;
 
@@ -157,14 +157,14 @@ public:
    * Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
    * to the WHATWG Encoding Standard.
    *
-   * See the [Rust documentation for `segment_utf16`](https://docs.rs/icu/latest/icu/segmenter/struct.WordSegmenter.html#method.segment_utf16) for more information.
+   * See the [Rust documentation for `segment_utf16`](https://docs.rs/icu/latest/icu/segmenter/struct.WordSegmenterBorrowed.html#method.segment_utf16) for more information.
    */
   inline std::unique_ptr<icu4x::WordBreakIteratorUtf16> segment16(std::u16string_view input) const;
 
   /**
    * Segments a Latin-1 string.
    *
-   * See the [Rust documentation for `segment_latin1`](https://docs.rs/icu/latest/icu/segmenter/struct.WordSegmenter.html#method.segment_latin1) for more information.
+   * See the [Rust documentation for `segment_latin1`](https://docs.rs/icu/latest/icu/segmenter/struct.WordSegmenterBorrowed.html#method.segment_latin1) for more information.
    */
   inline std::unique_ptr<icu4x::WordBreakIteratorLatin1> segment_latin1(diplomat::span<const uint8_t> input) const;
 

--- a/ffi/capi/bindings/dart/GraphemeClusterSegmenter.g.dart
+++ b/ffi/capi/bindings/dart/GraphemeClusterSegmenter.g.dart
@@ -52,7 +52,7 @@ final class GraphemeClusterSegmenter implements ffi.Finalizable {
   /// Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
   /// to the WHATWG Encoding Standard.
   ///
-  /// See the [Rust documentation for `segment_utf16`](https://docs.rs/icu/latest/icu/segmenter/struct.GraphemeClusterSegmenter.html#method.segment_utf16) for more information.
+  /// See the [Rust documentation for `segment_utf16`](https://docs.rs/icu/latest/icu/segmenter/struct.GraphemeClusterSegmenterBorrowed.html#method.segment_utf16) for more information.
   GraphemeClusterBreakIteratorUtf16 segment(String input) {
     final inputArena = _FinalizedArena();
     // This lifetime edge depends on lifetimes: 'a

--- a/ffi/capi/bindings/dart/LineSegmenter.g.dart
+++ b/ffi/capi/bindings/dart/LineSegmenter.g.dart
@@ -132,7 +132,7 @@ final class LineSegmenter implements ffi.Finalizable {
   /// Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
   /// to the WHATWG Encoding Standard.
   ///
-  /// See the [Rust documentation for `segment_utf16`](https://docs.rs/icu/latest/icu/segmenter/struct.LineSegmenter.html#method.segment_utf16) for more information.
+  /// See the [Rust documentation for `segment_utf16`](https://docs.rs/icu/latest/icu/segmenter/struct.LineSegmenterBorrowed.html#method.segment_utf16) for more information.
   LineBreakIteratorUtf16 segment(String input) {
     final inputArena = _FinalizedArena();
     // This lifetime edge depends on lifetimes: 'a

--- a/ffi/capi/bindings/dart/SentenceSegmenter.g.dart
+++ b/ffi/capi/bindings/dart/SentenceSegmenter.g.dart
@@ -60,7 +60,7 @@ final class SentenceSegmenter implements ffi.Finalizable {
   /// Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
   /// to the WHATWG Encoding Standard.
   ///
-  /// See the [Rust documentation for `segment_utf16`](https://docs.rs/icu/latest/icu/segmenter/struct.SentenceSegmenter.html#method.segment_utf16) for more information.
+  /// See the [Rust documentation for `segment_utf16`](https://docs.rs/icu/latest/icu/segmenter/struct.SentenceSegmenterBorrowed.html#method.segment_utf16) for more information.
   SentenceBreakIteratorUtf16 segment(String input) {
     final inputArena = _FinalizedArena();
     // This lifetime edge depends on lifetimes: 'a

--- a/ffi/capi/bindings/dart/WordSegmenter.g.dart
+++ b/ffi/capi/bindings/dart/WordSegmenter.g.dart
@@ -168,7 +168,7 @@ final class WordSegmenter implements ffi.Finalizable {
   /// Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
   /// to the WHATWG Encoding Standard.
   ///
-  /// See the [Rust documentation for `segment_utf16`](https://docs.rs/icu/latest/icu/segmenter/struct.WordSegmenter.html#method.segment_utf16) for more information.
+  /// See the [Rust documentation for `segment_utf16`](https://docs.rs/icu/latest/icu/segmenter/struct.WordSegmenterBorrowed.html#method.segment_utf16) for more information.
   WordBreakIteratorUtf16 segment(String input) {
     final inputArena = _FinalizedArena();
     // This lifetime edge depends on lifetimes: 'a

--- a/ffi/capi/bindings/js/GraphemeClusterSegmenter.d.ts
+++ b/ffi/capi/bindings/js/GraphemeClusterSegmenter.d.ts
@@ -30,7 +30,7 @@ export class GraphemeClusterSegmenter {
      * Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
      * to the WHATWG Encoding Standard.
      *
-     * See the [Rust documentation for `segment_utf16`](https://docs.rs/icu/latest/icu/segmenter/struct.GraphemeClusterSegmenter.html#method.segment_utf16) for more information.
+     * See the [Rust documentation for `segment_utf16`](https://docs.rs/icu/latest/icu/segmenter/struct.GraphemeClusterSegmenterBorrowed.html#method.segment_utf16) for more information.
      */
     segment(input: string): GraphemeClusterBreakIteratorUtf16;
 

--- a/ffi/capi/bindings/js/GraphemeClusterSegmenter.mjs
+++ b/ffi/capi/bindings/js/GraphemeClusterSegmenter.mjs
@@ -89,7 +89,7 @@ export class GraphemeClusterSegmenter {
      * Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
      * to the WHATWG Encoding Standard.
      *
-     * See the [Rust documentation for `segment_utf16`](https://docs.rs/icu/latest/icu/segmenter/struct.GraphemeClusterSegmenter.html#method.segment_utf16) for more information.
+     * See the [Rust documentation for `segment_utf16`](https://docs.rs/icu/latest/icu/segmenter/struct.GraphemeClusterSegmenterBorrowed.html#method.segment_utf16) for more information.
      */
     segment(input) {
         let functionGarbageCollectorGrip = new diplomatRuntime.GarbageCollectorGrip();

--- a/ffi/capi/bindings/js/LineSegmenter.d.ts
+++ b/ffi/capi/bindings/js/LineSegmenter.d.ts
@@ -97,7 +97,7 @@ export class LineSegmenter {
      * Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
      * to the WHATWG Encoding Standard.
      *
-     * See the [Rust documentation for `segment_utf16`](https://docs.rs/icu/latest/icu/segmenter/struct.LineSegmenter.html#method.segment_utf16) for more information.
+     * See the [Rust documentation for `segment_utf16`](https://docs.rs/icu/latest/icu/segmenter/struct.LineSegmenterBorrowed.html#method.segment_utf16) for more information.
      */
     segment(input: string): LineBreakIteratorUtf16;
 }

--- a/ffi/capi/bindings/js/LineSegmenter.mjs
+++ b/ffi/capi/bindings/js/LineSegmenter.mjs
@@ -244,7 +244,7 @@ export class LineSegmenter {
      * Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
      * to the WHATWG Encoding Standard.
      *
-     * See the [Rust documentation for `segment_utf16`](https://docs.rs/icu/latest/icu/segmenter/struct.LineSegmenter.html#method.segment_utf16) for more information.
+     * See the [Rust documentation for `segment_utf16`](https://docs.rs/icu/latest/icu/segmenter/struct.LineSegmenterBorrowed.html#method.segment_utf16) for more information.
      */
     segment(input) {
         let functionGarbageCollectorGrip = new diplomatRuntime.GarbageCollectorGrip();

--- a/ffi/capi/bindings/js/SentenceSegmenter.d.ts
+++ b/ffi/capi/bindings/js/SentenceSegmenter.d.ts
@@ -33,7 +33,7 @@ export class SentenceSegmenter {
      * Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
      * to the WHATWG Encoding Standard.
      *
-     * See the [Rust documentation for `segment_utf16`](https://docs.rs/icu/latest/icu/segmenter/struct.SentenceSegmenter.html#method.segment_utf16) for more information.
+     * See the [Rust documentation for `segment_utf16`](https://docs.rs/icu/latest/icu/segmenter/struct.SentenceSegmenterBorrowed.html#method.segment_utf16) for more information.
      */
     segment(input: string): SentenceBreakIteratorUtf16;
 

--- a/ffi/capi/bindings/js/SentenceSegmenter.mjs
+++ b/ffi/capi/bindings/js/SentenceSegmenter.mjs
@@ -108,7 +108,7 @@ export class SentenceSegmenter {
      * Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
      * to the WHATWG Encoding Standard.
      *
-     * See the [Rust documentation for `segment_utf16`](https://docs.rs/icu/latest/icu/segmenter/struct.SentenceSegmenter.html#method.segment_utf16) for more information.
+     * See the [Rust documentation for `segment_utf16`](https://docs.rs/icu/latest/icu/segmenter/struct.SentenceSegmenterBorrowed.html#method.segment_utf16) for more information.
      */
     segment(input) {
         let functionGarbageCollectorGrip = new diplomatRuntime.GarbageCollectorGrip();

--- a/ffi/capi/bindings/js/WordSegmenter.d.ts
+++ b/ffi/capi/bindings/js/WordSegmenter.d.ts
@@ -122,7 +122,7 @@ export class WordSegmenter {
      * Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
      * to the WHATWG Encoding Standard.
      *
-     * See the [Rust documentation for `segment_utf16`](https://docs.rs/icu/latest/icu/segmenter/struct.WordSegmenter.html#method.segment_utf16) for more information.
+     * See the [Rust documentation for `segment_utf16`](https://docs.rs/icu/latest/icu/segmenter/struct.WordSegmenterBorrowed.html#method.segment_utf16) for more information.
      */
     segment(input: string): WordBreakIteratorUtf16;
 }

--- a/ffi/capi/bindings/js/WordSegmenter.mjs
+++ b/ffi/capi/bindings/js/WordSegmenter.mjs
@@ -270,7 +270,7 @@ export class WordSegmenter {
      * Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
      * to the WHATWG Encoding Standard.
      *
-     * See the [Rust documentation for `segment_utf16`](https://docs.rs/icu/latest/icu/segmenter/struct.WordSegmenter.html#method.segment_utf16) for more information.
+     * See the [Rust documentation for `segment_utf16`](https://docs.rs/icu/latest/icu/segmenter/struct.WordSegmenterBorrowed.html#method.segment_utf16) for more information.
      */
     segment(input) {
         let functionGarbageCollectorGrip = new diplomatRuntime.GarbageCollectorGrip();

--- a/ffi/capi/src/segmenter_grapheme.rs
+++ b/ffi/capi/src/segmenter_grapheme.rs
@@ -15,6 +15,7 @@ pub mod ffi {
     /// An ICU4X grapheme-cluster-break segmenter, capable of finding grapheme cluster breakpoints
     /// in strings.
     #[diplomat::rust_link(icu::segmenter::GraphemeClusterSegmenter, Struct)]
+    #[diplomat::rust_link(icu::segmenter::GraphemeClusterSegmenterBorrowed, Struct, hidden)]
     pub struct GraphemeClusterSegmenter(icu_segmenter::GraphemeClusterSegmenter);
 
     #[diplomat::opaque]
@@ -75,7 +76,7 @@ pub mod ffi {
             FnInStruct,
             hidden
         )]
-        #[diplomat::rust_link(icu::segmenter::GraphemeClusterSegmenter::segment_utf8, FnInStruct)]
+        #[diplomat::rust_link(icu::segmenter::GraphemeClusterSegmenterBorrowed::segment_utf8, FnInStruct)]
         #[diplomat::attr(not(supports = utf8_strings), disable)]
         #[diplomat::attr(*, rename = "segment")]
         pub fn segment_utf8<'a>(
@@ -91,7 +92,7 @@ pub mod ffi {
         ///
         /// Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
         /// to the WHATWG Encoding Standard.
-        #[diplomat::rust_link(icu::segmenter::GraphemeClusterSegmenter::segment_utf16, FnInStruct)]
+        #[diplomat::rust_link(icu::segmenter::GraphemeClusterSegmenterBorrowed::segment_utf16, FnInStruct)]
         #[diplomat::attr(not(supports = utf8_strings), rename = "segment")]
         #[diplomat::attr(supports = utf8_strings, rename = "segment16")]
         pub fn segment_utf16<'a>(
@@ -104,7 +105,7 @@ pub mod ffi {
         }
 
         /// Segments a Latin-1 string.
-        #[diplomat::rust_link(icu::segmenter::GraphemeClusterSegmenter::segment_latin1, FnInStruct)]
+        #[diplomat::rust_link(icu::segmenter::GraphemeClusterSegmenterBorrowed::segment_latin1, FnInStruct)]
         #[diplomat::attr(not(supports = utf8_strings), disable)]
         pub fn segment_latin1<'a>(
             &'a self,

--- a/ffi/capi/src/segmenter_grapheme.rs
+++ b/ffi/capi/src/segmenter_grapheme.rs
@@ -72,11 +72,14 @@ pub mod ffi {
         /// Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
         /// to the WHATWG Encoding Standard.
         #[diplomat::rust_link(
-            icu::segmenter::GraphemeClusterSegmenter::segment_str,
+            icu::segmenter::GraphemeClusterSegmenterBorrowed::segment_str,
             FnInStruct,
             hidden
         )]
-        #[diplomat::rust_link(icu::segmenter::GraphemeClusterSegmenterBorrowed::segment_utf8, FnInStruct)]
+        #[diplomat::rust_link(
+            icu::segmenter::GraphemeClusterSegmenterBorrowed::segment_utf8,
+            FnInStruct
+        )]
         #[diplomat::attr(not(supports = utf8_strings), disable)]
         #[diplomat::attr(*, rename = "segment")]
         pub fn segment_utf8<'a>(
@@ -92,7 +95,10 @@ pub mod ffi {
         ///
         /// Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
         /// to the WHATWG Encoding Standard.
-        #[diplomat::rust_link(icu::segmenter::GraphemeClusterSegmenterBorrowed::segment_utf16, FnInStruct)]
+        #[diplomat::rust_link(
+            icu::segmenter::GraphemeClusterSegmenterBorrowed::segment_utf16,
+            FnInStruct
+        )]
         #[diplomat::attr(not(supports = utf8_strings), rename = "segment")]
         #[diplomat::attr(supports = utf8_strings, rename = "segment16")]
         pub fn segment_utf16<'a>(
@@ -105,7 +111,10 @@ pub mod ffi {
         }
 
         /// Segments a Latin-1 string.
-        #[diplomat::rust_link(icu::segmenter::GraphemeClusterSegmenterBorrowed::segment_latin1, FnInStruct)]
+        #[diplomat::rust_link(
+            icu::segmenter::GraphemeClusterSegmenterBorrowed::segment_latin1,
+            FnInStruct
+        )]
         #[diplomat::attr(not(supports = utf8_strings), disable)]
         pub fn segment_latin1<'a>(
             &'a self,

--- a/ffi/capi/src/segmenter_grapheme.rs
+++ b/ffi/capi/src/segmenter_grapheme.rs
@@ -50,7 +50,7 @@ pub mod ffi {
         #[cfg(feature = "compiled_data")]
         pub fn create() -> Box<GraphemeClusterSegmenter> {
             Box::new(GraphemeClusterSegmenter(
-                icu_segmenter::GraphemeClusterSegmenter::new(),
+                icu_segmenter::GraphemeClusterSegmenter::new().static_to_owned(),
             ))
         }
         /// Construct an [`GraphemeClusterSegmenter`].
@@ -82,7 +82,9 @@ pub mod ffi {
             &'a self,
             input: &'a DiplomatStr,
         ) -> Box<GraphemeClusterBreakIteratorUtf8<'a>> {
-            Box::new(GraphemeClusterBreakIteratorUtf8(self.0.segment_utf8(input)))
+            Box::new(GraphemeClusterBreakIteratorUtf8(
+                self.0.as_borrowed().segment_utf8(input),
+            ))
         }
 
         /// Segments a string.
@@ -97,7 +99,7 @@ pub mod ffi {
             input: &'a DiplomatStr16,
         ) -> Box<GraphemeClusterBreakIteratorUtf16<'a>> {
             Box::new(GraphemeClusterBreakIteratorUtf16(
-                self.0.segment_utf16(input),
+                self.0.as_borrowed().segment_utf16(input),
             ))
         }
 
@@ -109,7 +111,7 @@ pub mod ffi {
             input: &'a [u8],
         ) -> Box<GraphemeClusterBreakIteratorLatin1<'a>> {
             Box::new(GraphemeClusterBreakIteratorLatin1(
-                self.0.segment_latin1(input),
+                self.0.as_borrowed().segment_latin1(input),
             ))
         }
     }

--- a/ffi/capi/src/segmenter_line.rs
+++ b/ffi/capi/src/segmenter_line.rs
@@ -74,9 +74,9 @@ pub mod ffi {
         #[diplomat::attr(auto, named_constructor = "auto")]
         #[cfg(feature = "compiled_data")]
         pub fn create_auto() -> Box<LineSegmenter> {
-            Box::new(LineSegmenter(icu_segmenter::LineSegmenter::new_auto(
-                Default::default(),
-            ).static_to_owned()))
+            Box::new(LineSegmenter(
+                icu_segmenter::LineSegmenter::new_auto(Default::default()).static_to_owned(),
+            ))
         }
 
         /// Construct a [`LineSegmenter`] with default options (no locale-based tailoring) and LSTM payload data for
@@ -85,9 +85,9 @@ pub mod ffi {
         #[diplomat::attr(auto, named_constructor = "lstm")]
         #[cfg(feature = "compiled_data")]
         pub fn create_lstm() -> Box<LineSegmenter> {
-            Box::new(LineSegmenter(icu_segmenter::LineSegmenter::new_lstm(
-                Default::default(),
-            ).static_to_owned()))
+            Box::new(LineSegmenter(
+                icu_segmenter::LineSegmenter::new_lstm(Default::default()).static_to_owned(),
+            ))
         }
 
         /// Construct a [`LineSegmenter`] with default options (no locale-based tailoring) and dictionary payload data for
@@ -96,9 +96,9 @@ pub mod ffi {
         #[diplomat::attr(auto, named_constructor = "dictionary")]
         #[cfg(feature = "compiled_data")]
         pub fn create_dictionary() -> Box<LineSegmenter> {
-            Box::new(LineSegmenter(icu_segmenter::LineSegmenter::new_dictionary(
-                Default::default(),
-            ).static_to_owned()))
+            Box::new(LineSegmenter(
+                icu_segmenter::LineSegmenter::new_dictionary(Default::default()).static_to_owned(),
+            ))
         }
 
         /// Construct a [`LineSegmenter`] with custom options using compiled data. It automatically loads the best
@@ -114,9 +114,9 @@ pub mod ffi {
         ) -> Box<LineSegmenter> {
             let mut options: LineBreakOptions = options.into();
             options.content_locale = content_locale.map(|c| &c.0.id);
-            Box::new(LineSegmenter(icu_segmenter::LineSegmenter::new_auto(
-                options,
-            ).static_to_owned()))
+            Box::new(LineSegmenter(
+                icu_segmenter::LineSegmenter::new_auto(options).static_to_owned(),
+            ))
         }
         /// Construct a [`LineSegmenter`] with custom options. It automatically loads the best
         /// available payload data for Burmese, Khmer, Lao, and Thai, using a particular data source.
@@ -154,9 +154,9 @@ pub mod ffi {
             let mut options: LineBreakOptions = options.into();
             options.content_locale = content_locale.map(|c| &c.0.id);
 
-            Box::new(LineSegmenter(icu_segmenter::LineSegmenter::new_lstm(
-                options,
-            ).static_to_owned()))
+            Box::new(LineSegmenter(
+                icu_segmenter::LineSegmenter::new_lstm(options).static_to_owned(),
+            ))
         }
         /// Construct a [`LineSegmenter`] with custom options and LSTM payload data for
         /// Burmese, Khmer, Lao, and Thai, using a particular data source.
@@ -194,9 +194,9 @@ pub mod ffi {
             let mut options: LineBreakOptions = options.into();
             options.content_locale = content_locale.map(|c| &c.0.id);
 
-            Box::new(LineSegmenter(icu_segmenter::LineSegmenter::new_dictionary(
-                options,
-            ).static_to_owned()))
+            Box::new(LineSegmenter(
+                icu_segmenter::LineSegmenter::new_dictionary(options).static_to_owned(),
+            ))
         }
         /// Construct a [`LineSegmenter`] with custom options and dictionary payload data for
         /// Burmese, Khmer, Lao, and Thai, using a particular data source.
@@ -232,7 +232,9 @@ pub mod ffi {
             &'a self,
             input: &'a DiplomatStr,
         ) -> Box<LineBreakIteratorUtf8<'a>> {
-            Box::new(LineBreakIteratorUtf8(self.0.as_borrowed().segment_utf8(input)))
+            Box::new(LineBreakIteratorUtf8(
+                self.0.as_borrowed().segment_utf8(input),
+            ))
         }
 
         /// Segments a string.
@@ -246,14 +248,18 @@ pub mod ffi {
             &'a self,
             input: &'a DiplomatStr16,
         ) -> Box<LineBreakIteratorUtf16<'a>> {
-            Box::new(LineBreakIteratorUtf16(self.0.as_borrowed().segment_utf16(input)))
+            Box::new(LineBreakIteratorUtf16(
+                self.0.as_borrowed().segment_utf16(input),
+            ))
         }
 
         /// Segments a Latin-1 string.
         #[diplomat::rust_link(icu::segmenter::LineSegmenter::segment_latin1, FnInStruct)]
         #[diplomat::attr(not(supports = utf8_strings), disable)]
         pub fn segment_latin1<'a>(&'a self, input: &'a [u8]) -> Box<LineBreakIteratorLatin1<'a>> {
-            Box::new(LineBreakIteratorLatin1(self.0.as_borrowed().segment_latin1(input)))
+            Box::new(LineBreakIteratorLatin1(
+                self.0.as_borrowed().segment_latin1(input),
+            ))
         }
     }
 

--- a/ffi/capi/src/segmenter_line.rs
+++ b/ffi/capi/src/segmenter_line.rs
@@ -19,6 +19,7 @@ pub mod ffi {
     #[diplomat::opaque]
     /// An ICU4X line-break segmenter, capable of finding breakpoints in strings.
     #[diplomat::rust_link(icu::segmenter::LineSegmenter, Struct)]
+    #[diplomat::rust_link(icu::segmenter::LineSegmenterBorrowed, Struct, hidden)]
     pub struct LineSegmenter(icu_segmenter::LineSegmenter);
 
     #[diplomat::rust_link(icu::segmenter::options::LineBreakStrictness, Enum)]
@@ -224,8 +225,8 @@ pub mod ffi {
         ///
         /// Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
         /// to the WHATWG Encoding Standard.
-        #[diplomat::rust_link(icu::segmenter::LineSegmenter::segment_utf8, FnInStruct)]
-        #[diplomat::rust_link(icu::segmenter::LineSegmenter::segment_str, FnInStruct, hidden)]
+        #[diplomat::rust_link(icu::segmenter::LineSegmenterBorrowed::segment_utf8, FnInStruct)]
+        #[diplomat::rust_link(icu::segmenter::LineSegmenterBorrowed::segment_str, FnInStruct, hidden)]
         #[diplomat::attr(not(supports = utf8_strings), disable)]
         #[diplomat::attr(*, rename = "segment")]
         pub fn segment_utf8<'a>(
@@ -241,7 +242,7 @@ pub mod ffi {
         ///
         /// Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
         /// to the WHATWG Encoding Standard.
-        #[diplomat::rust_link(icu::segmenter::LineSegmenter::segment_utf16, FnInStruct)]
+        #[diplomat::rust_link(icu::segmenter::LineSegmenterBorrowed::segment_utf16, FnInStruct)]
         #[diplomat::attr(not(supports = utf8_strings), rename = "segment")]
         #[diplomat::attr(supports = utf8_strings, rename = "segment16")]
         pub fn segment_utf16<'a>(
@@ -254,7 +255,7 @@ pub mod ffi {
         }
 
         /// Segments a Latin-1 string.
-        #[diplomat::rust_link(icu::segmenter::LineSegmenter::segment_latin1, FnInStruct)]
+        #[diplomat::rust_link(icu::segmenter::LineSegmenterBorrowed::segment_latin1, FnInStruct)]
         #[diplomat::attr(not(supports = utf8_strings), disable)]
         pub fn segment_latin1<'a>(&'a self, input: &'a [u8]) -> Box<LineBreakIteratorLatin1<'a>> {
             Box::new(LineBreakIteratorLatin1(

--- a/ffi/capi/src/segmenter_line.rs
+++ b/ffi/capi/src/segmenter_line.rs
@@ -226,7 +226,11 @@ pub mod ffi {
         /// Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
         /// to the WHATWG Encoding Standard.
         #[diplomat::rust_link(icu::segmenter::LineSegmenterBorrowed::segment_utf8, FnInStruct)]
-        #[diplomat::rust_link(icu::segmenter::LineSegmenterBorrowed::segment_str, FnInStruct, hidden)]
+        #[diplomat::rust_link(
+            icu::segmenter::LineSegmenterBorrowed::segment_str,
+            FnInStruct,
+            hidden
+        )]
         #[diplomat::attr(not(supports = utf8_strings), disable)]
         #[diplomat::attr(*, rename = "segment")]
         pub fn segment_utf8<'a>(

--- a/ffi/capi/src/segmenter_line.rs
+++ b/ffi/capi/src/segmenter_line.rs
@@ -76,7 +76,7 @@ pub mod ffi {
         pub fn create_auto() -> Box<LineSegmenter> {
             Box::new(LineSegmenter(icu_segmenter::LineSegmenter::new_auto(
                 Default::default(),
-            )))
+            ).static_to_owned()))
         }
 
         /// Construct a [`LineSegmenter`] with default options (no locale-based tailoring) and LSTM payload data for
@@ -87,7 +87,7 @@ pub mod ffi {
         pub fn create_lstm() -> Box<LineSegmenter> {
             Box::new(LineSegmenter(icu_segmenter::LineSegmenter::new_lstm(
                 Default::default(),
-            )))
+            ).static_to_owned()))
         }
 
         /// Construct a [`LineSegmenter`] with default options (no locale-based tailoring) and dictionary payload data for
@@ -98,7 +98,7 @@ pub mod ffi {
         pub fn create_dictionary() -> Box<LineSegmenter> {
             Box::new(LineSegmenter(icu_segmenter::LineSegmenter::new_dictionary(
                 Default::default(),
-            )))
+            ).static_to_owned()))
         }
 
         /// Construct a [`LineSegmenter`] with custom options using compiled data. It automatically loads the best
@@ -116,7 +116,7 @@ pub mod ffi {
             options.content_locale = content_locale.map(|c| &c.0.id);
             Box::new(LineSegmenter(icu_segmenter::LineSegmenter::new_auto(
                 options,
-            )))
+            ).static_to_owned()))
         }
         /// Construct a [`LineSegmenter`] with custom options. It automatically loads the best
         /// available payload data for Burmese, Khmer, Lao, and Thai, using a particular data source.
@@ -156,7 +156,7 @@ pub mod ffi {
 
             Box::new(LineSegmenter(icu_segmenter::LineSegmenter::new_lstm(
                 options,
-            )))
+            ).static_to_owned()))
         }
         /// Construct a [`LineSegmenter`] with custom options and LSTM payload data for
         /// Burmese, Khmer, Lao, and Thai, using a particular data source.
@@ -196,7 +196,7 @@ pub mod ffi {
 
             Box::new(LineSegmenter(icu_segmenter::LineSegmenter::new_dictionary(
                 options,
-            )))
+            ).static_to_owned()))
         }
         /// Construct a [`LineSegmenter`] with custom options and dictionary payload data for
         /// Burmese, Khmer, Lao, and Thai, using a particular data source.
@@ -232,7 +232,7 @@ pub mod ffi {
             &'a self,
             input: &'a DiplomatStr,
         ) -> Box<LineBreakIteratorUtf8<'a>> {
-            Box::new(LineBreakIteratorUtf8(self.0.segment_utf8(input)))
+            Box::new(LineBreakIteratorUtf8(self.0.as_borrowed().segment_utf8(input)))
         }
 
         /// Segments a string.
@@ -246,14 +246,14 @@ pub mod ffi {
             &'a self,
             input: &'a DiplomatStr16,
         ) -> Box<LineBreakIteratorUtf16<'a>> {
-            Box::new(LineBreakIteratorUtf16(self.0.segment_utf16(input)))
+            Box::new(LineBreakIteratorUtf16(self.0.as_borrowed().segment_utf16(input)))
         }
 
         /// Segments a Latin-1 string.
         #[diplomat::rust_link(icu::segmenter::LineSegmenter::segment_latin1, FnInStruct)]
         #[diplomat::attr(not(supports = utf8_strings), disable)]
         pub fn segment_latin1<'a>(&'a self, input: &'a [u8]) -> Box<LineBreakIteratorLatin1<'a>> {
-            Box::new(LineBreakIteratorLatin1(self.0.segment_latin1(input)))
+            Box::new(LineBreakIteratorLatin1(self.0.as_borrowed().segment_latin1(input)))
         }
     }
 

--- a/ffi/capi/src/segmenter_sentence.rs
+++ b/ffi/capi/src/segmenter_sentence.rs
@@ -51,9 +51,9 @@ pub mod ffi {
         #[diplomat::attr(auto, constructor)]
         #[cfg(feature = "compiled_data")]
         pub fn create() -> Box<SentenceSegmenter> {
-            Box::new(SentenceSegmenter(icu_segmenter::SentenceSegmenter::new(
-                Default::default(),
-            )))
+            Box::new(SentenceSegmenter(
+                icu_segmenter::SentenceSegmenter::new(Default::default()).static_to_owned(),
+            ))
         }
         /// Construct a [`SentenceSegmenter`] for content known to be of a given locale, using compiled data.
         #[diplomat::rust_link(icu::segmenter::SentenceSegmenter::try_new, FnInStruct, hidden)]
@@ -96,7 +96,9 @@ pub mod ffi {
             &'a self,
             input: &'a DiplomatStr,
         ) -> Box<SentenceBreakIteratorUtf8<'a>> {
-            Box::new(SentenceBreakIteratorUtf8(self.0.segment_utf8(input)))
+            Box::new(SentenceBreakIteratorUtf8(
+                self.0.as_borrowed().segment_utf8(input),
+            ))
         }
 
         /// Segments a string.
@@ -110,7 +112,9 @@ pub mod ffi {
             &'a self,
             input: &'a DiplomatStr16,
         ) -> Box<SentenceBreakIteratorUtf16<'a>> {
-            Box::new(SentenceBreakIteratorUtf16(self.0.segment_utf16(input)))
+            Box::new(SentenceBreakIteratorUtf16(
+                self.0.as_borrowed().segment_utf16(input),
+            ))
         }
 
         /// Segments a Latin-1 string.
@@ -120,7 +124,9 @@ pub mod ffi {
             &'a self,
             input: &'a [u8],
         ) -> Box<SentenceBreakIteratorLatin1<'a>> {
-            Box::new(SentenceBreakIteratorLatin1(self.0.segment_latin1(input)))
+            Box::new(SentenceBreakIteratorLatin1(
+                self.0.as_borrowed().segment_latin1(input),
+            ))
         }
     }
 

--- a/ffi/capi/src/segmenter_sentence.rs
+++ b/ffi/capi/src/segmenter_sentence.rs
@@ -16,6 +16,7 @@ pub mod ffi {
     #[diplomat::opaque]
     /// An ICU4X sentence-break segmenter, capable of finding sentence breakpoints in strings.
     #[diplomat::rust_link(icu::segmenter::SentenceSegmenter, Struct)]
+    #[diplomat::rust_link(icu::segmenter::SentenceSegmenterBorrowed, Struct, hidden)]
     pub struct SentenceSegmenter(icu_segmenter::SentenceSegmenter);
 
     #[diplomat::opaque]
@@ -88,8 +89,8 @@ pub mod ffi {
         ///
         /// Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
         /// to the WHATWG Encoding Standard.
-        #[diplomat::rust_link(icu::segmenter::SentenceSegmenter::segment_utf8, FnInStruct)]
-        #[diplomat::rust_link(icu::segmenter::SentenceSegmenter::segment_str, FnInStruct, hidden)]
+        #[diplomat::rust_link(icu::segmenter::SentenceSegmenterBorrowed::segment_utf8, FnInStruct)]
+        #[diplomat::rust_link(icu::segmenter::SentenceSegmenterBorrowed::segment_str, FnInStruct, hidden)]
         #[diplomat::attr(not(supports = utf8_strings), disable)]
         #[diplomat::attr(*, rename = "segment")]
         pub fn segment_utf8<'a>(
@@ -105,7 +106,7 @@ pub mod ffi {
         ///
         /// Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
         /// to the WHATWG Encoding Standard.
-        #[diplomat::rust_link(icu::segmenter::SentenceSegmenter::segment_utf16, FnInStruct)]
+        #[diplomat::rust_link(icu::segmenter::SentenceSegmenterBorrowed::segment_utf16, FnInStruct)]
         #[diplomat::attr(not(supports = utf8_strings), rename = "segment")]
         #[diplomat::attr(supports = utf8_strings, rename = "segment16")]
         pub fn segment_utf16<'a>(
@@ -118,7 +119,7 @@ pub mod ffi {
         }
 
         /// Segments a Latin-1 string.
-        #[diplomat::rust_link(icu::segmenter::SentenceSegmenter::segment_latin1, FnInStruct)]
+        #[diplomat::rust_link(icu::segmenter::SentenceSegmenterBorrowed::segment_latin1, FnInStruct)]
         #[diplomat::attr(not(supports = utf8_strings), disable)]
         pub fn segment_latin1<'a>(
             &'a self,

--- a/ffi/capi/src/segmenter_sentence.rs
+++ b/ffi/capi/src/segmenter_sentence.rs
@@ -90,7 +90,11 @@ pub mod ffi {
         /// Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
         /// to the WHATWG Encoding Standard.
         #[diplomat::rust_link(icu::segmenter::SentenceSegmenterBorrowed::segment_utf8, FnInStruct)]
-        #[diplomat::rust_link(icu::segmenter::SentenceSegmenterBorrowed::segment_str, FnInStruct, hidden)]
+        #[diplomat::rust_link(
+            icu::segmenter::SentenceSegmenterBorrowed::segment_str,
+            FnInStruct,
+            hidden
+        )]
         #[diplomat::attr(not(supports = utf8_strings), disable)]
         #[diplomat::attr(*, rename = "segment")]
         pub fn segment_utf8<'a>(
@@ -119,7 +123,10 @@ pub mod ffi {
         }
 
         /// Segments a Latin-1 string.
-        #[diplomat::rust_link(icu::segmenter::SentenceSegmenterBorrowed::segment_latin1, FnInStruct)]
+        #[diplomat::rust_link(
+            icu::segmenter::SentenceSegmenterBorrowed::segment_latin1,
+            FnInStruct
+        )]
         #[diplomat::attr(not(supports = utf8_strings), disable)]
         pub fn segment_latin1<'a>(
             &'a self,

--- a/ffi/capi/src/segmenter_word.rs
+++ b/ffi/capi/src/segmenter_word.rs
@@ -68,9 +68,9 @@ pub mod ffi {
         #[diplomat::attr(auto, named_constructor = "auto")]
         #[cfg(feature = "compiled_data")]
         pub fn create_auto() -> Box<WordSegmenter> {
-            Box::new(WordSegmenter(icu_segmenter::WordSegmenter::new_auto(
-                Default::default(),
-            ).static_to_owned()))
+            Box::new(WordSegmenter(
+                icu_segmenter::WordSegmenter::new_auto(Default::default()).static_to_owned(),
+            ))
         }
 
         /// Construct an [`WordSegmenter`] with automatically selecting the best available LSTM
@@ -119,9 +119,9 @@ pub mod ffi {
         #[diplomat::attr(auto, named_constructor = "lstm")]
         #[cfg(feature = "compiled_data")]
         pub fn create_lstm() -> Box<WordSegmenter> {
-            Box::new(WordSegmenter(icu_segmenter::WordSegmenter::new_lstm(
-                Default::default(),
-            ).static_to_owned()))
+            Box::new(WordSegmenter(
+                icu_segmenter::WordSegmenter::new_lstm(Default::default()).static_to_owned(),
+            ))
         }
 
         /// Construct an [`WordSegmenter`] with LSTM payload data for Burmese, Khmer, Lao, and
@@ -169,9 +169,9 @@ pub mod ffi {
         #[diplomat::attr(auto, named_constructor = "dictionary")]
         #[cfg(feature = "compiled_data")]
         pub fn create_dictionary() -> Box<WordSegmenter> {
-            Box::new(WordSegmenter(icu_segmenter::WordSegmenter::new_dictionary(
-                Default::default(),
-            ).static_to_owned()))
+            Box::new(WordSegmenter(
+                icu_segmenter::WordSegmenter::new_dictionary(Default::default()).static_to_owned(),
+            ))
         }
 
         /// Construct an [`WordSegmenter`] with dictionary payload data for Chinese, Japanese,
@@ -221,7 +221,9 @@ pub mod ffi {
             &'a self,
             input: &'a DiplomatStr,
         ) -> Box<WordBreakIteratorUtf8<'a>> {
-            Box::new(WordBreakIteratorUtf8(self.0.as_borrowed().segment_utf8(input)))
+            Box::new(WordBreakIteratorUtf8(
+                self.0.as_borrowed().segment_utf8(input),
+            ))
         }
 
         /// Segments a string.
@@ -235,14 +237,18 @@ pub mod ffi {
             &'a self,
             input: &'a DiplomatStr16,
         ) -> Box<WordBreakIteratorUtf16<'a>> {
-            Box::new(WordBreakIteratorUtf16(self.0.as_borrowed().segment_utf16(input)))
+            Box::new(WordBreakIteratorUtf16(
+                self.0.as_borrowed().segment_utf16(input),
+            ))
         }
 
         /// Segments a Latin-1 string.
         #[diplomat::rust_link(icu::segmenter::WordSegmenter::segment_latin1, FnInStruct)]
         #[diplomat::attr(not(supports = utf8_strings), disable)]
         pub fn segment_latin1<'a>(&'a self, input: &'a [u8]) -> Box<WordBreakIteratorLatin1<'a>> {
-            Box::new(WordBreakIteratorLatin1(self.0.as_borrowed().segment_latin1(input)))
+            Box::new(WordBreakIteratorLatin1(
+                self.0.as_borrowed().segment_latin1(input),
+            ))
         }
     }
 

--- a/ffi/capi/src/segmenter_word.rs
+++ b/ffi/capi/src/segmenter_word.rs
@@ -70,7 +70,7 @@ pub mod ffi {
         pub fn create_auto() -> Box<WordSegmenter> {
             Box::new(WordSegmenter(icu_segmenter::WordSegmenter::new_auto(
                 Default::default(),
-            )))
+            ).static_to_owned()))
         }
 
         /// Construct an [`WordSegmenter`] with automatically selecting the best available LSTM
@@ -121,7 +121,7 @@ pub mod ffi {
         pub fn create_lstm() -> Box<WordSegmenter> {
             Box::new(WordSegmenter(icu_segmenter::WordSegmenter::new_lstm(
                 Default::default(),
-            )))
+            ).static_to_owned()))
         }
 
         /// Construct an [`WordSegmenter`] with LSTM payload data for Burmese, Khmer, Lao, and
@@ -171,7 +171,7 @@ pub mod ffi {
         pub fn create_dictionary() -> Box<WordSegmenter> {
             Box::new(WordSegmenter(icu_segmenter::WordSegmenter::new_dictionary(
                 Default::default(),
-            )))
+            ).static_to_owned()))
         }
 
         /// Construct an [`WordSegmenter`] with dictionary payload data for Chinese, Japanese,
@@ -221,7 +221,7 @@ pub mod ffi {
             &'a self,
             input: &'a DiplomatStr,
         ) -> Box<WordBreakIteratorUtf8<'a>> {
-            Box::new(WordBreakIteratorUtf8(self.0.segment_utf8(input)))
+            Box::new(WordBreakIteratorUtf8(self.0.as_borrowed().segment_utf8(input)))
         }
 
         /// Segments a string.
@@ -235,14 +235,14 @@ pub mod ffi {
             &'a self,
             input: &'a DiplomatStr16,
         ) -> Box<WordBreakIteratorUtf16<'a>> {
-            Box::new(WordBreakIteratorUtf16(self.0.segment_utf16(input)))
+            Box::new(WordBreakIteratorUtf16(self.0.as_borrowed().segment_utf16(input)))
         }
 
         /// Segments a Latin-1 string.
         #[diplomat::rust_link(icu::segmenter::WordSegmenter::segment_latin1, FnInStruct)]
         #[diplomat::attr(not(supports = utf8_strings), disable)]
         pub fn segment_latin1<'a>(&'a self, input: &'a [u8]) -> Box<WordBreakIteratorLatin1<'a>> {
-            Box::new(WordBreakIteratorLatin1(self.0.segment_latin1(input)))
+            Box::new(WordBreakIteratorLatin1(self.0.as_borrowed().segment_latin1(input)))
         }
     }
 

--- a/ffi/capi/src/segmenter_word.rs
+++ b/ffi/capi/src/segmenter_word.rs
@@ -24,6 +24,7 @@ pub mod ffi {
     #[diplomat::opaque]
     /// An ICU4X word-break segmenter, capable of finding word breakpoints in strings.
     #[diplomat::rust_link(icu::segmenter::WordSegmenter, Struct)]
+    #[diplomat::rust_link(icu::segmenter::WordSegmenterBorrowed, Struct, hidden)]
     #[diplomat::demo(custom_func = "../../npm/demo_gen_custom/WordSegmenter.mjs")]
     pub struct WordSegmenter(icu_segmenter::WordSegmenter);
 
@@ -213,8 +214,8 @@ pub mod ffi {
         ///
         /// Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
         /// to the WHATWG Encoding Standard.
-        #[diplomat::rust_link(icu::segmenter::WordSegmenter::segment_utf8, FnInStruct)]
-        #[diplomat::rust_link(icu::segmenter::WordSegmenter::segment_str, FnInStruct, hidden)]
+        #[diplomat::rust_link(icu::segmenter::WordSegmenterBorrowed::segment_utf8, FnInStruct)]
+        #[diplomat::rust_link(icu::segmenter::WordSegmenterBorrowed::segment_str, FnInStruct, hidden)]
         #[diplomat::attr(not(supports = utf8_strings), disable)]
         #[diplomat::attr(*, rename = "segment")]
         pub fn segment_utf8<'a>(
@@ -230,7 +231,7 @@ pub mod ffi {
         ///
         /// Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
         /// to the WHATWG Encoding Standard.
-        #[diplomat::rust_link(icu::segmenter::WordSegmenter::segment_utf16, FnInStruct)]
+        #[diplomat::rust_link(icu::segmenter::WordSegmenterBorrowed::segment_utf16, FnInStruct)]
         #[diplomat::attr(not(supports = utf8_strings), rename = "segment")]
         #[diplomat::attr(supports = utf8_strings, rename = "segment16")]
         pub fn segment_utf16<'a>(
@@ -243,7 +244,7 @@ pub mod ffi {
         }
 
         /// Segments a Latin-1 string.
-        #[diplomat::rust_link(icu::segmenter::WordSegmenter::segment_latin1, FnInStruct)]
+        #[diplomat::rust_link(icu::segmenter::WordSegmenterBorrowed::segment_latin1, FnInStruct)]
         #[diplomat::attr(not(supports = utf8_strings), disable)]
         pub fn segment_latin1<'a>(&'a self, input: &'a [u8]) -> Box<WordBreakIteratorLatin1<'a>> {
             Box::new(WordBreakIteratorLatin1(

--- a/ffi/capi/src/segmenter_word.rs
+++ b/ffi/capi/src/segmenter_word.rs
@@ -215,7 +215,11 @@ pub mod ffi {
         /// Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
         /// to the WHATWG Encoding Standard.
         #[diplomat::rust_link(icu::segmenter::WordSegmenterBorrowed::segment_utf8, FnInStruct)]
-        #[diplomat::rust_link(icu::segmenter::WordSegmenterBorrowed::segment_str, FnInStruct, hidden)]
+        #[diplomat::rust_link(
+            icu::segmenter::WordSegmenterBorrowed::segment_str,
+            FnInStruct,
+            hidden
+        )]
         #[diplomat::attr(not(supports = utf8_strings), disable)]
         #[diplomat::attr(*, rename = "segment")]
         pub fn segment_utf8<'a>(
@@ -271,6 +275,12 @@ pub mod ffi {
 
         /// Return the status value of break boundary.
         #[diplomat::rust_link(icu::segmenter::WordBreakIterator::word_type, FnInStruct)]
+        #[diplomat::rust_link(icu::segmenter::WordBreakIteratorWithWordType, Struct, hidden)]
+        #[diplomat::rust_link(
+            icu::segmenter::WordBreakIteratorWithWordType::next,
+            FnInStruct,
+            hidden
+        )]
         #[diplomat::attr(auto, getter)]
         pub fn word_type(&self) -> SegmenterWordType {
             self.0.word_type().into()

--- a/provider/source/src/segmenter/lstm.rs
+++ b/provider/source/src/segmenter/lstm.rs
@@ -260,6 +260,7 @@ mod tests {
 
         let segmenter =
             LineSegmenter::try_new_lstm_unstable(&provider, Default::default()).unwrap();
+        let segmenter = segmenter.as_borrowed();
 
         const TEST_STR: &str = "ภาษาไทยภาษาไทย";
         let utf16: Vec<u16> = TEST_STR.encode_utf16().collect();


### PR DESCRIPTION
Fixes #5514

This does mean all the borrowed methods take the borrowed types by-move, even the larger ones, since the data then needs to be further reborrowed by the iterators.

This is suboptimal but so far moving overhead doesn't seem to show up that often, so we ought to be fine

The alternate approach is #6394, but it can't be made to work in FFI without adding borrowed types to FFI.


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->