### PR TITLE
In zerovec, let the zerofrom dev-dependency be workspace rather than path

### DIFF
--- a/utils/zerovec/Cargo.toml
+++ b/utils/zerovec/Cargo.toml
@@ -47,7 +47,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 potential_utf = { path = "../../utils/potential_utf", features = ["zerovec"] }
 yoke = { workspace = true, features = ["derive"] }
-zerofrom = { path = "../../utils/zerofrom", features = ["derive"] }
+zerofrom = { workspace = true, features = ["derive"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 criterion = { workspace = true }


### PR DESCRIPTION
This allows the dev-dependency (and particularly, the dependency on the `derive` feature) to appear in the normalized `Cargo.toml` in the published crate.

```toml
[dev-dependencies.zerofrom]
version = "0.1.3"
features = ["derive"]
default-features = false
```

This is helpful when packaging for Fedora Linux, because the `dev-dependency` on `zerofrom` is the one that carries `features = ["derive"]`, needed for running various tests included in the published `zerovec` crate.

This PR is very similar to https://github.com/unicode-org/icu4x/pull/5537.
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->