### PR TITLE
Add semver CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -551,6 +551,9 @@ jobs:
     - name: Cargo doc
       run: cargo make ci-job-doc
 
+    - name: Check semver
+      uses: obi1kenobi/cargo-semver-checks-action@v2
+
 
   # Notify on slack  
   notify-slack:


### PR DESCRIPTION
This is overly restrictive, as it doesn't allow breakages in modules that we declare unstable (such as `provider`), but it's better to be notified about violations everywhere, and we can cross that bridge if we actually need to make breaking changes.

#2570 