### PR TITLE
Add TimeZoneParser::parse for TimeZoneRecord

### DIFF
--- a/utils/ixdtf/src/error.rs
+++ b/utils/ixdtf/src/error.rs
@@ -72,6 +72,8 @@ pub enum ParseError {
     AnnotationValueCharPostHyphen,
     #[displaydoc("Invalid annotation value character.")]
     AnnotationValueChar,
+    #[displaydoc("Offset must be minute precision")]
+    InvalidMinutePrecisionOffset,
 
     // Duplicate calendar with critical.
     #[displaydoc("Duplicate calendars cannot be provided when one is critical.")]

--- a/utils/ixdtf/src/parsers/tests.rs
+++ b/utils/ixdtf/src/parsers/tests.rs
@@ -684,6 +684,7 @@ fn duration_exceeds_range() {
 }
 
 #[test]
+#[cfg(feature = "duration")]
 fn maximum_duration_units() {
     use crate::parsers::IsoDurationParser;
 
@@ -1075,7 +1076,7 @@ fn invalid_offset() {
     let err = IxdtfParser::from_str(offset_leap_second).parse();
     assert_eq!(
         err,
-        Err(ParseError::AnnotationClose),
+        Err(ParseError::InvalidMinutePrecisionOffset),
         "Should enforce UtcMinutePrecision for annotations"
     );
 
@@ -1083,7 +1084,7 @@ fn invalid_offset() {
     let err = IxdtfParser::from_str(offset_leap_second).parse();
     assert_eq!(
         err,
-        Err(ParseError::AnnotationClose),
+        Err(ParseError::InvalidMinutePrecisionOffset),
         "Should enforce UtcMinutePrecision for annotations"
     );
 }


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->

This implements a `parse` method on `TimeZoneRecord` that parses a time zone identifier that could be a minute precision offset or IANA identifier to better support Temporal's `TimeZone` parsing.

A small refactor was also completed to make the minute precision parsing more strict, which has an added benefit of better error messaging in time zone annotations for minute precision offset.

