### PR TITLE
Internal datagen API: Return the distance from skeleton matching

### DIFF
--- a/components/datetime/src/provider/pattern/hour_cycle.rs
+++ b/components/datetime/src/provider/pattern/hour_cycle.rs
@@ -104,8 +104,8 @@ impl CoarseHourCycle {
             // requested fields.
             true,
         ) {
-            skeleton::BestSkeleton::AllFieldsMatch(patterns)
-            | skeleton::BestSkeleton::MissingOrExtraFields(patterns) => {
+            skeleton::BestSkeleton::AllFieldsMatch(patterns, _)
+            | skeleton::BestSkeleton::MissingOrExtraFields(patterns, _) => {
                 Some(reference::Pattern::from(&patterns.expect_pattern(
                     "Only week-of patterns have plural variants",
                 )))

--- a/components/datetime/src/provider/skeleton/helpers.rs
+++ b/components/datetime/src/provider/skeleton/helpers.rs
@@ -183,7 +183,7 @@ pub fn create_best_pattern_for_fields<'data>(
     ) = match get_best_available_format_pattern(skeletons, &date, prefer_matched_pattern) {
         BestSkeleton::MissingOrExtraFields(fields, d) => (Some(fields), true, d),
         BestSkeleton::AllFieldsMatch(fields, d) => (Some(fields), false, d),
-        BestSkeleton::NoMatch => (None, true, u32::MAX),
+        BestSkeleton::NoMatch => (None, true, REQUESTED_SYMBOL_MISSING),
     };
 
     let (time_patterns, time_missing_or_extra, time_distance): (
@@ -193,7 +193,7 @@ pub fn create_best_pattern_for_fields<'data>(
     ) = match get_best_available_format_pattern(skeletons, &time, prefer_matched_pattern) {
         BestSkeleton::MissingOrExtraFields(fields, d) => (Some(fields), true, d),
         BestSkeleton::AllFieldsMatch(fields, d) => (Some(fields), false, d),
-        BestSkeleton::NoMatch => (None, true, u32::MAX),
+        BestSkeleton::NoMatch => (None, true, REQUESTED_SYMBOL_MISSING),
     };
     let time_pattern: Option<runtime::Pattern<'data>> = time_patterns.map(|pattern_plurals| {
         let mut pattern =

--- a/components/datetime/src/provider/skeleton/helpers.rs
+++ b/components/datetime/src/provider/skeleton/helpers.rs
@@ -2,8 +2,6 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-extern crate std;
-
 use alloc::vec;
 use alloc::vec::Vec;
 use core::cmp::Ordering;
@@ -428,7 +426,6 @@ pub fn get_best_available_format_pattern<'data>(
     fields: &[Field],
     prefer_matched_pattern: bool,
 ) -> BestSkeleton<PatternPlurals<'data>> {
-    std::println!("gbafp: {:?}", fields);
     let mut closest_format_pattern = None;
     let mut closest_distance: u32 = u32::MAX;
     let mut closest_missing_fields = 0;
@@ -508,7 +505,6 @@ pub fn get_best_available_format_pattern<'data>(
         }
 
         if distance < closest_distance {
-            std::println!("Closer: {}", pattern.clone().expect_pattern(""));
             closest_format_pattern = Some(pattern);
             closest_distance = distance;
             closest_missing_fields = missing_fields;

--- a/provider/source/src/datetime/neo_skeleton.rs
+++ b/provider/source/src/datetime/neo_skeleton.rs
@@ -11,7 +11,7 @@ use icu::datetime::options::Length;
 use icu::datetime::provider::calendar::{DateSkeletonPatterns, TimeLengths};
 use icu::datetime::provider::fields::components;
 use icu::datetime::provider::pattern::{reference, runtime, CoarseHourCycle};
-use icu::datetime::provider::skeleton::PatternPlurals;
+use icu::datetime::provider::skeleton::{PatternPlurals, SkeletonQuality};
 use icu::datetime::provider::*;
 use icu::plurals::PluralElements;
 use icu_locale_core::preferences::extensions::unicode::keywords::HourCycle;
@@ -21,7 +21,7 @@ use super::DatagenCalendar;
 
 struct PatternsWithDistance<T> {
     inner: T,
-    distance: u32,
+    distance: SkeletonQuality,
 }
 
 impl<T> PatternsWithDistance<T> {
@@ -74,7 +74,7 @@ fn select_pattern<'data>(
             let pattern = runtime::Pattern::from(pattern_items);
             PatternsWithDistance {
                 inner: PatternPlurals::SinglePattern(pattern),
-                distance: u32::MAX,
+                distance: SkeletonQuality::worst(),
             }
         }
     }

--- a/provider/source/src/datetime/neo_skeleton.rs
+++ b/provider/source/src/datetime/neo_skeleton.rs
@@ -3,7 +3,6 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use std::collections::HashSet;
-use std::u32;
 
 use crate::{cldr_serde, IterableDataProviderCached, SourceDataProvider};
 use calendar::patterns::GenericLengthPatterns;

--- a/provider/source/src/datetime/skeletons.rs
+++ b/provider/source/src/datetime/skeletons.rs
@@ -122,8 +122,8 @@ mod test {
         let (_, skeletons) = get_data_payload();
 
         match get_best_available_format_pattern(&skeletons, &requested_fields, false) {
-            BestSkeleton::AllFieldsMatch(available_format_pattern)
-            | BestSkeleton::MissingOrExtraFields(available_format_pattern) => {
+            BestSkeleton::AllFieldsMatch(available_format_pattern, _)
+            | BestSkeleton::MissingOrExtraFields(available_format_pattern, _) => {
                 assert_eq!(
                     available_format_pattern
                         .expect_pattern("pattern should not have plural variants")
@@ -147,7 +147,7 @@ mod test {
         let (_, skeletons) = get_data_payload();
 
         match get_best_available_format_pattern(&skeletons, &requested_fields, false) {
-            BestSkeleton::MissingOrExtraFields(available_format_pattern) => {
+            BestSkeleton::MissingOrExtraFields(available_format_pattern, _) => {
                 assert_eq!(
                     available_format_pattern
                         .expect_pattern("pattern should not have plural variants")
@@ -182,7 +182,7 @@ mod test {
             &Default::default(),
             false,
         ) {
-            BestSkeleton::AllFieldsMatch(available_format_pattern) => {
+            BestSkeleton::AllFieldsMatch(available_format_pattern, _) => {
                 // TODO - Append items are needed here.
                 assert_eq!(
                     available_format_pattern
@@ -376,7 +376,7 @@ mod test {
         let (_, skeletons) = get_data_payload();
 
         match get_best_available_format_pattern(&skeletons, &requested_fields, false) {
-            BestSkeleton::AllFieldsMatch(available_format_pattern) => {
+            BestSkeleton::AllFieldsMatch(available_format_pattern, _) => {
                 assert_eq!(
                     available_format_pattern
                         .expect_pattern("pattern should not have plural variants")
@@ -399,7 +399,7 @@ mod test {
         let (_, skeletons) = get_data_payload();
 
         match get_best_available_format_pattern(&skeletons, &requested_fields, false) {
-            BestSkeleton::AllFieldsMatch(available_format_pattern) => {
+            BestSkeleton::AllFieldsMatch(available_format_pattern, _) => {
                 assert_eq!(
                     available_format_pattern
                         .expect_pattern("pattern should not have plural variants")


### PR DESCRIPTION
The distinction of synthetic vs match is not enough (https://unicode-org.atlassian.net/browse/CLDR-18535).

I can achieve what I want by looking at the distance.