### PR TITLE
CldrCalendar should be bound on UnstableSealed not private::Sealed

### DIFF
--- a/components/datetime/src/scaffold/calendar.rs
+++ b/components/datetime/src/scaffold/calendar.rs
@@ -22,10 +22,6 @@ use icu_time::{
     DateTime, Time, TimeZoneInfo, ZonedDateTime,
 };
 
-mod private {
-    pub trait Sealed {}
-}
-
 /// A calendar that can be found in CLDR.
 ///
 /// New implementors of this trait will likely also wish to modify `get_era_code_map()`
@@ -35,7 +31,7 @@ mod private {
 /// 🚫 This trait is sealed; it cannot be implemented by user code. If an API requests an item that implements this
 /// trait, please consider using a type from the implementors listed below.
 /// </div>
-pub trait CldrCalendar: private::Sealed {
+pub trait CldrCalendar: UnstableSealed {
     /// The data marker for loading year symbols for this calendar.
     type YearNamesV1: DataMarker<DataStruct = YearNames<'static>>;
 
@@ -46,112 +42,96 @@ pub trait CldrCalendar: private::Sealed {
     type SkeletaV1: DataMarker<DataStruct = PackedPatterns<'static>>;
 }
 
-impl private::Sealed for () {}
 impl CldrCalendar for () {
     type YearNamesV1 = NeverMarker<YearNames<'static>>;
     type MonthNamesV1 = NeverMarker<MonthNames<'static>>;
     type SkeletaV1 = NeverMarker<PackedPatterns<'static>>;
 }
 
-impl private::Sealed for Buddhist {}
 impl CldrCalendar for Buddhist {
     type YearNamesV1 = DatetimeNamesYearBuddhistV1;
     type MonthNamesV1 = DatetimeNamesMonthBuddhistV1;
     type SkeletaV1 = DatetimePatternsDateBuddhistV1;
 }
 
-impl private::Sealed for Chinese {}
 impl CldrCalendar for Chinese {
     type YearNamesV1 = DatetimeNamesYearChineseV1;
     type MonthNamesV1 = DatetimeNamesMonthChineseV1;
     type SkeletaV1 = DatetimePatternsDateChineseV1;
 }
 
-impl private::Sealed for Coptic {}
 impl CldrCalendar for Coptic {
     type YearNamesV1 = DatetimeNamesYearCopticV1;
     type MonthNamesV1 = DatetimeNamesMonthCopticV1;
     type SkeletaV1 = DatetimePatternsDateCopticV1;
 }
 
-impl private::Sealed for Dangi {}
 impl CldrCalendar for Dangi {
     type YearNamesV1 = DatetimeNamesYearDangiV1;
     type MonthNamesV1 = DatetimeNamesMonthDangiV1;
     type SkeletaV1 = DatetimePatternsDateDangiV1;
 }
 
-impl private::Sealed for Ethiopian {}
 impl CldrCalendar for Ethiopian {
     type YearNamesV1 = DatetimeNamesYearEthiopianV1;
     type MonthNamesV1 = DatetimeNamesMonthEthiopianV1;
     type SkeletaV1 = DatetimePatternsDateEthiopianV1;
 }
 
-impl private::Sealed for Gregorian {}
 impl CldrCalendar for Gregorian {
     type YearNamesV1 = DatetimeNamesYearGregorianV1;
     type MonthNamesV1 = DatetimeNamesMonthGregorianV1;
     type SkeletaV1 = DatetimePatternsDateGregorianV1;
 }
 
-impl private::Sealed for Hebrew {}
 impl CldrCalendar for Hebrew {
     type YearNamesV1 = DatetimeNamesYearHebrewV1;
     type MonthNamesV1 = DatetimeNamesMonthHebrewV1;
     type SkeletaV1 = DatetimePatternsDateHebrewV1;
 }
 
-impl private::Sealed for Indian {}
 impl CldrCalendar for Indian {
     type YearNamesV1 = DatetimeNamesYearIndianV1;
     type MonthNamesV1 = DatetimeNamesMonthIndianV1;
     type SkeletaV1 = DatetimePatternsDateIndianV1;
 }
 
-impl private::Sealed for HijriTabular {}
 impl CldrCalendar for HijriTabular {
     type YearNamesV1 = DatetimeNamesYearHijriV1;
     type MonthNamesV1 = DatetimeNamesMonthHijriV1;
     type SkeletaV1 = DatetimePatternsDateHijriV1;
 }
 
-impl private::Sealed for HijriSimulated {}
 impl CldrCalendar for HijriSimulated {
     type YearNamesV1 = DatetimeNamesYearHijriV1;
     type MonthNamesV1 = DatetimeNamesMonthHijriV1;
     type SkeletaV1 = DatetimePatternsDateHijriV1;
 }
 
-impl private::Sealed for HijriUmmAlQura {}
 impl CldrCalendar for HijriUmmAlQura {
     type YearNamesV1 = DatetimeNamesYearHijriV1;
     type MonthNamesV1 = DatetimeNamesMonthHijriV1;
     type SkeletaV1 = DatetimePatternsDateHijriV1;
 }
 
-impl private::Sealed for Japanese {}
 impl CldrCalendar for Japanese {
     type YearNamesV1 = DatetimeNamesYearJapaneseV1;
     type MonthNamesV1 = DatetimeNamesMonthJapaneseV1;
     type SkeletaV1 = DatetimePatternsDateJapaneseV1;
 }
 
-impl private::Sealed for JapaneseExtended {}
 impl CldrCalendar for JapaneseExtended {
     type YearNamesV1 = DatetimeNamesYearJapanextV1;
     type MonthNamesV1 = DatetimeNamesMonthJapanextV1;
     type SkeletaV1 = DatetimePatternsDateJapanextV1;
 }
 
-impl private::Sealed for Persian {}
 impl CldrCalendar for Persian {
     type YearNamesV1 = DatetimeNamesYearPersianV1;
     type MonthNamesV1 = DatetimeNamesMonthPersianV1;
     type SkeletaV1 = DatetimePatternsDatePersianV1;
 }
 
-impl private::Sealed for Roc {}
 impl CldrCalendar for Roc {
     type YearNamesV1 = DatetimeNamesYearRocV1;
     type MonthNamesV1 = DatetimeNamesMonthRocV1;


### PR DESCRIPTION
I noticed this while working on #6205. I no longer need it, but I think it was wrong?