### PR TITLE
Have icu_capi code be available under mod unstable in the public api

### DIFF
--- a/ffi/capi/src/lib.rs
+++ b/ffi/capi/src/lib.rs
@@ -56,109 +56,121 @@ extern crate alloc;
 #[cfg(all(not(feature = "std"), feature = "libc_alloc"))]
 extern crate libc_alloc;
 
-// Common modules
-pub mod errors;
-pub mod locale_core;
-#[cfg(feature = "logging")]
-pub mod logging;
-#[macro_use]
-pub mod provider;
+// *Private* reexports to keep paths simpler
+pub(crate) use unstable::*;
+
+
 #[cfg(feature = "datetime")]
 pub(crate) mod datetime_helpers;
 
-// Components
+/// The Rust API of this crate is **UNSTABLE**; this crate is primarily intended
+/// to be used from its FFI bindings, packaged with the crate.
+///
+/// The C ABI layer is stable.
+#[path = "."] // https://github.com/rust-lang/rust/issues/35016
+pub mod unstable {
+    // Common modules
+    pub mod errors;
+    pub mod locale_core;
+    #[cfg(feature = "logging")]
+    pub mod logging;
+    #[macro_use]
+    pub mod provider;
 
-#[cfg(feature = "properties")]
-pub mod bidi;
-#[cfg(any(feature = "datetime", feature = "timezone", feature = "calendar"))]
-pub mod calendar;
-#[cfg(feature = "casemap")]
-pub mod casemap;
-#[cfg(feature = "collator")]
-pub mod collator;
-#[cfg(feature = "properties")]
-pub mod collections_sets;
-#[cfg(any(feature = "datetime", feature = "timezone", feature = "calendar"))]
-pub mod date;
-#[cfg(feature = "datetime")]
-pub mod date_formatter;
-#[cfg(feature = "datetime")]
-pub mod date_time_formatter;
-#[cfg(any(feature = "datetime", feature = "timezone", feature = "calendar"))]
-pub mod datetime;
-#[cfg(feature = "datetime")]
-pub mod datetime_options;
-#[cfg(feature = "decimal")]
-pub mod decimal;
-#[cfg(feature = "experimental")]
-pub mod displaynames;
-#[cfg(feature = "locale")]
-pub mod exemplar_chars;
-#[cfg(feature = "locale")]
-pub mod fallbacker;
-#[cfg(feature = "decimal")]
-pub mod fixed_decimal;
-#[cfg(any(feature = "datetime", feature = "timezone"))]
-pub mod iana_parser;
-#[cfg(feature = "list")]
-pub mod list;
-#[cfg(feature = "locale")]
-pub mod locale;
-#[cfg(feature = "locale")]
-pub mod locale_directionality;
-#[cfg(feature = "experimental")]
-pub mod measure_unit_parser;
-#[cfg(feature = "normalizer")]
-pub mod normalizer;
-#[cfg(feature = "normalizer")]
-pub mod normalizer_properties;
-#[cfg(feature = "plurals")]
-pub mod pluralrules;
-#[cfg(feature = "properties")]
-pub mod properties_bidi;
-#[cfg(feature = "properties")]
-pub mod properties_enums;
-#[cfg(feature = "properties")]
-pub mod properties_iter;
-#[cfg(feature = "properties")]
-pub mod properties_maps;
-#[cfg(feature = "properties")]
-pub mod properties_names;
-#[cfg(feature = "properties")]
-pub mod properties_sets;
-#[cfg(feature = "properties")]
-pub mod properties_unisets;
-#[cfg(feature = "properties")]
-pub mod script;
-#[cfg(feature = "segmenter")]
-pub mod segmenter_grapheme;
-#[cfg(feature = "segmenter")]
-pub mod segmenter_line;
-#[cfg(feature = "segmenter")]
-pub mod segmenter_sentence;
-#[cfg(feature = "segmenter")]
-pub mod segmenter_word;
-#[cfg(any(feature = "datetime", feature = "timezone", feature = "calendar"))]
-pub mod time;
-#[cfg(feature = "datetime")]
-pub mod time_formatter;
-#[cfg(any(feature = "datetime", feature = "timezone"))]
-pub mod timezone;
-#[cfg(feature = "datetime")]
-pub mod timezone_formatter;
-#[cfg(feature = "experimental")]
-pub mod units_converter;
-#[cfg(any(feature = "datetime", feature = "timezone"))]
-pub mod variant_offset;
-#[cfg(feature = "calendar")]
-pub mod week;
-#[cfg(any(feature = "datetime", feature = "timezone"))]
-pub mod windows_parser;
-#[cfg(feature = "datetime")]
-pub mod zoned_date_formatter;
-#[cfg(feature = "datetime")]
-pub mod zoned_date_time_formatter;
-#[cfg(feature = "datetime")]
-pub mod zoned_datetime;
-#[cfg(feature = "datetime")]
-pub mod zoned_time_formatter;
+    // Components
+
+    #[cfg(feature = "properties")]
+    pub mod bidi;
+    #[cfg(any(feature = "datetime", feature = "timezone", feature = "calendar"))]
+    pub mod calendar;
+    #[cfg(feature = "casemap")]
+    pub mod casemap;
+    #[cfg(feature = "collator")]
+    pub mod collator;
+    #[cfg(feature = "properties")]
+    pub mod collections_sets;
+    #[cfg(any(feature = "datetime", feature = "timezone", feature = "calendar"))]
+    pub mod date;
+    #[cfg(feature = "datetime")]
+    pub mod date_formatter;
+    #[cfg(feature = "datetime")]
+    pub mod date_time_formatter;
+    #[cfg(any(feature = "datetime", feature = "timezone", feature = "calendar"))]
+    pub mod datetime;
+    #[cfg(feature = "datetime")]
+    pub mod datetime_options;
+    #[cfg(feature = "decimal")]
+    pub mod decimal;
+    #[cfg(feature = "experimental")]
+    pub mod displaynames;
+    #[cfg(feature = "locale")]
+    pub mod exemplar_chars;
+    #[cfg(feature = "locale")]
+    pub mod fallbacker;
+    #[cfg(feature = "decimal")]
+    pub mod fixed_decimal;
+    #[cfg(any(feature = "datetime", feature = "timezone"))]
+    pub mod iana_parser;
+    #[cfg(feature = "list")]
+    pub mod list;
+    #[cfg(feature = "locale")]
+    pub mod locale;
+    #[cfg(feature = "locale")]
+    pub mod locale_directionality;
+    #[cfg(feature = "experimental")]
+    pub mod measure_unit_parser;
+    #[cfg(feature = "normalizer")]
+    pub mod normalizer;
+    #[cfg(feature = "normalizer")]
+    pub mod normalizer_properties;
+    #[cfg(feature = "plurals")]
+    pub mod pluralrules;
+    #[cfg(feature = "properties")]
+    pub mod properties_bidi;
+    #[cfg(feature = "properties")]
+    pub mod properties_enums;
+    #[cfg(feature = "properties")]
+    pub mod properties_iter;
+    #[cfg(feature = "properties")]
+    pub mod properties_maps;
+    #[cfg(feature = "properties")]
+    pub mod properties_names;
+    #[cfg(feature = "properties")]
+    pub mod properties_sets;
+    #[cfg(feature = "properties")]
+    pub mod properties_unisets;
+    #[cfg(feature = "properties")]
+    pub mod script;
+    #[cfg(feature = "segmenter")]
+    pub mod segmenter_grapheme;
+    #[cfg(feature = "segmenter")]
+    pub mod segmenter_line;
+    #[cfg(feature = "segmenter")]
+    pub mod segmenter_sentence;
+    #[cfg(feature = "segmenter")]
+    pub mod segmenter_word;
+    #[cfg(any(feature = "datetime", feature = "timezone", feature = "calendar"))]
+    pub mod time;
+    #[cfg(feature = "datetime")]
+    pub mod time_formatter;
+    #[cfg(any(feature = "datetime", feature = "timezone"))]
+    pub mod timezone;
+    #[cfg(feature = "datetime")]
+    pub mod timezone_formatter;
+    #[cfg(feature = "experimental")]
+    pub mod units_converter;
+    #[cfg(any(feature = "datetime", feature = "timezone"))]
+    pub mod variant_offset;
+    #[cfg(feature = "calendar")]
+    pub mod week;
+    #[cfg(any(feature = "datetime", feature = "timezone"))]
+    pub mod windows_parser;
+    #[cfg(feature = "datetime")]
+    pub mod zoned_date_formatter;
+    #[cfg(feature = "datetime")]
+    pub mod zoned_date_time_formatter;
+    #[cfg(feature = "datetime")]
+    pub mod zoned_datetime;
+    #[cfg(feature = "datetime")]
+    pub mod zoned_time_formatter;
+}


### PR DESCRIPTION
Fixes #6274

I decided to not actually stick all the files in an `unstable` folder because it feels like unnecessary file structure complexity.

Annoyingly, https://github.com/rust-lang/rust/issues/139602 means we need a fake `unstable` directory for the path directives to work.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->