### PR TITLE
On big-endian, skip two tests failing due to #6588

### DIFF
--- a/utils/zerovec/src/hashmap/serde.rs
+++ b/utils/zerovec/src/hashmap/serde.rs
@@ -119,6 +119,8 @@ mod test {
         );
     }
 
+    // TODO(#6588): Fix sensitivity to host endianness.
+    #[cfg(target_endian = "little")]
     #[test]
     fn test_serde_valid_deser_zhm() {
         let hm = make_zerohashmap();
@@ -132,6 +134,8 @@ mod test {
         );
     }
 
+    // TODO(#6588): Fix sensitivity to host endianness.
+    #[cfg(target_endian = "little")]
     #[test]
     fn test_bincode_zhm() {
         let hm = make_zerohashmap();


### PR DESCRIPTION
Similar to 0da4e7c7d657ff4e0d55f95638dce93165cbb92b.

Fixes (on big-endian platforms):

```
failures:

---- hashmap::serde::test::test_bincode_zhm stdout ----

thread 'hashmap::serde::test::test_bincode_zhm' panicked at src/hashmap/serde.rs:139:9:
assertion `left == right` failed
  left: [24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 12, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 9, 0, 0, 0, 0, 0, 0, 0, 3, 0, 1, 0, 2, 0, 98, 99, 97]
 right: [24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 12, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 9, 0, 0, 0, 0, 0, 0, 0, 3, 0, 1, 0, 2, 0, 98, 99, 97]
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- hashmap::serde::test::test_serde_valid_deser_zhm stdout ----

thread 'hashmap::serde::test::test_serde_valid_deser_zhm' panicked at src/hashmap/serde.rs:126:9:
assertion `left == right` failed
  left: "[[[0,2],[0,0],[0,1]],[1,2,0],[\"b\",\"c\",\"a\"]]"
 right: "[[[0,0],[0,1],[0,1]],[1,2,0],[\"b\",\"c\",\"a\"]]"


failures:
    hashmap::serde::test::test_bincode_zhm
    hashmap::serde::test::test_serde_valid_deser_zhm
```

Tested on real big-endian `s390x` hardware while working on the `rust-zerovec` package in Fedora.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->