### PR TITLE
Remove crates.io CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -170,13 +170,9 @@ jobs:
       run: cargo make ci-job-test-gigo
 
 
-  # ci-job-test-tutorials
-  test-tutorials:
+  # ci-job-test-cargo
+  test-cargo:
     runs-on: ubuntu-latest
-    strategy:
-      matrix: 
-        behavior: [local, cratesio]
-      fail-fast: false
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
@@ -197,8 +193,8 @@ jobs:
       run: sudo apt install libharfbuzz-dev
 
     # Actual job
-    - name: Run `cargo make ci-job-test-tutorials-${{ matrix.behavior }}`
-      run: cargo make ci-job-test-tutorials-${{ matrix.behavior }}
+    - name: Run `cargo make ci-job-test-cargo`
+      run: cargo make ci-job-test-cargo
 
 
   # ci-job-testdata

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,7 +147,7 @@ Our wider testsuite is organized as `ci-job-foo` make tasks corresponding to eac
 
  - `ci-job-doc`: Builds all Rustdoc; any warning is treated as an error.
  - `ci-job-test-docs`: Runs `cargo test --doc` on all the crates. This takes a while but is the main way of ensuring that nothing has been broken.
- - `ci-job-test-tutorials`: Builds all our tutorials against both local code (`locale`), and released ICU4X (`cratesio`).
+ - `ci-job-test-cargo`: Tests all our Cargo examples.
 <br/>
  
  - `ci-job-testdata`: Runs an `icu_provider_source` integration test with a subset of CLDR, ICU, and LSTM source data.

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -97,18 +97,11 @@ dependencies = [
     "test-dev-without-assertions",
 ]
 
-[tasks.ci-job-test-tutorials-local]
-description = "Run all checks for the CI 'test-tutorials' job"
+[tasks.ci-job-test-cargo]
+description = "Run all checks for the CI 'test-cargo' job"
 category = "CI"
 dependencies = [
-    "test-tutorials-local",
-]
-
-[tasks.ci-job-test-tutorials-cratesio]
-description = "Run all checks for the CI 'test-tutorials' job"
-category = "CI"
-dependencies = [
-    "test-tutorials-cratesio",
+    "test-cargo",
 ]
 
 [tasks.ci-job-testdata]
@@ -278,7 +271,7 @@ dependencies = [
     # Get a coffee
     "ci-job-test",
     "ci-job-test-docs",
-    "ci-job-test-tutorials-cratesio",
+    "ci-job-test-cargo",
     "ci-job-testdata",
     "ci-job-msrv-features",
     "ci-job-full-datagen",

--- a/tools/make/tests.toml
+++ b/tools/make/tests.toml
@@ -72,7 +72,7 @@ exec --fail-on-error cargo check --manifest-path sync/Cargo.toml
 # custom_compiled doesn't compile without data
 '''
 
-[tasks.test-tutorials-local]
+[tasks.test-cargo]
 description = "Build and run the Cargo tutorial projects based on local crates"
 category = "ICU4X Development"
 script_runner = "@duckscript"
@@ -105,42 +105,6 @@ exec --fail-on-error cargo run --manifest-path buffer/Cargo.toml
 exec --fail-on-error make -C custom_compiled baked_data/mod.rs
 set_env ICU4X_DATA_DIR ${project_dir}/examples/cargo/custom_compiled/baked_data
 exec --fail-on-error cargo run --manifest-path custom_compiled/Cargo.toml
-'''
-
-[tasks.test-tutorials-cratesio]
-description = "Build and run the Cargo tutorial projects based on crates.io"
-category = "ICU4X Development"
-script_runner = "@duckscript"
-script = '''
-exit_on_error true
-
-cd examples/cargo
-
-# Delete the lockfile to make a clean crates.io build
-rm -f Cargo.lock
-# Delete the patch file to use crates.io
-rm -f ../.cargo/config.toml
-
-pwd = pwd
-set_env CARGO_TARGET_DIR ${pwd}/target/cratesio
-
-exec --fail-on-error cargo run --release --manifest-path default/Cargo.toml
-exec --fail-on-error cargo run --release --manifest-path experimental/Cargo.toml
-exec --fail-on-error cargo run --release --manifest-path sync/Cargo.toml
-exec --fail-on-error cargo run --release --manifest-path baked/Cargo.toml
-exec --fail-on-error cargo run --release --manifest-path harfbuzz/Cargo.toml
-
-# Build the postcard file
-# Use the full Makefile task
-exec --fail-on-error cargo build --release --manifest-path buffer/Cargo.toml
-exec --fail-on-error make -C buffer
-exec --fail-on-error cargo run --release --manifest-path buffer/Cargo.toml
-
-# Build custom compiled data
-# Use the full Makefile task
-exec --fail-on-error make -C custom_compiled
-set_env ICU4X_DATA_DIR ${pwd}/custom_compiled/baked_data
-exec --fail-on-error cargo run --release --manifest-path custom_compiled/Cargo.toml
 '''
 
 [tasks.install-cortex-7]


### PR DESCRIPTION
We now have a semver CI, and we branch tutorials to the website on releases, so we don't really need to test against crates.io anymore.