### PR TITLE
Infer the zone datetime in FFI when possible

### DIFF
--- a/components/datetime/src/format/input.rs
+++ b/components/datetime/src/format/input.rs
@@ -67,26 +67,26 @@ impl DateTimeInputUnchecked {
     /// responsible for making sure the calendar matches the formatter.
     pub fn set_date_fields_unchecked<C: Calendar, A: AsCalendar<Calendar = C>>(
         &mut self,
-        input: Date<A>,
+        date_in_calendar: Date<A>,
     ) {
-        self.year = Some(input.year());
-        self.month = Some(input.month());
-        self.day_of_month = Some(input.day_of_month());
-        self.iso_weekday = Some(input.day_of_week());
-        self.day_of_year = Some(input.day_of_year());
+        self.year = Some(date_in_calendar.year());
+        self.month = Some(date_in_calendar.month());
+        self.day_of_month = Some(date_in_calendar.day_of_month());
+        self.iso_weekday = Some(date_in_calendar.day_of_week());
+        self.day_of_year = Some(date_in_calendar.day_of_year());
     }
 
     /// Sets all fields from a [`Time`] input.
-    pub fn set_time_fields(&mut self, input: Time) {
-        self.hour = Some(input.hour);
-        self.minute = Some(input.minute);
-        self.second = Some(input.second);
-        self.subsecond = Some(input.subsecond);
+    pub fn set_time_fields(&mut self, time: Time) {
+        self.hour = Some(time.hour);
+        self.minute = Some(time.minute);
+        self.second = Some(time.second);
+        self.subsecond = Some(time.subsecond);
     }
 
     /// Sets the time zone UTC offset.
-    pub fn set_time_zone_utc_offset(&mut self, offset: UtcOffset) {
-        self.zone_offset = Some(offset);
+    pub fn set_time_zone_utc_offset(&mut self, utc_offset: UtcOffset) {
+        self.zone_offset = Some(utc_offset);
     }
 
     /// Sets the time zone ID.

--- a/ffi/capi/src/zoned_date_formatter.rs
+++ b/ffi/capi/src/zoned_date_formatter.rs
@@ -517,8 +517,8 @@ pub mod ffi {
             write: &mut diplomat_runtime::DiplomatWrite,
         ) -> Result<(), DateTimeWriteError> {
             let mut input = icu_datetime::DateTimeInputUnchecked::default();
-            let date = date.0.to_calendar(self.0.calendar());
-            input.set_date_fields_unchecked(date); // calendar conversion on previous line
+            let date_in_calendar = date.0.to_calendar(self.0.calendar());
+            input.set_date_fields_unchecked(date_in_calendar); // calendar conversion on previous line
             input.set_time_zone_id(zone.id);
             if let Some(offset) = zone.offset {
                 input.set_time_zone_utc_offset(offset);
@@ -1009,8 +1009,8 @@ pub mod ffi {
             write: &mut diplomat_runtime::DiplomatWrite,
         ) -> Result<(), DateTimeWriteError> {
             let mut input = icu_datetime::DateTimeInputUnchecked::default();
-            let date = date.0.to_calendar(Gregorian);
-            input.set_date_fields_unchecked(date); // calendar conversion on previous line
+            let date_in_calendar = date.0.to_calendar(Gregorian);
+            input.set_date_fields_unchecked(date_in_calendar); // calendar conversion on previous line
             input.set_time_zone_id(zone.id);
             if let Some(offset) = zone.offset {
                 input.set_time_zone_utc_offset(offset);

--- a/ffi/capi/src/zoned_date_time_formatter.rs
+++ b/ffi/capi/src/zoned_date_time_formatter.rs
@@ -518,8 +518,8 @@ pub mod ffi {
             write: &mut diplomat_runtime::DiplomatWrite,
         ) -> Result<(), DateTimeWriteError> {
             let mut input = icu_datetime::DateTimeInputUnchecked::default();
-            let date = date.0.to_calendar(self.0.calendar());
-            input.set_date_fields_unchecked(date); // calendar conversion on previous line
+            let date_in_calendar = date.0.to_calendar(self.0.calendar());
+            input.set_date_fields_unchecked(date_in_calendar); // calendar conversion on previous line
             input.set_time_fields(time.0);
             input.set_time_zone_id(zone.id);
             if let Some(offset) = zone.offset {
@@ -527,6 +527,12 @@ pub mod ffi {
             }
             if let Some(zone_name_timestamp) = zone.zone_name_timestamp {
                 input.set_time_zone_name_timestamp(zone_name_timestamp);
+            }
+            else {
+                input.set_time_zone_name_timestamp(icu_time::zone::ZoneNameTimestamp::from_date_time_iso(&icu_time::DateTime {
+                    date: date.0,
+                    time: time.0
+                }))
             }
             if let Some(variant) = zone.variant {
                 input.set_time_zone_variant(variant);
@@ -1012,8 +1018,8 @@ pub mod ffi {
             write: &mut diplomat_runtime::DiplomatWrite,
         ) -> Result<(), DateTimeWriteError> {
             let mut input = icu_datetime::DateTimeInputUnchecked::default();
-            let date = date.0.to_calendar(Gregorian);
-            input.set_date_fields_unchecked(date); // calendar conversion on previous line
+            let date_in_calendar = date.0.to_calendar(Gregorian);
+            input.set_date_fields_unchecked(date_in_calendar); // calendar conversion on previous line
             input.set_time_fields(time.0);
             input.set_time_zone_id(zone.id);
             if let Some(offset) = zone.offset {
@@ -1021,6 +1027,12 @@ pub mod ffi {
             }
             if let Some(zone_name_timestamp) = zone.zone_name_timestamp {
                 input.set_time_zone_name_timestamp(zone_name_timestamp);
+            }
+            else {
+                input.set_time_zone_name_timestamp(icu_time::zone::ZoneNameTimestamp::from_date_time_iso(&icu_time::DateTime {
+                    date: date.0,
+                    time: time.0
+                }))
             }
             if let Some(variant) = zone.variant {
                 input.set_time_zone_variant(variant);

--- a/ffi/dart/test/icu_test.dart
+++ b/ffi/dart/test/icu_test.dart
@@ -95,6 +95,16 @@ void main() {
       VariantOffsetsCalculator(),
     );
 
+    final utcOffset = UtcOffset.fromSeconds(-420);
+    final customZDT = ZonedIsoDateTime.fromEpochMillisecondsAndUtcOffset(
+      1746140981731,
+      utcOffset,
+    );
+    final customZone = TimeZoneInfo(
+      TimeZone.fromBcp47('uslax'),
+      offset: utcOffset,
+    );
+
     var locale = Locale.fromString('de-u-ca-islamic-umalqura');
 
     ///// DateFormatter /////
@@ -233,7 +243,7 @@ void main() {
     );
 
     expect(
-      () => ZonedDateTimeFormatter.genericLong(
+      () => ZonedDateTimeFormatter.specificLong(
         locale,
         DateTimeFormatter.ymdet(locale),
       ).formatIso(
@@ -266,6 +276,14 @@ void main() {
         zonedDateTimeIso.zone,
       ),
       '15.07.46 AH, 14:32:12 MEZ',
+    );
+
+    expect(
+      ZonedDateTimeFormatter.genericLong(
+        locale,
+        DateTimeFormatter.mdt(locale),
+      ).formatIso(customZDT.date, customZDT.time, customZone),
+      '03.11., 23:02:41 Nordamerikanische Westküstenzeit',
     );
 
     ///// ZonedDateTimeFormatterGregorian /////

--- a/tools/make/codegen/templates/zoned_formatter.rs.jinja
+++ b/tools/make/codegen/templates/zoned_formatter.rs.jinja
@@ -190,11 +190,11 @@ pub mod ffi {
             let mut input = icu_datetime::DateTimeInputUnchecked::default();
             {%- if flavor.has_date() %}
             {%- if formatter_kind.is_fixed_calendar %}
-            let date = date.0.to_calendar(Gregorian);
+            let date_in_calendar = date.0.to_calendar(Gregorian);
             {%- else %}
-            let date = date.0.to_calendar(self.0.calendar());
+            let date_in_calendar = date.0.to_calendar(self.0.calendar());
             {%- endif %}
-            input.set_date_fields_unchecked(date); // calendar conversion on previous line
+            input.set_date_fields_unchecked(date_in_calendar); // calendar conversion on previous line
             {%- endif %}
             {%- if flavor.has_time() %}
             input.set_time_fields(time.0);
@@ -206,6 +206,14 @@ pub mod ffi {
             if let Some(zone_name_timestamp) = zone.zone_name_timestamp {
                 input.set_time_zone_name_timestamp(zone_name_timestamp);
             }
+            {%- if flavor.has_date() && flavor.has_time() %}
+            else {
+                input.set_time_zone_name_timestamp(icu_time::zone::ZoneNameTimestamp::from_date_time_iso(&icu_time::DateTime {
+                    date: date.0,
+                    time: time.0
+                }))
+            }
+            {%- endif %}
             if let Some(variant) = zone.variant {
                 input.set_time_zone_variant(variant);
             }


### PR DESCRIPTION
Mostly fixes #6378

It doesn't make FFI work for ZonedDateFormatter and ZonedTimeFormatter since this trick only works for ZonedDateTimeFormatter, but at least this is progress.