### PR TITLE
Bump `icu_harfbuzz`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1436,7 +1436,7 @@ dependencies = [
 
 [[package]]
 name = "icu_harfbuzz"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "displaydoc",
  "harfbuzz-traits",

--- a/ffi/harfbuzz/Cargo.toml
+++ b/ffi/harfbuzz/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_harfbuzz"
 description = "HarfBuzz glue code for ICU4X"
-version = "0.2.0"
+version = "0.3.0"
 
 authors.workspace = true
 categories.workspace = true


### PR DESCRIPTION
It has ICU types on its API, and hasn't been bumped for 2.0