### PR TITLE
Rename ZonedDateTime::try_from_str to try_full_from_str

### DIFF
--- a/components/datetime/src/combo.rs
+++ b/components/datetime/src/combo.rs
@@ -129,7 +129,7 @@ use crate::{provider::neo::*, scaffold::*};
 /// )
 /// .unwrap();
 ///
-/// let zdt = ZonedDateTime::try_from_str(
+/// let zdt = ZonedDateTime::try_full_from_str(
 ///     "2024-10-18T15:44-0700[America/Los_Angeles]",
 ///     Gregorian,
 ///     IanaParser::new(),

--- a/components/datetime/src/parts.rs
+++ b/components/datetime/src/parts.rs
@@ -26,7 +26,7 @@
 //! )
 //! .unwrap();
 //!
-//! let dtz = ZonedDateTime::try_from_str("2023-11-20T11:35:03.5+00:00[Europe/London]", dtf.calendar(), IanaParser::new(), VariantOffsetsCalculator::new()).unwrap();
+//! let dtz = ZonedDateTime::try_full_from_str("2023-11-20T11:35:03.5+00:00[Europe/London]", dtf.calendar(), IanaParser::new(), VariantOffsetsCalculator::new()).unwrap();
 //!
 //! // Missing data is filled in on a best-effort basis, and an error is signaled.
 //! assert_writeable_parts_eq!(

--- a/components/datetime/src/pattern/formatter.rs
+++ b/components/datetime/src/pattern/formatter.rs
@@ -167,14 +167,14 @@ where
     /// use icu::time::zone::{IanaParser, VariantOffsetsCalculator};
     /// use writeable::TryWriteable;
     ///
-    /// let mut london_winter = ZonedDateTime::try_from_str(
+    /// let mut london_winter = ZonedDateTime::try_full_from_str(
     ///     "2024-01-01T00:00:00+00:00[Europe/London]",
     ///     Gregorian,
     ///     IanaParser::new(),
     ///     VariantOffsetsCalculator::new(),
     /// )
     /// .unwrap();
-    /// let mut london_summer = ZonedDateTime::try_from_str(
+    /// let mut london_summer = ZonedDateTime::try_full_from_str(
     ///     "2024-07-01T00:00:00+01:00[Europe/London]",
     ///     Gregorian,
     ///     IanaParser::new(),

--- a/components/datetime/src/pattern/names.rs
+++ b/components/datetime/src/pattern/names.rs
@@ -450,7 +450,7 @@ size_test!(
 /// // The pattern string contains lots of symbols including "E", "MMM", and "a",
 /// // but we did not load any data!
 ///
-/// let mut dtz = ZonedDateTime::try_from_str("2023-11-20T11:35:03+00:00[Europe/London]", Gregorian, IanaParser::new(), VariantOffsetsCalculator::new()).unwrap();
+/// let mut dtz = ZonedDateTime::try_full_from_str("2023-11-20T11:35:03+00:00[Europe/London]", Gregorian, IanaParser::new(), VariantOffsetsCalculator::new()).unwrap();
 ///
 /// // Missing data is filled in on a best-effort basis, and an error is signaled.
 /// assert_try_writeable_parts_eq!(
@@ -1583,7 +1583,7 @@ impl<C, FSet: DateTimeNamesMarker> FixedCalendarDateTimeNames<C, FSet> {
     /// use icu::time::zone::{IanaParser, VariantOffsetsCalculator};
     /// use writeable::assert_try_writeable_eq;
     ///
-    /// let mut zone_london_winter = ZonedDateTime::try_from_str(
+    /// let mut zone_london_winter = ZonedDateTime::try_full_from_str(
     ///     "2024-01-01T00:00:00+00:00[Europe/London]",
     ///     Gregorian,
     ///     IanaParser::new(),
@@ -1591,7 +1591,7 @@ impl<C, FSet: DateTimeNamesMarker> FixedCalendarDateTimeNames<C, FSet> {
     /// )
     /// .unwrap()
     /// .zone;
-    /// let mut zone_london_summer = ZonedDateTime::try_from_str(
+    /// let mut zone_london_summer = ZonedDateTime::try_full_from_str(
     ///     "2024-07-01T00:00:00+01:00[Europe/London]",
     ///     Gregorian,
     ///     IanaParser::new(),
@@ -1707,7 +1707,7 @@ impl<C, FSet: DateTimeNamesMarker> FixedCalendarDateTimeNames<C, FSet> {
     /// use icu::time::zone::{IanaParser, VariantOffsetsCalculator};
     /// use writeable::assert_try_writeable_eq;
     ///
-    /// let mut zone_london_winter = ZonedDateTime::try_from_str(
+    /// let mut zone_london_winter = ZonedDateTime::try_full_from_str(
     ///     "2024-01-01T00:00:00+00:00[Europe/London]",
     ///     Gregorian,
     ///     IanaParser::new(),
@@ -1779,7 +1779,7 @@ impl<C, FSet: DateTimeNamesMarker> FixedCalendarDateTimeNames<C, FSet> {
     /// use icu::time::zone::{IanaParser, VariantOffsetsCalculator};
     /// use writeable::assert_try_writeable_eq;
     ///
-    /// let mut zone_london_winter = ZonedDateTime::try_from_str(
+    /// let mut zone_london_winter = ZonedDateTime::try_full_from_str(
     ///     "2024-01-01T00:00:00+00:00[Europe/London]",
     ///     Gregorian,
     ///     IanaParser::new(),
@@ -1856,7 +1856,7 @@ impl<C, FSet: DateTimeNamesMarker> FixedCalendarDateTimeNames<C, FSet> {
     /// use icu::time::zone::{IanaParser, VariantOffsetsCalculator};
     /// use writeable::assert_try_writeable_eq;
     ///
-    /// let mut zone_london_winter = ZonedDateTime::try_from_str(
+    /// let mut zone_london_winter = ZonedDateTime::try_full_from_str(
     ///     "2024-01-01T00:00:00+00:00[Europe/London]",
     ///     Gregorian,
     ///     IanaParser::new(),
@@ -1864,7 +1864,7 @@ impl<C, FSet: DateTimeNamesMarker> FixedCalendarDateTimeNames<C, FSet> {
     /// )
     /// .unwrap()
     /// .zone;
-    /// let mut zone_london_summer = ZonedDateTime::try_from_str(
+    /// let mut zone_london_summer = ZonedDateTime::try_full_from_str(
     ///     "2024-07-01T00:00:00+01:00[Europe/London]",
     ///     Gregorian,
     ///     IanaParser::new(),
@@ -1947,7 +1947,7 @@ impl<C, FSet: DateTimeNamesMarker> FixedCalendarDateTimeNames<C, FSet> {
     /// use icu::time::zone::{IanaParser, VariantOffsetsCalculator};
     /// use writeable::assert_try_writeable_eq;
     ///
-    /// let mut zone_london_winter = ZonedDateTime::try_from_str(
+    /// let mut zone_london_winter = ZonedDateTime::try_full_from_str(
     ///     "2024-01-01T00:00:00+00:00[Europe/London]",
     ///     Gregorian,
     ///     IanaParser::new(),
@@ -1955,7 +1955,7 @@ impl<C, FSet: DateTimeNamesMarker> FixedCalendarDateTimeNames<C, FSet> {
     /// )
     /// .unwrap()
     /// .zone;
-    /// let mut zone_london_summer = ZonedDateTime::try_from_str(
+    /// let mut zone_london_summer = ZonedDateTime::try_full_from_str(
     ///     "2024-07-01T00:00:00+01:00[Europe/London]",
     ///     Gregorian,
     ///     IanaParser::new(),
@@ -2042,7 +2042,7 @@ impl<C, FSet: DateTimeNamesMarker> FixedCalendarDateTimeNames<C, FSet> {
     /// use icu::time::zone::{IanaParser, VariantOffsetsCalculator};
     /// use writeable::assert_try_writeable_eq;
     ///
-    /// let mut zone_london_winter = ZonedDateTime::try_from_str(
+    /// let mut zone_london_winter = ZonedDateTime::try_full_from_str(
     ///     "2024-01-01T00:00:00+00:00[Europe/London]",
     ///     Gregorian,
     ///     IanaParser::new(),
@@ -2050,7 +2050,7 @@ impl<C, FSet: DateTimeNamesMarker> FixedCalendarDateTimeNames<C, FSet> {
     /// )
     /// .unwrap()
     /// .zone;
-    /// let mut zone_london_summer = ZonedDateTime::try_from_str(
+    /// let mut zone_london_summer = ZonedDateTime::try_full_from_str(
     ///     "2024-07-01T00:00:00+01:00[Europe/London]",
     ///     Gregorian,
     ///     IanaParser::new(),
@@ -2129,7 +2129,7 @@ impl<C, FSet: DateTimeNamesMarker> FixedCalendarDateTimeNames<C, FSet> {
     /// use icu::time::zone::{IanaParser, VariantOffsetsCalculator};
     /// use writeable::assert_try_writeable_eq;
     ///
-    /// let mut zone_london_winter = ZonedDateTime::try_from_str(
+    /// let mut zone_london_winter = ZonedDateTime::try_full_from_str(
     ///     "2024-01-01T00:00:00+00:00[Europe/London]",
     ///     Gregorian,
     ///     IanaParser::new(),
@@ -2137,7 +2137,7 @@ impl<C, FSet: DateTimeNamesMarker> FixedCalendarDateTimeNames<C, FSet> {
     /// )
     /// .unwrap()
     /// .zone;
-    /// let mut zone_london_summer = ZonedDateTime::try_from_str(
+    /// let mut zone_london_summer = ZonedDateTime::try_full_from_str(
     ///     "2024-07-01T00:00:00+01:00[Europe/London]",
     ///     Gregorian,
     ///     IanaParser::new(),

--- a/components/datetime/tests/mock.rs
+++ b/components/datetime/tests/mock.rs
@@ -31,7 +31,7 @@ use icu_time::{
 pub fn parse_zoned_gregorian_from_str(
     input: &str,
 ) -> ZonedDateTime<Gregorian, TimeZoneInfo<models::Full>> {
-    match ZonedDateTime::try_from_str(
+    match ZonedDateTime::try_full_from_str(
         input,
         Gregorian,
         IanaParser::new(),

--- a/components/icu/examples/chrono_jiff.rs
+++ b/components/icu/examples/chrono_jiff.rs
@@ -26,7 +26,7 @@ fn main() {
             .with_timezone(&"Asia/Tokyo".parse().unwrap()),
     );
 
-    let from_ixdtf = ZonedDateTime::try_from_str(
+    let from_ixdtf = ZonedDateTime::try_full_from_str(
         "2024-09-11T08:37:20.123456789+09:00[Asia/Tokyo]",
         Iso,
         IanaParser::new(),

--- a/components/time/src/ixdtf.rs
+++ b/components/time/src/ixdtf.rs
@@ -454,7 +454,7 @@ impl<A: AsCalendar> ZonedDateTime<A, TimeZoneInfo<models::Full>> {
     /// };
     /// use icu::locale::subtags::subtag;
     ///
-    /// let zoneddatetime = ZonedDateTime::try_from_str(
+    /// let zoneddatetime = ZonedDateTime::try_full_from_str(
     ///     "2024-08-08T12:08:19-05:00[America/Chicago][u-ca=hebrew]",
     ///     Hebrew,
     ///     IanaParser::new(),
@@ -561,7 +561,7 @@ impl<A: AsCalendar> ZonedDateTime<A, TimeZoneInfo<models::Full>> {
     /// use icu::time::{TimeZoneInfo, ZonedDateTime, TimeZone, ParseError, zone::{UtcOffset, TimeZoneVariant, IanaParser, VariantOffsetsCalculator}};
     /// use icu::locale::subtags::subtag;
     ///
-    /// let consistent_tz_from_both = ZonedDateTime::try_from_str("2024-08-08T12:08:19-05:00[America/Chicago]", Iso, IanaParser::new(), VariantOffsetsCalculator::new()).unwrap();
+    /// let consistent_tz_from_both = ZonedDateTime::try_full_from_str("2024-08-08T12:08:19-05:00[America/Chicago]", Iso, IanaParser::new(), VariantOffsetsCalculator::new()).unwrap();
     ///
     ///
     /// assert_eq!(consistent_tz_from_both.zone.id(), TimeZone(subtag!("uschi")));
@@ -573,7 +573,7 @@ impl<A: AsCalendar> ZonedDateTime<A, TimeZoneInfo<models::Full>> {
     /// // time zone or the offset are wrong.
     /// // The only valid way to display this zoned datetime is "GMT-5", so we drop the time zone.
     /// assert_eq!(
-    ///     ZonedDateTime::try_from_str("2024-08-08T12:08:19-05:00[America/Los_Angeles]", Iso, IanaParser::new(), VariantOffsetsCalculator::new())
+    ///     ZonedDateTime::try_full_from_str("2024-08-08T12:08:19-05:00[America/Los_Angeles]", Iso, IanaParser::new(), VariantOffsetsCalculator::new())
     ///     .unwrap().zone.id(),
     ///     TimeZone::unknown()
     /// );
@@ -581,7 +581,7 @@ impl<A: AsCalendar> ZonedDateTime<A, TimeZoneInfo<models::Full>> {
     /// // We don't know that America/Los_Angeles didn't use standard time (-08:00) in August, but we have a
     /// // name for Los Angeles at -8 (Pacific Standard Time), so this parses successfully.
     /// assert!(
-    ///     ZonedDateTime::try_from_str("2024-08-08T12:08:19-08:00[America/Los_Angeles]", Iso, IanaParser::new(), VariantOffsetsCalculator::new()).is_ok()
+    ///     ZonedDateTime::try_full_from_str("2024-08-08T12:08:19-08:00[America/Los_Angeles]", Iso, IanaParser::new(), VariantOffsetsCalculator::new()).is_ok()
     /// );
     /// ```
     ///
@@ -617,13 +617,13 @@ impl<A: AsCalendar> ZonedDateTime<A, TimeZoneInfo<models::Full>> {
     ///     Err(ParseError::InconsistentTimeUtcOffsets)
     /// ));
     /// ```
-    pub fn try_from_str(
+    pub fn try_full_from_str(
         rfc_9557_str: &str,
         calendar: A,
         iana_parser: IanaParserBorrowed,
         offset_calculator: VariantOffsetsCalculatorBorrowed,
     ) -> Result<Self, ParseError> {
-        Self::try_from_utf8(
+        Self::try_full_from_utf8(
             rfc_9557_str.as_bytes(),
             calendar,
             iana_parser,
@@ -633,8 +633,8 @@ impl<A: AsCalendar> ZonedDateTime<A, TimeZoneInfo<models::Full>> {
 
     /// Create a [`ZonedDateTime`] in any calendar from RFC 9557 UTF-8 bytes.
     ///
-    /// See [`Self::try_from_str`].
-    pub fn try_from_utf8(
+    /// See [`Self::try_full_from_str`].
+    pub fn try_full_from_utf8(
         rfc_9557_str: &[u8],
         calendar: A,
         iana_parser: IanaParserBorrowed,

--- a/components/time/src/ixdtf.rs
+++ b/components/time/src/ixdtf.rs
@@ -407,7 +407,7 @@ impl<A: AsCalendar> ZonedDateTime<A, TimeZoneInfo<models::AtTime>> {
     /// neither. If the named time zone is missing, it is returned as Etc/Unknown.
     ///
     /// The zone variant is _not_ calculated with this function. If you need it, use
-    /// [`Self::try_from_str`].
+    /// [`Self::try_full_from_str`].
     pub fn try_lenient_from_str(
         rfc_9557_str: &str,
         calendar: A,

--- a/ffi/capi/bindings/c/ZonedDateTime.h
+++ b/ffi/capi/bindings/c/ZonedDateTime.h
@@ -19,8 +19,8 @@
 
 
 
-typedef struct icu4x_ZonedDateTime_from_string_mv1_result {union {ZonedDateTime ok; CalendarParseError err;}; bool is_ok;} icu4x_ZonedDateTime_from_string_mv1_result;
-icu4x_ZonedDateTime_from_string_mv1_result icu4x_ZonedDateTime_from_string_mv1(DiplomatStringView v, const Calendar* calendar, const IanaParser* iana_parser, const VariantOffsetsCalculator* offset_calculator);
+typedef struct icu4x_ZonedDateTime_full_from_string_mv1_result {union {ZonedDateTime ok; CalendarParseError err;}; bool is_ok;} icu4x_ZonedDateTime_full_from_string_mv1_result;
+icu4x_ZonedDateTime_full_from_string_mv1_result icu4x_ZonedDateTime_full_from_string_mv1(DiplomatStringView v, const Calendar* calendar, const IanaParser* iana_parser, const VariantOffsetsCalculator* offset_calculator);
 
 typedef struct icu4x_ZonedDateTime_location_only_from_string_mv1_result {union {ZonedDateTime ok; CalendarParseError err;}; bool is_ok;} icu4x_ZonedDateTime_location_only_from_string_mv1_result;
 icu4x_ZonedDateTime_location_only_from_string_mv1_result icu4x_ZonedDateTime_location_only_from_string_mv1(DiplomatStringView v, const Calendar* calendar, const IanaParser* iana_parser);
@@ -28,8 +28,8 @@ icu4x_ZonedDateTime_location_only_from_string_mv1_result icu4x_ZonedDateTime_loc
 typedef struct icu4x_ZonedDateTime_offset_only_from_string_mv1_result {union {ZonedDateTime ok; CalendarParseError err;}; bool is_ok;} icu4x_ZonedDateTime_offset_only_from_string_mv1_result;
 icu4x_ZonedDateTime_offset_only_from_string_mv1_result icu4x_ZonedDateTime_offset_only_from_string_mv1(DiplomatStringView v, const Calendar* calendar);
 
-typedef struct icu4x_ZonedDateTime_loose_from_string_mv1_result {union {ZonedDateTime ok; CalendarParseError err;}; bool is_ok;} icu4x_ZonedDateTime_loose_from_string_mv1_result;
-icu4x_ZonedDateTime_loose_from_string_mv1_result icu4x_ZonedDateTime_loose_from_string_mv1(DiplomatStringView v, const Calendar* calendar, const IanaParser* iana_parser);
+typedef struct icu4x_ZonedDateTime_lenient_from_string_mv1_result {union {ZonedDateTime ok; CalendarParseError err;}; bool is_ok;} icu4x_ZonedDateTime_lenient_from_string_mv1_result;
+icu4x_ZonedDateTime_lenient_from_string_mv1_result icu4x_ZonedDateTime_lenient_from_string_mv1(DiplomatStringView v, const Calendar* calendar, const IanaParser* iana_parser);
 
 
 

--- a/ffi/capi/bindings/c/ZonedIsoDateTime.h
+++ b/ffi/capi/bindings/c/ZonedIsoDateTime.h
@@ -18,8 +18,8 @@
 
 
 
-typedef struct icu4x_ZonedIsoDateTime_from_string_mv1_result {union {ZonedIsoDateTime ok; CalendarParseError err;}; bool is_ok;} icu4x_ZonedIsoDateTime_from_string_mv1_result;
-icu4x_ZonedIsoDateTime_from_string_mv1_result icu4x_ZonedIsoDateTime_from_string_mv1(DiplomatStringView v, const IanaParser* iana_parser, const VariantOffsetsCalculator* offset_calculator);
+typedef struct icu4x_ZonedIsoDateTime_full_from_string_mv1_result {union {ZonedIsoDateTime ok; CalendarParseError err;}; bool is_ok;} icu4x_ZonedIsoDateTime_full_from_string_mv1_result;
+icu4x_ZonedIsoDateTime_full_from_string_mv1_result icu4x_ZonedIsoDateTime_full_from_string_mv1(DiplomatStringView v, const IanaParser* iana_parser, const VariantOffsetsCalculator* offset_calculator);
 
 
 

--- a/ffi/capi/bindings/cpp/icu4x/ZonedDateTime.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/ZonedDateTime.d.hpp
@@ -55,9 +55,9 @@ struct ZonedDateTime {
   /**
    * Creates a new [`ZonedDateTime`] from an IXDTF string.
    *
-   * See the [Rust documentation for `try_from_str`](https://docs.rs/icu/latest/icu/time/struct.ZonedDateTime.html#method.try_from_str) for more information.
+   * See the [Rust documentation for `try_full_from_str`](https://docs.rs/icu/latest/icu/time/struct.ZonedDateTime.html#method.try_full_from_str) for more information.
    */
-  inline static diplomat::result<icu4x::ZonedDateTime, icu4x::CalendarParseError> from_string(std::string_view v, const icu4x::Calendar& calendar, const icu4x::IanaParser& iana_parser, const icu4x::VariantOffsetsCalculator& offset_calculator);
+  inline static diplomat::result<icu4x::ZonedDateTime, icu4x::CalendarParseError> full_from_string(std::string_view v, const icu4x::Calendar& calendar, const icu4x::IanaParser& iana_parser, const icu4x::VariantOffsetsCalculator& offset_calculator);
 
   /**
    * Creates a new [`ZonedDateTime`] from a location-only IXDTF string.
@@ -78,7 +78,7 @@ struct ZonedDateTime {
    *
    * See the [Rust documentation for `try_lenient_from_str`](https://docs.rs/icu/latest/icu/time/struct.ZonedDateTime.html#method.try_lenient_from_str) for more information.
    */
-  inline static diplomat::result<icu4x::ZonedDateTime, icu4x::CalendarParseError> loose_from_string(std::string_view v, const icu4x::Calendar& calendar, const icu4x::IanaParser& iana_parser);
+  inline static diplomat::result<icu4x::ZonedDateTime, icu4x::CalendarParseError> lenient_from_string(std::string_view v, const icu4x::Calendar& calendar, const icu4x::IanaParser& iana_parser);
 
   inline icu4x::capi::ZonedDateTime AsFFI() const;
   inline static icu4x::ZonedDateTime FromFFI(icu4x::capi::ZonedDateTime c_struct);

--- a/ffi/capi/bindings/cpp/icu4x/ZonedDateTime.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/ZonedDateTime.hpp
@@ -24,8 +24,8 @@ namespace icu4x {
 namespace capi {
     extern "C" {
     
-    typedef struct icu4x_ZonedDateTime_from_string_mv1_result {union {icu4x::capi::ZonedDateTime ok; icu4x::capi::CalendarParseError err;}; bool is_ok;} icu4x_ZonedDateTime_from_string_mv1_result;
-    icu4x_ZonedDateTime_from_string_mv1_result icu4x_ZonedDateTime_from_string_mv1(diplomat::capi::DiplomatStringView v, const icu4x::capi::Calendar* calendar, const icu4x::capi::IanaParser* iana_parser, const icu4x::capi::VariantOffsetsCalculator* offset_calculator);
+    typedef struct icu4x_ZonedDateTime_full_from_string_mv1_result {union {icu4x::capi::ZonedDateTime ok; icu4x::capi::CalendarParseError err;}; bool is_ok;} icu4x_ZonedDateTime_full_from_string_mv1_result;
+    icu4x_ZonedDateTime_full_from_string_mv1_result icu4x_ZonedDateTime_full_from_string_mv1(diplomat::capi::DiplomatStringView v, const icu4x::capi::Calendar* calendar, const icu4x::capi::IanaParser* iana_parser, const icu4x::capi::VariantOffsetsCalculator* offset_calculator);
     
     typedef struct icu4x_ZonedDateTime_location_only_from_string_mv1_result {union {icu4x::capi::ZonedDateTime ok; icu4x::capi::CalendarParseError err;}; bool is_ok;} icu4x_ZonedDateTime_location_only_from_string_mv1_result;
     icu4x_ZonedDateTime_location_only_from_string_mv1_result icu4x_ZonedDateTime_location_only_from_string_mv1(diplomat::capi::DiplomatStringView v, const icu4x::capi::Calendar* calendar, const icu4x::capi::IanaParser* iana_parser);
@@ -33,16 +33,16 @@ namespace capi {
     typedef struct icu4x_ZonedDateTime_offset_only_from_string_mv1_result {union {icu4x::capi::ZonedDateTime ok; icu4x::capi::CalendarParseError err;}; bool is_ok;} icu4x_ZonedDateTime_offset_only_from_string_mv1_result;
     icu4x_ZonedDateTime_offset_only_from_string_mv1_result icu4x_ZonedDateTime_offset_only_from_string_mv1(diplomat::capi::DiplomatStringView v, const icu4x::capi::Calendar* calendar);
     
-    typedef struct icu4x_ZonedDateTime_loose_from_string_mv1_result {union {icu4x::capi::ZonedDateTime ok; icu4x::capi::CalendarParseError err;}; bool is_ok;} icu4x_ZonedDateTime_loose_from_string_mv1_result;
-    icu4x_ZonedDateTime_loose_from_string_mv1_result icu4x_ZonedDateTime_loose_from_string_mv1(diplomat::capi::DiplomatStringView v, const icu4x::capi::Calendar* calendar, const icu4x::capi::IanaParser* iana_parser);
+    typedef struct icu4x_ZonedDateTime_lenient_from_string_mv1_result {union {icu4x::capi::ZonedDateTime ok; icu4x::capi::CalendarParseError err;}; bool is_ok;} icu4x_ZonedDateTime_lenient_from_string_mv1_result;
+    icu4x_ZonedDateTime_lenient_from_string_mv1_result icu4x_ZonedDateTime_lenient_from_string_mv1(diplomat::capi::DiplomatStringView v, const icu4x::capi::Calendar* calendar, const icu4x::capi::IanaParser* iana_parser);
     
     
     } // extern "C"
 } // namespace capi
 } // namespace
 
-inline diplomat::result<icu4x::ZonedDateTime, icu4x::CalendarParseError> icu4x::ZonedDateTime::from_string(std::string_view v, const icu4x::Calendar& calendar, const icu4x::IanaParser& iana_parser, const icu4x::VariantOffsetsCalculator& offset_calculator) {
-  auto result = icu4x::capi::icu4x_ZonedDateTime_from_string_mv1({v.data(), v.size()},
+inline diplomat::result<icu4x::ZonedDateTime, icu4x::CalendarParseError> icu4x::ZonedDateTime::full_from_string(std::string_view v, const icu4x::Calendar& calendar, const icu4x::IanaParser& iana_parser, const icu4x::VariantOffsetsCalculator& offset_calculator) {
+  auto result = icu4x::capi::icu4x_ZonedDateTime_full_from_string_mv1({v.data(), v.size()},
     calendar.AsFFI(),
     iana_parser.AsFFI(),
     offset_calculator.AsFFI());
@@ -62,8 +62,8 @@ inline diplomat::result<icu4x::ZonedDateTime, icu4x::CalendarParseError> icu4x::
   return result.is_ok ? diplomat::result<icu4x::ZonedDateTime, icu4x::CalendarParseError>(diplomat::Ok<icu4x::ZonedDateTime>(icu4x::ZonedDateTime::FromFFI(result.ok))) : diplomat::result<icu4x::ZonedDateTime, icu4x::CalendarParseError>(diplomat::Err<icu4x::CalendarParseError>(icu4x::CalendarParseError::FromFFI(result.err)));
 }
 
-inline diplomat::result<icu4x::ZonedDateTime, icu4x::CalendarParseError> icu4x::ZonedDateTime::loose_from_string(std::string_view v, const icu4x::Calendar& calendar, const icu4x::IanaParser& iana_parser) {
-  auto result = icu4x::capi::icu4x_ZonedDateTime_loose_from_string_mv1({v.data(), v.size()},
+inline diplomat::result<icu4x::ZonedDateTime, icu4x::CalendarParseError> icu4x::ZonedDateTime::lenient_from_string(std::string_view v, const icu4x::Calendar& calendar, const icu4x::IanaParser& iana_parser) {
+  auto result = icu4x::capi::icu4x_ZonedDateTime_lenient_from_string_mv1({v.data(), v.size()},
     calendar.AsFFI(),
     iana_parser.AsFFI());
   return result.is_ok ? diplomat::result<icu4x::ZonedDateTime, icu4x::CalendarParseError>(diplomat::Ok<icu4x::ZonedDateTime>(icu4x::ZonedDateTime::FromFFI(result.ok))) : diplomat::result<icu4x::ZonedDateTime, icu4x::CalendarParseError>(diplomat::Err<icu4x::CalendarParseError>(icu4x::CalendarParseError::FromFFI(result.err)));

--- a/ffi/capi/bindings/cpp/icu4x/ZonedIsoDateTime.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/ZonedIsoDateTime.d.hpp
@@ -53,9 +53,9 @@ struct ZonedIsoDateTime {
   /**
    * Creates a new [`ZonedIsoDateTime`] from an IXDTF string.
    *
-   * See the [Rust documentation for `try_from_str`](https://docs.rs/icu/latest/icu/time/struct.ZonedDateTime.html#method.try_from_str) for more information.
+   * See the [Rust documentation for `try_full_from_str`](https://docs.rs/icu/latest/icu/time/struct.ZonedDateTime.html#method.try_full_from_str) for more information.
    */
-  inline static diplomat::result<icu4x::ZonedIsoDateTime, icu4x::CalendarParseError> from_string(std::string_view v, const icu4x::IanaParser& iana_parser, const icu4x::VariantOffsetsCalculator& offset_calculator);
+  inline static diplomat::result<icu4x::ZonedIsoDateTime, icu4x::CalendarParseError> full_from_string(std::string_view v, const icu4x::IanaParser& iana_parser, const icu4x::VariantOffsetsCalculator& offset_calculator);
 
   inline icu4x::capi::ZonedIsoDateTime AsFFI() const;
   inline static icu4x::ZonedIsoDateTime FromFFI(icu4x::capi::ZonedIsoDateTime c_struct);

--- a/ffi/capi/bindings/cpp/icu4x/ZonedIsoDateTime.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/ZonedIsoDateTime.hpp
@@ -23,16 +23,16 @@ namespace icu4x {
 namespace capi {
     extern "C" {
     
-    typedef struct icu4x_ZonedIsoDateTime_from_string_mv1_result {union {icu4x::capi::ZonedIsoDateTime ok; icu4x::capi::CalendarParseError err;}; bool is_ok;} icu4x_ZonedIsoDateTime_from_string_mv1_result;
-    icu4x_ZonedIsoDateTime_from_string_mv1_result icu4x_ZonedIsoDateTime_from_string_mv1(diplomat::capi::DiplomatStringView v, const icu4x::capi::IanaParser* iana_parser, const icu4x::capi::VariantOffsetsCalculator* offset_calculator);
+    typedef struct icu4x_ZonedIsoDateTime_full_from_string_mv1_result {union {icu4x::capi::ZonedIsoDateTime ok; icu4x::capi::CalendarParseError err;}; bool is_ok;} icu4x_ZonedIsoDateTime_full_from_string_mv1_result;
+    icu4x_ZonedIsoDateTime_full_from_string_mv1_result icu4x_ZonedIsoDateTime_full_from_string_mv1(diplomat::capi::DiplomatStringView v, const icu4x::capi::IanaParser* iana_parser, const icu4x::capi::VariantOffsetsCalculator* offset_calculator);
     
     
     } // extern "C"
 } // namespace capi
 } // namespace
 
-inline diplomat::result<icu4x::ZonedIsoDateTime, icu4x::CalendarParseError> icu4x::ZonedIsoDateTime::from_string(std::string_view v, const icu4x::IanaParser& iana_parser, const icu4x::VariantOffsetsCalculator& offset_calculator) {
-  auto result = icu4x::capi::icu4x_ZonedIsoDateTime_from_string_mv1({v.data(), v.size()},
+inline diplomat::result<icu4x::ZonedIsoDateTime, icu4x::CalendarParseError> icu4x::ZonedIsoDateTime::full_from_string(std::string_view v, const icu4x::IanaParser& iana_parser, const icu4x::VariantOffsetsCalculator& offset_calculator) {
+  auto result = icu4x::capi::icu4x_ZonedIsoDateTime_full_from_string_mv1({v.data(), v.size()},
     iana_parser.AsFFI(),
     offset_calculator.AsFFI());
   return result.is_ok ? diplomat::result<icu4x::ZonedIsoDateTime, icu4x::CalendarParseError>(diplomat::Ok<icu4x::ZonedIsoDateTime>(icu4x::ZonedIsoDateTime::FromFFI(result.ok))) : diplomat::result<icu4x::ZonedIsoDateTime, icu4x::CalendarParseError>(diplomat::Err<icu4x::CalendarParseError>(icu4x::CalendarParseError::FromFFI(result.err)));

--- a/ffi/capi/bindings/dart/ZonedDateTime.g.dart
+++ b/ffi/capi/bindings/dart/ZonedDateTime.g.dart
@@ -39,12 +39,12 @@ final class ZonedDateTime {
 
   /// Creates a new [`ZonedDateTime`] from an IXDTF string.
   ///
-  /// See the [Rust documentation for `try_from_str`](https://docs.rs/icu/latest/icu/time/struct.ZonedDateTime.html#method.try_from_str) for more information.
+  /// See the [Rust documentation for `try_full_from_str`](https://docs.rs/icu/latest/icu/time/struct.ZonedDateTime.html#method.try_full_from_str) for more information.
   ///
   /// Throws [CalendarParseError] on failure.
-  factory ZonedDateTime.fromString(String v, Calendar calendar, IanaParser ianaParser, VariantOffsetsCalculator offsetCalculator) {
+  factory ZonedDateTime.fullFromString(String v, Calendar calendar, IanaParser ianaParser, VariantOffsetsCalculator offsetCalculator) {
     final temp = _FinalizedArena();
-    final result = _icu4x_ZonedDateTime_from_string_mv1(v._utf8AllocIn(temp.arena), calendar._ffi, ianaParser._ffi, offsetCalculator._ffi);
+    final result = _icu4x_ZonedDateTime_full_from_string_mv1(v._utf8AllocIn(temp.arena), calendar._ffi, ianaParser._ffi, offsetCalculator._ffi);
     if (!result.isOk) {
       throw CalendarParseError.values[result.union.err];
     }
@@ -84,9 +84,9 @@ final class ZonedDateTime {
   /// See the [Rust documentation for `try_lenient_from_str`](https://docs.rs/icu/latest/icu/time/struct.ZonedDateTime.html#method.try_lenient_from_str) for more information.
   ///
   /// Throws [CalendarParseError] on failure.
-  factory ZonedDateTime.looseFromString(String v, Calendar calendar, IanaParser ianaParser) {
+  factory ZonedDateTime.lenientFromString(String v, Calendar calendar, IanaParser ianaParser) {
     final temp = _FinalizedArena();
-    final result = _icu4x_ZonedDateTime_loose_from_string_mv1(v._utf8AllocIn(temp.arena), calendar._ffi, ianaParser._ffi);
+    final result = _icu4x_ZonedDateTime_lenient_from_string_mv1(v._utf8AllocIn(temp.arena), calendar._ffi, ianaParser._ffi);
     if (!result.isOk) {
       throw CalendarParseError.values[result.union.err];
     }
@@ -108,10 +108,10 @@ final class ZonedDateTime {
       ]);
 }
 
-@_DiplomatFfiUse('icu4x_ZonedDateTime_from_string_mv1')
-@ffi.Native<_ResultZonedDateTimeFfiInt32 Function(_SliceUtf8, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTime_from_string_mv1')
+@_DiplomatFfiUse('icu4x_ZonedDateTime_full_from_string_mv1')
+@ffi.Native<_ResultZonedDateTimeFfiInt32 Function(_SliceUtf8, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTime_full_from_string_mv1')
 // ignore: non_constant_identifier_names
-external _ResultZonedDateTimeFfiInt32 _icu4x_ZonedDateTime_from_string_mv1(_SliceUtf8 v, ffi.Pointer<ffi.Opaque> calendar, ffi.Pointer<ffi.Opaque> ianaParser, ffi.Pointer<ffi.Opaque> offsetCalculator);
+external _ResultZonedDateTimeFfiInt32 _icu4x_ZonedDateTime_full_from_string_mv1(_SliceUtf8 v, ffi.Pointer<ffi.Opaque> calendar, ffi.Pointer<ffi.Opaque> ianaParser, ffi.Pointer<ffi.Opaque> offsetCalculator);
 
 @_DiplomatFfiUse('icu4x_ZonedDateTime_location_only_from_string_mv1')
 @ffi.Native<_ResultZonedDateTimeFfiInt32 Function(_SliceUtf8, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTime_location_only_from_string_mv1')
@@ -123,9 +123,9 @@ external _ResultZonedDateTimeFfiInt32 _icu4x_ZonedDateTime_location_only_from_st
 // ignore: non_constant_identifier_names
 external _ResultZonedDateTimeFfiInt32 _icu4x_ZonedDateTime_offset_only_from_string_mv1(_SliceUtf8 v, ffi.Pointer<ffi.Opaque> calendar);
 
-@_DiplomatFfiUse('icu4x_ZonedDateTime_loose_from_string_mv1')
-@ffi.Native<_ResultZonedDateTimeFfiInt32 Function(_SliceUtf8, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTime_loose_from_string_mv1')
+@_DiplomatFfiUse('icu4x_ZonedDateTime_lenient_from_string_mv1')
+@ffi.Native<_ResultZonedDateTimeFfiInt32 Function(_SliceUtf8, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTime_lenient_from_string_mv1')
 // ignore: non_constant_identifier_names
-external _ResultZonedDateTimeFfiInt32 _icu4x_ZonedDateTime_loose_from_string_mv1(_SliceUtf8 v, ffi.Pointer<ffi.Opaque> calendar, ffi.Pointer<ffi.Opaque> ianaParser);
+external _ResultZonedDateTimeFfiInt32 _icu4x_ZonedDateTime_lenient_from_string_mv1(_SliceUtf8 v, ffi.Pointer<ffi.Opaque> calendar, ffi.Pointer<ffi.Opaque> ianaParser);
 
 // dart format on

--- a/ffi/capi/bindings/dart/ZonedIsoDateTime.g.dart
+++ b/ffi/capi/bindings/dart/ZonedIsoDateTime.g.dart
@@ -39,12 +39,12 @@ final class ZonedIsoDateTime {
 
   /// Creates a new [`ZonedIsoDateTime`] from an IXDTF string.
   ///
-  /// See the [Rust documentation for `try_from_str`](https://docs.rs/icu/latest/icu/time/struct.ZonedDateTime.html#method.try_from_str) for more information.
+  /// See the [Rust documentation for `try_full_from_str`](https://docs.rs/icu/latest/icu/time/struct.ZonedDateTime.html#method.try_full_from_str) for more information.
   ///
   /// Throws [CalendarParseError] on failure.
-  factory ZonedIsoDateTime.fromString(String v, IanaParser ianaParser, VariantOffsetsCalculator offsetCalculator) {
+  factory ZonedIsoDateTime.fullFromString(String v, IanaParser ianaParser, VariantOffsetsCalculator offsetCalculator) {
     final temp = _FinalizedArena();
-    final result = _icu4x_ZonedIsoDateTime_from_string_mv1(v._utf8AllocIn(temp.arena), ianaParser._ffi, offsetCalculator._ffi);
+    final result = _icu4x_ZonedIsoDateTime_full_from_string_mv1(v._utf8AllocIn(temp.arena), ianaParser._ffi, offsetCalculator._ffi);
     if (!result.isOk) {
       throw CalendarParseError.values[result.union.err];
     }
@@ -66,9 +66,9 @@ final class ZonedIsoDateTime {
       ]);
 }
 
-@_DiplomatFfiUse('icu4x_ZonedIsoDateTime_from_string_mv1')
-@ffi.Native<_ResultZonedIsoDateTimeFfiInt32 Function(_SliceUtf8, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedIsoDateTime_from_string_mv1')
+@_DiplomatFfiUse('icu4x_ZonedIsoDateTime_full_from_string_mv1')
+@ffi.Native<_ResultZonedIsoDateTimeFfiInt32 Function(_SliceUtf8, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedIsoDateTime_full_from_string_mv1')
 // ignore: non_constant_identifier_names
-external _ResultZonedIsoDateTimeFfiInt32 _icu4x_ZonedIsoDateTime_from_string_mv1(_SliceUtf8 v, ffi.Pointer<ffi.Opaque> ianaParser, ffi.Pointer<ffi.Opaque> offsetCalculator);
+external _ResultZonedIsoDateTimeFfiInt32 _icu4x_ZonedIsoDateTime_full_from_string_mv1(_SliceUtf8 v, ffi.Pointer<ffi.Opaque> ianaParser, ffi.Pointer<ffi.Opaque> offsetCalculator);
 
 // dart format on

--- a/ffi/capi/bindings/js/ZonedDateTime.d.ts
+++ b/ffi/capi/bindings/js/ZonedDateTime.d.ts
@@ -28,9 +28,9 @@ export class ZonedDateTime {
     /** 
      * Creates a new [`ZonedDateTime`] from an IXDTF string.
      *
-     * See the [Rust documentation for `try_from_str`](https://docs.rs/icu/latest/icu/time/struct.ZonedDateTime.html#method.try_from_str) for more information.
+     * See the [Rust documentation for `try_full_from_str`](https://docs.rs/icu/latest/icu/time/struct.ZonedDateTime.html#method.try_full_from_str) for more information.
      */
-    static fromString(v: string, calendar: Calendar, ianaParser: IanaParser, offsetCalculator: VariantOffsetsCalculator): ZonedDateTime;
+    static fullFromString(v: string, calendar: Calendar, ianaParser: IanaParser, offsetCalculator: VariantOffsetsCalculator): ZonedDateTime;
 
     /** 
      * Creates a new [`ZonedDateTime`] from a location-only IXDTF string.
@@ -51,5 +51,5 @@ export class ZonedDateTime {
      *
      * See the [Rust documentation for `try_lenient_from_str`](https://docs.rs/icu/latest/icu/time/struct.ZonedDateTime.html#method.try_lenient_from_str) for more information.
      */
-    static looseFromString(v: string, calendar: Calendar, ianaParser: IanaParser): ZonedDateTime;
+    static lenientFromString(v: string, calendar: Calendar, ianaParser: IanaParser): ZonedDateTime;
 }

--- a/ffi/capi/bindings/js/ZonedDateTime.mjs
+++ b/ffi/capi/bindings/js/ZonedDateTime.mjs
@@ -122,16 +122,16 @@ export class ZonedDateTime {
     /** 
      * Creates a new [`ZonedDateTime`] from an IXDTF string.
      *
-     * See the [Rust documentation for `try_from_str`](https://docs.rs/icu/latest/icu/time/struct.ZonedDateTime.html#method.try_from_str) for more information.
+     * See the [Rust documentation for `try_full_from_str`](https://docs.rs/icu/latest/icu/time/struct.ZonedDateTime.html#method.try_full_from_str) for more information.
      */
-    static fromString(v, calendar, ianaParser, offsetCalculator) {
+    static fullFromString(v, calendar, ianaParser, offsetCalculator) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
         const vSlice = diplomatRuntime.DiplomatBuf.str8(wasm, v);
         
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 13, 4, true);
         
-        const result = wasm.icu4x_ZonedDateTime_from_string_mv1(diplomatReceive.buffer, ...vSlice.splat(), calendar.ffiValue, ianaParser.ffiValue, offsetCalculator.ffiValue);
+        const result = wasm.icu4x_ZonedDateTime_full_from_string_mv1(diplomatReceive.buffer, ...vSlice.splat(), calendar.ffiValue, ianaParser.ffiValue, offsetCalculator.ffiValue);
     
         try {
             if (!diplomatReceive.resultFlag) {
@@ -211,14 +211,14 @@ export class ZonedDateTime {
      *
      * See the [Rust documentation for `try_lenient_from_str`](https://docs.rs/icu/latest/icu/time/struct.ZonedDateTime.html#method.try_lenient_from_str) for more information.
      */
-    static looseFromString(v, calendar, ianaParser) {
+    static lenientFromString(v, calendar, ianaParser) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
         const vSlice = diplomatRuntime.DiplomatBuf.str8(wasm, v);
         
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 13, 4, true);
         
-        const result = wasm.icu4x_ZonedDateTime_loose_from_string_mv1(diplomatReceive.buffer, ...vSlice.splat(), calendar.ffiValue, ianaParser.ffiValue);
+        const result = wasm.icu4x_ZonedDateTime_lenient_from_string_mv1(diplomatReceive.buffer, ...vSlice.splat(), calendar.ffiValue, ianaParser.ffiValue);
     
         try {
             if (!diplomatReceive.resultFlag) {

--- a/ffi/capi/bindings/js/ZonedIsoDateTime.d.ts
+++ b/ffi/capi/bindings/js/ZonedIsoDateTime.d.ts
@@ -27,7 +27,7 @@ export class ZonedIsoDateTime {
     /** 
      * Creates a new [`ZonedIsoDateTime`] from an IXDTF string.
      *
-     * See the [Rust documentation for `try_from_str`](https://docs.rs/icu/latest/icu/time/struct.ZonedDateTime.html#method.try_from_str) for more information.
+     * See the [Rust documentation for `try_full_from_str`](https://docs.rs/icu/latest/icu/time/struct.ZonedDateTime.html#method.try_full_from_str) for more information.
      */
-    static fromString(v: string, ianaParser: IanaParser, offsetCalculator: VariantOffsetsCalculator): ZonedIsoDateTime;
+    static fullFromString(v: string, ianaParser: IanaParser, offsetCalculator: VariantOffsetsCalculator): ZonedIsoDateTime;
 }

--- a/ffi/capi/bindings/js/ZonedIsoDateTime.mjs
+++ b/ffi/capi/bindings/js/ZonedIsoDateTime.mjs
@@ -121,16 +121,16 @@ export class ZonedIsoDateTime {
     /** 
      * Creates a new [`ZonedIsoDateTime`] from an IXDTF string.
      *
-     * See the [Rust documentation for `try_from_str`](https://docs.rs/icu/latest/icu/time/struct.ZonedDateTime.html#method.try_from_str) for more information.
+     * See the [Rust documentation for `try_full_from_str`](https://docs.rs/icu/latest/icu/time/struct.ZonedDateTime.html#method.try_full_from_str) for more information.
      */
-    static fromString(v, ianaParser, offsetCalculator) {
+    static fullFromString(v, ianaParser, offsetCalculator) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
         
         const vSlice = diplomatRuntime.DiplomatBuf.str8(wasm, v);
         
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 13, 4, true);
         
-        const result = wasm.icu4x_ZonedIsoDateTime_from_string_mv1(diplomatReceive.buffer, ...vSlice.splat(), ianaParser.ffiValue, offsetCalculator.ffiValue);
+        const result = wasm.icu4x_ZonedIsoDateTime_full_from_string_mv1(diplomatReceive.buffer, ...vSlice.splat(), ianaParser.ffiValue, offsetCalculator.ffiValue);
     
         try {
             if (!diplomatReceive.resultFlag) {

--- a/ffi/capi/src/zoned_datetime.rs
+++ b/ffi/capi/src/zoned_datetime.rs
@@ -28,16 +28,16 @@ pub mod ffi {
 
     impl ZonedIsoDateTime {
         /// Creates a new [`ZonedIsoDateTime`] from an IXDTF string.
-        #[diplomat::rust_link(icu::time::ZonedDateTime::try_from_str, FnInStruct)]
+        #[diplomat::rust_link(icu::time::ZonedDateTime::try_full_from_str, FnInStruct)]
         #[diplomat::rust_link(icu::time::ZonedDateTime::try_from_utf8, FnInStruct, hidden)]
-        #[diplomat::attr(all(supports = named_constructors, supports = fallible_constructors), named_constructor = "from_string")]
-        pub fn from_string(
+        #[diplomat::attr(all(supports = named_constructors, supports = fallible_constructors), named_constructor = "full_from_string")]
+        pub fn full_from_string(
             v: &DiplomatStr,
             iana_parser: &IanaParser,
             offset_calculator: &VariantOffsetsCalculator,
         ) -> Result<ZonedIsoDateTime, CalendarParseError> {
             let icu_time::ZonedDateTime { date, time, zone } =
-                icu_time::ZonedDateTime::try_from_utf8(
+                icu_time::ZonedDateTime::try_full_from_utf8(
                     v,
                     Iso,
                     iana_parser.0.as_borrowed(),
@@ -62,17 +62,17 @@ pub mod ffi {
 
     impl ZonedDateTime {
         /// Creates a new [`ZonedDateTime`] from an IXDTF string.
-        #[diplomat::rust_link(icu::time::ZonedDateTime::try_from_str, FnInStruct)]
+        #[diplomat::rust_link(icu::time::ZonedDateTime::try_full_from_str, FnInStruct)]
         #[diplomat::rust_link(icu::time::ZonedDateTime::try_from_utf8, FnInStruct, hidden)]
-        #[diplomat::attr(all(supports = named_constructors, supports = fallible_constructors), named_constructor = "from_string")]
-        pub fn from_string(
+        #[diplomat::attr(all(supports = named_constructors, supports = fallible_constructors), named_constructor = "full_from_string")]
+        pub fn full_from_string(
             v: &DiplomatStr,
             calendar: &Calendar,
             iana_parser: &IanaParser,
             offset_calculator: &VariantOffsetsCalculator,
         ) -> Result<ZonedDateTime, CalendarParseError> {
             let icu_time::ZonedDateTime { date, time, zone } =
-                icu_time::ZonedDateTime::try_from_utf8(
+                icu_time::ZonedDateTime::try_full_from_utf8(
                     v,
                     calendar.0.clone(),
                     iana_parser.0.as_borrowed(),
@@ -135,8 +135,8 @@ pub mod ffi {
         /// Creates a new [`ZonedDateTime`] from an IXDTF string, without requiring the offset or calculating the zone variant.
         #[diplomat::rust_link(icu::time::ZonedDateTime::try_lenient_from_str, FnInStruct)]
         #[diplomat::rust_link(icu::time::ZonedDateTime::try_lenient_from_utf8, FnInStruct, hidden)]
-        #[diplomat::attr(all(supports = named_constructors, supports = fallible_constructors), named_constructor = "loose_from_string")]
-        pub fn loose_from_string(
+        #[diplomat::attr(all(supports = named_constructors, supports = fallible_constructors), named_constructor = "lenient_from_string")]
+        pub fn lenient_from_string(
             v: &DiplomatStr,
             calendar: &Calendar,
             iana_parser: &IanaParser,

--- a/ffi/capi/src/zoned_datetime.rs
+++ b/ffi/capi/src/zoned_datetime.rs
@@ -29,7 +29,7 @@ pub mod ffi {
     impl ZonedIsoDateTime {
         /// Creates a new [`ZonedIsoDateTime`] from an IXDTF string.
         #[diplomat::rust_link(icu::time::ZonedDateTime::try_full_from_str, FnInStruct)]
-        #[diplomat::rust_link(icu::time::ZonedDateTime::try_from_utf8, FnInStruct, hidden)]
+        #[diplomat::rust_link(icu::time::ZonedDateTime::try_full_from_utf8, FnInStruct, hidden)]
         #[diplomat::attr(all(supports = named_constructors, supports = fallible_constructors), named_constructor = "full_from_string")]
         pub fn full_from_string(
             v: &DiplomatStr,

--- a/ffi/dart/test/icu_test.dart
+++ b/ffi/dart/test/icu_test.dart
@@ -82,13 +82,13 @@ void main() {
   });
 
   test('DateTime formatting', () {
-    final zonedDateTimeIso = ZonedIsoDateTime.fromString(
+    final zonedDateTimeIso = ZonedIsoDateTime.fullFromString(
       '2025-01-15T14:32:12.34+01[Europe/Zurich]',
       IanaParser(),
       VariantOffsetsCalculator(),
     );
 
-    final zonedDateTimeBuddhist = ZonedDateTime.fromString(
+    final zonedDateTimeBuddhist = ZonedDateTime.fullFromString(
       '2026-01-15T05:32:12.34+07[Asia/Bangkok][u-ca=buddhist]',
       Calendar(CalendarKind.buddhist),
       IanaParser(),


### PR DESCRIPTION
Part of #6354

Related to #6489

The function's signature and behavior are unintuitive and confusing. If we want to add back `try_from_str`, we can do it later. Let's not waste the name on the current function.