### PR TITLE
Introduce `duration` category for measure units

### DIFF
--- a/components/experimental/src/measure/category/duration.rs
+++ b/components/experimental/src/measure/category/duration.rs
@@ -1,0 +1,158 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+#![cfg(feature = "compiled_data")]
+use crate::measure::{
+    category::{CategorizedMeasureUnit, Duration},
+    measureunit::MeasureUnit,
+    provider::{
+        si_prefix::{Base, SiPrefix},
+        single_unit::SingleUnit,
+    },
+    single_unit_vec::SingleUnitVec,
+};
+
+impl Duration {
+    /// Returns a [`MeasureUnit`] representing duration in milliseconds.
+    pub fn millisecond() -> CategorizedMeasureUnit<Duration> {
+        CategorizedMeasureUnit {
+            _category: core::marker::PhantomData,
+            unit: MeasureUnit {
+                single_units: SingleUnitVec::One(SingleUnit {
+                    power: 1,
+                    si_prefix: SiPrefix {
+                        power: -3,
+                        base: Base::Decimal,
+                    },
+                    unit_id: *crate::provider::Baked::UNIT_IDS_V1_UND_SECOND,
+                }),
+                constant_denominator: 0,
+            },
+        }
+    }
+
+    /// Returns a [`MeasureUnit`] representing duration in seconds.
+    pub fn second() -> CategorizedMeasureUnit<Duration> {
+        CategorizedMeasureUnit {
+            _category: core::marker::PhantomData,
+            unit: MeasureUnit {
+                single_units: SingleUnitVec::One(SingleUnit {
+                    power: 1,
+                    si_prefix: SiPrefix {
+                        power: 0,
+                        base: Base::Decimal,
+                    },
+                    unit_id: *crate::provider::Baked::UNIT_IDS_V1_UND_SECOND,
+                }),
+                constant_denominator: 0,
+            },
+        }
+    }
+
+    /// Returns a [`MeasureUnit`] representing duration in minutes.
+    pub fn minute() -> CategorizedMeasureUnit<Duration> {
+        CategorizedMeasureUnit {
+            _category: core::marker::PhantomData,
+            unit: MeasureUnit {
+                single_units: SingleUnitVec::One(SingleUnit {
+                    power: 1,
+                    si_prefix: SiPrefix {
+                        power: 0,
+                        base: Base::Decimal,
+                    },
+                    unit_id: *crate::provider::Baked::UNIT_IDS_V1_UND_MINUTE,
+                }),
+                constant_denominator: 0,
+            },
+        }
+    }
+
+    /// Returns a [`MeasureUnit`] representing duration in hours.
+    pub fn hour() -> CategorizedMeasureUnit<Duration> {
+        CategorizedMeasureUnit {
+            _category: core::marker::PhantomData,
+            unit: MeasureUnit {
+                single_units: SingleUnitVec::One(SingleUnit {
+                    power: 1,
+                    si_prefix: SiPrefix {
+                        power: 0,
+                        base: Base::Decimal,
+                    },
+                    unit_id: *crate::provider::Baked::UNIT_IDS_V1_UND_HOUR,
+                }),
+                constant_denominator: 0,
+            },
+        }
+    }
+
+    /// Returns a [`MeasureUnit`] representing duration in days.
+    pub fn day() -> CategorizedMeasureUnit<Duration> {
+        CategorizedMeasureUnit {
+            _category: core::marker::PhantomData,
+            unit: MeasureUnit {
+                single_units: SingleUnitVec::One(SingleUnit {
+                    power: 1,
+                    si_prefix: SiPrefix {
+                        power: 0,
+                        base: Base::Decimal,
+                    },
+                    unit_id: *crate::provider::Baked::UNIT_IDS_V1_UND_DAY,
+                }),
+                constant_denominator: 0,
+            },
+        }
+    }
+
+    /// Returns a [`MeasureUnit`] representing duration in weeks.
+    pub fn week() -> CategorizedMeasureUnit<Duration> {
+        CategorizedMeasureUnit {
+            _category: core::marker::PhantomData,
+            unit: MeasureUnit {
+                single_units: SingleUnitVec::One(SingleUnit {
+                    power: 1,
+                    si_prefix: SiPrefix {
+                        power: 0,
+                        base: Base::Decimal,
+                    },
+                    unit_id: *crate::provider::Baked::UNIT_IDS_V1_UND_WEEK,
+                }),
+                constant_denominator: 0,
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::measure::parser::MeasureUnitParser;
+
+    #[test]
+    fn test_duration_category() {
+        let parser = MeasureUnitParser::default();
+        let millisecond = Duration::millisecond();
+        let millisecond_parsed = parser.try_from_str("millisecond").unwrap();
+        assert_eq!(millisecond.unit, millisecond_parsed);
+
+        let second = Duration::second();
+        let second_parsed = parser.try_from_str("second").unwrap();
+        assert_eq!(second.unit, second_parsed);
+
+        let minute = Duration::minute();
+        let minute_parsed = parser.try_from_str("minute").unwrap();
+        assert_eq!(minute.unit, minute_parsed);
+
+        let hour = Duration::hour();
+        let hour_parsed = parser.try_from_str("hour").unwrap();
+        assert_eq!(hour.unit, hour_parsed);
+
+        let day = Duration::day();
+        let day_parsed = parser.try_from_str("day").unwrap();
+        assert_eq!(day.unit, day_parsed);
+
+        let week = Duration::week();
+        let week_parsed = parser.try_from_str("week").unwrap();
+        assert_eq!(week.unit, week_parsed);
+    }
+}

--- a/components/experimental/src/measure/category/mod.rs
+++ b/components/experimental/src/measure/category/mod.rs
@@ -7,6 +7,7 @@ use core::marker::PhantomData;
 use crate::measure::measureunit::MeasureUnit;
 
 pub mod area;
+pub mod duration;
 pub mod length;
 pub mod mass;
 pub mod volume;
@@ -21,19 +22,23 @@ pub struct CategorizedMeasureUnit<T: MeasureUnitCategory> {
     pub unit: MeasureUnit,
 }
 
-/// A [`MeasureUnit`] that is related to the length category.
-pub struct Length;
-
 /// A [`MeasureUnit`] that is related to the area category.
 pub struct Area;
 
-/// A [`MeasureUnit`] that is related to the volume category.
-pub struct Volume;
+/// A [`MeasureUnit`] that is related to the duration category.
+pub struct Duration;
+
+/// A [`MeasureUnit`] that is related to the length category.
+pub struct Length;
 
 /// A [`MeasureUnit`] that is related to the mass category.
 pub struct Mass;
 
-impl MeasureUnitCategory for Length {}
+/// A [`MeasureUnit`] that is related to the volume category.
+pub struct Volume;
+
 impl MeasureUnitCategory for Area {}
-impl MeasureUnitCategory for Volume {}
+impl MeasureUnitCategory for Duration {}
+impl MeasureUnitCategory for Length {}
 impl MeasureUnitCategory for Mass {}
+impl MeasureUnitCategory for Volume {}


### PR DESCRIPTION
# Description

- Introducing a new module for duration measures, including methods for milliseconds, seconds, minutes, hours, days, and weeks.
- Updating the category module to include the new duration category and its associated traits.
- Adding unit tests to validate that the added units are the same as the parsed ones.
- 
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->