### PR TITLE
Handle CLDR era addition

### DIFF
--- a/provider/source/src/calendar/eras.rs
+++ b/provider/source/src/calendar/eras.rs
@@ -116,14 +116,18 @@ impl SourceDataProvider {
                             .eras
                             .into_iter()
                             .filter_map(|(key, mut data)| {
+                                let code = data.code.as_deref()?;
                                 // Check what ICU4X returns for the date 1-1-1 era
                                 data.icu4x_era_index = Date::try_new_from_codes(
-                                    Some(data.code.as_deref()?),
+                                    Some(code),
                                     1,
                                     MonthCode::new_normal(1).unwrap(),
                                     1,
                                     icu::calendar::Ref(&calendar),
                                 )
+                                .inspect_err(|e| {
+                                    log::warn!("Era '{code}' unknown by icu::calendar ({e:?})");
+                                })
                                 .ok()?
                                 .year()
                                 .era()?

--- a/provider/source/src/calendar/eras.rs
+++ b/provider/source/src/calendar/eras.rs
@@ -124,10 +124,9 @@ impl SourceDataProvider {
                                     1,
                                     icu::calendar::Ref(&calendar),
                                 )
-                                .unwrap()
+                                .ok()?
                                 .year()
-                                .era()
-                                .unwrap()
+                                .era()?
                                 .era_index;
                                 Some((key.parse::<usize>().ok()?, data))
                             })


### PR DESCRIPTION
This way datagen ignores eras that `icu::calendar` doesn't yet know about.

We cannot really do this in the other direction, as `icu::calendar` cannot tell us a list of eras for a calendar