### PR TITLE
Add explicit defaults to FFI enums where clear-cut.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+- Components
+    - General
+    - ...
+    - 
+- Data model and providers
+    - ...
+- FFI
+    - `icu_capi`
+        - All C++ enums now default to a valid value; which is the `Default` impl where there is one, and some semi-logical value otherwise. This has changed defaults in some cases and may cause a behavioral change for people relying on C++ default constructors. (unicode-org#6692)
+- Utils
+    - ...
+
 ## icu4x 2.0.x
 
 Several crates have had patch releases in the 2.0 stream:

--- a/components/experimental/src/displaynames/options.rs
+++ b/components/experimental/src/displaynames/options.rs
@@ -50,29 +50,19 @@ pub enum Style {
 /// requested display name.
 #[allow(missing_docs)] // The variants are self explanatory.
 #[non_exhaustive]
-#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+#[derive(Debug, Default, Eq, PartialEq, Clone, Copy)]
 pub enum Fallback {
+    #[default]
     Code,
     None,
-}
-
-impl Default for Fallback {
-    fn default() -> Self {
-        Self::Code
-    }
 }
 
 /// An enum for the language display kind.
 #[allow(missing_docs)] // The variants are self explanatory.
 #[non_exhaustive]
-#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+#[derive(Debug, Default, Eq, PartialEq, Clone, Copy)]
 pub enum LanguageDisplay {
+    #[default]
     Dialect,
     Standard,
-}
-
-impl Default for LanguageDisplay {
-    fn default() -> Self {
-        Self::Dialect
-    }
 }

--- a/components/experimental/src/displaynames/options.rs
+++ b/components/experimental/src/displaynames/options.rs
@@ -48,12 +48,14 @@ pub enum Style {
 
 /// An enum for fallback return when the system does not have the
 /// requested display name.
-#[allow(missing_docs)] // The variants are self explanatory.
+#[allow(missing_docs)]
 #[non_exhaustive]
 #[derive(Debug, Default, Eq, PartialEq, Clone, Copy)]
 pub enum Fallback {
+    /// Fall back to the BCP-47 code when display name cannot be found
     #[default]
     Code,
+    /// Do not fall back, return an error when the display name cannot be found
     None,
 }
 

--- a/components/time/src/zone/mod.rs
+++ b/components/time/src/zone/mod.rs
@@ -195,7 +195,7 @@ pub(crate) mod ule {
     /// This should not generally be constructed by client code. Instead, use
     /// * [`TimeZoneVariant::from_rearguard_isdst`]
     /// * [`TimeZoneInfo::infer_variant`](crate::TimeZoneInfo::infer_variant)
-    #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
+    #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
     #[zerovec::make_ule(TimeZoneVariantULE)]
     #[repr(u8)]
     #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
@@ -209,7 +209,6 @@ pub(crate) mod ule {
         /// name of this variant may or may not be called "Standard Time".
         ///
         /// This is the variant with the lower UTC offset.
-        #[default]
         Standard = 0,
         /// The variant corresponding to `"daylight"` in CLDR.
         ///

--- a/components/time/src/zone/mod.rs
+++ b/components/time/src/zone/mod.rs
@@ -195,7 +195,7 @@ pub(crate) mod ule {
     /// This should not generally be constructed by client code. Instead, use
     /// * [`TimeZoneVariant::from_rearguard_isdst`]
     /// * [`TimeZoneInfo::infer_variant`](crate::TimeZoneInfo::infer_variant)
-    #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+    #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
     #[zerovec::make_ule(TimeZoneVariantULE)]
     #[repr(u8)]
     #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
@@ -209,6 +209,7 @@ pub(crate) mod ule {
         /// name of this variant may or may not be called "Standard Time".
         ///
         /// This is the variant with the lower UTC offset.
+        #[default]
         Standard = 0,
         /// The variant corresponding to `"daylight"` in CLDR.
         ///

--- a/ffi/capi/bindings/cpp/icu4x/BidiPairedBracketType.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/BidiPairedBracketType.d.hpp
@@ -36,7 +36,7 @@ public:
     None = 2,
   };
 
-  BidiPairedBracketType(): value(Value::Open) {}
+  BidiPairedBracketType(): value(Value::None) {}
 
   // Implicit conversions between enum and ::Value
   constexpr BidiPairedBracketType(Value v) : value(v) {}

--- a/ffi/capi/bindings/cpp/icu4x/DateTimeLength.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/DateTimeLength.d.hpp
@@ -36,7 +36,7 @@ public:
     Short = 2,
   };
 
-  DateTimeLength(): value(Value::Long) {}
+  DateTimeLength(): value(Value::Medium) {}
 
   // Implicit conversions between enum and ::Value
   constexpr DateTimeLength(Value v) : value(v) {}

--- a/ffi/capi/bindings/cpp/icu4x/LineBreakStrictness.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/LineBreakStrictness.d.hpp
@@ -38,7 +38,7 @@ public:
     Anywhere = 3,
   };
 
-  LineBreakStrictness(): value(Value::Loose) {}
+  LineBreakStrictness(): value(Value::Strict) {}
 
   // Implicit conversions between enum and ::Value
   constexpr LineBreakStrictness(Value v) : value(v) {}

--- a/ffi/capi/bindings/cpp/icu4x/LocaleDirection.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/LocaleDirection.d.hpp
@@ -36,7 +36,7 @@ public:
     Unknown = 2,
   };
 
-  LocaleDirection(): value(Value::LeftToRight) {}
+  LocaleDirection(): value(Value::Unknown) {}
 
   // Implicit conversions between enum and ::Value
   constexpr LocaleDirection(Value v) : value(v) {}

--- a/ffi/capi/bindings/cpp/icu4x/PluralCategory.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/PluralCategory.d.hpp
@@ -46,7 +46,7 @@ public:
     Other = 5,
   };
 
-  PluralCategory(): value(Value::Zero) {}
+  PluralCategory(): value(Value::Other) {}
 
   // Implicit conversions between enum and ::Value
   constexpr PluralCategory(Value v) : value(v) {}

--- a/ffi/capi/bindings/cpp/icu4x/Script.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/Script.d.hpp
@@ -364,7 +364,7 @@ public:
     ZanabazarSquare = 177,
   };
 
-  Script(): value(Value::Common) {}
+  Script(): value(Value::Unknown) {}
 
   // Implicit conversions between enum and ::Value
   constexpr Script(Value v) : value(v) {}

--- a/ffi/capi/bindings/cpp/icu4x/TimePrecision.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/TimePrecision.d.hpp
@@ -62,7 +62,7 @@ public:
     Subsecond9 = 12,
   };
 
-  TimePrecision(): value(Value::Hour) {}
+  TimePrecision(): value(Value::Second) {}
 
   // Implicit conversions between enum and ::Value
   constexpr TimePrecision(Value v) : value(v) {}

--- a/ffi/capi/bindings/cpp/icu4x/TransformResult.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/TransformResult.d.hpp
@@ -34,7 +34,7 @@ public:
     Unmodified = 1,
   };
 
-  TransformResult(): value(Value::Modified) {}
+  TransformResult(): value(Value::Unmodified) {}
 
   // Implicit conversions between enum and ::Value
   constexpr TransformResult(Value v) : value(v) {}

--- a/ffi/capi/src/bidi.rs
+++ b/ffi/capi/src/bidi.rs
@@ -14,6 +14,9 @@ pub mod ffi {
     use crate::unstable::{errors::ffi::DataError, provider::ffi::DataProvider};
 
     pub enum BidiDirection {
+        // This is an output type, so the default mostly impacts deferred initialization.
+        // We pick Ltr since the algorithm defaults to Ltr in the absence of other info.
+        #[diplomat::attr(auto, default)]
         Ltr,
         Rtl,
         Mixed,

--- a/ffi/capi/src/calendar.rs
+++ b/ffi/capi/src/calendar.rs
@@ -20,6 +20,9 @@ pub mod ffi {
     #[diplomat::rust_link(icu::calendar::AnyCalendarKind, Enum)]
     pub enum CalendarKind {
         /// The kind of an Iso calendar
+        // AnyCalendarKind in Rust doesn't have a default, but it is useful to have one
+        // here for consistent behavior.
+        #[diplomat::attr(auto, default)]
         Iso = 0,
         /// The kind of a Gregorian calendar
         Gregorian = 1,

--- a/ffi/capi/src/casemap.rs
+++ b/ffi/capi/src/casemap.rs
@@ -22,6 +22,7 @@ pub mod ffi {
     #[diplomat::enum_convert(icu_casemap::options::LeadingAdjustment, needs_wildcard)]
     #[diplomat::rust_link(icu::casemap::options::LeadingAdjustment, Enum)]
     pub enum LeadingAdjustment {
+        #[diplomat::attr(auto, default)]
         Auto,
         None,
         ToCased,
@@ -30,6 +31,7 @@ pub mod ffi {
     #[diplomat::enum_convert(icu_casemap::options::TrailingCase, needs_wildcard)]
     #[diplomat::rust_link(icu::casemap::options::TrailingCase, Enum)]
     pub enum TrailingCase {
+        #[diplomat::attr(auto, default)]
         Lower,
         Unchanged,
     }

--- a/ffi/capi/src/datetime_options.rs
+++ b/ffi/capi/src/datetime_options.rs
@@ -10,6 +10,7 @@ pub mod ffi {
     #[diplomat::rust_link(icu::datetime::options::Length, Enum)]
     pub enum DateTimeLength {
         Long,
+        #[diplomat::attr(auto, default)]
         Medium,
         Short,
     }
@@ -17,6 +18,7 @@ pub mod ffi {
     #[diplomat::enum_convert(icu_datetime::options::Alignment, needs_wildcard)]
     #[diplomat::rust_link(icu::datetime::options::Alignment, Enum)]
     pub enum DateTimeAlignment {
+        #[diplomat::attr(auto, default)]
         Auto,
         Column,
     }
@@ -24,6 +26,7 @@ pub mod ffi {
     #[diplomat::enum_convert(icu_datetime::options::YearStyle, needs_wildcard)]
     #[diplomat::rust_link(icu::datetime::options::YearStyle, Enum)]
     pub enum YearStyle {
+        #[diplomat::attr(auto, default)]
         Auto,
         Full,
         WithEra,
@@ -35,6 +38,7 @@ pub mod ffi {
         Hour,
         Minute,
         MinuteOptional,
+        #[diplomat::attr(auto, default)]
         Second,
         Subsecond1,
         Subsecond2,

--- a/ffi/capi/src/decimal.rs
+++ b/ffi/capi/src/decimal.rs
@@ -28,6 +28,7 @@ pub mod ffi {
     #[diplomat::rust_link(icu::decimal::options::GroupingStrategy, Enum)]
     #[diplomat::enum_convert(icu_decimal::options::GroupingStrategy, needs_wildcard)]
     pub enum DecimalGroupingStrategy {
+        #[diplomat::attr(auto, default)]
         Auto,
         Never,
         Always,

--- a/ffi/capi/src/displaynames.rs
+++ b/ffi/capi/src/displaynames.rs
@@ -52,6 +52,7 @@ pub mod ffi {
     #[diplomat::rust_link(icu::experimental::displaynames::Fallback, Enum)]
     #[diplomat::enum_convert(icu_experimental::displaynames::Fallback, needs_wildcard)]
     pub enum DisplayNamesFallback {
+        #[diplomat::attr(auto, default)]
         Code,
         None,
     }
@@ -59,6 +60,7 @@ pub mod ffi {
     #[diplomat::rust_link(icu::experimental::displaynames::LanguageDisplay, Enum)]
     #[diplomat::enum_convert(icu_experimental::displaynames::LanguageDisplay, needs_wildcard)]
     pub enum LanguageDisplay {
+        #[diplomat::attr(auto, default)]
         Dialect,
         Standard,
     }

--- a/ffi/capi/src/fallbacker.rs
+++ b/ffi/capi/src/fallbacker.rs
@@ -27,6 +27,7 @@ pub mod ffi {
         hidden
     )]
     pub enum LocaleFallbackPriority {
+        #[diplomat::attr(auto, default)]
         Language = 0,
         Region = 1,
     }

--- a/ffi/capi/src/fixed_decimal.rs
+++ b/ffi/capi/src/fixed_decimal.rs
@@ -23,6 +23,7 @@ pub mod ffi {
     #[diplomat::enum_convert(fixed_decimal::Sign, needs_wildcard)]
     pub enum DecimalSign {
         /// No sign (implicitly positive, e.g., 1729).
+        #[diplomat::attr(auto, default)]
         None,
         /// A negative sign, e.g., -1729.
         Negative,
@@ -34,6 +35,7 @@ pub mod ffi {
     #[diplomat::rust_link(fixed_decimal::SignDisplay, Enum)]
     #[diplomat::enum_convert(fixed_decimal::SignDisplay, needs_wildcard)]
     pub enum DecimalSignDisplay {
+        #[diplomat::attr(auto, default)]
         Auto,
         Never,
         Always,
@@ -45,6 +47,7 @@ pub mod ffi {
     #[diplomat::rust_link(fixed_decimal::RoundingIncrement, Enum)]
     #[diplomat::enum_convert(fixed_decimal::RoundingIncrement, needs_wildcard)]
     pub enum DecimalRoundingIncrement {
+        #[diplomat::attr(auto, default)]
         MultiplesOf1,
         MultiplesOf2,
         MultiplesOf5,

--- a/ffi/capi/src/list.rs
+++ b/ffi/capi/src/list.rs
@@ -21,6 +21,7 @@ pub mod ffi {
     #[diplomat::rust_link(icu::list::options::ListLength, Enum)]
     #[diplomat::enum_convert(icu_list::options::ListLength, needs_wildcard)]
     pub enum ListLength {
+        #[diplomat::attr(auto, default)]
         Wide,
         Short,
         Narrow,

--- a/ffi/capi/src/locale.rs
+++ b/ffi/capi/src/locale.rs
@@ -16,6 +16,8 @@ pub mod ffi {
     #[diplomat::enum_convert(icu_locale::TransformResult)]
     pub enum TransformResult {
         Modified,
+        // This is an output type, so the default mostly impacts deferred initialization.
+        #[diplomat::attr(auto, default)]
         Unmodified,
     }
 

--- a/ffi/capi/src/locale_directionality.rs
+++ b/ffi/capi/src/locale_directionality.rs
@@ -19,6 +19,8 @@ pub mod ffi {
     pub enum LocaleDirection {
         LeftToRight,
         RightToLeft,
+        // This is an output type, so the default mostly impacts deferred initialization.
+        #[diplomat::attr(auto, default)]
         Unknown,
     }
 

--- a/ffi/capi/src/pluralrules.rs
+++ b/ffi/capi/src/pluralrules.rs
@@ -24,6 +24,8 @@ pub mod ffi {
         Two,
         Few,
         Many,
+        // This is an output type, so the default mostly impacts deferred initialization.
+        #[diplomat::attr(auto, default)]
         Other,
     }
 

--- a/ffi/capi/src/properties_bidi.rs
+++ b/ffi/capi/src/properties_bidi.rs
@@ -27,6 +27,8 @@ pub mod ffi {
         /// Represents Bidi_Paired_Bracket_Type=Close.
         Close,
         /// Represents Bidi_Paired_Bracket_Type=None.
+        // This is an output type, so the default mostly impacts deferred initialization.
+        #[diplomat::attr(auto, default)]
         None,
     }
 

--- a/ffi/capi/src/properties_enums.rs
+++ b/ffi/capi/src/properties_enums.rs
@@ -750,6 +750,7 @@ pub mod ffi {
         )]
         Ugaritic = 53,
         #[diplomat::rust_link(icu::properties::props::Script::Unknown, AssociatedConstantInStruct)]
+        #[diplomat::attr(auto, default)]
         Unknown = 103,
         #[diplomat::rust_link(icu::properties::props::Script::Vai, AssociatedConstantInStruct)]
         Vai = 99,

--- a/ffi/capi/src/segmenter_line.rs
+++ b/ffi/capi/src/segmenter_line.rs
@@ -28,6 +28,7 @@ pub mod ffi {
     pub enum LineBreakStrictness {
         Loose,
         Normal,
+        #[diplomat::attr(auto, default)]
         Strict,
         Anywhere,
     }
@@ -35,6 +36,7 @@ pub mod ffi {
     #[diplomat::rust_link(icu::segmenter::options::LineBreakWordOption, Enum)]
     #[diplomat::enum_convert(icu_segmenter::options::LineBreakWordOption, needs_wildcard)]
     pub enum LineBreakWordOption {
+        #[diplomat::attr(auto, default)]
         Normal,
         BreakAll,
         KeepAll,

--- a/ffi/capi/src/segmenter_word.rs
+++ b/ffi/capi/src/segmenter_word.rs
@@ -17,6 +17,8 @@ pub mod ffi {
     #[diplomat::enum_convert(icu_segmenter::options::WordType, needs_wildcard)]
     #[diplomat::rust_link(icu::segmenter::options::WordType, Enum)]
     pub enum SegmenterWordType {
+        // This is an output type, so the default mostly impacts deferred initialization.
+        #[diplomat::attr(auto, default)]
         None = 0,
         Number = 1,
         Letter = 2,

--- a/ffi/capi/src/timezone.rs
+++ b/ffi/capi/src/timezone.rs
@@ -63,6 +63,8 @@ pub mod ffi {
 
     #[diplomat::enum_convert(icu_time::zone::TimeZoneVariant, needs_wildcard)]
     pub enum TimeZoneVariant {
+        // TimeZoneVariant in Rust doesn't have a default, but it is useful to have one
+        // here for consistent behavior.
         #[diplomat::attr(auto, default)]
         Standard,
         Daylight,

--- a/ffi/capi/src/timezone.rs
+++ b/ffi/capi/src/timezone.rs
@@ -63,6 +63,7 @@ pub mod ffi {
 
     #[diplomat::enum_convert(icu_time::zone::TimeZoneVariant, needs_wildcard)]
     pub enum TimeZoneVariant {
+        #[diplomat::attr(auto, default)]
         Standard,
         Daylight,
     }

--- a/utils/fixed_decimal/src/variations.rs
+++ b/utils/fixed_decimal/src/variations.rs
@@ -24,10 +24,11 @@ pub enum Sign {
 ///
 /// **The primary definition of this type is in the [`fixed_decimal`](https://docs.rs/fixed_decimal) crate. Other ICU4X crates re-export it for convenience.**
 #[non_exhaustive]
-#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy, Default)]
 pub enum SignDisplay {
     /// Render the sign according to locale preferences. In most cases, this means a minus sign
     /// will be shown on negative numbers, and no sign will be shown on positive numbers.
+    #[default]
     Auto,
 
     /// Do not display the sign. Positive and negative numbers are indistinguishable.


### PR DESCRIPTION
This PR does a couple things.

 - Adds `#[default]` to Rust-side enums where unambiguous (e.g. "Auto")
 - Adds `#[diplomat::attr(default)]` to Diplomat-side enums where Rust has a default
 - Adds `#[diplomat::attr(default)]` to *non option* Diplomat-side enums where there is a somewhat sensible default, documenting the reason. In the case of returned enums an explicit default is still nice for stability, and there's no downside of lack of explicitness since our APIs are not accepting them anyway.
 - Adds `#[diplomat::attr(default)]` to CalendarKind::Iso and TimeZoneVariant since having that default be potentially unstable is a bigger deal than other defaults.


If a default has been added in FFI without a corresponding comment that means the Rust type has the same default.

A lot of FFI things still do not have an explicit default: I'm considering "explicit default" to mean that it is a commitment to that default only changing with intention. Most property enums do not have one, but they all have a 0 variant which is unlikely to change. A fair number of our options do not have a default either.

Note that the C++ backend will currently generate a default for every enum (picking, in order: explicit default, 0 variant, or first variant) because deferred initialization is a UB risk without it. Us setting these defaults just provides some stability.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->