### PR TITLE
Reject empty durations when parsing ISO8601 durations

### DIFF
--- a/utils/ixdtf/src/parsers/duration.rs
+++ b/utils/ixdtf/src/parsers/duration.rs
@@ -37,7 +37,10 @@ pub(crate) fn parse_duration<T: EncodingType>(
         DurationDisgnator,
     );
 
-    let date = if cursor.check_or(false, is_time_designator)? {
+    let date = if cursor
+        .check(is_time_designator)?
+        .ok_or(ParseError::abrupt_end("Duration"))?
+    {
         None
     } else {
         Some(parse_date_duration(cursor)?)

--- a/utils/ixdtf/src/parsers/tests.rs
+++ b/utils/ixdtf/src/parsers/tests.rs
@@ -614,7 +614,15 @@ fn temporal_duration_parsing() {
 fn temporal_invalid_durations() {
     use crate::parsers::IsoDurationParser;
 
-    let invalids = ["P1Y1M1W0,5D", "+PT", "P1Y1M1W1DT1H0.5M0.5S"];
+    let invalids = [
+        "P1Y1M1W0,5D",
+        "+PT",
+        "P1Y1M1W1DT1H0.5M0.5S",
+        "P",
+        "PT",
+        "-P",
+        "-PT",
+    ];
 
     for test in invalids {
         let err = IsoDurationParser::from_str(test).parse();


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->

This fixes a small bug where `P` was being returned as valid. It also adds more test cases to the current invalid durations.