### PR TITLE
Docs should say ZonedIsoDateTime

### DIFF
--- a/ffi/capi/bindings/cpp/icu4x/ZonedIsoDateTime.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/ZonedIsoDateTime.d.hpp
@@ -60,9 +60,9 @@ struct ZonedIsoDateTime {
   inline static diplomat::result<icu4x::ZonedIsoDateTime, icu4x::CalendarParseError> full_from_string(std::string_view v, const icu4x::IanaParser& iana_parser, const icu4x::VariantOffsetsCalculator& offset_calculator);
 
   /**
-   * Creates a new [`ZonedDateTime`] from milliseconds since epoch (timestamp) and a UTC offset.
+   * Creates a new [`ZonedIsoDateTime`] from milliseconds since epoch (timestamp) and a UTC offset.
    *
-   * Note: [`ZonedDateTime`]s created with this constructor can only be formatted using localized offset zone styles.
+   * Note: [`ZonedIsoDateTime`]s created with this constructor can only be formatted using localized offset zone styles.
    *
    * See the [Rust documentation for `from_epoch_milliseconds_and_utc_offset`](https://docs.rs/icu/latest/icu/time/struct.ZonedDateTime.html#method.from_epoch_milliseconds_and_utc_offset) for more information.
    */

--- a/ffi/capi/bindings/dart/ZonedIsoDateTime.g.dart
+++ b/ffi/capi/bindings/dart/ZonedIsoDateTime.g.dart
@@ -51,9 +51,9 @@ final class ZonedIsoDateTime {
     return ZonedIsoDateTime._fromFfi(result.union.ok);
   }
 
-  /// Creates a new [`ZonedDateTime`] from milliseconds since epoch (timestamp) and a UTC offset.
+  /// Creates a new [`ZonedIsoDateTime`] from milliseconds since epoch (timestamp) and a UTC offset.
   ///
-  /// Note: [`ZonedDateTime`]s created with this constructor can only be formatted using localized offset zone styles.
+  /// Note: [`ZonedIsoDateTime`]s created with this constructor can only be formatted using localized offset zone styles.
   ///
   /// See the [Rust documentation for `from_epoch_milliseconds_and_utc_offset`](https://docs.rs/icu/latest/icu/time/struct.ZonedDateTime.html#method.from_epoch_milliseconds_and_utc_offset) for more information.
   factory ZonedIsoDateTime.fromEpochMillisecondsAndUtcOffset(int epochMilliseconds, UtcOffset utcOffset) {

--- a/ffi/capi/bindings/js/ZonedIsoDateTime.d.ts
+++ b/ffi/capi/bindings/js/ZonedIsoDateTime.d.ts
@@ -33,9 +33,9 @@ export class ZonedIsoDateTime {
     static fullFromString(v: string, ianaParser: IanaParser, offsetCalculator: VariantOffsetsCalculator): ZonedIsoDateTime;
 
     /** 
-     * Creates a new [`ZonedDateTime`] from milliseconds since epoch (timestamp) and a UTC offset.
+     * Creates a new [`ZonedIsoDateTime`] from milliseconds since epoch (timestamp) and a UTC offset.
      *
-     * Note: [`ZonedDateTime`]s created with this constructor can only be formatted using localized offset zone styles.
+     * Note: [`ZonedIsoDateTime`]s created with this constructor can only be formatted using localized offset zone styles.
      *
      * See the [Rust documentation for `from_epoch_milliseconds_and_utc_offset`](https://docs.rs/icu/latest/icu/time/struct.ZonedDateTime.html#method.from_epoch_milliseconds_and_utc_offset) for more information.
      */

--- a/ffi/capi/bindings/js/ZonedIsoDateTime.mjs
+++ b/ffi/capi/bindings/js/ZonedIsoDateTime.mjs
@@ -149,9 +149,9 @@ export class ZonedIsoDateTime {
     }
 
     /** 
-     * Creates a new [`ZonedDateTime`] from milliseconds since epoch (timestamp) and a UTC offset.
+     * Creates a new [`ZonedIsoDateTime`] from milliseconds since epoch (timestamp) and a UTC offset.
      *
-     * Note: [`ZonedDateTime`]s created with this constructor can only be formatted using localized offset zone styles.
+     * Note: [`ZonedIsoDateTime`]s created with this constructor can only be formatted using localized offset zone styles.
      *
      * See the [Rust documentation for `from_epoch_milliseconds_and_utc_offset`](https://docs.rs/icu/latest/icu/time/struct.ZonedDateTime.html#method.from_epoch_milliseconds_and_utc_offset) for more information.
      */

--- a/ffi/capi/src/zoned_datetime.rs
+++ b/ffi/capi/src/zoned_datetime.rs
@@ -50,9 +50,9 @@ pub mod ffi {
             })
         }
 
-        /// Creates a new [`ZonedDateTime`] from milliseconds since epoch (timestamp) and a UTC offset.
+        /// Creates a new [`ZonedIsoDateTime`] from milliseconds since epoch (timestamp) and a UTC offset.
         ///
-        /// Note: [`ZonedDateTime`]s created with this constructor can only be formatted using localized offset zone styles.
+        /// Note: [`ZonedIsoDateTime`]s created with this constructor can only be formatted using localized offset zone styles.
         #[diplomat::rust_link(
             icu::time::ZonedDateTime::from_epoch_milliseconds_and_utc_offset,
             FnInStruct


### PR DESCRIPTION
@gemini-code-assist You should have noticed this earlier.

Follow-up to #6515