### PR TITLE
In locale_core, let litemap dev-dep. be workspace rather than path

### DIFF
--- a/components/locale_core/Cargo.toml
+++ b/components/locale_core/Cargo.toml
@@ -33,7 +33,7 @@ zerovec = { workspace = true, optional = true }
 iai = { workspace = true }
 icu = { path = "../../components/icu", default-features = false }
 icu_provider = { path = "../../provider/core" }
-litemap = { path = "../../utils/litemap", features = ["testing"] }
+litemap = { workspace = true, features = ["testing"] }
 postcard = { workspace = true, features = ["use-std"] }
 potential_utf = { workspace = true }
 serde = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
This allows the dev-dependency (and particularly, the dependency on the `testing` feature) to appear in the normalized `Cargo.toml` in the published crate.

This is helpful when packaging for Fedora Linux, because the `dev-dependency` on `zerofrom` is the one that carries `features = ["derive"]`, needed for running various tests included in the published `zerovec` crate.

This PR is very similar to https://github.com/unicode-org/icu4x/pull/5537 and https://github.com/unicode-org/icu4x/pull/6585, only, unlike https://github.com/unicode-org/icu4x/pull/6585, it actually does help me with running tests from the crate in the downstream package.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->