### PR TITLE
Add `set_unicode_extension` to FFI`

### DIFF
--- a/ffi/capi/bindings/c/Locale.h
+++ b/ffi/capi/bindings/c/Locale.h
@@ -28,6 +28,9 @@ void icu4x_Locale_basename_mv1(const Locale* self, DiplomatWrite* write);
 typedef struct icu4x_Locale_get_unicode_extension_mv1_result { bool is_ok;} icu4x_Locale_get_unicode_extension_mv1_result;
 icu4x_Locale_get_unicode_extension_mv1_result icu4x_Locale_get_unicode_extension_mv1(const Locale* self, DiplomatStringView s, DiplomatWrite* write);
 
+typedef struct icu4x_Locale_set_unicode_extension_mv1_result { bool is_ok;} icu4x_Locale_set_unicode_extension_mv1_result;
+icu4x_Locale_set_unicode_extension_mv1_result icu4x_Locale_set_unicode_extension_mv1(Locale* self, DiplomatStringView k, DiplomatStringView v);
+
 void icu4x_Locale_language_mv1(const Locale* self, DiplomatWrite* write);
 
 typedef struct icu4x_Locale_set_language_mv1_result {union { LocaleParseError err;}; bool is_ok;} icu4x_Locale_set_language_mv1_result;

--- a/ffi/capi/bindings/cpp/icu4x/Locale.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/Locale.d.hpp
@@ -74,6 +74,13 @@ public:
   inline std::optional<std::string> get_unicode_extension(std::string_view s) const;
 
   /**
+   * Set a Unicode extension.
+   *
+   * See the [Rust documentation for `extensions`](https://docs.rs/icu/2.0.0/icu/locale/struct.Locale.html#structfield.extensions) for more information.
+   */
+  inline std::optional<std::monostate> set_unicode_extension(std::string_view k, std::string_view v);
+
+  /**
    * Returns a string representation of {@link Locale} language.
    *
    * See the [Rust documentation for `id`](https://docs.rs/icu/2.0.0/icu/locale/struct.Locale.html#structfield.id) for more information.

--- a/ffi/capi/bindings/cpp/icu4x/Locale.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/Locale.hpp
@@ -31,6 +31,9 @@ namespace capi {
     typedef struct icu4x_Locale_get_unicode_extension_mv1_result { bool is_ok;} icu4x_Locale_get_unicode_extension_mv1_result;
     icu4x_Locale_get_unicode_extension_mv1_result icu4x_Locale_get_unicode_extension_mv1(const icu4x::capi::Locale* self, diplomat::capi::DiplomatStringView s, diplomat::capi::DiplomatWrite* write);
 
+    typedef struct icu4x_Locale_set_unicode_extension_mv1_result { bool is_ok;} icu4x_Locale_set_unicode_extension_mv1_result;
+    icu4x_Locale_set_unicode_extension_mv1_result icu4x_Locale_set_unicode_extension_mv1(icu4x::capi::Locale* self, diplomat::capi::DiplomatStringView k, diplomat::capi::DiplomatStringView v);
+
     void icu4x_Locale_language_mv1(const icu4x::capi::Locale* self, diplomat::capi::DiplomatWrite* write);
 
     typedef struct icu4x_Locale_set_language_mv1_result {union { icu4x::capi::LocaleParseError err;}; bool is_ok;} icu4x_Locale_set_language_mv1_result;
@@ -95,6 +98,13 @@ inline std::optional<std::string> icu4x::Locale::get_unicode_extension(std::stri
     {s.data(), s.size()},
     &write);
   return result.is_ok ? std::optional<std::string>(std::move(output)) : std::nullopt;
+}
+
+inline std::optional<std::monostate> icu4x::Locale::set_unicode_extension(std::string_view k, std::string_view v) {
+  auto result = icu4x::capi::icu4x_Locale_set_unicode_extension_mv1(this->AsFFI(),
+    {k.data(), k.size()},
+    {v.data(), v.size()});
+  return result.is_ok ? std::optional<std::monostate>() : std::nullopt;
 }
 
 inline std::string icu4x::Locale::language() const {

--- a/ffi/capi/bindings/dart/Locale.g.dart
+++ b/ffi/capi/bindings/dart/Locale.g.dart
@@ -82,6 +82,15 @@ final class Locale implements ffi.Finalizable, core.Comparable<Locale> {
     return write.finalize();
   }
 
+  /// Set a Unicode extension.
+  ///
+  /// See the [Rust documentation for `extensions`](https://docs.rs/icu/2.0.0/icu/locale/struct.Locale.html#structfield.extensions) for more information.
+  bool setUnicodeExtension(String k, String v) {
+    final temp = _FinalizedArena();
+    final result = _icu4x_Locale_set_unicode_extension_mv1(_ffi, k._utf8AllocIn(temp.arena), v._utf8AllocIn(temp.arena));
+    return result.isOk;
+  }
+
   /// Returns a string representation of [Locale] language.
   ///
   /// See the [Rust documentation for `id`](https://docs.rs/icu/2.0.0/icu/locale/struct.Locale.html#structfield.id) for more information.
@@ -236,6 +245,11 @@ external void _icu4x_Locale_basename_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Point
 @ffi.Native<_ResultVoidVoid Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Locale_get_unicode_extension_mv1')
 // ignore: non_constant_identifier_names
 external _ResultVoidVoid _icu4x_Locale_get_unicode_extension_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUtf8 s, ffi.Pointer<ffi.Opaque> write);
+
+@_DiplomatFfiUse('icu4x_Locale_set_unicode_extension_mv1')
+@ffi.Native<_ResultVoidVoid Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8, _SliceUtf8)>(isLeaf: true, symbol: 'icu4x_Locale_set_unicode_extension_mv1')
+// ignore: non_constant_identifier_names
+external _ResultVoidVoid _icu4x_Locale_set_unicode_extension_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUtf8 k, _SliceUtf8 v);
 
 @_DiplomatFfiUse('icu4x_Locale_language_mv1')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Locale_language_mv1')

--- a/ffi/capi/bindings/js/Locale.d.ts
+++ b/ffi/capi/bindings/js/Locale.d.ts
@@ -57,6 +57,13 @@ export class Locale {
     getUnicodeExtension(s: string): string | null;
 
     /**
+     * Set a Unicode extension.
+     *
+     * See the [Rust documentation for `extensions`](https://docs.rs/icu/2.0.0/icu/locale/struct.Locale.html#structfield.extensions) for more information.
+     */
+    setUnicodeExtension(k: string, v: string): boolean;
+
+    /**
      * Returns a string representation of {@link Locale} language.
      *
      * See the [Rust documentation for `id`](https://docs.rs/icu/2.0.0/icu/locale/struct.Locale.html#structfield.id) for more information.

--- a/ffi/capi/bindings/js/Locale.mjs
+++ b/ffi/capi/bindings/js/Locale.mjs
@@ -154,6 +154,29 @@ export class Locale {
     }
 
     /**
+     * Set a Unicode extension.
+     *
+     * See the [Rust documentation for `extensions`](https://docs.rs/icu/2.0.0/icu/locale/struct.Locale.html#structfield.extensions) for more information.
+     */
+    setUnicodeExtension(k, v) {
+        let functionCleanupArena = new diplomatRuntime.CleanupArena();
+
+        const kSlice = diplomatRuntime.DiplomatBuf.str8(wasm, k);
+        const vSlice = diplomatRuntime.DiplomatBuf.str8(wasm, v);
+
+        const result = wasm.icu4x_Locale_set_unicode_extension_mv1(this.ffiValue, ...kSlice.splat(), ...vSlice.splat());
+
+        try {
+            return result === 1;
+        }
+
+        finally {
+            functionCleanupArena.free();
+
+        }
+    }
+
+    /**
      * Returns a string representation of {@link Locale} language.
      *
      * See the [Rust documentation for `id`](https://docs.rs/icu/2.0.0/icu/locale/struct.Locale.html#structfield.id) for more information.

--- a/ffi/capi/src/locale_core.rs
+++ b/ffi/capi/src/locale_core.rs
@@ -77,6 +77,15 @@ pub mod ffi {
                 })
         }
 
+        /// Set a Unicode extension.
+        #[diplomat::rust_link(icu::locale::Locale::extensions, StructField)]
+        pub fn set_unicode_extension(&mut self, k: &DiplomatStr, v: &DiplomatStr) -> Option<()> {
+            let k = icu_locale_core::extensions::unicode::Key::try_from_utf8(k).ok()?;
+            let v = icu_locale_core::extensions::unicode::Value::try_from_utf8(v).ok()?;
+            self.0.extensions.unicode.keywords.set(k, v);
+            Some(())
+        }
+
         /// Returns a string representation of [`Locale`] language.
         #[diplomat::rust_link(icu::locale::Locale::id, StructField)]
         #[diplomat::attr(auto, getter)]

--- a/ffi/dart/test/icu_test.dart
+++ b/ffi/dart/test/icu_test.dart
@@ -59,6 +59,18 @@ void main() {
     );
   });
 
+  test('Locale extensions', () {
+    var locale = Locale.fromString('en-GB');
+    expect(locale.getUnicodeExtension('ca'), null);
+    expect(locale.setUnicodeExtension('ca', 'gregory'), true);
+    expect(locale.setUnicodeExtension('ca', 'gregorian'), false);
+    expect(locale.setUnicodeExtension('calendar', 'gregory'), false);
+    expect(locale.getUnicodeExtension('ca'), 'gregory');
+    expect(locale.toString(), 'en-GB-u-ca-gregory');
+    expect(locale.setUnicodeExtension('ka', 'gregory'), true);
+    expect(locale.toString(), 'en-GB-u-ca-gregory-ka-gregory');
+  });
+
   test('Time zones', () {
     final iter = IanaParserExtended().iterAll();
     iter.moveNext();


### PR DESCRIPTION
We probably want to patch-release this, as it's blocking Dart upgrading to 2.0.