### PR TITLE
Add Latin1 comparisons to the collator

### DIFF
--- a/components/collator/Cargo.toml
+++ b/components/collator/Cargo.toml
@@ -53,6 +53,7 @@ default = ["compiled_data"]
 serde = ["dep:serde", "zerovec/serde", "icu_properties/serde", "icu_normalizer/serde", "icu_collections/serde", "icu_provider/serde"]
 datagen = ["serde", "dep:databake", "zerovec/databake", "icu_properties/datagen", "icu_normalizer/datagen", "icu_collections/databake", "icu_provider/export"]
 compiled_data = ["dep:icu_collator_data", "icu_normalizer/compiled_data", "dep:icu_locale", "icu_locale?/compiled_data", "icu_provider/baked"]
+latin1 = []
 
 [[bench]]
 name = "bench"

--- a/components/collator/tests/tests.rs
+++ b/components/collator/tests/tests.rs
@@ -2014,6 +2014,54 @@ fn test_middle_contraction_markers() {
     );
 }
 
+#[cfg(feature = "latin1")]
+#[test]
+fn test_latin1_root() {
+    let mut options = CollatorOptions::default();
+    options.strength = Some(Strength::Primary);
+    let collator = Collator::try_new(Default::default(), options).unwrap();
+    assert_eq!(
+        collator.compare_latin1(b"ax", b"a\xE4"),
+        core::cmp::Ordering::Greater
+    );
+}
+
+#[cfg(feature = "latin1")]
+#[test]
+fn test_latin1_utf16_root() {
+    let mut options = CollatorOptions::default();
+    options.strength = Some(Strength::Primary);
+    let collator = Collator::try_new(Default::default(), options).unwrap();
+    assert_eq!(
+        collator.compare_latin1_utf16(b"ax", &[0x0061, 0x00E4]),
+        core::cmp::Ordering::Greater
+    );
+}
+
+#[cfg(feature = "latin1")]
+#[test]
+fn test_latin1_fi() {
+    let mut options = CollatorOptions::default();
+    options.strength = Some(Strength::Primary);
+    let collator = Collator::try_new(locale!("fi").into(), options).unwrap();
+    assert_eq!(
+        collator.compare_latin1(b"ax", b"a\xE4"),
+        core::cmp::Ordering::Less
+    );
+}
+
+#[cfg(feature = "latin1")]
+#[test]
+fn test_latin1_utf16_fi() {
+    let mut options = CollatorOptions::default();
+    options.strength = Some(Strength::Primary);
+    let collator = Collator::try_new(locale!("fi").into(), options).unwrap();
+    assert_eq!(
+        collator.compare_latin1_utf16(b"ax", &[0x0061, 0x00E4]),
+        core::cmp::Ordering::Less
+    );
+}
+
 // TODO: Test languages that map to the root.
 // The languages that map to root without script reordering are:
 // ca (at least for now)

--- a/ffi/capi/tests/missing_apis.txt
+++ b/ffi/capi/tests/missing_apis.txt
@@ -14,6 +14,8 @@
 # Please check in with @Manishearth, @robertbastian, or @sffc if you have questions
 
 
+icu::collator::CollatorBorrowed::compare_latin1#FnInStruct
+icu::collator::CollatorBorrowed::compare_latin1_utf16#FnInStruct
 icu::collator::CollatorBorrowed::write_sort_key_to#FnInStruct
 icu::collator::CollatorBorrowed::write_sort_key_utf16_to#FnInStruct
 icu::collator::CollatorBorrowed::write_sort_key_utf8_to#FnInStruct


### PR DESCRIPTION
The motivation is for SpiderMonkey to be able to compare strings that are represented as Latin1 without converting them into a UTF-16 buffer. There is deliberately no sort key generation and no FFI, since those are not needed for the motivating use case.

The macro shape here could easily be extended to support the CPython use case from #545.