### PR TITLE
Use nightly feature documentation

### DIFF
--- a/.github/workflows/artifacts-build.yml
+++ b/.github/workflows/artifacts-build.yml
@@ -78,15 +78,16 @@ jobs:
       uses: google-github-actions/setup-gcloud@98ddc00a17442e89a24bbf282954a3b65ce6d200 # v2.1.0
 
     - name: Build docs
-      run: >
-          cargo doc --workspace --release --all-features --no-deps --lib 
-          --exclude icu_benchmark_macros
-          --exclude icu_ffi_coverage
-          --exclude md-tests
-          --exclude databake-derive
-          --exclude yoke-derive
-          --exclude zerofrom-derive
-          --exclude zerovec-derive
+      run: |
+          rustup install nightly
+          RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --workspace --release --all-features --no-deps --lib \
+          --exclude icu_benchmark_macros  \
+          --exclude icu_ffi_coverage \
+          --exclude md-tests \
+          --exclude databake-derive \
+          --exclude yoke-derive \
+          --exclude zerofrom-derive \
+          --exclude zerovec-derive \
 
     - uses: actions/upload-artifact@v4
       with:

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -251,6 +251,7 @@ dependencies = [
 [tasks.ci-job-doc]
 description = "Runs rustdoc generation for the CI 'doc' job"
 category = "CI"
+dependencies = ["install-nightly"]
 env = { RUSTDOCFLAGS = "-Dwarnings --cfg docsrs", ICU4X_DATA_DIR = "../stubdata" }
 command = "cargo"
 toolchain = "${PINNED_CI_NIGHTLY}"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -251,8 +251,9 @@ dependencies = [
 [tasks.ci-job-doc]
 description = "Runs rustdoc generation for the CI 'doc' job"
 category = "CI"
-env = { RUSTDOCFLAGS = "-Dwarnings", ICU4X_DATA_DIR = "../stubdata" }
+env = { RUSTDOCFLAGS = "-Dwarnings --cfg docsrs", ICU4X_DATA_DIR = "../stubdata" }
 command = "cargo"
+toolchain = "${PINNED_CI_NIGHTLY}"
 args = ["doc", "--workspace", "--release", "--all-features", "--no-deps", "--lib"]
 
 [tasks.ci-all]

--- a/components/calendar/src/any_calendar.rs
+++ b/components/calendar/src/any_calendar.rs
@@ -549,8 +549,6 @@ impl Calendar for AnyCalendar {
 impl AnyCalendar {
     /// Constructs an AnyCalendar for a given calendar kind from compiled data.
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
     pub const fn new(kind: AnyCalendarKind) -> Self {

--- a/components/calendar/src/cal/chinese.rs
+++ b/components/calendar/src/cal/chinese.rs
@@ -114,8 +114,6 @@ impl Ord for Chinese {
 impl Chinese {
     /// Creates a new [`Chinese`] with some precomputed calendrical calculations.
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
     pub const fn new() -> Self {

--- a/components/calendar/src/cal/dangi.rs
+++ b/components/calendar/src/cal/dangi.rs
@@ -112,8 +112,6 @@ impl Ord for Dangi {
 impl Dangi {
     /// Creates a new [`Dangi`] with some precomputed calendrical calculations.
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
     pub const fn new() -> Self {

--- a/components/calendar/src/cal/hijri.rs
+++ b/components/calendar/src/cal/hijri.rs
@@ -122,8 +122,6 @@ pub struct HijriTabular {
 impl HijriSimulated {
     /// Creates a new [`HijriSimulated`] for reference location Mecca, with some compiled data containing precomputed calendrical calculations.
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
     pub const fn new_mecca() -> Self {

--- a/components/calendar/src/cal/japanese.rs
+++ b/components/calendar/src/cal/japanese.rs
@@ -99,8 +99,6 @@ pub struct JapaneseDateInner {
 impl Japanese {
     /// Creates a new [`Japanese`] using only modern eras (post-meiji) from compiled data.
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
     pub const fn new() -> Self {
@@ -133,8 +131,6 @@ impl Japanese {
 
 impl JapaneseExtended {
     /// Creates a new [`Japanese`] from using all eras (including pre-meiji) from compiled data.
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]

--- a/components/calendar/src/ixdtf.rs
+++ b/components/calendar/src/ixdtf.rs
@@ -54,8 +54,6 @@ impl<A: AsCalendar> Date<A> {
     /// Returns an error if the string has a calendar annotation that does not
     /// match the calendar argument, unless the argument is [`Iso`].
     ///
-    /// ✨ *Enabled with the `ixdtf` Cargo feature.*
-    ///
     /// # Examples
     ///
     /// ```
@@ -84,8 +82,6 @@ impl<A: AsCalendar> Date<A> {
     /// match the calendar argument.
     ///
     /// See [`Self::try_from_str()`].
-    ///
-    /// ✨ *Enabled with the `ixdtf` Cargo feature.*
     pub fn try_from_utf8(rfc_9557_str: &[u8], calendar: A) -> Result<Self, ParseError> {
         let ixdtf_record = IxdtfParser::from_utf8(rfc_9557_str).parse()?;
         Self::try_from_ixdtf_record(&ixdtf_record, calendar)

--- a/components/calendar/src/lib.rs
+++ b/components/calendar/src/lib.rs
@@ -88,6 +88,7 @@
     )
 )]
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/components/casemap/src/casemapper.rs
+++ b/components/casemap/src/casemapper.rs
@@ -68,8 +68,6 @@ impl CaseMapperBorrowed<'static> {
     }
     /// Creates a [`CaseMapperBorrowed`] using compiled data.
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     ///
     /// # Examples
@@ -601,8 +599,6 @@ impl<'a> CaseMapperBorrowed<'a> {
 
 impl CaseMapper {
     /// Creates a [`CaseMapperBorrowed`] using compiled data.
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     ///

--- a/components/casemap/src/closer.rs
+++ b/components/casemap/src/closer.rs
@@ -89,8 +89,6 @@ impl CaseMapCloser<CaseMapper> {
     /// assert!(set.contains('ẞ'));
     /// ```
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
     #[allow(clippy::new_ret_no_self)] // Intentional
@@ -111,8 +109,6 @@ impl<CM: AsRef<CaseMapper>> CaseMapCloser<CM> {
 
     /// A constructor which creates a [`CaseMapCloser`] from an existing [`CaseMapper`]
     /// (either owned or as a reference)
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
@@ -181,8 +177,6 @@ impl CaseMapCloserBorrowed<'static> {
     /// assert!(set.contains('ß'));
     /// assert!(set.contains('ẞ'));
     /// ```
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]

--- a/components/casemap/src/lib.rs
+++ b/components/casemap/src/lib.rs
@@ -43,6 +43,7 @@
     )
 )]
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 // We're using Greek identifiers here on purpose. These lints can only be disabled at the crate level
 #![allow(confusable_idents, uncommon_codepoints)]
 

--- a/components/casemap/src/titlecase.rs
+++ b/components/casemap/src/titlecase.rs
@@ -234,8 +234,6 @@ impl TitlecaseMapper<CaseMapper> {
 impl TitlecaseMapper<CaseMapper> {
     /// A constructor which creates a [`TitlecaseMapperBorrowed`] using compiled data
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
     #[allow(clippy::new_ret_no_self)] // Intentional
@@ -255,8 +253,6 @@ impl<CM: AsRef<CaseMapper>> TitlecaseMapper<CM> {
 
     /// A constructor which creates a [`TitlecaseMapper`] from an existing [`CaseMapper`]
     /// (either owned or as a reference) and compiled data
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
@@ -298,8 +294,6 @@ pub struct TitlecaseMapperBorrowed<'a> {
 
 impl TitlecaseMapperBorrowed<'static> {
     /// A constructor which creates a [`TitlecaseMapperBorrowed`] using compiled data
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]

--- a/components/collator/src/lib.rs
+++ b/components/collator/src/lib.rs
@@ -22,6 +22,7 @@
     )
 )]
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 //! Comparing strings according to language-dependent conventions.
 //!

--- a/components/collections/codepointtrie_builder/src/lib.rs
+++ b/components/collections/codepointtrie_builder/src/lib.rs
@@ -137,8 +137,6 @@ where
     /// Under the hood, this function runs ICU4C code compiled into WASM,
     /// or links natively to ICU4C as specified by the `ICU4C_LIB_PATH` env var
     ///
-    /// ✨ *Enabled with either the `wasm` or the `icu4c` Cargo feature.*
-    ///
     /// [`CodePointTrie`]: icu_collections::codepointtrie::CodePointTrie
     #[cfg(any(feature = "wasm", feature = "icu4c"))]
     pub fn build(self) -> icu_collections::codepointtrie::CodePointTrie<'static, T> {

--- a/components/collections/src/codepointinvlist/mod.rs
+++ b/components/collections/src/codepointinvlist/mod.rs
@@ -52,6 +52,7 @@
 //! [`ICU4X`]: ../icu/index.html
 
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 extern crate alloc;
 

--- a/components/collections/src/lib.rs
+++ b/components/collections/src/lib.rs
@@ -32,6 +32,7 @@
     )
 )]
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/components/datetime/src/builder.rs
+++ b/components/datetime/src/builder.rs
@@ -314,8 +314,6 @@ mod _serde {
 
     /// Serialization for [`FieldSetBuilder`].
     ///
-    /// ✨ *Enabled with the `serde` and `experimental` Cargo features.*
-    ///
     /// # Examples
     ///
     /// ```
@@ -377,8 +375,6 @@ mod _serde {
     }
 
     /// Deserialization for [`FieldSetBuilder`].
-    ///
-    /// ✨ *Enabled with the `serde` and `experimental` Cargo features.*
     ///
     /// For an example, see the `Serialize` impl.
     impl<'de> Deserialize<'de> for FieldSetBuilder {

--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -90,6 +90,7 @@
     )
 )]
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 extern crate alloc;
 

--- a/components/datetime/src/neo.rs
+++ b/components/datetime/src/neo.rs
@@ -220,8 +220,6 @@ where
     /// This ignores the `calendar_kind` preference and instead uses the static calendar type,
     /// and supports calendars that are not expressible as preferences, such as [`JapaneseExtended`](icu_calendar::cal::JapaneseExtended).
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
     pub fn try_new(
@@ -439,8 +437,6 @@ where
     ///
     /// This method will use the calendar specified in the `calendar_algorithm` preference, or fall back to the default
     /// calendar for the preferences if unspecified or unsupported. See [`IntoFormattableAnyCalendar`] for a list of supported calendars.
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[inline(never)]

--- a/components/datetime/src/pattern/names.rs
+++ b/components/datetime/src/pattern/names.rs
@@ -781,8 +781,6 @@ impl<C, FSet: DateTimeNamesMarker> FixedCalendarDateTimeNames<C, FSet> {
     ///
     /// For an example, see [`FixedCalendarDateTimeNames`].
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
     pub fn try_new(prefs: DateTimeFormatterPreferences) -> Result<Self, DataError> {
@@ -962,8 +960,6 @@ where
     ///
     /// The names in the current [`FixedCalendarDateTimeNames`] _must_ be sufficient for the field set.
     /// If not, the input object will be returned with an error.
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     ///
@@ -1169,8 +1165,6 @@ where
     /// The names in the current [`DateTimeNames`] _must_ be sufficient for the field set.
     /// If not, the input object will be returned with an error.
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     ///
     /// # Examples
@@ -1320,8 +1314,6 @@ impl<C: CldrCalendar, FSet: DateTimeNamesMarker> FixedCalendarDateTimeNames<C, F
     ///
     /// Does not support multiple field symbols or lengths. See [#4337](https://github.com/unicode-org/icu4x/issues/4337)
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// # Examples
     ///
     /// ```
@@ -1381,8 +1373,6 @@ impl<C: CldrCalendar, FSet: DateTimeNamesMarker> FixedCalendarDateTimeNames<C, F
     /// Includes month names for the specified symbol and length with compiled data.
     ///
     /// Does not support multiple field symbols or lengths. See [#4337](https://github.com/unicode-org/icu4x/issues/4337)
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// # Examples
     ///
@@ -1451,8 +1441,6 @@ impl<C, FSet: DateTimeNamesMarker> FixedCalendarDateTimeNames<C, FSet> {
     ///
     /// Does not support multiple field symbols or lengths. See [#4337](https://github.com/unicode-org/icu4x/issues/4337)
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// # Examples
     ///
     /// ```
@@ -1514,8 +1502,6 @@ impl<C, FSet: DateTimeNamesMarker> FixedCalendarDateTimeNames<C, FSet> {
     ///
     /// Does not support multiple field symbols or lengths. See [#4337](https://github.com/unicode-org/icu4x/issues/4337)
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// # Examples
     ///
     /// ```
@@ -1574,8 +1560,6 @@ impl<C, FSet: DateTimeNamesMarker> FixedCalendarDateTimeNames<C, FSet> {
     ///
     /// This data should always be loaded when performing time zone formatting.
     /// By itself, it allows localized offset formats.
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// # Examples
     ///
@@ -1699,8 +1683,6 @@ impl<C, FSet: DateTimeNamesMarker> FixedCalendarDateTimeNames<C, FSet> {
     /// - [`FixedCalendarDateTimeNames::include_time_zone_essentials`]
     /// - [`FixedCalendarDateTimeNames::load_time_zone_essentials`]
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// # Examples
     ///
     /// ```
@@ -1770,8 +1752,6 @@ impl<C, FSet: DateTimeNamesMarker> FixedCalendarDateTimeNames<C, FSet> {
     ///
     /// - [`FixedCalendarDateTimeNames::include_time_zone_location_names`]
     /// - [`FixedCalendarDateTimeNames::load_time_zone_location_names`]
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// # Examples
     ///
@@ -1847,8 +1827,6 @@ impl<C, FSet: DateTimeNamesMarker> FixedCalendarDateTimeNames<C, FSet> {
     ///
     /// - [`FixedCalendarDateTimeNames::include_time_zone_essentials`]
     /// - [`FixedCalendarDateTimeNames::load_time_zone_essentials`]
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// # Examples
     ///
@@ -1938,8 +1916,6 @@ impl<C, FSet: DateTimeNamesMarker> FixedCalendarDateTimeNames<C, FSet> {
     ///
     /// - [`FixedCalendarDateTimeNames::include_time_zone_essentials`]
     /// - [`FixedCalendarDateTimeNames::load_time_zone_essentials`]
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// # Examples
     ///
@@ -2034,8 +2010,6 @@ impl<C, FSet: DateTimeNamesMarker> FixedCalendarDateTimeNames<C, FSet> {
     /// - [`FixedCalendarDateTimeNames::include_time_zone_essentials`]
     /// - [`FixedCalendarDateTimeNames::load_time_zone_essentials`]
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// # Examples
     ///
     /// ```
@@ -2120,8 +2094,6 @@ impl<C, FSet: DateTimeNamesMarker> FixedCalendarDateTimeNames<C, FSet> {
     ///
     /// - [`FixedCalendarDateTimeNames::include_time_zone_essentials`]
     /// - [`FixedCalendarDateTimeNames::load_time_zone_essentials`]
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// # Examples
     ///
@@ -2221,8 +2193,6 @@ impl<C, FSet: DateTimeNamesMarker> FixedCalendarDateTimeNames<C, FSet> {
     /// and all data required for its fallback formats, with compiled data.
     ///
     /// See [`GenericShort`](crate::fieldsets::zone::GenericShort)
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     #[cfg(feature = "compiled_data")]
     pub fn include_time_zone_generic_short_names_with_fallback(
         &mut self,
@@ -2279,8 +2249,6 @@ impl<C, FSet: DateTimeNamesMarker> FixedCalendarDateTimeNames<C, FSet> {
     /// and all data required for its fallback formats, with compiled data.
     ///
     /// See [`GenericLong`](crate::fieldsets::zone::GenericLong)
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     #[cfg(feature = "compiled_data")]
     pub fn include_time_zone_generic_long_names_with_fallback(
         &mut self,
@@ -2336,8 +2304,6 @@ impl<C, FSet: DateTimeNamesMarker> FixedCalendarDateTimeNames<C, FSet> {
     /// except for decimal formatting, with compiled data.
     ///
     /// See [`SpecificShort`](crate::fieldsets::zone::SpecificShort)
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     #[cfg(feature = "compiled_data")]
     pub fn include_time_zone_specific_short_names_with_fallback(
         &mut self,
@@ -2394,8 +2360,6 @@ impl<C, FSet: DateTimeNamesMarker> FixedCalendarDateTimeNames<C, FSet> {
     /// except for decimal formatting, with compiled data.
     ///
     /// See [`SpecificLong`](crate::fieldsets::zone::SpecificLong)
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     #[cfg(feature = "compiled_data")]
     pub fn include_time_zone_specific_long_names_with_fallback(
         &mut self,
@@ -2448,8 +2412,6 @@ impl<C, FSet: DateTimeNamesMarker> FixedCalendarDateTimeNames<C, FSet> {
     ///
     /// - [`LocalizedOffsetShort`](crate::fieldsets::zone::LocalizedOffsetShort)
     /// - [`LocalizedOffsetLong`](crate::fieldsets::zone::LocalizedOffsetLong)
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     #[cfg(feature = "compiled_data")]
     pub fn include_time_zone_localized_offset_names_with_fallback(
         &mut self,
@@ -2475,8 +2437,6 @@ impl<C, FSet: DateTimeNamesMarker> FixedCalendarDateTimeNames<C, FSet> {
     }
 
     /// Loads a [`DecimalFormatter`] with compiled data.
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// # Examples
     ///
@@ -2588,8 +2548,6 @@ impl<C: CldrCalendar, FSet: DateTimeNamesMarker> FixedCalendarDateTimeNames<C, F
     /// and includes all data required for that pattern, from compiled data.
     ///
     /// Does not support duplicate textual field symbols. See [#4337](https://github.com/unicode-org/icu4x/issues/4337)
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// # Examples
     ///

--- a/components/datetime/src/provider/skeleton/mod.rs
+++ b/components/datetime/src/provider/skeleton/mod.rs
@@ -8,8 +8,6 @@
 //!
 //! See [`Skeleton`](reference::Skeleton) and [`Bag`](components::Bag) for more information.
 //!
-//! ✨ *Enabled with the `datagen` Cargo feature.*
-//!
 //! # Implementation status
 //!
 //! This is currently only a partial implementation of the UTS-35 skeleton matching algorithm.

--- a/components/decimal/src/lib.rs
+++ b/components/decimal/src/lib.rs
@@ -89,6 +89,7 @@
     )
 )]
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/components/experimental/src/compactdecimal/formatter.rs
+++ b/components/experimental/src/compactdecimal/formatter.rs
@@ -87,8 +87,6 @@ impl CompactDecimalFormatter {
     /// then collects all compiled data necessary to format numbers in short compact
     /// decimal notation for the given locale.
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     ///
     /// # Examples
@@ -172,8 +170,6 @@ impl CompactDecimalFormatter {
     /// Constructor that takes a selected locale and a list of preferences,
     /// then collects all compiled data necessary to format numbers in short compact
     /// decimal notation for the given locale.
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     ///
@@ -314,8 +310,6 @@ impl CompactDecimalFormatter {
     /// The result may have a fractional digit only if it is compact and its
     /// significand is less than 10. Trailing fractional 0s are omitted, and
     /// a sign is shown only for negative values.
-    ///
-    /// ✨ *Enabled with the `ryu` Cargo feature.*
     ///
     /// # Examples
     ///

--- a/components/experimental/src/compactdecimal/mod.rs
+++ b/components/experimental/src/compactdecimal/mod.rs
@@ -19,6 +19,7 @@
     )
 )]
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 mod error;
 mod format;

--- a/components/experimental/src/dimension/currency/compact_formatter.rs
+++ b/components/experimental/src/dimension/currency/compact_formatter.rs
@@ -79,8 +79,6 @@ impl CompactCurrencyFormatter {
 
     /// Creates a new [`CompactCurrencyFormatter`] from compiled locale data and an options bag.
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
     pub fn try_new(

--- a/components/experimental/src/dimension/currency/formatter.rs
+++ b/components/experimental/src/dimension/currency/formatter.rs
@@ -68,8 +68,6 @@ impl CurrencyFormatter {
 
     /// Creates a new [`CurrencyFormatter`] from compiled locale data and an options bag.
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
     pub fn try_new(

--- a/components/experimental/src/dimension/currency/long_compact_formatter.rs
+++ b/components/experimental/src/dimension/currency/long_compact_formatter.rs
@@ -76,8 +76,6 @@ impl LongCompactCurrencyFormatter {
 
     /// Creates a new [`LongCompactCurrencyFormatter`] from compiled locale data.
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
     pub fn try_new(

--- a/components/experimental/src/dimension/currency/long_formatter.rs
+++ b/components/experimental/src/dimension/currency/long_formatter.rs
@@ -53,8 +53,6 @@ impl LongCurrencyFormatter {
 
     /// Creates a new [`LongCurrencyFormatter`] from compiled locale data.
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
     pub fn try_new(

--- a/components/experimental/src/dimension/percent/formatter.rs
+++ b/components/experimental/src/dimension/percent/formatter.rs
@@ -61,8 +61,6 @@ impl PercentFormatter<DecimalFormatter> {
 
     /// Creates a new [`PercentFormatter`] from compiled locale data and an options bag.
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
     pub fn try_new(
@@ -132,8 +130,6 @@ where
     R: AsRef<DecimalFormatter>,
 {
     /// Creates a new [`PercentFormatter`] from compiled locale data, an options bag and fixed decimal formatter.
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]

--- a/components/experimental/src/dimension/units/formatter.rs
+++ b/components/experimental/src/dimension/units/formatter.rs
@@ -86,8 +86,6 @@ impl UnitsFormatter {
 
     /// Creates a new [`UnitsFormatter`] from compiled locale data and an options bag.
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
     pub fn try_new(

--- a/components/experimental/src/displaynames/mod.rs
+++ b/components/experimental/src/displaynames/mod.rs
@@ -20,6 +20,7 @@
     )
 )]
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 mod displaynames;
 mod options;

--- a/components/experimental/src/duration/formatter.rs
+++ b/components/experimental/src/duration/formatter.rs
@@ -203,8 +203,6 @@ impl DurationFormatter {
 
     /// Creates a new [`DurationFormatter`] from compiled locale data and an options bag.
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
     pub fn try_new(

--- a/components/experimental/src/duration/mod.rs
+++ b/components/experimental/src/duration/mod.rs
@@ -5,6 +5,7 @@
 //! Duration formatting
 
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 mod duration;
 mod format;

--- a/components/experimental/src/measure/parser.rs
+++ b/components/experimental/src/measure/parser.rs
@@ -26,8 +26,6 @@ pub struct MeasureUnitParser {
 impl Default for MeasureUnitParser {
     /// Creates a new [`MeasureUnitParser`] from compiled data.
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
     fn default() -> Self {
@@ -39,8 +37,6 @@ impl Default for MeasureUnitParser {
 
 impl MeasureUnitParser {
     /// Creates a new [`MeasureUnitParser`] from compiled data.
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]

--- a/components/experimental/src/relativetime/mod.rs
+++ b/components/experimental/src/relativetime/mod.rs
@@ -5,6 +5,7 @@
 //! Relative time formatting
 
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 mod format;
 pub mod options;

--- a/components/experimental/src/relativetime/relativetime.rs
+++ b/components/experimental/src/relativetime/relativetime.rs
@@ -130,8 +130,6 @@ macro_rules! constructor {
 
         /// Create a new [`RelativeTimeFormatter`] from compiled data.
         ///
-        /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-        ///
         /// [📚 Help choosing a constructor](icu_provider::constructors)
         #[cfg(feature = "compiled_data")]
         pub fn $baked(

--- a/components/experimental/src/transliterate/compile/mod.rs
+++ b/components/experimental/src/transliterate/compile/mod.rs
@@ -49,8 +49,6 @@ impl Direction {
 #[derive(Debug, Default)]
 /// A collection of transliteration rules.
 ///
-/// ✨ *Enabled with the `compile` Cargo feature.*
-///
 /// # Example
 /// ```
 /// use icu::experimental::transliterate::{RuleCollection, Transliterator};
@@ -146,8 +144,6 @@ impl RuleCollection {
     }
 
     /// Returns a provider that is usable by [`Transliterator::try_new_unstable`](crate::transliterate::Transliterator::try_new_unstable).
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     #[cfg(feature = "compiled_data")]
     pub fn as_provider(
         &self,

--- a/components/experimental/src/transliterate/mod.rs
+++ b/components/experimental/src/transliterate/mod.rs
@@ -21,6 +21,7 @@
     )
 )]
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 pub mod provider;
 

--- a/components/experimental/src/unicodeset_parse/mod.rs
+++ b/components/experimental/src/unicodeset_parse/mod.rs
@@ -25,6 +25,7 @@
     )
 )]
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 mod parse;
 

--- a/components/experimental/src/unicodeset_parse/parse.rs
+++ b/components/experimental/src/unicodeset_parse/parse.rs
@@ -1529,8 +1529,6 @@ where
 ///   `General_Category` property.
 /// * We do not support `\N{Unicode code point name}` character escaping. Use any other escape method described in UTS35.
 ///
-/// ✨ *Enabled with the `compiled_data` Cargo feature.*
-///
 /// [📚 Help choosing a constructor](icu_provider::constructors)
 ///
 /// # Examples

--- a/components/experimental/src/units/converter_factory.rs
+++ b/components/experimental/src/units/converter_factory.rs
@@ -50,8 +50,6 @@ impl ConverterFactory {
 
     /// Creates a new [`ConverterFactory`] from compiled data.
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
     pub const fn new() -> Self {

--- a/components/icu/src/lib.rs
+++ b/components/icu/src/lib.rs
@@ -136,6 +136,7 @@
     )
 )]
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 #[cfg(doc)]
 // Needed for intra-doc link to work, since icu_provider is otherwise never mentioned in this crate

--- a/components/list/src/lib.rs
+++ b/components/list/src/lib.rs
@@ -90,6 +90,7 @@
     )
 )]
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/components/locale/src/canonicalizer.rs
+++ b/components/locale/src/canonicalizer.rs
@@ -198,8 +198,6 @@ impl LocaleCanonicalizer<LocaleExpander> {
     /// A constructor which creates a [`LocaleCanonicalizer`] from compiled data,
     /// using a [`LocaleExpander`] for common locales.
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
     pub const fn new_common() -> Self {
@@ -229,8 +227,6 @@ impl LocaleCanonicalizer<LocaleExpander> {
 
     /// A constructor which creates a [`LocaleCanonicalizer`] from compiled data,
     /// using a [`LocaleExpander`] for all locales.
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
@@ -263,8 +259,6 @@ impl LocaleCanonicalizer<LocaleExpander> {
 
 impl<Expander: AsRef<LocaleExpander>> LocaleCanonicalizer<Expander> {
     /// Creates a [`LocaleCanonicalizer`] with a custom [`LocaleExpander`] and compiled data.
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]

--- a/components/locale/src/exemplar_chars.rs
+++ b/components/locale/src/exemplar_chars.rs
@@ -151,8 +151,6 @@ make_exemplar_chars_unicode_set_property!(
 
     /// Get the "main" set of exemplar characters.
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     ///
     /// # Examples
@@ -181,8 +179,6 @@ make_exemplar_chars_unicode_set_property!(
     pub fn try_new_auxiliary_unstable();
 
     /// Get the "auxiliary" set of exemplar characters.
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     ///
@@ -213,8 +209,6 @@ make_exemplar_chars_unicode_set_property!(
     pub fn try_new_punctuation_unstable();
 
     /// Get the "punctuation" set of exemplar characters.
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     ///
@@ -247,8 +241,6 @@ make_exemplar_chars_unicode_set_property!(
 
     /// Get the "numbers" set of exemplar characters.
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     ///
     /// # Examples
@@ -279,8 +271,6 @@ make_exemplar_chars_unicode_set_property!(
     pub fn try_new_index_unstable();
 
     /// Get the "index" set of exemplar characters.
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     ///

--- a/components/locale/src/expander.rs
+++ b/components/locale/src/expander.rs
@@ -215,8 +215,6 @@ impl LocaleExpander {
     ///
     /// Use this constructor if you want limited likely subtags for data-oriented use cases.
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     ///
     /// [CLDR coverage]: https://www.unicode.org/reports/tr35/tr35-info.html#Coverage_Levels
@@ -262,8 +260,6 @@ impl LocaleExpander {
     ///
     /// Use this constructor if you want to include data for all locales, including ones
     /// that may not have data for other services (i.e. [CLDR coverage] below *Basic*).
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     ///

--- a/components/locale/src/fallback/mod.rs
+++ b/components/locale/src/fallback/mod.rs
@@ -100,8 +100,6 @@ pub struct LocaleFallbackIterator<'a> {
 impl LocaleFallbacker {
     /// Creates a [`LocaleFallbacker`] with compiled fallback data (likely subtags and parent locales).
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
     #[allow(clippy::new_ret_no_self)] // keeping constructors together
@@ -184,8 +182,6 @@ impl<'a> LocaleFallbackerBorrowed<'a> {
 
 impl LocaleFallbackerBorrowed<'static> {
     /// Creates a [`LocaleFallbackerBorrowed`] with compiled fallback data (likely subtags and parent locales).
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]

--- a/components/locale/src/lib.rs
+++ b/components/locale/src/lib.rs
@@ -84,6 +84,7 @@
     )
 )]
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 extern crate alloc;
 

--- a/components/locale_core/src/lib.rs
+++ b/components/locale_core/src/lib.rs
@@ -64,6 +64,7 @@
     )
 )]
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/components/normalizer/src/lib.rs
+++ b/components/normalizer/src/lib.rs
@@ -18,6 +18,7 @@
     )
 )]
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 //! Normalizing text into Unicode Normalization Forms.
 //!
@@ -1488,8 +1489,6 @@ macro_rules! normalizer_methods {
         ///
         /// Unpaired surrogates are mapped to the REPLACEMENT CHARACTER
         /// before normalizing.
-        ///
-        /// ✨ *Enabled with the `utf16_iter` Cargo feature.*
         #[cfg(feature = "utf16_iter")]
         pub fn normalize_utf16<'a>(&self, text: &'a [u16]) -> Cow<'a, [u16]> {
             let (head, tail) = self.split_normalized_utf16(text);
@@ -1505,8 +1504,6 @@ macro_rules! normalizer_methods {
         /// Split a slice of potentially-invalid UTF-16 into maximum normalized (and valid)
         /// prefix and unnormalized suffix such that the concatenation of the prefix and the
         /// normalization of the suffix is the normalization of the whole input.
-        ///
-        /// ✨ *Enabled with the `utf16_iter` Cargo feature.*
         #[cfg(feature = "utf16_iter")]
         pub fn split_normalized_utf16<'a>(&self, text: &'a [u16]) -> (&'a [u16], &'a [u16]) {
             let up_to = self.is_normalized_utf16_up_to(text);
@@ -1518,8 +1515,6 @@ macro_rules! normalizer_methods {
         }
 
         /// Return the index a slice of potentially-invalid UTF-16 is normalized up to.
-        ///
-        /// ✨ *Enabled with the `utf16_iter` Cargo feature.*
         #[cfg(feature = "utf16_iter")]
         fn is_normalized_utf16_up_to(&self, text: &[u16]) -> usize {
             let mut sink = IsNormalizedSinkUtf16::new(text);
@@ -1530,8 +1525,6 @@ macro_rules! normalizer_methods {
         /// Checks whether a slice of potentially-invalid UTF-16 is normalized.
         ///
         /// Unpaired surrogates are treated as the REPLACEMENT CHARACTER.
-        ///
-        /// ✨ *Enabled with the `utf16_iter` Cargo feature.*
         #[cfg(feature = "utf16_iter")]
         pub fn is_normalized_utf16(&self, text: &[u16]) -> bool {
             self.is_normalized_utf16_up_to(text) == text.len()
@@ -1541,8 +1534,6 @@ macro_rules! normalizer_methods {
         ///
         /// Ill-formed byte sequences are mapped to the REPLACEMENT CHARACTER
         /// according to the WHATWG Encoding Standard.
-        ///
-        /// ✨ *Enabled with the `utf8_iter` Cargo feature.*
         #[cfg(feature = "utf8_iter")]
         pub fn normalize_utf8<'a>(&self, text: &'a [u8]) -> Cow<'a, str> {
             let (head, tail) = self.split_normalized_utf8(text);
@@ -1559,8 +1550,6 @@ macro_rules! normalizer_methods {
         /// Split a slice of potentially-invalid UTF-8 into maximum normalized (and valid)
         /// prefix and unnormalized suffix such that the concatenation of the prefix and the
         /// normalization of the suffix is the normalization of the whole input.
-        ///
-        /// ✨ *Enabled with the `utf8_iter` Cargo feature.*
         #[cfg(feature = "utf8_iter")]
         pub fn split_normalized_utf8<'a>(&self, text: &'a [u8]) -> (&'a str, &'a [u8]) {
             let up_to = self.is_normalized_utf8_up_to(text);
@@ -1575,8 +1564,6 @@ macro_rules! normalizer_methods {
         }
 
         /// Return the index a slice of potentially-invalid UTF-8 is normalized up to
-        ///
-        /// ✨ *Enabled with the `utf8_iter` Cargo feature.*
         #[cfg(feature = "utf8_iter")]
         fn is_normalized_utf8_up_to(&self, text: &[u8]) -> usize {
             let mut sink = IsNormalizedSinkUtf8::new(text);
@@ -1588,8 +1575,6 @@ macro_rules! normalizer_methods {
         ///
         /// Ill-formed byte sequences are mapped to the REPLACEMENT CHARACTER
         /// according to the WHATWG Encoding Standard before checking.
-        ///
-        /// ✨ *Enabled with the `utf8_iter` Cargo feature.*
         #[cfg(feature = "utf8_iter")]
         pub fn is_normalized_utf8(&self, text: &[u8]) -> bool {
             self.is_normalized_utf8_up_to(text) == text.len()
@@ -1629,8 +1614,6 @@ impl DecomposingNormalizerBorrowed<'static> {
 
     /// NFD constructor using compiled data.
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
     pub const fn new_nfd() -> Self {
@@ -1655,8 +1638,6 @@ impl DecomposingNormalizerBorrowed<'static> {
     }
 
     /// NFKD constructor using compiled data.
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
@@ -1844,8 +1825,6 @@ impl<'data> DecomposingNormalizerBorrowed<'data> {
         ///
         /// Ill-formed byte sequences are mapped to the REPLACEMENT CHARACTER
         /// according to the WHATWG Encoding Standard.
-        ///
-        /// ✨ *Enabled with the `utf8_iter` Cargo feature.*
         #[cfg(feature = "utf8_iter")]
         ,
         normalize_utf8_to,
@@ -1942,8 +1921,6 @@ impl<'data> DecomposingNormalizerBorrowed<'data> {
         ///
         /// Unpaired surrogates are mapped to the REPLACEMENT CHARACTER
         /// before normalizing.
-        ///
-        /// ✨ *Enabled with the `utf16_iter` Cargo feature.*
         #[cfg(feature = "utf16_iter")]
         ,
         normalize_utf16_to,
@@ -2064,8 +2041,6 @@ impl DecomposingNormalizer {
 
     /// NFD constructor using compiled data.
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
     pub const fn new_nfd() -> DecomposingNormalizerBorrowed<'static> {
@@ -2130,8 +2105,6 @@ impl DecomposingNormalizer {
     );
 
     /// NFKD constructor using compiled data.
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
@@ -2272,8 +2245,6 @@ impl ComposingNormalizerBorrowed<'static> {
 
     /// NFC constructor using compiled data.
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
     pub const fn new_nfc() -> Self {
@@ -2284,8 +2255,6 @@ impl ComposingNormalizerBorrowed<'static> {
     }
 
     /// NFKC constructor using compiled data.
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
@@ -2414,8 +2383,6 @@ impl<'data> ComposingNormalizerBorrowed<'data> {
         ///
         /// Ill-formed byte sequences are mapped to the REPLACEMENT CHARACTER
         /// according to the WHATWG Encoding Standard.
-        ///
-        /// ✨ *Enabled with the `utf8_iter` Cargo feature.*
         #[cfg(feature = "utf8_iter")]
         ,
         normalize_utf8_to,
@@ -2498,8 +2465,6 @@ impl<'data> ComposingNormalizerBorrowed<'data> {
         ///
         /// Unpaired surrogates are mapped to the REPLACEMENT CHARACTER
         /// before normalizing.
-        ///
-        /// ✨ *Enabled with the `utf16_iter` Cargo feature.*
         #[cfg(feature = "utf16_iter")]
         ,
         normalize_utf16_to,
@@ -2630,8 +2595,6 @@ impl ComposingNormalizer {
 
     /// NFC constructor using compiled data.
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
     pub const fn new_nfc() -> ComposingNormalizerBorrowed<'static> {
@@ -2668,8 +2631,6 @@ impl ComposingNormalizer {
     }
 
     /// NFKC constructor using compiled data.
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]

--- a/components/normalizer/src/properties.rs
+++ b/components/normalizer/src/properties.rs
@@ -69,8 +69,6 @@ impl CanonicalCompositionBorrowed<'static> {
 
     /// Constructs a new `CanonicalComposition` using compiled data.
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
     pub const fn new() -> Self {
@@ -135,8 +133,6 @@ impl CanonicalComposition {
     }
 
     /// Constructs a new `CanonicalCompositionBorrowed` using compiled data.
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
@@ -213,8 +209,6 @@ impl CanonicalDecompositionBorrowed<'static> {
     }
 
     /// Construct from compiled data.
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
@@ -463,8 +457,6 @@ impl CanonicalDecomposition {
 
     /// Construct from compiled data.
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
     #[allow(clippy::new_ret_no_self)]
@@ -552,8 +544,6 @@ impl CanonicalCombiningClassMapBorrowed<'static> {
 
     /// Construct from compiled data.
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
     pub const fn new() -> Self {
@@ -591,8 +581,6 @@ impl CanonicalCombiningClassMapBorrowed<'_> {
     }
 
     /// Look up the canonical combining class for a scalar value
-    ///
-    /// ✨ *Enabled with the `icu_properties` Cargo feature.*
     #[inline(always)]
     #[cfg(feature = "icu_properties")]
     pub fn get(&self, c: char) -> CanonicalCombiningClass {
@@ -602,8 +590,6 @@ impl CanonicalCombiningClassMapBorrowed<'_> {
     /// Look up the canonical combining class for a scalar value
     /// represented as `u32`. If the argument is outside the scalar
     /// value range, `CanonicalCombiningClass::NotReordered` is returned.
-    ///
-    /// ✨ *Enabled with the `icu_properties` Cargo feature.*
     #[cfg(feature = "icu_properties")]
     pub fn get32(&self, c: u32) -> CanonicalCombiningClass {
         CanonicalCombiningClass::from_icu4c_value(self.get32_u8(c))
@@ -633,8 +619,6 @@ impl CanonicalCombiningClassMap {
     }
 
     /// Construct from compiled data.
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]

--- a/components/pattern/src/common.rs
+++ b/components/pattern/src/common.rs
@@ -26,8 +26,6 @@ pub enum PatternItem<'a, T> {
 
 /// A borrowed-or-owned item in a [`Pattern`]. Items are either string literals or placeholders.
 ///
-/// ✨ *Enabled with the `alloc` Cargo feature.*
-///
 /// [`Pattern`]: crate::Pattern
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[allow(clippy::exhaustive_enums)] // Part of core data model

--- a/components/pattern/src/frontend/mod.rs
+++ b/components/pattern/src/frontend/mod.rs
@@ -158,8 +158,6 @@ where
 {
     /// Creates a pattern from an iterator of pattern items.
     ///
-    /// ✨ *Enabled with the `alloc` Cargo feature.*
-    ///
     /// # Examples
     ///
     /// ```
@@ -202,8 +200,6 @@ where
     <B::PlaceholderKeyCow<'a> as FromStr>::Err: fmt::Debug,
 {
     /// Creates a pattern by parsing a syntax string.
-    ///
-    /// ✨ *Enabled with the `alloc` Cargo feature.*
     ///
     /// # Examples
     ///
@@ -261,8 +257,6 @@ where
     /// Interpolates the pattern directly to a string, returning the string or an error.
     ///
     /// In addition to the error, the lossy fallback string is returned in the failure case.
-    ///
-    /// ✨ *Enabled with the `alloc` Cargo feature.*
     pub fn try_interpolate_to_string<'a, P>(
         &'a self,
         value_provider: P,
@@ -295,8 +289,6 @@ where
 
     #[cfg(feature = "alloc")]
     /// Interpolates the pattern directly to a string.
-    ///
-    /// ✨ *Enabled with the `alloc` Cargo feature.*
     pub fn interpolate_to_string<'a, P>(&'a self, value_provider: P) -> String
     where
         P: PlaceholderValueProvider<B::PlaceholderKey<'a>, Error = B::Error<'a>> + 'a,

--- a/components/pattern/src/parser/error.rs
+++ b/components/pattern/src/parser/error.rs
@@ -7,8 +7,6 @@ use displaydoc::Display;
 
 /// An error returned when parsing a pattern.
 ///
-/// ✨ *Enabled with the `alloc` Cargo feature.*
-///
 /// # Examples
 /// ```
 /// use icu_pattern::{Parser, ParserError, ParserOptions};

--- a/components/pattern/src/parser/mod.rs
+++ b/components/pattern/src/parser/mod.rs
@@ -41,8 +41,6 @@ macro_rules! handle_literal {
 }
 
 /// Options passed to the constructor of [`Parser`].
-///
-/// ✨ *Enabled with the `alloc` Cargo feature.*
 #[derive(Debug, Default)]
 #[non_exhaustive]
 pub struct ParserOptions {
@@ -84,8 +82,6 @@ impl From<QuoteMode> for ParserOptions {
 /// characters in the input pattern string.
 ///
 /// At the moment the parser is written as a custom fallible iterator.
-///
-/// ✨ *Enabled with the `alloc` Cargo feature.*
 ///
 /// # Examples
 ///

--- a/components/pattern/src/parser/token.rs
+++ b/components/pattern/src/parser/token.rs
@@ -6,8 +6,6 @@ use alloc::borrow::Cow;
 
 /// A [`PatternItem`] with additional detail returned by the [`Parser`].
 ///
-/// ✨ *Enabled with the `alloc` Cargo feature.*
-///
 /// # Examples
 ///
 /// ```

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -73,6 +73,7 @@
     )
 )]
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 extern crate alloc;
 
@@ -525,8 +526,6 @@ impl PluralRules {
 
 /// A [`PluralRules`] that also has the ability to retrieve an appropriate [`Plural Category`] for a
 /// range.
-///
-/// ✨ *Enabled with the `experimental` Cargo feature.*
 ///
 /// <div class="stab unstable">
 /// 🚧 This code is experimental; it may change at any time, in breaking or non-breaking ways,

--- a/components/properties/src/bidi.rs
+++ b/components/properties/src/bidi.rs
@@ -70,8 +70,6 @@ pub enum BidiPairedBracketType {
 
 /// Implements [`unicode_bidi::BidiDataSource`] on [`CodePointMapDataBorrowed<BidiClass>`](crate::CodePointMapDataBorrowed).
 ///
-/// ✨ *Enabled with the `unicode_bidi` Cargo feature.*
-///
 /// # Examples
 ///
 ///```

--- a/components/properties/src/code_point_map.rs
+++ b/components/properties/src/code_point_map.rs
@@ -28,8 +28,6 @@ impl<T: TrieValue> CodePointMapData<T> {
     ///
     /// See the documentation on [`EnumeratedProperty`] implementations for details.
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
     #[allow(clippy::new_ret_no_self)]
@@ -304,8 +302,6 @@ impl<T: TrieValue> CodePointMapDataBorrowed<'static, T> {
     ///
     /// See the documentation on [`EnumeratedProperty`] implementations for details.
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
     pub const fn new() -> Self
@@ -380,8 +376,6 @@ pub trait EnumeratedProperty: crate::private::Sealed + TrieValue {
     const SHORT_NAME: &'static [u8];
 
     /// Convenience method for `CodePointMapData::new().get(ch)`
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     #[cfg(feature = "compiled_data")]
     fn for_char(ch: char) -> Self {
         CodePointMapData::new().get(ch)

--- a/components/properties/src/code_point_set.rs
+++ b/components/properties/src/code_point_set.rs
@@ -31,8 +31,6 @@ pub struct CodePointSetData {
 impl CodePointSetData {
     /// Creates a new [`CodePointSetDataBorrowed`] for a [`BinaryProperty`].
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[allow(clippy::new_ret_no_self)]
     #[cfg(feature = "compiled_data")]
@@ -113,8 +111,6 @@ pub struct CodePointSetDataBorrowed<'a> {
 
 impl CodePointSetDataBorrowed<'static> {
     /// Creates a new [`CodePointSetData`] for a [`BinaryProperty`].
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[inline]
@@ -233,8 +229,6 @@ pub trait BinaryProperty: crate::private::Sealed + Sized {
     const SHORT_NAME: &'static [u8];
 
     /// Convenience method for `CodePointSetData::new().contains(ch)`
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     #[cfg(feature = "compiled_data")]
     fn for_char(ch: char) -> bool {
         CodePointSetData::new::<Self>().contains(ch)

--- a/components/properties/src/emoji.rs
+++ b/components/properties/src/emoji.rs
@@ -18,8 +18,6 @@ impl EmojiSetData {
     ///
     /// See the documentation on [`EmojiSet`] implementations for details.
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
     #[allow(clippy::new_ret_no_self)]
@@ -135,8 +133,6 @@ impl EmojiSetDataBorrowed<'static> {
     /// Creates a new [`EmojiSetDataBorrowed`] for a [`EmojiSet`].
     ///
     /// See the documentation on [`EmojiSet`] implementations for details.
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[inline]

--- a/components/properties/src/lib.rs
+++ b/components/properties/src/lib.rs
@@ -67,6 +67,7 @@
     )
 )]
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/components/properties/src/names.rs
+++ b/components/properties/src/names.rs
@@ -81,8 +81,6 @@ impl<T> Copy for PropertyParserBorrowed<'_, T> {}
 impl<T> PropertyParser<T> {
     /// Creates a new instance of `PropertyParser<T>` using compiled data.
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
     #[allow(clippy::new_ret_no_self)]
@@ -251,8 +249,6 @@ impl<T: ParseableEnumeratedProperty> Default for PropertyParserBorrowed<'static,
 impl<T: TrieValue> PropertyParserBorrowed<'static, T> {
     /// Creates a new instance of `PropertyParserBorrowed<T>` using compiled data.
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
     pub fn new() -> Self
@@ -378,8 +374,6 @@ impl<T: NamedEnumeratedProperty> Copy for PropertyNamesLongBorrowed<'_, T> {}
 impl<T: NamedEnumeratedProperty> PropertyNamesLong<T> {
     /// Creates a new instance of `PropertyNamesLongBorrowed<T>`.
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
     #[allow(clippy::new_ret_no_self)]
@@ -442,8 +436,6 @@ impl<T: NamedEnumeratedProperty> Default for PropertyNamesLongBorrowed<'static, 
 
 impl<T: NamedEnumeratedProperty> PropertyNamesLongBorrowed<'static, T> {
     /// Creates a new instance of `PropertyNamesLongBorrowed<T>`.
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
@@ -510,8 +502,6 @@ impl<T: NamedEnumeratedProperty> Copy for PropertyNamesShortBorrowed<'_, T> {}
 
 impl<T: NamedEnumeratedProperty> PropertyNamesShort<T> {
     /// Creates a new instance of `PropertyNamesShortBorrowed<T>`.
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
@@ -616,8 +606,6 @@ impl<T: NamedEnumeratedProperty> Default for PropertyNamesShortBorrowed<'static,
 impl<T: NamedEnumeratedProperty> PropertyNamesShortBorrowed<'static, T> {
     /// Creates a new instance of `PropertyNamesShortBorrowed<T>`.
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
     pub fn new() -> Self {
@@ -721,22 +709,16 @@ pub trait NamedEnumeratedProperty: ParseableEnumeratedProperty {
     ) -> &'static Self::DataStructShort;
 
     /// Convenience method for `PropertyParser::new().get_loose(s)`
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     #[cfg(feature = "compiled_data")]
     fn try_from_str(s: &str) -> Option<Self> {
         PropertyParser::new().get_loose(s)
     }
     /// Convenience method for `PropertyNamesLong::new().get(*self).unwrap()`
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     #[cfg(feature = "compiled_data")]
     fn long_name(&self) -> &'static str {
         PropertyNamesLong::new().get(*self).unwrap_or("unreachable")
     }
     /// Convenience method for `PropertyNamesShort::new().get(*self).unwrap()`
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     #[cfg(feature = "compiled_data")]
     fn short_name(&self) -> &'static str {
         PropertyNamesShort::new()

--- a/components/properties/src/runtime.rs
+++ b/components/properties/src/runtime.rs
@@ -239,8 +239,6 @@ impl CodePointSetData {
     /// - `General_Category` property values can themselves be treated like properties using a shorthand in ECMA262,
     ///   simply create the corresponding `GeneralCategory` set.
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     ///
     /// ```

--- a/components/properties/src/script.rs
+++ b/components/properties/src/script.rs
@@ -233,8 +233,6 @@ impl<'a> ScriptExtensionsSet<'a> {
 
 /// A struct that represents the data for the Script and Script_Extensions properties.
 ///
-/// ✨ *Enabled with the `compiled_data` Cargo feature.*
-///
 /// [📚 Help choosing a constructor](icu_provider::constructors)
 ///
 /// Most useful methods are on [`ScriptWithExtensionsBorrowed`] obtained by calling [`ScriptWithExtensions::as_borrowed()`]
@@ -305,8 +303,6 @@ pub struct ScriptWithExtensionsBorrowed<'a> {
 
 impl ScriptWithExtensions {
     /// Creates a new instance of `ScriptWithExtensionsBorrowed` using compiled data.
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
@@ -665,8 +661,6 @@ impl Default for ScriptWithExtensionsBorrowed<'static> {
 
 impl ScriptWithExtensionsBorrowed<'static> {
     /// Creates a new instance of `ScriptWithExtensionsBorrowed` using compiled data.
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]

--- a/components/segmenter/src/grapheme.rs
+++ b/components/segmenter/src/grapheme.rs
@@ -121,8 +121,6 @@ pub struct GraphemeClusterSegmenterBorrowed<'data> {
 impl GraphemeClusterSegmenter {
     /// Constructs a [`GraphemeClusterSegmenterBorrowed`] with an invariant locale from compiled data.
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
     #[allow(clippy::new_ret_no_self)] // Deliberate choice, see #5554

--- a/components/segmenter/src/lib.rs
+++ b/components/segmenter/src/lib.rs
@@ -119,6 +119,7 @@
     )
 )]
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 extern crate alloc;
 

--- a/components/segmenter/src/line.rs
+++ b/components/segmenter/src/line.rs
@@ -377,8 +377,6 @@ impl LineSegmenter {
     ///
     /// See also [`Self::new_auto`].
     ///
-    /// ✨ *Enabled with the `compiled_data` and `auto` Cargo features.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "auto")]
     #[cfg(feature = "compiled_data")]
@@ -419,8 +417,6 @@ impl LineSegmenter {
     /// the full dictionary but more expensive during segmentation (inference).
     ///
     /// See also [`Self::new_lstm`].
-    ///
-    /// ✨ *Enabled with the `compiled_data` and `lstm` Cargo features.*
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "lstm")]
@@ -470,8 +466,6 @@ impl LineSegmenter {
     /// faster than the LSTM model but requires more data.
     ///
     /// See also [`Self::new_dictionary`].
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]

--- a/components/segmenter/src/sentence.rs
+++ b/components/segmenter/src/sentence.rs
@@ -119,8 +119,6 @@ pub struct SentenceSegmenterBorrowed<'data> {
 impl SentenceSegmenter {
     /// Constructs a [`SentenceSegmenterBorrowed`] with an invariant locale and compiled data.
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
     #[allow(clippy::new_ret_no_self)]

--- a/components/segmenter/src/word.rs
+++ b/components/segmenter/src/word.rs
@@ -208,8 +208,6 @@ impl WordSegmenter {
     /// The current behavior, which is subject to change, is to use the LSTM model when available
     /// and the dictionary model for Chinese and Japanese.
     ///
-    /// ✨ *Enabled with the `compiled_data` and `auto` Cargo features.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     ///
     /// # Examples
@@ -298,8 +296,6 @@ impl WordSegmenter {
     /// Warning: there is not currently an LSTM model for Chinese or Japanese, so the [`WordSegmenter`]
     /// created by this function will have unexpected behavior in spans of those scripts.
     ///
-    /// ✨ *Enabled with the `compiled_data` and `lstm` Cargo features.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     ///
     /// # Examples
@@ -385,8 +381,6 @@ impl WordSegmenter {
     ///
     /// The dictionary model uses a list of words to determine appropriate breakpoints. It is
     /// faster than the LSTM model but requires more data.
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     ///

--- a/components/time/src/ixdtf.rs
+++ b/components/time/src/ixdtf.rs
@@ -666,8 +666,6 @@ impl<A: AsCalendar> DateTime<A> {
     /// Returns an error if the string has a calendar annotation that does not
     /// match the calendar argument, unless the argument is [`Iso`].
     ///
-    /// ✨ *Enabled with the `ixdtf` Cargo feature.*
-    ///
     /// # Examples
     ///
     /// ```
@@ -697,8 +695,6 @@ impl<A: AsCalendar> DateTime<A> {
     /// Creates a [`DateTime`] in any calendar from an RFC 9557 string.
     ///
     /// See [`Self::try_from_str()`].
-    ///
-    /// ✨ *Enabled with the `ixdtf` Cargo feature.*
     pub fn try_from_utf8(rfc_9557_str: &[u8], calendar: A) -> Result<Self, ParseError> {
         let ixdtf_record = IxdtfParser::from_utf8(rfc_9557_str).parse()?;
         let date = Date::try_from_ixdtf_record(&ixdtf_record, calendar)?;
@@ -711,8 +707,6 @@ impl Time {
     /// Creates a [`Time`] from an RFC 9557 string of a time.
     ///
     /// Does not support parsing an RFC 9557 string with a date and time; for that, use [`DateTime`].
-    ///
-    /// ✨ *Enabled with the `ixdtf` Cargo feature.*
     ///
     /// # Examples
     ///
@@ -731,8 +725,6 @@ impl Time {
     }
 
     /// Creates a [`Time`] in the ISO-8601 calendar from an RFC 9557 string.
-    ///
-    /// ✨ *Enabled with the `ixdtf` Cargo feature.*
     ///
     /// See [`Self::try_from_str()`].
     pub fn try_from_utf8(rfc_9557_str: &[u8]) -> Result<Self, ParseError> {

--- a/components/time/src/lib.rs
+++ b/components/time/src/lib.rs
@@ -18,6 +18,7 @@
     )
 )]
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 //! Time and timezone functionality.
 //!

--- a/components/time/src/zone/iana.rs
+++ b/components/time/src/zone/iana.rs
@@ -75,8 +75,6 @@ impl IanaParser {
     ///
     /// See [`IanaParser`] for an example.
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
     #[allow(clippy::new_ret_no_self)]
@@ -145,8 +143,6 @@ impl IanaParserBorrowed<'static> {
     /// Creates a new [`IanaParserBorrowed`] using compiled data.
     ///
     /// See [`IanaParserBorrowed`] for an example.
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
@@ -266,8 +262,6 @@ impl IanaParserExtended<IanaParser> {
     ///
     /// See [`IanaParserExtended`] for an example.
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
     #[allow(clippy::new_ret_no_self)]
@@ -304,8 +298,6 @@ where
     /// and a pre-existing [`IanaParser`], which can be borrowed.
     ///
     /// See [`IanaParserExtended`] for an example.
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
@@ -385,8 +377,6 @@ impl IanaParserExtendedBorrowed<'static> {
     /// Creates a new [`IanaParserExtendedBorrowed`] using compiled data.
     ///
     /// See [`IanaParserExtendedBorrowed`] for an example.
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]

--- a/components/time/src/zone/offset.rs
+++ b/components/time/src/zone/offset.rs
@@ -192,8 +192,6 @@ impl Default for VariantOffsetsCalculatorBorrowed<'static> {
 impl VariantOffsetsCalculator {
     /// Constructs a `VariantOffsetsCalculator` using compiled data.
     ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
-    ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]
     #[inline]
@@ -233,8 +231,6 @@ impl VariantOffsetsCalculator {
 
 impl VariantOffsetsCalculatorBorrowed<'static> {
     /// Constructs a `VariantOffsetsCalculatorBorrowed` using compiled data.
-    ///
-    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// [📚 Help choosing a constructor](icu_provider::constructors)
     #[cfg(feature = "compiled_data")]

--- a/ffi/harfbuzz/src/lib.rs
+++ b/ffi/harfbuzz/src/lib.rs
@@ -19,6 +19,7 @@
     )
 )]
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 //! Using ICU4X as the Unicode Database back end for HarfBuzz.
 //!

--- a/provider/adapters/src/lib.rs
+++ b/provider/adapters/src/lib.rs
@@ -25,6 +25,7 @@
     )
 )]
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 extern crate alloc;
 

--- a/provider/blob/src/lib.rs
+++ b/provider/blob/src/lib.rs
@@ -31,6 +31,7 @@
     )
 )]
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/provider/core/src/constructors.rs
+++ b/provider/core/src/constructors.rs
@@ -106,7 +106,6 @@ macro_rules! gen_buffer_unstable_docs {
         concat!(
             "A version of [`", stringify!($data), "`] that uses custom data ",
             "provided by a [`BufferProvider`](icu_provider::buf::BufferProvider).\n\n",
-            "✨ *Enabled with the `serde` feature.*\n\n",
             "[📚 Help choosing a constructor](icu_provider::constructors)",
         )
     };
@@ -196,8 +195,6 @@ macro_rules! gen_buffer_data_constructors {
     (($($options_arg:ident: $options_ty:ty),*) -> result: $result_ty:ty, $(#[$doc:meta])* functions: [$baked:ident, $buffer:ident, $unstable:ident $(, $struct:ident)? $(,)?]) => {
         #[cfg(feature = "compiled_data")]
         $(#[$doc])*
-        ///
-        /// ✨ *Enabled with the `compiled_data` Cargo feature.*
         ///
         /// [📚 Help choosing a constructor](icu_provider::constructors)
         pub fn $baked($($options_arg: $options_ty),* ) -> $result_ty {

--- a/provider/core/src/export/mod.rs
+++ b/provider/core/src/export/mod.rs
@@ -4,8 +4,6 @@
 
 //! This module contains types required to export ICU4X data via the `icu_provider_export` crate.
 //! End users should not need to consume anything in this module.
-//!
-//! This module is enabled with the `export` Cargo feature.
 
 mod payload;
 

--- a/provider/core/src/lib.rs
+++ b/provider/core/src/lib.rs
@@ -93,6 +93,7 @@
     )
 )]
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/provider/core/src/varule_traits.rs
+++ b/provider/core/src/varule_traits.rs
@@ -26,8 +26,6 @@ pub trait MaybeAsVarULE {
 
 /// Export-only trait associated with [`MaybeAsVarULE`]. See that trait
 /// for additional details.
-///
-/// ✨ *Enabled with the `export` Cargo feature.*
 #[cfg(feature = "export")]
 pub trait MaybeEncodeAsVarULE: MaybeAsVarULE {
     /// Returns the [`MaybeAsVarULE::EncodedStruct`] that represents this data struct,

--- a/provider/export/src/lib.rs
+++ b/provider/export/src/lib.rs
@@ -59,6 +59,7 @@
     )
 )]
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 mod export_impl;
 mod locale_family;

--- a/provider/fs/src/lib.rs
+++ b/provider/fs/src/lib.rs
@@ -91,6 +91,7 @@
     )
 )]
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 mod datapath;
 mod fs_data_provider;

--- a/provider/source/src/lib.rs
+++ b/provider/source/src/lib.rs
@@ -125,8 +125,6 @@ impl SourceDataProvider {
     /// [`TESTED_ICUEXPORT_TAG`](Self::TESTED_ICUEXPORT_TAG),
     /// [`TESTED_SEGMENTER_LSTM_TAG`](Self::TESTED_SEGMENTER_LSTM_TAG),
     /// [`TESTED_TZDB_TAG`](Self::TESTED_TZDB_TAG).
-    ///
-    /// ✨ *Enabled with the `networking` Cargo feature.*
     #[cfg(feature = "networking")]
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
@@ -209,8 +207,6 @@ impl SourceDataProvider {
     /// using the given tag (see [GitHub releases](https://github.com/unicode-org/cldr-json/releases)).
     ///
     /// Also see: [`TESTED_CLDR_TAG`](Self::TESTED_CLDR_TAG)
-    ///
-    /// ✨ *Enabled with the `networking` Cargo feature.*
     #[cfg(feature = "networking")]
     pub fn with_cldr_for_tag(self, tag: &str) -> Self {
         Self {
@@ -225,8 +221,6 @@ impl SourceDataProvider {
     /// using the given tag (see [GitHub releases](https://github.com/unicode-org/icu/releases)).
     ///
     /// Also see: [`TESTED_ICUEXPORT_TAG`](Self::TESTED_ICUEXPORT_TAG)
-    ///
-    /// ✨ *Enabled with the `networking` Cargo feature.*
     #[cfg(feature = "networking")]
     pub fn with_icuexport_for_tag(self, mut tag: &str) -> Self {
         if tag == "release-71-1" {
@@ -245,8 +239,6 @@ impl SourceDataProvider {
     /// using the given tag (see [GitHub releases](https://github.com/unicode-org/lstm_word_segmentation/releases)).
     ///
     /// Also see: [`TESTED_SEGMENTER_LSTM_TAG`](Self::TESTED_SEGMENTER_LSTM_TAG)
-    ///
-    /// ✨ *Enabled with the `networking` Cargo feature.*
     #[cfg(feature = "networking")]
     pub fn with_segmenter_lstm_for_tag(self, tag: &str) -> Self {
         Self {
@@ -261,8 +253,6 @@ impl SourceDataProvider {
     /// using the given tag (see [GitHub](https://github.com/eggert/tz)).
     ///
     /// Also see: [`TESTED_SEGMENTER_LSTM_TAG`](Self::TESTED_SEGMENTER_LSTM_TAG)
-    ///
-    /// ✨ *Enabled with the `networking` Cargo feature.*
     #[cfg(feature = "networking")]
     pub fn with_tzdb_for_tag(self, tag: &str) -> Self {
         Self {

--- a/utils/calendrical_calculations/src/lib.rs
+++ b/utils/calendrical_calculations/src/lib.rs
@@ -34,6 +34,7 @@
     )
 )]
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 mod astronomy;
 /// Chinese-like lunar calendars (Chinese, Dangi)

--- a/utils/ixdtf/src/lib.rs
+++ b/utils/ixdtf/src/lib.rs
@@ -387,6 +387,7 @@
         missing_debug_implementations,
     )
 )]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 mod error;
 pub mod parsers;

--- a/utils/ixdtf/src/parsers/mod.rs
+++ b/utils/ixdtf/src/parsers/mod.rs
@@ -231,8 +231,6 @@ impl<'a> IxdtfParser<'a> {
 }
 
 /// A parser for time zone offset and IANA identifier strings.
-///
-/// ✨ *Enabled with the `timezone` Cargo feature.*
 #[derive(Debug)]
 pub struct TimeZoneParser<'a> {
     cursor: Cursor<'a>,
@@ -325,8 +323,6 @@ impl<'a> TimeZoneParser<'a> {
 }
 
 /// A parser for ISO8601 Duration strings.
-///
-/// ✨ *Enabled with the `duration` Cargo feature.*
 ///
 /// # Example
 ///

--- a/utils/resb/src/lib.rs
+++ b/utils/resb/src/lib.rs
@@ -26,6 +26,7 @@
     )
 )]
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 pub mod binary;
 

--- a/utils/tzif/src/lib.rs
+++ b/utils/tzif/src/lib.rs
@@ -25,6 +25,7 @@
 //! ```
 
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 use combine::{stream, Parser};
 use data::{posix::PosixTzString, tzif::TzifData};

--- a/utils/yoke/src/erased.rs
+++ b/utils/yoke/src/erased.rs
@@ -6,8 +6,6 @@
 //!
 //! See the docs of [`Yoke::erase_rc_cart()`](crate::Yoke::erase_rc_cart)
 //! and [`Yoke::erase_box_cart()`](crate::Yoke::erase_box_cart) for more info.
-//!
-//! ✨ *Enabled with the `alloc` Cargo feature.*
 
 use alloc::boxed::Box;
 use alloc::rc::Rc;
@@ -24,18 +22,12 @@ impl<T: 'static> ErasedDestructor for T {}
 /// A type-erased Cart that has `Arc` semantics
 ///
 /// See the docs of [`Yoke::erase_arc_cart()`](crate::Yoke::erase_rc_cart) for more info.
-///
-/// ✨ *Enabled with the `alloc` Cargo feature.*
 pub type ErasedArcCart = Arc<dyn ErasedDestructor + Send + Sync>;
 /// A type-erased Cart that has `Rc` semantics
 ///
 /// See the docs of [`Yoke::erase_rc_cart()`](crate::Yoke::erase_rc_cart) for more info.
-///
-/// ✨ *Enabled with the `alloc` Cargo feature.*
 pub type ErasedRcCart = Rc<dyn ErasedDestructor>;
 /// A type-erased Cart that has `Box` semantics
 ///
 /// See the docs of [`Yoke::erase_box_cart()`](crate::Yoke::erase_box_cart) for more info.
-///
-/// ✨ *Enabled with the `alloc` Cargo feature.*
 pub type ErasedBoxCart = Box<dyn ErasedDestructor>;

--- a/utils/yoke/src/lib.rs
+++ b/utils/yoke/src/lib.rs
@@ -42,6 +42,7 @@
 // The lifetimes here are important for safety and explicitly writing
 // them out is good even when redundant
 #![allow(clippy::needless_lifetimes)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -1113,8 +1113,6 @@ impl<Y: for<'a> Yokeable<'a>, C: 'static + Sized> Yoke<Y, Rc<C>> {
     /// In case the cart type `C` is not already an `Rc<T>`, you can use
     /// [`Yoke::wrap_cart_in_rc()`] to wrap it.
     ///
-    /// ✨ *Enabled with the `alloc` Cargo feature.*
-    ///
     /// # Example
     ///
     /// ```rust
@@ -1155,8 +1153,6 @@ impl<Y: for<'a> Yokeable<'a>, C: 'static + Sized + Send + Sync> Yoke<Y, Arc<C>> 
     ///
     /// In case the cart type `C` is not already an `Arc<T>`, you can use
     /// [`Yoke::wrap_cart_in_arc()`] to wrap it.
-    ///
-    /// ✨ *Enabled with the `alloc` Cargo feature.*
     ///
     /// # Example
     ///
@@ -1199,8 +1195,6 @@ impl<Y: for<'a> Yokeable<'a>, C: 'static + Sized> Yoke<Y, Box<C>> {
     /// In case the cart type `C` is not already `Box<T>`, you can use
     /// [`Yoke::wrap_cart_in_box()`] to wrap it.
     ///
-    /// ✨ *Enabled with the `alloc` Cargo feature.*
-    ///
     /// # Example
     ///
     /// ```rust
@@ -1232,8 +1226,6 @@ impl<Y: for<'a> Yokeable<'a>, C: 'static + Sized> Yoke<Y, Box<C>> {
 impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
     /// Helper function allowing one to wrap the cart type `C` in a `Box<T>`.
     /// Can be paired with [`Yoke::erase_box_cart()`]
-    ///
-    /// ✨ *Enabled with the `alloc` Cargo feature.*
     #[inline]
     pub fn wrap_cart_in_box(self) -> Yoke<Y, Box<C>> {
         // Safety: safe because the cart is preserved, as it is just wrapped.
@@ -1242,8 +1234,6 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
     /// Helper function allowing one to wrap the cart type `C` in an `Rc<T>`.
     /// Can be paired with [`Yoke::erase_rc_cart()`], or generally used
     /// to make the [`Yoke`] cloneable.
-    ///
-    /// ✨ *Enabled with the `alloc` Cargo feature.*
     #[inline]
     pub fn wrap_cart_in_rc(self) -> Yoke<Y, Rc<C>> {
         // Safety: safe because the cart is preserved, as it is just wrapped
@@ -1252,8 +1242,6 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
     /// Helper function allowing one to wrap the cart type `C` in an `Rc<T>`.
     /// Can be paired with [`Yoke::erase_arc_cart()`], or generally used
     /// to make the [`Yoke`] cloneable.
-    ///
-    /// ✨ *Enabled with the `alloc` Cargo feature.*
     #[inline]
     pub fn wrap_cart_in_arc(self) -> Yoke<Y, Arc<C>> {
         // Safety: safe because the cart is preserved, as it is just wrapped

--- a/utils/zerotrie/src/lib.rs
+++ b/utils/zerotrie/src/lib.rs
@@ -50,6 +50,7 @@
     )
 )]
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/utils/zerotrie/src/zerotrie.rs
+++ b/utils/zerotrie/src/zerotrie.rs
@@ -375,8 +375,6 @@ macro_rules! impl_zerotrie_subtype {
         {
             /// Converts a possibly-borrowed $name to an owned one.
             ///
-            /// ✨ *Enabled with the `alloc` Cargo feature.*
-            ///
             /// # Examples
             ///
             /// ```
@@ -395,8 +393,6 @@ macro_rules! impl_zerotrie_subtype {
                 )
             }
             /// Returns an iterator over the key/value pairs in this trie.
-            ///
-            /// ✨ *Enabled with the `alloc` Cargo feature.*
             ///
             /// # Examples
             ///
@@ -479,8 +475,6 @@ macro_rules! impl_zerotrie_subtype {
         {
             /// Exports the data from this ZeroTrie type into a BTreeMap.
             ///
-            /// ✨ *Enabled with the `alloc` Cargo feature.*
-            ///
             /// # Examples
             ///
             /// ```
@@ -537,8 +531,6 @@ macro_rules! impl_zerotrie_subtype {
             Store: AsRef<[u8]> + ?Sized,
         {
             /// Exports the data from this ZeroTrie type into a LiteMap.
-            ///
-            /// ✨ *Enabled with the `litemap` Cargo feature.*
             ///
             /// # Examples
             ///
@@ -613,8 +605,6 @@ macro_rules! impl_zerotrie_subtype {
             #[doc = concat!("This impl allows [`", stringify!($name), "`] to be used inside of a [`Cow`](alloc::borrow::Cow).")]
             ///
             #[doc = concat!("Note that it is also possible to use `", stringify!($name), "<ZeroVec<u8>>` for a similar result.")]
-            ///
-            /// ✨ *Enabled with the `alloc` Cargo feature.*
             ///
             /// # Examples
             ///


### PR DESCRIPTION
Instead of documenting "✨ *Enabled with the `xy` Cargo feature.*", this uses the rustdoc `doc_cfg` feature. These automatically apply recursively to items within modules as well.

<img width="1120" alt="image" src="https://github.com/user-attachments/assets/cdbd5d14-f3ca-4f78-ac6b-4f6d66ba8308" />
<img width="1129" alt="image" src="https://github.com/user-attachments/assets/9fa470fd-a386-4852-bff8-a021e4906caf" />
