### PR TITLE
Improve comments in the collator

### DIFF
--- a/components/collator/src/comparison.rs
+++ b/components/collator/src/comparison.rs
@@ -79,7 +79,7 @@ fn in_inclusive_range16(i: u16, start: u16, end: u16) -> bool {
 }
 
 /// Finds the identical prefix of `left` and `right` containing
-/// potentially ill-formed UTF-16 avoiding splitting a
+/// potentially ill-formed UTF-16, while avoiding splitting a
 /// well-formed surrogate pair. In case of ill-formed
 /// UTF-16, the prefix is not guaranteed to be maximal.
 ///
@@ -110,7 +110,7 @@ fn split_prefix_u16<'a, 'b>(
 }
 
 /// Finds the identical prefix of `left` and `right` containing
-/// potentially ill-formed UTF-8 avoiding splitting a UTF-8
+/// potentially ill-formed UTF-8, while avoiding splitting a UTF-8
 /// byte sequence. In case of ill-formed UTF-8, the prefix is
 /// not guaranteed to be maximal.
 ///
@@ -696,7 +696,7 @@ impl CollatorBorrowed<'_> {
     /// Currently, all three have the same concrete type, so the
     /// trait bound is given as `DoubleEndedIterator`.
     /// `head_chars` is iterated backwards and `left_chars` and
-    /// `right_chars` forwards. It this was a public API, this
+    /// `right_chars` forward. If this were a public API, this
     /// should have three generic types, one for each argument,
     /// for maximum flexibility.
     fn compare_impl<I: DoubleEndedIterator<Item = char>>(
@@ -809,9 +809,9 @@ impl CollatorBorrowed<'_> {
         // The logic here to check whether the boundary found by skipping
         // the identical prefix is safe is complicated compared to the ICU4C
         // approach of having a set of characters that are unsafe as the character
-        // immediately after. However, this avoids extra data and working on the
-        // main data avoids the bug possibility data structures not being mutually
-        // consistent.
+        // immediately following the identical prefix. However, the approach here
+        // avoids extra data, and working on the main data avoids the bug
+        // possibility of data structures not being mutually consistent.
 
         // This code intentionally does not keep around the `CollationElement32`s
         // that have been read from the collation data tries, because keeping

--- a/components/collator/src/elements.rs
+++ b/components/collator/src/elements.rs
@@ -53,7 +53,7 @@ use crate::provider::CollationData;
 /// This should probably either be halved to 4 on the logic
 /// that especially in the presence of the identical prefix
 /// optimization, most comparisons return after a couple of
-/// primary compasions or increased to 32 on the logic that
+/// primary comparisons or increased to 32 on the logic that
 /// such a buffer could better hold a file or human name that
 /// differs on secordary or higher level.
 pub(crate) const CE_BUFFER_SIZE: usize = 8;
@@ -167,7 +167,7 @@ pub(crate) const QUATERNARY_MASK: u16 = 0xC0;
 
 // A CE32 is special if its low byte is this or greater.
 // Impossible case bits 11 mark special CE32s.
-// This value itself is used to indicate a fallback to the base collator.
+// This value itself is used to indicate a fallback to the root collation.
 const SPECIAL_CE32_LOW_BYTE: u8 = 0xC0;
 pub(crate) const FALLBACK_CE32: CollationElement32 =
     CollationElement32(SPECIAL_CE32_LOW_BYTE as u32);
@@ -827,7 +827,7 @@ impl CharacterAndClass {
 /// It is _extremely_ important for performance that `SmallVec`s not be
 /// moved. To facilitate move-avoidance, this struct has the following
 /// life cycle where `new` returns the struct in a state that is not
-/// yet valid for a `next` call:
+/// yet valid for a `next` call until `init` is called:
 ///
 /// 1. `new`.
 /// 2. Some number of calls to `iter_next_before_init` and


### PR DESCRIPTION
Addresses post-merge comments from #6496 and also adds a couple of other doc tweaks.