### PR TITLE
Change VariantOffsetsCalculator to take TimeZoneInfo

### DIFF
--- a/components/datetime/examples/timezone_picker.rs
+++ b/components/datetime/examples/timezone_picker.rs
@@ -8,7 +8,6 @@ use icu::calendar::Date;
 use icu::datetime::{fieldsets, NoCalendarFormatter};
 use icu::locale::locale;
 use icu::time::{DateTime, Time};
-use icu_time::zone::ZoneNameTimestamp;
 use icu_time::TimeZone;
 
 fn main() {
@@ -38,8 +37,7 @@ fn main() {
 
         let offsets = offsets
             .compute_offsets_from_time_zone(
-                tz,
-                ZoneNameTimestamp::from_date_time_iso(reference_date_time),
+                tz.without_offset().at_date_time_iso(reference_date_time),
             )
             .unwrap();
 

--- a/components/time/src/zone/mod.rs
+++ b/components/time/src/zone/mod.rs
@@ -460,7 +460,7 @@ impl TimeZoneInfo<models::AtTime> {
                 .with_variant(TimeZoneVariant::Standard);
         };
         let Some(variant) = calculator
-            .compute_offsets_from_time_zone_internal(self.id, self.zone_name_timestamp)
+            .compute_offsets_from_time_zone(self)
             .and_then(|os| {
                 if os.standard == offset {
                     Some(TimeZoneVariant::Standard)

--- a/components/time/src/zone/mod.rs
+++ b/components/time/src/zone/mod.rs
@@ -460,7 +460,7 @@ impl TimeZoneInfo<models::AtTime> {
                 .with_variant(TimeZoneVariant::Standard);
         };
         let Some(variant) = calculator
-            .compute_offsets_from_time_zone(self.id, self.zone_name_timestamp)
+            .compute_offsets_from_time_zone_internal(self.id, self.zone_name_timestamp)
             .and_then(|os| {
                 if os.standard == offset {
                     Some(TimeZoneVariant::Standard)

--- a/components/time/src/zone/offset.rs
+++ b/components/time/src/zone/offset.rs
@@ -11,7 +11,8 @@ use icu_provider::prelude::*;
 use displaydoc::Display;
 use zerovec::ZeroMap2d;
 
-use super::ZoneNameTimestamp;
+use super::models::AtTime;
+use super::{TimeZoneInfo, ZoneNameTimestamp};
 
 /// The time zone offset was invalid. Must be within ±18:00:00.
 #[derive(Display, Debug, Copy, Clone, PartialEq)]
@@ -330,6 +331,13 @@ impl VariantOffsetsCalculatorBorrowed<'_> {
     /// assert_eq!(offsets.daylight, None);
     /// ```
     pub fn compute_offsets_from_time_zone(
+        &self,
+        time_zone: TimeZoneInfo<AtTime>,
+    ) -> Option<VariantOffsets> {
+        self.compute_offsets_from_time_zone_internal(time_zone.id, time_zone.zone_name_timestamp)
+    }
+
+    pub(crate) fn compute_offsets_from_time_zone_internal(
         &self,
         time_zone_id: TimeZone,
         zone_name_timestamp: ZoneNameTimestamp,

--- a/components/time/src/zone/offset.rs
+++ b/components/time/src/zone/offset.rs
@@ -334,6 +334,7 @@ impl VariantOffsetsCalculatorBorrowed<'_> {
         &self,
         time_zone: TimeZoneInfo<AtTime>,
     ) -> Option<VariantOffsets> {
+        // TODO(#6238): Make use of the offset if available
         self.compute_offsets_from_time_zone_internal(time_zone.id, time_zone.zone_name_timestamp)
     }
 


### PR DESCRIPTION
See #6238

VariantOffsetsCalculator might need to know the offset in order to correctly determine the variant offsets. Rather than rely solely on ZoneNameTimestamp for this, I realized that it should take a TimeZoneInfo, which can contain an offset.