### PR TITLE
Rename `get_constant_denominator` to `constant_denominator`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1386,7 +1386,7 @@ version = "2.0.0"
 
 [[package]]
 name = "icu_experimental"
-version = "0.3.0"
+version = "0.4.0-dev"
 dependencies = [
  "criterion",
  "databake",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,7 +145,7 @@ icu_collections = { version = "~2.0.0", path = "components/collections", default
 icu_codepointtrie_builder = { version = "~0.5.0", path = "components/collections/codepointtrie_builder", default-features = false }
 icu_datetime = { version = "~2.0.0", path = "components/datetime", default-features = false }
 icu_decimal = { version = "~2.0.0", path = "components/decimal", default-features = false }
-icu_experimental = { version = "~0.3.0", path = "components/experimental", default-features = false }
+icu_experimental = { version = "~0.4.0-dev", path = "components/experimental", default-features = false }
 icu_list = { version = "~2.0.0", path = "components/list", default-features = false }
 icu_locale = { version = "~2.0.0", path = "components/locale", default-features = false }
 icu_normalizer = { version = "~2.0.0", path = "components/normalizer", default-features = false }

--- a/components/experimental/Cargo.toml
+++ b/components/experimental/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_experimental"
 description = "ICU4X pre-release components under active development; all code in this crate is unstable."
-version = "0.3.0"
+version = "0.4.0-dev"
 
 authors.workspace = true
 categories.workspace = true

--- a/components/experimental/src/measure/measureunit.rs
+++ b/components/experimental/src/measure/measureunit.rs
@@ -43,7 +43,7 @@ impl MeasureUnit {
     ///
     /// NOTE:
     ///   If the constant denominator is not set, a value of `0` is returned.
-    pub fn get_constant_denominator(&self) -> u64 {
+    pub fn constant_denominator(&self) -> u64 {
         self.constant_denominator
     }
 }

--- a/components/experimental/src/units/converter_factory.rs
+++ b/components/experimental/src/units/converter_factory.rs
@@ -281,8 +281,8 @@ impl ConverterFactory {
             conversion_rate *= Self::compute_conversion_term(self, input_item, 1)?;
         }
 
-        if input_unit.constant_denominator != 0 {
-            conversion_rate /= IcuRatio::from_integer(input_unit.constant_denominator);
+        if input_unit.constant_denominator() != 0 {
+            conversion_rate /= IcuRatio::from_integer(input_unit.constant_denominator());
         }
 
         for output_item in output_unit.single_units.iter() {
@@ -290,11 +290,11 @@ impl ConverterFactory {
                 Self::compute_conversion_term(self, output_item, root_to_unit2_direction_sign)?;
         }
 
-        if output_unit.constant_denominator != 0 {
+        if output_unit.constant_denominator() != 0 {
             if is_reciprocal {
-                conversion_rate /= IcuRatio::from_integer(output_unit.constant_denominator);
+                conversion_rate /= IcuRatio::from_integer(output_unit.constant_denominator());
             } else {
-                conversion_rate *= IcuRatio::from_integer(output_unit.constant_denominator);
+                conversion_rate *= IcuRatio::from_integer(output_unit.constant_denominator());
             }
         }
 


### PR DESCRIPTION
# Description

- Renamed `get_constant_denominator` to `constant_denominator` for improved readability.
- Updated references in `converter_factory.rs` to use the new method.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->