### PR TITLE
Fix any calendar checks

### DIFF
--- a/components/calendar/src/any_calendar.rs
+++ b/components/calendar/src/any_calendar.rs
@@ -1206,7 +1206,12 @@ impl From<Indian> for AnyCalendar {
 impl IntoAnyCalendar for HijriTabular {
     #[inline]
     fn to_any(self) -> AnyCalendar {
-        AnyCalendar::HijriTabularCivil(self)
+        match self.0 {
+            calendrical_calculations::islamic::ISLAMIC_EPOCH_FRIDAY => {
+                AnyCalendar::HijriTabularCivil(self)
+            }
+            _ => AnyCalendar::HijriTabularAstronomical(self),
+        }
     }
     #[inline]
     fn kind(&self) -> AnyCalendarKind {
@@ -1219,7 +1224,9 @@ impl IntoAnyCalendar for HijriTabular {
     }
     #[inline]
     fn from_any(any: AnyCalendar) -> Result<Self, AnyCalendar> {
-        if let AnyCalendar::HijriTabularCivil(cal) = any {
+        if let AnyCalendar::HijriTabularCivil(cal) | AnyCalendar::HijriTabularAstronomical(cal) =
+            any
+        {
             Ok(cal)
         } else {
             Err(any)
@@ -1227,7 +1234,9 @@ impl IntoAnyCalendar for HijriTabular {
     }
     #[inline]
     fn from_any_ref(any: &AnyCalendar) -> Option<&Self> {
-        if let AnyCalendar::HijriTabularCivil(cal) = any {
+        if let AnyCalendar::HijriTabularCivil(cal) | AnyCalendar::HijriTabularAstronomical(cal) =
+            any
+        {
             Some(cal)
         } else {
             None
@@ -1235,7 +1244,12 @@ impl IntoAnyCalendar for HijriTabular {
     }
     #[inline]
     fn date_to_any(&self, d: &Self::DateInner) -> AnyDateInner {
-        AnyDateInner::HijriTabularCivil(*d)
+        match self.0 {
+            calendrical_calculations::islamic::ISLAMIC_EPOCH_FRIDAY => {
+                AnyDateInner::HijriTabularCivil(*d)
+            }
+            _ => AnyDateInner::HijriTabularAstronomical(*d),
+        }
     }
 }
 

--- a/components/datetime/src/scaffold/calendar.rs
+++ b/components/datetime/src/scaffold/calendar.rs
@@ -748,21 +748,17 @@ impl<C: Calendar, A: AsCalendar<Calendar = C>> InSameCalendar for DateTime<A> {
         &self,
         any_calendar_kind: AnyCalendarKind,
     ) -> Result<(), MismatchedCalendarError> {
-        if self.date.calendar().any_calendar_kind() == Some(any_calendar_kind) {
-            Ok(())
-        } else {
-            Err(MismatchedCalendarError {
-                this_kind: any_calendar_kind,
-                date_kind: self.date.calendar().any_calendar_kind(),
-            })
-        }
+        self.date.check_any_calendar_kind(any_calendar_kind)
     }
 }
 
 impl<C: Calendar, A: AsCalendar<Calendar = C>, Z> InSameCalendar for ZonedDateTime<A, Z> {
     #[inline]
-    fn check_any_calendar_kind(&self, _: AnyCalendarKind) -> Result<(), MismatchedCalendarError> {
-        Ok(())
+    fn check_any_calendar_kind(
+        &self,
+        any_calendar_kind: AnyCalendarKind,
+    ) -> Result<(), MismatchedCalendarError> {
+        self.date.check_any_calendar_kind(any_calendar_kind)
     }
 }
 

--- a/components/datetime/tests/fixtures/tests/components.json
+++ b/components/datetime/tests/fixtures/tests/components.json
@@ -29,6 +29,8 @@
                 "zh-u-ca-chinese-hc-h23": "2019己亥年腊月27星期二 08:25:07",
                 "en-u-ca-japanese-hc-h23": "Tuesday, January 21, 2 Reiwa, 08:25:07",
                 "ja-u-ca-japanese-hc-h23": "令和2年1月21日火曜日 8:25:07",
+                "en-u-ca-japanese-hc-h23-x-extended": "Tuesday, January 21, 2 Reiwa, 08:25:07",
+                "ja-u-ca-japanese-hc-h23-x-extended": "令和2年1月21日火曜日 8:25:07",
                 "en-u-ca-coptic-hc-h23": "Tuesday, Toba 12, 1736 ERA1, 08:25:07",
                 "fr-u-ca-coptic-hc-h23": "mardi 12 toubah 1736 ap. D., 08:25:07",
                 "en-u-ca-dangi-hc-h23": "Tuesday, Twelfth Month 27, 2019(ji-hai), 08:25:07",


### PR DESCRIPTION
`ZonedDateTime` has not been enforcing `AnyCalendarKind`s since [#5150](https://github.com/unicode-org/icu4x/pull/5150/files#diff-a4f5d62814d01dd02fae0ad0975c4e7a978e185454bced0d1ea4830ff34829f5R114) added formatting for it. #6384 then introduced a bug that wasn't caught by tests.