### PR TITLE
Allow different calendars to return different year-info types

### DIFF
--- a/components/calendar/README.md
+++ b/components/calendar/README.md
@@ -34,7 +34,7 @@ let mut date_iso = Date::try_new_iso(1992, 9, 2)
     .expect("Failed to initialize ISO Date instance.");
 
 assert_eq!(date_iso.day_of_week(), Weekday::Wednesday);
-assert_eq!(date_iso.era_year().era_year, 1992);
+assert_eq!(date_iso.era_year().year, 1992);
 assert_eq!(date_iso.month().ordinal, 9);
 assert_eq!(date_iso.day_of_month().0, 2);
 
@@ -53,19 +53,19 @@ use icu::calendar::Date;
 let mut date_iso = Date::try_new_iso(1992, 9, 2)
     .expect("Failed to initialize ISO Date instance.");
 
-assert_eq!(date_iso.era_year().era_year, 1992);
+assert_eq!(date_iso.era_year().year, 1992);
 assert_eq!(date_iso.month().ordinal, 9);
 assert_eq!(date_iso.day_of_month().0, 2);
 
 // Conversion into Indian calendar: 1914-08-02.
 let date_indian = date_iso.to_calendar(Indian);
-assert_eq!(date_indian.era_year().era_year, 1914);
+assert_eq!(date_indian.era_year().year, 1914);
 assert_eq!(date_indian.month().ordinal, 6);
 assert_eq!(date_indian.day_of_month().0, 11);
 
 // Conversion into Buddhist calendar: 2535-09-02.
 let date_buddhist = date_iso.to_calendar(Buddhist);
-assert_eq!(date_buddhist.era_year().era_year, 2535);
+assert_eq!(date_buddhist.era_year().year, 2535);
 assert_eq!(date_buddhist.month().ordinal, 9);
 assert_eq!(date_buddhist.day_of_month().0, 2);
 ```

--- a/components/calendar/README.md
+++ b/components/calendar/README.md
@@ -34,7 +34,7 @@ let mut date_iso = Date::try_new_iso(1992, 9, 2)
     .expect("Failed to initialize ISO Date instance.");
 
 assert_eq!(date_iso.day_of_week(), Weekday::Wednesday);
-assert_eq!(date_iso.year().era_year_or_related_iso(), 1992);
+assert_eq!(date_iso.year().era().unwrap().era_year, 1992);
 assert_eq!(date_iso.month().ordinal, 9);
 assert_eq!(date_iso.day_of_month().0, 2);
 
@@ -53,19 +53,19 @@ use icu::calendar::Date;
 let mut date_iso = Date::try_new_iso(1992, 9, 2)
     .expect("Failed to initialize ISO Date instance.");
 
-assert_eq!(date_iso.year().era_year_or_related_iso(), 1992);
+assert_eq!(date_iso.year().era().unwrap().era_year, 1992);
 assert_eq!(date_iso.month().ordinal, 9);
 assert_eq!(date_iso.day_of_month().0, 2);
 
 // Conversion into Indian calendar: 1914-08-02.
 let date_indian = date_iso.to_calendar(Indian);
-assert_eq!(date_indian.year().era_year_or_related_iso(), 1914);
+assert_eq!(date_indian.year().era().unwrap().era_year, 1914);
 assert_eq!(date_indian.month().ordinal, 6);
 assert_eq!(date_indian.day_of_month().0, 11);
 
 // Conversion into Buddhist calendar: 2535-09-02.
 let date_buddhist = date_iso.to_calendar(Buddhist);
-assert_eq!(date_buddhist.year().era_year_or_related_iso(), 2535);
+assert_eq!(date_buddhist.year().era().unwrap().era_year, 2535);
 assert_eq!(date_buddhist.month().ordinal, 9);
 assert_eq!(date_buddhist.day_of_month().0, 2);
 ```

--- a/components/calendar/README.md
+++ b/components/calendar/README.md
@@ -34,7 +34,7 @@ let mut date_iso = Date::try_new_iso(1992, 9, 2)
     .expect("Failed to initialize ISO Date instance.");
 
 assert_eq!(date_iso.day_of_week(), Weekday::Wednesday);
-assert_eq!(date_iso.year().era().unwrap().era_year, 1992);
+assert_eq!(date_iso.era_year().era_year, 1992);
 assert_eq!(date_iso.month().ordinal, 9);
 assert_eq!(date_iso.day_of_month().0, 2);
 
@@ -53,19 +53,19 @@ use icu::calendar::Date;
 let mut date_iso = Date::try_new_iso(1992, 9, 2)
     .expect("Failed to initialize ISO Date instance.");
 
-assert_eq!(date_iso.year().era().unwrap().era_year, 1992);
+assert_eq!(date_iso.era_year().era_year, 1992);
 assert_eq!(date_iso.month().ordinal, 9);
 assert_eq!(date_iso.day_of_month().0, 2);
 
 // Conversion into Indian calendar: 1914-08-02.
 let date_indian = date_iso.to_calendar(Indian);
-assert_eq!(date_indian.year().era().unwrap().era_year, 1914);
+assert_eq!(date_indian.era_year().era_year, 1914);
 assert_eq!(date_indian.month().ordinal, 6);
 assert_eq!(date_indian.day_of_month().0, 11);
 
 // Conversion into Buddhist calendar: 2535-09-02.
 let date_buddhist = date_iso.to_calendar(Buddhist);
-assert_eq!(date_buddhist.year().era().unwrap().era_year, 2535);
+assert_eq!(date_buddhist.era_year().era_year, 2535);
 assert_eq!(date_buddhist.month().ordinal, 9);
 assert_eq!(date_buddhist.day_of_month().0, 2);
 ```

--- a/components/calendar/benches/convert.rs
+++ b/components/calendar/benches/convert.rs
@@ -18,9 +18,9 @@ fn bench_calendar<C: Clone + Calendar>(
     group.bench_function(name, |b| {
         b.iter(|| {
             let converted = black_box(iso).to_calendar(Ref(&calendar));
-            let year = black_box(converted.year().era_year_or_related_iso());
-            let month = black_box(converted.month().ordinal);
-            let day = black_box(converted.day_of_month().0);
+            let year = black_box(converted.year());
+            let month = black_box(converted.month());
+            let day = black_box(converted.day_of_month());
             black_box((converted, year, month, day))
         })
     });

--- a/components/calendar/benches/date.rs
+++ b/components/calendar/benches/date.rs
@@ -21,9 +21,9 @@ fn bench_date<A: AsCalendar>(date: &mut Date<A>) {
     ));
 
     // Retrieving vals
-    let _ = black_box(date.year().era_year_or_related_iso());
-    let _ = black_box(date.month().ordinal);
-    let _ = black_box(date.day_of_month().0);
+    let _ = black_box(date.year());
+    let _ = black_box(date.month());
+    let _ = black_box(date.day_of_month());
 
     // Conversion to ISO.
     let _ = black_box(date.to_iso());

--- a/components/calendar/examples/iso_date_manipulations.rs
+++ b/components/calendar/examples/iso_date_manipulations.rs
@@ -32,7 +32,7 @@ fn main() {
         let date = Date::try_new_iso(year, month, day).expect("date should parse");
         println!(
             "Year: {}, Month: {}, Day: {}",
-            date.year().extended_year,
+            date.extended_year(),
             date.month().ordinal,
             date.day_of_month().0,
         );

--- a/components/calendar/examples/iso_date_manipulations.rs
+++ b/components/calendar/examples/iso_date_manipulations.rs
@@ -32,7 +32,7 @@ fn main() {
         let date = Date::try_new_iso(year, month, day).expect("date should parse");
         println!(
             "Year: {}, Month: {}, Day: {}",
-            date.year().era_year_or_related_iso(),
+            date.year().extended_year,
             date.month().ordinal,
             date.day_of_month().0,
         );

--- a/components/calendar/src/any_calendar.rs
+++ b/components/calendar/src/any_calendar.rs
@@ -12,6 +12,7 @@ use crate::cal::{
     Iso, Japanese, JapaneseExtended, Persian, Roc,
 };
 use crate::error::DateError;
+use crate::types::YearInfo;
 use crate::{types, AsCalendar, Calendar, Date, DateDuration, DateDurationUnit, Ref};
 
 use crate::preferences::{CalendarAlgorithm, HijriCalendarAlgorithm};
@@ -219,6 +220,8 @@ macro_rules! match_cal {
 
 impl Calendar for AnyCalendar {
     type DateInner = AnyDateInner;
+    type Year = YearInfo;
+
     fn from_codes(
         &self,
         era: Option<&str>,
@@ -465,9 +468,14 @@ impl Calendar for AnyCalendar {
         }
     }
 
-    fn year(&self, date: &Self::DateInner) -> types::YearInfo {
-        match_cal_and_date!(match (self, date): (c, d) => c.year(d))
+    fn year_info(&self, date: &Self::DateInner) -> types::YearInfo {
+        match_cal_and_date!(match (self, date): (c, d) => c.year_info(d).into())
     }
+
+    fn extended_year(&self, date: &Self::DateInner) -> i32 {
+        match_cal_and_date!(match (self, date): (c, d) => c.extended_year(d))
+    }
+
     /// The calendar-specific check if `date` is in a leap year
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
         match_cal_and_date!(match (self, date): (c, d) => c.is_in_leap_year(d))

--- a/components/calendar/src/cal/buddhist.rs
+++ b/components/calendar/src/cal/buddhist.rs
@@ -11,7 +11,7 @@
 //!     .expect("Failed to initialize ISO Date instance.");
 //! let date_buddhist = Date::new_from_iso(date_iso, Buddhist);
 //!
-//! assert_eq!(date_buddhist.year().era_year_or_related_iso(), 2513);
+//! assert_eq!(date_buddhist.year().era().unwrap().era_year, 2513);
 //! assert_eq!(date_buddhist.month().ordinal, 1);
 //! assert_eq!(date_buddhist.day_of_month().0, 2);
 //! ```
@@ -167,7 +167,7 @@ impl Date<Buddhist> {
     /// let date_buddhist = Date::try_new_buddhist(1970, 1, 2)
     ///     .expect("Failed to initialize Buddhist Date instance.");
     ///
-    /// assert_eq!(date_buddhist.year().era_year_or_related_iso(), 1970);
+    /// assert_eq!(date_buddhist.year().era().unwrap().era_year, 1970);
     /// assert_eq!(date_buddhist.month().ordinal, 1);
     /// assert_eq!(date_buddhist.day_of_month().0, 2);
     /// ```
@@ -280,7 +280,7 @@ mod test {
         let iso1 = Date::try_new_iso(iso_year, iso_month, iso_day).unwrap();
         let buddhist1 = iso1.to_calendar(Buddhist);
         assert_eq!(
-            buddhist1.year().era_year_or_related_iso(),
+            buddhist1.year().era().unwrap().era_year,
             buddhist_year,
             "Iso -> Buddhist year check failed for case: {case:?}"
         );
@@ -299,7 +299,7 @@ mod test {
             Date::try_new_buddhist(buddhist_year, buddhist_month, buddhist_day).unwrap();
         let iso2 = buddhist2.to_calendar(Iso);
         assert_eq!(
-            iso2.year().era_year_or_related_iso(),
+            iso2.year().era().unwrap().era_year,
             iso_year,
             "Buddhist -> Iso year check failed for case: {case:?}"
         );

--- a/components/calendar/src/cal/buddhist.rs
+++ b/components/calendar/src/cal/buddhist.rs
@@ -11,7 +11,7 @@
 //!     .expect("Failed to initialize ISO Date instance.");
 //! let date_buddhist = Date::new_from_iso(date_iso, Buddhist);
 //!
-//! assert_eq!(date_buddhist.era_year().era_year, 2513);
+//! assert_eq!(date_buddhist.era_year().year, 2513);
 //! assert_eq!(date_buddhist.month().ordinal, 1);
 //! assert_eq!(date_buddhist.day_of_month().0, 2);
 //! ```
@@ -120,7 +120,7 @@ impl Calendar for Buddhist {
         types::EraYear {
             standard_era: tinystr!(16, "be").into(),
             formatting_era: types::FormattingEra::Index(0, tinystr!(16, "BE")),
-            era_year: self.extended_year(date),
+            year: self.extended_year(date),
             ambiguity: types::YearAmbiguity::CenturyRequired,
         }
     }
@@ -168,7 +168,7 @@ impl Date<Buddhist> {
     /// let date_buddhist = Date::try_new_buddhist(1970, 1, 2)
     ///     .expect("Failed to initialize Buddhist Date instance.");
     ///
-    /// assert_eq!(date_buddhist.era_year().era_year, 1970);
+    /// assert_eq!(date_buddhist.era_year().year, 1970);
     /// assert_eq!(date_buddhist.month().ordinal, 1);
     /// assert_eq!(date_buddhist.day_of_month().0, 2);
     /// ```
@@ -281,7 +281,7 @@ mod test {
         let iso1 = Date::try_new_iso(iso_year, iso_month, iso_day).unwrap();
         let buddhist1 = iso1.to_calendar(Buddhist);
         assert_eq!(
-            buddhist1.era_year().era_year,
+            buddhist1.era_year().year,
             buddhist_year,
             "Iso -> Buddhist year check failed for case: {case:?}"
         );
@@ -300,7 +300,7 @@ mod test {
             Date::try_new_buddhist(buddhist_year, buddhist_month, buddhist_day).unwrap();
         let iso2 = buddhist2.to_calendar(Iso);
         assert_eq!(
-            iso2.era_year().era_year,
+            iso2.era_year().year,
             iso_year,
             "Buddhist -> Iso year check failed for case: {case:?}"
         );

--- a/components/calendar/src/cal/buddhist.rs
+++ b/components/calendar/src/cal/buddhist.rs
@@ -11,7 +11,7 @@
 //!     .expect("Failed to initialize ISO Date instance.");
 //! let date_buddhist = Date::new_from_iso(date_iso, Buddhist);
 //!
-//! assert_eq!(date_buddhist.year().era().unwrap().era_year, 2513);
+//! assert_eq!(date_buddhist.era_year().era_year, 2513);
 //! assert_eq!(date_buddhist.month().ordinal, 1);
 //! assert_eq!(date_buddhist.day_of_month().0, 2);
 //! ```
@@ -52,6 +52,7 @@ pub struct Buddhist;
 
 impl Calendar for Buddhist {
     type DateInner = IsoDateInner;
+    type Year = types::EraYear;
 
     fn from_codes(
         &self,
@@ -115,17 +116,17 @@ impl Calendar for Buddhist {
     }
 
     /// The calendar-specific year represented by `date`
-    fn year(&self, date: &Self::DateInner) -> types::YearInfo {
-        let buddhist_year = date.0.year + BUDDHIST_ERA_OFFSET;
-        types::YearInfo::new(
-            buddhist_year,
-            types::EraYear {
-                standard_era: tinystr!(16, "be").into(),
-                formatting_era: types::FormattingEra::Index(0, tinystr!(16, "BE")),
-                era_year: buddhist_year,
-                ambiguity: types::YearAmbiguity::CenturyRequired,
-            },
-        )
+    fn year_info(&self, date: &Self::DateInner) -> Self::Year {
+        types::EraYear {
+            standard_era: tinystr!(16, "be").into(),
+            formatting_era: types::FormattingEra::Index(0, tinystr!(16, "BE")),
+            era_year: self.extended_year(date),
+            ambiguity: types::YearAmbiguity::CenturyRequired,
+        }
+    }
+
+    fn extended_year(&self, date: &Self::DateInner) -> i32 {
+        Iso.extended_year(date) + BUDDHIST_ERA_OFFSET
     }
 
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
@@ -167,7 +168,7 @@ impl Date<Buddhist> {
     /// let date_buddhist = Date::try_new_buddhist(1970, 1, 2)
     ///     .expect("Failed to initialize Buddhist Date instance.");
     ///
-    /// assert_eq!(date_buddhist.year().era().unwrap().era_year, 1970);
+    /// assert_eq!(date_buddhist.era_year().era_year, 1970);
     /// assert_eq!(date_buddhist.month().ordinal, 1);
     /// assert_eq!(date_buddhist.day_of_month().0, 2);
     /// ```
@@ -280,7 +281,7 @@ mod test {
         let iso1 = Date::try_new_iso(iso_year, iso_month, iso_day).unwrap();
         let buddhist1 = iso1.to_calendar(Buddhist);
         assert_eq!(
-            buddhist1.year().era().unwrap().era_year,
+            buddhist1.era_year().era_year,
             buddhist_year,
             "Iso -> Buddhist year check failed for case: {case:?}"
         );
@@ -299,7 +300,7 @@ mod test {
             Date::try_new_buddhist(buddhist_year, buddhist_month, buddhist_day).unwrap();
         let iso2 = buddhist2.to_calendar(Iso);
         assert_eq!(
-            iso2.year().era().unwrap().era_year,
+            iso2.era_year().era_year,
             iso_year,
             "Buddhist -> Iso year check failed for case: {case:?}"
         );

--- a/components/calendar/src/cal/chinese.rs
+++ b/components/calendar/src/cal/chinese.rs
@@ -11,8 +11,8 @@
 //! let chinese_date = Date::try_new_chinese_with_calendar(2023, 6, 6, chinese)
 //!     .expect("Failed to initialize Chinese Date instance.");
 //!
-//! assert_eq!(chinese_date.year().era_year_or_related_iso(), 2023);
-//! assert_eq!(chinese_date.year().cyclic().unwrap().get(), 40);
+//! assert_eq!(chinese_date.year().cyclic().unwrap().related_iso, 2023);
+//! assert_eq!(chinese_date.year().cyclic().unwrap().year.get(), 40);
 //! assert_eq!(chinese_date.month().ordinal, 6);
 //! assert_eq!(chinese_date.day_of_month().0, 6);
 //! ```
@@ -302,9 +302,8 @@ impl<A: AsCalendar<Calendar = Chinese>> Date<A> {
     ///     Date::try_new_chinese_with_calendar(2023, 6, 11, chinese)
     ///         .expect("Failed to initialize Chinese Date instance.");
     ///
-    /// assert_eq!(date_chinese.year().era_year_or_related_iso(), 2023);
-    /// assert_eq!(date_chinese.year().cyclic().unwrap().get(), 40);
-    /// assert_eq!(date_chinese.year().related_iso(), Some(2023));
+    /// assert_eq!(date_chinese.year().cyclic().unwrap().related_iso, 2023);
+    /// assert_eq!(date_chinese.year().cyclic().unwrap().year.get(), 40);
     /// assert_eq!(date_chinese.month().ordinal, 6);
     /// assert_eq!(date_chinese.day_of_month().0, 11);
     /// ```
@@ -560,12 +559,12 @@ mod test {
             |chinese, _calendar_type| {
                 let chinese = iso.to_calendar(chinese);
 
-                assert_eq!(chinese.year().era_year_or_related_iso(), -2636);
+                assert_eq!(chinese.year().cyclic().unwrap().related_iso, -2636);
                 assert_eq!(chinese.month().ordinal, 1);
                 assert_eq!(chinese.month().standard_code.0, "M01");
                 assert_eq!(chinese.day_of_month().0, 1);
-                assert_eq!(chinese.year().cyclic().unwrap().get(), 1);
-                assert_eq!(chinese.year().related_iso(), Some(-2636));
+                assert_eq!(chinese.year().cyclic().unwrap().year.get(), 1);
+                assert_eq!(chinese.year().cyclic().unwrap().related_iso, -2636);
             },
         )
     }
@@ -613,7 +612,7 @@ mod test {
                     let chinese = iso.to_calendar(chinese);
                     assert_eq!(
                         case.expected_year,
-                        chinese.year().era_year_or_related_iso(),
+                        chinese.year().cyclic().unwrap().related_iso,
                         "[{calendar_type}] ISO to Chinese failed for case: {case:?}"
                     );
                     assert_eq!(
@@ -1010,18 +1009,17 @@ mod test {
                 &chinese_cached,
                 |chinese, calendar_type| {
                     let chinese = iso.to_calendar(chinese);
-                    let chinese_rel_iso = chinese.year().related_iso();
-                    let chinese_cyclic = chinese.year().cyclic();
+                    let chinese_rel_iso = chinese.year().cyclic().unwrap().related_iso;
+                    let chinese_cyclic = chinese.year().cyclic().unwrap().year;
                     let chinese_month = chinese.month().ordinal;
                     let chinese_day = chinese.day_of_month().0;
 
                     assert_eq!(
-                        chinese_rel_iso,
-                        Some(case.expected_rel_iso),
+                        chinese_rel_iso, case.expected_rel_iso,
                         "[{calendar_type}] Related ISO failed for test case: {case:?}"
                     );
                     assert_eq!(
-                        chinese_cyclic.unwrap().get(),
+                        chinese_cyclic.get(),
                         case.expected_cyclic,
                         "[{calendar_type}] Cyclic year failed for test case: {case:?}"
                     );

--- a/components/calendar/src/cal/coptic.rs
+++ b/components/calendar/src/cal/coptic.rs
@@ -11,7 +11,7 @@
 //!     .expect("Failed to initialize ISO Date instance.");
 //! let date_coptic = Date::new_from_iso(date_iso, Coptic);
 //!
-//! assert_eq!(date_coptic.year().era().unwrap().era_year, 1686);
+//! assert_eq!(date_coptic.era_year().era_year, 1686);
 //! assert_eq!(date_coptic.month().ordinal, 4);
 //! assert_eq!(date_coptic.day_of_month().0, 24);
 //! ```
@@ -94,6 +94,7 @@ impl CalendarArithmetic for Coptic {
 
 impl Calendar for Coptic {
     type DateInner = CopticDateInner;
+    type Year = types::EraYear;
     fn from_codes(
         &self,
         era: Option<&str>,
@@ -160,29 +161,27 @@ impl Calendar for Coptic {
         date1.0.until(date2.0, _largest_unit, _smallest_unit)
     }
 
-    fn year(&self, date: &Self::DateInner) -> types::YearInfo {
-        let year = date.0.year;
+    fn year_info(&self, date: &Self::DateInner) -> Self::Year {
+        let year = self.extended_year(date);
         if year > 0 {
-            types::YearInfo::new(
-                year,
-                types::EraYear {
-                    standard_era: tinystr!(16, "am").into(),
-                    formatting_era: types::FormattingEra::Index(1, tinystr!(16, "AM")),
-                    era_year: year,
-                    ambiguity: types::YearAmbiguity::CenturyRequired,
-                },
-            )
+            types::EraYear {
+                standard_era: tinystr!(16, "am").into(),
+                formatting_era: types::FormattingEra::Index(1, tinystr!(16, "AM")),
+                era_year: year,
+                ambiguity: types::YearAmbiguity::CenturyRequired,
+            }
         } else {
-            types::YearInfo::new(
-                year,
-                types::EraYear {
-                    standard_era: tinystr!(16, "bd").into(),
-                    formatting_era: types::FormattingEra::Index(0, tinystr!(16, "BD")),
-                    era_year: 1 - year,
-                    ambiguity: types::YearAmbiguity::EraAndCenturyRequired,
-                },
-            )
+            types::EraYear {
+                standard_era: tinystr!(16, "bd").into(),
+                formatting_era: types::FormattingEra::Index(0, tinystr!(16, "BD")),
+                era_year: 1 - year,
+                ambiguity: types::YearAmbiguity::EraAndCenturyRequired,
+            }
         }
+    }
+
+    fn extended_year(&self, date: &Self::DateInner) -> i32 {
+        date.0.extended_year()
     }
 
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
@@ -221,7 +220,7 @@ impl Date<Coptic> {
     /// let date_coptic = Date::try_new_coptic(1686, 5, 6)
     ///     .expect("Failed to initialize Coptic Date instance.");
     ///
-    /// assert_eq!(date_coptic.year().era().unwrap().era_year, 1686);
+    /// assert_eq!(date_coptic.era_year().era_year, 1686);
     /// assert_eq!(date_coptic.month().ordinal, 5);
     /// assert_eq!(date_coptic.day_of_month().0, 6);
     /// ```

--- a/components/calendar/src/cal/coptic.rs
+++ b/components/calendar/src/cal/coptic.rs
@@ -11,7 +11,7 @@
 //!     .expect("Failed to initialize ISO Date instance.");
 //! let date_coptic = Date::new_from_iso(date_iso, Coptic);
 //!
-//! assert_eq!(date_coptic.era_year().era_year, 1686);
+//! assert_eq!(date_coptic.era_year().year, 1686);
 //! assert_eq!(date_coptic.month().ordinal, 4);
 //! assert_eq!(date_coptic.day_of_month().0, 24);
 //! ```
@@ -167,14 +167,14 @@ impl Calendar for Coptic {
             types::EraYear {
                 standard_era: tinystr!(16, "am").into(),
                 formatting_era: types::FormattingEra::Index(1, tinystr!(16, "AM")),
-                era_year: year,
+                year,
                 ambiguity: types::YearAmbiguity::CenturyRequired,
             }
         } else {
             types::EraYear {
                 standard_era: tinystr!(16, "bd").into(),
                 formatting_era: types::FormattingEra::Index(0, tinystr!(16, "BD")),
-                era_year: 1 - year,
+                year: 1 - year,
                 ambiguity: types::YearAmbiguity::EraAndCenturyRequired,
             }
         }
@@ -220,7 +220,7 @@ impl Date<Coptic> {
     /// let date_coptic = Date::try_new_coptic(1686, 5, 6)
     ///     .expect("Failed to initialize Coptic Date instance.");
     ///
-    /// assert_eq!(date_coptic.era_year().era_year, 1686);
+    /// assert_eq!(date_coptic.era_year().year, 1686);
     /// assert_eq!(date_coptic.month().ordinal, 5);
     /// assert_eq!(date_coptic.day_of_month().0, 6);
     /// ```

--- a/components/calendar/src/cal/coptic.rs
+++ b/components/calendar/src/cal/coptic.rs
@@ -11,7 +11,7 @@
 //!     .expect("Failed to initialize ISO Date instance.");
 //! let date_coptic = Date::new_from_iso(date_iso, Coptic);
 //!
-//! assert_eq!(date_coptic.year().era_year_or_related_iso(), 1686);
+//! assert_eq!(date_coptic.year().era().unwrap().era_year, 1686);
 //! assert_eq!(date_coptic.month().ordinal, 4);
 //! assert_eq!(date_coptic.day_of_month().0, 24);
 //! ```
@@ -221,7 +221,7 @@ impl Date<Coptic> {
     /// let date_coptic = Date::try_new_coptic(1686, 5, 6)
     ///     .expect("Failed to initialize Coptic Date instance.");
     ///
-    /// assert_eq!(date_coptic.year().era_year_or_related_iso(), 1686);
+    /// assert_eq!(date_coptic.year().era().unwrap().era_year, 1686);
     /// assert_eq!(date_coptic.month().ordinal, 5);
     /// assert_eq!(date_coptic.day_of_month().0, 6);
     /// ```

--- a/components/calendar/src/cal/ethiopian.rs
+++ b/components/calendar/src/cal/ethiopian.rs
@@ -11,7 +11,7 @@
 //!     .expect("Failed to initialize ISO Date instance.");
 //! let date_ethiopian = Date::new_from_iso(date_iso, Ethiopian::new());
 //!
-//! assert_eq!(date_ethiopian.era_year().era_year, 1962);
+//! assert_eq!(date_ethiopian.era_year().year, 1962);
 //! assert_eq!(date_ethiopian.month().ordinal, 4);
 //! assert_eq!(date_ethiopian.day_of_month().0, 24);
 //! ```
@@ -201,14 +201,14 @@ impl Calendar for Ethiopian {
             types::EraYear {
                 standard_era: tinystr!(16, "aa").into(),
                 formatting_era: types::FormattingEra::Index(0, tinystr!(16, "AA")),
-                era_year: year,
+                year,
                 ambiguity: types::YearAmbiguity::CenturyRequired,
             }
         } else {
             types::EraYear {
                 standard_era: tinystr!(16, "am").into(),
                 formatting_era: types::FormattingEra::Index(1, tinystr!(16, "AM")),
-                era_year: year - INCARNATION_OFFSET,
+                year: year - INCARNATION_OFFSET,
                 ambiguity: types::YearAmbiguity::CenturyRequired,
             }
         }
@@ -279,7 +279,7 @@ impl Date<Ethiopian> {
     ///     Date::try_new_ethiopian(EthiopianEraStyle::AmeteMihret, 2014, 8, 25)
     ///         .expect("Failed to initialize Ethopic Date instance.");
     ///
-    /// assert_eq!(date_ethiopian.era_year().era_year, 2014);
+    /// assert_eq!(date_ethiopian.era_year().year, 2014);
     /// assert_eq!(date_ethiopian.month().ordinal, 8);
     /// assert_eq!(date_ethiopian.day_of_month().0, 25);
     /// ```

--- a/components/calendar/src/cal/ethiopian.rs
+++ b/components/calendar/src/cal/ethiopian.rs
@@ -11,7 +11,7 @@
 //!     .expect("Failed to initialize ISO Date instance.");
 //! let date_ethiopian = Date::new_from_iso(date_iso, Ethiopian::new());
 //!
-//! assert_eq!(date_ethiopian.year().era_year_or_related_iso(), 1962);
+//! assert_eq!(date_ethiopian.year().era().unwrap().era_year, 1962);
 //! assert_eq!(date_ethiopian.month().ordinal, 4);
 //! assert_eq!(date_ethiopian.day_of_month().0, 24);
 //! ```
@@ -275,7 +275,7 @@ impl Date<Ethiopian> {
     ///     Date::try_new_ethiopian(EthiopianEraStyle::AmeteMihret, 2014, 8, 25)
     ///         .expect("Failed to initialize Ethopic Date instance.");
     ///
-    /// assert_eq!(date_ethiopian.year().era_year_or_related_iso(), 2014);
+    /// assert_eq!(date_ethiopian.year().era().unwrap().era_year, 2014);
     /// assert_eq!(date_ethiopian.month().ordinal, 8);
     /// assert_eq!(date_ethiopian.day_of_month().0, 25);
     /// ```

--- a/components/calendar/src/cal/gregorian.rs
+++ b/components/calendar/src/cal/gregorian.rs
@@ -11,7 +11,7 @@
 //!     .expect("Failed to initialize ISO Date instance.");
 //! let date_gregorian = Date::new_from_iso(date_iso, Gregorian);
 //!
-//! assert_eq!(date_gregorian.era_year().era_year, 1970);
+//! assert_eq!(date_gregorian.era_year().year, 1970);
 //! assert_eq!(date_gregorian.month().ordinal, 1);
 //! assert_eq!(date_gregorian.day_of_month().0, 2);
 //! ```
@@ -112,7 +112,7 @@ impl Calendar for Gregorian {
             types::EraYear {
                 standard_era: tinystr!(16, "ce").into(),
                 formatting_era: types::FormattingEra::Index(1, tinystr!(16, "CE")),
-                era_year: extended_year,
+                year: extended_year,
                 ambiguity: match extended_year {
                     ..=999 => types::YearAmbiguity::EraAndCenturyRequired,
                     1000..=1949 => types::YearAmbiguity::CenturyRequired,
@@ -124,7 +124,7 @@ impl Calendar for Gregorian {
             types::EraYear {
                 standard_era: tinystr!(16, "bce").into(),
                 formatting_era: types::FormattingEra::Index(0, tinystr!(16, "BCE")),
-                era_year: 1_i32.saturating_sub(extended_year),
+                year: 1_i32.saturating_sub(extended_year),
                 ambiguity: types::YearAmbiguity::EraAndCenturyRequired,
             }
         }
@@ -174,7 +174,7 @@ impl Date<Gregorian> {
     /// let date_gregorian = Date::try_new_gregorian(1970, 1, 2)
     ///     .expect("Failed to initialize Gregorian Date instance.");
     ///
-    /// assert_eq!(date_gregorian.era_year().era_year, 1970);
+    /// assert_eq!(date_gregorian.era_year().year, 1970);
     /// assert_eq!(date_gregorian.month().ordinal, 1);
     /// assert_eq!(date_gregorian.day_of_month().0, 2);
     /// ```
@@ -205,7 +205,7 @@ mod test {
     fn check_test_case(case: TestCase) {
         let iso_from_rd = Date::from_rata_die(case.rd, Iso);
         let greg_date_from_rd = Date::from_rata_die(case.rd, Gregorian);
-        assert_eq!(greg_date_from_rd.era_year().era_year, case.expected_year,
+        assert_eq!(greg_date_from_rd.era_year().year, case.expected_year,
             "Failed year check from RD: {case:?}\nISO: {iso_from_rd:?}\nGreg: {greg_date_from_rd:?}");
         assert_eq!(
             greg_date_from_rd.era_year().standard_era,

--- a/components/calendar/src/cal/gregorian.rs
+++ b/components/calendar/src/cal/gregorian.rs
@@ -11,7 +11,7 @@
 //!     .expect("Failed to initialize ISO Date instance.");
 //! let date_gregorian = Date::new_from_iso(date_iso, Gregorian);
 //!
-//! assert_eq!(date_gregorian.year().era_year_or_related_iso(), 1970);
+//! assert_eq!(date_gregorian.year().era().unwrap().era_year, 1970);
 //! assert_eq!(date_gregorian.month().ordinal, 1);
 //! assert_eq!(date_gregorian.day_of_month().0, 2);
 //! ```
@@ -175,7 +175,7 @@ impl Date<Gregorian> {
     /// let date_gregorian = Date::try_new_gregorian(1970, 1, 2)
     ///     .expect("Failed to initialize Gregorian Date instance.");
     ///
-    /// assert_eq!(date_gregorian.year().era_year_or_related_iso(), 1970);
+    /// assert_eq!(date_gregorian.year().era().unwrap().era_year, 1970);
     /// assert_eq!(date_gregorian.month().ordinal, 1);
     /// assert_eq!(date_gregorian.day_of_month().0, 2);
     /// ```
@@ -206,10 +206,10 @@ mod test {
     fn check_test_case(case: TestCase) {
         let iso_from_rd = Date::from_rata_die(case.rd, Iso);
         let greg_date_from_rd = Date::from_rata_die(case.rd, Gregorian);
-        assert_eq!(greg_date_from_rd.year().era_year_or_related_iso(), case.expected_year,
+        assert_eq!(greg_date_from_rd.year().era().unwrap().era_year, case.expected_year,
             "Failed year check from RD: {case:?}\nISO: {iso_from_rd:?}\nGreg: {greg_date_from_rd:?}");
         assert_eq!(
-            greg_date_from_rd.year().standard_era().unwrap(),
+            greg_date_from_rd.year().era().unwrap().standard_era,
             case.expected_era,
             "Failed era check from RD: {case:?}\nISO: {iso_from_rd:?}\nGreg: {greg_date_from_rd:?}"
         );

--- a/components/calendar/src/cal/hebrew.rs
+++ b/components/calendar/src/cal/hebrew.rs
@@ -10,7 +10,7 @@
 //! let hebrew_date = Date::try_new_hebrew(3425, 10, 11)
 //!     .expect("Failed to initialize hebrew Date instance.");
 //!
-//! assert_eq!(hebrew_date.year().era_year_or_related_iso(), 3425);
+//! assert_eq!(hebrew_date.year().era().unwrap().era_year, 3425);
 //! assert_eq!(hebrew_date.month().ordinal, 10);
 //! assert_eq!(hebrew_date.day_of_month().0, 11);
 //! ```
@@ -348,7 +348,7 @@ impl Date<Hebrew> {
     /// let date_hebrew = Date::try_new_hebrew(3425, 4, 25)
     ///     .expect("Failed to initialize Hebrew Date instance.");
     ///
-    /// assert_eq!(date_hebrew.year().era_year_or_related_iso(), 3425);
+    /// assert_eq!(date_hebrew.year().era().unwrap().era_year, 3425);
     /// assert_eq!(date_hebrew.month().ordinal, 4);
     /// assert_eq!(date_hebrew.day_of_month().0, 25);
     /// ```
@@ -485,18 +485,17 @@ mod tests {
     #[test]
     fn test_negative_era_years() {
         let greg_date = Date::try_new_gregorian(-5000, 1, 1).unwrap();
-        // Extended year is accessible via the inner value.
-        // Era year is accessible via the public getter.
-        // TODO(#3962): Make extended year publicly accessible.
+        let greg_year = greg_date.year().era().unwrap();
         assert_eq!(greg_date.inner.0 .0.year, -5000);
-        assert_eq!(greg_date.year().standard_era().unwrap().0, "bce");
+        assert_eq!(greg_year.standard_era.0, "bce");
         // In Gregorian, era year is 1 - extended year
-        assert_eq!(greg_date.year().era_year().unwrap(), 5001);
+        assert_eq!(greg_year.era_year, 5001);
         let hebr_date = greg_date.to_calendar(Hebrew);
+        let hebr_year = hebr_date.year().era().unwrap();
         assert_eq!(hebr_date.inner.0.year.value, -1240);
-        assert_eq!(hebr_date.year().standard_era().unwrap().0, "am");
+        assert_eq!(hebr_year.standard_era.0, "am");
         // In Hebrew, there is no inverse era, so negative extended years are negative era years
-        assert_eq!(hebr_date.year().era_year_or_related_iso(), -1240);
+        assert_eq!(hebr_year.era_year, -1240);
     }
 
     #[test]

--- a/components/calendar/src/cal/hebrew.rs
+++ b/components/calendar/src/cal/hebrew.rs
@@ -10,7 +10,7 @@
 //! let hebrew_date = Date::try_new_hebrew(3425, 10, 11)
 //!     .expect("Failed to initialize hebrew Date instance.");
 //!
-//! assert_eq!(hebrew_date.era_year().era_year, 3425);
+//! assert_eq!(hebrew_date.era_year().year, 3425);
 //! assert_eq!(hebrew_date.month().ordinal, 10);
 //! assert_eq!(hebrew_date.day_of_month().0, 11);
 //! ```
@@ -263,7 +263,7 @@ impl Calendar for Hebrew {
         types::EraYear {
             formatting_era: types::FormattingEra::Index(0, tinystr!(16, "AM")),
             standard_era: tinystr!(16, "am").into(),
-            era_year: self.extended_year(date),
+            year: self.extended_year(date),
             ambiguity: types::YearAmbiguity::CenturyRequired,
         }
     }
@@ -350,7 +350,7 @@ impl Date<Hebrew> {
     /// let date_hebrew = Date::try_new_hebrew(3425, 4, 25)
     ///     .expect("Failed to initialize Hebrew Date instance.");
     ///
-    /// assert_eq!(date_hebrew.era_year().era_year, 3425);
+    /// assert_eq!(date_hebrew.era_year().year, 3425);
     /// assert_eq!(date_hebrew.month().ordinal, 4);
     /// assert_eq!(date_hebrew.day_of_month().0, 25);
     /// ```
@@ -491,13 +491,13 @@ mod tests {
         assert_eq!(greg_date.inner.0 .0.year, -5000);
         assert_eq!(greg_year.standard_era.0, "bce");
         // In Gregorian, era year is 1 - extended year
-        assert_eq!(greg_year.era_year, 5001);
+        assert_eq!(greg_year.year, 5001);
         let hebr_date = greg_date.to_calendar(Hebrew);
         let hebr_year = hebr_date.era_year();
         assert_eq!(hebr_date.inner.0.year.value, -1240);
         assert_eq!(hebr_year.standard_era.0, "am");
         // In Hebrew, there is no inverse era, so negative extended years are negative era years
-        assert_eq!(hebr_year.era_year, -1240);
+        assert_eq!(hebr_year.year, -1240);
     }
 
     #[test]

--- a/components/calendar/src/cal/hijri.rs
+++ b/components/calendar/src/cal/hijri.rs
@@ -14,7 +14,7 @@
 //! )
 //! .expect("Failed to initialize Hijri Date instance.");
 //!
-//! assert_eq!(hijri_date.year().era_year_or_related_iso(), 1348);
+//! assert_eq!(hijri_date.year().era().unwrap().era_year, 1348);
 //! assert_eq!(hijri_date.month().ordinal, 10);
 //! assert_eq!(hijri_date.day_of_month().0, 11);
 //! ```
@@ -585,7 +585,7 @@ impl<A: AsCalendar<Calendar = HijriSimulated>> Date<A> {
     ///     Date::try_new_simulated_hijri_with_calendar(1392, 4, 25, hijri)
     ///         .expect("Failed to initialize Hijri Date instance.");
     ///
-    /// assert_eq!(date_hijri.year().era_year_or_related_iso(), 1392);
+    /// assert_eq!(date_hijri.year().era().unwrap().era_year, 1392);
     /// assert_eq!(date_hijri.month().ordinal, 4);
     /// assert_eq!(date_hijri.day_of_month().0, 25);
     /// ```
@@ -1094,7 +1094,7 @@ impl Date<HijriUmmAlQura> {
     ///     Date::try_new_ummalqura(1392, 4, 25)
     ///         .expect("Failed to initialize Hijri Date instance.");
     ///
-    /// assert_eq!(date_hijri.year().era_year_or_related_iso(), 1392);
+    /// assert_eq!(date_hijri.year().era().unwrap().era_year, 1392);
     /// assert_eq!(date_hijri.month().ordinal, 4);
     /// assert_eq!(date_hijri.day_of_month().0, 25);
     /// ```
@@ -1281,7 +1281,7 @@ impl<A: AsCalendar<Calendar = HijriTabular>> Date<A> {
     ///     Date::try_new_hijri_tabular_with_calendar(1392, 4, 25, hijri)
     ///         .expect("Failed to initialize Hijri Date instance.");
     ///
-    /// assert_eq!(date_hijri.year().era_year_or_related_iso(), 1392);
+    /// assert_eq!(date_hijri.year().era().unwrap().era_year, 1392);
     /// assert_eq!(date_hijri.month().ordinal, 4);
     /// assert_eq!(date_hijri.day_of_month().0, 25);
     /// ```
@@ -2154,7 +2154,7 @@ mod test {
         // Data from https://www.ummulqura.org.sa/Index.aspx
         assert_eq!(hijri.day_of_month().0, 30);
         assert_eq!(hijri.month().ordinal, 4);
-        assert_eq!(hijri.year().era_year_or_related_iso(), 1432);
+        assert_eq!(hijri.year().era().unwrap().era_year, 1432);
     }
 
     #[test]
@@ -2218,7 +2218,7 @@ mod test {
             (
                 cached.day_of_month().0,
                 cached.month().ordinal,
-                cached.year().era_year_or_related_iso()
+                cached.year().era().unwrap().era_year
             ),
             (27, 8, 1446)
         );

--- a/components/calendar/src/cal/hijri.rs
+++ b/components/calendar/src/cal/hijri.rs
@@ -14,7 +14,7 @@
 //! )
 //! .expect("Failed to initialize Hijri Date instance.");
 //!
-//! assert_eq!(hijri_date.era_year().era_year, 1348);
+//! assert_eq!(hijri_date.era_year().year, 1348);
 //! assert_eq!(hijri_date.month().ordinal, 10);
 //! assert_eq!(hijri_date.day_of_month().0, 11);
 //! ```
@@ -38,7 +38,7 @@ fn era_year(year: i32) -> EraYear {
     types::EraYear {
         standard_era: types::Era(tinystr!(16, "ah")),
         formatting_era: types::FormattingEra::Index(0, tinystr!(16, "AH")),
-        era_year: year,
+        year,
         ambiguity: types::YearAmbiguity::CenturyRequired,
     }
 }
@@ -588,7 +588,7 @@ impl<A: AsCalendar<Calendar = HijriSimulated>> Date<A> {
     ///     Date::try_new_simulated_hijri_with_calendar(1392, 4, 25, hijri)
     ///         .expect("Failed to initialize Hijri Date instance.");
     ///
-    /// assert_eq!(date_hijri.era_year().era_year, 1392);
+    /// assert_eq!(date_hijri.era_year().year, 1392);
     /// assert_eq!(date_hijri.month().ordinal, 4);
     /// assert_eq!(date_hijri.day_of_month().0, 25);
     /// ```
@@ -1102,7 +1102,7 @@ impl Date<HijriUmmAlQura> {
     ///     Date::try_new_ummalqura(1392, 4, 25)
     ///         .expect("Failed to initialize Hijri Date instance.");
     ///
-    /// assert_eq!(date_hijri.era_year().era_year, 1392);
+    /// assert_eq!(date_hijri.era_year().year, 1392);
     /// assert_eq!(date_hijri.month().ordinal, 4);
     /// assert_eq!(date_hijri.day_of_month().0, 25);
     /// ```
@@ -1294,7 +1294,7 @@ impl<A: AsCalendar<Calendar = HijriTabular>> Date<A> {
     ///     Date::try_new_hijri_tabular_with_calendar(1392, 4, 25, hijri)
     ///         .expect("Failed to initialize Hijri Date instance.");
     ///
-    /// assert_eq!(date_hijri.era_year().era_year, 1392);
+    /// assert_eq!(date_hijri.era_year().year, 1392);
     /// assert_eq!(date_hijri.month().ordinal, 4);
     /// assert_eq!(date_hijri.day_of_month().0, 25);
     /// ```
@@ -2167,7 +2167,7 @@ mod test {
         // Data from https://www.ummulqura.org.sa/Index.aspx
         assert_eq!(hijri.day_of_month().0, 30);
         assert_eq!(hijri.month().ordinal, 4);
-        assert_eq!(hijri.era_year().era_year, 1432);
+        assert_eq!(hijri.era_year().year, 1432);
     }
 
     #[test]
@@ -2231,7 +2231,7 @@ mod test {
             (
                 cached.day_of_month().0,
                 cached.month().ordinal,
-                cached.era_year().era_year
+                cached.era_year().year
             ),
             (27, 8, 1446)
         );

--- a/components/calendar/src/cal/hijri.rs
+++ b/components/calendar/src/cal/hijri.rs
@@ -14,7 +14,7 @@
 //! )
 //! .expect("Failed to initialize Hijri Date instance.");
 //!
-//! assert_eq!(hijri_date.year().era().unwrap().era_year, 1348);
+//! assert_eq!(hijri_date.era_year().era_year, 1348);
 //! assert_eq!(hijri_date.month().ordinal, 10);
 //! assert_eq!(hijri_date.day_of_month().0, 11);
 //! ```
@@ -25,6 +25,7 @@ use crate::calendar_arithmetic::{ArithmeticDate, CalendarArithmetic};
 use crate::error::DateError;
 use crate::provider::hijri::PackedHijriYearInfo;
 use crate::provider::hijri::{CalendarHijriSimulatedMeccaV1, HijriData};
+use crate::types::EraYear;
 use crate::{types, Calendar, Date, DateDuration, DateDurationUnit};
 use crate::{AsCalendar, RangeError};
 use calendrical_calculations::islamic::{ISLAMIC_EPOCH_FRIDAY, ISLAMIC_EPOCH_THURSDAY};
@@ -33,16 +34,13 @@ use icu_provider::marker::ErasedMarker;
 use icu_provider::prelude::*;
 use tinystr::tinystr;
 
-fn year_as_hijri(year: i32) -> types::YearInfo {
-    types::YearInfo::new(
-        year,
-        types::EraYear {
-            standard_era: types::Era(tinystr!(16, "ah")),
-            formatting_era: types::FormattingEra::Index(0, tinystr!(16, "AH")),
-            era_year: year,
-            ambiguity: types::YearAmbiguity::CenturyRequired,
-        },
-    )
+fn era_year(year: i32) -> EraYear {
+    types::EraYear {
+        standard_era: types::Era(tinystr!(16, "ah")),
+        formatting_era: types::FormattingEra::Index(0, tinystr!(16, "AH")),
+        era_year: year,
+        ambiguity: types::YearAmbiguity::CenturyRequired,
+    }
 }
 
 /// The [simulated Hijri Calendar](https://en.wikipedia.org/wiki/Islamic_calendar)
@@ -365,6 +363,7 @@ impl CalendarArithmetic for HijriSimulated {
 
 impl Calendar for HijriSimulated {
     type DateInner = HijriSimulatedDateInner;
+    type Year = types::EraYear;
     fn from_codes(
         &self,
         era: Option<&str>,
@@ -454,8 +453,12 @@ impl Calendar for HijriSimulated {
         Self::DEBUG_NAME
     }
 
-    fn year(&self, date: &Self::DateInner) -> types::YearInfo {
-        year_as_hijri(date.0.year.value)
+    fn year_info(&self, date: &Self::DateInner) -> Self::Year {
+        era_year(self.extended_year(date))
+    }
+
+    fn extended_year(&self, date: &Self::DateInner) -> i32 {
+        date.0.extended_year()
     }
 
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
@@ -585,7 +588,7 @@ impl<A: AsCalendar<Calendar = HijriSimulated>> Date<A> {
     ///     Date::try_new_simulated_hijri_with_calendar(1392, 4, 25, hijri)
     ///         .expect("Failed to initialize Hijri Date instance.");
     ///
-    /// assert_eq!(date_hijri.year().era().unwrap().era_year, 1392);
+    /// assert_eq!(date_hijri.era_year().era_year, 1392);
     /// assert_eq!(date_hijri.month().ordinal, 4);
     /// assert_eq!(date_hijri.day_of_month().0, 25);
     /// ```
@@ -635,6 +638,7 @@ impl CalendarArithmetic for HijriUmmAlQura {
 
 impl Calendar for HijriUmmAlQura {
     type DateInner = HijriUmmAlQuraDateInner;
+    type Year = types::EraYear;
     fn from_codes(
         &self,
         era: Option<&str>,
@@ -724,8 +728,12 @@ impl Calendar for HijriUmmAlQura {
         Self::DEBUG_NAME
     }
 
-    fn year(&self, date: &Self::DateInner) -> types::YearInfo {
-        year_as_hijri(date.0.year.value)
+    fn year_info(&self, date: &Self::DateInner) -> Self::Year {
+        era_year(self.extended_year(date))
+    }
+
+    fn extended_year(&self, date: &Self::DateInner) -> i32 {
+        date.0.extended_year()
     }
 
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
@@ -1094,7 +1102,7 @@ impl Date<HijriUmmAlQura> {
     ///     Date::try_new_ummalqura(1392, 4, 25)
     ///         .expect("Failed to initialize Hijri Date instance.");
     ///
-    /// assert_eq!(date_hijri.year().era().unwrap().era_year, 1392);
+    /// assert_eq!(date_hijri.era_year().era_year, 1392);
     /// assert_eq!(date_hijri.month().ordinal, 4);
     /// assert_eq!(date_hijri.day_of_month().0, 25);
     /// ```
@@ -1156,6 +1164,7 @@ impl CalendarArithmetic for HijriTabular {
 
 impl Calendar for HijriTabular {
     type DateInner = HijriTabularDateInner;
+    type Year = types::EraYear;
 
     fn from_codes(
         &self,
@@ -1243,8 +1252,12 @@ impl Calendar for HijriTabular {
         }
     }
 
-    fn year(&self, date: &Self::DateInner) -> types::YearInfo {
-        year_as_hijri(date.0.year)
+    fn year_info(&self, date: &Self::DateInner) -> Self::Year {
+        era_year(self.extended_year(date))
+    }
+
+    fn extended_year(&self, date: &Self::DateInner) -> i32 {
+        date.0.extended_year()
     }
 
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
@@ -1281,7 +1294,7 @@ impl<A: AsCalendar<Calendar = HijriTabular>> Date<A> {
     ///     Date::try_new_hijri_tabular_with_calendar(1392, 4, 25, hijri)
     ///         .expect("Failed to initialize Hijri Date instance.");
     ///
-    /// assert_eq!(date_hijri.year().era().unwrap().era_year, 1392);
+    /// assert_eq!(date_hijri.era_year().era_year, 1392);
     /// assert_eq!(date_hijri.month().ordinal, 4);
     /// assert_eq!(date_hijri.day_of_month().0, 25);
     /// ```
@@ -2154,7 +2167,7 @@ mod test {
         // Data from https://www.ummulqura.org.sa/Index.aspx
         assert_eq!(hijri.day_of_month().0, 30);
         assert_eq!(hijri.month().ordinal, 4);
-        assert_eq!(hijri.year().era().unwrap().era_year, 1432);
+        assert_eq!(hijri.era_year().era_year, 1432);
     }
 
     #[test]
@@ -2218,7 +2231,7 @@ mod test {
             (
                 cached.day_of_month().0,
                 cached.month().ordinal,
-                cached.year().era().unwrap().era_year
+                cached.era_year().era_year
             ),
             (27, 8, 1446)
         );

--- a/components/calendar/src/cal/indian.rs
+++ b/components/calendar/src/cal/indian.rs
@@ -11,7 +11,7 @@
 //!     .expect("Failed to initialize ISO Date instance.");
 //! let date_indian = Date::new_from_iso(date_iso, Indian);
 //!
-//! assert_eq!(date_indian.era_year().era_year, 1891);
+//! assert_eq!(date_indian.era_year().year, 1891);
 //! assert_eq!(date_indian.month().ordinal, 10);
 //! assert_eq!(date_indian.day_of_month().0, 12);
 //! ```
@@ -186,7 +186,7 @@ impl Calendar for Indian {
         types::EraYear {
             formatting_era: types::FormattingEra::Index(0, tinystr!(16, "Saka")),
             standard_era: tinystr!(16, "saka").into(),
-            era_year: self.extended_year(date),
+            year: self.extended_year(date),
             ambiguity: types::YearAmbiguity::CenturyRequired,
         }
     }
@@ -236,7 +236,7 @@ impl Date<Indian> {
     /// let date_indian = Date::try_new_indian(1891, 10, 12)
     ///     .expect("Failed to initialize Indian Date instance.");
     ///
-    /// assert_eq!(date_indian.era_year().era_year, 1891);
+    /// assert_eq!(date_indian.era_year().year, 1891);
     /// assert_eq!(date_indian.month().ordinal, 10);
     /// assert_eq!(date_indian.day_of_month().0, 12);
     /// ```
@@ -257,7 +257,7 @@ mod tests {
         let iso = indian.to_iso();
 
         assert_eq!(
-            iso.era_year().era_year,
+            iso.era_year().year,
             iso_y,
             "{y}-{m}-{d}: ISO year did not match"
         );
@@ -275,8 +275,8 @@ mod tests {
         let roundtrip = iso.to_calendar(Indian);
 
         assert_eq!(
-            roundtrip.era_year().era_year,
-            indian.era_year().era_year,
+            roundtrip.era_year().year,
+            indian.era_year().year,
             "{y}-{m}-{d}: roundtrip year did not match"
         );
         assert_eq!(
@@ -321,7 +321,7 @@ mod tests {
         let iso = Date::try_new_iso(case.iso_year, case.iso_month, case.iso_day).unwrap();
         let saka = iso.to_calendar(Indian);
         assert_eq!(
-            saka.era_year().era_year,
+            saka.era_year().year,
             case.expected_year,
             "Year check failed for case: {case:?}"
         );

--- a/components/calendar/src/cal/indian.rs
+++ b/components/calendar/src/cal/indian.rs
@@ -11,7 +11,7 @@
 //!     .expect("Failed to initialize ISO Date instance.");
 //! let date_indian = Date::new_from_iso(date_iso, Indian);
 //!
-//! assert_eq!(date_indian.year().era_year_or_related_iso(), 1891);
+//! assert_eq!(date_indian.year().era().unwrap().era_year, 1891);
 //! assert_eq!(date_indian.month().ordinal, 10);
 //! assert_eq!(date_indian.day_of_month().0, 12);
 //! ```
@@ -234,7 +234,7 @@ impl Date<Indian> {
     /// let date_indian = Date::try_new_indian(1891, 10, 12)
     ///     .expect("Failed to initialize Indian Date instance.");
     ///
-    /// assert_eq!(date_indian.year().era_year_or_related_iso(), 1891);
+    /// assert_eq!(date_indian.year().era().unwrap().era_year, 1891);
     /// assert_eq!(date_indian.month().ordinal, 10);
     /// assert_eq!(date_indian.day_of_month().0, 12);
     /// ```
@@ -255,7 +255,7 @@ mod tests {
         let iso = indian.to_iso();
 
         assert_eq!(
-            iso.year().era_year_or_related_iso(),
+            iso.year().era().unwrap().era_year,
             iso_y,
             "{y}-{m}-{d}: ISO year did not match"
         );
@@ -273,8 +273,8 @@ mod tests {
         let roundtrip = iso.to_calendar(Indian);
 
         assert_eq!(
-            roundtrip.year().era_year_or_related_iso(),
-            indian.year().era_year_or_related_iso(),
+            roundtrip.year().era().unwrap().era_year,
+            indian.year().era().unwrap().era_year,
             "{y}-{m}-{d}: roundtrip year did not match"
         );
         assert_eq!(
@@ -319,7 +319,7 @@ mod tests {
         let iso = Date::try_new_iso(case.iso_year, case.iso_month, case.iso_day).unwrap();
         let saka = iso.to_calendar(Indian);
         assert_eq!(
-            saka.year().era_year_or_related_iso(),
+            saka.year().era().unwrap().era_year,
             case.expected_year,
             "Year check failed for case: {case:?}"
         );

--- a/components/calendar/src/cal/iso.rs
+++ b/components/calendar/src/cal/iso.rs
@@ -10,7 +10,7 @@
 //! let date_iso = Date::try_new_iso(1970, 1, 2)
 //!     .expect("Failed to initialize ISO Date instance.");
 //!
-//! assert_eq!(date_iso.year().era().unwrap().era_year, 1970);
+//! assert_eq!(date_iso.era_year().era_year, 1970);
 //! assert_eq!(date_iso.month().ordinal, 1);
 //! assert_eq!(date_iso.day_of_month().0, 2);
 //! ```
@@ -78,6 +78,7 @@ impl CalendarArithmetic for Iso {
 
 impl Calendar for Iso {
     type DateInner = IsoDateInner;
+    type Year = types::EraYear;
     /// Construct a date from era/month codes and fields
     fn from_codes(
         &self,
@@ -142,16 +143,17 @@ impl Calendar for Iso {
         date1.0.until(date2.0, _largest_unit, _smallest_unit)
     }
 
-    fn year(&self, date: &Self::DateInner) -> types::YearInfo {
-        types::YearInfo::new(
-            date.0.year,
-            types::EraYear {
-                formatting_era: types::FormattingEra::Index(0, tinystr!(16, "")),
-                standard_era: tinystr!(16, "default").into(),
-                era_year: date.0.year,
-                ambiguity: types::YearAmbiguity::Unambiguous,
-            },
-        )
+    fn year_info(&self, date: &Self::DateInner) -> Self::Year {
+        types::EraYear {
+            formatting_era: types::FormattingEra::Index(0, tinystr!(16, "")),
+            standard_era: tinystr!(16, "default").into(),
+            era_year: self.extended_year(date),
+            ambiguity: types::YearAmbiguity::Unambiguous,
+        }
+    }
+
+    fn extended_year(&self, date: &Self::DateInner) -> i32 {
+        date.0.extended_year()
     }
 
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
@@ -190,7 +192,7 @@ impl Date<Iso> {
     /// let date_iso = Date::try_new_iso(1970, 1, 2)
     ///     .expect("Failed to initialize ISO Date instance.");
     ///
-    /// assert_eq!(date_iso.year().era().unwrap().era_year, 1970);
+    /// assert_eq!(date_iso.era_year().era_year, 1970);
     /// assert_eq!(date_iso.month().ordinal, 1);
     /// assert_eq!(date_iso.day_of_month().0, 2);
     /// ```

--- a/components/calendar/src/cal/iso.rs
+++ b/components/calendar/src/cal/iso.rs
@@ -10,7 +10,7 @@
 //! let date_iso = Date::try_new_iso(1970, 1, 2)
 //!     .expect("Failed to initialize ISO Date instance.");
 //!
-//! assert_eq!(date_iso.year().era_year_or_related_iso(), 1970);
+//! assert_eq!(date_iso.year().era().unwrap().era_year, 1970);
 //! assert_eq!(date_iso.month().ordinal, 1);
 //! assert_eq!(date_iso.day_of_month().0, 2);
 //! ```
@@ -190,7 +190,7 @@ impl Date<Iso> {
     /// let date_iso = Date::try_new_iso(1970, 1, 2)
     ///     .expect("Failed to initialize ISO Date instance.");
     ///
-    /// assert_eq!(date_iso.year().era_year_or_related_iso(), 1970);
+    /// assert_eq!(date_iso.year().era().unwrap().era_year, 1970);
     /// assert_eq!(date_iso.month().ordinal, 1);
     /// assert_eq!(date_iso.day_of_month().0, 2);
     /// ```
@@ -396,7 +396,9 @@ mod test {
         assert_eq!(
             Date::from_rata_die(RataDie::big_negative(), Iso)
                 .year()
-                .era_year_or_related_iso(),
+                .era()
+                .unwrap()
+                .era_year,
             i32::MIN
         );
     }

--- a/components/calendar/src/cal/iso.rs
+++ b/components/calendar/src/cal/iso.rs
@@ -10,7 +10,7 @@
 //! let date_iso = Date::try_new_iso(1970, 1, 2)
 //!     .expect("Failed to initialize ISO Date instance.");
 //!
-//! assert_eq!(date_iso.era_year().era_year, 1970);
+//! assert_eq!(date_iso.era_year().year, 1970);
 //! assert_eq!(date_iso.month().ordinal, 1);
 //! assert_eq!(date_iso.day_of_month().0, 2);
 //! ```
@@ -147,7 +147,7 @@ impl Calendar for Iso {
         types::EraYear {
             formatting_era: types::FormattingEra::Index(0, tinystr!(16, "")),
             standard_era: tinystr!(16, "default").into(),
-            era_year: self.extended_year(date),
+            year: self.extended_year(date),
             ambiguity: types::YearAmbiguity::Unambiguous,
         }
     }
@@ -192,7 +192,7 @@ impl Date<Iso> {
     /// let date_iso = Date::try_new_iso(1970, 1, 2)
     ///     .expect("Failed to initialize ISO Date instance.");
     ///
-    /// assert_eq!(date_iso.era_year().era_year, 1970);
+    /// assert_eq!(date_iso.era_year().year, 1970);
     /// assert_eq!(date_iso.month().ordinal, 1);
     /// assert_eq!(date_iso.day_of_month().0, 2);
     /// ```
@@ -400,7 +400,7 @@ mod test {
                 .year()
                 .era()
                 .unwrap()
-                .era_year,
+                .year,
             i32::MIN
         );
     }

--- a/components/calendar/src/cal/japanese.rs
+++ b/components/calendar/src/cal/japanese.rs
@@ -15,11 +15,11 @@
 //!     .expect("Failed to initialize ISO Date instance.");
 //! let date_japanese = Date::new_from_iso(date_iso, japanese_calendar);
 //!
-//! assert_eq!(date_japanese.year().era().unwrap().era_year, 45);
+//! assert_eq!(date_japanese.era_year().era_year, 45);
 //! assert_eq!(date_japanese.month().ordinal, 1);
 //! assert_eq!(date_japanese.day_of_month().0, 2);
 //! assert_eq!(
-//!     date_japanese.year().era().unwrap().standard_era.0,
+//!     date_japanese.era_year().standard_era.0,
 //!     "showa"
 //! );
 //! ```
@@ -171,6 +171,7 @@ impl JapaneseExtended {
 
 impl Calendar for Japanese {
     type DateInner = JapaneseDateInner;
+    type Year = types::EraYear;
 
     fn from_codes(
         &self,
@@ -248,16 +249,17 @@ impl Calendar for Japanese {
         .cast_unit()
     }
 
-    fn year(&self, date: &Self::DateInner) -> types::YearInfo {
-        types::YearInfo::new(
-            date.inner.0.year,
-            types::EraYear {
-                formatting_era: types::FormattingEra::Code(date.era.into()),
-                standard_era: date.era.into(),
-                era_year: date.adjusted_year,
-                ambiguity: types::YearAmbiguity::CenturyRequired,
-            },
-        )
+    fn year_info(&self, date: &Self::DateInner) -> Self::Year {
+        types::EraYear {
+            formatting_era: types::FormattingEra::Code(date.era.into()),
+            standard_era: date.era.into(),
+            era_year: date.adjusted_year,
+            ambiguity: types::YearAmbiguity::CenturyRequired,
+        }
+    }
+
+    fn extended_year(&self, date: &Self::DateInner) -> i32 {
+        Iso.extended_year(&date.inner)
     }
 
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
@@ -289,6 +291,7 @@ impl Calendar for Japanese {
 
 impl Calendar for JapaneseExtended {
     type DateInner = JapaneseDateInner;
+    type Year = types::EraYear;
 
     fn from_codes(
         &self,
@@ -351,8 +354,12 @@ impl Calendar for JapaneseExtended {
         .cast_unit()
     }
 
-    fn year(&self, date: &Self::DateInner) -> types::YearInfo {
-        Japanese::year(&self.0, date)
+    fn year_info(&self, date: &Self::DateInner) -> Self::Year {
+        Japanese::year_info(&self.0, date)
+    }
+
+    fn extended_year(&self, date: &Self::DateInner) -> i32 {
+        Japanese::extended_year(&self.0, date)
     }
 
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
@@ -407,8 +414,8 @@ impl Date<Japanese> {
     ///     Date::try_new_japanese_with_calendar(era, 14, 1, 2, japanese_calendar)
     ///         .expect("Constructing a date should succeed");
     ///
-    /// assert_eq!(date.year().era().unwrap().standard_era.0, era);
-    /// assert_eq!(date.year().era().unwrap().era_year, 14);
+    /// assert_eq!(date.era_year().standard_era.0, era);
+    /// assert_eq!(date.era_year().era_year, 14);
     /// assert_eq!(date.month().ordinal, 1);
     /// assert_eq!(date.day_of_month().0, 2);
     ///
@@ -472,8 +479,8 @@ impl Date<JapaneseExtended> {
     /// )
     /// .expect("Constructing a date should succeed");
     ///
-    /// assert_eq!(date.year().era().unwrap().standard_era.0, era);
-    /// assert_eq!(date.year().era().unwrap().era_year, 7);
+    /// assert_eq!(date.era_year().standard_era.0, era);
+    /// assert_eq!(date.era_year().era_year, 7);
     /// assert_eq!(date.month().ordinal, 1);
     /// assert_eq!(date.day_of_month().0, 2);
     /// ```
@@ -747,8 +754,8 @@ mod tests {
         );
 
         // Extra coverage for https://github.com/unicode-org/icu4x/issues/4968
-        assert_eq!(reconstructed.year().era().unwrap().standard_era.0, era);
-        assert_eq!(reconstructed.year().era().unwrap().era_year, year);
+        assert_eq!(reconstructed.era_year().standard_era.0, era);
+        assert_eq!(reconstructed.era_year().era_year, year);
     }
 
     fn single_test_roundtrip_ext(

--- a/components/calendar/src/cal/japanese.rs
+++ b/components/calendar/src/cal/japanese.rs
@@ -15,12 +15,12 @@
 //!     .expect("Failed to initialize ISO Date instance.");
 //! let date_japanese = Date::new_from_iso(date_iso, japanese_calendar);
 //!
-//! assert_eq!(date_japanese.year().era_year_or_related_iso(), 45);
+//! assert_eq!(date_japanese.year().era().unwrap().era_year, 45);
 //! assert_eq!(date_japanese.month().ordinal, 1);
 //! assert_eq!(date_japanese.day_of_month().0, 2);
 //! assert_eq!(
-//!     date_japanese.year().standard_era().unwrap(),
-//!     Era(tinystr!(16, "showa"))
+//!     date_japanese.year().era().unwrap().standard_era.0,
+//!     "showa"
 //! );
 //! ```
 
@@ -407,8 +407,8 @@ impl Date<Japanese> {
     ///     Date::try_new_japanese_with_calendar(era, 14, 1, 2, japanese_calendar)
     ///         .expect("Constructing a date should succeed");
     ///
-    /// assert_eq!(date.year().standard_era().unwrap().0, era);
-    /// assert_eq!(date.year().era_year_or_related_iso(), 14);
+    /// assert_eq!(date.year().era().unwrap().standard_era.0, era);
+    /// assert_eq!(date.year().era().unwrap().era_year, 14);
     /// assert_eq!(date.month().ordinal, 1);
     /// assert_eq!(date.day_of_month().0, 2);
     ///
@@ -472,8 +472,8 @@ impl Date<JapaneseExtended> {
     /// )
     /// .expect("Constructing a date should succeed");
     ///
-    /// assert_eq!(date.year().standard_era().unwrap().0, era);
-    /// assert_eq!(date.year().era_year_or_related_iso(), 7);
+    /// assert_eq!(date.year().era().unwrap().standard_era.0, era);
+    /// assert_eq!(date.year().era().unwrap().era_year, 7);
     /// assert_eq!(date.month().ordinal, 1);
     /// assert_eq!(date.day_of_month().0, 2);
     /// ```
@@ -747,8 +747,8 @@ mod tests {
         );
 
         // Extra coverage for https://github.com/unicode-org/icu4x/issues/4968
-        assert_eq!(reconstructed.year().standard_era().unwrap().0, era);
-        assert_eq!(reconstructed.year().era_year().unwrap(), year);
+        assert_eq!(reconstructed.year().era().unwrap().standard_era.0, era);
+        assert_eq!(reconstructed.year().era().unwrap().era_year, year);
     }
 
     fn single_test_roundtrip_ext(

--- a/components/calendar/src/cal/japanese.rs
+++ b/components/calendar/src/cal/japanese.rs
@@ -15,7 +15,7 @@
 //!     .expect("Failed to initialize ISO Date instance.");
 //! let date_japanese = Date::new_from_iso(date_iso, japanese_calendar);
 //!
-//! assert_eq!(date_japanese.era_year().era_year, 45);
+//! assert_eq!(date_japanese.era_year().year, 45);
 //! assert_eq!(date_japanese.month().ordinal, 1);
 //! assert_eq!(date_japanese.day_of_month().0, 2);
 //! assert_eq!(
@@ -253,7 +253,7 @@ impl Calendar for Japanese {
         types::EraYear {
             formatting_era: types::FormattingEra::Code(date.era.into()),
             standard_era: date.era.into(),
-            era_year: date.adjusted_year,
+            year: date.adjusted_year,
             ambiguity: types::YearAmbiguity::CenturyRequired,
         }
     }
@@ -415,7 +415,7 @@ impl Date<Japanese> {
     ///         .expect("Constructing a date should succeed");
     ///
     /// assert_eq!(date.era_year().standard_era.0, era);
-    /// assert_eq!(date.era_year().era_year, 14);
+    /// assert_eq!(date.era_year().year, 14);
     /// assert_eq!(date.month().ordinal, 1);
     /// assert_eq!(date.day_of_month().0, 2);
     ///
@@ -480,7 +480,7 @@ impl Date<JapaneseExtended> {
     /// .expect("Constructing a date should succeed");
     ///
     /// assert_eq!(date.era_year().standard_era.0, era);
-    /// assert_eq!(date.era_year().era_year, 7);
+    /// assert_eq!(date.era_year().year, 7);
     /// assert_eq!(date.month().ordinal, 1);
     /// assert_eq!(date.day_of_month().0, 2);
     /// ```
@@ -755,7 +755,7 @@ mod tests {
 
         // Extra coverage for https://github.com/unicode-org/icu4x/issues/4968
         assert_eq!(reconstructed.era_year().standard_era.0, era);
-        assert_eq!(reconstructed.era_year().era_year, year);
+        assert_eq!(reconstructed.era_year().year, year);
     }
 
     fn single_test_roundtrip_ext(

--- a/components/calendar/src/cal/julian.rs
+++ b/components/calendar/src/cal/julian.rs
@@ -11,7 +11,7 @@
 //!     .expect("Failed to initialize ISO Date instance.");
 //! let date_julian = Date::new_from_iso(date_iso, Julian);
 //!
-//! assert_eq!(date_julian.year().era_year_or_related_iso(), 1969);
+//! assert_eq!(date_julian.year().era().unwrap().era_year, 1969);
 //! assert_eq!(date_julian.month().ordinal, 12);
 //! assert_eq!(date_julian.day_of_month().0, 20);
 //! ```
@@ -223,7 +223,7 @@ impl Date<Julian> {
     /// let date_julian = Date::try_new_julian(1969, 12, 20)
     ///     .expect("Failed to initialize Julian Date instance.");
     ///
-    /// assert_eq!(date_julian.year().era_year_or_related_iso(), 1969);
+    /// assert_eq!(date_julian.year().era().unwrap().era_year, 1969);
     /// assert_eq!(date_julian.month().ordinal, 12);
     /// assert_eq!(date_julian.day_of_month().0, 20);
     /// ```
@@ -425,9 +425,9 @@ mod test {
         for case in cases {
             let iso_from_rd = Date::from_rata_die(RataDie::new(case.rd), crate::Iso);
             let julian_from_rd = Date::from_rata_die(RataDie::new(case.rd), Julian);
-            assert_eq!(julian_from_rd.year().era_year().unwrap(), case.expected_year,
+            assert_eq!(julian_from_rd.year().era().unwrap().era_year, case.expected_year,
                 "Failed year check from RD: {case:?}\nISO: {iso_from_rd:?}\nJulian: {julian_from_rd:?}");
-            assert_eq!(julian_from_rd.year().standard_era().unwrap(), case.expected_era,
+            assert_eq!(julian_from_rd.year().era().unwrap().standard_era, case.expected_era,
                 "Failed era check from RD: {case:?}\nISO: {iso_from_rd:?}\nJulian: {julian_from_rd:?}");
             assert_eq!(julian_from_rd.month().ordinal, case.expected_month,
                 "Failed month check from RD: {case:?}\nISO: {iso_from_rd:?}\nJulian: {julian_from_rd:?}");

--- a/components/calendar/src/cal/julian.rs
+++ b/components/calendar/src/cal/julian.rs
@@ -11,7 +11,7 @@
 //!     .expect("Failed to initialize ISO Date instance.");
 //! let date_julian = Date::new_from_iso(date_iso, Julian);
 //!
-//! assert_eq!(date_julian.era_year().era_year, 1969);
+//! assert_eq!(date_julian.era_year().year, 1969);
 //! assert_eq!(date_julian.month().ordinal, 12);
 //! assert_eq!(date_julian.day_of_month().0, 20);
 //! ```
@@ -161,14 +161,14 @@ impl Calendar for Julian {
             types::EraYear {
                 standard_era: tinystr!(16, "ad").into(),
                 formatting_era: types::FormattingEra::Index(1, tinystr!(16, "AD")),
-                era_year: extended_year,
+                year: extended_year,
                 ambiguity: types::YearAmbiguity::CenturyRequired,
             }
         } else {
             types::EraYear {
                 standard_era: tinystr!(16, "bc").into(),
                 formatting_era: types::FormattingEra::Index(0, tinystr!(16, "BC")),
-                era_year: 1_i32.saturating_sub(extended_year),
+                year: 1_i32.saturating_sub(extended_year),
                 ambiguity: types::YearAmbiguity::EraAndCenturyRequired,
             }
         }
@@ -223,7 +223,7 @@ impl Date<Julian> {
     /// let date_julian = Date::try_new_julian(1969, 12, 20)
     ///     .expect("Failed to initialize Julian Date instance.");
     ///
-    /// assert_eq!(date_julian.era_year().era_year, 1969);
+    /// assert_eq!(date_julian.era_year().year, 1969);
     /// assert_eq!(date_julian.month().ordinal, 12);
     /// assert_eq!(date_julian.day_of_month().0, 20);
     /// ```
@@ -425,7 +425,7 @@ mod test {
         for case in cases {
             let iso_from_rd = Date::from_rata_die(RataDie::new(case.rd), crate::Iso);
             let julian_from_rd = Date::from_rata_die(RataDie::new(case.rd), Julian);
-            assert_eq!(julian_from_rd.era_year().era_year, case.expected_year,
+            assert_eq!(julian_from_rd.era_year().year, case.expected_year,
                 "Failed year check from RD: {case:?}\nISO: {iso_from_rd:?}\nJulian: {julian_from_rd:?}");
             assert_eq!(julian_from_rd.era_year().standard_era, case.expected_era,
                 "Failed era check from RD: {case:?}\nISO: {iso_from_rd:?}\nJulian: {julian_from_rd:?}");

--- a/components/calendar/src/cal/julian.rs
+++ b/components/calendar/src/cal/julian.rs
@@ -11,7 +11,7 @@
 //!     .expect("Failed to initialize ISO Date instance.");
 //! let date_julian = Date::new_from_iso(date_iso, Julian);
 //!
-//! assert_eq!(date_julian.year().era().unwrap().era_year, 1969);
+//! assert_eq!(date_julian.era_year().era_year, 1969);
 //! assert_eq!(date_julian.month().ordinal, 12);
 //! assert_eq!(date_julian.day_of_month().0, 20);
 //! ```
@@ -85,6 +85,8 @@ impl CalendarArithmetic for Julian {
 
 impl Calendar for Julian {
     type DateInner = JulianDateInner;
+    type Year = types::EraYear;
+
     fn from_codes(
         &self,
         era: Option<&str>,
@@ -153,29 +155,27 @@ impl Calendar for Julian {
 
     /// The calendar-specific year represented by `date`
     /// Julian has the same era scheme as Gregorian
-    fn year(&self, date: &Self::DateInner) -> types::YearInfo {
-        let year = date.0.year;
-        if year > 0 {
-            types::YearInfo::new(
-                year,
-                types::EraYear {
-                    standard_era: tinystr!(16, "ad").into(),
-                    formatting_era: types::FormattingEra::Index(1, tinystr!(16, "AD")),
-                    era_year: year,
-                    ambiguity: types::YearAmbiguity::CenturyRequired,
-                },
-            )
+    fn year_info(&self, date: &Self::DateInner) -> Self::Year {
+        let extended_year = self.extended_year(date);
+        if extended_year > 0 {
+            types::EraYear {
+                standard_era: tinystr!(16, "ad").into(),
+                formatting_era: types::FormattingEra::Index(1, tinystr!(16, "AD")),
+                era_year: extended_year,
+                ambiguity: types::YearAmbiguity::CenturyRequired,
+            }
         } else {
-            types::YearInfo::new(
-                year,
-                types::EraYear {
-                    standard_era: tinystr!(16, "bc").into(),
-                    formatting_era: types::FormattingEra::Index(0, tinystr!(16, "BC")),
-                    era_year: 1_i32.saturating_sub(year),
-                    ambiguity: types::YearAmbiguity::EraAndCenturyRequired,
-                },
-            )
+            types::EraYear {
+                standard_era: tinystr!(16, "bc").into(),
+                formatting_era: types::FormattingEra::Index(0, tinystr!(16, "BC")),
+                era_year: 1_i32.saturating_sub(extended_year),
+                ambiguity: types::YearAmbiguity::EraAndCenturyRequired,
+            }
         }
+    }
+
+    fn extended_year(&self, date: &Self::DateInner) -> i32 {
+        date.0.extended_year()
     }
 
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
@@ -223,7 +223,7 @@ impl Date<Julian> {
     /// let date_julian = Date::try_new_julian(1969, 12, 20)
     ///     .expect("Failed to initialize Julian Date instance.");
     ///
-    /// assert_eq!(date_julian.year().era().unwrap().era_year, 1969);
+    /// assert_eq!(date_julian.era_year().era_year, 1969);
     /// assert_eq!(date_julian.month().ordinal, 12);
     /// assert_eq!(date_julian.day_of_month().0, 20);
     /// ```
@@ -425,9 +425,9 @@ mod test {
         for case in cases {
             let iso_from_rd = Date::from_rata_die(RataDie::new(case.rd), crate::Iso);
             let julian_from_rd = Date::from_rata_die(RataDie::new(case.rd), Julian);
-            assert_eq!(julian_from_rd.year().era().unwrap().era_year, case.expected_year,
+            assert_eq!(julian_from_rd.era_year().era_year, case.expected_year,
                 "Failed year check from RD: {case:?}\nISO: {iso_from_rd:?}\nJulian: {julian_from_rd:?}");
-            assert_eq!(julian_from_rd.year().era().unwrap().standard_era, case.expected_era,
+            assert_eq!(julian_from_rd.era_year().standard_era, case.expected_era,
                 "Failed era check from RD: {case:?}\nISO: {iso_from_rd:?}\nJulian: {julian_from_rd:?}");
             assert_eq!(julian_from_rd.month().ordinal, case.expected_month,
                 "Failed month check from RD: {case:?}\nISO: {iso_from_rd:?}\nJulian: {julian_from_rd:?}");

--- a/components/calendar/src/cal/persian.rs
+++ b/components/calendar/src/cal/persian.rs
@@ -10,7 +10,7 @@
 //! let persian_date = Date::try_new_persian(1348, 10, 11)
 //!     .expect("Failed to initialize Persian Date instance.");
 //!
-//! assert_eq!(persian_date.year().era().unwrap().era_year, 1348);
+//! assert_eq!(persian_date.era_year().era_year, 1348);
 //! assert_eq!(persian_date.month().ordinal, 10);
 //! assert_eq!(persian_date.day_of_month().0, 11);
 //! ```
@@ -86,6 +86,8 @@ impl CalendarArithmetic for Persian {
 
 impl Calendar for Persian {
     type DateInner = PersianDateInner;
+    type Year = types::EraYear;
+
     fn from_codes(
         &self,
         era: Option<&str>,
@@ -155,18 +157,19 @@ impl Calendar for Persian {
         date1.0.until(date2.0, _largest_unit, _smallest_unit)
     }
 
-    fn year(&self, date: &Self::DateInner) -> types::YearInfo {
-        let year = date.0.year;
-        types::YearInfo::new(
-            year,
-            types::EraYear {
-                standard_era: tinystr!(16, "ap").into(),
-                formatting_era: types::FormattingEra::Index(0, tinystr!(16, "AP")),
-                era_year: year,
-                ambiguity: types::YearAmbiguity::CenturyRequired,
-            },
-        )
+    fn year_info(&self, date: &Self::DateInner) -> Self::Year {
+        types::EraYear {
+            standard_era: tinystr!(16, "ap").into(),
+            formatting_era: types::FormattingEra::Index(0, tinystr!(16, "AP")),
+            era_year: self.extended_year(date),
+            ambiguity: types::YearAmbiguity::CenturyRequired,
+        }
     }
+
+    fn extended_year(&self, date: &Self::DateInner) -> i32 {
+        date.0.extended_year()
+    }
+
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
         Self::provided_year_is_leap(date.0.year)
     }
@@ -210,7 +213,7 @@ impl Date<Persian> {
     /// let date_persian = Date::try_new_persian(1392, 4, 25)
     ///     .expect("Failed to initialize Persian Date instance.");
     ///
-    /// assert_eq!(date_persian.year().era().unwrap().era_year, 1392);
+    /// assert_eq!(date_persian.era_year().era_year, 1392);
     /// assert_eq!(date_persian.month().ordinal, 4);
     /// assert_eq!(date_persian.day_of_month().0, 25);
     /// ```
@@ -714,7 +717,7 @@ mod tests {
             assert_eq!(Persian::provided_year_is_leap(*p_year), *leap);
             let persian_date = Date::try_new_persian(*p_year, 1, 1).unwrap();
             let iso_date = persian_date.to_calendar(Iso);
-            assert_eq!(iso_date.year().era().unwrap().era_year, *iso_year);
+            assert_eq!(iso_date.era_year().era_year, *iso_year);
             assert_eq!(iso_date.month().ordinal, *iso_month);
             assert_eq!(iso_date.day_of_month().0, *iso_day);
         }

--- a/components/calendar/src/cal/persian.rs
+++ b/components/calendar/src/cal/persian.rs
@@ -10,7 +10,7 @@
 //! let persian_date = Date::try_new_persian(1348, 10, 11)
 //!     .expect("Failed to initialize Persian Date instance.");
 //!
-//! assert_eq!(persian_date.era_year().era_year, 1348);
+//! assert_eq!(persian_date.era_year().year, 1348);
 //! assert_eq!(persian_date.month().ordinal, 10);
 //! assert_eq!(persian_date.day_of_month().0, 11);
 //! ```
@@ -161,7 +161,7 @@ impl Calendar for Persian {
         types::EraYear {
             standard_era: tinystr!(16, "ap").into(),
             formatting_era: types::FormattingEra::Index(0, tinystr!(16, "AP")),
-            era_year: self.extended_year(date),
+            year: self.extended_year(date),
             ambiguity: types::YearAmbiguity::CenturyRequired,
         }
     }
@@ -213,7 +213,7 @@ impl Date<Persian> {
     /// let date_persian = Date::try_new_persian(1392, 4, 25)
     ///     .expect("Failed to initialize Persian Date instance.");
     ///
-    /// assert_eq!(date_persian.era_year().era_year, 1392);
+    /// assert_eq!(date_persian.era_year().year, 1392);
     /// assert_eq!(date_persian.month().ordinal, 4);
     /// assert_eq!(date_persian.day_of_month().0, 25);
     /// ```
@@ -717,7 +717,7 @@ mod tests {
             assert_eq!(Persian::provided_year_is_leap(*p_year), *leap);
             let persian_date = Date::try_new_persian(*p_year, 1, 1).unwrap();
             let iso_date = persian_date.to_calendar(Iso);
-            assert_eq!(iso_date.era_year().era_year, *iso_year);
+            assert_eq!(iso_date.era_year().year, *iso_year);
             assert_eq!(iso_date.month().ordinal, *iso_month);
             assert_eq!(iso_date.day_of_month().0, *iso_day);
         }

--- a/components/calendar/src/cal/persian.rs
+++ b/components/calendar/src/cal/persian.rs
@@ -10,7 +10,7 @@
 //! let persian_date = Date::try_new_persian(1348, 10, 11)
 //!     .expect("Failed to initialize Persian Date instance.");
 //!
-//! assert_eq!(persian_date.year().era_year_or_related_iso(), 1348);
+//! assert_eq!(persian_date.year().era().unwrap().era_year, 1348);
 //! assert_eq!(persian_date.month().ordinal, 10);
 //! assert_eq!(persian_date.day_of_month().0, 11);
 //! ```
@@ -210,7 +210,7 @@ impl Date<Persian> {
     /// let date_persian = Date::try_new_persian(1392, 4, 25)
     ///     .expect("Failed to initialize Persian Date instance.");
     ///
-    /// assert_eq!(date_persian.year().era_year_or_related_iso(), 1392);
+    /// assert_eq!(date_persian.year().era().unwrap().era_year, 1392);
     /// assert_eq!(date_persian.month().ordinal, 4);
     /// assert_eq!(date_persian.day_of_month().0, 25);
     /// ```
@@ -714,7 +714,7 @@ mod tests {
             assert_eq!(Persian::provided_year_is_leap(*p_year), *leap);
             let persian_date = Date::try_new_persian(*p_year, 1, 1).unwrap();
             let iso_date = persian_date.to_calendar(Iso);
-            assert_eq!(iso_date.year().era_year_or_related_iso(), *iso_year);
+            assert_eq!(iso_date.year().era().unwrap().era_year, *iso_year);
             assert_eq!(iso_date.month().ordinal, *iso_month);
             assert_eq!(iso_date.day_of_month().0, *iso_day);
         }

--- a/components/calendar/src/cal/roc.rs
+++ b/components/calendar/src/cal/roc.rs
@@ -11,7 +11,7 @@
 //!     .expect("Failed to initialize ISO Date instance.");
 //! let date_roc = Date::new_from_iso(date_iso, Roc);
 //!
-//! assert_eq!(date_roc.era_year().era_year, 59);
+//! assert_eq!(date_roc.era_year().year, 59);
 //! assert_eq!(date_roc.month().ordinal, 1);
 //! assert_eq!(date_roc.day_of_month().0, 2);
 //! ```
@@ -130,14 +130,14 @@ impl Calendar for Roc {
             types::EraYear {
                 standard_era: tinystr!(16, "minguo").into(),
                 formatting_era: types::FormattingEra::Index(1, tinystr!(16, "min guo")),
-                era_year: extended_year.saturating_sub(ROC_ERA_OFFSET),
+                year: extended_year.saturating_sub(ROC_ERA_OFFSET),
                 ambiguity: types::YearAmbiguity::CenturyRequired,
             }
         } else {
             types::EraYear {
                 standard_era: tinystr!(16, "minguo-qian").into(),
                 formatting_era: types::FormattingEra::Index(0, tinystr!(16, "min guo qian")),
-                era_year: (ROC_ERA_OFFSET + 1).saturating_sub(extended_year),
+                year: (ROC_ERA_OFFSET + 1).saturating_sub(extended_year),
                 ambiguity: types::YearAmbiguity::EraAndCenturyRequired,
             }
         }
@@ -185,14 +185,14 @@ impl Date<Roc> {
     ///     .expect("Failed to initialize ROC Date instance.");
     ///
     /// assert_eq!(date_roc.era_year().standard_era.0, tinystr!(16, "minguo"));
-    /// assert_eq!(date_roc.era_year().era_year, 1, "ROC year check failed!");
+    /// assert_eq!(date_roc.era_year().year, 1, "ROC year check failed!");
     /// assert_eq!(date_roc.month().ordinal, 2, "ROC month check failed!");
     /// assert_eq!(date_roc.day_of_month().0, 3, "ROC day of month check failed!");
     ///
     /// // Convert to an equivalent Gregorian date
     /// let date_gregorian = date_roc.to_calendar(Gregorian);
     ///
-    /// assert_eq!(date_gregorian.era_year().era_year, 1912, "Gregorian from ROC year check failed!");
+    /// assert_eq!(date_gregorian.era_year().year, 1912, "Gregorian from ROC year check failed!");
     /// assert_eq!(date_gregorian.month().ordinal, 2, "Gregorian from ROC month check failed!");
     /// assert_eq!(date_gregorian.day_of_month().0, 3, "Gregorian from ROC day of month check failed!");
     pub fn try_new_roc(year: i32, month: u8, day: u8) -> Result<Date<Roc>, RangeError> {
@@ -224,7 +224,7 @@ mod test {
         let iso_from_rd = Date::from_rata_die(case.rd, Iso);
         let roc_from_rd = Date::from_rata_die(case.rd, Roc);
         assert_eq!(
-            roc_from_rd.era_year().era_year,
+            roc_from_rd.era_year().year,
             case.expected_year,
             "Failed year check from RD: {case:?}\nISO: {iso_from_rd:?}\nROC: {roc_from_rd:?}"
         );

--- a/components/calendar/src/cal/roc.rs
+++ b/components/calendar/src/cal/roc.rs
@@ -11,7 +11,7 @@
 //!     .expect("Failed to initialize ISO Date instance.");
 //! let date_roc = Date::new_from_iso(date_iso, Roc);
 //!
-//! assert_eq!(date_roc.year().era_year_or_related_iso(), 59);
+//! assert_eq!(date_roc.year().era().unwrap().era_year, 59);
 //! assert_eq!(date_roc.month().ordinal, 1);
 //! assert_eq!(date_roc.day_of_month().0, 2);
 //! ```
@@ -184,15 +184,15 @@ impl Date<Roc> {
     /// let date_roc = Date::try_new_roc(1, 2, 3)
     ///     .expect("Failed to initialize ROC Date instance.");
     ///
-    /// assert_eq!(date_roc.year().standard_era().unwrap().0, tinystr!(16, "minguo"));
-    /// assert_eq!(date_roc.year().era_year_or_related_iso(), 1, "ROC year check failed!");
+    /// assert_eq!(date_roc.year().era().unwrap().standard_era.0, tinystr!(16, "minguo"));
+    /// assert_eq!(date_roc.year().era().unwrap().era_year, 1, "ROC year check failed!");
     /// assert_eq!(date_roc.month().ordinal, 2, "ROC month check failed!");
     /// assert_eq!(date_roc.day_of_month().0, 3, "ROC day of month check failed!");
     ///
     /// // Convert to an equivalent Gregorian date
     /// let date_gregorian = date_roc.to_calendar(Gregorian);
     ///
-    /// assert_eq!(date_gregorian.year().era_year_or_related_iso(), 1912, "Gregorian from ROC year check failed!");
+    /// assert_eq!(date_gregorian.year().era().unwrap().era_year, 1912, "Gregorian from ROC year check failed!");
     /// assert_eq!(date_gregorian.month().ordinal, 2, "Gregorian from ROC month check failed!");
     /// assert_eq!(date_gregorian.day_of_month().0, 3, "Gregorian from ROC day of month check failed!");
     pub fn try_new_roc(year: i32, month: u8, day: u8) -> Result<Date<Roc>, RangeError> {
@@ -224,12 +224,12 @@ mod test {
         let iso_from_rd = Date::from_rata_die(case.rd, Iso);
         let roc_from_rd = Date::from_rata_die(case.rd, Roc);
         assert_eq!(
-            roc_from_rd.year().era_year().unwrap(),
+            roc_from_rd.year().era().unwrap().era_year,
             case.expected_year,
             "Failed year check from RD: {case:?}\nISO: {iso_from_rd:?}\nROC: {roc_from_rd:?}"
         );
         assert_eq!(
-            roc_from_rd.year().standard_era().unwrap(),
+            roc_from_rd.year().era().unwrap().standard_era,
             case.expected_era,
             "Failed era check from RD: {case:?}\nISO: {iso_from_rd:?}\nROC: {roc_from_rd:?}"
         );

--- a/components/calendar/src/cal/roc.rs
+++ b/components/calendar/src/cal/roc.rs
@@ -11,7 +11,7 @@
 //!     .expect("Failed to initialize ISO Date instance.");
 //! let date_roc = Date::new_from_iso(date_iso, Roc);
 //!
-//! assert_eq!(date_roc.year().era().unwrap().era_year, 59);
+//! assert_eq!(date_roc.era_year().era_year, 59);
 //! assert_eq!(date_roc.month().ordinal, 1);
 //! assert_eq!(date_roc.day_of_month().0, 2);
 //! ```
@@ -56,6 +56,7 @@ pub struct RocDateInner(IsoDateInner);
 
 impl Calendar for Roc {
     type DateInner = RocDateInner;
+    type Year = types::EraYear;
 
     fn from_codes(
         &self,
@@ -123,30 +124,29 @@ impl Calendar for Roc {
         "ROC"
     }
 
-    fn year(&self, date: &Self::DateInner) -> crate::types::YearInfo {
-        let year = date.0 .0.year;
-        if year > ROC_ERA_OFFSET {
-            types::YearInfo::new(
-                year,
-                types::EraYear {
-                    standard_era: tinystr!(16, "minguo").into(),
-                    formatting_era: types::FormattingEra::Index(1, tinystr!(16, "min guo")),
-                    era_year: year.saturating_sub(ROC_ERA_OFFSET),
-                    ambiguity: types::YearAmbiguity::CenturyRequired,
-                },
-            )
+    fn year_info(&self, date: &Self::DateInner) -> Self::Year {
+        let extended_year = self.extended_year(date);
+        if extended_year > ROC_ERA_OFFSET {
+            types::EraYear {
+                standard_era: tinystr!(16, "minguo").into(),
+                formatting_era: types::FormattingEra::Index(1, tinystr!(16, "min guo")),
+                era_year: extended_year.saturating_sub(ROC_ERA_OFFSET),
+                ambiguity: types::YearAmbiguity::CenturyRequired,
+            }
         } else {
-            types::YearInfo::new(
-                year,
-                types::EraYear {
-                    standard_era: tinystr!(16, "minguo-qian").into(),
-                    formatting_era: types::FormattingEra::Index(0, tinystr!(16, "min guo qian")),
-                    era_year: (ROC_ERA_OFFSET + 1).saturating_sub(year),
-                    ambiguity: types::YearAmbiguity::EraAndCenturyRequired,
-                },
-            )
+            types::EraYear {
+                standard_era: tinystr!(16, "minguo-qian").into(),
+                formatting_era: types::FormattingEra::Index(0, tinystr!(16, "min guo qian")),
+                era_year: (ROC_ERA_OFFSET + 1).saturating_sub(extended_year),
+                ambiguity: types::YearAmbiguity::EraAndCenturyRequired,
+            }
         }
     }
+
+    fn extended_year(&self, date: &Self::DateInner) -> i32 {
+        Iso.extended_year(&date.0)
+    }
+
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
         Iso.is_in_leap_year(&date.0)
     }
@@ -184,15 +184,15 @@ impl Date<Roc> {
     /// let date_roc = Date::try_new_roc(1, 2, 3)
     ///     .expect("Failed to initialize ROC Date instance.");
     ///
-    /// assert_eq!(date_roc.year().era().unwrap().standard_era.0, tinystr!(16, "minguo"));
-    /// assert_eq!(date_roc.year().era().unwrap().era_year, 1, "ROC year check failed!");
+    /// assert_eq!(date_roc.era_year().standard_era.0, tinystr!(16, "minguo"));
+    /// assert_eq!(date_roc.era_year().era_year, 1, "ROC year check failed!");
     /// assert_eq!(date_roc.month().ordinal, 2, "ROC month check failed!");
     /// assert_eq!(date_roc.day_of_month().0, 3, "ROC day of month check failed!");
     ///
     /// // Convert to an equivalent Gregorian date
     /// let date_gregorian = date_roc.to_calendar(Gregorian);
     ///
-    /// assert_eq!(date_gregorian.year().era().unwrap().era_year, 1912, "Gregorian from ROC year check failed!");
+    /// assert_eq!(date_gregorian.era_year().era_year, 1912, "Gregorian from ROC year check failed!");
     /// assert_eq!(date_gregorian.month().ordinal, 2, "Gregorian from ROC month check failed!");
     /// assert_eq!(date_gregorian.day_of_month().0, 3, "Gregorian from ROC day of month check failed!");
     pub fn try_new_roc(year: i32, month: u8, day: u8) -> Result<Date<Roc>, RangeError> {
@@ -224,12 +224,12 @@ mod test {
         let iso_from_rd = Date::from_rata_die(case.rd, Iso);
         let roc_from_rd = Date::from_rata_die(case.rd, Roc);
         assert_eq!(
-            roc_from_rd.year().era().unwrap().era_year,
+            roc_from_rd.era_year().era_year,
             case.expected_year,
             "Failed year check from RD: {case:?}\nISO: {iso_from_rd:?}\nROC: {roc_from_rd:?}"
         );
         assert_eq!(
-            roc_from_rd.year().era().unwrap().standard_era,
+            roc_from_rd.era_year().standard_era,
             case.expected_era,
             "Failed era check from RD: {case:?}\nISO: {iso_from_rd:?}\nROC: {roc_from_rd:?}"
         );

--- a/components/calendar/src/calendar.rs
+++ b/components/calendar/src/calendar.rs
@@ -64,7 +64,7 @@ pub trait Calendar {
 
     /// Information about the year
     fn year_info(&self, date: &Self::DateInner) -> Self::Year;
-    /// TODO
+    /// The extended year value
     fn extended_year(&self, date: &Self::DateInner) -> i32;
     /// The calendar-specific month represented by `date`
     fn month(&self, date: &Self::DateInner) -> types::MonthInfo;

--- a/components/calendar/src/calendar.rs
+++ b/components/calendar/src/calendar.rs
@@ -23,6 +23,9 @@ use core::fmt;
 pub trait Calendar {
     /// The internal type used to represent dates
     type DateInner: Eq + Copy + fmt::Debug;
+    /// The type of YearInfo returned by the date
+    type Year: fmt::Debug + Into<types::YearInfo>;
+
     /// Construct a date from era/month codes and fields
     ///
     /// The year is extended_year if no era is provided
@@ -60,7 +63,9 @@ pub trait Calendar {
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool;
 
     /// Information about the year
-    fn year(&self, date: &Self::DateInner) -> types::YearInfo;
+    fn year_info(&self, date: &Self::DateInner) -> Self::Year;
+    /// TODO
+    fn extended_year(&self, date: &Self::DateInner) -> i32;
     /// The calendar-specific month represented by `date`
     fn month(&self, date: &Self::DateInner) -> types::MonthInfo;
     /// The calendar-specific day-of-month represented by `date`

--- a/components/calendar/src/calendar_arithmetic.rs
+++ b/components/calendar/src/calendar_arithmetic.rs
@@ -283,6 +283,10 @@ impl<C: CalendarArithmetic> ArithmeticDate<C> {
         DayOfYear(day_of_year + (self.day as u16))
     }
 
+    pub fn extended_year(&self) -> i32 {
+        self.year.into()
+    }
+
     /// The [`types::MonthInfo`] for the current month (with month code) for a solar calendar
     /// Lunar calendars should not use this method and instead manually implement a month code
     /// resolver.

--- a/components/calendar/src/date.rs
+++ b/components/calendar/src/date.rs
@@ -5,7 +5,7 @@
 use crate::any_calendar::{AnyCalendar, IntoAnyCalendar};
 use crate::calendar_arithmetic::CalendarArithmetic;
 use crate::error::DateError;
-use crate::types::IsoWeekOfYear;
+use crate::types::{CyclicYear, EraYear, IsoWeekOfYear};
 use crate::week::{RelativeUnit, WeekCalculator, WeekOf};
 use crate::{types, Calendar, DateDuration, DateDurationUnit, Iso};
 #[cfg(feature = "alloc")]
@@ -107,7 +107,7 @@ impl<C> Deref for Ref<'_, C> {
 /// let date_iso = Date::try_new_iso(1970, 1, 2)
 ///     .expect("Failed to initialize ISO Date instance.");
 ///
-/// assert_eq!(date_iso.year().era().unwrap().era_year, 1970);
+/// assert_eq!(date_iso.era_year().era_year, 1970);
 /// assert_eq!(date_iso.month().ordinal, 1);
 /// assert_eq!(date_iso.day_of_month().0, 2);
 /// ```
@@ -227,10 +227,22 @@ impl<A: AsCalendar> Date<A> {
         )
     }
 
-    /// The calendar-specific year represented by `self`
+    /// The calendar-specific year-info.
+    ///
+    /// This returns an enum, see [`Date::era_year()`] and [`Date::cyclic_year()`] which are available
+    /// for concrete calendar types and return concrete types.
     #[inline]
     pub fn year(&self) -> types::YearInfo {
-        self.calendar.as_calendar().year(&self.inner)
+        self.calendar.as_calendar().year_info(&self.inner).into()
+    }
+
+    /// The "extended year", typically anchored with year 1 as the year 1 of either the most modern or
+    /// otherwise some "major" era for the calendar
+    ///
+    /// See [`Self::year()`] for more information about the year.
+    #[inline]
+    pub fn extended_year(&self) -> i32 {
+        self.calendar.as_calendar().extended_year(&self.inner)
     }
 
     /// Returns whether `self` is in a calendar-specific leap year
@@ -288,6 +300,20 @@ impl<A: AsCalendar> Date<A> {
     #[inline]
     pub fn calendar_wrapper(&self) -> &A {
         &self.calendar
+    }
+}
+
+impl<A: AsCalendar<Calendar = C>, C: Calendar<Year = EraYear>> Date<A> {
+    /// Returns information about the era for calendars using eras.
+    pub fn era_year(&self) -> EraYear {
+        self.calendar.as_calendar().year_info(self.inner())
+    }
+}
+
+impl<A: AsCalendar<Calendar = C>, C: Calendar<Year = CyclicYear>> Date<A> {
+    /// Returns information about the year cycle, for cyclic calendars.
+    pub fn cyclic_year(&self) -> CyclicYear {
+        self.calendar.as_calendar().year_info(self.inner())
     }
 }
 
@@ -415,8 +441,8 @@ impl<A: AsCalendar> fmt::Debug for Date<A> {
         let month = self.month().ordinal;
         let day = self.day_of_month().0;
         let calendar = self.calendar.as_calendar().debug_name();
-        match self.year().kind {
-            types::YearKind::Era(e) => {
+        match self.year() {
+            types::YearInfo::Era(e) => {
                 let era = e.standard_era.0;
                 let era_year = e.era_year;
                 write!(
@@ -424,7 +450,7 @@ impl<A: AsCalendar> fmt::Debug for Date<A> {
                     "Date({era_year}-{month}-{day}, {era} era, for calendar {calendar})"
                 )
             }
-            types::YearKind::Cyclic(cy) => {
+            types::YearInfo::Cyclic(cy) => {
                 let year = cy.year;
                 let related_iso = cy.related_iso;
                 write!(

--- a/components/calendar/src/date.rs
+++ b/components/calendar/src/date.rs
@@ -107,7 +107,7 @@ impl<C> Deref for Ref<'_, C> {
 /// let date_iso = Date::try_new_iso(1970, 1, 2)
 ///     .expect("Failed to initialize ISO Date instance.");
 ///
-/// assert_eq!(date_iso.era_year().era_year, 1970);
+/// assert_eq!(date_iso.era_year().year, 1970);
 /// assert_eq!(date_iso.month().ordinal, 1);
 /// assert_eq!(date_iso.day_of_month().0, 2);
 /// ```
@@ -444,7 +444,7 @@ impl<A: AsCalendar> fmt::Debug for Date<A> {
         match self.year() {
             types::YearInfo::Era(e) => {
                 let era = e.standard_era.0;
-                let era_year = e.era_year;
+                let era_year = e.year;
                 write!(
                     f,
                     "Date({era_year}-{month}-{day}, {era} era, for calendar {calendar})"

--- a/components/calendar/src/date.rs
+++ b/components/calendar/src/date.rs
@@ -107,7 +107,7 @@ impl<C> Deref for Ref<'_, C> {
 /// let date_iso = Date::try_new_iso(1970, 1, 2)
 ///     .expect("Failed to initialize ISO Date instance.");
 ///
-/// assert_eq!(date_iso.year().era_year_or_related_iso(), 1970);
+/// assert_eq!(date_iso.year().era().unwrap().era_year, 1970);
 /// assert_eq!(date_iso.month().ordinal, 1);
 /// assert_eq!(date_iso.day_of_month().0, 2);
 /// ```

--- a/components/calendar/src/duration.rs
+++ b/components/calendar/src/duration.rs
@@ -20,7 +20,7 @@ use core::marker::PhantomData;
 ///     .expect("Failed to initialize ISO Date instance.");
 ///
 /// assert_eq!(date_iso.day_of_week(), Weekday::Wednesday);
-/// assert_eq!(date_iso.year().era_year_or_related_iso(), 1992);
+/// assert_eq!(date_iso.year().era().unwrap().era_year, 1992);
 /// assert_eq!(date_iso.month().ordinal, 9);
 /// assert_eq!(date_iso.day_of_month().0, 2);
 ///
@@ -30,13 +30,13 @@ use core::marker::PhantomData;
 ///
 /// // Advancing date in-place by 1 year, 2 months, 3 weeks, 4 days.
 /// date_iso.add(DateDuration::new(1, 2, 3, 4));
-/// assert_eq!(date_iso.year().era_year_or_related_iso(), 1993);
+/// assert_eq!(date_iso.year().era().unwrap().era_year, 1993);
 /// assert_eq!(date_iso.month().ordinal, 11);
 /// assert_eq!(date_iso.day_of_month().0, 27);
 ///
 /// // Reverse date advancement.
 /// date_iso.add(DateDuration::new(-1, -2, -3, -4));
-/// assert_eq!(date_iso.year().era_year_or_related_iso(), 1992);
+/// assert_eq!(date_iso.year().era().unwrap().era_year, 1992);
 /// assert_eq!(date_iso.month().ordinal, 9);
 /// assert_eq!(date_iso.day_of_month().0, 2);
 ///
@@ -56,7 +56,7 @@ use core::marker::PhantomData;
 ///
 /// // Create new date with date advancement. Reassign to new variable.
 /// let mutated_date_iso = date_iso.added(DateDuration::new(1, 2, 3, 4));
-/// assert_eq!(mutated_date_iso.year().era_year_or_related_iso(), 1993);
+/// assert_eq!(mutated_date_iso.year().era().unwrap().era_year, 1993);
 /// assert_eq!(mutated_date_iso.month().ordinal, 11);
 /// assert_eq!(mutated_date_iso.day_of_month().0, 27);
 /// ```

--- a/components/calendar/src/duration.rs
+++ b/components/calendar/src/duration.rs
@@ -20,7 +20,7 @@ use core::marker::PhantomData;
 ///     .expect("Failed to initialize ISO Date instance.");
 ///
 /// assert_eq!(date_iso.day_of_week(), Weekday::Wednesday);
-/// assert_eq!(date_iso.year().era().unwrap().era_year, 1992);
+/// assert_eq!(date_iso.era_year().era_year, 1992);
 /// assert_eq!(date_iso.month().ordinal, 9);
 /// assert_eq!(date_iso.day_of_month().0, 2);
 ///
@@ -30,13 +30,13 @@ use core::marker::PhantomData;
 ///
 /// // Advancing date in-place by 1 year, 2 months, 3 weeks, 4 days.
 /// date_iso.add(DateDuration::new(1, 2, 3, 4));
-/// assert_eq!(date_iso.year().era().unwrap().era_year, 1993);
+/// assert_eq!(date_iso.era_year().era_year, 1993);
 /// assert_eq!(date_iso.month().ordinal, 11);
 /// assert_eq!(date_iso.day_of_month().0, 27);
 ///
 /// // Reverse date advancement.
 /// date_iso.add(DateDuration::new(-1, -2, -3, -4));
-/// assert_eq!(date_iso.year().era().unwrap().era_year, 1992);
+/// assert_eq!(date_iso.era_year().era_year, 1992);
 /// assert_eq!(date_iso.month().ordinal, 9);
 /// assert_eq!(date_iso.day_of_month().0, 2);
 ///
@@ -56,7 +56,7 @@ use core::marker::PhantomData;
 ///
 /// // Create new date with date advancement. Reassign to new variable.
 /// let mutated_date_iso = date_iso.added(DateDuration::new(1, 2, 3, 4));
-/// assert_eq!(mutated_date_iso.year().era().unwrap().era_year, 1993);
+/// assert_eq!(mutated_date_iso.era_year().era_year, 1993);
 /// assert_eq!(mutated_date_iso.month().ordinal, 11);
 /// assert_eq!(mutated_date_iso.day_of_month().0, 27);
 /// ```

--- a/components/calendar/src/duration.rs
+++ b/components/calendar/src/duration.rs
@@ -20,7 +20,7 @@ use core::marker::PhantomData;
 ///     .expect("Failed to initialize ISO Date instance.");
 ///
 /// assert_eq!(date_iso.day_of_week(), Weekday::Wednesday);
-/// assert_eq!(date_iso.era_year().era_year, 1992);
+/// assert_eq!(date_iso.era_year().year, 1992);
 /// assert_eq!(date_iso.month().ordinal, 9);
 /// assert_eq!(date_iso.day_of_month().0, 2);
 ///
@@ -30,13 +30,13 @@ use core::marker::PhantomData;
 ///
 /// // Advancing date in-place by 1 year, 2 months, 3 weeks, 4 days.
 /// date_iso.add(DateDuration::new(1, 2, 3, 4));
-/// assert_eq!(date_iso.era_year().era_year, 1993);
+/// assert_eq!(date_iso.era_year().year, 1993);
 /// assert_eq!(date_iso.month().ordinal, 11);
 /// assert_eq!(date_iso.day_of_month().0, 27);
 ///
 /// // Reverse date advancement.
 /// date_iso.add(DateDuration::new(-1, -2, -3, -4));
-/// assert_eq!(date_iso.era_year().era_year, 1992);
+/// assert_eq!(date_iso.era_year().year, 1992);
 /// assert_eq!(date_iso.month().ordinal, 9);
 /// assert_eq!(date_iso.day_of_month().0, 2);
 ///
@@ -56,7 +56,7 @@ use core::marker::PhantomData;
 ///
 /// // Create new date with date advancement. Reassign to new variable.
 /// let mutated_date_iso = date_iso.added(DateDuration::new(1, 2, 3, 4));
-/// assert_eq!(mutated_date_iso.era_year().era_year, 1993);
+/// assert_eq!(mutated_date_iso.era_year().year, 1993);
 /// assert_eq!(mutated_date_iso.month().ordinal, 11);
 /// assert_eq!(mutated_date_iso.day_of_month().0, 27);
 /// ```

--- a/components/calendar/src/ixdtf.rs
+++ b/components/calendar/src/ixdtf.rs
@@ -67,7 +67,7 @@ impl<A: AsCalendar> Date<A> {
     /// let _ =
     ///     Date::try_from_str("2024-07-17[u-ca=julian]", Gregorian).unwrap_err();
     ///
-    /// assert_eq!(date.year().era().unwrap().era_year, 2024);
+    /// assert_eq!(date.era_year().era_year, 2024);
     /// assert_eq!(
     ///     date.month().standard_code,
     ///     icu::calendar::types::MonthCode(tinystr::tinystr!(4, "M07"))

--- a/components/calendar/src/ixdtf.rs
+++ b/components/calendar/src/ixdtf.rs
@@ -67,7 +67,7 @@ impl<A: AsCalendar> Date<A> {
     /// let _ =
     ///     Date::try_from_str("2024-07-17[u-ca=julian]", Gregorian).unwrap_err();
     ///
-    /// assert_eq!(date.year().era_year_or_related_iso(), 2024);
+    /// assert_eq!(date.year().era().unwrap().era_year, 2024);
     /// assert_eq!(
     ///     date.month().standard_code,
     ///     icu::calendar::types::MonthCode(tinystr::tinystr!(4, "M07"))

--- a/components/calendar/src/ixdtf.rs
+++ b/components/calendar/src/ixdtf.rs
@@ -67,7 +67,7 @@ impl<A: AsCalendar> Date<A> {
     /// let _ =
     ///     Date::try_from_str("2024-07-17[u-ca=julian]", Gregorian).unwrap_err();
     ///
-    /// assert_eq!(date.era_year().era_year, 2024);
+    /// assert_eq!(date.era_year().year, 2024);
     /// assert_eq!(
     ///     date.month().standard_code,
     ///     icu::calendar::types::MonthCode(tinystr::tinystr!(4, "M07"))

--- a/components/calendar/src/lib.rs
+++ b/components/calendar/src/lib.rs
@@ -34,7 +34,7 @@
 //!     .expect("Failed to initialize ISO Date instance.");
 //!
 //! assert_eq!(date_iso.day_of_week(), Weekday::Wednesday);
-//! assert_eq!(date_iso.era_year().era_year, 1992);
+//! assert_eq!(date_iso.era_year().year, 1992);
 //! assert_eq!(date_iso.month().ordinal, 9);
 //! assert_eq!(date_iso.day_of_month().0, 2);
 //!
@@ -53,19 +53,19 @@
 //! let mut date_iso = Date::try_new_iso(1992, 9, 2)
 //!     .expect("Failed to initialize ISO Date instance.");
 //!
-//! assert_eq!(date_iso.era_year().era_year, 1992);
+//! assert_eq!(date_iso.era_year().year, 1992);
 //! assert_eq!(date_iso.month().ordinal, 9);
 //! assert_eq!(date_iso.day_of_month().0, 2);
 //!
 //! // Conversion into Indian calendar: 1914-08-02.
 //! let date_indian = date_iso.to_calendar(Indian);
-//! assert_eq!(date_indian.era_year().era_year, 1914);
+//! assert_eq!(date_indian.era_year().year, 1914);
 //! assert_eq!(date_indian.month().ordinal, 6);
 //! assert_eq!(date_indian.day_of_month().0, 11);
 //!
 //! // Conversion into Buddhist calendar: 2535-09-02.
 //! let date_buddhist = date_iso.to_calendar(Buddhist);
-//! assert_eq!(date_buddhist.era_year().era_year, 2535);
+//! assert_eq!(date_buddhist.era_year().year, 2535);
 //! assert_eq!(date_buddhist.month().ordinal, 9);
 //! assert_eq!(date_buddhist.day_of_month().0, 2);
 //! ```

--- a/components/calendar/src/lib.rs
+++ b/components/calendar/src/lib.rs
@@ -34,7 +34,7 @@
 //!     .expect("Failed to initialize ISO Date instance.");
 //!
 //! assert_eq!(date_iso.day_of_week(), Weekday::Wednesday);
-//! assert_eq!(date_iso.year().era().unwrap().era_year, 1992);
+//! assert_eq!(date_iso.era_year().era_year, 1992);
 //! assert_eq!(date_iso.month().ordinal, 9);
 //! assert_eq!(date_iso.day_of_month().0, 2);
 //!
@@ -53,19 +53,19 @@
 //! let mut date_iso = Date::try_new_iso(1992, 9, 2)
 //!     .expect("Failed to initialize ISO Date instance.");
 //!
-//! assert_eq!(date_iso.year().era().unwrap().era_year, 1992);
+//! assert_eq!(date_iso.era_year().era_year, 1992);
 //! assert_eq!(date_iso.month().ordinal, 9);
 //! assert_eq!(date_iso.day_of_month().0, 2);
 //!
 //! // Conversion into Indian calendar: 1914-08-02.
 //! let date_indian = date_iso.to_calendar(Indian);
-//! assert_eq!(date_indian.year().era().unwrap().era_year, 1914);
+//! assert_eq!(date_indian.era_year().era_year, 1914);
 //! assert_eq!(date_indian.month().ordinal, 6);
 //! assert_eq!(date_indian.day_of_month().0, 11);
 //!
 //! // Conversion into Buddhist calendar: 2535-09-02.
 //! let date_buddhist = date_iso.to_calendar(Buddhist);
-//! assert_eq!(date_buddhist.year().era().unwrap().era_year, 2535);
+//! assert_eq!(date_buddhist.era_year().era_year, 2535);
 //! assert_eq!(date_buddhist.month().ordinal, 9);
 //! assert_eq!(date_buddhist.day_of_month().0, 2);
 //! ```

--- a/components/calendar/src/lib.rs
+++ b/components/calendar/src/lib.rs
@@ -34,7 +34,7 @@
 //!     .expect("Failed to initialize ISO Date instance.");
 //!
 //! assert_eq!(date_iso.day_of_week(), Weekday::Wednesday);
-//! assert_eq!(date_iso.year().era_year_or_related_iso(), 1992);
+//! assert_eq!(date_iso.year().era().unwrap().era_year, 1992);
 //! assert_eq!(date_iso.month().ordinal, 9);
 //! assert_eq!(date_iso.day_of_month().0, 2);
 //!
@@ -53,19 +53,19 @@
 //! let mut date_iso = Date::try_new_iso(1992, 9, 2)
 //!     .expect("Failed to initialize ISO Date instance.");
 //!
-//! assert_eq!(date_iso.year().era_year_or_related_iso(), 1992);
+//! assert_eq!(date_iso.year().era().unwrap().era_year, 1992);
 //! assert_eq!(date_iso.month().ordinal, 9);
 //! assert_eq!(date_iso.day_of_month().0, 2);
 //!
 //! // Conversion into Indian calendar: 1914-08-02.
 //! let date_indian = date_iso.to_calendar(Indian);
-//! assert_eq!(date_indian.year().era_year_or_related_iso(), 1914);
+//! assert_eq!(date_indian.year().era().unwrap().era_year, 1914);
 //! assert_eq!(date_indian.month().ordinal, 6);
 //! assert_eq!(date_indian.day_of_month().0, 11);
 //!
 //! // Conversion into Buddhist calendar: 2535-09-02.
 //! let date_buddhist = date_iso.to_calendar(Buddhist);
-//! assert_eq!(date_buddhist.year().era_year_or_related_iso(), 2535);
+//! assert_eq!(date_buddhist.year().era().unwrap().era_year, 2535);
 //! assert_eq!(date_buddhist.month().ordinal, 9);
 //! assert_eq!(date_buddhist.day_of_month().0, 2);
 //! ```

--- a/components/calendar/src/types.rs
+++ b/components/calendar/src/types.rs
@@ -61,7 +61,7 @@ impl YearInfo {
     /// Gets the era year for era calendars, and the related ISO year for cyclic calendars.
     pub fn era_year_or_related_iso(self) -> i32 {
         match self {
-            YearInfo::Era(e) => e.era_year,
+            YearInfo::Era(e) => e.year,
             YearInfo::Cyclic(c) => c.related_iso,
         }
     }
@@ -148,7 +148,7 @@ pub struct EraYear {
     /// <https://tc39.es/proposal-intl-era-monthcode/#table-eras>
     pub standard_era: Era,
     /// The numeric year in that era
-    pub era_year: i32,
+    pub year: i32,
     /// The ambiguity when formatting this year
     pub ambiguity: YearAmbiguity,
 }

--- a/components/calendar/src/types.rs
+++ b/components/calendar/src/types.rs
@@ -72,23 +72,6 @@ impl YearInfo {
             }),
         }
     }
-    /// Get the year in the era if this is a non-cyclic calendar
-    ///
-    /// Gets the eraYear for era dates, otherwise falls back to Extended Year
-    pub fn era_year(self) -> Option<i32> {
-        match self.kind {
-            YearKind::Era(e) => Some(e.era_year),
-            YearKind::Cyclic(..) => None,
-        }
-    }
-
-    /// Get the year ambiguity.
-    pub fn year_ambiguity(self) -> YearAmbiguity {
-        match self.kind {
-            YearKind::Cyclic(_) => YearAmbiguity::EraRequired,
-            YearKind::Era(e) => e.ambiguity,
-        }
-    }
 
     /// Get *some* year number that can be displayed
     ///
@@ -100,34 +83,19 @@ impl YearInfo {
         }
     }
 
-    /// Get the era, if available
-    pub fn formatting_era(self) -> Option<FormattingEra> {
+    /// Get the era year information, if available
+    pub fn era(self) -> Option<EraYear> {
         match self.kind {
-            YearKind::Era(e) => Some(e.formatting_era),
+            YearKind::Era(e) => Some(e),
             YearKind::Cyclic(..) => None,
         }
     }
 
-    /// Get the era, if available
-    pub fn standard_era(self) -> Option<Era> {
+    /// Get the cyclic year information, if available
+    pub fn cyclic(self) -> Option<CyclicYear> {
         match self.kind {
-            YearKind::Era(e) => Some(e.standard_era),
-            YearKind::Cyclic(..) => None,
-        }
-    }
-
-    /// Return the cyclic year, if any
-    pub fn cyclic(self) -> Option<NonZeroU8> {
-        match self.kind {
-            YearKind::Era(..) => None,
-            YearKind::Cyclic(cy) => Some(cy.year),
-        }
-    }
-    /// Return the Related ISO year, if any
-    pub fn related_iso(self) -> Option<i32> {
-        match self.kind {
-            YearKind::Era(..) => None,
-            YearKind::Cyclic(cy) => Some(cy.related_iso),
+            YearKind::Cyclic(cyclic) => Some(cyclic),
+            YearKind::Era(_) => None,
         }
     }
 }

--- a/components/datetime/src/error.rs
+++ b/components/datetime/src/error.rs
@@ -13,7 +13,7 @@ use icu_provider::DataError;
 #[cfg(doc)]
 use crate::pattern::FixedCalendarDateTimeNames;
 #[cfg(doc)]
-use icu_calendar::types::YearInfo;
+use icu_calendar::types::CyclicYear;
 #[cfg(doc)]
 use icu_decimal::DecimalFormatter;
 
@@ -74,11 +74,11 @@ pub enum DateTimeWriteError {
     /// The output will contain [`FormattingEra::fallback_name`] as the fallback.
     #[displaydoc("Invalid era {0:?}")]
     InvalidEra(FormattingEra),
-    /// The [`YearInfo::cyclic`] of the input is not valid for this calendar.
+    /// The [`CyclicYear::year`] of the input is not valid for this calendar.
     ///
     /// This is guaranteed not to happen for `icu::calendar` inputs, but may happen for custom inputs.
     ///
-    /// The output will contain [`YearInfo::extended_year`] as a fallback value.
+    /// The output will contain [`CyclicYear::related_iso`] as a fallback value.
     #[displaydoc("Invalid cyclic year {value} (maximum {max})")]
     InvalidCyclicYear {
         /// Value

--- a/components/datetime/src/format/datetime.rs
+++ b/components/datetime/src/format/datetime.rs
@@ -134,7 +134,8 @@ where
         (FieldSymbol::Era, l) => {
             const PART: Part = parts::ERA;
             input!(PART, year = input.year);
-            input!(PART, era = year.formatting_era());
+            input!(PART, era = year.era());
+            let era = era.formatting_era;
             let era_symbol = datetime_names
                 .get_name_for_era(l, era)
                 .map_err(|e| match e {
@@ -171,7 +172,7 @@ where
             input!(PART, year = input.year);
             input!(PART, cyclic = year.cyclic());
 
-            match datetime_names.get_name_for_cyclic(l, cyclic) {
+            match datetime_names.get_name_for_cyclic(l, cyclic.year) {
                 Ok(name) => Ok(w.with_part(PART, |w| w.write_str(name))?),
                 Err(e) => {
                     w.with_part(PART, |w| {
@@ -179,7 +180,7 @@ where
                             try_write_number_without_part(
                                 w,
                                 decimal_formatter,
-                                year.era_year_or_related_iso().into(),
+                                cyclic.related_iso.into(),
                                 FieldLength::One,
                             )
                             .map(|_| ())
@@ -188,7 +189,7 @@ where
                     return Ok(Err(match e {
                         GetNameForCyclicYearError::InvalidYearNumber { max } => {
                             DateTimeWriteError::InvalidCyclicYear {
-                                value: cyclic.get() as usize,
+                                value: cyclic.year.get() as usize,
                                 max,
                             }
                         }
@@ -205,11 +206,11 @@ where
         (FieldSymbol::Year(Year::RelatedIso), l) => {
             const PART: Part = parts::RELATED_YEAR;
             input!(PART, year = input.year);
-            input!(PART, related_iso = year.related_iso());
+            input!(PART, cyclic = year.cyclic());
 
             // Always in latin digits according to spec
             w.with_part(PART, |w| {
-                let mut num = Decimal::from(related_iso);
+                let mut num = Decimal::from(cyclic.related_iso);
                 num.pad_start(l.to_len() as i16);
                 num.write_to(w)
             })?;

--- a/components/datetime/src/raw/neo.rs
+++ b/components/datetime/src/raw/neo.rs
@@ -186,7 +186,11 @@ impl DatePatternSelectionData {
             year_style,
             input
                 .year
-                .map(|y| y.year_ambiguity())
+                .map(|y| {
+                    y.era()
+                        .map(|e| e.ambiguity)
+                        .unwrap_or(YearAmbiguity::EraRequired)
+                })
                 .unwrap_or(YearAmbiguity::EraAndCenturyRequired),
         ) {
             (YearStyle::WithEra, _) | (_, YearAmbiguity::EraAndCenturyRequired) => {

--- a/components/time/src/ixdtf.rs
+++ b/components/time/src/ixdtf.rs
@@ -461,7 +461,7 @@ impl<A: AsCalendar> ZonedDateTime<A, TimeZoneInfo<models::Full>> {
     /// )
     /// .unwrap();
     ///
-    /// assert_eq!(zoneddatetime.date.year().extended_year, 5784);
+    /// assert_eq!(zoneddatetime.date.extended_year(), 5784);
     /// assert_eq!(
     ///     zoneddatetime.date.month().standard_code,
     ///     icu::calendar::types::MonthCode(tinystr::tinystr!(4, "M11"))
@@ -674,7 +674,7 @@ impl<A: AsCalendar> DateTime<A> {
     ///     DateTime::try_from_str("2024-07-17T16:01:17.045[u-ca=hebrew]", Hebrew)
     ///         .unwrap();
     ///
-    /// assert_eq!(datetime.date.year().era().unwrap().era_year, 5784);
+    /// assert_eq!(datetime.date.era_year().era_year, 5784);
     /// assert_eq!(
     ///     datetime.date.month().standard_code,
     ///     icu::calendar::types::MonthCode(tinystr::tinystr!(4, "M10"))

--- a/components/time/src/ixdtf.rs
+++ b/components/time/src/ixdtf.rs
@@ -674,7 +674,7 @@ impl<A: AsCalendar> DateTime<A> {
     ///     DateTime::try_from_str("2024-07-17T16:01:17.045[u-ca=hebrew]", Hebrew)
     ///         .unwrap();
     ///
-    /// assert_eq!(datetime.date.year().era_year_or_related_iso(), 5784);
+    /// assert_eq!(datetime.date.year().era().unwrap().era_year, 5784);
     /// assert_eq!(
     ///     datetime.date.month().standard_code,
     ///     icu::calendar::types::MonthCode(tinystr::tinystr!(4, "M10"))

--- a/components/time/src/ixdtf.rs
+++ b/components/time/src/ixdtf.rs
@@ -674,7 +674,7 @@ impl<A: AsCalendar> DateTime<A> {
     ///     DateTime::try_from_str("2024-07-17T16:01:17.045[u-ca=hebrew]", Hebrew)
     ///         .unwrap();
     ///
-    /// assert_eq!(datetime.date.era_year().era_year, 5784);
+    /// assert_eq!(datetime.date.era_year().year, 5784);
     /// assert_eq!(
     ///     datetime.date.month().standard_code,
     ///     icu::calendar::types::MonthCode(tinystr::tinystr!(4, "M10"))

--- a/components/time/src/provider/mod.rs
+++ b/components/time/src/provider/mod.rs
@@ -114,7 +114,7 @@ impl serde::Serialize for MinutesSinceEpoch {
             let hour = self.0 / 60 % 24;
             let days = self.0 / 60 / 24;
             let date = Date::from_rata_die(Self::EPOCH + days as i64, Iso);
-            let year = date.year().extended_year;
+            let year = date.extended_year();
             let month = date.month().month_number();
             let day = date.day_of_month().0;
             return serializer.serialize_str(&alloc::format!(

--- a/ffi/capi/bindings/cpp/icu4x/Date.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/Date.d.hpp
@@ -153,7 +153,7 @@ public:
    *
    * For calendars without an era, returns the related ISO year.
    *
-   * See the [Rust documentation for `era_year_or_related_iso`](https://docs.rs/icu/latest/icu/calendar/types/struct.YearInfo.html#method.era_year_or_related_iso) for more information.
+   * See the [Rust documentation for `era_year_or_related_iso`](https://docs.rs/icu/latest/icu/calendar/types/enum.YearInfo.html#method.era_year_or_related_iso) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/latest/icu/calendar/types/struct.EraYear.html#structfield.era_year), [2](https://docs.rs/icu/latest/icu/calendar/types/struct.CyclicYear.html#structfield.related_iso), [3](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year)
    */
@@ -162,7 +162,7 @@ public:
   /**
    * Returns the extended year in the Date
    *
-   * See the [Rust documentation for `extended_year`](https://docs.rs/icu/latest/icu/calendar/types/struct.YearInfo.html#structfield.extended_year) for more information.
+   * See the [Rust documentation for `extended_year`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.extended_year) for more information.
    */
   inline int32_t extended_year() const;
 

--- a/ffi/capi/bindings/cpp/icu4x/Date.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/Date.d.hpp
@@ -155,7 +155,7 @@ public:
    *
    * See the [Rust documentation for `era_year_or_related_iso`](https://docs.rs/icu/latest/icu/calendar/types/struct.YearInfo.html#method.era_year_or_related_iso) for more information.
    *
-   * Additional information: [1](https://docs.rs/icu/latest/icu/calendar/types/struct.EraYear.html#structfield.era_year), [2](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year)
+   * Additional information: [1](https://docs.rs/icu/latest/icu/calendar/types/struct.EraYear.html#structfield.era_year), [2](https://docs.rs/icu/latest/icu/calendar/types/struct.CyclicYear.html#structfield.related_iso), [3](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year)
    */
   inline int32_t era_year_or_related_iso() const;
 

--- a/ffi/capi/bindings/cpp/icu4x/Date.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/Date.d.hpp
@@ -155,7 +155,7 @@ public:
    *
    * See the [Rust documentation for `era_year_or_related_iso`](https://docs.rs/icu/latest/icu/calendar/types/enum.YearInfo.html#method.era_year_or_related_iso) for more information.
    *
-   * Additional information: [1](https://docs.rs/icu/latest/icu/calendar/types/struct.EraYear.html#structfield.era_year), [2](https://docs.rs/icu/latest/icu/calendar/types/struct.CyclicYear.html#structfield.related_iso), [3](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year)
+   * Additional information: [1](https://docs.rs/icu/latest/icu/calendar/types/struct.EraYear.html#structfield.year), [2](https://docs.rs/icu/latest/icu/calendar/types/struct.CyclicYear.html#structfield.related_iso), [3](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year)
    */
   inline int32_t era_year_or_related_iso() const;
 

--- a/ffi/capi/bindings/dart/Date.g.dart
+++ b/ffi/capi/bindings/dart/Date.g.dart
@@ -176,7 +176,7 @@ final class Date implements ffi.Finalizable {
   ///
   /// For calendars without an era, returns the related ISO year.
   ///
-  /// See the [Rust documentation for `era_year_or_related_iso`](https://docs.rs/icu/latest/icu/calendar/types/struct.YearInfo.html#method.era_year_or_related_iso) for more information.
+  /// See the [Rust documentation for `era_year_or_related_iso`](https://docs.rs/icu/latest/icu/calendar/types/enum.YearInfo.html#method.era_year_or_related_iso) for more information.
   ///
   /// Additional information: [1](https://docs.rs/icu/latest/icu/calendar/types/struct.EraYear.html#structfield.era_year), [2](https://docs.rs/icu/latest/icu/calendar/types/struct.CyclicYear.html#structfield.related_iso), [3](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year)
   int get eraYearOrRelatedIso {
@@ -186,7 +186,7 @@ final class Date implements ffi.Finalizable {
 
   /// Returns the extended year in the Date
   ///
-  /// See the [Rust documentation for `extended_year`](https://docs.rs/icu/latest/icu/calendar/types/struct.YearInfo.html#structfield.extended_year) for more information.
+  /// See the [Rust documentation for `extended_year`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.extended_year) for more information.
   int get extendedYear {
     final result = _icu4x_Date_extended_year_mv1(_ffi);
     return result;

--- a/ffi/capi/bindings/dart/Date.g.dart
+++ b/ffi/capi/bindings/dart/Date.g.dart
@@ -178,7 +178,7 @@ final class Date implements ffi.Finalizable {
   ///
   /// See the [Rust documentation for `era_year_or_related_iso`](https://docs.rs/icu/latest/icu/calendar/types/enum.YearInfo.html#method.era_year_or_related_iso) for more information.
   ///
-  /// Additional information: [1](https://docs.rs/icu/latest/icu/calendar/types/struct.EraYear.html#structfield.era_year), [2](https://docs.rs/icu/latest/icu/calendar/types/struct.CyclicYear.html#structfield.related_iso), [3](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year)
+  /// Additional information: [1](https://docs.rs/icu/latest/icu/calendar/types/struct.EraYear.html#structfield.year), [2](https://docs.rs/icu/latest/icu/calendar/types/struct.CyclicYear.html#structfield.related_iso), [3](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year)
   int get eraYearOrRelatedIso {
     final result = _icu4x_Date_era_year_or_related_iso_mv1(_ffi);
     return result;

--- a/ffi/capi/bindings/dart/Date.g.dart
+++ b/ffi/capi/bindings/dart/Date.g.dart
@@ -178,7 +178,7 @@ final class Date implements ffi.Finalizable {
   ///
   /// See the [Rust documentation for `era_year_or_related_iso`](https://docs.rs/icu/latest/icu/calendar/types/struct.YearInfo.html#method.era_year_or_related_iso) for more information.
   ///
-  /// Additional information: [1](https://docs.rs/icu/latest/icu/calendar/types/struct.EraYear.html#structfield.era_year), [2](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year)
+  /// Additional information: [1](https://docs.rs/icu/latest/icu/calendar/types/struct.EraYear.html#structfield.era_year), [2](https://docs.rs/icu/latest/icu/calendar/types/struct.CyclicYear.html#structfield.related_iso), [3](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year)
   int get eraYearOrRelatedIso {
     final result = _icu4x_Date_era_year_or_related_iso_mv1(_ffi);
     return result;

--- a/ffi/capi/bindings/js/Date.d.ts
+++ b/ffi/capi/bindings/js/Date.d.ts
@@ -135,7 +135,7 @@ export class Date {
      *
      * See the [Rust documentation for `era_year_or_related_iso`](https://docs.rs/icu/latest/icu/calendar/types/enum.YearInfo.html#method.era_year_or_related_iso) for more information.
      *
-     * Additional information: [1](https://docs.rs/icu/latest/icu/calendar/types/struct.EraYear.html#structfield.era_year), [2](https://docs.rs/icu/latest/icu/calendar/types/struct.CyclicYear.html#structfield.related_iso), [3](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year)
+     * Additional information: [1](https://docs.rs/icu/latest/icu/calendar/types/struct.EraYear.html#structfield.year), [2](https://docs.rs/icu/latest/icu/calendar/types/struct.CyclicYear.html#structfield.related_iso), [3](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year)
      */
     get eraYearOrRelatedIso(): number;
 

--- a/ffi/capi/bindings/js/Date.d.ts
+++ b/ffi/capi/bindings/js/Date.d.ts
@@ -135,7 +135,7 @@ export class Date {
      *
      * See the [Rust documentation for `era_year_or_related_iso`](https://docs.rs/icu/latest/icu/calendar/types/struct.YearInfo.html#method.era_year_or_related_iso) for more information.
      *
-     * Additional information: [1](https://docs.rs/icu/latest/icu/calendar/types/struct.EraYear.html#structfield.era_year), [2](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year)
+     * Additional information: [1](https://docs.rs/icu/latest/icu/calendar/types/struct.EraYear.html#structfield.era_year), [2](https://docs.rs/icu/latest/icu/calendar/types/struct.CyclicYear.html#structfield.related_iso), [3](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year)
      */
     get eraYearOrRelatedIso(): number;
 

--- a/ffi/capi/bindings/js/Date.d.ts
+++ b/ffi/capi/bindings/js/Date.d.ts
@@ -133,7 +133,7 @@ export class Date {
      *
      * For calendars without an era, returns the related ISO year.
      *
-     * See the [Rust documentation for `era_year_or_related_iso`](https://docs.rs/icu/latest/icu/calendar/types/struct.YearInfo.html#method.era_year_or_related_iso) for more information.
+     * See the [Rust documentation for `era_year_or_related_iso`](https://docs.rs/icu/latest/icu/calendar/types/enum.YearInfo.html#method.era_year_or_related_iso) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/latest/icu/calendar/types/struct.EraYear.html#structfield.era_year), [2](https://docs.rs/icu/latest/icu/calendar/types/struct.CyclicYear.html#structfield.related_iso), [3](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year)
      */
@@ -142,7 +142,7 @@ export class Date {
     /** 
      * Returns the extended year in the Date
      *
-     * See the [Rust documentation for `extended_year`](https://docs.rs/icu/latest/icu/calendar/types/struct.YearInfo.html#structfield.extended_year) for more information.
+     * See the [Rust documentation for `extended_year`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.extended_year) for more information.
      */
     get extendedYear(): number;
 

--- a/ffi/capi/bindings/js/Date.mjs
+++ b/ffi/capi/bindings/js/Date.mjs
@@ -322,7 +322,7 @@ export class Date {
      *
      * For calendars without an era, returns the related ISO year.
      *
-     * See the [Rust documentation for `era_year_or_related_iso`](https://docs.rs/icu/latest/icu/calendar/types/struct.YearInfo.html#method.era_year_or_related_iso) for more information.
+     * See the [Rust documentation for `era_year_or_related_iso`](https://docs.rs/icu/latest/icu/calendar/types/enum.YearInfo.html#method.era_year_or_related_iso) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/latest/icu/calendar/types/struct.EraYear.html#structfield.era_year), [2](https://docs.rs/icu/latest/icu/calendar/types/struct.CyclicYear.html#structfield.related_iso), [3](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year)
      */
@@ -339,7 +339,7 @@ export class Date {
     /** 
      * Returns the extended year in the Date
      *
-     * See the [Rust documentation for `extended_year`](https://docs.rs/icu/latest/icu/calendar/types/struct.YearInfo.html#structfield.extended_year) for more information.
+     * See the [Rust documentation for `extended_year`](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.extended_year) for more information.
      */
     get extendedYear() {
         const result = wasm.icu4x_Date_extended_year_mv1(this.ffiValue);

--- a/ffi/capi/bindings/js/Date.mjs
+++ b/ffi/capi/bindings/js/Date.mjs
@@ -324,7 +324,7 @@ export class Date {
      *
      * See the [Rust documentation for `era_year_or_related_iso`](https://docs.rs/icu/latest/icu/calendar/types/enum.YearInfo.html#method.era_year_or_related_iso) for more information.
      *
-     * Additional information: [1](https://docs.rs/icu/latest/icu/calendar/types/struct.EraYear.html#structfield.era_year), [2](https://docs.rs/icu/latest/icu/calendar/types/struct.CyclicYear.html#structfield.related_iso), [3](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year)
+     * Additional information: [1](https://docs.rs/icu/latest/icu/calendar/types/struct.EraYear.html#structfield.year), [2](https://docs.rs/icu/latest/icu/calendar/types/struct.CyclicYear.html#structfield.related_iso), [3](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year)
      */
     get eraYearOrRelatedIso() {
         const result = wasm.icu4x_Date_era_year_or_related_iso_mv1(this.ffiValue);

--- a/ffi/capi/bindings/js/Date.mjs
+++ b/ffi/capi/bindings/js/Date.mjs
@@ -324,7 +324,7 @@ export class Date {
      *
      * See the [Rust documentation for `era_year_or_related_iso`](https://docs.rs/icu/latest/icu/calendar/types/struct.YearInfo.html#method.era_year_or_related_iso) for more information.
      *
-     * Additional information: [1](https://docs.rs/icu/latest/icu/calendar/types/struct.EraYear.html#structfield.era_year), [2](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year)
+     * Additional information: [1](https://docs.rs/icu/latest/icu/calendar/types/struct.EraYear.html#structfield.era_year), [2](https://docs.rs/icu/latest/icu/calendar/types/struct.CyclicYear.html#structfield.related_iso), [3](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year)
      */
     get eraYearOrRelatedIso() {
         const result = wasm.icu4x_Date_era_year_or_related_iso_mv1(this.ffiValue);

--- a/ffi/capi/src/date.rs
+++ b/ffi/capi/src/date.rs
@@ -324,7 +324,7 @@ pub mod ffi {
         ///
         /// For calendars without an era, returns the related ISO year.
         #[diplomat::rust_link(icu::calendar::types::YearInfo::era_year_or_related_iso, FnInEnum)]
-        #[diplomat::rust_link(icu::calendar::types::EraYear::era_year, StructField, compact)]
+        #[diplomat::rust_link(icu::calendar::types::EraYear::year, StructField, compact)]
         #[diplomat::rust_link(icu::calendar::types::CyclicYear::related_iso, StructField, compact)]
         #[diplomat::rust_link(icu::calendar::Date::year, FnInStruct, compact)]
         #[diplomat::rust_link(icu::calendar::Date::era_year, FnInStruct, hidden)]

--- a/ffi/capi/src/date.rs
+++ b/ffi/capi/src/date.rs
@@ -126,7 +126,7 @@ pub mod ffi {
         #[diplomat::rust_link(icu::calendar::Date::year, FnInStruct)]
         #[diplomat::attr(auto, getter)]
         pub fn year(&self) -> i32 {
-            self.0.year().extended_year
+            self.0.extended_year()
         }
 
         /// Returns if the year is a leap year for this date
@@ -323,14 +323,15 @@ pub mod ffi {
         /// Returns the year number in the current era for this date
         ///
         /// For calendars without an era, returns the related ISO year.
-        #[diplomat::rust_link(icu::calendar::types::YearInfo::era_year_or_related_iso, FnInStruct)]
+        #[diplomat::rust_link(icu::calendar::types::YearInfo::era_year_or_related_iso, FnInEnum)]
         #[diplomat::rust_link(icu::calendar::types::EraYear::era_year, StructField, compact)]
         #[diplomat::rust_link(icu::calendar::types::CyclicYear::related_iso, StructField, compact)]
         #[diplomat::rust_link(icu::calendar::Date::year, FnInStruct, compact)]
-        #[diplomat::rust_link(icu::calendar::types::YearInfo, Struct, hidden)]
-        #[diplomat::rust_link(icu::calendar::types::YearKind, Enum, hidden)]
-        #[diplomat::rust_link(icu::calendar::types::YearInfo::era, FnInStruct, hidden)]
-        #[diplomat::rust_link(icu::calendar::types::YearInfo::cyclic, FnInStruct, hidden)]
+        #[diplomat::rust_link(icu::calendar::Date::era_year, FnInStruct, hidden)]
+        #[diplomat::rust_link(icu::calendar::Date::cyclic_year, FnInStruct, hidden)]
+        #[diplomat::rust_link(icu::calendar::types::YearInfo, Enum, hidden)]
+        #[diplomat::rust_link(icu::calendar::types::YearInfo::era, FnInEnum, hidden)]
+        #[diplomat::rust_link(icu::calendar::types::YearInfo::cyclic, FnInEnum, hidden)]
         #[diplomat::rust_link(icu::calendar::types::EraYear, Struct, hidden)]
         #[diplomat::rust_link(icu::calendar::types::CyclicYear, Struct, hidden)]
         #[diplomat::attr(auto, getter)]
@@ -339,10 +340,10 @@ pub mod ffi {
         }
 
         /// Returns the extended year in the Date
-        #[diplomat::rust_link(icu::calendar::types::YearInfo::extended_year, StructField)]
+        #[diplomat::rust_link(icu::calendar::Date::extended_year, FnInStruct)]
         #[diplomat::attr(auto, getter)]
         pub fn extended_year(&self) -> i32 {
-            self.0.year().extended_year
+            self.0.extended_year()
         }
 
         /// Returns the era for this date, or an empty string

--- a/ffi/capi/src/date.rs
+++ b/ffi/capi/src/date.rs
@@ -325,11 +325,14 @@ pub mod ffi {
         /// For calendars without an era, returns the related ISO year.
         #[diplomat::rust_link(icu::calendar::types::YearInfo::era_year_or_related_iso, FnInStruct)]
         #[diplomat::rust_link(icu::calendar::types::EraYear::era_year, StructField, compact)]
-        #[diplomat::rust_link(icu::calendar::types::YearInfo::era_year, FnInStruct, hidden)]
+        #[diplomat::rust_link(icu::calendar::types::CyclicYear::related_iso, StructField, compact)]
         #[diplomat::rust_link(icu::calendar::Date::year, FnInStruct, compact)]
-        #[diplomat::rust_link(icu::calendar::types::EraYear, Struct, hidden)]
-        #[diplomat::rust_link(icu::calendar::types::YearKind, Enum, hidden)]
         #[diplomat::rust_link(icu::calendar::types::YearInfo, Struct, hidden)]
+        #[diplomat::rust_link(icu::calendar::types::YearKind, Enum, hidden)]
+        #[diplomat::rust_link(icu::calendar::types::YearInfo::era, FnInStruct, hidden)]
+        #[diplomat::rust_link(icu::calendar::types::YearInfo::cyclic, FnInStruct, hidden)]
+        #[diplomat::rust_link(icu::calendar::types::EraYear, Struct, hidden)]
+        #[diplomat::rust_link(icu::calendar::types::CyclicYear, Struct, hidden)]
         #[diplomat::attr(auto, getter)]
         pub fn era_year_or_related_iso(&self) -> i32 {
             self.0.year().era_year_or_related_iso()
@@ -337,7 +340,6 @@ pub mod ffi {
 
         /// Returns the extended year in the Date
         #[diplomat::rust_link(icu::calendar::types::YearInfo::extended_year, StructField)]
-        #[diplomat::rust_link(icu::calendar::types::YearInfo, StructField, hidden)]
         #[diplomat::attr(auto, getter)]
         pub fn extended_year(&self) -> i32 {
             self.0.year().extended_year
@@ -345,17 +347,11 @@ pub mod ffi {
 
         /// Returns the era for this date, or an empty string
         #[diplomat::rust_link(icu::calendar::types::EraYear::standard_era, StructField)]
-        #[diplomat::rust_link(icu::calendar::types::YearInfo::standard_era, FnInStruct, hidden)]
         #[diplomat::rust_link(icu::calendar::Date::year, FnInStruct, compact)]
-        #[diplomat::rust_link(icu::calendar::types::EraYear, Struct, hidden)]
-        #[diplomat::rust_link(icu::calendar::types::YearKind, Enum, hidden)]
-        #[diplomat::rust_link(icu::calendar::types::YearInfo, Struct, hidden)]
-        #[diplomat::rust_link(icu::calendar::types::EraYear::formatting_era, StructField, hidden)]
-        #[diplomat::rust_link(icu::calendar::types::YearInfo::formatting_era, FnInStruct, hidden)]
         #[diplomat::attr(auto, getter)]
         pub fn era(&self, write: &mut diplomat_runtime::DiplomatWrite) {
-            if let Some(era) = self.0.year().standard_era() {
-                let _infallible = write.write_str(&era.0);
+            if let Some(era) = self.0.year().era() {
+                let _infallible = write.write_str(&era.standard_era.0);
             }
         }
 

--- a/provider/source/src/calendar/eras.rs
+++ b/provider/source/src/calendar/eras.rs
@@ -476,6 +476,7 @@ fn test_calendar_eras() {
     for (calendar, data) in era_dates_map {
         let kind = match calendar.as_str() {
             "generic" | "islamic" => continue,
+            "chinese" | "dangi" => continue, // no eras
             "ethiopic-amete-alem" => AnyCalendarKind::EthiopianAmeteAlem,
             "gregorian" => AnyCalendarKind::Gregorian,
             "japanese" => AnyCalendarKind::JapaneseExtended,
@@ -516,7 +517,7 @@ fn test_calendar_eras() {
             //     assert_eq!(
             //         Date::try_new_from_codes(
             //             Some(era),
-            //             in_era.year().era_year_or_related_iso(),
+            //             in_era.year().era().unwrap().era_year,
             //             in_era.month().standard_code,
             //             in_era.day_of_month().0,
             //             cal,
@@ -525,32 +526,29 @@ fn test_calendar_eras() {
             //     );
             // }
 
+            let era_year = in_era.year().era().unwrap();
+
             // Unless this is the first era and it's not an inverse era, check that the
             // not_in_era date is in a different era
             if idx != "0" || era.end.is_some() {
                 assert_ne!(
-                    not_in_era.year().standard_era(),
-                    in_era.year().standard_era()
+                    not_in_era.year().era().unwrap().standard_era,
+                    era_year.standard_era
                 );
             }
 
-            // The remaining tests don't work for cyclic calendars
-            if calendar == "dangi" || calendar == "chinese" {
-                continue;
-            }
-
-            if let Some(FormattingEra::Index(i, _)) = in_era.year().formatting_era() {
+            if let FormattingEra::Index(i, _) = era_year.formatting_era {
                 assert_eq!(i.to_string(), idx);
             }
 
             // TODO: reenable with CLDR-48
             // // Check that the correct era code is returned
             // if let Some(code) = era.code.as_deref() {
-            //     assert_eq!(in_era.year().standard_era().unwrap().0, code);
+            //     assert_eq!(era_year.standard_era.0, code);
             // }
 
             // Check that the start/end date uses year 1, and minimal/maximal month/day
-            assert_eq!(in_era.year().era_year_or_related_iso(), 1);
+            assert_eq!(era_year.era_year, 1);
             if calendar == "japanese" {
                 // Japanese is the only calendar that doesn't have its own months
             } else if era.start.is_some() {

--- a/provider/source/src/calendar/eras.rs
+++ b/provider/source/src/calendar/eras.rs
@@ -139,7 +139,7 @@ fn process_era_dates_map(
             .unwrap()
             .to_iso();
         *d = EraStartDate {
-            year: date.year().extended_year,
+            year: date.extended_year(),
             month: date.month().ordinal,
             day: date.day_of_month().0,
         };

--- a/provider/source/src/calendar/eras.rs
+++ b/provider/source/src/calendar/eras.rs
@@ -548,7 +548,7 @@ fn test_calendar_eras() {
             // }
 
             // Check that the start/end date uses year 1, and minimal/maximal month/day
-            assert_eq!(era_year.era_year, 1);
+            assert_eq!(era_year.year, 1);
             if calendar == "japanese" {
                 // Japanese is the only calendar that doesn't have its own months
             } else if era.start.is_some() {

--- a/tools/make/diplomat-coverage/src/allowlist.rs
+++ b/tools/make/diplomat-coverage/src/allowlist.rs
@@ -154,11 +154,7 @@ lazy_static::lazy_static! {
         "icu::calendar::types::RataDie",
 
         // Not planned for 2.0: Temporal doesn't yet want this.
-        "icu::calendar::types::CyclicYear",
-        "icu::calendar::types::YearInfo::cyclic",
-        "icu::calendar::types::YearInfo::related_iso",
         "icu::calendar::types::YearAmbiguity",
-        "icu::calendar::types::YearInfo::year_ambiguity",
 
         // Not planned for 2.0: Would need to introduce diplomat writeable with parts
         "icu::list::parts",


### PR DESCRIPTION
This is implemented by adding a type parameter to the `Calendar` trait, which the `year_info` method returns. The methods on `Date` are as follows:

* `Date::era_year() -> EraYear` - available on calendars that use eras
* `Date::cyclic_year() -> CyclicYear` - available on calendars that use cyclic years
* `Date::year() -> YearInfo` - as before, available on all calendars (including `AnyCalendar`)
  * returns the enum that was formerly `YearKind`, i.e. without the extended year
  * implemented by an `Into<YearInfo>` bound on the associated type
  * `YearInfo` gains getters `era()` and `cyclic()` that return options of the concrete types  
    * DTF uses these to get all information with a single check
* `Date::extended_year() -> i32` - available on all calendars (including `AnyCalendar`)
  * pulled out of the `YearInfo` type
