### PR TITLE
Bump nightlies and LLVM

### DIFF
--- a/.github/workflows/artifacts-build.yml
+++ b/.github/workflows/artifacts-build.yml
@@ -267,8 +267,6 @@ jobs:
       run: |
         npm -C ffi/npm ci
         npm -C tutorials/web-demo ci
-      env: 
-        PINNED_CI_NIGHTLY: nightly-2024-07-23
 
     - name: Run Webpack
       run: npm -C tutorials/web-demo run build

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -280,6 +280,11 @@ jobs:
     - name: Show the selected Rust toolchain
       run: rustup show
 
+    # Job-specific dependencies
+    # TODO: Remove on 2025-05-05, when clang-19 is in ubuntu-latest (https://github.com/actions/runner-images/issues/11895)
+    - name: Install LLD and Clang
+      run: sudo apt-get install lld-19 clang-19
+
     # Actual job
     - name: Run `cargo make ci-job-test-c`
       run: cargo make ci-job-test-c
@@ -309,6 +314,11 @@ jobs:
       run: cargo make set-ci-toolchain
     - name: Show the selected Rust toolchain
       run: rustup show
+
+    # Job-specific dependencies
+    # TODO: Remove on 2025-05-05, when clang-19 is in ubuntu-latest (https://github.com/actions/runner-images/issues/11895)
+    - name: Install LLD
+      run: sudo apt-get install lld-19
 
     # Actual job
     - name: Run `cargo make ci-job-test-js`

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,7 +29,7 @@ jobs:
   
       - uses:                   actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
         with:
-          toolchain:            nightly-2024-07-23
+          toolchain:            nightly-2024-09-01
           override:             true
 
       - run: cargo test --all-features --no-fail-fast

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,7 +112,7 @@ Our wider testsuite is organized as `ci-job-foo` make tasks corresponding to eac
 <br/>
  
  - `ci-job-test-c`: Runs all C/C++ FFI tests; mostly important if you're changing the FFI interface.
-     + Requires `clang-18` and `lld-18` with the `gold` plugin (APT packages `llvm-18` and `lld-18`).
+     + Requires `clang-19` and `lld-19` with the `gold` plugin (APT packages `llvm-19` and `lld-19`).
  - `ci-job-test-js`: Runs all JS/WASM/Node FFI tests; mostly important if you're changing the FFI interface.
      + Requires Node.js version 16.18.0. This may not the one offered by the package manager; get it from the NodeJS website or `nvm`.
  - `ci-job-nostd`: Builds ICU4X for a `#[no_std]` target to verify that it's compatible.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2687,9 +2687,9 @@ dependencies = [
 
 [[package]]
 name = "rustdoc-types"
-version = "0.28.1"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edcdc023d622eeec23ac48f064126eb09b69e19728308aa905bdc28b562b4319"
+checksum = "e5e9c03264c20dcf51813b421e60809fa17637d8fb917bf4e7de448ccbdf409e"
 dependencies = [
  "serde",
 ]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -19,7 +19,7 @@ default_to_workspace = false
 # The toolchain that CI is being run in. Allows tests to change under beta/nightly.
 CI_TOOLCHAIN = { value = "pinned-stable", condition = { env_not_set = ["CI_TOOLCHAIN"]}}
 # The pinned nightly toolchain for jobs that require a nightly compiler.
-PINNED_CI_NIGHTLY = { value = "nightly-2024-07-23", condition = { env_not_set = ["PINNED_CI_NIGHTLY"] } }
+PINNED_CI_NIGHTLY = { value = "nightly-2025-02-17", condition = { env_not_set = ["PINNED_CI_NIGHTLY"] } }
 
 [tasks.quick]
 description = "Run quick version of all lints and builds (useful before pushing to GitHub)"

--- a/tools/make/diplomat-coverage/Cargo.toml
+++ b/tools/make/diplomat-coverage/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 diplomat_core = { workspace = true }
 elsa = { workspace = true }
 lazy_static = "1"
-rustdoc-types = "0.28"
+rustdoc-types = "0.36"
 serde_json = { workspace = true }
 syn-inline-mod = "0.6.0"
 

--- a/tools/make/diplomat-coverage/src/main.rs
+++ b/tools/make/diplomat-coverage/src/main.rs
@@ -99,13 +99,13 @@ fn collect_public_types(krate: &str) -> impl Iterator<Item = (Vec<String>, ast::
         if CRATES.get(krate).is_none() {
             eprintln!("Parsing crate {krate}");
             std::process::Command::new("rustup")
-                .args(["install", "nightly-2024-07-23"])
+                .args(["install", "nightly-2025-02-17"])
                 .output()
                 .expect("failed to install nightly");
             let output = std::process::Command::new("rustup")
                 .args([
                     "run",
-                    "nightly-2024-07-23",
+                    "nightly-2025-02-17",
                     "cargo",
                     "rustdoc",
                     "-p",
@@ -186,8 +186,8 @@ fn collect_public_types(krate: &str) -> impl Iterator<Item = (Vec<String>, ast::
             return;
         }
         match &item.inner {
-            ItemEnum::Import(import) => {
-                if !import.glob {
+            ItemEnum::Use(import) => {
+                if !import.is_glob {
                     path.push(import.name.clone());
                 }
 
@@ -235,7 +235,7 @@ fn collect_public_types(krate: &str) -> impl Iterator<Item = (Vec<String>, ast::
                                     .iter()
                                     .map(|id| &external_crate.index[id])
                                     .find(|item| match &item.inner {
-                                        ItemEnum::Import(import) => {
+                                        ItemEnum::Use(import) => {
                                             if import.name.as_str() == segment {
                                                 path.pop();
                                                 true
@@ -272,11 +272,10 @@ fn collect_public_types(krate: &str) -> impl Iterator<Item = (Vec<String>, ast::
                             if let ItemEnum::Impl(inner) = &krate.index[id].inner {
                                 let mut trait_name = None;
                                 if let Some(path) = &inner.trait_ {
-                                    let name = &path.name;
-                                    if IGNORED_TRAITS.contains(name.as_str()) {
+                                    if IGNORED_TRAITS.contains(path.path.as_str()) {
                                         continue;
                                     }
-                                    trait_name = Some(&*path.name);
+                                    trait_name = Some(path.path.as_str());
                                 }
                                 for id in &inner.items {
                                     recurse(
@@ -302,11 +301,10 @@ fn collect_public_types(krate: &str) -> impl Iterator<Item = (Vec<String>, ast::
                             if let ItemEnum::Impl(inner) = &krate.index[id].inner {
                                 let mut trait_name = None;
                                 if let Some(path) = &inner.trait_ {
-                                    let name = &path.name;
-                                    if IGNORED_TRAITS.contains(name.as_str()) {
+                                    if IGNORED_TRAITS.contains(path.path.as_str()) {
                                         continue;
                                     }
-                                    trait_name = Some(&*path.name);
+                                    trait_name = Some(path.path.as_str());
                                 }
                                 for id in &inner.items {
                                     recurse(

--- a/tutorials/c-tiny/README.md
+++ b/tutorials/c-tiny/README.md
@@ -30,9 +30,9 @@ The maximally low-size build documented here involves using LTO with `-Clinker-p
 
 ```bash
 # Pick a toolchain where Rust and Clang use the same underlying LLVM version
-CLANG := clang-17
-LLD := lld-17
-LLVM_COMPATIBLE_NIGHTLY = "nightly-2024-01-01"
+CLANG := clang-19
+LLD := lld-19
+LLVM_COMPATIBLE_NIGHTLY = "nightly-2025-02-17"
 
 # Rust build
 # ============

--- a/tutorials/c-tiny/fixeddecimal/Makefile
+++ b/tutorials/c-tiny/fixeddecimal/Makefile
@@ -22,9 +22,9 @@ ALL_RUST_SRC = $(wildcard ../../../components/**/*.rs) $(wildcard ../../../provi
 $(ALL_HEADERS):
 
 GCC := gcc
-CLANG := clang-18
-LLD := lld-18
-LLVM_COMPATIBLE_NIGHTLY = "nightly-2024-07-01"
+CLANG := clang-19
+LLD := lld-19
+LLVM_COMPATIBLE_NIGHTLY = "nightly-2025-02-17"
 
 
 target/release/icu4x-datagen: $(ALL_RUST_SRC)

--- a/tutorials/c-tiny/segmenter/Makefile
+++ b/tutorials/c-tiny/segmenter/Makefile
@@ -22,9 +22,9 @@ ALL_RUST_SRC = $(wildcard ../../../components/**/*.rs) $(wildcard ../../../provi
 $(ALL_HEADERS):
 
 GCC := gcc
-CLANG := clang-18
-LLD := lld-18
-LLVM_COMPATIBLE_NIGHTLY = "nightly-2024-07-01"
+CLANG := clang-19
+LLD := lld-19
+LLVM_COMPATIBLE_NIGHTLY = "nightly-2025-02-17"
 
 
 target-normal/release/libicu_capi.a:

--- a/tutorials/js-tiny/Makefile
+++ b/tutorials/js-tiny/Makefile
@@ -9,7 +9,7 @@ ICU_CAPI := $(shell cargo metadata --format-version 1 | jq '.packages[] | select
 HEADERS := ${ICU_CAPI}/bindings/js
 ALL_HEADERS := $(wildcard ${HEADERS}/*)
 
-LLVM_COMPATIBLE_NIGHTLY ?= "nightly-2024-07-01"
+LLVM_COMPATIBLE_NIGHTLY ?= "nightly-2025-02-17"
 
 $(ALL_HEADERS):
 

--- a/tutorials/js-tiny/ld.py
+++ b/tutorials/js-tiny/ld.py
@@ -32,7 +32,7 @@ def main():
         else:
             new_argv += [arg]
             is_export = False
-    result = subprocess.run(["lld-18"] + new_argv, stdout=sys.stdout, stderr=sys.stderr)
+    result = subprocess.run(["lld-19"] + new_argv, stdout=sys.stdout, stderr=sys.stderr)
     return result.returncode
 
 if __name__ == "__main__":

--- a/tutorials/rust/buffer/Makefile
+++ b/tutorials/rust/buffer/Makefile
@@ -4,7 +4,7 @@
 
 export CARGO_TARGET_DIR ?= target
 
-PINNED_CI_NIGHTLY = "nightly-2024-07-23"
+PINNED_CI_NIGHTLY = "nightly-2025-02-17"
 
 all: buffer_data.postcard bin/tutorial_buffer.wasm
 


### PR DESCRIPTION
This PR bumps the nightlies to `nightly-2025-02-17` and LLVM to version 19.

Rust was on LLVM 19 from `nightly-2024-08-01` to `nightly-2025-02-17`. 

https://github.com/unicode-org/icu4x/blob/main/documents/process/rust_versions.md:

* It MUST be available via apt on all currently-supported Ubuntu LTS
  * ✅ 24.04 https://launchpad.net/ubuntu/+source/llvm-toolchain-19
  * ✅ 22.04 available through https://apt.llvm.org/
* It MUST be available via apt on Debian `testing`
  * ✅ https://packages.debian.org/trixie/llvm-19
* It MUST be available via `brew`
  * ✅ https://formulae.brew.sh/formula/lld@19
* It MUST be available on Fedora via `yum`
  * ✅ https://packages.fedoraproject.org/pkgs/llvm/llvm/
  * There is no dedicated `llvm-19` package, but the `llvm` package is version 19
* It MUST be available on the GitHub Actions runners with ubuntu-latest
  * 🟨 Coming on 2025-05-05 (https://github.com/actions/runner-images/issues/11895)
  * installing through apt in the meantime
* It SHOULD be available on the latest XCode
  * ✅ https://github.com/swiftlang/llvm-project/blob/swift-6.1-RELEASE/llvm/utils/gn/secondary/llvm/version.gni
* It SHOULD be available on ICU4X developer machines using nonstandard package management
  * ✅ Confirmed available on GLinux 
* It SHOULD be available on RHEL and latest Rocky Linux via yum
  * ✅ Rocky Linux confirmed