### PR TITLE
Handle ambiguous time parsing with MonthDay and YearMonth in `ixdtf`

### DIFF
--- a/utils/ixdtf/src/core.rs
+++ b/utils/ixdtf/src/core.rs
@@ -106,6 +106,11 @@ impl<'a, T: EncodingType> Cursor<'a, T> {
         self.pos
     }
 
+    /// Get current position
+    pub(crate) const fn set_position(&mut self, pos: usize) {
+        self.pos = pos;
+    }
+
     /// Peek the value at next position (current + 1).
     pub(crate) fn peek(&self) -> ParserResult<Option<u8>> {
         self.peek_n(1)

--- a/utils/ixdtf/src/core.rs
+++ b/utils/ixdtf/src/core.rs
@@ -107,7 +107,7 @@ impl<'a, T: EncodingType> Cursor<'a, T> {
     }
 
     /// Get current position
-    pub(crate) const fn set_position(&mut self, pos: usize) {
+    pub(crate) fn set_position(&mut self, pos: usize) {
         self.pos = pos;
     }
 

--- a/utils/ixdtf/src/error.rs
+++ b/utils/ixdtf/src/error.rs
@@ -54,6 +54,10 @@ pub enum ParseError {
     TimeSeparator,
     #[displaydoc("Invalid character while parsing decimal separator.")]
     DecimalSeparator,
+    #[displaydoc("Time is ambiguous with MonthDay")]
+    AmbiguousTimeMonthDay,
+    #[displaydoc("Time is ambiguous with YearMonth")]
+    AmbiguousTimeYearMonth,
 
     // Annotation Related Errors
     #[displaydoc("Invalid annotation.")]
@@ -96,6 +100,8 @@ pub enum ParseError {
     // MonthDay Errors
     #[displaydoc("MonthDay must begin with a month or '--'")]
     MonthDayHyphen,
+    #[displaydoc("MonthDay was not valid.")]
+    InvalidMonthDay,
 
     // Duration Errors
     #[displaydoc("Invalid duration designator.")]

--- a/utils/ixdtf/src/error.rs
+++ b/utils/ixdtf/src/error.rs
@@ -54,10 +54,6 @@ pub enum ParseError {
     TimeSeparator,
     #[displaydoc("Invalid character while parsing decimal separator.")]
     DecimalSeparator,
-    #[displaydoc("Time is ambiguous with MonthDay")]
-    AmbiguousTimeMonthDay,
-    #[displaydoc("Time is ambiguous with YearMonth")]
-    AmbiguousTimeYearMonth,
 
     // Annotation Related Errors
     #[displaydoc("Invalid annotation.")]
@@ -100,8 +96,6 @@ pub enum ParseError {
     // MonthDay Errors
     #[displaydoc("MonthDay must begin with a month or '--'")]
     MonthDayHyphen,
-    #[displaydoc("MonthDay was not valid.")]
-    InvalidMonthDay,
 
     // Duration Errors
     #[displaydoc("Invalid duration designator.")]
@@ -114,6 +108,13 @@ pub enum ParseError {
     TimeDurationPartOrder,
     #[displaydoc("Invalid time duration designator.")]
     TimeDurationDesignator,
+
+    #[displaydoc("Time is ambiguous with MonthDay")]
+    AmbiguousTimeMonthDay,
+    #[displaydoc("Time is ambiguous with YearMonth")]
+    AmbiguousTimeYearMonth,
+    #[displaydoc("MonthDay was not valid.")]
+    InvalidMonthDay,
 }
 
 impl core::error::Error for ParseError {}

--- a/utils/ixdtf/src/parsers/datetime.rs
+++ b/utils/ixdtf/src/parsers/datetime.rs
@@ -71,74 +71,6 @@ pub(crate) fn parse_annotated_date_time<'a, T: EncodingType>(
     })
 }
 
-/// Parses an AnnotatedMonthDay.
-pub(crate) fn parse_annotated_month_day<'a, T: EncodingType>(
-    cursor: &mut Cursor<'a, T>,
-    handler: impl FnMut(Annotation<'a, T>) -> Option<Annotation<'a, T>>,
-) -> ParserResult<IxdtfParseRecord<'a, T>> {
-    let date = parse_month_day(cursor)?;
-
-    if !cursor.check_or(false, is_annotation_open)? {
-        cursor.close()?;
-
-        return Ok(IxdtfParseRecord {
-            date: Some(date),
-            time: None,
-            offset: None,
-            tz: None,
-            calendar: None,
-        });
-    }
-
-    let annotation_set = annotations::parse_annotation_set(cursor, handler)?;
-
-    Ok(IxdtfParseRecord {
-        date: Some(date),
-        time: None,
-        offset: None,
-        tz: annotation_set.tz,
-        calendar: annotation_set.calendar,
-    })
-}
-
-/// Parse an annotated YearMonth
-pub(crate) fn parse_annotated_year_month<'a, T: EncodingType>(
-    cursor: &mut Cursor<'a, T>,
-    handler: impl FnMut(Annotation<'a, T>) -> Option<Annotation<'a, T>>,
-) -> ParserResult<IxdtfParseRecord<'a, T>> {
-    let year = parse_date_year(cursor)?;
-    cursor.advance_if(cursor.check_or(false, is_hyphen)?);
-    let month = parse_date_month(cursor)?;
-
-    let date = DateRecord {
-        year,
-        month,
-        day: 1,
-    };
-
-    if !cursor.check_or(false, is_annotation_open)? {
-        cursor.close()?;
-
-        return Ok(IxdtfParseRecord {
-            date: Some(date),
-            time: None,
-            offset: None,
-            tz: None,
-            calendar: None,
-        });
-    }
-
-    let annotation_set = annotations::parse_annotation_set(cursor, handler)?;
-
-    Ok(IxdtfParseRecord {
-        date: Some(date),
-        time: None,
-        offset: None,
-        tz: annotation_set.tz,
-        calendar: annotation_set.calendar,
-    })
-}
-
 /// Parses a `DateTime` record.
 fn parse_date_time<T: EncodingType>(cursor: &mut Cursor<T>) -> ParserResult<DateTimeRecord> {
     let date = parse_date(cursor)?;
@@ -191,7 +123,82 @@ fn parse_date<T: EncodingType>(cursor: &mut Cursor<T>) -> ParserResult<DateRecor
     Ok(DateRecord { year, month, day })
 }
 
+// ==== `YearMonth` parsing functions ====
+
+/// Parse an annotated YearMonth
+pub(crate) fn parse_annotated_year_month<'a, T: EncodingType>(
+    cursor: &mut Cursor<'a, T>,
+    handler: impl FnMut(Annotation<'a, T>) -> Option<Annotation<'a, T>>,
+) -> ParserResult<IxdtfParseRecord<'a, T>> {
+    let year_month = parse_year_month(cursor)?;
+    if !cursor.check_or(false, is_annotation_open)? {
+        cursor.close()?;
+
+        return Ok(IxdtfParseRecord {
+            date: Some(year_month),
+            time: None,
+            offset: None,
+            tz: None,
+            calendar: None,
+        });
+    }
+
+    let annotation_set = annotations::parse_annotation_set(cursor, handler)?;
+
+    Ok(IxdtfParseRecord {
+        date: Some(year_month),
+        time: None,
+        offset: None,
+        tz: annotation_set.tz,
+        calendar: annotation_set.calendar,
+    })
+}
+
+pub(crate) fn parse_year_month<T: EncodingType>(
+    cursor: &mut Cursor<T>,
+) -> ParserResult<DateRecord> {
+    let year = parse_date_year(cursor)?;
+    cursor.advance_if(cursor.check_or(false, is_hyphen)?);
+    let month = parse_date_month(cursor)?;
+
+    Ok(DateRecord {
+        year,
+        month,
+        day: 1,
+    })
+}
+
 // ==== `MonthDay` parsing functions ====
+
+/// Parses an AnnotatedMonthDay.
+pub(crate) fn parse_annotated_month_day<'a, T: EncodingType>(
+    cursor: &mut Cursor<'a, T>,
+    handler: impl FnMut(Annotation<'a, T>) -> Option<Annotation<'a, T>>,
+) -> ParserResult<IxdtfParseRecord<'a, T>> {
+    let date = parse_month_day(cursor)?;
+
+    if !cursor.check_or(false, is_annotation_open)? {
+        cursor.close()?;
+
+        return Ok(IxdtfParseRecord {
+            date: Some(date),
+            time: None,
+            offset: None,
+            tz: None,
+            calendar: None,
+        });
+    }
+
+    let annotation_set = annotations::parse_annotation_set(cursor, handler)?;
+
+    Ok(IxdtfParseRecord {
+        date: Some(date),
+        time: None,
+        offset: None,
+        tz: annotation_set.tz,
+        calendar: annotation_set.calendar,
+    })
+}
 
 /// Parses a `DateSpecMonthDay`
 pub(crate) fn parse_month_day<T: EncodingType>(cursor: &mut Cursor<T>) -> ParserResult<DateRecord> {
@@ -215,13 +222,23 @@ pub(crate) fn parse_month_day<T: EncodingType>(cursor: &mut Cursor<T>) -> Parser
 
     let day = parse_date_day(cursor)?;
 
-    assert_syntax!(cursor.check_or(true, is_annotation_open)?, InvalidEnd);
+    if !is_valid_month_day(day, month) {
+        return Err(ParseError::InvalidMonthDay);
+    }
 
     Ok(DateRecord {
         year: 0,
         month,
         day,
     })
+}
+
+fn is_valid_month_day(month: u8, day: u8) -> bool {
+    match month {
+        2 | 4 | 6 | 9 | 11 if day >= 31 => false,
+        2 if day == 30 => false,
+        _ => day <= 31,
+    }
 }
 
 // ==== Unit Parsers ====

--- a/utils/ixdtf/src/parsers/tests.rs
+++ b/utils/ixdtf/src/parsers/tests.rs
@@ -526,6 +526,33 @@ fn invalid_time() {
 }
 
 #[test]
+fn invalid_ambiguous_time() {
+    let bad_value = "1208-10";
+    let err = IxdtfParser::from_str(bad_value).parse_time();
+    assert_eq!(
+        err,
+        Err(ParseError::AmbiguousTimeMonthDay),
+        "Invalid time parsing: \"{bad_value}\" is ambiguous."
+    );
+
+    let bad_value = "12-14";
+    let err = IxdtfParser::from_str(bad_value).parse_time();
+    assert_eq!(
+        err,
+        Err(ParseError::AmbiguousTimeMonthDay),
+        "Invalid time parsing: \"{bad_value}\" is ambiguous."
+    );
+
+    let bad_value = "202112";
+    let err = IxdtfParser::from_str(bad_value).parse_time();
+    assert_eq!(
+        err,
+        Err(ParseError::AmbiguousTimeYearMonth),
+        "Invalid time parsing: \"{bad_value}\" is ambiguous."
+    );
+}
+
+#[test]
 fn temporal_valid_instant_strings() {
     let instants = [
         "1970-01-01T00:00+00:00[!Africa/Abidjan]",


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->

This PR adds handling for ambiguous cases that may occur when parsing time values that may be mistaken as a MonthDay or YearMonth.

There's also a little reorganization in `datetime.rs`. It basically moves `parse_month_day` and `parse_annotated_year_month` further down the file so that the structure is date_time/date, year_month, month_day.