### PR TITLE
Minor collation key improvements

### DIFF
--- a/components/collator/src/comparison.rs
+++ b/components/collator/src/comparison.rs
@@ -44,7 +44,7 @@ use crate::provider::CollationSpecialPrimariesValidated;
 use crate::provider::CollationTailoringV1;
 use core::array;
 use core::cmp::Ordering;
-use core::convert::TryFrom;
+use core::convert::{Infallible, TryFrom};
 use icu_normalizer::provider::DecompositionData;
 use icu_normalizer::provider::DecompositionTables;
 use icu_normalizer::provider::NormalizerNfdDataV1;
@@ -2175,8 +2175,7 @@ pub trait CollationKeySink {
 
     /// Write a single byte into the writer.
     fn write_byte(&mut self, state: &mut Self::State, b: u8) -> Result<(), Self::Error> {
-        self.write(state, &[b])?;
-        Ok(())
+        self.write(state, &[b])
     }
 
     /// Finalize any internal sink state (perhaps by flushing a buffer) and return the final
@@ -2185,7 +2184,7 @@ pub trait CollationKeySink {
 }
 
 impl CollationKeySink for Vec<u8> {
-    type Error = core::convert::Infallible;
+    type Error = Infallible;
     type State = ();
     type Output = ();
 
@@ -2200,7 +2199,7 @@ impl CollationKeySink for Vec<u8> {
 }
 
 impl CollationKeySink for VecDeque<u8> {
-    type Error = core::convert::Infallible;
+    type Error = Infallible;
     type State = ();
     type Output = ();
 
@@ -2215,11 +2214,11 @@ impl CollationKeySink for VecDeque<u8> {
 }
 
 impl<const N: usize> CollationKeySink for SmallVec<[u8; N]> {
-    type Error = core::convert::Infallible;
+    type Error = Infallible;
     type State = ();
     type Output = ();
 
-    fn write(&mut self, _: &mut (), buf: &[u8]) -> Result<(), Self::Error> {
+    fn write(&mut self, _: &mut Self::State, buf: &[u8]) -> Result<(), Self::Error> {
         self.extend_from_slice(buf);
         Ok(())
     }

--- a/components/collator/src/comparison.rs
+++ b/components/collator/src/comparison.rs
@@ -2180,7 +2180,7 @@ pub trait CollationKeySink {
 
     /// Finalize any internal sink state (perhaps by flushing a buffer) and return the final
     /// output value.
-    fn finish(&self, state: Self::State) -> Result<Self::Output, Self::Error>;
+    fn finish(&mut self, state: Self::State) -> Result<Self::Output, Self::Error>;
 }
 
 impl CollationKeySink for Vec<u8> {
@@ -2193,7 +2193,7 @@ impl CollationKeySink for Vec<u8> {
         Ok(())
     }
 
-    fn finish(&self, _: Self::State) -> Result<Self::Output, Self::Error> {
+    fn finish(&mut self, _: Self::State) -> Result<Self::Output, Self::Error> {
         Ok(())
     }
 }
@@ -2208,7 +2208,7 @@ impl CollationKeySink for VecDeque<u8> {
         Ok(())
     }
 
-    fn finish(&self, _: Self::State) -> Result<Self::Output, Self::Error> {
+    fn finish(&mut self, _: Self::State) -> Result<Self::Output, Self::Error> {
         Ok(())
     }
 }
@@ -2223,7 +2223,7 @@ impl<const N: usize> CollationKeySink for SmallVec<[u8; N]> {
         Ok(())
     }
 
-    fn finish(&self, _: Self::State) -> Result<Self::Output, Self::Error> {
+    fn finish(&mut self, _: Self::State) -> Result<Self::Output, Self::Error> {
         Ok(())
     }
 }
@@ -2245,7 +2245,7 @@ impl CollationKeySink for [u8] {
         }
     }
 
-    fn finish(&self, used: Self::State) -> Result<Self::Output, Self::Error> {
+    fn finish(&mut self, used: Self::State) -> Result<Self::Output, Self::Error> {
         Ok(used)
     }
 }


### PR DESCRIPTION
- Minor style cleanups to make the file consistent
- Make `CollationKeySink::finish` take mutable receiver — I envisioned that the function might write to its output, but I mistakenly didn't give it a mutable reference.
- Return full collation key length on too small error — This is the polite thing to do when given a too small buffer so the caller doesn't have to guess a new size.
