### PR TITLE
In locale_core, skip check_sizes() test on non-64-bit arches

### DIFF
--- a/components/locale_core/src/locale.rs
+++ b/components/locale_core/src/locale.rs
@@ -99,6 +99,8 @@ pub struct Locale {
 }
 
 #[test]
+// Expected sizes are based on a 64-bit architecture
+#[cfg(target_pointer_width = "64")]
 fn test_sizes() {
     assert_eq!(core::mem::size_of::<subtags::Language>(), 3);
     assert_eq!(core::mem::size_of::<subtags::Script>(), 4);


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->

Since the expected sizes are based on 64-bit architectures, we need to either maintain additional expected sizes for 32-bit architectures, or (as implemented in this commit) just skip this test on architectures that are not 64-bit.

I didn’t file an issue for this, but it fixes failures like this:

```
---- locale::test_sizes stdout ----

thread 'locale::test_sizes' panicked at src/locale.rs:107:5:
assertion `left == right` failed
  left: 12
 right: 16
```

This is basically the same problem and fix as https://github.com/unicode-org/icu4x/pull/5606.