### PR TITLE
Fix collator constructor bindings

### DIFF
--- a/ffi/capi/bindings/dart/Collator.g.dart
+++ b/ffi/capi/bindings/dart/Collator.g.dart
@@ -28,7 +28,7 @@ final class Collator implements ffi.Finalizable {
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/latest/icu/collator/struct.Collator.html#method.try_new) for more information.
   ///
   /// Throws [DataError] on failure.
-  factory Collator.create(Locale locale, CollatorOptions options) {
+  factory Collator(Locale locale, CollatorOptions options) {
     final temp = _FinalizedArena();
     final result = _icu4x_Collator_create_v1_mv1(locale._ffi, options._toFfi(temp.arena));
     if (!result.isOk) {
@@ -42,7 +42,7 @@ final class Collator implements ffi.Finalizable {
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/latest/icu/collator/struct.Collator.html#method.try_new) for more information.
   ///
   /// Throws [DataError] on failure.
-  factory Collator(DataProvider provider, Locale locale, CollatorOptions options) {
+  factory Collator.createWithProvider(DataProvider provider, Locale locale, CollatorOptions options) {
     final temp = _FinalizedArena();
     final result = _icu4x_Collator_create_v1_with_provider_mv1(provider._ffi, locale._ffi, options._toFfi(temp.arena));
     if (!result.isOk) {

--- a/ffi/capi/bindings/js/Collator.d.ts
+++ b/ffi/capi/bindings/js/Collator.d.ts
@@ -18,11 +18,11 @@ export class Collator {
 
 
     /**
-     * Construct a new Collator instance using compiled data.
+     * Construct a new Collator instance using a particular data source.
      *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/latest/icu/collator/struct.Collator.html#method.try_new) for more information.
      */
-    static create(locale: Locale, options: CollatorOptions_obj): Collator;
+    static createWithProvider(provider: DataProvider, locale: Locale, options: CollatorOptions_obj): Collator;
 
     /**
      * Compare two strings.
@@ -44,9 +44,9 @@ export class Collator {
     get resolvedOptions(): CollatorResolvedOptions;
 
     /**
-     * Construct a new Collator instance using a particular data source.
+     * Construct a new Collator instance using compiled data.
      *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/latest/icu/collator/struct.Collator.html#method.try_new) for more information.
      */
-    constructor(provider: DataProvider, locale: Locale, options: CollatorOptions_obj);
+    constructor(locale: Locale, options: CollatorOptions_obj);
 }

--- a/ffi/capi/bindings/js/Collator.mjs
+++ b/ffi/capi/bindings/js/Collator.mjs
@@ -48,7 +48,7 @@ export class Collator {
      *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/latest/icu/collator/struct.Collator.html#method.try_new) for more information.
      */
-    static create(locale, options) {
+    #defaultConstructor(locale, options) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
 
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
@@ -76,7 +76,7 @@ export class Collator {
      *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/latest/icu/collator/struct.Collator.html#method.try_new) for more information.
      */
-    #defaultConstructor(provider, locale, options) {
+    static createWithProvider(provider, locale, options) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
 
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
@@ -148,11 +148,11 @@ export class Collator {
     }
 
     /**
-     * Construct a new Collator instance using a particular data source.
+     * Construct a new Collator instance using compiled data.
      *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/latest/icu/collator/struct.Collator.html#method.try_new) for more information.
      */
-    constructor(provider, locale, options) {
+    constructor(locale, options) {
         if (arguments[0] === diplomatRuntime.exposeConstructor) {
             return this.#internalConstructor(...Array.prototype.slice.call(arguments, 1));
         } else if (arguments[0] === diplomatRuntime.internalConstructor) {

--- a/ffi/capi/src/collator.rs
+++ b/ffi/capi/src/collator.rs
@@ -104,10 +104,9 @@ pub mod ffi {
         #[diplomat::rust_link(icu::collator::CollatorBorrowed::try_new, FnInStruct, hidden)]
         #[diplomat::rust_link(icu::collator::CollatorPreferences, Struct, hidden)]
         #[diplomat::rust_link(icu::collator::CollatorPreferences::extend, FnInStruct, hidden)]
-        #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "with_provider")]
+        #[diplomat::attr(supports = fallible_constructors, constructor)]
         #[diplomat::attr(supports = non_exhaustive_structs, rename = "create")]
         #[cfg(feature = "compiled_data")]
-        #[diplomat::demo(default_constructor)]
         pub fn create_v1(
             locale: &Locale,
             options: CollatorOptionsV1,
@@ -122,7 +121,7 @@ pub mod ffi {
         #[diplomat::rust_link(icu::collator::Collator::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::collator::CollatorBorrowed::try_new, FnInStruct, hidden)]
         #[diplomat::rust_link(icu::collator::CollatorPreferences, Struct, hidden)]
-        #[diplomat::attr(supports = fallible_constructors, constructor)]
+        #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "with_provider")]
         #[diplomat::attr(supports = non_exhaustive_structs, rename = "create_with_provider")]
         #[cfg(feature = "buffer_provider")]
         pub fn create_v1_with_provider(

--- a/tools/web-demo/gen/Collator.mjs
+++ b/tools/web-demo/gen/Collator.mjs
@@ -12,7 +12,7 @@ export function compare(selfLocaleName, selfOptionsStrength, selfOptionsAlternat
         caseLevel: selfOptionsCaseLevel
     });
     
-    let self = Collator.create(selfLocale,selfOptions);
+    let self = new Collator(selfLocale,selfOptions);
     
     let out = self.compare(left,right);
     


### PR DESCRIPTION
The compiled data constructor is not the default in JS, Dart.