### PR TITLE
Mark Calendar UnstableSealed

### DIFF
--- a/components/calendar/src/any_calendar.rs
+++ b/components/calendar/src/any_calendar.rs
@@ -218,6 +218,7 @@ macro_rules! match_cal {
     };
 }
 
+impl crate::cal::scaffold::UnstableSealed for AnyCalendar {}
 impl Calendar for AnyCalendar {
     type DateInner = AnyDateInner;
     type Year = YearInfo;

--- a/components/calendar/src/cal/buddhist.rs
+++ b/components/calendar/src/cal/buddhist.rs
@@ -49,6 +49,7 @@ const BUDDHIST_ERA_OFFSET: i32 = 543;
 #[allow(clippy::exhaustive_structs)] // this type is stable
 pub struct Buddhist;
 
+impl crate::cal::scaffold::UnstableSealed for Buddhist {}
 impl Calendar for Buddhist {
     type DateInner = IsoDateInner;
     type Year = types::EraYear;

--- a/components/calendar/src/cal/chinese.rs
+++ b/components/calendar/src/cal/chinese.rs
@@ -151,6 +151,7 @@ impl Chinese {
     pub(crate) const DEBUG_NAME: &'static str = "Chinese";
 }
 
+impl crate::cal::scaffold::UnstableSealed for Chinese {}
 impl Calendar for Chinese {
     type DateInner = ChineseDateInner;
     type Year = types::CyclicYear;

--- a/components/calendar/src/cal/coptic.rs
+++ b/components/calendar/src/cal/coptic.rs
@@ -92,6 +92,7 @@ impl CalendarArithmetic for Coptic {
     }
 }
 
+impl crate::cal::scaffold::UnstableSealed for Coptic {}
 impl Calendar for Coptic {
     type DateInner = CopticDateInner;
     type Year = types::EraYear;

--- a/components/calendar/src/cal/dangi.rs
+++ b/components/calendar/src/cal/dangi.rs
@@ -149,6 +149,7 @@ impl Dangi {
     pub(crate) const DEBUG_NAME: &'static str = "Dangi";
 }
 
+impl crate::cal::scaffold::UnstableSealed for Dangi {}
 impl Calendar for Dangi {
     type DateInner = DangiDateInner;
     type Year = CyclicYear;

--- a/components/calendar/src/cal/ethiopian.rs
+++ b/components/calendar/src/cal/ethiopian.rs
@@ -110,6 +110,7 @@ impl CalendarArithmetic for Ethiopian {
     }
 }
 
+impl crate::cal::scaffold::UnstableSealed for Ethiopian {}
 impl Calendar for Ethiopian {
     type DateInner = EthiopianDateInner;
     type Year = types::EraYear;

--- a/components/calendar/src/cal/gregorian.rs
+++ b/components/calendar/src/cal/gregorian.rs
@@ -44,6 +44,7 @@ pub struct Gregorian;
 /// The inner date type used for representing [`Date`]s of [`Gregorian`]. See [`Date`] and [`Gregorian`] for more details.
 pub struct GregorianDateInner(pub(crate) IsoDateInner);
 
+impl crate::cal::scaffold::UnstableSealed for Gregorian {}
 impl Calendar for Gregorian {
     type DateInner = GregorianDateInner;
     type Year = types::EraYear;

--- a/components/calendar/src/cal/hebrew.rs
+++ b/components/calendar/src/cal/hebrew.rs
@@ -130,6 +130,7 @@ impl PrecomputedDataSource<HebrewYearInfo> for () {
     }
 }
 
+impl crate::cal::scaffold::UnstableSealed for Hebrew {}
 impl Calendar for Hebrew {
     type DateInner = HebrewDateInner;
     type Year = types::EraYear;

--- a/components/calendar/src/cal/hijri.rs
+++ b/components/calendar/src/cal/hijri.rs
@@ -361,6 +361,7 @@ impl CalendarArithmetic for HijriSimulated {
     }
 }
 
+impl crate::cal::scaffold::UnstableSealed for HijriSimulated {}
 impl Calendar for HijriSimulated {
     type DateInner = HijriSimulatedDateInner;
     type Year = types::EraYear;
@@ -642,6 +643,7 @@ impl CalendarArithmetic for HijriUmmAlQura {
     }
 }
 
+impl crate::cal::scaffold::UnstableSealed for HijriUmmAlQura {}
 impl Calendar for HijriUmmAlQura {
     type DateInner = HijriUmmAlQuraDateInner;
     type Year = types::EraYear;
@@ -1171,6 +1173,7 @@ impl CalendarArithmetic for HijriTabular {
     }
 }
 
+impl crate::cal::scaffold::UnstableSealed for HijriTabular {}
 impl Calendar for HijriTabular {
     type DateInner = HijriTabularDateInner;
     type Year = types::EraYear;

--- a/components/calendar/src/cal/indian.rs
+++ b/components/calendar/src/cal/indian.rs
@@ -90,6 +90,7 @@ const DAY_OFFSET: u16 = 80;
 /// The Saka calendar is 78 years behind Gregorian. This number should be added to Gregorian dates
 const YEAR_OFFSET: i32 = 78;
 
+impl crate::cal::scaffold::UnstableSealed for Indian {}
 impl Calendar for Indian {
     type DateInner = IndianDateInner;
     type Year = types::EraYear;

--- a/components/calendar/src/cal/iso.rs
+++ b/components/calendar/src/cal/iso.rs
@@ -76,6 +76,7 @@ impl CalendarArithmetic for Iso {
     }
 }
 
+impl crate::cal::scaffold::UnstableSealed for Iso {}
 impl Calendar for Iso {
     type DateInner = IsoDateInner;
     type Year = types::EraYear;

--- a/components/calendar/src/cal/japanese.rs
+++ b/components/calendar/src/cal/japanese.rs
@@ -166,6 +166,7 @@ impl JapaneseExtended {
     pub(crate) const DEBUG_NAME: &'static str = "Japanese (historical era data)";
 }
 
+impl crate::cal::scaffold::UnstableSealed for Japanese {}
 impl Calendar for Japanese {
     type DateInner = JapaneseDateInner;
     type Year = types::EraYear;
@@ -286,6 +287,7 @@ impl Calendar for Japanese {
     }
 }
 
+impl crate::cal::scaffold::UnstableSealed for JapaneseExtended {}
 impl Calendar for JapaneseExtended {
     type DateInner = JapaneseDateInner;
     type Year = types::EraYear;

--- a/components/calendar/src/cal/julian.rs
+++ b/components/calendar/src/cal/julian.rs
@@ -82,6 +82,7 @@ impl CalendarArithmetic for Julian {
     }
 }
 
+impl crate::cal::scaffold::UnstableSealed for Julian {}
 impl Calendar for Julian {
     type DateInner = JulianDateInner;
     type Year = types::EraYear;

--- a/components/calendar/src/cal/mod.rs
+++ b/components/calendar/src/cal/mod.rs
@@ -37,3 +37,15 @@ pub use persian::Persian;
 pub use roc::Roc;
 
 pub use crate::any_calendar::{AnyCalendar, AnyCalendarKind};
+
+/// Internal scaffolding types
+pub mod scaffold {
+    /// Trait marking other traits that are considered unstable and should not generally be
+    /// implemented outside of the calendar crate.
+    ///
+    /// <div class="stab unstable">
+    /// 🚧 This trait is considered unstable; it may change at any time, in breaking or non-breaking ways,
+    /// including in SemVer minor releases. Do not implement this trait in userland unless you are prepared for things to occasionally break.
+    /// </div>
+    pub trait UnstableSealed {}
+}

--- a/components/calendar/src/cal/persian.rs
+++ b/components/calendar/src/cal/persian.rs
@@ -84,6 +84,7 @@ impl CalendarArithmetic for Persian {
     }
 }
 
+impl crate::cal::scaffold::UnstableSealed for Persian {}
 impl Calendar for Persian {
     type DateInner = PersianDateInner;
     type Year = types::EraYear;

--- a/components/calendar/src/cal/roc.rs
+++ b/components/calendar/src/cal/roc.rs
@@ -54,6 +54,7 @@ pub struct Roc;
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
 pub struct RocDateInner(IsoDateInner);
 
+impl crate::cal::scaffold::UnstableSealed for Roc {}
 impl Calendar for Roc {
     type DateInner = RocDateInner;
     type Year = types::EraYear;

--- a/components/calendar/src/calendar.rs
+++ b/components/calendar/src/calendar.rs
@@ -17,9 +17,14 @@ use core::fmt;
 /// Individual [`Calendar`] implementations may have inherent utility methods
 /// allowing for direct construction, etc.
 ///
-/// For ICU4X 1.0, implementing this trait or calling methods directly is considered
-/// unstable and prone to change, especially for `offset_date()` and `until()`.
-pub trait Calendar {
+/// <div class="stab unstable">
+/// 🚫 This trait is sealed; it should not be implemented by user code. If an API requests an item that implements this
+/// trait, please consider using a type from the implementors listed below.
+///
+/// It is still possible to implement this trait in userland (since `UnstableSealed` is public),
+/// do not do so unless you are prepared for things to occasionally break.
+/// </div>
+pub trait Calendar: crate::cal::scaffold::UnstableSealed {
     /// The internal type used to represent dates
     type DateInner: Eq + Copy + fmt::Debug;
     /// The type of YearInfo returned by the date


### PR DESCRIPTION
Note: I used a different header than in datetime for the trait, since I think unlike datetime this is a non-scaffolding trait that people will reference often.

Personally my rule of thumb for UnstableSealed is that we expect people to want to implement it (check) and we have some idea that this is the direction in which we want to go for custom impls. I hadn't put full thought into that in the past for this crate but with some of the formatting stuff split out I'm more confident. So I'm fine with this being unstable sealed.


I'm not sure if UnstableSealed should live in the cal module or at the top level.



<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->