### PR TITLE
Add `Time::noon()`

### DIFF
--- a/components/time/src/types.rs
+++ b/components/time/src/types.rs
@@ -150,13 +150,23 @@ impl Time {
         }
     }
 
-    /// Construct a new [`Time`] representing the start of the day (00:00.000)
+    /// Construct a new [`Time`] representing the start of the day (00:00:00.000)
     pub const fn start_of_day() -> Self {
         Self {
-            hour: Hour::zero(),
-            minute: Minute::zero(),
-            second: Second::zero(),
-            subsecond: Nanosecond::zero(),
+            hour: Hour(0),
+            minute: Minute(0),
+            second: Second(0),
+            subsecond: Nanosecond(0),
+        }
+    }
+
+    /// Construct a new [`Time`] representing noon (12:00:00.000)
+    pub const fn noon() -> Self {
+        Self {
+            hour: Hour(12),
+            minute: Minute(0),
+            second: Second(0),
+            subsecond: Nanosecond(0),
         }
     }
 

--- a/ffi/capi/bindings/c/Time.h
+++ b/ffi/capi/bindings/c/Time.h
@@ -26,6 +26,9 @@ icu4x_Time_from_string_mv1_result icu4x_Time_from_string_mv1(DiplomatStringView 
 typedef struct icu4x_Time_start_of_day_mv1_result {union {Time* ok; CalendarError err;}; bool is_ok;} icu4x_Time_start_of_day_mv1_result;
 icu4x_Time_start_of_day_mv1_result icu4x_Time_start_of_day_mv1(void);
 
+typedef struct icu4x_Time_noon_mv1_result {union {Time* ok; CalendarError err;}; bool is_ok;} icu4x_Time_noon_mv1_result;
+icu4x_Time_noon_mv1_result icu4x_Time_noon_mv1(void);
+
 uint8_t icu4x_Time_hour_mv1(const Time* self);
 
 uint8_t icu4x_Time_minute_mv1(const Time* self);

--- a/ffi/capi/bindings/cpp/icu4x/Time.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/Time.d.hpp
@@ -48,11 +48,18 @@ public:
   inline static diplomat::result<std::unique_ptr<icu4x::Time>, icu4x::CalendarParseError> from_string(std::string_view v);
 
   /**
-   * Creates a new [`Time`] representing midnight (00:00.000).
+   * Creates a new [`Time`] representing the start of the day (00:00:00.000).
    *
    * See the [Rust documentation for `start_of_day`](https://docs.rs/icu/latest/icu/time/struct.Time.html#method.start_of_day) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::Time>, icu4x::CalendarError> start_of_day();
+
+  /**
+   * Creates a new [`Time`] representing noon (12:00:00.000).
+   *
+   * See the [Rust documentation for `noon`](https://docs.rs/icu/latest/icu/time/struct.Time.html#method.noon) for more information.
+   */
+  inline static diplomat::result<std::unique_ptr<icu4x::Time>, icu4x::CalendarError> noon();
 
   /**
    * Returns the hour in this time

--- a/ffi/capi/bindings/cpp/icu4x/Time.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/Time.hpp
@@ -28,6 +28,9 @@ namespace capi {
     typedef struct icu4x_Time_start_of_day_mv1_result {union {icu4x::capi::Time* ok; icu4x::capi::CalendarError err;}; bool is_ok;} icu4x_Time_start_of_day_mv1_result;
     icu4x_Time_start_of_day_mv1_result icu4x_Time_start_of_day_mv1(void);
     
+    typedef struct icu4x_Time_noon_mv1_result {union {icu4x::capi::Time* ok; icu4x::capi::CalendarError err;}; bool is_ok;} icu4x_Time_noon_mv1_result;
+    icu4x_Time_noon_mv1_result icu4x_Time_noon_mv1(void);
+    
     uint8_t icu4x_Time_hour_mv1(const icu4x::capi::Time* self);
     
     uint8_t icu4x_Time_minute_mv1(const icu4x::capi::Time* self);
@@ -58,6 +61,11 @@ inline diplomat::result<std::unique_ptr<icu4x::Time>, icu4x::CalendarParseError>
 
 inline diplomat::result<std::unique_ptr<icu4x::Time>, icu4x::CalendarError> icu4x::Time::start_of_day() {
   auto result = icu4x::capi::icu4x_Time_start_of_day_mv1();
+  return result.is_ok ? diplomat::result<std::unique_ptr<icu4x::Time>, icu4x::CalendarError>(diplomat::Ok<std::unique_ptr<icu4x::Time>>(std::unique_ptr<icu4x::Time>(icu4x::Time::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<icu4x::Time>, icu4x::CalendarError>(diplomat::Err<icu4x::CalendarError>(icu4x::CalendarError::FromFFI(result.err)));
+}
+
+inline diplomat::result<std::unique_ptr<icu4x::Time>, icu4x::CalendarError> icu4x::Time::noon() {
+  auto result = icu4x::capi::icu4x_Time_noon_mv1();
   return result.is_ok ? diplomat::result<std::unique_ptr<icu4x::Time>, icu4x::CalendarError>(diplomat::Ok<std::unique_ptr<icu4x::Time>>(std::unique_ptr<icu4x::Time>(icu4x::Time::FromFFI(result.ok)))) : diplomat::result<std::unique_ptr<icu4x::Time>, icu4x::CalendarError>(diplomat::Err<icu4x::CalendarError>(icu4x::CalendarError::FromFFI(result.err)));
 }
 

--- a/ffi/capi/bindings/dart/Time.g.dart
+++ b/ffi/capi/bindings/dart/Time.g.dart
@@ -52,13 +52,26 @@ final class Time implements ffi.Finalizable {
     return Time._fromFfi(result.union.ok, []);
   }
 
-  /// Creates a new [`Time`] representing midnight (00:00.000).
+  /// Creates a new [`Time`] representing the start of the day (00:00:00.000).
   ///
   /// See the [Rust documentation for `start_of_day`](https://docs.rs/icu/latest/icu/time/struct.Time.html#method.start_of_day) for more information.
   ///
   /// Throws [CalendarError] on failure.
   factory Time.startOfDay() {
     final result = _icu4x_Time_start_of_day_mv1();
+    if (!result.isOk) {
+      throw CalendarError.values[result.union.err];
+    }
+    return Time._fromFfi(result.union.ok, []);
+  }
+
+  /// Creates a new [`Time`] representing noon (12:00:00.000).
+  ///
+  /// See the [Rust documentation for `noon`](https://docs.rs/icu/latest/icu/time/struct.Time.html#method.noon) for more information.
+  ///
+  /// Throws [CalendarError] on failure.
+  factory Time.noon() {
+    final result = _icu4x_Time_noon_mv1();
     if (!result.isOk) {
       throw CalendarError.values[result.union.err];
     }
@@ -117,6 +130,11 @@ external _ResultOpaqueInt32 _icu4x_Time_from_string_mv1(_SliceUtf8 v);
 @ffi.Native<_ResultOpaqueInt32 Function()>(isLeaf: true, symbol: 'icu4x_Time_start_of_day_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_Time_start_of_day_mv1();
+
+@_DiplomatFfiUse('icu4x_Time_noon_mv1')
+@ffi.Native<_ResultOpaqueInt32 Function()>(isLeaf: true, symbol: 'icu4x_Time_noon_mv1')
+// ignore: non_constant_identifier_names
+external _ResultOpaqueInt32 _icu4x_Time_noon_mv1();
 
 @_DiplomatFfiUse('icu4x_Time_hour_mv1')
 @ffi.Native<ffi.Uint8 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Time_hour_mv1')

--- a/ffi/capi/bindings/js/Time.d.ts
+++ b/ffi/capi/bindings/js/Time.d.ts
@@ -23,11 +23,18 @@ export class Time {
     static fromString(v: string): Time;
 
     /** 
-     * Creates a new [`Time`] representing midnight (00:00.000).
+     * Creates a new [`Time`] representing the start of the day (00:00:00.000).
      *
      * See the [Rust documentation for `start_of_day`](https://docs.rs/icu/latest/icu/time/struct.Time.html#method.start_of_day) for more information.
      */
     static startOfDay(): Time;
+
+    /** 
+     * Creates a new [`Time`] representing noon (12:00:00.000).
+     *
+     * See the [Rust documentation for `noon`](https://docs.rs/icu/latest/icu/time/struct.Time.html#method.noon) for more information.
+     */
+    static noon(): Time;
 
     /** 
      * Returns the hour in this time

--- a/ffi/capi/bindings/js/Time.mjs
+++ b/ffi/capi/bindings/js/Time.mjs
@@ -96,7 +96,7 @@ export class Time {
     }
 
     /** 
-     * Creates a new [`Time`] representing midnight (00:00.000).
+     * Creates a new [`Time`] representing the start of the day (00:00:00.000).
      *
      * See the [Rust documentation for `start_of_day`](https://docs.rs/icu/latest/icu/time/struct.Time.html#method.start_of_day) for more information.
      */
@@ -104,6 +104,29 @@ export class Time {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
         
         const result = wasm.icu4x_Time_start_of_day_mv1(diplomatReceive.buffer);
+    
+        try {
+            if (!diplomatReceive.resultFlag) {
+                const cause = new CalendarError(diplomatRuntime.internalConstructor, diplomatRuntime.enumDiscriminant(wasm, diplomatReceive.buffer));
+                throw new globalThis.Error('CalendarError: ' + cause.value, { cause });
+            }
+            return new Time(diplomatRuntime.internalConstructor, diplomatRuntime.ptrRead(wasm, diplomatReceive.buffer), []);
+        }
+        
+        finally {
+            diplomatReceive.free();
+        }
+    }
+
+    /** 
+     * Creates a new [`Time`] representing noon (12:00:00.000).
+     *
+     * See the [Rust documentation for `noon`](https://docs.rs/icu/latest/icu/time/struct.Time.html#method.noon) for more information.
+     */
+    static noon() {
+        const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
+        
+        const result = wasm.icu4x_Time_noon_mv1(diplomatReceive.buffer);
     
         try {
             if (!diplomatReceive.resultFlag) {

--- a/ffi/capi/src/time.rs
+++ b/ffi/capi/src/time.rs
@@ -48,11 +48,19 @@ pub mod ffi {
             Ok(Box::new(Time(icu_time::Time::try_from_utf8(v)?)))
         }
 
-        /// Creates a new [`Time`] representing midnight (00:00.000).
+        /// Creates a new [`Time`] representing the start of the day (00:00:00.000).
         #[diplomat::rust_link(icu::time::Time::start_of_day, FnInStruct)]
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor)]
         pub fn start_of_day() -> Result<Box<Time>, CalendarError> {
             let time = icu_time::Time::start_of_day();
+            Ok(Box::new(Time(time)))
+        }
+
+        /// Creates a new [`Time`] representing noon (12:00:00.000).
+        #[diplomat::rust_link(icu::time::Time::noon, FnInStruct)]
+        #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor)]
+        pub fn noon() -> Result<Box<Time>, CalendarError> {
+            let time = icu_time::Time::noon();
             Ok(Box::new(Time(time)))
         }
 


### PR DESCRIPTION
Fixes #6530 

Not calling this `middle_of_day` because that feels more ambiguous than noon, e.g. it's different for 23h/25h days.