### PR TITLE
Map Windows `_radstr` to CLDR `unihan` in env_preferences

### DIFF
--- a/utils/env_preferences/src/parse/aliases.rs
+++ b/utils/env_preferences/src/parse/aliases.rs
@@ -18,7 +18,7 @@ pub fn strip_windows_collation_suffix_lossy(
         let collation_value = match suffix {
             "phoneb" => value!("phonebk"),
             "pronun" => value!("zhuyin"),
-            "radstr" => value!("stroke"),
+            "radstr" => value!("unihan"),
             "stroke" => value!("stroke"),
             "tradnl" => value!("trad"),
             // Strip the suffix on LCIDs with an underscore but no (known) matching CLDR data

--- a/utils/env_preferences/tests/parse/windows.rs
+++ b/utils/env_preferences/tests/parse/windows.rs
@@ -22,16 +22,16 @@ fn collation() {
     const CASES: [(&str, &str); 12] = [
         ("de-DE_phoneb", "de-DE-u-co-phonebk"),
         ("es-ES_tradnl", "es-ES-u-co-trad"),
-        ("ja-JP_radstr", "ja-JP-u-co-stroke"),
+        ("ja-JP_radstr", "ja-JP-u-co-unihan"),
         ("zh-CN_phoneb", "zh-CN-u-co-phonebk"),
         ("zh-CN_stroke", "zh-CN-u-co-stroke"),
-        ("zh-HK_radstr", "zh-HK-u-co-stroke"),
-        ("zh-MO_radstr", "zh-MO-u-co-stroke"),
+        ("zh-HK_radstr", "zh-HK-u-co-unihan"),
+        ("zh-MO_radstr", "zh-MO-u-co-unihan"),
         ("zh-MO_stroke", "zh-MO-u-co-stroke"),
         ("zh-SG_phoneb", "zh-SG-u-co-phonebk"),
         ("zh-SG_stroke", "zh-SG-u-co-stroke"),
         ("zh-TW_pronun", "zh-TW-u-co-zhuyin"),
-        ("zh-TW_radstr", "zh-TW-u-co-stroke"),
+        ("zh-TW_radstr", "zh-TW-u-co-unihan"),
     ];
 
     for (src, expected) in CASES {


### PR DESCRIPTION
Fixes issue #6572, where the `_radstr` suffix was being incorrectly mapped to `-u-co-stroke`, instead of `-u-co-unihan`.

CC @hsivonen, thanks for pointing out the mistake :)