### PR TITLE
WASM demo: expose functions under `ICU4X` namespace in the global scope

### DIFF
--- a/tools/web-demo/gen/rendering/rendering.mjs
+++ b/tools/web-demo/gen/rendering/rendering.mjs
@@ -290,7 +290,7 @@ export class TerminusRender extends HTMLElement {
     #parameters;
     #output;
     #code;
-    constructor(library, evaluateExternal, terminus, exprCallback = ((element) => {})) {
+    constructor(library, evaluateExternal, terminus, renderExpr = (el, expr) => el.textContent = expr) {
         super();
         generateTemplate(TerminusRender, "template", "template#terminus");
         let clone = TerminusRender.template.cloneNode(true);
@@ -329,12 +329,10 @@ export class TerminusRender extends HTMLElement {
         const shadowRoot = this.attachShadow({ mode: "open" });
         shadowRoot.appendChild(clone);
 
-        this.#code.textContent = this.#expr(...this.#parameters.exprs);
-        exprCallback(this.#code);
+        renderExpr(this.#code, this.#expr(...this.#parameters.exprs));
         for (let param of this.#parameters.children) {
             param.addEventListener('parameter-input', () => {
-                this.#code.textContent = this.#expr(...this.#parameters.exprs);
-                exprCallback(this.#code);
+                renderExpr(this.#code, this.#expr(...this.#parameters.exprs));
                 this.#output.textContent = "";
                 this.#output.classList = "";
                 if (this.#parameters.values.every((e) => e != undefined)) {

--- a/tools/web-demo/gen/rendering/rendering.mjs
+++ b/tools/web-demo/gen/rendering/rendering.mjs
@@ -314,9 +314,13 @@ export class TerminusRender extends HTMLElement {
         this.#parameters.slot = "parameters";
         this.appendChild(this.#parameters);
 
+        const pre = document.createElement("pre");
+        pre.classList.add("language-js");
+        pre.slot = "code";
+        this.appendChild(pre);
+
         this.#code = document.createElement("code");
-        this.#code.slot = "code";
-        this.appendChild(this.#code);
+        pre.appendChild(this.#code);
 
         this.#output = document.createElement("span");
         this.#output.slot = "output";
@@ -325,13 +329,13 @@ export class TerminusRender extends HTMLElement {
         const shadowRoot = this.attachShadow({ mode: "open" });
         shadowRoot.appendChild(clone);
 
-        this.#code.innerText = this.#expr(...this.#parameters.exprs);
+        this.#code.textContent = this.#expr(...this.#parameters.exprs);
         exprCallback(this.#code);
         for (let param of this.#parameters.children) {
             param.addEventListener('parameter-input', () => {
-                this.#code.innerText = this.#expr(...this.#parameters.exprs);
-                exprCallback(this.#code);                
-                this.#output.innerText = "";
+                this.#code.textContent = this.#expr(...this.#parameters.exprs);
+                exprCallback(this.#code);
+                this.#output.textContent = "";
                 this.#output.classList = "";
                 if (this.#parameters.values.every((e) => e != undefined)) {
                     button.removeAttribute("disabled");

--- a/tools/web-demo/gen/rendering/rendering.mjs
+++ b/tools/web-demo/gen/rendering/rendering.mjs
@@ -290,7 +290,7 @@ export class TerminusRender extends HTMLElement {
     #parameters;
     #output;
     #code;
-    constructor(library, evaluateExternal, terminus, renderExpr = (el, expr) => el.textContent = expr) {
+    constructor(library, evaluateExternal, terminus, exprCallback = ((element) => {})) {
         super();
         generateTemplate(TerminusRender, "template", "template#terminus");
         let clone = TerminusRender.template.cloneNode(true);
@@ -314,13 +314,9 @@ export class TerminusRender extends HTMLElement {
         this.#parameters.slot = "parameters";
         this.appendChild(this.#parameters);
 
-        const pre = document.createElement("pre");
-        pre.classList.add("language-js");
-        pre.slot = "code";
-        this.appendChild(pre);
-
         this.#code = document.createElement("code");
-        pre.appendChild(this.#code);
+        this.#code.slot = "code";
+        this.appendChild(this.#code);
 
         this.#output = document.createElement("span");
         this.#output.slot = "output";
@@ -329,11 +325,13 @@ export class TerminusRender extends HTMLElement {
         const shadowRoot = this.attachShadow({ mode: "open" });
         shadowRoot.appendChild(clone);
 
-        renderExpr(this.#code, this.#expr(...this.#parameters.exprs));
+        this.#code.innerText = this.#expr(...this.#parameters.exprs);
+        exprCallback(this.#code);
         for (let param of this.#parameters.children) {
             param.addEventListener('parameter-input', () => {
-                renderExpr(this.#code, this.#expr(...this.#parameters.exprs));
-                this.#output.textContent = "";
+                this.#code.innerText = this.#expr(...this.#parameters.exprs);
+                exprCallback(this.#code);                
+                this.#output.innerText = "";
                 this.#output.classList = "";
                 if (this.#parameters.values.every((e) => e != undefined)) {
                     button.removeAttribute("disabled");

--- a/tools/web-demo/package.json
+++ b/tools/web-demo/package.json
@@ -9,7 +9,8 @@
 	"license": "ISC",
 	"dependencies": {
 		"icu4x": "file:../../ffi/npm",
-		"js-beautify": "^1.15.4"
+		"js-beautify": "^1.15.4",
+		"prismjs": "^1.30.0"
 	},
 	"devDependencies": {
 		"bootstrap": "^5.3.3",

--- a/tools/web-demo/public/index.html
+++ b/tools/web-demo/public/index.html
@@ -7,13 +7,21 @@
         <link rel="stylesheet" href="dist/index.css"/>
         <meta name="viewport" content="width=device-width, initial-scale=1">
     </head>
-    <body class="container">
+    <body class="container my-2 mx-0 readable-width">
+        <div id="loading">Loading...</div>
+        <div id="loaded" hidden>
+            <p>
+                The ICU4X classes can be accessed in the browser console under the
+                <code>ICU4X</code> module, e.g.
+                <code>const { TitlecaseMapper, TitlecaseOptions } = ICU4X</code>.
+            </p>
+        </div>
         <template id="terminus">
             <link rel="stylesheet" href="dist/index.css"/>
             <div class="vstack gap-2">
                 <slot name="parameters"></slot>
-                <div class="input-group mb-3">
-                    <div class="form-control" style="background: var(--bs-secondary-bg); min-width: 400px"><pre><slot name="code"></slot></pre></div>
+                <div class="input-group mb-small">
+                    <div class="form-control" style="background: var(--bs-secondary-bg); min-width: 400px"><slot name="code"></slot></div>
                     <button type="submit" class="btn btn-primary" data-submit>▶</button>
                     <div class="form-control" style="background: var(--bs-secondary-bg)"><slot name="output"></slot></div>
                 </div>

--- a/tools/web-demo/public/index.html
+++ b/tools/web-demo/public/index.html
@@ -21,7 +21,7 @@
             <div class="vstack gap-2">
                 <slot name="parameters"></slot>
                 <div class="input-group mb-small">
-                    <div class="form-control" style="background: var(--bs-secondary-bg); min-width: 400px"><slot name="code"></slot></div>
+                    <div class="form-control" style="background: var(--bs-secondary-bg); min-width: 400px"><pre><slot name="code"></slot></pre></div>
                     <button type="submit" class="btn btn-primary" data-submit>▶</button>
                     <div class="form-control" style="background: var(--bs-secondary-bg)"><slot name="output"></slot></div>
                 </div>

--- a/tools/web-demo/src/js/index.mjs
+++ b/tools/web-demo/src/js/index.mjs
@@ -17,17 +17,18 @@ Object.values(RenderInfo.termini).toSorted((a, b) => a.funcName < b.funcName ? -
 	summary.innerHTML = `<code>${t.funcName}</code>`;
 	details.appendChild(summary);
 	details.appendChild(document.createElement("br"));
-	details.appendChild(new TerminusRender(lib, () => { }, RenderInfo.termini[t.funcName],
-		(code) => {
-			code.textContent = beautify.js(code.textContent, {
+	details.appendChild(new TerminusRender(lib, () => {}, RenderInfo.termini[t.funcName],
+		(el, expr) => {
+			el.textContent = beautify.js(expr, {
 				indent_size: 2,
 				indent_char: " ",
 				break_chained_methods: true,
 				// brace_style: "collapse",
 				wrap_line_length: 45,
 			});
-			Prism.highlightElement(code);
-		}));
+			Prism.highlightElement(el);
+		},
+	));
 	document.getElementsByClassName("container")[0].appendChild(details);
 });
 

--- a/tools/web-demo/src/js/index.mjs
+++ b/tools/web-demo/src/js/index.mjs
@@ -5,6 +5,10 @@
 import { RenderInfo, lib } from "../../gen/index.mjs";
 import { TerminusRender } from "../../gen/rendering/rendering.mjs";
 import beautify from 'js-beautify';
+import * as ICU4X from 'icu4x'
+import Prism from 'prismjs';
+
+window.ICU4X = window.top.ICU4X = ICU4X;
 
 // Renders all termini into the class="container" element
 Object.values(RenderInfo.termini).toSorted((a, b) => a.funcName < b.funcName ? -1 : 1).forEach((t) => {
@@ -15,13 +19,17 @@ Object.values(RenderInfo.termini).toSorted((a, b) => a.funcName < b.funcName ? -
 	details.appendChild(document.createElement("br"));
 	details.appendChild(new TerminusRender(lib, () => { }, RenderInfo.termini[t.funcName],
 		(code) => {
-			code.innerText = beautify.js(code.innerText, {
-				"indent_size": "2",
-				"indent_char": " ",
-				"break_chained_methods": true,
-				// "brace_style": "collapse",
-				"wrap_line_length": "45"
+			code.textContent = beautify.js(code.textContent, {
+				indent_size: 2,
+				indent_char: " ",
+				break_chained_methods: true,
+				// brace_style: "collapse",
+				wrap_line_length: 45,
 			});
+			Prism.highlightElement(code);
 		}));
 	document.getElementsByClassName("container")[0].appendChild(details);
 });
+
+document.querySelector("#loading").hidden = true;
+document.querySelector("#loaded").hidden = false;

--- a/tools/web-demo/src/js/index.mjs
+++ b/tools/web-demo/src/js/index.mjs
@@ -18,8 +18,11 @@ Object.values(RenderInfo.termini).toSorted((a, b) => a.funcName < b.funcName ? -
 	details.appendChild(summary);
 	details.appendChild(document.createElement("br"));
 	details.appendChild(new TerminusRender(lib, () => {}, RenderInfo.termini[t.funcName],
-		(el, expr) => {
-			el.textContent = beautify.js(expr, {
+		(el) => {
+			// Necessary for Prism to know the language to highlight for, and also
+			// to ensure CSS `white-space: pre-wrap` is applied from selector
+			el.classList.add("language-js");
+			el.textContent = beautify.js(el.textContent, {
 				indent_size: 2,
 				indent_char: " ",
 				break_chained_methods: true,

--- a/tools/web-demo/src/scss/styles.scss
+++ b/tools/web-demo/src/scss/styles.scss
@@ -2,14 +2,28 @@
 @import "~bootstrap/scss/bootstrap";
 @import "~prismjs/themes/prism.css";
 
+:is(.readable-width) {
+  max-width: 120ch;
+}
+
 :is(.mb-small) {
   margin-bottom: 5px;
 }
 
-:is(code, pre)[class*="language-"] {
+.form-control pre {
+  white-space: pre-wrap;
+  margin: 0;
   font-size: 0.875rem;
 }
 
-:is(.readable-width) {
-  max-width: 120ch;
+code[class*="language-"][slot="code"] {
+  // Unset all `:not(pre) > code` styles from prismjs, which erroneously matches
+  // due to being rendered inside a shadow DOM `<slot>`
+  all: unset;
+  white-space: pre-wrap;
+
+  .token.operator {
+    background: none;
+    opacity: .6;
+  }
 }

--- a/tools/web-demo/src/scss/styles.scss
+++ b/tools/web-demo/src/scss/styles.scss
@@ -1,6 +1,15 @@
 // Import all of Bootstrap's CSS
 @import "~bootstrap/scss/bootstrap";
+@import "~prismjs/themes/prism.css";
 
-.mb-3 {
-  margin-bottom: 5px !important;
+:is(.mb-small) {
+  margin-bottom: 5px;
+}
+
+:is(code, pre)[class*="language-"] {
+  font-size: 0.875rem;
+}
+
+:is(.readable-width) {
+  max-width: 120ch;
 }


### PR DESCRIPTION
This exposes the ICU4X module as `ICU4X` in the global scope of the WASM demo, allowing the classes to be used directly from the browser console.

It also adds code highlighting to the new snippets.

![image](https://github.com/user-attachments/assets/b11c183f-3ecb-46fb-b401-a46950e9c46f)