### PR TITLE
Make compiled data casemapper method not take by-self

### DIFF
--- a/ffi/capi/bindings/c/CaseMapper.h
+++ b/ffi/capi/bindings/c/CaseMapper.h
@@ -31,7 +31,7 @@ void icu4x_CaseMapper_uppercase_mv1(const CaseMapper* self, DiplomatStringView s
 
 void icu4x_CaseMapper_lowercase_with_compiled_data_mv1(DiplomatStringView s, const Locale* locale, DiplomatWrite* write);
 
-void icu4x_CaseMapper_uppercase_with_compiled_data_mv1(const CaseMapper* self, DiplomatStringView s, const Locale* locale, DiplomatWrite* write);
+void icu4x_CaseMapper_uppercase_with_compiled_data_mv1(DiplomatStringView s, const Locale* locale, DiplomatWrite* write);
 
 void icu4x_CaseMapper_titlecase_segment_with_only_case_data_v1_mv1(const CaseMapper* self, DiplomatStringView s, const Locale* locale, TitlecaseOptionsV1 options, DiplomatWrite* write);
 

--- a/ffi/capi/bindings/cpp/icu4x/CaseMapper.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/CaseMapper.d.hpp
@@ -77,7 +77,7 @@ public:
    *
    * See the [Rust documentation for `uppercase`](https://docs.rs/icu/latest/icu/casemap/struct.CaseMapperBorrowed.html#method.uppercase) for more information.
    */
-  inline diplomat::result<std::string, diplomat::Utf8Error> uppercase_with_compiled_data(std::string_view s, const icu4x::Locale& locale) const;
+  inline static diplomat::result<std::string, diplomat::Utf8Error> uppercase_with_compiled_data(std::string_view s, const icu4x::Locale& locale);
 
   /**
    * Returns the full titlecase mapping of the given string, performing head adjustment without

--- a/ffi/capi/bindings/cpp/icu4x/CaseMapper.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/CaseMapper.hpp
@@ -33,7 +33,7 @@ namespace capi {
     
     void icu4x_CaseMapper_lowercase_with_compiled_data_mv1(diplomat::capi::DiplomatStringView s, const icu4x::capi::Locale* locale, diplomat::capi::DiplomatWrite* write);
     
-    void icu4x_CaseMapper_uppercase_with_compiled_data_mv1(const icu4x::capi::CaseMapper* self, diplomat::capi::DiplomatStringView s, const icu4x::capi::Locale* locale, diplomat::capi::DiplomatWrite* write);
+    void icu4x_CaseMapper_uppercase_with_compiled_data_mv1(diplomat::capi::DiplomatStringView s, const icu4x::capi::Locale* locale, diplomat::capi::DiplomatWrite* write);
     
     void icu4x_CaseMapper_titlecase_segment_with_only_case_data_v1_mv1(const icu4x::capi::CaseMapper* self, diplomat::capi::DiplomatStringView s, const icu4x::capi::Locale* locale, icu4x::capi::TitlecaseOptionsV1 options, diplomat::capi::DiplomatWrite* write);
     
@@ -108,14 +108,13 @@ inline diplomat::result<std::string, diplomat::Utf8Error> icu4x::CaseMapper::low
   return diplomat::Ok<std::string>(std::move(output));
 }
 
-inline diplomat::result<std::string, diplomat::Utf8Error> icu4x::CaseMapper::uppercase_with_compiled_data(std::string_view s, const icu4x::Locale& locale) const {
+inline diplomat::result<std::string, diplomat::Utf8Error> icu4x::CaseMapper::uppercase_with_compiled_data(std::string_view s, const icu4x::Locale& locale) {
   if (!diplomat::capi::diplomat_is_str(s.data(), s.size())) {
     return diplomat::Err<diplomat::Utf8Error>();
   }
   std::string output;
   diplomat::capi::DiplomatWrite write = diplomat::WriteFromString(output);
-  icu4x::capi::icu4x_CaseMapper_uppercase_with_compiled_data_mv1(this->AsFFI(),
-    {s.data(), s.size()},
+  icu4x::capi::icu4x_CaseMapper_uppercase_with_compiled_data_mv1({s.data(), s.size()},
     locale.AsFFI(),
     &write);
   return diplomat::Ok<std::string>(std::move(output));

--- a/ffi/capi/bindings/dart/CaseMapper.g.dart
+++ b/ffi/capi/bindings/dart/CaseMapper.g.dart
@@ -77,10 +77,10 @@ final class CaseMapper implements ffi.Finalizable {
   /// Returns the full uppercase mapping of the given string, using compiled data (avoids having to allocate a CaseMapper object)
   ///
   /// See the [Rust documentation for `uppercase`](https://docs.rs/icu/latest/icu/casemap/struct.CaseMapperBorrowed.html#method.uppercase) for more information.
-  String uppercaseWithCompiledData(String s, Locale locale) {
+  static String uppercaseWithCompiledData(String s, Locale locale) {
     final temp = _FinalizedArena();
     final write = _Write();
-    _icu4x_CaseMapper_uppercase_with_compiled_data_mv1(_ffi, s._utf8AllocIn(temp.arena), locale._ffi, write._ffi);
+    _icu4x_CaseMapper_uppercase_with_compiled_data_mv1(s._utf8AllocIn(temp.arena), locale._ffi, write._ffi);
     return write.finalize();
   }
 
@@ -226,9 +226,9 @@ external void _icu4x_CaseMapper_uppercase_mv1(ffi.Pointer<ffi.Opaque> self, _Sli
 external void _icu4x_CaseMapper_lowercase_with_compiled_data_mv1(_SliceUtf8 s, ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> write);
 
 @_DiplomatFfiUse('icu4x_CaseMapper_uppercase_with_compiled_data_mv1')
-@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CaseMapper_uppercase_with_compiled_data_mv1')
+@ffi.Native<ffi.Void Function(_SliceUtf8, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CaseMapper_uppercase_with_compiled_data_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_CaseMapper_uppercase_with_compiled_data_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUtf8 s, ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> write);
+external void _icu4x_CaseMapper_uppercase_with_compiled_data_mv1(_SliceUtf8 s, ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> write);
 
 @_DiplomatFfiUse('icu4x_CaseMapper_titlecase_segment_with_only_case_data_v1_mv1')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8, ffi.Pointer<ffi.Opaque>, _TitlecaseOptionsFfi, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CaseMapper_titlecase_segment_with_only_case_data_v1_mv1')

--- a/ffi/capi/bindings/demo_gen/CaseMapper.mjs
+++ b/ffi/capi/bindings/demo_gen/CaseMapper.mjs
@@ -34,11 +34,9 @@ export function lowercaseWithCompiledData(s, localeName) {
 }
 export function uppercaseWithCompiledData(s, localeName) {
     
-    let caseMapper = new CaseMapper();
-    
     let locale = Locale.fromString(localeName);
     
-    let out = caseMapper.uppercaseWithCompiledData(s,locale);
+    let out = CaseMapper.uppercaseWithCompiledData(s,locale);
     
 
     return out;

--- a/ffi/capi/bindings/js/CaseMapper.d.ts
+++ b/ffi/capi/bindings/js/CaseMapper.d.ts
@@ -50,7 +50,7 @@ export class CaseMapper {
      *
      * See the [Rust documentation for `uppercase`](https://docs.rs/icu/latest/icu/casemap/struct.CaseMapperBorrowed.html#method.uppercase) for more information.
      */
-    uppercaseWithCompiledData(s: string, locale: Locale): string;
+    static uppercaseWithCompiledData(s: string, locale: Locale): string;
 
     /** 
      * Returns the full titlecase mapping of the given string, performing head adjustment without

--- a/ffi/capi/bindings/js/CaseMapper.mjs
+++ b/ffi/capi/bindings/js/CaseMapper.mjs
@@ -159,13 +159,13 @@ export class CaseMapper {
      *
      * See the [Rust documentation for `uppercase`](https://docs.rs/icu/latest/icu/casemap/struct.CaseMapperBorrowed.html#method.uppercase) for more information.
      */
-    uppercaseWithCompiledData(s, locale) {
+    static uppercaseWithCompiledData(s, locale) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
         const sSlice = functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.str8(wasm, s));
         
         const write = new diplomatRuntime.DiplomatWriteBuf(wasm);
-        wasm.icu4x_CaseMapper_uppercase_with_compiled_data_mv1(this.ffiValue, ...sSlice.splat(), locale.ffiValue, write.buffer);
+        wasm.icu4x_CaseMapper_uppercase_with_compiled_data_mv1(...sSlice.splat(), locale.ffiValue, write.buffer);
     
         try {
             return write.readString8();

--- a/ffi/capi/src/casemap.rs
+++ b/ffi/capi/src/casemap.rs
@@ -129,12 +129,7 @@ pub mod ffi {
             hidden
         )]
         #[cfg(feature = "compiled_data")]
-        pub fn uppercase_with_compiled_data(
-            &self,
-            s: &str,
-            locale: &Locale,
-            write: &mut DiplomatWrite,
-        ) {
+        pub fn uppercase_with_compiled_data(s: &str, locale: &Locale, write: &mut DiplomatWrite) {
             let _infallible = icu_casemap::CaseMapper::new()
                 .uppercase(s, &locale.0.id)
                 .write_to(write);


### PR DESCRIPTION
oops

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->