### PR TITLE
Replace examples symlink by markdown link

### DIFF
--- a/examples/rust
+++ b/examples/rust
@@ -1,1 +1,0 @@
-../components/icu/examples

--- a/examples/rust.md
+++ b/examples/rust.md
@@ -1,0 +1,1 @@
+See [/components/icu/examples](../components/icu/examples)


### PR DESCRIPTION
Symlink doesn't work in Github UI