### PR TITLE
Add docs about locale consistency in zoned formatter

### DIFF
--- a/ffi/capi/bindings/cpp/icu4x/TimeZoneFormatter.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/TimeZoneFormatter.d.hpp
@@ -39,81 +39,161 @@ class TimeZoneFormatter {
 public:
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::TimeZoneFormatter>, icu4x::DateTimeFormatterLoadError> create_specific_long(const icu4x::Locale& locale);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::TimeZoneFormatter>, icu4x::DateTimeFormatterLoadError> create_specific_long_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::TimeZoneFormatter>, icu4x::DateTimeFormatterLoadError> create_specific_short(const icu4x::Locale& locale);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::TimeZoneFormatter>, icu4x::DateTimeFormatterLoadError> create_specific_short_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::TimeZoneFormatter>, icu4x::DateTimeFormatterLoadError> create_localized_offset_long(const icu4x::Locale& locale);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::TimeZoneFormatter>, icu4x::DateTimeFormatterLoadError> create_localized_offset_long_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::TimeZoneFormatter>, icu4x::DateTimeFormatterLoadError> create_localized_offset_short(const icu4x::Locale& locale);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::TimeZoneFormatter>, icu4x::DateTimeFormatterLoadError> create_localized_offset_short_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::TimeZoneFormatter>, icu4x::DateTimeFormatterLoadError> create_generic_long(const icu4x::Locale& locale);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::TimeZoneFormatter>, icu4x::DateTimeFormatterLoadError> create_generic_long_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::TimeZoneFormatter>, icu4x::DateTimeFormatterLoadError> create_generic_short(const icu4x::Locale& locale);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::TimeZoneFormatter>, icu4x::DateTimeFormatterLoadError> create_generic_short_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::TimeZoneFormatter>, icu4x::DateTimeFormatterLoadError> create_location(const icu4x::Locale& locale);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::TimeZoneFormatter>, icu4x::DateTimeFormatterLoadError> create_location_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::TimeZoneFormatter>, icu4x::DateTimeFormatterLoadError> create_exemplar_city(const icu4x::Locale& locale);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::TimeZoneFormatter>, icu4x::DateTimeFormatterLoadError> create_exemplar_city_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale);

--- a/ffi/capi/bindings/cpp/icu4x/ZonedDateFormatter.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/ZonedDateFormatter.d.hpp
@@ -43,81 +43,161 @@ class ZonedDateFormatter {
 public:
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateFormatter>, icu4x::DateTimeFormatterLoadError> create_specific_long(const icu4x::Locale& locale, const icu4x::DateFormatter& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateFormatter>, icu4x::DateTimeFormatterLoadError> create_specific_long_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::DateFormatter& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateFormatter>, icu4x::DateTimeFormatterLoadError> create_specific_short(const icu4x::Locale& locale, const icu4x::DateFormatter& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateFormatter>, icu4x::DateTimeFormatterLoadError> create_specific_short_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::DateFormatter& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateFormatter>, icu4x::DateTimeFormatterLoadError> create_localized_offset_long(const icu4x::Locale& locale, const icu4x::DateFormatter& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateFormatter>, icu4x::DateTimeFormatterLoadError> create_localized_offset_long_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::DateFormatter& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateFormatter>, icu4x::DateTimeFormatterLoadError> create_localized_offset_short(const icu4x::Locale& locale, const icu4x::DateFormatter& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateFormatter>, icu4x::DateTimeFormatterLoadError> create_localized_offset_short_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::DateFormatter& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateFormatter>, icu4x::DateTimeFormatterLoadError> create_generic_long(const icu4x::Locale& locale, const icu4x::DateFormatter& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateFormatter>, icu4x::DateTimeFormatterLoadError> create_generic_long_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::DateFormatter& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateFormatter>, icu4x::DateTimeFormatterLoadError> create_generic_short(const icu4x::Locale& locale, const icu4x::DateFormatter& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateFormatter>, icu4x::DateTimeFormatterLoadError> create_generic_short_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::DateFormatter& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateFormatter>, icu4x::DateTimeFormatterLoadError> create_location(const icu4x::Locale& locale, const icu4x::DateFormatter& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateFormatter>, icu4x::DateTimeFormatterLoadError> create_location_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::DateFormatter& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateFormatter>, icu4x::DateTimeFormatterLoadError> create_exemplar_city(const icu4x::Locale& locale, const icu4x::DateFormatter& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateFormatter>, icu4x::DateTimeFormatterLoadError> create_exemplar_city_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::DateFormatter& formatter);

--- a/ffi/capi/bindings/cpp/icu4x/ZonedDateFormatterGregorian.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/ZonedDateFormatterGregorian.d.hpp
@@ -43,81 +43,161 @@ class ZonedDateFormatterGregorian {
 public:
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_specific_long(const icu4x::Locale& locale, const icu4x::DateFormatterGregorian& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_specific_long_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::DateFormatterGregorian& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_specific_short(const icu4x::Locale& locale, const icu4x::DateFormatterGregorian& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_specific_short_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::DateFormatterGregorian& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_localized_offset_long(const icu4x::Locale& locale, const icu4x::DateFormatterGregorian& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_localized_offset_long_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::DateFormatterGregorian& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_localized_offset_short(const icu4x::Locale& locale, const icu4x::DateFormatterGregorian& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_localized_offset_short_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::DateFormatterGregorian& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_generic_long(const icu4x::Locale& locale, const icu4x::DateFormatterGregorian& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_generic_long_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::DateFormatterGregorian& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_generic_short(const icu4x::Locale& locale, const icu4x::DateFormatterGregorian& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_generic_short_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::DateFormatterGregorian& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_location(const icu4x::Locale& locale, const icu4x::DateFormatterGregorian& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_location_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::DateFormatterGregorian& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_exemplar_city(const icu4x::Locale& locale, const icu4x::DateFormatterGregorian& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_exemplar_city_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::DateFormatterGregorian& formatter);

--- a/ffi/capi/bindings/cpp/icu4x/ZonedDateTimeFormatter.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/ZonedDateTimeFormatter.d.hpp
@@ -45,81 +45,161 @@ class ZonedDateTimeFormatter {
 public:
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateTimeFormatter>, icu4x::DateTimeFormatterLoadError> create_specific_long(const icu4x::Locale& locale, const icu4x::DateTimeFormatter& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateTimeFormatter>, icu4x::DateTimeFormatterLoadError> create_specific_long_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::DateTimeFormatter& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateTimeFormatter>, icu4x::DateTimeFormatterLoadError> create_specific_short(const icu4x::Locale& locale, const icu4x::DateTimeFormatter& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateTimeFormatter>, icu4x::DateTimeFormatterLoadError> create_specific_short_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::DateTimeFormatter& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateTimeFormatter>, icu4x::DateTimeFormatterLoadError> create_localized_offset_long(const icu4x::Locale& locale, const icu4x::DateTimeFormatter& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateTimeFormatter>, icu4x::DateTimeFormatterLoadError> create_localized_offset_long_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::DateTimeFormatter& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateTimeFormatter>, icu4x::DateTimeFormatterLoadError> create_localized_offset_short(const icu4x::Locale& locale, const icu4x::DateTimeFormatter& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateTimeFormatter>, icu4x::DateTimeFormatterLoadError> create_localized_offset_short_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::DateTimeFormatter& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateTimeFormatter>, icu4x::DateTimeFormatterLoadError> create_generic_long(const icu4x::Locale& locale, const icu4x::DateTimeFormatter& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateTimeFormatter>, icu4x::DateTimeFormatterLoadError> create_generic_long_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::DateTimeFormatter& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateTimeFormatter>, icu4x::DateTimeFormatterLoadError> create_generic_short(const icu4x::Locale& locale, const icu4x::DateTimeFormatter& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateTimeFormatter>, icu4x::DateTimeFormatterLoadError> create_generic_short_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::DateTimeFormatter& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateTimeFormatter>, icu4x::DateTimeFormatterLoadError> create_location(const icu4x::Locale& locale, const icu4x::DateTimeFormatter& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateTimeFormatter>, icu4x::DateTimeFormatterLoadError> create_location_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::DateTimeFormatter& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateTimeFormatter>, icu4x::DateTimeFormatterLoadError> create_exemplar_city(const icu4x::Locale& locale, const icu4x::DateTimeFormatter& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateTimeFormatter>, icu4x::DateTimeFormatterLoadError> create_exemplar_city_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::DateTimeFormatter& formatter);

--- a/ffi/capi/bindings/cpp/icu4x/ZonedDateTimeFormatterGregorian.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/ZonedDateTimeFormatterGregorian.d.hpp
@@ -45,81 +45,161 @@ class ZonedDateTimeFormatterGregorian {
 public:
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateTimeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_specific_long(const icu4x::Locale& locale, const icu4x::DateTimeFormatterGregorian& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateTimeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_specific_long_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::DateTimeFormatterGregorian& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateTimeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_specific_short(const icu4x::Locale& locale, const icu4x::DateTimeFormatterGregorian& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateTimeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_specific_short_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::DateTimeFormatterGregorian& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateTimeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_localized_offset_long(const icu4x::Locale& locale, const icu4x::DateTimeFormatterGregorian& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateTimeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_localized_offset_long_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::DateTimeFormatterGregorian& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateTimeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_localized_offset_short(const icu4x::Locale& locale, const icu4x::DateTimeFormatterGregorian& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateTimeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_localized_offset_short_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::DateTimeFormatterGregorian& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateTimeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_generic_long(const icu4x::Locale& locale, const icu4x::DateTimeFormatterGregorian& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateTimeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_generic_long_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::DateTimeFormatterGregorian& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateTimeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_generic_short(const icu4x::Locale& locale, const icu4x::DateTimeFormatterGregorian& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateTimeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_generic_short_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::DateTimeFormatterGregorian& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateTimeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_location(const icu4x::Locale& locale, const icu4x::DateTimeFormatterGregorian& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateTimeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_location_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::DateTimeFormatterGregorian& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateTimeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_exemplar_city(const icu4x::Locale& locale, const icu4x::DateTimeFormatterGregorian& formatter);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedDateTimeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_exemplar_city_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::DateTimeFormatterGregorian& formatter);

--- a/ffi/capi/bindings/cpp/icu4x/ZonedTimeFormatter.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/ZonedTimeFormatter.d.hpp
@@ -44,81 +44,161 @@ class ZonedTimeFormatter {
 public:
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedTimeFormatter>, icu4x::DateTimeFormatterLoadError> create_specific_long(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedTimeFormatter>, icu4x::DateTimeFormatterLoadError> create_specific_long_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedTimeFormatter>, icu4x::DateTimeFormatterLoadError> create_specific_short(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedTimeFormatter>, icu4x::DateTimeFormatterLoadError> create_specific_short_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedTimeFormatter>, icu4x::DateTimeFormatterLoadError> create_localized_offset_long(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedTimeFormatter>, icu4x::DateTimeFormatterLoadError> create_localized_offset_long_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedTimeFormatter>, icu4x::DateTimeFormatterLoadError> create_localized_offset_short(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedTimeFormatter>, icu4x::DateTimeFormatterLoadError> create_localized_offset_short_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedTimeFormatter>, icu4x::DateTimeFormatterLoadError> create_generic_long(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedTimeFormatter>, icu4x::DateTimeFormatterLoadError> create_generic_long_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedTimeFormatter>, icu4x::DateTimeFormatterLoadError> create_generic_short(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedTimeFormatter>, icu4x::DateTimeFormatterLoadError> create_generic_short_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedTimeFormatter>, icu4x::DateTimeFormatterLoadError> create_location(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedTimeFormatter>, icu4x::DateTimeFormatterLoadError> create_location_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedTimeFormatter>, icu4x::DateTimeFormatterLoadError> create_exemplar_city(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * Creates a zoned formatter based on a non-zoned formatter.
+   *
+   * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+   * or else unexpected behavior may occur!
+   *
    * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
    */
   inline static diplomat::result<std::unique_ptr<icu4x::ZonedTimeFormatter>, icu4x::DateTimeFormatterLoadError> create_exemplar_city_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);

--- a/ffi/capi/bindings/dart/TimeZoneFormatter.g.dart
+++ b/ffi/capi/bindings/dart/TimeZoneFormatter.g.dart
@@ -23,6 +23,11 @@ final class TimeZoneFormatter implements ffi.Finalizable {
 
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_TimeZoneFormatter_destroy_mv1));
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -34,6 +39,11 @@ final class TimeZoneFormatter implements ffi.Finalizable {
     return TimeZoneFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -45,6 +55,11 @@ final class TimeZoneFormatter implements ffi.Finalizable {
     return TimeZoneFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -56,6 +71,11 @@ final class TimeZoneFormatter implements ffi.Finalizable {
     return TimeZoneFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -67,6 +87,11 @@ final class TimeZoneFormatter implements ffi.Finalizable {
     return TimeZoneFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -78,6 +103,11 @@ final class TimeZoneFormatter implements ffi.Finalizable {
     return TimeZoneFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -89,6 +119,11 @@ final class TimeZoneFormatter implements ffi.Finalizable {
     return TimeZoneFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -100,6 +135,11 @@ final class TimeZoneFormatter implements ffi.Finalizable {
     return TimeZoneFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -111,6 +151,11 @@ final class TimeZoneFormatter implements ffi.Finalizable {
     return TimeZoneFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -122,6 +167,11 @@ final class TimeZoneFormatter implements ffi.Finalizable {
     return TimeZoneFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -133,6 +183,11 @@ final class TimeZoneFormatter implements ffi.Finalizable {
     return TimeZoneFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -144,6 +199,11 @@ final class TimeZoneFormatter implements ffi.Finalizable {
     return TimeZoneFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -155,6 +215,11 @@ final class TimeZoneFormatter implements ffi.Finalizable {
     return TimeZoneFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -166,6 +231,11 @@ final class TimeZoneFormatter implements ffi.Finalizable {
     return TimeZoneFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -177,6 +247,11 @@ final class TimeZoneFormatter implements ffi.Finalizable {
     return TimeZoneFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -188,6 +263,11 @@ final class TimeZoneFormatter implements ffi.Finalizable {
     return TimeZoneFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.

--- a/ffi/capi/bindings/dart/ZonedDateFormatter.g.dart
+++ b/ffi/capi/bindings/dart/ZonedDateFormatter.g.dart
@@ -23,6 +23,11 @@ final class ZonedDateFormatter implements ffi.Finalizable {
 
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_ZonedDateFormatter_destroy_mv1));
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -34,6 +39,11 @@ final class ZonedDateFormatter implements ffi.Finalizable {
     return ZonedDateFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -45,6 +55,11 @@ final class ZonedDateFormatter implements ffi.Finalizable {
     return ZonedDateFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -56,6 +71,11 @@ final class ZonedDateFormatter implements ffi.Finalizable {
     return ZonedDateFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -67,6 +87,11 @@ final class ZonedDateFormatter implements ffi.Finalizable {
     return ZonedDateFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -78,6 +103,11 @@ final class ZonedDateFormatter implements ffi.Finalizable {
     return ZonedDateFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -89,6 +119,11 @@ final class ZonedDateFormatter implements ffi.Finalizable {
     return ZonedDateFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -100,6 +135,11 @@ final class ZonedDateFormatter implements ffi.Finalizable {
     return ZonedDateFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -111,6 +151,11 @@ final class ZonedDateFormatter implements ffi.Finalizable {
     return ZonedDateFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -122,6 +167,11 @@ final class ZonedDateFormatter implements ffi.Finalizable {
     return ZonedDateFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -133,6 +183,11 @@ final class ZonedDateFormatter implements ffi.Finalizable {
     return ZonedDateFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -144,6 +199,11 @@ final class ZonedDateFormatter implements ffi.Finalizable {
     return ZonedDateFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -155,6 +215,11 @@ final class ZonedDateFormatter implements ffi.Finalizable {
     return ZonedDateFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -166,6 +231,11 @@ final class ZonedDateFormatter implements ffi.Finalizable {
     return ZonedDateFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -177,6 +247,11 @@ final class ZonedDateFormatter implements ffi.Finalizable {
     return ZonedDateFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -188,6 +263,11 @@ final class ZonedDateFormatter implements ffi.Finalizable {
     return ZonedDateFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.

--- a/ffi/capi/bindings/dart/ZonedDateFormatterGregorian.g.dart
+++ b/ffi/capi/bindings/dart/ZonedDateFormatterGregorian.g.dart
@@ -23,6 +23,11 @@ final class ZonedDateFormatterGregorian implements ffi.Finalizable {
 
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_ZonedDateFormatterGregorian_destroy_mv1));
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -34,6 +39,11 @@ final class ZonedDateFormatterGregorian implements ffi.Finalizable {
     return ZonedDateFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -45,6 +55,11 @@ final class ZonedDateFormatterGregorian implements ffi.Finalizable {
     return ZonedDateFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -56,6 +71,11 @@ final class ZonedDateFormatterGregorian implements ffi.Finalizable {
     return ZonedDateFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -67,6 +87,11 @@ final class ZonedDateFormatterGregorian implements ffi.Finalizable {
     return ZonedDateFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -78,6 +103,11 @@ final class ZonedDateFormatterGregorian implements ffi.Finalizable {
     return ZonedDateFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -89,6 +119,11 @@ final class ZonedDateFormatterGregorian implements ffi.Finalizable {
     return ZonedDateFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -100,6 +135,11 @@ final class ZonedDateFormatterGregorian implements ffi.Finalizable {
     return ZonedDateFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -111,6 +151,11 @@ final class ZonedDateFormatterGregorian implements ffi.Finalizable {
     return ZonedDateFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -122,6 +167,11 @@ final class ZonedDateFormatterGregorian implements ffi.Finalizable {
     return ZonedDateFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -133,6 +183,11 @@ final class ZonedDateFormatterGregorian implements ffi.Finalizable {
     return ZonedDateFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -144,6 +199,11 @@ final class ZonedDateFormatterGregorian implements ffi.Finalizable {
     return ZonedDateFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -155,6 +215,11 @@ final class ZonedDateFormatterGregorian implements ffi.Finalizable {
     return ZonedDateFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -166,6 +231,11 @@ final class ZonedDateFormatterGregorian implements ffi.Finalizable {
     return ZonedDateFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -177,6 +247,11 @@ final class ZonedDateFormatterGregorian implements ffi.Finalizable {
     return ZonedDateFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -188,6 +263,11 @@ final class ZonedDateFormatterGregorian implements ffi.Finalizable {
     return ZonedDateFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.

--- a/ffi/capi/bindings/dart/ZonedDateTimeFormatter.g.dart
+++ b/ffi/capi/bindings/dart/ZonedDateTimeFormatter.g.dart
@@ -23,6 +23,11 @@ final class ZonedDateTimeFormatter implements ffi.Finalizable {
 
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_ZonedDateTimeFormatter_destroy_mv1));
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -34,6 +39,11 @@ final class ZonedDateTimeFormatter implements ffi.Finalizable {
     return ZonedDateTimeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -45,6 +55,11 @@ final class ZonedDateTimeFormatter implements ffi.Finalizable {
     return ZonedDateTimeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -56,6 +71,11 @@ final class ZonedDateTimeFormatter implements ffi.Finalizable {
     return ZonedDateTimeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -67,6 +87,11 @@ final class ZonedDateTimeFormatter implements ffi.Finalizable {
     return ZonedDateTimeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -78,6 +103,11 @@ final class ZonedDateTimeFormatter implements ffi.Finalizable {
     return ZonedDateTimeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -89,6 +119,11 @@ final class ZonedDateTimeFormatter implements ffi.Finalizable {
     return ZonedDateTimeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -100,6 +135,11 @@ final class ZonedDateTimeFormatter implements ffi.Finalizable {
     return ZonedDateTimeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -111,6 +151,11 @@ final class ZonedDateTimeFormatter implements ffi.Finalizable {
     return ZonedDateTimeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -122,6 +167,11 @@ final class ZonedDateTimeFormatter implements ffi.Finalizable {
     return ZonedDateTimeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -133,6 +183,11 @@ final class ZonedDateTimeFormatter implements ffi.Finalizable {
     return ZonedDateTimeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -144,6 +199,11 @@ final class ZonedDateTimeFormatter implements ffi.Finalizable {
     return ZonedDateTimeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -155,6 +215,11 @@ final class ZonedDateTimeFormatter implements ffi.Finalizable {
     return ZonedDateTimeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -166,6 +231,11 @@ final class ZonedDateTimeFormatter implements ffi.Finalizable {
     return ZonedDateTimeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -177,6 +247,11 @@ final class ZonedDateTimeFormatter implements ffi.Finalizable {
     return ZonedDateTimeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -188,6 +263,11 @@ final class ZonedDateTimeFormatter implements ffi.Finalizable {
     return ZonedDateTimeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.

--- a/ffi/capi/bindings/dart/ZonedDateTimeFormatterGregorian.g.dart
+++ b/ffi/capi/bindings/dart/ZonedDateTimeFormatterGregorian.g.dart
@@ -23,6 +23,11 @@ final class ZonedDateTimeFormatterGregorian implements ffi.Finalizable {
 
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_ZonedDateTimeFormatterGregorian_destroy_mv1));
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -34,6 +39,11 @@ final class ZonedDateTimeFormatterGregorian implements ffi.Finalizable {
     return ZonedDateTimeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -45,6 +55,11 @@ final class ZonedDateTimeFormatterGregorian implements ffi.Finalizable {
     return ZonedDateTimeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -56,6 +71,11 @@ final class ZonedDateTimeFormatterGregorian implements ffi.Finalizable {
     return ZonedDateTimeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -67,6 +87,11 @@ final class ZonedDateTimeFormatterGregorian implements ffi.Finalizable {
     return ZonedDateTimeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -78,6 +103,11 @@ final class ZonedDateTimeFormatterGregorian implements ffi.Finalizable {
     return ZonedDateTimeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -89,6 +119,11 @@ final class ZonedDateTimeFormatterGregorian implements ffi.Finalizable {
     return ZonedDateTimeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -100,6 +135,11 @@ final class ZonedDateTimeFormatterGregorian implements ffi.Finalizable {
     return ZonedDateTimeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -111,6 +151,11 @@ final class ZonedDateTimeFormatterGregorian implements ffi.Finalizable {
     return ZonedDateTimeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -122,6 +167,11 @@ final class ZonedDateTimeFormatterGregorian implements ffi.Finalizable {
     return ZonedDateTimeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -133,6 +183,11 @@ final class ZonedDateTimeFormatterGregorian implements ffi.Finalizable {
     return ZonedDateTimeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -144,6 +199,11 @@ final class ZonedDateTimeFormatterGregorian implements ffi.Finalizable {
     return ZonedDateTimeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -155,6 +215,11 @@ final class ZonedDateTimeFormatterGregorian implements ffi.Finalizable {
     return ZonedDateTimeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -166,6 +231,11 @@ final class ZonedDateTimeFormatterGregorian implements ffi.Finalizable {
     return ZonedDateTimeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -177,6 +247,11 @@ final class ZonedDateTimeFormatterGregorian implements ffi.Finalizable {
     return ZonedDateTimeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -188,6 +263,11 @@ final class ZonedDateTimeFormatterGregorian implements ffi.Finalizable {
     return ZonedDateTimeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.

--- a/ffi/capi/bindings/dart/ZonedTimeFormatter.g.dart
+++ b/ffi/capi/bindings/dart/ZonedTimeFormatter.g.dart
@@ -23,6 +23,11 @@ final class ZonedTimeFormatter implements ffi.Finalizable {
 
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_ZonedTimeFormatter_destroy_mv1));
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -34,6 +39,11 @@ final class ZonedTimeFormatter implements ffi.Finalizable {
     return ZonedTimeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -45,6 +55,11 @@ final class ZonedTimeFormatter implements ffi.Finalizable {
     return ZonedTimeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -56,6 +71,11 @@ final class ZonedTimeFormatter implements ffi.Finalizable {
     return ZonedTimeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -67,6 +87,11 @@ final class ZonedTimeFormatter implements ffi.Finalizable {
     return ZonedTimeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -78,6 +103,11 @@ final class ZonedTimeFormatter implements ffi.Finalizable {
     return ZonedTimeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -89,6 +119,11 @@ final class ZonedTimeFormatter implements ffi.Finalizable {
     return ZonedTimeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -100,6 +135,11 @@ final class ZonedTimeFormatter implements ffi.Finalizable {
     return ZonedTimeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -111,6 +151,11 @@ final class ZonedTimeFormatter implements ffi.Finalizable {
     return ZonedTimeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -122,6 +167,11 @@ final class ZonedTimeFormatter implements ffi.Finalizable {
     return ZonedTimeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -133,6 +183,11 @@ final class ZonedTimeFormatter implements ffi.Finalizable {
     return ZonedTimeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -144,6 +199,11 @@ final class ZonedTimeFormatter implements ffi.Finalizable {
     return ZonedTimeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -155,6 +215,11 @@ final class ZonedTimeFormatter implements ffi.Finalizable {
     return ZonedTimeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -166,6 +231,11 @@ final class ZonedTimeFormatter implements ffi.Finalizable {
     return ZonedTimeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -177,6 +247,11 @@ final class ZonedTimeFormatter implements ffi.Finalizable {
     return ZonedTimeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
@@ -188,6 +263,11 @@ final class ZonedTimeFormatter implements ffi.Finalizable {
     return ZonedTimeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// Creates a zoned formatter based on a non-zoned formatter.
+  ///
+  /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+  /// or else unexpected behavior may occur!
+  ///
   /// See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.

--- a/ffi/capi/bindings/js/TimeZoneFormatter.d.ts
+++ b/ffi/capi/bindings/js/TimeZoneFormatter.d.ts
@@ -17,81 +17,161 @@ export class TimeZoneFormatter {
 
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
      */
     static createSpecificLong(locale: Locale): TimeZoneFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
      */
     static createSpecificLongWithProvider(provider: DataProvider, locale: Locale): TimeZoneFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
      */
     static createSpecificShort(locale: Locale): TimeZoneFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
      */
     static createSpecificShortWithProvider(provider: DataProvider, locale: Locale): TimeZoneFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
      */
     static createLocalizedOffsetLong(locale: Locale): TimeZoneFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
      */
     static createLocalizedOffsetLongWithProvider(provider: DataProvider, locale: Locale): TimeZoneFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
      */
     static createLocalizedOffsetShort(locale: Locale): TimeZoneFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
      */
     static createLocalizedOffsetShortWithProvider(provider: DataProvider, locale: Locale): TimeZoneFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
      */
     static createGenericLong(locale: Locale): TimeZoneFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
      */
     static createGenericLongWithProvider(provider: DataProvider, locale: Locale): TimeZoneFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
      */
     static createGenericShort(locale: Locale): TimeZoneFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
      */
     static createGenericShortWithProvider(provider: DataProvider, locale: Locale): TimeZoneFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
      */
     static createLocation(locale: Locale): TimeZoneFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
      */
     static createLocationWithProvider(provider: DataProvider, locale: Locale): TimeZoneFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
      */
     static createExemplarCity(locale: Locale): TimeZoneFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
      */
     static createExemplarCityWithProvider(provider: DataProvider, locale: Locale): TimeZoneFormatter;

--- a/ffi/capi/bindings/js/TimeZoneFormatter.mjs
+++ b/ffi/capi/bindings/js/TimeZoneFormatter.mjs
@@ -44,6 +44,11 @@ export class TimeZoneFormatter {
 
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
      */
     static createSpecificLong(locale) {
@@ -66,6 +71,11 @@ export class TimeZoneFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
      */
     static createSpecificLongWithProvider(provider, locale) {
@@ -88,6 +98,11 @@ export class TimeZoneFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
      */
     static createSpecificShort(locale) {
@@ -110,6 +125,11 @@ export class TimeZoneFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
      */
     static createSpecificShortWithProvider(provider, locale) {
@@ -132,6 +152,11 @@ export class TimeZoneFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
      */
     static createLocalizedOffsetLong(locale) {
@@ -154,6 +179,11 @@ export class TimeZoneFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
      */
     static createLocalizedOffsetLongWithProvider(provider, locale) {
@@ -176,6 +206,11 @@ export class TimeZoneFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
      */
     static createLocalizedOffsetShort(locale) {
@@ -198,6 +233,11 @@ export class TimeZoneFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
      */
     static createLocalizedOffsetShortWithProvider(provider, locale) {
@@ -220,6 +260,11 @@ export class TimeZoneFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
      */
     static createGenericLong(locale) {
@@ -242,6 +287,11 @@ export class TimeZoneFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
      */
     static createGenericLongWithProvider(provider, locale) {
@@ -264,6 +314,11 @@ export class TimeZoneFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
      */
     static createGenericShort(locale) {
@@ -286,6 +341,11 @@ export class TimeZoneFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
      */
     static createGenericShortWithProvider(provider, locale) {
@@ -308,6 +368,11 @@ export class TimeZoneFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
      */
     static createLocation(locale) {
@@ -330,6 +395,11 @@ export class TimeZoneFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
      */
     static createLocationWithProvider(provider, locale) {
@@ -352,6 +422,11 @@ export class TimeZoneFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
      */
     static createExemplarCity(locale) {
@@ -374,6 +449,11 @@ export class TimeZoneFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
      */
     static createExemplarCityWithProvider(provider, locale) {

--- a/ffi/capi/bindings/js/ZonedDateFormatter.d.ts
+++ b/ffi/capi/bindings/js/ZonedDateFormatter.d.ts
@@ -19,81 +19,161 @@ export class ZonedDateFormatter {
 
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
      */
     static createSpecificLong(locale: Locale, formatter: DateFormatter): ZonedDateFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
      */
     static createSpecificLongWithProvider(provider: DataProvider, locale: Locale, formatter: DateFormatter): ZonedDateFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
      */
     static createSpecificShort(locale: Locale, formatter: DateFormatter): ZonedDateFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
      */
     static createSpecificShortWithProvider(provider: DataProvider, locale: Locale, formatter: DateFormatter): ZonedDateFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
      */
     static createLocalizedOffsetLong(locale: Locale, formatter: DateFormatter): ZonedDateFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
      */
     static createLocalizedOffsetLongWithProvider(provider: DataProvider, locale: Locale, formatter: DateFormatter): ZonedDateFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
      */
     static createLocalizedOffsetShort(locale: Locale, formatter: DateFormatter): ZonedDateFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
      */
     static createLocalizedOffsetShortWithProvider(provider: DataProvider, locale: Locale, formatter: DateFormatter): ZonedDateFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
      */
     static createGenericLong(locale: Locale, formatter: DateFormatter): ZonedDateFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
      */
     static createGenericLongWithProvider(provider: DataProvider, locale: Locale, formatter: DateFormatter): ZonedDateFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
      */
     static createGenericShort(locale: Locale, formatter: DateFormatter): ZonedDateFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
      */
     static createGenericShortWithProvider(provider: DataProvider, locale: Locale, formatter: DateFormatter): ZonedDateFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
      */
     static createLocation(locale: Locale, formatter: DateFormatter): ZonedDateFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
      */
     static createLocationWithProvider(provider: DataProvider, locale: Locale, formatter: DateFormatter): ZonedDateFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
      */
     static createExemplarCity(locale: Locale, formatter: DateFormatter): ZonedDateFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
      */
     static createExemplarCityWithProvider(provider: DataProvider, locale: Locale, formatter: DateFormatter): ZonedDateFormatter;

--- a/ffi/capi/bindings/js/ZonedDateFormatter.mjs
+++ b/ffi/capi/bindings/js/ZonedDateFormatter.mjs
@@ -46,6 +46,11 @@ export class ZonedDateFormatter {
 
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
      */
     static createSpecificLong(locale, formatter) {
@@ -68,6 +73,11 @@ export class ZonedDateFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
      */
     static createSpecificLongWithProvider(provider, locale, formatter) {
@@ -90,6 +100,11 @@ export class ZonedDateFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
      */
     static createSpecificShort(locale, formatter) {
@@ -112,6 +127,11 @@ export class ZonedDateFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
      */
     static createSpecificShortWithProvider(provider, locale, formatter) {
@@ -134,6 +154,11 @@ export class ZonedDateFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
      */
     static createLocalizedOffsetLong(locale, formatter) {
@@ -156,6 +181,11 @@ export class ZonedDateFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
      */
     static createLocalizedOffsetLongWithProvider(provider, locale, formatter) {
@@ -178,6 +208,11 @@ export class ZonedDateFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
      */
     static createLocalizedOffsetShort(locale, formatter) {
@@ -200,6 +235,11 @@ export class ZonedDateFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
      */
     static createLocalizedOffsetShortWithProvider(provider, locale, formatter) {
@@ -222,6 +262,11 @@ export class ZonedDateFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
      */
     static createGenericLong(locale, formatter) {
@@ -244,6 +289,11 @@ export class ZonedDateFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
      */
     static createGenericLongWithProvider(provider, locale, formatter) {
@@ -266,6 +316,11 @@ export class ZonedDateFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
      */
     static createGenericShort(locale, formatter) {
@@ -288,6 +343,11 @@ export class ZonedDateFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
      */
     static createGenericShortWithProvider(provider, locale, formatter) {
@@ -310,6 +370,11 @@ export class ZonedDateFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
      */
     static createLocation(locale, formatter) {
@@ -332,6 +397,11 @@ export class ZonedDateFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
      */
     static createLocationWithProvider(provider, locale, formatter) {
@@ -354,6 +424,11 @@ export class ZonedDateFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
      */
     static createExemplarCity(locale, formatter) {
@@ -376,6 +451,11 @@ export class ZonedDateFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
      */
     static createExemplarCityWithProvider(provider, locale, formatter) {

--- a/ffi/capi/bindings/js/ZonedDateFormatterGregorian.d.ts
+++ b/ffi/capi/bindings/js/ZonedDateFormatterGregorian.d.ts
@@ -19,81 +19,161 @@ export class ZonedDateFormatterGregorian {
 
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
      */
     static createSpecificLong(locale: Locale, formatter: DateFormatterGregorian): ZonedDateFormatterGregorian;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
      */
     static createSpecificLongWithProvider(provider: DataProvider, locale: Locale, formatter: DateFormatterGregorian): ZonedDateFormatterGregorian;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
      */
     static createSpecificShort(locale: Locale, formatter: DateFormatterGregorian): ZonedDateFormatterGregorian;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
      */
     static createSpecificShortWithProvider(provider: DataProvider, locale: Locale, formatter: DateFormatterGregorian): ZonedDateFormatterGregorian;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
      */
     static createLocalizedOffsetLong(locale: Locale, formatter: DateFormatterGregorian): ZonedDateFormatterGregorian;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
      */
     static createLocalizedOffsetLongWithProvider(provider: DataProvider, locale: Locale, formatter: DateFormatterGregorian): ZonedDateFormatterGregorian;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
      */
     static createLocalizedOffsetShort(locale: Locale, formatter: DateFormatterGregorian): ZonedDateFormatterGregorian;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
      */
     static createLocalizedOffsetShortWithProvider(provider: DataProvider, locale: Locale, formatter: DateFormatterGregorian): ZonedDateFormatterGregorian;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
      */
     static createGenericLong(locale: Locale, formatter: DateFormatterGregorian): ZonedDateFormatterGregorian;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
      */
     static createGenericLongWithProvider(provider: DataProvider, locale: Locale, formatter: DateFormatterGregorian): ZonedDateFormatterGregorian;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
      */
     static createGenericShort(locale: Locale, formatter: DateFormatterGregorian): ZonedDateFormatterGregorian;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
      */
     static createGenericShortWithProvider(provider: DataProvider, locale: Locale, formatter: DateFormatterGregorian): ZonedDateFormatterGregorian;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
      */
     static createLocation(locale: Locale, formatter: DateFormatterGregorian): ZonedDateFormatterGregorian;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
      */
     static createLocationWithProvider(provider: DataProvider, locale: Locale, formatter: DateFormatterGregorian): ZonedDateFormatterGregorian;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
      */
     static createExemplarCity(locale: Locale, formatter: DateFormatterGregorian): ZonedDateFormatterGregorian;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
      */
     static createExemplarCityWithProvider(provider: DataProvider, locale: Locale, formatter: DateFormatterGregorian): ZonedDateFormatterGregorian;

--- a/ffi/capi/bindings/js/ZonedDateFormatterGregorian.mjs
+++ b/ffi/capi/bindings/js/ZonedDateFormatterGregorian.mjs
@@ -46,6 +46,11 @@ export class ZonedDateFormatterGregorian {
 
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
      */
     static createSpecificLong(locale, formatter) {
@@ -68,6 +73,11 @@ export class ZonedDateFormatterGregorian {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
      */
     static createSpecificLongWithProvider(provider, locale, formatter) {
@@ -90,6 +100,11 @@ export class ZonedDateFormatterGregorian {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
      */
     static createSpecificShort(locale, formatter) {
@@ -112,6 +127,11 @@ export class ZonedDateFormatterGregorian {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
      */
     static createSpecificShortWithProvider(provider, locale, formatter) {
@@ -134,6 +154,11 @@ export class ZonedDateFormatterGregorian {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
      */
     static createLocalizedOffsetLong(locale, formatter) {
@@ -156,6 +181,11 @@ export class ZonedDateFormatterGregorian {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
      */
     static createLocalizedOffsetLongWithProvider(provider, locale, formatter) {
@@ -178,6 +208,11 @@ export class ZonedDateFormatterGregorian {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
      */
     static createLocalizedOffsetShort(locale, formatter) {
@@ -200,6 +235,11 @@ export class ZonedDateFormatterGregorian {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
      */
     static createLocalizedOffsetShortWithProvider(provider, locale, formatter) {
@@ -222,6 +262,11 @@ export class ZonedDateFormatterGregorian {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
      */
     static createGenericLong(locale, formatter) {
@@ -244,6 +289,11 @@ export class ZonedDateFormatterGregorian {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
      */
     static createGenericLongWithProvider(provider, locale, formatter) {
@@ -266,6 +316,11 @@ export class ZonedDateFormatterGregorian {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
      */
     static createGenericShort(locale, formatter) {
@@ -288,6 +343,11 @@ export class ZonedDateFormatterGregorian {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
      */
     static createGenericShortWithProvider(provider, locale, formatter) {
@@ -310,6 +370,11 @@ export class ZonedDateFormatterGregorian {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
      */
     static createLocation(locale, formatter) {
@@ -332,6 +397,11 @@ export class ZonedDateFormatterGregorian {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
      */
     static createLocationWithProvider(provider, locale, formatter) {
@@ -354,6 +424,11 @@ export class ZonedDateFormatterGregorian {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
      */
     static createExemplarCity(locale, formatter) {
@@ -376,6 +451,11 @@ export class ZonedDateFormatterGregorian {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
      */
     static createExemplarCityWithProvider(provider, locale, formatter) {

--- a/ffi/capi/bindings/js/ZonedDateTimeFormatter.d.ts
+++ b/ffi/capi/bindings/js/ZonedDateTimeFormatter.d.ts
@@ -20,81 +20,161 @@ export class ZonedDateTimeFormatter {
 
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
      */
     static createSpecificLong(locale: Locale, formatter: DateTimeFormatter): ZonedDateTimeFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
      */
     static createSpecificLongWithProvider(provider: DataProvider, locale: Locale, formatter: DateTimeFormatter): ZonedDateTimeFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
      */
     static createSpecificShort(locale: Locale, formatter: DateTimeFormatter): ZonedDateTimeFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
      */
     static createSpecificShortWithProvider(provider: DataProvider, locale: Locale, formatter: DateTimeFormatter): ZonedDateTimeFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
      */
     static createLocalizedOffsetLong(locale: Locale, formatter: DateTimeFormatter): ZonedDateTimeFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
      */
     static createLocalizedOffsetLongWithProvider(provider: DataProvider, locale: Locale, formatter: DateTimeFormatter): ZonedDateTimeFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
      */
     static createLocalizedOffsetShort(locale: Locale, formatter: DateTimeFormatter): ZonedDateTimeFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
      */
     static createLocalizedOffsetShortWithProvider(provider: DataProvider, locale: Locale, formatter: DateTimeFormatter): ZonedDateTimeFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
      */
     static createGenericLong(locale: Locale, formatter: DateTimeFormatter): ZonedDateTimeFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
      */
     static createGenericLongWithProvider(provider: DataProvider, locale: Locale, formatter: DateTimeFormatter): ZonedDateTimeFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
      */
     static createGenericShort(locale: Locale, formatter: DateTimeFormatter): ZonedDateTimeFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
      */
     static createGenericShortWithProvider(provider: DataProvider, locale: Locale, formatter: DateTimeFormatter): ZonedDateTimeFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
      */
     static createLocation(locale: Locale, formatter: DateTimeFormatter): ZonedDateTimeFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
      */
     static createLocationWithProvider(provider: DataProvider, locale: Locale, formatter: DateTimeFormatter): ZonedDateTimeFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
      */
     static createExemplarCity(locale: Locale, formatter: DateTimeFormatter): ZonedDateTimeFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
      */
     static createExemplarCityWithProvider(provider: DataProvider, locale: Locale, formatter: DateTimeFormatter): ZonedDateTimeFormatter;

--- a/ffi/capi/bindings/js/ZonedDateTimeFormatter.mjs
+++ b/ffi/capi/bindings/js/ZonedDateTimeFormatter.mjs
@@ -47,6 +47,11 @@ export class ZonedDateTimeFormatter {
 
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
      */
     static createSpecificLong(locale, formatter) {
@@ -69,6 +74,11 @@ export class ZonedDateTimeFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
      */
     static createSpecificLongWithProvider(provider, locale, formatter) {
@@ -91,6 +101,11 @@ export class ZonedDateTimeFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
      */
     static createSpecificShort(locale, formatter) {
@@ -113,6 +128,11 @@ export class ZonedDateTimeFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
      */
     static createSpecificShortWithProvider(provider, locale, formatter) {
@@ -135,6 +155,11 @@ export class ZonedDateTimeFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
      */
     static createLocalizedOffsetLong(locale, formatter) {
@@ -157,6 +182,11 @@ export class ZonedDateTimeFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
      */
     static createLocalizedOffsetLongWithProvider(provider, locale, formatter) {
@@ -179,6 +209,11 @@ export class ZonedDateTimeFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
      */
     static createLocalizedOffsetShort(locale, formatter) {
@@ -201,6 +236,11 @@ export class ZonedDateTimeFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
      */
     static createLocalizedOffsetShortWithProvider(provider, locale, formatter) {
@@ -223,6 +263,11 @@ export class ZonedDateTimeFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
      */
     static createGenericLong(locale, formatter) {
@@ -245,6 +290,11 @@ export class ZonedDateTimeFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
      */
     static createGenericLongWithProvider(provider, locale, formatter) {
@@ -267,6 +317,11 @@ export class ZonedDateTimeFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
      */
     static createGenericShort(locale, formatter) {
@@ -289,6 +344,11 @@ export class ZonedDateTimeFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
      */
     static createGenericShortWithProvider(provider, locale, formatter) {
@@ -311,6 +371,11 @@ export class ZonedDateTimeFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
      */
     static createLocation(locale, formatter) {
@@ -333,6 +398,11 @@ export class ZonedDateTimeFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
      */
     static createLocationWithProvider(provider, locale, formatter) {
@@ -355,6 +425,11 @@ export class ZonedDateTimeFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
      */
     static createExemplarCity(locale, formatter) {
@@ -377,6 +452,11 @@ export class ZonedDateTimeFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
      */
     static createExemplarCityWithProvider(provider, locale, formatter) {

--- a/ffi/capi/bindings/js/ZonedDateTimeFormatterGregorian.d.ts
+++ b/ffi/capi/bindings/js/ZonedDateTimeFormatterGregorian.d.ts
@@ -20,81 +20,161 @@ export class ZonedDateTimeFormatterGregorian {
 
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
      */
     static createSpecificLong(locale: Locale, formatter: DateTimeFormatterGregorian): ZonedDateTimeFormatterGregorian;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
      */
     static createSpecificLongWithProvider(provider: DataProvider, locale: Locale, formatter: DateTimeFormatterGregorian): ZonedDateTimeFormatterGregorian;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
      */
     static createSpecificShort(locale: Locale, formatter: DateTimeFormatterGregorian): ZonedDateTimeFormatterGregorian;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
      */
     static createSpecificShortWithProvider(provider: DataProvider, locale: Locale, formatter: DateTimeFormatterGregorian): ZonedDateTimeFormatterGregorian;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
      */
     static createLocalizedOffsetLong(locale: Locale, formatter: DateTimeFormatterGregorian): ZonedDateTimeFormatterGregorian;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
      */
     static createLocalizedOffsetLongWithProvider(provider: DataProvider, locale: Locale, formatter: DateTimeFormatterGregorian): ZonedDateTimeFormatterGregorian;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
      */
     static createLocalizedOffsetShort(locale: Locale, formatter: DateTimeFormatterGregorian): ZonedDateTimeFormatterGregorian;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
      */
     static createLocalizedOffsetShortWithProvider(provider: DataProvider, locale: Locale, formatter: DateTimeFormatterGregorian): ZonedDateTimeFormatterGregorian;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
      */
     static createGenericLong(locale: Locale, formatter: DateTimeFormatterGregorian): ZonedDateTimeFormatterGregorian;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
      */
     static createGenericLongWithProvider(provider: DataProvider, locale: Locale, formatter: DateTimeFormatterGregorian): ZonedDateTimeFormatterGregorian;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
      */
     static createGenericShort(locale: Locale, formatter: DateTimeFormatterGregorian): ZonedDateTimeFormatterGregorian;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
      */
     static createGenericShortWithProvider(provider: DataProvider, locale: Locale, formatter: DateTimeFormatterGregorian): ZonedDateTimeFormatterGregorian;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
      */
     static createLocation(locale: Locale, formatter: DateTimeFormatterGregorian): ZonedDateTimeFormatterGregorian;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
      */
     static createLocationWithProvider(provider: DataProvider, locale: Locale, formatter: DateTimeFormatterGregorian): ZonedDateTimeFormatterGregorian;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
      */
     static createExemplarCity(locale: Locale, formatter: DateTimeFormatterGregorian): ZonedDateTimeFormatterGregorian;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
      */
     static createExemplarCityWithProvider(provider: DataProvider, locale: Locale, formatter: DateTimeFormatterGregorian): ZonedDateTimeFormatterGregorian;

--- a/ffi/capi/bindings/js/ZonedDateTimeFormatterGregorian.mjs
+++ b/ffi/capi/bindings/js/ZonedDateTimeFormatterGregorian.mjs
@@ -47,6 +47,11 @@ export class ZonedDateTimeFormatterGregorian {
 
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
      */
     static createSpecificLong(locale, formatter) {
@@ -69,6 +74,11 @@ export class ZonedDateTimeFormatterGregorian {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
      */
     static createSpecificLongWithProvider(provider, locale, formatter) {
@@ -91,6 +101,11 @@ export class ZonedDateTimeFormatterGregorian {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
      */
     static createSpecificShort(locale, formatter) {
@@ -113,6 +128,11 @@ export class ZonedDateTimeFormatterGregorian {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
      */
     static createSpecificShortWithProvider(provider, locale, formatter) {
@@ -135,6 +155,11 @@ export class ZonedDateTimeFormatterGregorian {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
      */
     static createLocalizedOffsetLong(locale, formatter) {
@@ -157,6 +182,11 @@ export class ZonedDateTimeFormatterGregorian {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
      */
     static createLocalizedOffsetLongWithProvider(provider, locale, formatter) {
@@ -179,6 +209,11 @@ export class ZonedDateTimeFormatterGregorian {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
      */
     static createLocalizedOffsetShort(locale, formatter) {
@@ -201,6 +236,11 @@ export class ZonedDateTimeFormatterGregorian {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
      */
     static createLocalizedOffsetShortWithProvider(provider, locale, formatter) {
@@ -223,6 +263,11 @@ export class ZonedDateTimeFormatterGregorian {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
      */
     static createGenericLong(locale, formatter) {
@@ -245,6 +290,11 @@ export class ZonedDateTimeFormatterGregorian {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
      */
     static createGenericLongWithProvider(provider, locale, formatter) {
@@ -267,6 +317,11 @@ export class ZonedDateTimeFormatterGregorian {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
      */
     static createGenericShort(locale, formatter) {
@@ -289,6 +344,11 @@ export class ZonedDateTimeFormatterGregorian {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
      */
     static createGenericShortWithProvider(provider, locale, formatter) {
@@ -311,6 +371,11 @@ export class ZonedDateTimeFormatterGregorian {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
      */
     static createLocation(locale, formatter) {
@@ -333,6 +398,11 @@ export class ZonedDateTimeFormatterGregorian {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
      */
     static createLocationWithProvider(provider, locale, formatter) {
@@ -355,6 +425,11 @@ export class ZonedDateTimeFormatterGregorian {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
      */
     static createExemplarCity(locale, formatter) {
@@ -377,6 +452,11 @@ export class ZonedDateTimeFormatterGregorian {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
      */
     static createExemplarCityWithProvider(provider, locale, formatter) {

--- a/ffi/capi/bindings/js/ZonedTimeFormatter.d.ts
+++ b/ffi/capi/bindings/js/ZonedTimeFormatter.d.ts
@@ -21,81 +21,161 @@ export class ZonedTimeFormatter {
 
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
      */
     static createSpecificLong(locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): ZonedTimeFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
      */
     static createSpecificLongWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): ZonedTimeFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
      */
     static createSpecificShort(locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): ZonedTimeFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
      */
     static createSpecificShortWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): ZonedTimeFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
      */
     static createLocalizedOffsetLong(locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): ZonedTimeFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
      */
     static createLocalizedOffsetLongWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): ZonedTimeFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
      */
     static createLocalizedOffsetShort(locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): ZonedTimeFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
      */
     static createLocalizedOffsetShortWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): ZonedTimeFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
      */
     static createGenericLong(locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): ZonedTimeFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
      */
     static createGenericLongWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): ZonedTimeFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
      */
     static createGenericShort(locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): ZonedTimeFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
      */
     static createGenericShortWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): ZonedTimeFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
      */
     static createLocation(locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): ZonedTimeFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
      */
     static createLocationWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): ZonedTimeFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
      */
     static createExemplarCity(locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): ZonedTimeFormatter;
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
      */
     static createExemplarCityWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): ZonedTimeFormatter;

--- a/ffi/capi/bindings/js/ZonedTimeFormatter.mjs
+++ b/ffi/capi/bindings/js/ZonedTimeFormatter.mjs
@@ -48,6 +48,11 @@ export class ZonedTimeFormatter {
 
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
      */
     static createSpecificLong(locale, length, timePrecision, alignment) {
@@ -74,6 +79,11 @@ export class ZonedTimeFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
      */
     static createSpecificLongWithProvider(provider, locale, length, timePrecision, alignment) {
@@ -100,6 +110,11 @@ export class ZonedTimeFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
      */
     static createSpecificShort(locale, length, timePrecision, alignment) {
@@ -126,6 +141,11 @@ export class ZonedTimeFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
      */
     static createSpecificShortWithProvider(provider, locale, length, timePrecision, alignment) {
@@ -152,6 +172,11 @@ export class ZonedTimeFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
      */
     static createLocalizedOffsetLong(locale, length, timePrecision, alignment) {
@@ -178,6 +203,11 @@ export class ZonedTimeFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
      */
     static createLocalizedOffsetLongWithProvider(provider, locale, length, timePrecision, alignment) {
@@ -204,6 +234,11 @@ export class ZonedTimeFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
      */
     static createLocalizedOffsetShort(locale, length, timePrecision, alignment) {
@@ -230,6 +265,11 @@ export class ZonedTimeFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
      */
     static createLocalizedOffsetShortWithProvider(provider, locale, length, timePrecision, alignment) {
@@ -256,6 +296,11 @@ export class ZonedTimeFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
      */
     static createGenericLong(locale, length, timePrecision, alignment) {
@@ -282,6 +327,11 @@ export class ZonedTimeFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
      */
     static createGenericLongWithProvider(provider, locale, length, timePrecision, alignment) {
@@ -308,6 +358,11 @@ export class ZonedTimeFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
      */
     static createGenericShort(locale, length, timePrecision, alignment) {
@@ -334,6 +389,11 @@ export class ZonedTimeFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
      */
     static createGenericShortWithProvider(provider, locale, length, timePrecision, alignment) {
@@ -360,6 +420,11 @@ export class ZonedTimeFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
      */
     static createLocation(locale, length, timePrecision, alignment) {
@@ -386,6 +451,11 @@ export class ZonedTimeFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `Location`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
      */
     static createLocationWithProvider(provider, locale, length, timePrecision, alignment) {
@@ -412,6 +482,11 @@ export class ZonedTimeFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
      */
     static createExemplarCity(locale, length, timePrecision, alignment) {
@@ -438,6 +513,11 @@ export class ZonedTimeFormatter {
     }
 
     /**
+     * Creates a zoned formatter based on a non-zoned formatter.
+     *
+     * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+     * or else unexpected behavior may occur!
+     *
      * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/latest/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
      */
     static createExemplarCityWithProvider(provider, locale, length, timePrecision, alignment) {

--- a/ffi/capi/src/timezone_formatter.rs
+++ b/ffi/capi/src/timezone_formatter.rs
@@ -42,6 +42,10 @@ pub mod ffi {
     );
 
     impl TimeZoneFormatter {
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "specific_long")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::SpecificLong, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -63,6 +67,10 @@ pub mod ffi {
             )))
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "specific_long_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::SpecificLong, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -87,6 +95,10 @@ pub mod ffi {
             )))
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "specific_short")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::SpecificShort, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -108,6 +120,10 @@ pub mod ffi {
             )))
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "specific_short_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::SpecificShort, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -132,6 +148,10 @@ pub mod ffi {
             )))
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "localized_offset_long")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::LocalizedOffsetLong, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -153,6 +173,10 @@ pub mod ffi {
             )))
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "localized_offset_long_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::LocalizedOffsetLong, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -177,6 +201,10 @@ pub mod ffi {
             )))
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "localized_offset_short")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::LocalizedOffsetShort, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -198,6 +226,10 @@ pub mod ffi {
             )))
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "localized_offset_short_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::LocalizedOffsetShort, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -222,6 +254,10 @@ pub mod ffi {
             )))
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "generic_long")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::GenericLong, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -243,6 +279,10 @@ pub mod ffi {
             )))
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "generic_long_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::GenericLong, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -267,6 +307,10 @@ pub mod ffi {
             )))
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "generic_short")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::GenericShort, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -289,6 +333,10 @@ pub mod ffi {
             )))
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "generic_short_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::GenericShort, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -313,6 +361,10 @@ pub mod ffi {
             )))
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "location")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::Location, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -334,6 +386,10 @@ pub mod ffi {
             )))
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "location_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::Location, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -358,6 +414,10 @@ pub mod ffi {
             )))
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "exemplar_city")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::ExemplarCity, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -379,6 +439,10 @@ pub mod ffi {
             )))
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "exemplar_city_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::ExemplarCity, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]

--- a/ffi/capi/src/zoned_date_formatter.rs
+++ b/ffi/capi/src/zoned_date_formatter.rs
@@ -42,6 +42,10 @@ pub mod ffi {
     );
 
     impl ZonedDateFormatter {
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "specific_long")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::SpecificLong, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -68,6 +72,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "specific_long_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::SpecificLong, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -100,6 +108,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "specific_short")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::SpecificShort, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -126,6 +138,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "specific_short_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::SpecificShort, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -158,6 +174,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "localized_offset_long")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::LocalizedOffsetLong, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -184,6 +204,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "localized_offset_long_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::LocalizedOffsetLong, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -216,6 +240,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "localized_offset_short")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::LocalizedOffsetShort, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -242,6 +270,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "localized_offset_short_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::LocalizedOffsetShort, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -274,6 +306,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "generic_long")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::GenericLong, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -300,6 +336,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "generic_long_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::GenericLong, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -332,6 +372,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "generic_short")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::GenericShort, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -359,6 +403,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "generic_short_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::GenericShort, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -391,6 +439,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "location")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::Location, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -417,6 +469,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "location_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::Location, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -449,6 +505,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "exemplar_city")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::ExemplarCity, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -475,6 +535,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "exemplar_city_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::ExemplarCity, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -556,6 +620,10 @@ pub mod ffi {
     );
 
     impl ZonedDateFormatterGregorian {
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "specific_long")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::SpecificLong, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -581,6 +649,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "specific_long_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::SpecificLong, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -612,6 +684,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "specific_short")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::SpecificShort, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -637,6 +713,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "specific_short_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::SpecificShort, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -668,6 +748,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "localized_offset_long")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::LocalizedOffsetLong, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -693,6 +777,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "localized_offset_long_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::LocalizedOffsetLong, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -724,6 +812,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "localized_offset_short")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::LocalizedOffsetShort, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -749,6 +841,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "localized_offset_short_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::LocalizedOffsetShort, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -780,6 +876,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "generic_long")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::GenericLong, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -805,6 +905,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "generic_long_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::GenericLong, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -836,6 +940,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "generic_short")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::GenericShort, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -862,6 +970,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "generic_short_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::GenericShort, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -893,6 +1005,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "location")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::Location, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -918,6 +1034,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "location_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::Location, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -949,6 +1069,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "exemplar_city")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::ExemplarCity, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -974,6 +1098,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "exemplar_city_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::ExemplarCity, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]

--- a/ffi/capi/src/zoned_date_time_formatter.rs
+++ b/ffi/capi/src/zoned_date_time_formatter.rs
@@ -42,6 +42,10 @@ pub mod ffi {
     );
 
     impl ZonedDateTimeFormatter {
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "specific_long")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::SpecificLong, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -68,6 +72,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "specific_long_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::SpecificLong, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -100,6 +108,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "specific_short")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::SpecificShort, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -126,6 +138,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "specific_short_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::SpecificShort, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -158,6 +174,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "localized_offset_long")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::LocalizedOffsetLong, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -184,6 +204,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "localized_offset_long_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::LocalizedOffsetLong, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -216,6 +240,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "localized_offset_short")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::LocalizedOffsetShort, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -242,6 +270,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "localized_offset_short_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::LocalizedOffsetShort, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -274,6 +306,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "generic_long")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::GenericLong, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -300,6 +336,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "generic_long_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::GenericLong, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -332,6 +372,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "generic_short")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::GenericShort, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -359,6 +403,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "generic_short_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::GenericShort, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -391,6 +439,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "location")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::Location, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -417,6 +469,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "location_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::Location, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -449,6 +505,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "exemplar_city")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::ExemplarCity, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -475,6 +535,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "exemplar_city_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::ExemplarCity, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -558,6 +622,10 @@ pub mod ffi {
     );
 
     impl ZonedDateTimeFormatterGregorian {
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "specific_long")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::SpecificLong, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -583,6 +651,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "specific_long_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::SpecificLong, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -614,6 +686,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "specific_short")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::SpecificShort, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -639,6 +715,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "specific_short_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::SpecificShort, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -670,6 +750,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "localized_offset_long")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::LocalizedOffsetLong, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -695,6 +779,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "localized_offset_long_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::LocalizedOffsetLong, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -726,6 +814,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "localized_offset_short")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::LocalizedOffsetShort, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -751,6 +843,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "localized_offset_short_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::LocalizedOffsetShort, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -782,6 +878,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "generic_long")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::GenericLong, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -807,6 +907,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "generic_long_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::GenericLong, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -838,6 +942,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "generic_short")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::GenericShort, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -864,6 +972,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "generic_short_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::GenericShort, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -895,6 +1007,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "location")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::Location, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -920,6 +1036,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "location_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::Location, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -951,6 +1071,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "exemplar_city")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::ExemplarCity, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -976,6 +1100,10 @@ pub mod ffi {
             )
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "exemplar_city_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::ExemplarCity, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]

--- a/ffi/capi/src/zoned_time_formatter.rs
+++ b/ffi/capi/src/zoned_time_formatter.rs
@@ -42,6 +42,10 @@ pub mod ffi {
     );
 
     impl ZonedTimeFormatter {
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "specific_long")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::SpecificLong, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -69,6 +73,10 @@ pub mod ffi {
             )))
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "specific_long_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::SpecificLong, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -99,6 +107,10 @@ pub mod ffi {
             )))
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "specific_short")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::SpecificShort, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -126,6 +138,10 @@ pub mod ffi {
             )))
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "specific_short_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::SpecificShort, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -156,6 +172,10 @@ pub mod ffi {
             )))
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "localized_offset_long")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::LocalizedOffsetLong, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -183,6 +203,10 @@ pub mod ffi {
             )))
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "localized_offset_long_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::LocalizedOffsetLong, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -213,6 +237,10 @@ pub mod ffi {
             )))
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "localized_offset_short")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::LocalizedOffsetShort, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -240,6 +268,10 @@ pub mod ffi {
             )))
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "localized_offset_short_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::LocalizedOffsetShort, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -270,6 +302,10 @@ pub mod ffi {
             )))
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "generic_long")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::GenericLong, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -297,6 +333,10 @@ pub mod ffi {
             )))
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "generic_long_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::GenericLong, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -327,6 +367,10 @@ pub mod ffi {
             )))
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "generic_short")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::GenericShort, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -355,6 +399,10 @@ pub mod ffi {
             )))
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "generic_short_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::GenericShort, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -385,6 +433,10 @@ pub mod ffi {
             )))
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "location")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::Location, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -412,6 +464,10 @@ pub mod ffi {
             )))
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "location_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::Location, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -442,6 +498,10 @@ pub mod ffi {
             )))
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "exemplar_city")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::ExemplarCity, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]
@@ -469,6 +529,10 @@ pub mod ffi {
             )))
         }
         
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "exemplar_city_with_provider")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::ExemplarCity, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]

--- a/tools/make/codegen/templates/zoned_formatter.rs.jinja
+++ b/tools/make/codegen/templates/zoned_formatter.rs.jinja
@@ -81,6 +81,10 @@ pub mod ffi {
     impl {{ ffi_type }} {
         {%- for variant in variants %}
         {%- for ctor in ConstructorType::VALUES %}
+        /// Creates a zoned formatter based on a non-zoned formatter.
+        ///
+        /// Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+        /// or else unexpected behavior may occur!
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "{{ variant.name_lower() }}{{ ctor.suffix_ffi() }}")]
         #[diplomat::rust_link(icu::datetime::fieldsets::zone::{{ variant.name_camel() }}, Struct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Combo, Struct, hidden)]


### PR DESCRIPTION
Strange things happen when mixing locales, as can be seen in the WASM Demo.