### PR TITLE
Add `TimeZoneInfo::offset` getter to FFI

### DIFF
--- a/ffi/capi/bindings/c/TimeZoneInfo.h
+++ b/ffi/capi/bindings/c/TimeZoneInfo.h
@@ -35,6 +35,8 @@ icu4x_TimeZoneInfo_zone_name_date_time_mv1_result icu4x_TimeZoneInfo_zone_name_d
 
 TimeZoneInfo* icu4x_TimeZoneInfo_with_variant_mv1(const TimeZoneInfo* self, TimeZoneVariant time_variant);
 
+UtcOffset* icu4x_TimeZoneInfo_offset_mv1(const TimeZoneInfo* self);
+
 typedef struct icu4x_TimeZoneInfo_infer_variant_mv1_result { bool is_ok;} icu4x_TimeZoneInfo_infer_variant_mv1_result;
 icu4x_TimeZoneInfo_infer_variant_mv1_result icu4x_TimeZoneInfo_infer_variant_mv1(TimeZoneInfo* self, const VariantOffsetsCalculator* offset_calculator);
 

--- a/ffi/capi/bindings/cpp/icu4x/TimeZoneInfo.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/TimeZoneInfo.d.hpp
@@ -85,6 +85,8 @@ public:
    */
   inline std::unique_ptr<icu4x::TimeZoneInfo> with_variant(icu4x::TimeZoneVariant time_variant) const;
 
+  inline std::unique_ptr<icu4x::UtcOffset> offset() const;
+
   /**
    * Infers the zone variant.
    *

--- a/ffi/capi/bindings/cpp/icu4x/TimeZoneInfo.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/TimeZoneInfo.hpp
@@ -38,6 +38,8 @@ namespace capi {
 
     icu4x::capi::TimeZoneInfo* icu4x_TimeZoneInfo_with_variant_mv1(const icu4x::capi::TimeZoneInfo* self, icu4x::capi::TimeZoneVariant time_variant);
 
+    icu4x::capi::UtcOffset* icu4x_TimeZoneInfo_offset_mv1(const icu4x::capi::TimeZoneInfo* self);
+
     typedef struct icu4x_TimeZoneInfo_infer_variant_mv1_result { bool is_ok;} icu4x_TimeZoneInfo_infer_variant_mv1_result;
     icu4x_TimeZoneInfo_infer_variant_mv1_result icu4x_TimeZoneInfo_infer_variant_mv1(icu4x::capi::TimeZoneInfo* self, const icu4x::capi::VariantOffsetsCalculator* offset_calculator);
 
@@ -83,6 +85,11 @@ inline std::unique_ptr<icu4x::TimeZoneInfo> icu4x::TimeZoneInfo::with_variant(ic
   auto result = icu4x::capi::icu4x_TimeZoneInfo_with_variant_mv1(this->AsFFI(),
     time_variant.AsFFI());
   return std::unique_ptr<icu4x::TimeZoneInfo>(icu4x::TimeZoneInfo::FromFFI(result));
+}
+
+inline std::unique_ptr<icu4x::UtcOffset> icu4x::TimeZoneInfo::offset() const {
+  auto result = icu4x::capi::icu4x_TimeZoneInfo_offset_mv1(this->AsFFI());
+  return std::unique_ptr<icu4x::UtcOffset>(icu4x::UtcOffset::FromFFI(result));
 }
 
 inline std::optional<std::monostate> icu4x::TimeZoneInfo::infer_variant(const icu4x::VariantOffsetsCalculator& offset_calculator) {

--- a/ffi/capi/bindings/dart/TimeZoneInfo.g.dart
+++ b/ffi/capi/bindings/dart/TimeZoneInfo.g.dart
@@ -38,7 +38,7 @@ final class TimeZoneInfo implements ffi.Finalizable {
   }
 
   /// See the [Rust documentation for `id`](https://docs.rs/icu/2.0.0/icu/time/struct.TimeZoneInfo.html#method.id) for more information.
-  TimeZone id() {
+  TimeZone get id {
     final result = _icu4x_TimeZoneInfo_id_mv1(_ffi);
     return TimeZone._fromFfi(result, []);
   }
@@ -61,7 +61,7 @@ final class TimeZoneInfo implements ffi.Finalizable {
   }
 
   /// See the [Rust documentation for `zone_name_timestamp`](https://docs.rs/icu/2.0.0/icu/time/struct.TimeZoneInfo.html#method.zone_name_timestamp) for more information.
-  IsoDateTime? zoneNameDateTime() {
+  IsoDateTime? get zoneNameDateTime {
     final result = _icu4x_TimeZoneInfo_zone_name_date_time_mv1(_ffi);
     if (!result.isOk) {
       return null;
@@ -73,6 +73,11 @@ final class TimeZoneInfo implements ffi.Finalizable {
   TimeZoneInfo withVariant(TimeZoneVariant timeVariant) {
     final result = _icu4x_TimeZoneInfo_with_variant_mv1(_ffi, timeVariant.index);
     return TimeZoneInfo._fromFfi(result, []);
+  }
+
+  UtcOffset? get offset {
+    final result = _icu4x_TimeZoneInfo_offset_mv1(_ffi);
+    return result.address == 0 ? null : UtcOffset._fromFfi(result, []);
   }
 
   /// Infers the zone variant.
@@ -132,6 +137,11 @@ external _ResultIsoDateTimeFfiVoid _icu4x_TimeZoneInfo_zone_name_date_time_mv1(f
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Int32)>(isLeaf: true, symbol: 'icu4x_TimeZoneInfo_with_variant_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_TimeZoneInfo_with_variant_mv1(ffi.Pointer<ffi.Opaque> self, int timeVariant);
+
+@_DiplomatFfiUse('icu4x_TimeZoneInfo_offset_mv1')
+@ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_TimeZoneInfo_offset_mv1')
+// ignore: non_constant_identifier_names
+external ffi.Pointer<ffi.Opaque> _icu4x_TimeZoneInfo_offset_mv1(ffi.Pointer<ffi.Opaque> self);
 
 @_DiplomatFfiUse('icu4x_TimeZoneInfo_infer_variant_mv1')
 @ffi.Native<_ResultVoidVoid Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_TimeZoneInfo_infer_variant_mv1')

--- a/ffi/capi/bindings/js/TimeZoneInfo.d.ts
+++ b/ffi/capi/bindings/js/TimeZoneInfo.d.ts
@@ -28,7 +28,7 @@ export class TimeZoneInfo {
     /**
      * See the [Rust documentation for `id`](https://docs.rs/icu/2.0.0/icu/time/struct.TimeZoneInfo.html#method.id) for more information.
      */
-    id(): TimeZone;
+    get id(): TimeZone;
 
     /**
      * Sets the datetime at which to interpret the time zone
@@ -49,12 +49,14 @@ export class TimeZoneInfo {
     /**
      * See the [Rust documentation for `zone_name_timestamp`](https://docs.rs/icu/2.0.0/icu/time/struct.TimeZoneInfo.html#method.zone_name_timestamp) for more information.
      */
-    zoneNameDateTime(): IsoDateTime | null;
+    get zoneNameDateTime(): IsoDateTime | null;
 
     /**
      * See the [Rust documentation for `with_variant`](https://docs.rs/icu/2.0.0/icu/time/struct.TimeZoneInfo.html#method.with_variant) for more information.
      */
     withVariant(timeVariant: TimeZoneVariant): TimeZoneInfo;
+
+    get offset(): UtcOffset | null;
 
     /**
      * Infers the zone variant.

--- a/ffi/capi/bindings/js/TimeZoneInfo.mjs
+++ b/ffi/capi/bindings/js/TimeZoneInfo.mjs
@@ -84,7 +84,7 @@ export class TimeZoneInfo {
     /**
      * See the [Rust documentation for `id`](https://docs.rs/icu/2.0.0/icu/time/struct.TimeZoneInfo.html#method.id) for more information.
      */
-    id() {
+    get id() {
 
         const result = wasm.icu4x_TimeZoneInfo_id_mv1(this.ffiValue);
 
@@ -125,7 +125,7 @@ export class TimeZoneInfo {
     /**
      * See the [Rust documentation for `zone_name_timestamp`](https://docs.rs/icu/2.0.0/icu/time/struct.TimeZoneInfo.html#method.zone_name_timestamp) for more information.
      */
-    zoneNameDateTime() {
+    get zoneNameDateTime() {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 9, 4, true);
 
 
@@ -152,6 +152,18 @@ export class TimeZoneInfo {
 
         try {
             return new TimeZoneInfo(diplomatRuntime.internalConstructor, result, []);
+        }
+
+        finally {
+        }
+    }
+
+    get offset() {
+
+        const result = wasm.icu4x_TimeZoneInfo_offset_mv1(this.ffiValue);
+
+        try {
+            return result === 0 ? null : new UtcOffset(diplomatRuntime.internalConstructor, result, []);
         }
 
         finally {

--- a/ffi/capi/src/timezone.rs
+++ b/ffi/capi/src/timezone.rs
@@ -114,6 +114,7 @@ pub mod ffi {
 
         #[diplomat::rust_link(icu::time::TimeZoneInfo::id, FnInStruct)]
         #[diplomat::attr(demo_gen, disable)] // this just returns a constructor argument
+        #[diplomat::attr(*, getter)]
         pub fn id(&self) -> Box<TimeZone> {
             Box::new(TimeZone(self.id))
         }
@@ -162,6 +163,7 @@ pub mod ffi {
             FnInStruct,
             hidden
         )]
+        #[diplomat::attr(*, getter)]
         pub fn zone_name_date_time(&self) -> Option<IsoDateTime> {
             let datetime = self.zone_name_timestamp?.to_date_time_iso();
             Some(IsoDateTime {
@@ -177,6 +179,12 @@ pub mod ffi {
                 ..*self
             })
         }
+
+        #[diplomat::attr(*, getter)]
+        pub fn offset(&self) -> Option<Box<UtcOffset>> {
+            self.offset.map(UtcOffset).map(Box::new)
+        }
+
 
         /// Infers the zone variant.
         ///


### PR DESCRIPTION
Also `id` and `zone_name_date_time` should be getters, although this is technically semver breaking for JS and Dart. I don't think we care?