### PR TITLE
Handle locales without `territories.json`, locales with inconsistent patterns

### DIFF
--- a/provider/source/src/datetime/patterns.rs
+++ b/provider/source/src/datetime/patterns.rs
@@ -138,10 +138,9 @@ impl From<&cldr_serde::ca::Dates> for TimeLengths<'_> {
         let iter = arr.iter().flatten();
         for hour_cycle in iter {
             if let Some(preferred_hour_cycle) = preferred_hour_cycle {
-                assert_eq!(
-                    *hour_cycle, preferred_hour_cycle,
-                    "A locale contained a mix of coarse hour cycle types"
-                );
+                if *hour_cycle != preferred_hour_cycle {
+                    log::warn!("A locale contained a mix of coarse hour cycle types");
+                }
             } else {
                 preferred_hour_cycle = Some(*hour_cycle);
             }

--- a/provider/source/src/time_zones/convert.rs
+++ b/provider/source/src/time_zones/convert.rs
@@ -145,7 +145,11 @@ impl SourceDataProvider {
 
         let primary_zones_values = primary_zones.values().copied().collect::<BTreeSet<_>>();
 
-        let region_display_names = if locale.is_unknown() {
+        let region_display_names = if !self
+            .cldr()?
+            .displaynames()
+            .file_exists(locale, "territories.json")?
+        {
             BTreeMap::default()
         } else {
             let regions = &self

--- a/tools/make/bakeddata/src/main.rs
+++ b/tools/make/bakeddata/src/main.rs
@@ -261,6 +261,28 @@ fn main() {
             writeln!(&mut out, "{line}").unwrap();
         }
     }
+
+    // validate that `--markers all --locales full` works
+    struct SinkExporter;
+    impl DataExporter for SinkExporter {
+        fn put_payload(
+            &self,
+            _marker: DataMarkerInfo,
+            _id: DataIdentifierBorrowed,
+            _payload: &DataPayload<ExportMarker>,
+        ) -> Result<(), DataError> {
+            Ok(())
+        }
+    }
+    ExportDriver::new(
+        [DataLocaleFamily::FULL],
+        DeduplicationStrategy::Maximal.into(),
+        LocaleFallbacker::try_new_unstable(&source).unwrap(),
+    )
+    // These are all supported models
+    .with_recommended_segmenter_models()
+    .export(&source, SinkExporter)
+    .unwrap();
 }
 
 struct StubExporter<E>(E);


### PR DESCRIPTION
`icu4x-datagen --markers all --locales full` currently fails.