### PR TITLE
Segmenter cleanups, part 2 (reduce trait complexity)

### DIFF
--- a/components/segmenter/src/complex/dictionary.rs
+++ b/components/segmenter/src/complex/dictionary.rs
@@ -41,8 +41,8 @@ struct DictionaryBreakIterator<
 /// - `'s` = lifetime of the string being segmented
 ///
 /// [`Iterator`]: core::iter::Iterator
-impl<'l, 's, Y: DictionaryType + ?Sized, X: Iterator<Item = usize> + ?Sized> Iterator
-    for DictionaryBreakIterator<'l, 's, Y, X>
+impl<Y: DictionaryType + ?Sized, X: Iterator<Item = usize> + ?Sized> Iterator
+    for DictionaryBreakIterator<'_, '_, Y, X>
 {
     type Item = usize;
 

--- a/components/segmenter/src/complex/dictionary.rs
+++ b/components/segmenter/src/complex/dictionary.rs
@@ -9,9 +9,9 @@ use core::str::CharIndices;
 use icu_collections::char16trie::{Char16Trie, TrieResult};
 
 /// A trait for dictionary based iterator
-trait DictionaryType<'l, 's> {
+trait DictionaryType {
     /// The iterator over characters.
-    type IterAttr: Iterator<Item = (usize, Self::CharType)> + Clone;
+    type IterAttr<'s>: Iterator<Item = (usize, Self::CharType)> + Clone;
 
     /// The character type.
     type CharType: Copy + Into<u32>;
@@ -23,11 +23,11 @@ trait DictionaryType<'l, 's> {
 struct DictionaryBreakIterator<
     'l,
     's,
-    Y: DictionaryType<'l, 's> + ?Sized,
+    Y: DictionaryType + ?Sized,
     X: Iterator<Item = usize> + ?Sized,
 > {
     trie: Char16Trie<'l>,
-    iter: Y::IterAttr,
+    iter: Y::IterAttr<'s>,
     len: usize,
     grapheme_iter: X,
     // TODO transform value for byte trie
@@ -41,7 +41,7 @@ struct DictionaryBreakIterator<
 /// - `'s` = lifetime of the string being segmented
 ///
 /// [`Iterator`]: core::iter::Iterator
-impl<'l, 's, Y: DictionaryType<'l, 's> + ?Sized, X: Iterator<Item = usize> + ?Sized> Iterator
+impl<'l, 's, Y: DictionaryType + ?Sized, X: Iterator<Item = usize> + ?Sized> Iterator
     for DictionaryBreakIterator<'l, 's, Y, X>
 {
     type Item = usize;
@@ -106,8 +106,8 @@ impl<'l, 's, Y: DictionaryType<'l, 's> + ?Sized, X: Iterator<Item = usize> + ?Si
     }
 }
 
-impl<'s> DictionaryType<'_, 's> for u32 {
-    type IterAttr = Utf16Indices<'s>;
+impl DictionaryType for u32 {
+    type IterAttr<'s> = Utf16Indices<'s>;
     type CharType = u32;
 
     fn to_char(c: u32) -> char {
@@ -123,8 +123,8 @@ impl<'s> DictionaryType<'_, 's> for u32 {
     }
 }
 
-impl<'s> DictionaryType<'_, 's> for char {
-    type IterAttr = CharIndices<'s>;
+impl DictionaryType for char {
+    type IterAttr<'s> = CharIndices<'s>;
     type CharType = char;
 
     fn to_char(c: char) -> char {

--- a/components/segmenter/src/grapheme.rs
+++ b/components/segmenter/src/grapheme.rs
@@ -34,25 +34,25 @@ derive_usize_iterator_with_type!(GraphemeClusterBreakIterator, 'data);
 ///
 /// For examples of use, see [`GraphemeClusterSegmenter`].
 pub type GraphemeClusterBreakIteratorUtf8<'data, 's> =
-    GraphemeClusterBreakIterator<'data, 's, RuleBreakTypeUtf8>;
+    GraphemeClusterBreakIterator<'data, 's, Utf8>;
 
 /// Grapheme cluster break iterator for a potentially invalid UTF-8 string.
 ///
 /// For examples of use, see [`GraphemeClusterSegmenter`].
 pub type GraphemeClusterBreakIteratorPotentiallyIllFormedUtf8<'data, 's> =
-    GraphemeClusterBreakIterator<'data, 's, RuleBreakTypePotentiallyIllFormedUtf8>;
+    GraphemeClusterBreakIterator<'data, 's, PotentiallyIllFormedUtf8>;
 
 /// Grapheme cluster break iterator for a Latin-1 (8-bit) string.
 ///
 /// For examples of use, see [`GraphemeClusterSegmenter`].
 pub type GraphemeClusterBreakIteratorLatin1<'data, 's> =
-    GraphemeClusterBreakIterator<'data, 's, RuleBreakTypeLatin1>;
+    GraphemeClusterBreakIterator<'data, 's, Latin1>;
 
 /// Grapheme cluster break iterator for a UTF-16 string.
 ///
 /// For examples of use, see [`GraphemeClusterSegmenter`].
 pub type GraphemeClusterBreakIteratorUtf16<'data, 's> =
-    GraphemeClusterBreakIterator<'data, 's, RuleBreakTypeUtf16>;
+    GraphemeClusterBreakIterator<'data, 's, Utf16>;
 
 /// Segments a string into grapheme clusters.
 ///

--- a/components/segmenter/src/grapheme.rs
+++ b/components/segmenter/src/grapheme.rs
@@ -195,6 +195,7 @@ impl<'data> GraphemeClusterSegmenterBorrowed<'data> {
             complex: None,
             boundary_property: 0,
             locale_override: None,
+            handle_complex_language: empty_handle_complex_language,
         })
     }
     /// Creates a grapheme cluster break iterator for a potentially ill-formed UTF8 string
@@ -215,6 +216,7 @@ impl<'data> GraphemeClusterSegmenterBorrowed<'data> {
             complex: None,
             boundary_property: 0,
             locale_override: None,
+            handle_complex_language: empty_handle_complex_language,
         })
     }
     /// Creates a grapheme cluster break iterator for a Latin-1 (8-bit) string.
@@ -233,6 +235,7 @@ impl<'data> GraphemeClusterSegmenterBorrowed<'data> {
             complex: None,
             boundary_property: 0,
             locale_override: None,
+            handle_complex_language: empty_handle_complex_language,
         })
     }
 
@@ -252,6 +255,7 @@ impl<'data> GraphemeClusterSegmenterBorrowed<'data> {
             complex: None,
             boundary_property: 0,
             locale_override: None,
+            handle_complex_language: empty_handle_complex_language,
         })
     }
 }

--- a/components/segmenter/src/grapheme.rs
+++ b/components/segmenter/src/grapheme.rs
@@ -24,7 +24,7 @@ use utf8_iter::Utf8CharIndices;
 ///
 /// For examples of use, see [`GraphemeClusterSegmenter`].
 #[derive(Debug)]
-pub struct GraphemeClusterBreakIterator<'data, 's, Y: RuleBreakType<'s> + ?Sized>(
+pub struct GraphemeClusterBreakIterator<'data, 's, Y: RuleBreakType>(
     RuleBreakIterator<'data, 's, Y>,
 );
 

--- a/components/segmenter/src/iterator_helpers.rs
+++ b/components/segmenter/src/iterator_helpers.rs
@@ -6,7 +6,7 @@
 
 macro_rules! derive_usize_iterator_with_type {
     ($ty:tt, $($lt:lifetime),* ) => {
-        impl<$($lt,)* 's, Y: RuleBreakType<'s> + ?Sized> Iterator for $ty<$($lt,)* 's, Y> {
+        impl<$($lt,)* 's, Y: RuleBreakType> Iterator for $ty<$($lt,)* 's, Y> {
             type Item = usize;
             #[inline]
             fn next(&mut self) -> Option<Self::Item> {

--- a/components/segmenter/src/lib.rs
+++ b/components/segmenter/src/lib.rs
@@ -163,10 +163,7 @@ pub mod options {
 /// Largely-internal scaffolding types (You should very rarely need to reference these directly)
 pub mod scaffold {
     pub use crate::line::LineBreakType;
-    pub use crate::rule_segmenter::{
-        RuleBreakType, RuleBreakTypeLatin1, RuleBreakTypePotentiallyIllFormedUtf8,
-        RuleBreakTypeUtf16, RuleBreakTypeUtf8,
-    };
+    pub use crate::rule_segmenter::{Latin1, PotentiallyIllFormedUtf8, RuleBreakType, Utf16, Utf8};
     pub use crate::word::WordBreakType;
 }
 

--- a/components/segmenter/src/lib.rs
+++ b/components/segmenter/src/lib.rs
@@ -162,10 +162,12 @@ pub mod options {
 
 /// Largely-internal scaffolding types (You should very rarely need to reference these directly)
 pub mod scaffold {
+    pub use crate::line::LineBreakType;
     pub use crate::rule_segmenter::{
         RuleBreakType, RuleBreakTypeLatin1, RuleBreakTypePotentiallyIllFormedUtf8,
         RuleBreakTypeUtf16, RuleBreakTypeUtf8,
     };
+    pub use crate::word::WordBreakType;
 }
 
 pub(crate) mod private {

--- a/components/segmenter/src/line.rs
+++ b/components/segmenter/src/line.rs
@@ -789,7 +789,7 @@ pub struct LineBreakIterator<'data, 's, Y: LineBreakType> {
     complex: ComplexPayloadsBorrowed<'data>,
 }
 
-impl<'s, Y: LineBreakType> Iterator for LineBreakIterator<'_, 's, Y> {
+impl<Y: LineBreakType> Iterator for LineBreakIterator<'_, '_, Y> {
     type Item = usize;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -1035,7 +1035,7 @@ enum StringBoundaryPosType {
     End,
 }
 
-impl<'s, Y: LineBreakType> LineBreakIterator<'_, 's, Y> {
+impl<Y: LineBreakType> LineBreakIterator<'_, '_, Y> {
     fn advance_iter(&mut self) {
         self.current_pos_data = self.iter.next();
     }
@@ -1135,8 +1135,8 @@ impl LineBreakType for RuleBreakTypePotentiallyIllFormedUtf8 {
     }
 }
 /// line_handle_complex_language impl for UTF8 iterators
-fn line_handle_complex_language_utf8<'data, 's, T>(
-    iter: &mut LineBreakIterator<'data, 's, T>,
+fn line_handle_complex_language_utf8<T>(
+    iter: &mut LineBreakIterator<'_, '_, T>,
     left_codepoint: char,
 ) -> Option<usize>
 where

--- a/components/segmenter/src/line.rs
+++ b/components/segmenter/src/line.rs
@@ -769,7 +769,7 @@ pub trait LineBreakType: crate::private::Sealed + Sized {
     fn get_current_position_character_len(iterator: &LineBreakIterator<'_, '_, Self>) -> usize;
 
     #[doc(hidden)]
-    fn handle_complex_language(
+    fn line_handle_complex_language(
         iterator: &mut LineBreakIterator<'_, '_, Self>,
         left_codepoint: Self::CharType,
     ) -> Option<usize>;
@@ -913,7 +913,7 @@ impl<'s, Y: LineBreakType> Iterator for LineBreakIterator<'_, 's, Y> {
                 && Y::use_complex_breaking(self, left_codepoint)
                 && Y::use_complex_breaking(self, right_codepoint)
             {
-                let result = Y::handle_complex_language(self, left_codepoint);
+                let result = Y::line_handle_complex_language(self, left_codepoint);
                 if result.is_some() {
                     return result;
                 }
@@ -1128,11 +1128,11 @@ impl LineBreakType for LineBreakTypeUtf8 {
         iterator.get_current_codepoint().map_or(0, |c| c.len_utf8())
     }
 
-    fn handle_complex_language(
+    fn line_handle_complex_language(
         iter: &mut LineBreakIterator<'_, '_, Self>,
         left_codepoint: char,
     ) -> Option<usize> {
-        handle_complex_language_utf8(iter, left_codepoint)
+        line_handle_complex_language_utf8(iter, left_codepoint)
     }
 }
 
@@ -1164,15 +1164,15 @@ impl LineBreakType for LineBreakTypePotentiallyIllFormedUtf8 {
         iterator.get_current_codepoint().map_or(0, |c| c.len_utf8())
     }
 
-    fn handle_complex_language(
+    fn line_handle_complex_language(
         iter: &mut LineBreakIterator<'_, '_, Self>,
         left_codepoint: char,
     ) -> Option<usize> {
-        handle_complex_language_utf8(iter, left_codepoint)
+        line_handle_complex_language_utf8(iter, left_codepoint)
     }
 }
-/// handle_complex_language impl for UTF8 iterators
-fn handle_complex_language_utf8<'data, 's, T>(
+/// line_handle_complex_language impl for UTF8 iterators
+fn line_handle_complex_language_utf8<'data, 's, T>(
     iter: &mut LineBreakIterator<'data, 's, T>,
     left_codepoint: char,
 ) -> Option<usize>
@@ -1250,7 +1250,7 @@ impl LineBreakType for LineBreakTypeLatin1 {
         unreachable!()
     }
 
-    fn handle_complex_language(
+    fn line_handle_complex_language(
         _: &mut LineBreakIterator<Self>,
         _: Self::CharType,
     ) -> Option<usize> {
@@ -1289,7 +1289,7 @@ impl LineBreakType for LineBreakTypeUtf16 {
         }
     }
 
-    fn handle_complex_language(
+    fn line_handle_complex_language(
         iterator: &mut LineBreakIterator<Self>,
         left_codepoint: Self::CharType,
     ) -> Option<usize> {

--- a/components/segmenter/src/line.rs
+++ b/components/segmenter/src/line.rs
@@ -233,23 +233,23 @@ impl From<LineBreakOptions<'_>> for ResolvedLineBreakOptions {
 /// Line break iterator for an `str` (a UTF-8 string).
 ///
 /// For examples of use, see [`LineSegmenter`].
-pub type LineBreakIteratorUtf8<'l, 's> = LineBreakIterator<'l, 's, RuleBreakTypeUtf8>;
+pub type LineBreakIteratorUtf8<'l, 's> = LineBreakIterator<'l, 's, Utf8>;
 
 /// Line break iterator for a potentially invalid UTF-8 string.
 ///
 /// For examples of use, see [`LineSegmenter`].
 pub type LineBreakIteratorPotentiallyIllFormedUtf8<'l, 's> =
-    LineBreakIterator<'l, 's, RuleBreakTypePotentiallyIllFormedUtf8>;
+    LineBreakIterator<'l, 's, PotentiallyIllFormedUtf8>;
 
 /// Line break iterator for a Latin-1 (8-bit) string.
 ///
 /// For examples of use, see [`LineSegmenter`].
-pub type LineBreakIteratorLatin1<'l, 's> = LineBreakIterator<'l, 's, RuleBreakTypeLatin1>;
+pub type LineBreakIteratorLatin1<'l, 's> = LineBreakIterator<'l, 's, Latin1>;
 
 /// Line break iterator for a UTF-16 string.
 ///
 /// For examples of use, see [`LineSegmenter`].
-pub type LineBreakIteratorUtf16<'l, 's> = LineBreakIterator<'l, 's, RuleBreakTypeUtf16>;
+pub type LineBreakIteratorUtf16<'l, 's> = LineBreakIterator<'l, 's, Utf16>;
 
 /// Supports loading line break data, and creating line break iterators for different string
 /// encodings.
@@ -1091,7 +1091,7 @@ impl<Y: LineBreakType> LineBreakIterator<'_, '_, Y> {
     }
 }
 
-impl LineBreakType for RuleBreakTypeUtf8 {
+impl LineBreakType for Utf8 {
     fn get_linebreak_property_with_rule(iterator: &LineBreakIterator<Self>, c: char) -> u8 {
         iterator.data.get_linebreak_property_utf32_with_rule(
             c as u32,
@@ -1113,7 +1113,7 @@ impl LineBreakType for RuleBreakTypeUtf8 {
     }
 }
 
-impl LineBreakType for RuleBreakTypePotentiallyIllFormedUtf8 {
+impl LineBreakType for PotentiallyIllFormedUtf8 {
     fn get_linebreak_property_with_rule(iterator: &LineBreakIterator<Self>, c: char) -> u8 {
         iterator.data.get_linebreak_property_utf32_with_rule(
             c as u32,
@@ -1188,7 +1188,7 @@ where
     }
 }
 
-impl LineBreakType for RuleBreakTypeLatin1 {
+impl LineBreakType for Latin1 {
     fn get_linebreak_property_with_rule(iterator: &LineBreakIterator<Self>, c: u8) -> u8 {
         // No CJ on Latin1
         // Note: Default value is 0 == UNKNOWN
@@ -1208,7 +1208,7 @@ impl LineBreakType for RuleBreakTypeLatin1 {
     }
 }
 
-impl LineBreakType for RuleBreakTypeUtf16 {
+impl LineBreakType for Utf16 {
     fn get_linebreak_property_with_rule(iterator: &LineBreakIterator<Self>, c: u32) -> u8 {
         iterator.data.get_linebreak_property_utf32_with_rule(
             c,

--- a/components/segmenter/src/rule_segmenter.rs
+++ b/components/segmenter/src/rule_segmenter.rs
@@ -49,7 +49,7 @@ pub trait RuleBreakType<'s>: crate::private::Sealed {
 /// _after_ the boundary (for a boundary at the end of text, this index is the length
 /// of the [`str`] or array of code units).
 #[derive(Debug)]
-pub struct RuleBreakIterator<'data, 's, Y: RuleBreakType<'s> + ?Sized> {
+pub(crate) struct RuleBreakIterator<'data, 's, Y: RuleBreakType<'s> + ?Sized> {
     pub(crate) iter: Y::IterAttr,
     pub(crate) len: usize,
     pub(crate) current_pos_data: Option<(usize, Y::CharType)>,

--- a/components/segmenter/src/rule_segmenter.rs
+++ b/components/segmenter/src/rule_segmenter.rs
@@ -59,7 +59,10 @@ pub(crate) fn empty_handle_complex_language<Y: RuleBreakType>(
     _i: &mut RuleBreakIterator<'_, '_, Y>,
     _c: Y::CharType,
 ) -> Option<usize> {
-    debug_assert!(false, "grapheme/sentence segmenters should never need complex language handling");
+    debug_assert!(
+        false,
+        "grapheme/sentence segmenters should never need complex language handling"
+    );
     None
 }
 

--- a/components/segmenter/src/rule_segmenter.rs
+++ b/components/segmenter/src/rule_segmenter.rs
@@ -276,11 +276,11 @@ impl<Y: RuleBreakType> RuleBreakIterator<'_, '_, Y> {
 #[derive(Debug)]
 #[non_exhaustive]
 /// [`RuleBreakType`] for UTF-8 strings
-pub struct RuleBreakTypeUtf8;
+pub struct Utf8;
 
-impl crate::private::Sealed for RuleBreakTypeUtf8 {}
+impl crate::private::Sealed for Utf8 {}
 
-impl RuleBreakType for RuleBreakTypeUtf8 {
+impl RuleBreakType for Utf8 {
     type IterAttr<'s> = CharIndices<'s>;
     type CharType = char;
 
@@ -292,11 +292,11 @@ impl RuleBreakType for RuleBreakTypeUtf8 {
 #[derive(Debug)]
 #[non_exhaustive]
 /// [`RuleBreakType`] for potentially ill-formed UTF-8 strings
-pub struct RuleBreakTypePotentiallyIllFormedUtf8;
+pub struct PotentiallyIllFormedUtf8;
 
-impl crate::private::Sealed for RuleBreakTypePotentiallyIllFormedUtf8 {}
+impl crate::private::Sealed for PotentiallyIllFormedUtf8 {}
 
-impl RuleBreakType for RuleBreakTypePotentiallyIllFormedUtf8 {
+impl RuleBreakType for PotentiallyIllFormedUtf8 {
     type IterAttr<'s> = Utf8CharIndices<'s>;
     type CharType = char;
 
@@ -308,11 +308,11 @@ impl RuleBreakType for RuleBreakTypePotentiallyIllFormedUtf8 {
 #[derive(Debug)]
 #[non_exhaustive]
 /// [`RuleBreakType`] for Latin-1 strings
-pub struct RuleBreakTypeLatin1;
+pub struct Latin1;
 
-impl crate::private::Sealed for RuleBreakTypeLatin1 {}
+impl crate::private::Sealed for Latin1 {}
 
-impl RuleBreakType for RuleBreakTypeLatin1 {
+impl RuleBreakType for Latin1 {
     type IterAttr<'s> = Latin1Indices<'s>;
     type CharType = u8;
 
@@ -324,11 +324,11 @@ impl RuleBreakType for RuleBreakTypeLatin1 {
 #[derive(Debug)]
 #[non_exhaustive]
 /// [`RuleBreakType`] for UTF-16 strings
-pub struct RuleBreakTypeUtf16;
+pub struct Utf16;
 
-impl crate::private::Sealed for RuleBreakTypeUtf16 {}
+impl crate::private::Sealed for Utf16 {}
 
-impl RuleBreakType for RuleBreakTypeUtf16 {
+impl RuleBreakType for Utf16 {
     type IterAttr<'s> = Utf16Indices<'s>;
     type CharType = u32;
 

--- a/components/segmenter/src/sentence.rs
+++ b/components/segmenter/src/sentence.rs
@@ -227,6 +227,7 @@ impl<'data> SentenceSegmenterBorrowed<'data> {
             complex: None,
             boundary_property: 0,
             locale_override: self.locale_override,
+            handle_complex_language: empty_handle_complex_language,
         })
     }
     /// Creates a sentence break iterator for a potentially ill-formed UTF8 string
@@ -247,6 +248,7 @@ impl<'data> SentenceSegmenterBorrowed<'data> {
             complex: None,
             boundary_property: 0,
             locale_override: self.locale_override,
+            handle_complex_language: empty_handle_complex_language,
         })
     }
     /// Creates a sentence break iterator for a Latin-1 (8-bit) string.
@@ -262,6 +264,7 @@ impl<'data> SentenceSegmenterBorrowed<'data> {
             complex: None,
             boundary_property: 0,
             locale_override: self.locale_override,
+            handle_complex_language: empty_handle_complex_language,
         })
     }
 
@@ -278,6 +281,7 @@ impl<'data> SentenceSegmenterBorrowed<'data> {
             complex: None,
             boundary_property: 0,
             locale_override: self.locale_override,
+            handle_complex_language: empty_handle_complex_language,
         })
     }
 }

--- a/components/segmenter/src/sentence.rs
+++ b/components/segmenter/src/sentence.rs
@@ -42,9 +42,7 @@ pub struct SentenceBreakInvariantOptions {}
 ///
 /// For examples of use, see [`SentenceSegmenter`].
 #[derive(Debug)]
-pub struct SentenceBreakIterator<'data, 's, Y: RuleBreakType<'s> + ?Sized>(
-    RuleBreakIterator<'data, 's, Y>,
-);
+pub struct SentenceBreakIterator<'data, 's, Y: RuleBreakType>(RuleBreakIterator<'data, 's, Y>);
 
 derive_usize_iterator_with_type!(SentenceBreakIterator, 'data);
 

--- a/components/segmenter/src/sentence.rs
+++ b/components/segmenter/src/sentence.rs
@@ -49,25 +49,23 @@ derive_usize_iterator_with_type!(SentenceBreakIterator, 'data);
 /// Sentence break iterator for an `str` (a UTF-8 string).
 ///
 /// For examples of use, see [`SentenceSegmenter`].
-pub type SentenceBreakIteratorUtf8<'data, 's> = SentenceBreakIterator<'data, 's, RuleBreakTypeUtf8>;
+pub type SentenceBreakIteratorUtf8<'data, 's> = SentenceBreakIterator<'data, 's, Utf8>;
 
 /// Sentence break iterator for a potentially invalid UTF-8 string.
 ///
 /// For examples of use, see [`SentenceSegmenter`].
 pub type SentenceBreakIteratorPotentiallyIllFormedUtf8<'data, 's> =
-    SentenceBreakIterator<'data, 's, RuleBreakTypePotentiallyIllFormedUtf8>;
+    SentenceBreakIterator<'data, 's, PotentiallyIllFormedUtf8>;
 
 /// Sentence break iterator for a Latin-1 (8-bit) string.
 ///
 /// For examples of use, see [`SentenceSegmenter`].
-pub type SentenceBreakIteratorLatin1<'data, 's> =
-    SentenceBreakIterator<'data, 's, RuleBreakTypeLatin1>;
+pub type SentenceBreakIteratorLatin1<'data, 's> = SentenceBreakIterator<'data, 's, Latin1>;
 
 /// Sentence break iterator for a UTF-16 string.
 ///
 /// For examples of use, see [`SentenceSegmenter`].
-pub type SentenceBreakIteratorUtf16<'data, 's> =
-    SentenceBreakIterator<'data, 's, RuleBreakTypeUtf16>;
+pub type SentenceBreakIteratorUtf16<'data, 's> = SentenceBreakIterator<'data, 's, Utf16>;
 
 /// Supports loading sentence break data, and creating sentence break iterators for different string
 /// encodings.

--- a/components/segmenter/src/word.rs
+++ b/components/segmenter/src/word.rs
@@ -45,9 +45,7 @@ pub struct WordBreakInvariantOptions {}
 ///
 /// For examples of use, see [`WordSegmenter`].
 #[derive(Debug)]
-pub struct WordBreakIterator<'data, 's, Y: RuleBreakType<'s> + ?Sized>(
-    RuleBreakIterator<'data, 's, Y>,
-);
+pub struct WordBreakIterator<'data, 's, Y: RuleBreakType>(RuleBreakIterator<'data, 's, Y>);
 
 derive_usize_iterator_with_type!(WordBreakIterator, 'data);
 
@@ -80,7 +78,7 @@ impl WordType {
     }
 }
 
-impl<'data, 's, Y: RuleBreakType<'s> + ?Sized> WordBreakIterator<'data, 's, Y> {
+impl<'data, 's, Y: RuleBreakType> WordBreakIterator<'data, 's, Y> {
     /// Returns the word type of the segment preceding the current boundary.
     #[inline]
     pub fn word_type(&self) -> WordType {
@@ -103,11 +101,11 @@ impl<'data, 's, Y: RuleBreakType<'s> + ?Sized> WordBreakIterator<'data, 's, Y> {
 /// Word break iterator that also returns the word type
 // We can use impl Trait here once `use<..>` syntax is available, see https://github.com/rust-lang/rust/issues/61756
 #[derive(Debug)]
-pub struct WordBreakIteratorWithWordType<'data, 's, Y: RuleBreakType<'s> + ?Sized>(
+pub struct WordBreakIteratorWithWordType<'data, 's, Y: RuleBreakType>(
     WordBreakIterator<'data, 's, Y>,
 );
 
-impl<'s, Y: RuleBreakType<'s> + ?Sized> Iterator for WordBreakIteratorWithWordType<'_, 's, Y> {
+impl<'s, Y: RuleBreakType> Iterator for WordBreakIteratorWithWordType<'_, 's, Y> {
     type Item = (usize, WordType);
     fn next(&mut self) -> Option<Self::Item> {
         let ret = self.0.next()?;
@@ -591,8 +589,8 @@ impl WordSegmenterBorrowed<'static> {
 pub struct WordBreakTypeUtf8;
 impl crate::private::Sealed for WordBreakTypeUtf8 {}
 
-impl<'s> RuleBreakType<'s> for WordBreakTypeUtf8 {
-    type IterAttr = CharIndices<'s>;
+impl RuleBreakType for WordBreakTypeUtf8 {
+    type IterAttr<'s> = CharIndices<'s>;
     type CharType = char;
 
     fn get_current_position_character_len(iter: &RuleBreakIterator<Self>) -> usize {
@@ -600,7 +598,7 @@ impl<'s> RuleBreakType<'s> for WordBreakTypeUtf8 {
     }
 
     fn handle_complex_language(
-        iter: &mut RuleBreakIterator<'_, 's, Self>,
+        iter: &mut RuleBreakIterator<'_, '_, Self>,
         left_codepoint: Self::CharType,
     ) -> Option<usize> {
         handle_complex_language_utf8(iter, left_codepoint)
@@ -613,8 +611,8 @@ impl<'s> RuleBreakType<'s> for WordBreakTypeUtf8 {
 pub struct WordBreakTypePotentiallyIllFormedUtf8;
 impl crate::private::Sealed for WordBreakTypePotentiallyIllFormedUtf8 {}
 
-impl<'s> RuleBreakType<'s> for WordBreakTypePotentiallyIllFormedUtf8 {
-    type IterAttr = Utf8CharIndices<'s>;
+impl RuleBreakType for WordBreakTypePotentiallyIllFormedUtf8 {
+    type IterAttr<'s> = Utf8CharIndices<'s>;
     type CharType = char;
 
     fn get_current_position_character_len(iter: &RuleBreakIterator<Self>) -> usize {
@@ -622,7 +620,7 @@ impl<'s> RuleBreakType<'s> for WordBreakTypePotentiallyIllFormedUtf8 {
     }
 
     fn handle_complex_language(
-        iter: &mut RuleBreakIterator<'_, 's, Self>,
+        iter: &mut RuleBreakIterator<'_, '_, Self>,
         left_codepoint: Self::CharType,
     ) -> Option<usize> {
         handle_complex_language_utf8(iter, left_codepoint)
@@ -635,7 +633,7 @@ fn handle_complex_language_utf8<'data, 's, T>(
     left_codepoint: T::CharType,
 ) -> Option<usize>
 where
-    T: RuleBreakType<'s, CharType = char>,
+    T: RuleBreakType<CharType = char>,
 {
     // word segmenter doesn't define break rules for some languages such as Thai.
     let start_iter = iter.iter.clone();
@@ -691,8 +689,8 @@ pub struct WordBreakTypeUtf16;
 
 impl crate::private::Sealed for WordBreakTypeUtf16 {}
 
-impl<'s> RuleBreakType<'s> for WordBreakTypeUtf16 {
-    type IterAttr = Utf16Indices<'s>;
+impl RuleBreakType for WordBreakTypeUtf16 {
+    type IterAttr<'s> = Utf16Indices<'s>;
     type CharType = u32;
 
     fn get_current_position_character_len(iter: &RuleBreakIterator<Self>) -> usize {

--- a/components/segmenter/src/word.rs
+++ b/components/segmenter/src/word.rs
@@ -10,7 +10,6 @@ use crate::rule_segmenter::*;
 use alloc::string::String;
 use alloc::vec;
 use alloc::vec::Vec;
-use core::str::CharIndices;
 use icu_locale_core::LanguageIdentifier;
 use icu_provider::prelude::*;
 use utf8_iter::Utf8CharIndices;
@@ -627,7 +626,10 @@ impl WordBreakType for RuleBreakTypeLatin1 {
         _iter: &mut RuleBreakIterator<'_, '_, Self>,
         _left_codepoint: Self::CharType,
     ) -> Option<usize> {
-        debug_assert!(false, "latin-1 text should never need complex language handling");
+        debug_assert!(
+            false,
+            "latin-1 text should never need complex language handling"
+        );
         None
     }
 }

--- a/components/segmenter/src/word.rs
+++ b/components/segmenter/src/word.rs
@@ -115,23 +115,23 @@ impl<Y: RuleBreakType> Iterator for WordBreakIteratorWithWordType<'_, '_, Y> {
 /// Word break iterator for an `str` (a UTF-8 string).
 ///
 /// For examples of use, see [`WordSegmenter`].
-pub type WordBreakIteratorUtf8<'data, 's> = WordBreakIterator<'data, 's, RuleBreakTypeUtf8>;
+pub type WordBreakIteratorUtf8<'data, 's> = WordBreakIterator<'data, 's, Utf8>;
 
 /// Word break iterator for a potentially invalid UTF-8 string.
 ///
 /// For examples of use, see [`WordSegmenter`].
 pub type WordBreakIteratorPotentiallyIllFormedUtf8<'data, 's> =
-    WordBreakIterator<'data, 's, RuleBreakTypePotentiallyIllFormedUtf8>;
+    WordBreakIterator<'data, 's, PotentiallyIllFormedUtf8>;
 
 /// Word break iterator for a Latin-1 (8-bit) string.
 ///
 /// For examples of use, see [`WordSegmenter`].
-pub type WordBreakIteratorLatin1<'data, 's> = WordBreakIterator<'data, 's, RuleBreakTypeLatin1>;
+pub type WordBreakIteratorLatin1<'data, 's> = WordBreakIterator<'data, 's, Latin1>;
 
 /// Word break iterator for a UTF-16 string.
 ///
 /// For examples of use, see [`WordSegmenter`].
-pub type WordBreakIteratorUtf16<'data, 's> = WordBreakIterator<'data, 's, RuleBreakTypeUtf16>;
+pub type WordBreakIteratorUtf16<'data, 's> = WordBreakIterator<'data, 's, Utf16>;
 
 /// Supports loading word break data, and creating word break iterators for different string
 /// encodings.
@@ -510,7 +510,7 @@ impl<'data> WordSegmenterBorrowed<'data> {
             complex: Some(self.complex),
             boundary_property: 0,
             locale_override: self.locale_override,
-            handle_complex_language: RuleBreakTypeUtf8::word_handle_complex_language,
+            handle_complex_language: Utf8::word_handle_complex_language,
         })
     }
 
@@ -532,8 +532,7 @@ impl<'data> WordSegmenterBorrowed<'data> {
             complex: Some(self.complex),
             boundary_property: 0,
             locale_override: self.locale_override,
-            handle_complex_language:
-                RuleBreakTypePotentiallyIllFormedUtf8::word_handle_complex_language,
+            handle_complex_language: PotentiallyIllFormedUtf8::word_handle_complex_language,
         })
     }
 
@@ -550,7 +549,7 @@ impl<'data> WordSegmenterBorrowed<'data> {
             complex: Some(self.complex),
             boundary_property: 0,
             locale_override: self.locale_override,
-            handle_complex_language: RuleBreakTypeLatin1::word_handle_complex_language,
+            handle_complex_language: Latin1::word_handle_complex_language,
         })
     }
 
@@ -567,7 +566,7 @@ impl<'data> WordSegmenterBorrowed<'data> {
             complex: Some(self.complex),
             boundary_property: 0,
             locale_override: self.locale_override,
-            handle_complex_language: RuleBreakTypeUtf16::word_handle_complex_language,
+            handle_complex_language: Utf16::word_handle_complex_language,
         })
     }
 }
@@ -603,7 +602,7 @@ pub trait WordBreakType: crate::private::Sealed + Sized + RuleBreakType {
     ) -> Option<usize>;
 }
 
-impl WordBreakType for RuleBreakTypeUtf8 {
+impl WordBreakType for Utf8 {
     fn word_handle_complex_language(
         iter: &mut RuleBreakIterator<'_, '_, Self>,
         left_codepoint: Self::CharType,
@@ -612,7 +611,7 @@ impl WordBreakType for RuleBreakTypeUtf8 {
     }
 }
 
-impl WordBreakType for RuleBreakTypePotentiallyIllFormedUtf8 {
+impl WordBreakType for PotentiallyIllFormedUtf8 {
     fn word_handle_complex_language(
         iter: &mut RuleBreakIterator<'_, '_, Self>,
         left_codepoint: Self::CharType,
@@ -621,7 +620,7 @@ impl WordBreakType for RuleBreakTypePotentiallyIllFormedUtf8 {
     }
 }
 
-impl WordBreakType for RuleBreakTypeLatin1 {
+impl WordBreakType for Latin1 {
     fn word_handle_complex_language(
         _iter: &mut RuleBreakIterator<'_, '_, Self>,
         _left_codepoint: Self::CharType,
@@ -689,7 +688,7 @@ where
     }
 }
 
-impl WordBreakType for RuleBreakTypeUtf16 {
+impl WordBreakType for Utf16 {
     fn word_handle_complex_language(
         iter: &mut RuleBreakIterator<Self>,
         left_codepoint: Self::CharType,

--- a/components/segmenter/src/word.rs
+++ b/components/segmenter/src/word.rs
@@ -104,7 +104,7 @@ pub struct WordBreakIteratorWithWordType<'data, 's, Y: RuleBreakType>(
     WordBreakIterator<'data, 's, Y>,
 );
 
-impl<'s, Y: RuleBreakType> Iterator for WordBreakIteratorWithWordType<'_, 's, Y> {
+impl<Y: RuleBreakType> Iterator for WordBreakIteratorWithWordType<'_, '_, Y> {
     type Item = (usize, WordType);
     fn next(&mut self) -> Option<Self::Item> {
         let ret = self.0.next()?;
@@ -635,8 +635,8 @@ impl WordBreakType for RuleBreakTypeLatin1 {
 }
 
 /// handle_complex_language impl for UTF8 iterators
-fn handle_complex_language_utf8<'data, 's, T>(
-    iter: &mut RuleBreakIterator<'data, 's, T>,
+fn handle_complex_language_utf8<T>(
+    iter: &mut RuleBreakIterator<'_, '_, T>,
     left_codepoint: T::CharType,
 ) -> Option<usize>
 where

--- a/components/segmenter/src/word.rs
+++ b/components/segmenter/src/word.rs
@@ -593,8 +593,8 @@ impl RuleBreakType for WordBreakTypeUtf8 {
     type IterAttr<'s> = CharIndices<'s>;
     type CharType = char;
 
-    fn get_current_position_character_len(iter: &RuleBreakIterator<Self>) -> usize {
-        iter.get_current_codepoint().map_or(0, |c| c.len_utf8())
+    fn char_len(ch: Self::CharType) -> usize {
+        ch.len_utf8()
     }
 
     fn handle_complex_language(
@@ -615,8 +615,8 @@ impl RuleBreakType for WordBreakTypePotentiallyIllFormedUtf8 {
     type IterAttr<'s> = Utf8CharIndices<'s>;
     type CharType = char;
 
-    fn get_current_position_character_len(iter: &RuleBreakIterator<Self>) -> usize {
-        iter.get_current_codepoint().map_or(0, |c| c.len_utf8())
+    fn char_len(ch: Self::CharType) -> usize {
+        ch.len_utf8()
     }
 
     fn handle_complex_language(
@@ -673,7 +673,7 @@ where
             "we should always arrive at first_pos: near index {:?}",
             iter.get_current_position()
         );
-        i += T::get_current_position_character_len(iter);
+        i += iter.get_current_codepoint().map_or(0, T::char_len);
         iter.advance_iter();
         if iter.is_eof() {
             iter.result_cache.clear();
@@ -693,11 +693,11 @@ impl RuleBreakType for WordBreakTypeUtf16 {
     type IterAttr<'s> = Utf16Indices<'s>;
     type CharType = u32;
 
-    fn get_current_position_character_len(iter: &RuleBreakIterator<Self>) -> usize {
-        match iter.get_current_codepoint() {
-            None => 0,
-            Some(ch) if ch >= 0x10000 => 2,
-            _ => 1,
+    fn char_len(ch: Self::CharType) -> usize {
+        if ch >= 0x10000 {
+            2
+        } else {
+            1
         }
     }
 

--- a/ffi/capi/src/segmenter_line.rs
+++ b/ffi/capi/src/segmenter_line.rs
@@ -53,18 +53,12 @@ pub mod ffi {
         Typedef,
         compact
     )]
-    #[diplomat::rust_link(
-        icu::segmenter::line::LineBreakTypePotentiallyIllFormedUtf8,
-        Struct,
-        hidden
-    )]
     #[diplomat::rust_link(icu::segmenter::line::LineBreakIteratorUtf8, Typedef, hidden)]
     #[diplomat::rust_link(
         icu::segmenter::line::LineBreakTypePotentiallyIllFormedUtf8,
         Struct,
         hidden
     )]
-    #[diplomat::rust_link(icu::segmenter::line::LineBreakTypeUtf8, Struct, hidden)]
     pub struct LineBreakIteratorUtf8<'a>(
         icu_segmenter::line::LineBreakIteratorPotentiallyIllFormedUtf8<'a, 'a>,
     );
@@ -72,13 +66,11 @@ pub mod ffi {
     #[diplomat::opaque]
     #[diplomat::rust_link(icu::segmenter::line::LineBreakIterator, Struct)]
     #[diplomat::rust_link(icu::segmenter::line::LineBreakIteratorUtf16, Typedef, compact)]
-    #[diplomat::rust_link(icu::segmenter::line::LineBreakTypeUtf16, Struct, hidden)]
     pub struct LineBreakIteratorUtf16<'a>(icu_segmenter::line::LineBreakIteratorUtf16<'a, 'a>);
 
     #[diplomat::opaque]
     #[diplomat::rust_link(icu::segmenter::line::LineBreakIterator, Struct)]
     #[diplomat::rust_link(icu::segmenter::line::LineBreakIteratorLatin1, Typedef, compact)]
-    #[diplomat::rust_link(icu::segmenter::line::LineBreakTypeLatin1, Struct, hidden)]
     pub struct LineBreakIteratorLatin1<'a>(icu_segmenter::line::LineBreakIteratorLatin1<'a, 'a>);
 
     impl LineSegmenter {

--- a/ffi/capi/src/segmenter_word.rs
+++ b/ffi/capi/src/segmenter_word.rs
@@ -36,12 +36,6 @@ pub mod ffi {
         hidden
     )]
     #[diplomat::rust_link(icu::segmenter::word::WordBreakIteratorUtf8, Typedef, hidden)]
-    #[diplomat::rust_link(icu::segmenter::word::WordBreakTypeUtf8, Struct, hidden)]
-    #[diplomat::rust_link(
-        icu::segmenter::word::WordBreakTypePotentiallyIllFormedUtf8,
-        Struct,
-        hidden
-    )]
     pub struct WordBreakIteratorUtf8<'a>(
         icu_segmenter::word::WordBreakIteratorPotentiallyIllFormedUtf8<'a, 'a>,
     );
@@ -49,13 +43,11 @@ pub mod ffi {
     #[diplomat::opaque]
     #[diplomat::rust_link(icu::segmenter::word::WordBreakIterator, Struct)]
     #[diplomat::rust_link(icu::segmenter::word::WordBreakIteratorUtf16, Typedef, hidden)]
-    #[diplomat::rust_link(icu::segmenter::word::WordBreakTypeUtf16, Struct, hidden)]
     pub struct WordBreakIteratorUtf16<'a>(icu_segmenter::word::WordBreakIteratorUtf16<'a, 'a>);
 
     #[diplomat::opaque]
     #[diplomat::rust_link(icu::segmenter::word::WordBreakIterator, Struct)]
     #[diplomat::rust_link(icu::segmenter::word::WordBreakIteratorLatin1, Typedef, hidden)]
-    #[diplomat::rust_link(icu::segmenter::word::WordBreakTypeLatin1, Struct, hidden)]
     pub struct WordBreakIteratorLatin1<'a>(icu_segmenter::word::WordBreakIteratorLatin1<'a, 'a>);
 
     impl SegmenterWordType {

--- a/tools/make/diplomat-coverage/src/allowlist.rs
+++ b/tools/make/diplomat-coverage/src/allowlist.rs
@@ -343,6 +343,8 @@ lazy_static::lazy_static! {
         "icu::segmenter::word::WordBreakInvariantOptions",
         "icu::segmenter::word::WordBreakOptions",
         "icu::segmenter::word::WordType",
+        "icu::segmenter::word::WordBreakType",
+        "icu::segmenter::line::LineBreakType",
 
         // Reexported input modules
         "icu::datetime::input",


### PR DESCRIPTION
First set of followups after https://github.com/unicode-org/icu4x/pull/6409

This:

 - Removes lifetimes and `?Sized` from the BreakType traits
 - Coalesces the BreakType markers into a single set of RuleBreakTypeFoo markers
 - Makes LineBreakType depend on RuleBreakType
 - Adds a new WordBreakType that depends on RuleBreakType


previously the wordbreaktype distinction was awkwardly handled by `unreachable!()`s and trait impls; which meant it was not straightforward to make WordBreak use RuleBreakType instead of WordBreakType. Moving that required moving it to a function, but it seemed to work well.

This does not intend to finalize the module structure, it's still doing cleanups, I didn't wish to have these be blocked on module structure decisions.

A cleanup I may make is to use a secondary type parameter on RuleBReakIterator instead of a function pointer. It ought not matter, though.



<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->