### PR TITLE
Simplify EraYear

### DIFF
--- a/components/calendar/src/any_calendar.rs
+++ b/components/calendar/src/any_calendar.rs
@@ -44,7 +44,7 @@ define_preferences!(
 ///
 /// There are many ways of constructing an AnyCalendar'd date:
 /// ```
-/// use icu::calendar::{AnyCalendar, AnyCalendarKind, Date, cal::Japanese, types::{Era, MonthCode}};
+/// use icu::calendar::{AnyCalendar, AnyCalendarKind, Date, cal::Japanese, types::MonthCode};
 /// use icu::locale::locale;
 /// use tinystr::tinystr;
 /// # use std::rc::Rc;

--- a/components/calendar/src/cal/buddhist.rs
+++ b/components/calendar/src/cal/buddhist.rs
@@ -118,8 +118,8 @@ impl Calendar for Buddhist {
     /// The calendar-specific year represented by `date`
     fn year_info(&self, date: &Self::DateInner) -> Self::Year {
         types::EraYear {
-            standard_era: tinystr!(16, "be").into(),
-            formatting_era: types::FormattingEra::Index(0, tinystr!(16, "BE")),
+            era: tinystr!(16, "be"),
+            era_ordinal: Some(0),
             year: self.extended_year(date),
             ambiguity: types::YearAmbiguity::CenturyRequired,
         }

--- a/components/calendar/src/cal/buddhist.rs
+++ b/components/calendar/src/cal/buddhist.rs
@@ -119,7 +119,7 @@ impl Calendar for Buddhist {
     fn year_info(&self, date: &Self::DateInner) -> Self::Year {
         types::EraYear {
             era: tinystr!(16, "be"),
-            era_ordinal: Some(0),
+            era_index: Some(0),
             year: self.extended_year(date),
             ambiguity: types::YearAmbiguity::CenturyRequired,
         }

--- a/components/calendar/src/cal/coptic.rs
+++ b/components/calendar/src/cal/coptic.rs
@@ -166,14 +166,14 @@ impl Calendar for Coptic {
         if year > 0 {
             types::EraYear {
                 era: tinystr!(16, "am"),
-                era_ordinal: Some(1),
+                era_index: Some(1),
                 year,
                 ambiguity: types::YearAmbiguity::CenturyRequired,
             }
         } else {
             types::EraYear {
                 era: tinystr!(16, "bd"),
-                era_ordinal: Some(0),
+                era_index: Some(0),
                 year: 1 - year,
                 ambiguity: types::YearAmbiguity::EraAndCenturyRequired,
             }

--- a/components/calendar/src/cal/coptic.rs
+++ b/components/calendar/src/cal/coptic.rs
@@ -165,15 +165,15 @@ impl Calendar for Coptic {
         let year = self.extended_year(date);
         if year > 0 {
             types::EraYear {
-                standard_era: tinystr!(16, "am").into(),
-                formatting_era: types::FormattingEra::Index(1, tinystr!(16, "AM")),
+                era: tinystr!(16, "am"),
+                era_ordinal: Some(1),
                 year,
                 ambiguity: types::YearAmbiguity::CenturyRequired,
             }
         } else {
             types::EraYear {
-                standard_era: tinystr!(16, "bd").into(),
-                formatting_era: types::FormattingEra::Index(0, tinystr!(16, "BD")),
+                era: tinystr!(16, "bd"),
+                era_ordinal: Some(0),
                 year: 1 - year,
                 ambiguity: types::YearAmbiguity::EraAndCenturyRequired,
             }

--- a/components/calendar/src/cal/ethiopian.rs
+++ b/components/calendar/src/cal/ethiopian.rs
@@ -200,14 +200,14 @@ impl Calendar for Ethiopian {
         if self.0 || year <= INCARNATION_OFFSET {
             types::EraYear {
                 era: tinystr!(16, "aa"),
-                era_ordinal: Some(0),
+                era_index: Some(0),
                 year,
                 ambiguity: types::YearAmbiguity::CenturyRequired,
             }
         } else {
             types::EraYear {
                 era: tinystr!(16, "am"),
-                era_ordinal: Some(1),
+                era_index: Some(1),
                 year: year - INCARNATION_OFFSET,
                 ambiguity: types::YearAmbiguity::CenturyRequired,
             }

--- a/components/calendar/src/cal/ethiopian.rs
+++ b/components/calendar/src/cal/ethiopian.rs
@@ -199,15 +199,15 @@ impl Calendar for Ethiopian {
         let year = date.0.year;
         if self.0 || year <= INCARNATION_OFFSET {
             types::EraYear {
-                standard_era: tinystr!(16, "aa").into(),
-                formatting_era: types::FormattingEra::Index(0, tinystr!(16, "AA")),
+                era: tinystr!(16, "aa"),
+                era_ordinal: Some(0),
                 year,
                 ambiguity: types::YearAmbiguity::CenturyRequired,
             }
         } else {
             types::EraYear {
-                standard_era: tinystr!(16, "am").into(),
-                formatting_era: types::FormattingEra::Index(1, tinystr!(16, "AM")),
+                era: tinystr!(16, "am"),
+                era_ordinal: Some(1),
                 year: year - INCARNATION_OFFSET,
                 ambiguity: types::YearAmbiguity::CenturyRequired,
             }

--- a/components/calendar/src/cal/gregorian.rs
+++ b/components/calendar/src/cal/gregorian.rs
@@ -110,8 +110,8 @@ impl Calendar for Gregorian {
         let extended_year = self.extended_year(date);
         if extended_year > 0 {
             types::EraYear {
-                standard_era: tinystr!(16, "ce").into(),
-                formatting_era: types::FormattingEra::Index(1, tinystr!(16, "CE")),
+                era: tinystr!(16, "ce"),
+                era_ordinal: Some(1),
                 year: extended_year,
                 ambiguity: match extended_year {
                     ..=999 => types::YearAmbiguity::EraAndCenturyRequired,
@@ -122,8 +122,8 @@ impl Calendar for Gregorian {
             }
         } else {
             types::EraYear {
-                standard_era: tinystr!(16, "bce").into(),
-                formatting_era: types::FormattingEra::Index(0, tinystr!(16, "BCE")),
+                era: tinystr!(16, "bce"),
+                era_ordinal: Some(0),
                 year: 1_i32.saturating_sub(extended_year),
                 ambiguity: types::YearAmbiguity::EraAndCenturyRequired,
             }
@@ -188,7 +188,6 @@ mod test {
     use calendrical_calculations::rata_die::RataDie;
 
     use super::*;
-    use types::Era;
 
     #[derive(Debug)]
     struct TestCase {
@@ -197,7 +196,7 @@ mod test {
         iso_month: u8,
         iso_day: u8,
         expected_year: i32,
-        expected_era: Era,
+        expected_era: &'static str,
         expected_month: u8,
         expected_day: u8,
     }
@@ -208,7 +207,7 @@ mod test {
         assert_eq!(greg_date_from_rd.era_year().year, case.expected_year,
             "Failed year check from RD: {case:?}\nISO: {iso_from_rd:?}\nGreg: {greg_date_from_rd:?}");
         assert_eq!(
-            greg_date_from_rd.era_year().standard_era,
+            greg_date_from_rd.era_year().era,
             case.expected_era,
             "Failed era check from RD: {case:?}\nISO: {iso_from_rd:?}\nGreg: {greg_date_from_rd:?}"
         );
@@ -242,7 +241,7 @@ mod test {
                 iso_month: 1,
                 iso_day: 1,
                 expected_year: 1,
-                expected_era: Era(tinystr!(16, "ce")),
+                expected_era: "ce",
                 expected_month: 1,
                 expected_day: 1,
             },
@@ -252,7 +251,7 @@ mod test {
                 iso_month: 6,
                 iso_day: 30,
                 expected_year: 1,
-                expected_era: Era(tinystr!(16, "ce")),
+                expected_era: "ce",
                 expected_month: 6,
                 expected_day: 30,
             },
@@ -262,7 +261,7 @@ mod test {
                 iso_month: 2,
                 iso_day: 29,
                 expected_year: 4,
-                expected_era: Era(tinystr!(16, "ce")),
+                expected_era: "ce",
                 expected_month: 2,
                 expected_day: 29,
             },
@@ -272,7 +271,7 @@ mod test {
                 iso_month: 9,
                 iso_day: 5,
                 expected_year: 4,
-                expected_era: Era(tinystr!(16, "ce")),
+                expected_era: "ce",
                 expected_month: 9,
                 expected_day: 5,
             },
@@ -282,7 +281,7 @@ mod test {
                 iso_month: 3,
                 iso_day: 1,
                 expected_year: 100,
-                expected_era: Era(tinystr!(16, "ce")),
+                expected_era: "ce",
                 expected_month: 3,
                 expected_day: 1,
             },
@@ -305,7 +304,7 @@ mod test {
                 iso_month: 12,
                 iso_day: 31,
                 expected_year: 1,
-                expected_era: Era(tinystr!(16, "bce")),
+                expected_era: "bce",
                 expected_month: 12,
                 expected_day: 31,
             },
@@ -315,7 +314,7 @@ mod test {
                 iso_month: 1,
                 iso_day: 1,
                 expected_year: 1,
-                expected_era: Era(tinystr!(16, "bce")),
+                expected_era: "bce",
                 expected_month: 1,
                 expected_day: 1,
             },
@@ -325,7 +324,7 @@ mod test {
                 iso_month: 12,
                 iso_day: 31,
                 expected_year: 2,
-                expected_era: Era(tinystr!(16, "bce")),
+                expected_era: "bce",
                 expected_month: 12,
                 expected_day: 31,
             },
@@ -335,7 +334,7 @@ mod test {
                 iso_month: 12,
                 iso_day: 31,
                 expected_year: 5,
-                expected_era: Era(tinystr!(16, "bce")),
+                expected_era: "bce",
                 expected_month: 12,
                 expected_day: 31,
             },
@@ -345,7 +344,7 @@ mod test {
                 iso_month: 1,
                 iso_day: 1,
                 expected_year: 5,
-                expected_era: Era(tinystr!(16, "bce")),
+                expected_era: "bce",
                 expected_month: 1,
                 expected_day: 1,
             },

--- a/components/calendar/src/cal/gregorian.rs
+++ b/components/calendar/src/cal/gregorian.rs
@@ -111,7 +111,7 @@ impl Calendar for Gregorian {
         if extended_year > 0 {
             types::EraYear {
                 era: tinystr!(16, "ce"),
-                era_ordinal: Some(1),
+                era_index: Some(1),
                 year: extended_year,
                 ambiguity: match extended_year {
                     ..=999 => types::YearAmbiguity::EraAndCenturyRequired,
@@ -123,7 +123,7 @@ impl Calendar for Gregorian {
         } else {
             types::EraYear {
                 era: tinystr!(16, "bce"),
-                era_ordinal: Some(0),
+                era_index: Some(0),
                 year: 1_i32.saturating_sub(extended_year),
                 ambiguity: types::YearAmbiguity::EraAndCenturyRequired,
             }

--- a/components/calendar/src/cal/hebrew.rs
+++ b/components/calendar/src/cal/hebrew.rs
@@ -261,7 +261,7 @@ impl Calendar for Hebrew {
 
     fn year_info(&self, date: &Self::DateInner) -> Self::Year {
         types::EraYear {
-            era_ordinal: Some(0),
+            era_index: Some(0),
             era: tinystr!(16, "am"),
             year: self.extended_year(date),
             ambiguity: types::YearAmbiguity::CenturyRequired,

--- a/components/calendar/src/cal/hebrew.rs
+++ b/components/calendar/src/cal/hebrew.rs
@@ -261,8 +261,8 @@ impl Calendar for Hebrew {
 
     fn year_info(&self, date: &Self::DateInner) -> Self::Year {
         types::EraYear {
-            formatting_era: types::FormattingEra::Index(0, tinystr!(16, "AM")),
-            standard_era: tinystr!(16, "am").into(),
+            era_ordinal: Some(0),
+            era: tinystr!(16, "am"),
             year: self.extended_year(date),
             ambiguity: types::YearAmbiguity::CenturyRequired,
         }
@@ -489,13 +489,13 @@ mod tests {
         let greg_date = Date::try_new_gregorian(-5000, 1, 1).unwrap();
         let greg_year = greg_date.era_year();
         assert_eq!(greg_date.inner.0 .0.year, -5000);
-        assert_eq!(greg_year.standard_era.0, "bce");
+        assert_eq!(greg_year.era, "bce");
         // In Gregorian, era year is 1 - extended year
         assert_eq!(greg_year.year, 5001);
         let hebr_date = greg_date.to_calendar(Hebrew);
         let hebr_year = hebr_date.era_year();
         assert_eq!(hebr_date.inner.0.year.value, -1240);
-        assert_eq!(hebr_year.standard_era.0, "am");
+        assert_eq!(hebr_year.era, "am");
         // In Hebrew, there is no inverse era, so negative extended years are negative era years
         assert_eq!(hebr_year.year, -1240);
     }

--- a/components/calendar/src/cal/hijri.rs
+++ b/components/calendar/src/cal/hijri.rs
@@ -37,7 +37,7 @@ use tinystr::tinystr;
 fn era_year(year: i32) -> EraYear {
     types::EraYear {
         era: tinystr!(16, "ah"),
-        era_ordinal: Some(0),
+        era_index: Some(0),
         year,
         ambiguity: types::YearAmbiguity::CenturyRequired,
     }

--- a/components/calendar/src/cal/hijri.rs
+++ b/components/calendar/src/cal/hijri.rs
@@ -36,8 +36,8 @@ use tinystr::tinystr;
 
 fn era_year(year: i32) -> EraYear {
     types::EraYear {
-        standard_era: types::Era(tinystr!(16, "ah")),
-        formatting_era: types::FormattingEra::Index(0, tinystr!(16, "AH")),
+        era: tinystr!(16, "ah"),
+        era_ordinal: Some(0),
         year,
         ambiguity: types::YearAmbiguity::CenturyRequired,
     }

--- a/components/calendar/src/cal/indian.rs
+++ b/components/calendar/src/cal/indian.rs
@@ -184,7 +184,7 @@ impl Calendar for Indian {
 
     fn year_info(&self, date: &Self::DateInner) -> Self::Year {
         types::EraYear {
-            era_ordinal: Some(0),
+            era_index: Some(0),
             era: tinystr!(16, "saka"),
             year: self.extended_year(date),
             ambiguity: types::YearAmbiguity::CenturyRequired,

--- a/components/calendar/src/cal/indian.rs
+++ b/components/calendar/src/cal/indian.rs
@@ -184,8 +184,8 @@ impl Calendar for Indian {
 
     fn year_info(&self, date: &Self::DateInner) -> Self::Year {
         types::EraYear {
-            formatting_era: types::FormattingEra::Index(0, tinystr!(16, "Saka")),
-            standard_era: tinystr!(16, "saka").into(),
+            era_ordinal: Some(0),
+            era: tinystr!(16, "saka"),
             year: self.extended_year(date),
             ambiguity: types::YearAmbiguity::CenturyRequired,
         }

--- a/components/calendar/src/cal/iso.rs
+++ b/components/calendar/src/cal/iso.rs
@@ -145,8 +145,8 @@ impl Calendar for Iso {
 
     fn year_info(&self, date: &Self::DateInner) -> Self::Year {
         types::EraYear {
-            formatting_era: types::FormattingEra::Index(0, tinystr!(16, "")),
-            standard_era: tinystr!(16, "default").into(),
+            era_ordinal: Some(0),
+            era: tinystr!(16, "default"),
             year: self.extended_year(date),
             ambiguity: types::YearAmbiguity::Unambiguous,
         }

--- a/components/calendar/src/cal/iso.rs
+++ b/components/calendar/src/cal/iso.rs
@@ -145,7 +145,7 @@ impl Calendar for Iso {
 
     fn year_info(&self, date: &Self::DateInner) -> Self::Year {
         types::EraYear {
-            era_ordinal: Some(0),
+            era_index: Some(0),
             era: tinystr!(16, "default"),
             year: self.extended_year(date),
             ambiguity: types::YearAmbiguity::Unambiguous,

--- a/components/calendar/src/cal/japanese.rs
+++ b/components/calendar/src/cal/japanese.rs
@@ -6,7 +6,7 @@
 //!
 //! ```rust
 //! use icu::calendar::cal::Japanese;
-//! use icu::calendar::{types::Era, Date};
+//! use icu::calendar::Date;
 //! use tinystr::tinystr;
 //!
 //! let japanese_calendar = Japanese::new();
@@ -18,10 +18,7 @@
 //! assert_eq!(date_japanese.era_year().year, 45);
 //! assert_eq!(date_japanese.month().ordinal, 1);
 //! assert_eq!(date_japanese.day_of_month().0, 2);
-//! assert_eq!(
-//!     date_japanese.era_year().standard_era.0,
-//!     "showa"
-//! );
+//! assert_eq!(date_japanese.era_year().era, "showa");
 //! ```
 
 use crate::cal::iso::{Iso, IsoDateInner};
@@ -251,8 +248,8 @@ impl Calendar for Japanese {
 
     fn year_info(&self, date: &Self::DateInner) -> Self::Year {
         types::EraYear {
-            formatting_era: types::FormattingEra::Code(date.era.into()),
-            standard_era: date.era.into(),
+            era: date.era,
+            era_ordinal: None,
             year: date.adjusted_year,
             ambiguity: types::YearAmbiguity::CenturyRequired,
         }
@@ -414,7 +411,7 @@ impl Date<Japanese> {
     ///     Date::try_new_japanese_with_calendar(era, 14, 1, 2, japanese_calendar)
     ///         .expect("Constructing a date should succeed");
     ///
-    /// assert_eq!(date.era_year().standard_era.0, era);
+    /// assert_eq!(date.era_year().era, era);
     /// assert_eq!(date.era_year().year, 14);
     /// assert_eq!(date.month().ordinal, 1);
     /// assert_eq!(date.day_of_month().0, 2);
@@ -479,7 +476,7 @@ impl Date<JapaneseExtended> {
     /// )
     /// .expect("Constructing a date should succeed");
     ///
-    /// assert_eq!(date.era_year().standard_era.0, era);
+    /// assert_eq!(date.era_year().era, era);
     /// assert_eq!(date.era_year().year, 7);
     /// assert_eq!(date.month().ordinal, 1);
     /// assert_eq!(date.day_of_month().0, 2);
@@ -754,7 +751,7 @@ mod tests {
         );
 
         // Extra coverage for https://github.com/unicode-org/icu4x/issues/4968
-        assert_eq!(reconstructed.era_year().standard_era.0, era);
+        assert_eq!(reconstructed.era_year().era, era);
         assert_eq!(reconstructed.era_year().year, year);
     }
 

--- a/components/calendar/src/cal/japanese.rs
+++ b/components/calendar/src/cal/japanese.rs
@@ -249,7 +249,7 @@ impl Calendar for Japanese {
     fn year_info(&self, date: &Self::DateInner) -> Self::Year {
         types::EraYear {
             era: date.era,
-            era_ordinal: None,
+            era_index: None,
             year: date.adjusted_year,
             ambiguity: types::YearAmbiguity::CenturyRequired,
         }

--- a/components/calendar/src/cal/julian.rs
+++ b/components/calendar/src/cal/julian.rs
@@ -160,14 +160,14 @@ impl Calendar for Julian {
         if extended_year > 0 {
             types::EraYear {
                 era: tinystr!(16, "ad"),
-                era_ordinal: Some(1),
+                era_index: Some(1),
                 year: extended_year,
                 ambiguity: types::YearAmbiguity::CenturyRequired,
             }
         } else {
             types::EraYear {
                 era: tinystr!(16, "bc"),
-                era_ordinal: Some(0),
+                era_index: Some(0),
                 year: 1_i32.saturating_sub(extended_year),
                 ambiguity: types::YearAmbiguity::EraAndCenturyRequired,
             }

--- a/components/calendar/src/cal/julian.rs
+++ b/components/calendar/src/cal/julian.rs
@@ -159,15 +159,15 @@ impl Calendar for Julian {
         let extended_year = self.extended_year(date);
         if extended_year > 0 {
             types::EraYear {
-                standard_era: tinystr!(16, "ad").into(),
-                formatting_era: types::FormattingEra::Index(1, tinystr!(16, "AD")),
+                era: tinystr!(16, "ad"),
+                era_ordinal: Some(1),
                 year: extended_year,
                 ambiguity: types::YearAmbiguity::CenturyRequired,
             }
         } else {
             types::EraYear {
-                standard_era: tinystr!(16, "bc").into(),
-                formatting_era: types::FormattingEra::Index(0, tinystr!(16, "BC")),
+                era: tinystr!(16, "bc"),
+                era_ordinal: Some(0),
                 year: 1_i32.saturating_sub(extended_year),
                 ambiguity: types::YearAmbiguity::EraAndCenturyRequired,
             }
@@ -237,7 +237,6 @@ impl Date<Julian> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use types::Era;
 
     #[test]
     fn test_day_iso_to_julian() {
@@ -324,7 +323,7 @@ mod test {
             iso_month: u8,
             iso_day: u8,
             expected_year: i32,
-            expected_era: Era,
+            expected_era: &'static str,
             expected_month: u8,
             expected_day: u8,
         }
@@ -336,7 +335,7 @@ mod test {
                 iso_month: 1,
                 iso_day: 1,
                 expected_year: 1,
-                expected_era: Era(tinystr!(16, "ad")),
+                expected_era: "ad",
                 expected_month: 1,
                 expected_day: 3,
             },
@@ -346,7 +345,7 @@ mod test {
                 iso_month: 12,
                 iso_day: 31,
                 expected_year: 1,
-                expected_era: Era(tinystr!(16, "ad")),
+                expected_era: "ad",
                 expected_month: 1,
                 expected_day: 2,
             },
@@ -356,7 +355,7 @@ mod test {
                 iso_month: 12,
                 iso_day: 30,
                 expected_year: 1,
-                expected_era: Era(tinystr!(16, "ad")),
+                expected_era: "ad",
                 expected_month: 1,
                 expected_day: 1,
             },
@@ -366,7 +365,7 @@ mod test {
                 iso_month: 12,
                 iso_day: 29,
                 expected_year: 1,
-                expected_era: Era(tinystr!(16, "bc")),
+                expected_era: "bc",
                 expected_month: 12,
                 expected_day: 31,
             },
@@ -376,7 +375,7 @@ mod test {
                 iso_month: 12,
                 iso_day: 28,
                 expected_year: 1,
-                expected_era: Era(tinystr!(16, "bc")),
+                expected_era: "bc",
                 expected_month: 12,
                 expected_day: 30,
             },
@@ -386,7 +385,7 @@ mod test {
                 iso_month: 12,
                 iso_day: 30,
                 expected_year: 1,
-                expected_era: Era(tinystr!(16, "bc")),
+                expected_era: "bc",
                 expected_month: 1,
                 expected_day: 1,
             },
@@ -396,7 +395,7 @@ mod test {
                 iso_month: 12,
                 iso_day: 29,
                 expected_year: 2,
-                expected_era: Era(tinystr!(16, "bc")),
+                expected_era: "bc",
                 expected_month: 12,
                 expected_day: 31,
             },
@@ -406,7 +405,7 @@ mod test {
                 iso_month: 12,
                 iso_day: 30,
                 expected_year: 4,
-                expected_era: Era(tinystr!(16, "bc")),
+                expected_era: "bc",
                 expected_month: 1,
                 expected_day: 1,
             },
@@ -416,7 +415,7 @@ mod test {
                 iso_month: 12,
                 iso_day: 29,
                 expected_year: 5,
-                expected_era: Era(tinystr!(16, "bc")),
+                expected_era: "bc",
                 expected_month: 12,
                 expected_day: 31,
             },
@@ -427,7 +426,7 @@ mod test {
             let julian_from_rd = Date::from_rata_die(RataDie::new(case.rd), Julian);
             assert_eq!(julian_from_rd.era_year().year, case.expected_year,
                 "Failed year check from RD: {case:?}\nISO: {iso_from_rd:?}\nJulian: {julian_from_rd:?}");
-            assert_eq!(julian_from_rd.era_year().standard_era, case.expected_era,
+            assert_eq!(julian_from_rd.era_year().era, case.expected_era,
                 "Failed era check from RD: {case:?}\nISO: {iso_from_rd:?}\nJulian: {julian_from_rd:?}");
             assert_eq!(julian_from_rd.month().ordinal, case.expected_month,
                 "Failed month check from RD: {case:?}\nISO: {iso_from_rd:?}\nJulian: {julian_from_rd:?}");

--- a/components/calendar/src/cal/persian.rs
+++ b/components/calendar/src/cal/persian.rs
@@ -159,8 +159,8 @@ impl Calendar for Persian {
 
     fn year_info(&self, date: &Self::DateInner) -> Self::Year {
         types::EraYear {
-            standard_era: tinystr!(16, "ap").into(),
-            formatting_era: types::FormattingEra::Index(0, tinystr!(16, "AP")),
+            era: tinystr!(16, "ap"),
+            era_ordinal: Some(0),
             year: self.extended_year(date),
             ambiguity: types::YearAmbiguity::CenturyRequired,
         }

--- a/components/calendar/src/cal/persian.rs
+++ b/components/calendar/src/cal/persian.rs
@@ -160,7 +160,7 @@ impl Calendar for Persian {
     fn year_info(&self, date: &Self::DateInner) -> Self::Year {
         types::EraYear {
             era: tinystr!(16, "ap"),
-            era_ordinal: Some(0),
+            era_index: Some(0),
             year: self.extended_year(date),
             ambiguity: types::YearAmbiguity::CenturyRequired,
         }

--- a/components/calendar/src/cal/roc.rs
+++ b/components/calendar/src/cal/roc.rs
@@ -128,15 +128,15 @@ impl Calendar for Roc {
         let extended_year = self.extended_year(date);
         if extended_year > ROC_ERA_OFFSET {
             types::EraYear {
-                standard_era: tinystr!(16, "minguo").into(),
-                formatting_era: types::FormattingEra::Index(1, tinystr!(16, "min guo")),
+                era: tinystr!(16, "minguo"),
+                era_ordinal: Some(1),
                 year: extended_year.saturating_sub(ROC_ERA_OFFSET),
                 ambiguity: types::YearAmbiguity::CenturyRequired,
             }
         } else {
             types::EraYear {
-                standard_era: tinystr!(16, "minguo-qian").into(),
-                formatting_era: types::FormattingEra::Index(0, tinystr!(16, "min guo qian")),
+                era: tinystr!(16, "minguo-qian"),
+                era_ordinal: Some(0),
                 year: (ROC_ERA_OFFSET + 1).saturating_sub(extended_year),
                 ambiguity: types::YearAmbiguity::EraAndCenturyRequired,
             }
@@ -184,7 +184,7 @@ impl Date<Roc> {
     /// let date_roc = Date::try_new_roc(1, 2, 3)
     ///     .expect("Failed to initialize ROC Date instance.");
     ///
-    /// assert_eq!(date_roc.era_year().standard_era.0, tinystr!(16, "minguo"));
+    /// assert_eq!(date_roc.era_year().era, tinystr!(16, "minguo"));
     /// assert_eq!(date_roc.era_year().year, 1, "ROC year check failed!");
     /// assert_eq!(date_roc.month().ordinal, 2, "ROC month check failed!");
     /// assert_eq!(date_roc.day_of_month().0, 3, "ROC day of month check failed!");
@@ -205,7 +205,6 @@ impl Date<Roc> {
 mod test {
 
     use super::*;
-    use crate::types::Era;
     use calendrical_calculations::rata_die::RataDie;
 
     #[derive(Debug)]
@@ -215,7 +214,7 @@ mod test {
         iso_month: u8,
         iso_day: u8,
         expected_year: i32,
-        expected_era: Era,
+        expected_era: &'static str,
         expected_month: u8,
         expected_day: u8,
     }
@@ -229,7 +228,7 @@ mod test {
             "Failed year check from RD: {case:?}\nISO: {iso_from_rd:?}\nROC: {roc_from_rd:?}"
         );
         assert_eq!(
-            roc_from_rd.era_year().standard_era,
+            roc_from_rd.era_year().era,
             case.expected_era,
             "Failed era check from RD: {case:?}\nISO: {iso_from_rd:?}\nROC: {roc_from_rd:?}"
         );
@@ -264,7 +263,7 @@ mod test {
                 iso_month: 1,
                 iso_day: 1,
                 expected_year: 1,
-                expected_era: Era(tinystr!(16, "minguo")),
+                expected_era: "minguo",
                 expected_month: 1,
                 expected_day: 1,
             },
@@ -274,7 +273,7 @@ mod test {
                 iso_month: 2,
                 iso_day: 29,
                 expected_year: 1,
-                expected_era: Era(tinystr!(16, "minguo")),
+                expected_era: "minguo",
                 expected_month: 2,
                 expected_day: 29,
             },
@@ -284,7 +283,7 @@ mod test {
                 iso_month: 6,
                 iso_day: 30,
                 expected_year: 2,
-                expected_era: Era(tinystr!(16, "minguo")),
+                expected_era: "minguo",
                 expected_month: 6,
                 expected_day: 30,
             },
@@ -294,7 +293,7 @@ mod test {
                 iso_month: 7,
                 iso_day: 13,
                 expected_year: 112,
-                expected_era: Era(tinystr!(16, "minguo")),
+                expected_era: "minguo",
                 expected_month: 7,
                 expected_day: 13,
             },
@@ -318,7 +317,7 @@ mod test {
                 iso_month: 12,
                 iso_day: 31,
                 expected_year: 1,
-                expected_era: Era(tinystr!(16, "minguo-qian")),
+                expected_era: "minguo-qian",
                 expected_month: 12,
                 expected_day: 31,
             },
@@ -328,7 +327,7 @@ mod test {
                 iso_month: 1,
                 iso_day: 1,
                 expected_year: 1,
-                expected_era: Era(tinystr!(16, "minguo-qian")),
+                expected_era: "minguo-qian",
                 expected_month: 1,
                 expected_day: 1,
             },
@@ -338,7 +337,7 @@ mod test {
                 iso_month: 12,
                 iso_day: 31,
                 expected_year: 2,
-                expected_era: Era(tinystr!(16, "minguo-qian")),
+                expected_era: "minguo-qian",
                 expected_month: 12,
                 expected_day: 31,
             },
@@ -348,7 +347,7 @@ mod test {
                 iso_month: 2,
                 iso_day: 29,
                 expected_year: 4,
-                expected_era: Era(tinystr!(16, "minguo-qian")),
+                expected_era: "minguo-qian",
                 expected_month: 2,
                 expected_day: 29,
             },
@@ -358,7 +357,7 @@ mod test {
                 iso_month: 1,
                 iso_day: 1,
                 expected_year: 1911,
-                expected_era: Era(tinystr!(16, "minguo-qian")),
+                expected_era: "minguo-qian",
                 expected_month: 1,
                 expected_day: 1,
             },
@@ -368,7 +367,7 @@ mod test {
                 iso_month: 12,
                 iso_day: 31,
                 expected_year: 1912,
-                expected_era: Era(tinystr!(16, "minguo-qian")),
+                expected_era: "minguo-qian",
                 expected_month: 12,
                 expected_day: 31,
             },

--- a/components/calendar/src/cal/roc.rs
+++ b/components/calendar/src/cal/roc.rs
@@ -129,14 +129,14 @@ impl Calendar for Roc {
         if extended_year > ROC_ERA_OFFSET {
             types::EraYear {
                 era: tinystr!(16, "minguo"),
-                era_ordinal: Some(1),
+                era_index: Some(1),
                 year: extended_year.saturating_sub(ROC_ERA_OFFSET),
                 ambiguity: types::YearAmbiguity::CenturyRequired,
             }
         } else {
             types::EraYear {
                 era: tinystr!(16, "minguo-qian"),
-                era_ordinal: Some(0),
+                era_index: Some(0),
                 year: (ROC_ERA_OFFSET + 1).saturating_sub(extended_year),
                 ambiguity: types::YearAmbiguity::EraAndCenturyRequired,
             }

--- a/components/calendar/src/date.rs
+++ b/components/calendar/src/date.rs
@@ -442,17 +442,13 @@ impl<A: AsCalendar> fmt::Debug for Date<A> {
         let day = self.day_of_month().0;
         let calendar = self.calendar.as_calendar().debug_name();
         match self.year() {
-            types::YearInfo::Era(e) => {
-                let era = e.standard_era.0;
-                let era_year = e.year;
+            types::YearInfo::Era(EraYear { year, era, .. }) => {
                 write!(
                     f,
-                    "Date({era_year}-{month}-{day}, {era} era, for calendar {calendar})"
+                    "Date({year}-{month}-{day}, {era} era, for calendar {calendar})"
                 )
             }
-            types::YearInfo::Cyclic(cy) => {
-                let year = cy.year;
-                let related_iso = cy.related_iso;
+            types::YearInfo::Cyclic(CyclicYear { year, related_iso }) => {
                 write!(
                     f,
                     "Date({year}-{month}-{day}, ISO year {related_iso}, for calendar {calendar})"

--- a/components/calendar/src/types.rs
+++ b/components/calendar/src/types.rs
@@ -95,8 +95,8 @@ pub struct EraYear {
     ///
     /// In this context, chronological ordering of eras is obtained by ordering by their start date (or in the case of
     /// negative eras, their end date) first, and for eras sharing a date, put the negative one first. For example,
-    /// bce < ce, and mundi < incar for Ethiopian.
-    pub era_ordinal: Option<u8>,
+    /// bce < ce.
+    pub era_index: Option<u8>,
     /// The ambiguity of the era/year combination
     pub ambiguity: YearAmbiguity,
 }

--- a/components/calendar/src/types.rs
+++ b/components/calendar/src/types.rs
@@ -13,24 +13,6 @@ use tinystr::{TinyStr16, TinyStr4};
 use zerovec::maps::ZeroMapKV;
 use zerovec::ule::AsULE;
 
-/// The era of a particular date
-///
-/// Different calendars use different era codes, see their documentation
-/// for details.
-///
-/// Era codes are shared with Temporal, [see Temporal proposal][era-proposal].
-///
-/// [era-proposal]: https://tc39.es/proposal-intl-era-monthcode/
-#[derive(Copy, Clone, Debug, PartialEq)]
-#[allow(clippy::exhaustive_structs)] // this is a newtype
-pub struct Era(pub TinyStr16);
-
-impl From<TinyStr16> for Era {
-    fn from(o: TinyStr16) -> Self {
-        Self(o)
-    }
-}
-
 /// The type of year: Calendars like Chinese don't have an era and instead format with cyclic years.
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[non_exhaustive]
@@ -101,56 +83,21 @@ pub enum YearAmbiguity {
     EraAndCenturyRequired,
 }
 
-/// Information about the era as usable for formatting
-///
-/// This is optimized for storing datetime formatting data.
+/// Year information for a year that is specified with an era
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[non_exhaustive]
-pub enum FormattingEra {
+pub struct EraYear {
+    /// The numeric year in that era
+    pub year: i32,
+    /// The era code as defined by CLDR, expect for cases where CLDR does not define a code.
+    pub era: TinyStr16,
     /// An Era Index, for calendars with a small, fixed set of eras. The eras are indexed chronologically.
     ///
     /// In this context, chronological ordering of eras is obtained by ordering by their start date (or in the case of
     /// negative eras, their end date) first, and for eras sharing a date, put the negative one first. For example,
     /// bce < ce, and mundi < incar for Ethiopian.
-    ///
-    /// The TInyStr16 is a fallback string for the era when a display name is not available. It need not be an era code, it should
-    /// be something sensible (or empty).
-    Index(u8, TinyStr16),
-    /// An era code, for calendars with a large set of era codes (Japanese)
-    ///
-    /// This code may not be the canonical era code, but will typically be a valid era alias
-    Code(Era),
-}
-
-impl FormattingEra {
-    /// Get a fallback era name suitable for display to the user when the real era name is not availabe
-    pub fn fallback_name(self) -> TinyStr16 {
-        match self {
-            Self::Index(_idx, fallback) => fallback,
-            Self::Code(era) => era.0,
-        }
-    }
-}
-
-/// Year information for a year that is specified with an era
-#[derive(Copy, Clone, Debug, PartialEq)]
-#[non_exhaustive]
-pub struct EraYear {
-    /// The era code as used in formatting. This era code is not necessarily unique for the calendar, and
-    /// is whatever ICU4X datetime datagen uses for this era.
-    ///
-    /// It will typically be a valid era alias.
-    ///
-    /// <https://tc39.es/proposal-intl-era-monthcode/#table-eras>
-    pub formatting_era: FormattingEra,
-    /// The era code as expected by Temporal/CLDR. This era code is unique for the calendar
-    /// and follows a particular scheme.
-    ///
-    /// <https://tc39.es/proposal-intl-era-monthcode/#table-eras>
-    pub standard_era: Era,
-    /// The numeric year in that era
-    pub year: i32,
-    /// The ambiguity when formatting this year
+    pub era_ordinal: Option<u8>,
+    /// The ambiguity of the era/year combination
     pub ambiguity: YearAmbiguity,
 }
 

--- a/components/calendar/src/types.rs
+++ b/components/calendar/src/types.rs
@@ -91,11 +91,13 @@ pub struct EraYear {
     pub year: i32,
     /// The era code as defined by CLDR, expect for cases where CLDR does not define a code.
     pub era: TinyStr16,
-    /// An Era Index, for calendars with a small, fixed set of eras. The eras are indexed chronologically.
+    /// An era index, for calendars with a small set of eras.
     ///
-    /// In this context, chronological ordering of eras is obtained by ordering by their start date (or in the case of
-    /// negative eras, their end date) first, and for eras sharing a date, put the negative one first. For example,
-    /// bce < ce.
+    /// It is obtained by ordering all eras' start/end dates, and for eras sharing a date, put the negative
+    /// one first. For example, bce < ce.
+    ///
+    /// As eras might be added or removed across CLDR releases, this does not have a stable correspondence
+    /// with the era code.
     pub era_index: Option<u8>,
     /// The ambiguity of the era/year combination
     pub ambiguity: YearAmbiguity,

--- a/components/datetime/src/error.rs
+++ b/components/datetime/src/error.rs
@@ -65,7 +65,7 @@ pub enum DateTimeWriteError {
     /// The output will contain the raw [`MonthCode`] as a fallback value.
     #[displaydoc("Invalid month {0:?}")]
     InvalidMonthCode(MonthCode),
-    /// The [`FormattingEra`] of the input is not valid for this calendar.
+    /// The era code of the input is not valid for this calendar.
     ///
     /// This is guaranteed not to happen for `icu::calendar` inputs, but may happen for custom inputs.
     ///

--- a/components/datetime/src/error.rs
+++ b/components/datetime/src/error.rs
@@ -4,11 +4,9 @@
 
 use crate::pattern::PatternLoadError;
 use displaydoc::Display;
-use icu_calendar::{
-    types::{FormattingEra, MonthCode},
-    AnyCalendarKind,
-};
+use icu_calendar::{types::MonthCode, AnyCalendarKind};
 use icu_provider::DataError;
+use tinystr::TinyStr16;
 
 #[cfg(doc)]
 use crate::pattern::FixedCalendarDateTimeNames;
@@ -71,9 +69,9 @@ pub enum DateTimeWriteError {
     ///
     /// This is guaranteed not to happen for `icu::calendar` inputs, but may happen for custom inputs.
     ///
-    /// The output will contain [`FormattingEra::fallback_name`] as the fallback.
+    /// The output will contain the era code as the fallback.
     #[displaydoc("Invalid era {0:?}")]
-    InvalidEra(FormattingEra),
+    InvalidEra(TinyStr16),
     /// The [`CyclicYear::year`] of the input is not valid for this calendar.
     ///
     /// This is guaranteed not to happen for `icu::calendar` inputs, but may happen for custom inputs.

--- a/components/datetime/src/format/datetime.rs
+++ b/components/datetime/src/format/datetime.rs
@@ -134,12 +134,13 @@ where
         (FieldSymbol::Era, l) => {
             const PART: Part = parts::ERA;
             input!(PART, year = input.year);
-            input!(PART, era = year.era());
-            let era = era.formatting_era;
+            input!(PART, era_year = year.era());
             let era_symbol = datetime_names
-                .get_name_for_era(l, era)
+                .get_name_for_era(l, era_year)
                 .map_err(|e| match e {
-                    GetNameForEraError::InvalidEraCode => DateTimeWriteError::InvalidEra(era),
+                    GetNameForEraError::InvalidEraCode => {
+                        DateTimeWriteError::InvalidEra(era_year.era)
+                    }
                     GetNameForEraError::InvalidFieldLength => {
                         DateTimeWriteError::UnsupportedLength(ErrorField(field))
                     }
@@ -150,7 +151,7 @@ where
             match era_symbol {
                 Err(e) => {
                     w.with_part(PART, |w| {
-                        w.with_part(Part::ERROR, |w| w.write_str(&era.fallback_name()))
+                        w.with_part(Part::ERROR, |w| w.write_str(&era_year.era))
                     })?;
                     Err(e)
                 }

--- a/components/datetime/src/pattern/names.rs
+++ b/components/datetime/src/pattern/names.rs
@@ -3577,7 +3577,7 @@ impl RawDateTimeNamesBorrowed<'_> {
             .get_with_variables(year_name_length)
             .ok_or(GetNameForEraError::NotLoaded)?;
 
-        match (year_names, era_year.era_ordinal) {
+        match (year_names, era_year.era_index) {
             (YearNames::VariableEras(era_names), None) => {
                 crate::provider::neo::get_year_name_from_map(
                     era_names,

--- a/ffi/capi/bindings/cpp/icu4x/Date.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/Date.d.hpp
@@ -169,7 +169,7 @@ public:
   /**
    * Returns the era for this date, or an empty string
    *
-   * See the [Rust documentation for `standard_era`](https://docs.rs/icu/latest/icu/calendar/types/struct.EraYear.html#structfield.standard_era) for more information.
+   * See the [Rust documentation for `era`](https://docs.rs/icu/latest/icu/calendar/types/struct.EraYear.html#structfield.era) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year)
    */

--- a/ffi/capi/bindings/dart/Date.g.dart
+++ b/ffi/capi/bindings/dart/Date.g.dart
@@ -194,7 +194,7 @@ final class Date implements ffi.Finalizable {
 
   /// Returns the era for this date, or an empty string
   ///
-  /// See the [Rust documentation for `standard_era`](https://docs.rs/icu/latest/icu/calendar/types/struct.EraYear.html#structfield.standard_era) for more information.
+  /// See the [Rust documentation for `era`](https://docs.rs/icu/latest/icu/calendar/types/struct.EraYear.html#structfield.era) for more information.
   ///
   /// Additional information: [1](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year)
   String get era {

--- a/ffi/capi/bindings/js/Date.d.ts
+++ b/ffi/capi/bindings/js/Date.d.ts
@@ -149,7 +149,7 @@ export class Date {
     /** 
      * Returns the era for this date, or an empty string
      *
-     * See the [Rust documentation for `standard_era`](https://docs.rs/icu/latest/icu/calendar/types/struct.EraYear.html#structfield.standard_era) for more information.
+     * See the [Rust documentation for `era`](https://docs.rs/icu/latest/icu/calendar/types/struct.EraYear.html#structfield.era) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year)
      */

--- a/ffi/capi/bindings/js/Date.mjs
+++ b/ffi/capi/bindings/js/Date.mjs
@@ -354,7 +354,7 @@ export class Date {
     /** 
      * Returns the era for this date, or an empty string
      *
-     * See the [Rust documentation for `standard_era`](https://docs.rs/icu/latest/icu/calendar/types/struct.EraYear.html#structfield.standard_era) for more information.
+     * See the [Rust documentation for `era`](https://docs.rs/icu/latest/icu/calendar/types/struct.EraYear.html#structfield.era) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/latest/icu/calendar/struct.Date.html#method.year)
      */

--- a/ffi/capi/src/date.rs
+++ b/ffi/capi/src/date.rs
@@ -347,12 +347,12 @@ pub mod ffi {
         }
 
         /// Returns the era for this date, or an empty string
-        #[diplomat::rust_link(icu::calendar::types::EraYear::standard_era, StructField)]
+        #[diplomat::rust_link(icu::calendar::types::EraYear::era, StructField)]
         #[diplomat::rust_link(icu::calendar::Date::year, FnInStruct, compact)]
         #[diplomat::attr(auto, getter)]
         pub fn era(&self, write: &mut diplomat_runtime::DiplomatWrite) {
             if let Some(era) = self.0.year().era() {
-                let _infallible = write.write_str(&era.standard_era.0);
+                let _infallible = write.write_str(&era.era);
             }
         }
 

--- a/provider/source/src/calendar/eras.rs
+++ b/provider/source/src/calendar/eras.rs
@@ -533,7 +533,7 @@ fn test_calendar_eras() {
                 assert_ne!(not_in_era.year().era().unwrap().era, era_year.era);
             }
 
-            if let Some(i) = era_year.era_ordinal {
+            if let Some(i) = era_year.era_index {
                 assert_eq!(i.to_string(), idx);
             }
 

--- a/provider/source/src/calendar/eras.rs
+++ b/provider/source/src/calendar/eras.rs
@@ -455,7 +455,6 @@ pub fn japanese_and_japanext_are_compatible() {
 
 #[test]
 fn test_calendar_eras() {
-    use icu::calendar::types::FormattingEra;
     use icu::calendar::Iso;
     use icu::calendar::{AnyCalendar, AnyCalendarKind, Date};
     use icu::datetime::preferences::CalendarAlgorithm;
@@ -531,20 +530,17 @@ fn test_calendar_eras() {
             // Unless this is the first era and it's not an inverse era, check that the
             // not_in_era date is in a different era
             if idx != "0" || era.end.is_some() {
-                assert_ne!(
-                    not_in_era.year().era().unwrap().standard_era,
-                    era_year.standard_era
-                );
+                assert_ne!(not_in_era.year().era().unwrap().era, era_year.era);
             }
 
-            if let FormattingEra::Index(i, _) = era_year.formatting_era {
+            if let Some(i) = era_year.era_ordinal {
                 assert_eq!(i.to_string(), idx);
             }
 
             // TODO: reenable with CLDR-48
             // // Check that the correct era code is returned
             // if let Some(code) = era.code.as_deref() {
-            //     assert_eq!(era_year.standard_era.0, code);
+            //     assert_eq!(era_year.era, code);
             // }
 
             // Check that the start/end date uses year 1, and minimal/maximal month/day

--- a/tools/make/diplomat-coverage/src/allowlist.rs
+++ b/tools/make/diplomat-coverage/src/allowlist.rs
@@ -147,10 +147,6 @@ lazy_static::lazy_static! {
         // Not planned for 2.0: Calendar structs mostly for internal use but which might expose
         // useful information to clients.
         "icu::calendar::types::MonthInfo",
-        "icu::calendar::types::FormattingEra",
-        "icu::calendar::Date::formattable_year",
-        "icu::calendar::types::FormattableYear",
-        "icu::calendar::types::FormattableYearKind",
         "icu::calendar::types::RataDie",
 
         // Not planned for 2.0: Temporal doesn't yet want this.
@@ -388,7 +384,6 @@ lazy_static::lazy_static! {
         "icu::calendar::types::DayOfMonth",
         "icu::calendar::types::DayOfWeekInMonth",
         "icu::calendar::types::DayOfYear",
-        "icu::calendar::types::Era",
         "icu::calendar::types::Weekday",
         "icu::calendar::types::MonthCode",
         "icu::calendar::types::WeekOfMonth",


### PR DESCRIPTION
This removes the duplication between `standard_era` and `formatting_era`.

Effectively, whenever `formatting_era` is `FormattingEra::Code`, it is the same code as `standard_era`, so it could just be `Option<(u8, TinyStr16)>`. But the fallback era name isn't really needed, as it's always the same as code up to capitalization, and we don't really care about capitalization in gigo paths.

The new `era_index` field can be documented without deferring to whatever datagen does.