### PR TITLE
Port sort key code from ICU4C (#2689)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1293,6 +1293,7 @@ dependencies = [
  "smallvec",
  "utf16_iter",
  "utf8_iter",
+ "write16",
  "zerovec",
 ]
 

--- a/components/collator/Cargo.toml
+++ b/components/collator/Cargo.toml
@@ -21,13 +21,14 @@ all-features = true
 [dependencies]
 displaydoc = { workspace = true }
 icu_collections = { workspace = true }
-icu_normalizer = { workspace = true }
+icu_normalizer = { workspace = true, features = ["utf8_iter", "utf16_iter"] }
 icu_locale_core = { workspace = true, features = ["alloc"] }
 icu_properties = { workspace = true }
 icu_provider = { workspace = true }
 utf8_iter = { workspace = true }
 utf16_iter = { workspace = true }
 smallvec = { workspace = true, features = ["union", "const_generics", "const_new"] } # alloc
+write16 = { workspace = true }
 zerovec = { workspace = true }
 
 databake = { workspace = true, optional = true, features = ["derive"] }

--- a/components/collator/src/comparison.rs
+++ b/components/collator/src/comparison.rs
@@ -1677,9 +1677,9 @@ impl CollatorBorrowed<'_> {
     /// options.strength = Some(Strength::Primary);
     /// let collator = Collator::try_new(locale, options).unwrap();
     ///
-    /// let mut k1: Vec<u8> = Vec::new();
+    /// let mut k1 = Vec::new();
     /// collator.write_sort_key("hello", &mut k1);
-    /// let mut k2: Vec<u8> = Vec::new();
+    /// let mut k2 = Vec::new();
     /// collator.write_sort_key("Héłłö", &mut k2);
     /// assert_eq!(k1, k2);
     /// ```
@@ -2287,11 +2287,11 @@ mod test {
     fn keys(strength: Strength) -> (Key, Key, Key) {
         let collator = collator_en(strength);
 
-        let mut k0: Key = Vec::new();
+        let mut k0 = Vec::new();
         collator.write_sort_key("aabc", &mut k0).unwrap();
-        let mut k1: Key = Vec::new();
+        let mut k1 = Vec::new();
         collator.write_sort_key("aAbc", &mut k1).unwrap();
-        let mut k2: Key = Vec::new();
+        let mut k2 = Vec::new();
         collator.write_sort_key("áAbc", &mut k2).unwrap();
 
         (k0, k1, k2)
@@ -2328,9 +2328,9 @@ mod test {
     fn keys_ja_strs(strength: Strength, s0: &str, s1: &str) -> (Key, Key) {
         let collator = collator_ja(strength);
 
-        let mut k0: Key = Vec::new();
+        let mut k0 = Vec::new();
         collator.write_sort_key(s0, &mut k0).unwrap();
-        let mut k1: Key = Vec::new();
+        let mut k1 = Vec::new();
         collator.write_sort_key(s1, &mut k1).unwrap();
 
         (k0, k1)
@@ -2365,13 +2365,13 @@ mod test {
         let collator = collator_en(Strength::Identical);
 
         const STR8: &[u8] = b"hello world!";
-        let mut k8: Key = Vec::new();
+        let mut k8 = Vec::new();
         collator.write_sort_key_utf8(STR8, &mut k8).unwrap();
 
         const STR16: &[u16] = &[
             0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64, 0x21,
         ];
-        let mut k16: Key = Vec::new();
+        let mut k16 = Vec::new();
         collator.write_sort_key_utf16(STR16, &mut k16).unwrap();
         assert_eq!(k8, k16);
     }
@@ -2381,9 +2381,9 @@ mod test {
         let collator = collator_en(Strength::Identical);
 
         // some invalid strings
-        let mut k: Key = Vec::new();
+        let mut k = Vec::new();
         collator.write_sort_key_utf8(b"\xf0\x90", &mut k).unwrap();
-        let mut k: Key = Vec::new();
+        let mut k = Vec::new();
         collator.write_sort_key_utf16(&[0xdd1e], &mut k).unwrap();
     }
 }

--- a/components/collator/src/comparison.rs
+++ b/components/collator/src/comparison.rs
@@ -1914,7 +1914,7 @@ impl CollatorBorrowed<'_> {
                     if 0 < p && p <= MERGE_SEPARATOR_PRIMARY {
                         // The backwards secondary level compares secondary weights backwards
                         // within segments separated by the merge separator (U+FFFE).
-                        let secs = secondaries.as_mut();
+                        let secs = &mut secondaries.buf;
                         let last = secs.len() - 1;
                         if sec_segment_start < last {
                             let mut q = sec_segment_start;
@@ -2111,7 +2111,7 @@ impl CollatorBorrowed<'_> {
             ($key:ident, $level:expr, $flag:ident) => {
                 if levels & $flag != 0 {
                     sink.write(&[LEVEL_SEPARATOR_BYTE])?;
-                    sink.write($key.as_ref())?;
+                    sink.write(&$key.buf)?;
                 }
             };
         }
@@ -2123,7 +2123,7 @@ impl CollatorBorrowed<'_> {
 
             // Write pairs of nibbles as bytes, except separator bytes as themselves.
             let mut b = 0;
-            for c in cases.as_ref() {
+            for c in &cases.buf {
                 debug_assert_eq!(*c & 0xf, 0);
                 debug_assert_ne!(*c, 0);
                 if b == 0 {
@@ -2227,18 +2227,6 @@ impl SortKeyLevel {
                 }
             }
         }
-    }
-}
-
-impl AsRef<SmallVec<[u8; 40]>> for SortKeyLevel {
-    fn as_ref(&self) -> &SmallVec<[u8; 40]> {
-        &self.buf
-    }
-}
-
-impl AsMut<SmallVec<[u8; 40]>> for SortKeyLevel {
-    fn as_mut(&mut self) -> &mut SmallVec<[u8; 40]> {
-        &mut self.buf
     }
 }
 

--- a/components/collator/src/comparison.rs
+++ b/components/collator/src/comparison.rs
@@ -1892,7 +1892,8 @@ impl CollatorBorrowed<'_> {
                             // mixed=14, upper=15.  If there are only common (=lowest) weights
                             // in the whole level, then we need not write anything.  Level
                             // length differences are handled already on the next-higher level.
-                            if common_cases != 0 && (c > LEVEL_SEPARATOR_BYTE || cases.is_empty()) {
+                            if common_cases != 0 && (c > LEVEL_SEPARATOR_BYTE || !cases.is_empty())
+                            {
                                 common_cases -= 1;
                                 while common_cases >= CASE_LOWER_FIRST_COMMON[WEIGHT_MAX_COUNT] {
                                     cases.append_byte(CASE_LOWER_FIRST_COMMON[WEIGHT_MIDDLE] << 4);

--- a/components/collator/src/comparison.rs
+++ b/components/collator/src/comparison.rs
@@ -1744,18 +1744,7 @@ impl CollatorBorrowed<'_> {
         I: Iterator<Item = char>,
         S: Write,
     {
-        // The following code started as a port from ICU4C which carried the
-        // following notice:
-        //
-        // // © 2016 and later: Unicode, Inc. and others.
-        // // License & terms of use: http://www.unicode.org/copyright.html
-        // /*
-        // *******************************************************************************
-        // * Copyright (C) 2012-2015, International Business Machines
-        // * Corporation and others.  All Rights Reserved.
-        // *******************************************************************************
-        // * collationkeys.cpp
-
+        // This algorithm comes from `CollationKeys::writeSortKeyUpToQuaternary` in ICU4C.
         let levels = self.sort_key_levels();
 
         let mut iter =

--- a/components/collator/src/comparison.rs
+++ b/components/collator/src/comparison.rs
@@ -10,7 +10,7 @@
 //! the comparison of collation element sequences.
 
 extern crate alloc;
-use alloc::{vec, vec::Vec};
+use alloc::vec::Vec;
 
 use crate::elements::CharacterAndClassAndTrieValue;
 use crate::elements::CollationElement32;
@@ -2281,12 +2281,16 @@ where
         let iter = char::decode_utf16(s.iter().cloned());
         for c in iter {
             let c = c.unwrap_or(char::REPLACEMENT_CHARACTER); // shouldn't happen
-            let len = c.len_utf8();
-            let mut bytes = vec![0u8; len];
+            let mut bytes = [0u8; 4];
             c.encode_utf8(&mut bytes);
-            self.inner.write(&bytes)?;
+            self.inner.write(c.encode_utf8(&mut bytes).as_bytes())?;
         }
         Ok(())
+    }
+
+    fn write_char(&mut self, c: char) -> core::fmt::Result {
+        let mut buf = [0u8; 4];
+        self.inner.write(c.encode_utf8(&mut buf).as_bytes())
     }
 }
 

--- a/components/collator/src/comparison.rs
+++ b/components/collator/src/comparison.rs
@@ -1678,12 +1678,12 @@ impl CollatorBorrowed<'_> {
     /// let collator = Collator::try_new(locale, options).unwrap();
     ///
     /// let mut k1 = Vec::new();
-    /// collator.write_sort_key("hello", &mut k1);
+    /// collator.write_sort_key_to("hello", &mut k1);
     /// let mut k2 = Vec::new();
-    /// collator.write_sort_key("Héłłö", &mut k2);
+    /// collator.write_sort_key_to("Héłłö", &mut k2);
     /// assert_eq!(k1, k2);
     /// ```
-    pub fn write_sort_key<S>(&self, s: &str, sink: &mut S) -> Result<(), core::fmt::Error>
+    pub fn write_sort_key_to<S>(&self, s: &str, sink: &mut S) -> Result<(), core::fmt::Error>
     where
         S: CollationKeySink,
     {
@@ -1692,8 +1692,8 @@ impl CollatorBorrowed<'_> {
 
     /// Given potentially invalid UTF-8, write the sort key bytes up to the collator's strength.
     ///
-    /// For further details, see [`Self::write_sort_key`].
-    pub fn write_sort_key_utf8<S>(&self, s: &[u8], sink: &mut S) -> Result<(), core::fmt::Error>
+    /// For further details, see [`Self::write_sort_key_to`].
+    pub fn write_sort_key_utf8_to<S>(&self, s: &[u8], sink: &mut S) -> Result<(), core::fmt::Error>
     where
         S: CollationKeySink,
     {
@@ -1702,8 +1702,8 @@ impl CollatorBorrowed<'_> {
 
     /// Given potentially invalid UTF-16, write the sort key bytes up to the collator's strength.
     ///
-    /// For further details, see [`Self::write_sort_key`].
-    pub fn write_sort_key_utf16<S>(&self, s: &[u16], sink: &mut S) -> Result<(), core::fmt::Error>
+    /// For further details, see [`Self::write_sort_key_to`].
+    pub fn write_sort_key_utf16_to<S>(&self, s: &[u16], sink: &mut S) -> Result<(), core::fmt::Error>
     where
         S: CollationKeySink,
     {
@@ -2288,11 +2288,11 @@ mod test {
         let collator = collator_en(strength);
 
         let mut k0 = Vec::new();
-        collator.write_sort_key("aabc", &mut k0).unwrap();
+        collator.write_sort_key_to("aabc", &mut k0).unwrap();
         let mut k1 = Vec::new();
-        collator.write_sort_key("aAbc", &mut k1).unwrap();
+        collator.write_sort_key_to("aAbc", &mut k1).unwrap();
         let mut k2 = Vec::new();
-        collator.write_sort_key("áAbc", &mut k2).unwrap();
+        collator.write_sort_key_to("áAbc", &mut k2).unwrap();
 
         (k0, k1, k2)
     }
@@ -2329,9 +2329,9 @@ mod test {
         let collator = collator_ja(strength);
 
         let mut k0 = Vec::new();
-        collator.write_sort_key(s0, &mut k0).unwrap();
+        collator.write_sort_key_to(s0, &mut k0).unwrap();
         let mut k1 = Vec::new();
-        collator.write_sort_key(s1, &mut k1).unwrap();
+        collator.write_sort_key_to(s1, &mut k1).unwrap();
 
         (k0, k1)
     }
@@ -2366,13 +2366,13 @@ mod test {
 
         const STR8: &[u8] = b"hello world!";
         let mut k8 = Vec::new();
-        collator.write_sort_key_utf8(STR8, &mut k8).unwrap();
+        collator.write_sort_key_utf8_to(STR8, &mut k8).unwrap();
 
         const STR16: &[u16] = &[
             0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64, 0x21,
         ];
         let mut k16 = Vec::new();
-        collator.write_sort_key_utf16(STR16, &mut k16).unwrap();
+        collator.write_sort_key_utf16_to(STR16, &mut k16).unwrap();
         assert_eq!(k8, k16);
     }
 
@@ -2382,8 +2382,8 @@ mod test {
 
         // some invalid strings
         let mut k = Vec::new();
-        collator.write_sort_key_utf8(b"\xf0\x90", &mut k).unwrap();
+        collator.write_sort_key_utf8_to(b"\xf0\x90", &mut k).unwrap();
         let mut k = Vec::new();
-        collator.write_sort_key_utf16(&[0xdd1e], &mut k).unwrap();
+        collator.write_sort_key_utf16_to(&[0xdd1e], &mut k).unwrap();
     }
 }

--- a/components/collator/src/comparison.rs
+++ b/components/collator/src/comparison.rs
@@ -1818,7 +1818,7 @@ impl CollatorBorrowed<'_> {
             // primary level but terminate compression on all levels and then exit the loop.
             if p > NO_CE_PRIMARY && levels & PRIMARY_LEVEL_FLAG != 0 {
                 // Test the un-reordered primary for compressibility.
-                let is_compressible = false; // TODO?
+                let is_compressible = self.special_primaries.is_compressible((p >> 24) as _);
                 if let Some(reordering) = &self.reordering {
                     p = reordering.reorder(p);
                 }

--- a/components/collator/src/comparison.rs
+++ b/components/collator/src/comparison.rs
@@ -2185,6 +2185,8 @@ where
         Ok(())
     }
 
+    // guaranteed to get at least one byte and the rest are checked incrementally
+    #[allow(clippy::indexing_slicing)]
     fn write_to_zero(&mut self, buf: &[u8]) -> Result<(), core::fmt::Error> {
         self.write_byte(buf[0])?;
         if buf.len() > 1 && buf[1] != 0 {
@@ -2276,7 +2278,7 @@ impl<'a, W> SinkAdapter<'a, W> {
     }
 }
 
-impl<'a, W> core::fmt::Write for SinkAdapter<'a, W>
+impl<W> core::fmt::Write for SinkAdapter<'_, W>
 where
     W: CollationKeySink,
 {
@@ -2286,7 +2288,7 @@ where
     }
 }
 
-impl<'a, W> write16::Write16 for SinkAdapter<'a, W>
+impl<W> write16::Write16 for SinkAdapter<'_, W>
 where
     W: CollationKeySink,
 {

--- a/components/collator/src/comparison.rs
+++ b/components/collator/src/comparison.rs
@@ -2152,6 +2152,12 @@ impl CollatorBorrowed<'_> {
 pub trait CollationKeySink {
     /// Writes a buffer into the writer.
     fn write(&mut self, buf: &[u8]) -> Result<(), core::fmt::Error>;
+
+    /// Write a single byte into the writer.
+    fn write_byte(&mut self, b: u8) -> Result<(), core::fmt::Error> {
+        self.write(&[b])?;
+        Ok(())
+    }
 }
 
 impl CollationKeySink for Vec<u8> {
@@ -2164,21 +2170,6 @@ impl CollationKeySink for Vec<u8> {
 impl<const N: usize> CollationKeySink for SmallVec<[u8; N]> {
     fn write(&mut self, buf: &[u8]) -> Result<(), core::fmt::Error> {
         self.extend_from_slice(buf);
-        Ok(())
-    }
-}
-
-trait CollationKeySinkExt {
-    /// Write a single byte into the writer.
-    fn write_byte(&mut self, b: u8) -> Result<(), core::fmt::Error>;
-}
-
-impl<T> CollationKeySinkExt for T
-where
-    T: CollationKeySink,
-{
-    fn write_byte(&mut self, b: u8) -> Result<(), core::fmt::Error> {
-        self.write(&[b])?;
         Ok(())
     }
 }

--- a/components/collator/src/comparison.rs
+++ b/components/collator/src/comparison.rs
@@ -9,7 +9,6 @@
 //! This module holds the `Collator` struct whose `compare_impl()` contains
 //! the comparison of collation element sequences.
 
-extern crate alloc;
 use alloc::vec::Vec;
 
 use crate::elements::CharacterAndClassAndTrieValue;

--- a/components/collator/src/comparison.rs
+++ b/components/collator/src/comparison.rs
@@ -59,7 +59,6 @@ use utf8_iter::Utf8CharsEx;
 use zerovec::ule::AsULE;
 
 // Special sort key bytes for all levels.
-const TERMINATOR_BYTE: u8 = 0;
 const LEVEL_SEPARATOR_BYTE: u8 = 1;
 
 /// Merge-sort-key separator.
@@ -1658,7 +1657,6 @@ impl CollatorBorrowed<'_> {
     /// Write the sort key bytes up to the collator's strength.
     ///
     /// For identical strength, the UTF-8 NFD normalization is appended for breaking ties.
-    /// The key ends with a `TERMINATOR_BYTE`.
     pub fn write_sort_key<S>(&self, s: &str, sink: &mut S)
     where
         S: Write,
@@ -1672,15 +1670,10 @@ impl CollatorBorrowed<'_> {
             sink.write_byte(LEVEL_SEPARATOR_BYTE);
             sink.write(s.as_bytes());
         }
-
-        sink.write(&[TERMINATOR_BYTE]);
     }
 
     /// Write the sort key bytes up to the collator's strength.
     ///
-    /// Optionally write the case level.  Stop writing levels when `need_to_write` returns
-    /// `false`.  Separate levels with the `LEVEL_SEPARATOR_BYTE`, but do not write a
-    /// `TERMINATOR_BYTE`.
     pub fn write_sort_key_up_to_quaternary<I, S, W>(&self, iter: I, sink: &mut S, need_to_write: W)
     where
         I: Iterator<Item = char>,

--- a/components/collator/src/comparison.rs
+++ b/components/collator/src/comparison.rs
@@ -2270,10 +2270,9 @@ where
     fn write_slice(&mut self, s: &[u16]) -> core::fmt::Result {
         // For the identical level, if the input is UTF-16, transcode to UTF-8.
         let iter = char::decode_utf16(s.iter().cloned());
+        let mut bytes = [0u8; 4];
         for c in iter {
             let c = c.unwrap_or(char::REPLACEMENT_CHARACTER); // shouldn't happen
-            let mut bytes = [0u8; 4];
-            c.encode_utf8(&mut bytes);
             self.inner.write(c.encode_utf8(&mut bytes).as_bytes())?;
         }
         Ok(())

--- a/components/collator/src/comparison.rs
+++ b/components/collator/src/comparison.rs
@@ -2230,19 +2230,19 @@ impl SortKeyLevel {
     }
 }
 
-struct SinkAdapter<'a, W> {
-    inner: &'a mut W,
+struct SinkAdapter<'a, S> {
+    inner: &'a mut S,
 }
 
-impl<'a, W> SinkAdapter<'a, W> {
-    fn new(inner: &'a mut W) -> Self {
+impl<'a, S> SinkAdapter<'a, S> {
+    fn new(inner: &'a mut S) -> Self {
         Self { inner }
     }
 }
 
-impl<W> core::fmt::Write for SinkAdapter<'_, W>
+impl<S> core::fmt::Write for SinkAdapter<'_, S>
 where
-    W: CollationKeySink,
+    S: CollationKeySink,
 {
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
         self.inner.write(s.as_bytes())?;
@@ -2250,9 +2250,9 @@ where
     }
 }
 
-impl<W> write16::Write16 for SinkAdapter<'_, W>
+impl<S> write16::Write16 for SinkAdapter<'_, S>
 where
-    W: CollationKeySink,
+    S: CollationKeySink,
 {
     fn write_slice(&mut self, s: &[u16]) -> core::fmt::Result {
         // For the identical level, if the input is UTF-16, transcode to UTF-8.

--- a/components/collator/src/comparison.rs
+++ b/components/collator/src/comparison.rs
@@ -1883,7 +1883,7 @@ impl CollatorBorrowed<'_> {
                 } else {
                     // case bits & tertiary lead byte
                     let mut c = ((non_primary.bits() >> 8) & 0xff) as u8;
-                    assert_ne!(c & 0xc0, 0xc0);
+                    debug_assert_ne!(c & 0xc0, 0xc0);
                     if c & 0xc0 == 0 && c > LEVEL_SEPARATOR_BYTE {
                         common_cases += 1;
                     } else {
@@ -1940,7 +1940,7 @@ impl CollatorBorrowed<'_> {
 
             if levels & TERTIARY_LEVEL_FLAG != 0 {
                 let mut t = non_primary.tertiary_case_quarternary(tertiary_mask);
-                assert_ne!(non_primary.bits() & 0xc000, 0xc000);
+                debug_assert_ne!(non_primary.bits() & 0xc000, 0xc000);
                 if t == COMMON_WEIGHT16 {
                     common_tertiaries += 1;
                 } else if tertiary_mask & 0x8000 == 0 {
@@ -1982,7 +1982,7 @@ impl CollatorBorrowed<'_> {
                         }
                     } else {
                         // Keep uppercase bits of tertiary CEs.
-                        assert!((0x8600..=0xbfff).contains(&t));
+                        debug_assert!((0x8600..=0xbfff).contains(&t));
                         t += 0x4000;
                     }
                     handle_common!(
@@ -2051,8 +2051,8 @@ impl CollatorBorrowed<'_> {
             // Write pairs of nibbles as bytes, except separator bytes as themselves.
             let mut b = 0;
             for c in cases.as_ref() {
-                assert_eq!(*c & 0xf, 0);
-                assert_ne!(*c, 0);
+                debug_assert_eq!(*c & 0xf, 0);
+                debug_assert_ne!(*c, 0);
                 if b == 0 {
                     b = *c;
                 } else {
@@ -2124,7 +2124,7 @@ impl SortKeyLevel {
     }
 
     fn append_weight_16(&mut self, w: u16) {
-        assert_ne!(w, 0);
+        debug_assert_ne!(w, 0);
         let b0 = (w >> 8) as u8;
         let b1 = w as u8;
         self.append_byte(b0);
@@ -2134,7 +2134,7 @@ impl SortKeyLevel {
     }
 
     fn append_reverse_weight_16(&mut self, w: u16) {
-        assert_ne!(w, 0);
+        debug_assert_ne!(w, 0);
         let b0 = (w >> 8) as u8;
         let b1 = w as u8;
         if b1 != 0 {
@@ -2144,7 +2144,7 @@ impl SortKeyLevel {
     }
 
     fn append_weight_32(&mut self, w: u32) {
-        assert_ne!(w, 0);
+        debug_assert_ne!(w, 0);
         let b0 = (w >> 24) as u8;
         let b1 = (w >> 16) as u8;
         let b2 = (w >> 8) as u8;

--- a/components/collator/src/comparison.rs
+++ b/components/collator/src/comparison.rs
@@ -9,8 +9,8 @@
 //! This module holds the `Collator` struct whose `compare_impl()` contains
 //! the comparison of collation element sequences.
 
-use alloc::vec::Vec;
 use alloc::collections::VecDeque;
+use alloc::vec::Vec;
 
 use crate::elements::CharacterAndClassAndTrieValue;
 use crate::elements::CollationElement32;

--- a/components/collator/src/comparison.rs
+++ b/components/collator/src/comparison.rs
@@ -1679,9 +1679,9 @@ impl CollatorBorrowed<'_> {
     /// let collator = Collator::try_new(locale, options).unwrap();
     ///
     /// let mut k1 = Vec::new();
-    /// collator.write_sort_key_to("hello", &mut k1);
+    /// let Ok(()) = collator.write_sort_key_to("hello", &mut k1);
     /// let mut k2 = Vec::new();
-    /// collator.write_sort_key_to("Héłłö", &mut k2);
+    /// let Ok(()) = collator.write_sort_key_to("Héłłö", &mut k2);
     /// assert_eq!(k1, k2);
     /// ```
     pub fn write_sort_key_to<S>(&self, s: &str, sink: &mut S) -> Result<S::Output, S::Error>

--- a/components/collator/src/comparison.rs
+++ b/components/collator/src/comparison.rs
@@ -2266,8 +2266,7 @@ where
     }
 
     fn write_char(&mut self, c: char) -> core::fmt::Result {
-        let mut buf = [0u8; 4];
-        self.inner.write(c.encode_utf8(&mut buf).as_bytes())
+        self.inner.write(c.encode_utf8(&mut [0u8; 4]).as_bytes())
     }
 }
 

--- a/components/collator/src/comparison.rs
+++ b/components/collator/src/comparison.rs
@@ -1772,7 +1772,7 @@ impl CollatorBorrowed<'_> {
                     prev_reordered_primary = if is_compressible { p } else { 0 };
                 }
 
-                let p2 = (p >> 16) as u16;
+                let p2 = (p >> 16) as u8;
                 if p2 != 0 {
                     let buf = [p2 as _, (p >> 8) as _, p as _];
                     sink.write_to_zero(&buf);

--- a/components/collator/src/comparison.rs
+++ b/components/collator/src/comparison.rs
@@ -1701,7 +1701,7 @@ impl CollatorBorrowed<'_> {
     ///
     /// Optionally write the case level.  Separate levels with the `LEVEL_SEPARATOR_BYTE`, but
     /// do not write a terminating zero as with a C string.
-    pub fn write_sort_key_up_to_quaternary<I, S>(&self, iter: I, sink: &mut S)
+    fn write_sort_key_up_to_quaternary<I, S>(&self, iter: I, sink: &mut S)
     where
         I: Iterator<Item = char>,
         S: Write,

--- a/components/collator/src/elements.rs
+++ b/components/collator/src/elements.rs
@@ -206,6 +206,7 @@ pub(crate) const NO_CE_PRIMARY: u32 = 1; // not a left-adjusted weight
                                          // const NO_CE_NON_PRIMARY: NonPrimary = NonPrimary::default();
 pub(crate) const NO_CE_SECONDARY: u16 = 0x0100;
 pub(crate) const NO_CE_TERTIARY: u16 = 0x0100;
+pub(crate) const NO_CE_QUATERNARY: u16 = 0x0100;
 const NO_CE_VALUE: u64 =
     ((NO_CE_PRIMARY as u64) << 32) | ((NO_CE_SECONDARY as u64) << 16) | (NO_CE_TERTIARY as u64); // 0x101000100
 
@@ -680,6 +681,11 @@ impl NonPrimary {
     #[inline(always)]
     pub fn case_quaternary(self) -> u16 {
         (self.0 as u16) & (CASE_MASK | QUATERNARY_MASK)
+    }
+
+    #[inline(always)]
+    pub fn ignorable(self) -> bool {
+        self.0 == 0
     }
 }
 

--- a/components/collator/src/lib.rs
+++ b/components/collator/src/lib.rs
@@ -308,6 +308,8 @@
 //!
 //! [`CollatorOptions`]: options::CollatorOptions
 
+extern crate alloc;
+
 mod comparison;
 #[cfg(doc)]
 pub mod docs;

--- a/components/collator/src/options.rs
+++ b/components/collator/src/options.rs
@@ -109,7 +109,7 @@ pub enum Strength {
     /// ```
     Tertiary = 2,
 
-    /// Compare also on the quaternary level. For Japanese, Higana
+    /// Compare also on the quaternary level. For Japanese, Hiragana
     /// and Katakana are distinguished at the quaternary level. Also,
     /// if `AlternateHandling::Shifted` is used, the collation
     /// elements whose level gets shifted are shifted to this

--- a/components/normalizer/src/lib.rs
+++ b/components/normalizer/src/lib.rs
@@ -1760,6 +1760,7 @@ impl<'data> DecomposingNormalizerBorrowed<'data> {
     /// This constructor is intended for use by collations.
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
+    #[doc(hidden)]
     pub fn new_with_data(
         decompositions: &'data DecompositionData<'data>,
         tables: &'data DecompositionTables<'data>,

--- a/components/normalizer/src/lib.rs
+++ b/components/normalizer/src/lib.rs
@@ -1755,6 +1755,24 @@ impl DecomposingNormalizerBorrowed<'static> {
 }
 
 impl<'data> DecomposingNormalizerBorrowed<'data> {
+    /// NFD constructor using already-loaded data.
+    ///
+    /// This constructor is intended for use by collations.
+    ///
+    /// [📚 Help choosing a constructor](icu_provider::constructors)
+    pub fn new_with_data(
+        decompositions: &'data DecompositionData<'data>,
+        tables: &'data DecompositionTables<'data>,
+    ) -> Self {
+        Self {
+            decompositions,
+            tables,
+            supplementary_tables: None,
+            decomposition_passthrough_bound: 0xC0,
+            composition_passthrough_bound: 0x0300,
+        }
+    }
+
     /// Wraps a delegate iterator into a decomposing iterator
     /// adapter by using the data already held by this normalizer.
     pub fn normalize_iter<I: Iterator<Item = char>>(&self, iter: I) -> Decomposition<'data, I> {

--- a/ffi/capi/tests/missing_apis.txt
+++ b/ffi/capi/tests/missing_apis.txt
@@ -14,4 +14,3 @@
 # Please check in with @Manishearth, @robertbastian, or @sffc if you have questions
 
 
-icu::collator::CollatorBorrowed::write_sort_key#FnInStruct

--- a/ffi/capi/tests/missing_apis.txt
+++ b/ffi/capi/tests/missing_apis.txt
@@ -14,3 +14,6 @@
 # Please check in with @Manishearth, @robertbastian, or @sffc if you have questions
 
 
+icu::collator::CollatorBorrowed::write_sort_key_to#FnInStruct
+icu::collator::CollatorBorrowed::write_sort_key_utf16_to#FnInStruct
+icu::collator::CollatorBorrowed::write_sort_key_utf8_to#FnInStruct

--- a/ffi/capi/tests/missing_apis.txt
+++ b/ffi/capi/tests/missing_apis.txt
@@ -14,3 +14,4 @@
 # Please check in with @Manishearth, @robertbastian, or @sffc if you have questions
 
 
+icu::collator::CollatorBorrowed::write_sort_key#FnInStruct

--- a/tools/make/diplomat-coverage/src/allowlist.rs
+++ b/tools/make/diplomat-coverage/src/allowlist.rs
@@ -226,7 +226,8 @@ lazy_static::lazy_static! {
 
         // Trait required
         "icu::collator::CollatorBorrowed::write_sort_key",
-        "icu::collator::CollatorBorrowed::write_sort_key_up_to_quaternary",
+        "icu::collator::CollatorBorrowed::write_sort_key_utf8",
+        "icu::collator::CollatorBorrowed::write_sort_key_utf16",
 
         // Not planned for 2.0
         // We aren't exposing these collections directly, we instead expose them in a domain specific

--- a/tools/make/diplomat-coverage/src/allowlist.rs
+++ b/tools/make/diplomat-coverage/src/allowlist.rs
@@ -221,11 +221,6 @@ lazy_static::lazy_static! {
         "icu::normalizer::Composition",
         "icu::normalizer::Decomposition",
 
-        // Trait required
-        "icu::collator::CollatorBorrowed::write_sort_key_to",
-        "icu::collator::CollatorBorrowed::write_sort_key_utf8_to",
-        "icu::collator::CollatorBorrowed::write_sort_key_utf16_to",
-
         // Not planned for 2.0
         // We aren't exposing these collections directly, we instead expose them in a domain specific
         // way like CodePointSetDataBuilder. We may eventually add these as utilities for users.

--- a/tools/make/diplomat-coverage/src/allowlist.rs
+++ b/tools/make/diplomat-coverage/src/allowlist.rs
@@ -224,6 +224,10 @@ lazy_static::lazy_static! {
         "icu::normalizer::Composition",
         "icu::normalizer::Decomposition",
 
+        // Trait required
+        "icu::collator::CollatorBorrowed::write_sort_key",
+        "icu::collator::CollatorBorrowed::write_sort_key_up_to_quaternary",
+
         // Not planned for 2.0
         // We aren't exposing these collections directly, we instead expose them in a domain specific
         // way like CodePointSetDataBuilder. We may eventually add these as utilities for users.

--- a/tools/make/diplomat-coverage/src/allowlist.rs
+++ b/tools/make/diplomat-coverage/src/allowlist.rs
@@ -222,9 +222,9 @@ lazy_static::lazy_static! {
         "icu::normalizer::Decomposition",
 
         // Trait required
-        "icu::collator::CollatorBorrowed::write_sort_key",
-        "icu::collator::CollatorBorrowed::write_sort_key_utf8",
-        "icu::collator::CollatorBorrowed::write_sort_key_utf16",
+        "icu::collator::CollatorBorrowed::write_sort_key_to",
+        "icu::collator::CollatorBorrowed::write_sort_key_utf8_to",
+        "icu::collator::CollatorBorrowed::write_sort_key_utf16_to",
 
         // Not planned for 2.0
         // We aren't exposing these collections directly, we instead expose them in a domain specific

--- a/tools/make/diplomat-coverage/src/allowlist.rs
+++ b/tools/make/diplomat-coverage/src/allowlist.rs
@@ -207,6 +207,9 @@ lazy_static::lazy_static! {
         "icu::normalizer::uts46::Uts46Mapper",
         "icu::normalizer::uts46::Uts46MapperBorrowed",
 
+        // For internal use only by icu::collator::CollatorBorrowed::write_sort_key
+        "icu::normalizer::DecomposingNormalizerBorrowed::new_with_data",
+
         // Not planned for 2.0: we need DiplomatWriteable16
         "icu::normalizer::ComposingNormalizerBorrowed::normalize_utf16",
         "icu::normalizer::ComposingNormalizerBorrowed::normalize_utf16_to",

--- a/tools/make/diplomat-coverage/src/allowlist.rs
+++ b/tools/make/diplomat-coverage/src/allowlist.rs
@@ -207,9 +207,6 @@ lazy_static::lazy_static! {
         "icu::normalizer::uts46::Uts46Mapper",
         "icu::normalizer::uts46::Uts46MapperBorrowed",
 
-        // For internal use only by icu::collator::CollatorBorrowed::write_sort_key
-        "icu::normalizer::DecomposingNormalizerBorrowed::new_with_data",
-
         // Not planned for 2.0: we need DiplomatWriteable16
         "icu::normalizer::ComposingNormalizerBorrowed::normalize_utf16",
         "icu::normalizer::ComposingNormalizerBorrowed::normalize_utf16_to",


### PR DESCRIPTION
I mostly translate the C++ code straight across, but I made some minor changes to match the mindset of the Rust codebase, to match Rust practice, to satisfy Clippy, and to reduce copy-and-paste.

A comment on the issue suggested handling the identical level by appending UTF-8.  That's not what ICU4C does, but it's a whole lot simpler, so that's what I did.

At the end, some simple tests are included.

Fixes #2689