### PR TITLE
Add datetime FFI test for #6688

### DIFF
--- a/ffi/capi/Cargo.toml
+++ b/ffi/capi/Cargo.toml
@@ -159,3 +159,6 @@ libc_alloc = { workspace = true, features = ["global"], optional = true }
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "none")))'.dependencies]
 icu_provider_fs = { workspace = true, optional = true }
 
+[[test]]
+name = "datetime"
+required-features = ["compiled_data", "datetime"]

--- a/ffi/capi/tests/datetime.rs
+++ b/ffi/capi/tests/datetime.rs
@@ -1,0 +1,24 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+//! Tests for the datetime FFI.
+
+use icu_capi::unstable::time_formatter::ffi::*;
+use icu_capi::unstable::locale_core::ffi::*;
+use icu_capi::unstable::datetime_options::ffi::*;
+use icu_capi::unstable::time::ffi::*;
+
+#[test]
+fn test_6688_time_alignment() {
+    let locale = Locale::from_string(b"de").unwrap();
+    let formatter = TimeFormatter::create(&locale, Some(DateTimeLength::Long), Some(TimePrecision::Minute), Some(DateTimeAlignment::Auto)).unwrap();
+    let time = Time::create(12, 12, 12, 12).unwrap();
+    let buffer = diplomat_runtime::diplomat_buffer_write_create(50);
+    formatter.format(&time, unsafe { &mut *buffer });
+    assert_eq!(b"12:12", unsafe { core::slice::from_raw_parts(
+        diplomat_runtime::diplomat_buffer_write_get_bytes(&*buffer),
+        diplomat_runtime::diplomat_buffer_write_len(&*buffer)
+    ) });
+    unsafe { diplomat_runtime::diplomat_buffer_write_destroy(buffer); }
+}


### PR DESCRIPTION
Waiting on https://github.com/rust-diplomat/diplomat/pull/898 before this can land

But when I do manage to run the test (manually exporting the missing functions from diplomat-runtime), the test passes. I can't reproduce the issue reported in #6688 via Rust code. @robertbastian 