### PR TITLE
Fix test failures in zerotrie on 32-bit platforms

### DIFF
--- a/utils/zerotrie/src/varint.rs
+++ b/utils/zerotrie/src/varint.rs
@@ -434,6 +434,7 @@ mod tests {
         );
         assert!(remainder.is_empty());
         assert_eq!(recovered_value, MAX_VARINT);
+        #[cfg(target_pointer_width = "64")]
         assert_eq!(
             write_bytes.as_slice(),
             &[
@@ -443,6 +444,17 @@ mod tests {
                 0b11011111, //
                 0b11011111, //
                 0b11011111, //
+                0b11011111, //
+                0b11011111, //
+                0b11011111, //
+                0b01011111, //
+            ]
+        );
+        #[cfg(target_pointer_width = "32")]
+        assert_eq!(
+            write_bytes.as_slice(),
+            &[
+                0b00101111, //
                 0b11011111, //
                 0b11011111, //
                 0b11011111, //
@@ -459,6 +471,7 @@ mod tests {
         let (recovered_value, remainder) = read_varint_meta3(*lead, trailing);
         assert!(remainder.is_empty());
         assert_eq!(recovered_value, MAX_VARINT);
+        #[cfg(target_pointer_width = "64")]
         assert_eq!(
             write_bytes.as_slice(),
             &[
@@ -468,6 +481,17 @@ mod tests {
                 0b11101111, //
                 0b11101111, //
                 0b11101111, //
+                0b11101111, //
+                0b11101111, //
+                0b11101111, //
+                0b01101111, //
+            ]
+        );
+        #[cfg(target_pointer_width = "32")]
+        assert_eq!(
+            write_bytes.as_slice(),
+            &[
+                0b00011111, //
                 0b11101111, //
                 0b11101111, //
                 0b11101111, //

--- a/utils/zerotrie/tests/locale_aux_test.rs
+++ b/utils/zerotrie/tests/locale_aux_test.rs
@@ -19,6 +19,7 @@ use testdata::locales_with_aux::{NUM_UNIQUE_BLOBS, STRINGS};
 use testdata::strings_to_litemap;
 
 #[test]
+#[cfg(target_pointer_width = "64")]
 fn test_combined() {
     let litemap = strings_to_litemap(STRINGS);
 
@@ -81,6 +82,7 @@ fn test_combined() {
 }
 
 #[test]
+#[cfg(target_pointer_width = "64")]
 fn test_aux_split() {
     let locales: Vec<Locale> = STRINGS.iter().map(|s| s.parse().unwrap()).collect();
 


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->
- Provide 32-bit cases for `MAX_VARINT` tests
- Make `test_combined` and `test_aux_split` 64-bit-only

Fixes https://github.com/unicode-org/icu4x/issues/6696; see the discussion in that issue for rationale.