### PR TITLE
Make ZeroVec miri-clean with stacked borrows

### DIFF
--- a/components/casemap/src/lib.rs
+++ b/components/casemap/src/lib.rs
@@ -2,6 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+#![feature(ptr_metadata)]
+
 //! Case mapping for Unicode characters and strings.
 //!
 //! This module is published as its own crate ([`icu_casemap`](https://docs.rs/icu_casemap/latest/icu_casemap/))

--- a/components/collections/src/lib.rs
+++ b/components/collections/src/lib.rs
@@ -32,6 +32,7 @@
     )
 )]
 #![warn(missing_docs)]
+#![feature(ptr_metadata)]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -2,6 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+#![cfg(ptr_metadata)]
+
 //! Localized formatting of dates, times, and time zones.
 //!
 //! This module is published as its own crate ([`icu_datetime`](https://docs.rs/icu_datetime/latest/icu_datetime/))

--- a/components/decimal/src/lib.rs
+++ b/components/decimal/src/lib.rs
@@ -2,6 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+#![feature(ptr_metadata)]
+
 //! Formatting basic decimal numbers.
 //!
 //! This module is published as its own crate ([`icu_decimal`](https://docs.rs/icu_decimal/latest/icu_decimal/))

--- a/components/locale/src/lib.rs
+++ b/components/locale/src/lib.rs
@@ -2,6 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+#![feature(ptr_metadata)]
+
 //! Canonicalization of locale identifiers based on [`CLDR`] data.
 //!
 //! This module is published as its own crate ([`icu_locale`](https://docs.rs/icu_locale/latest/icu_locale/))

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -73,6 +73,7 @@
     )
 )]
 #![warn(missing_docs)]
+#![feature(ptr_metadata)]
 
 extern crate alloc;
 

--- a/utils/zerovec/derive/src/varule.rs
+++ b/utils/zerovec/derive/src/varule.rs
@@ -117,12 +117,9 @@ pub fn derive_impl(
                 // Safety: The invariants of this function allow us to assume bytes is valid, and
                 // having at least #ule_size bytes is a validity constraint for the ULE type.
                 let unsized_bytes = bytes.get_unchecked(#ule_size..);
-                let unsized_ref = <#unsized_field as zerovec::ule::VarULE>::from_bytes_unchecked(unsized_bytes);
-                // We should use the pointer metadata APIs here when they are stable: https://github.com/rust-lang/rust/issues/81513
-                // For now we rely on all DST metadata being a usize to extract it via a fake slice pointer
-                let (_ptr, metadata): (usize, usize) = ::core::mem::transmute(unsized_ref);
-                let entire_struct_as_slice: *const [u8] = ::core::slice::from_raw_parts(bytes.as_ptr(), metadata);
-                &*(entire_struct_as_slice as *const Self)
+                let metadata = core::ptr::metadata(unsized_bytes);
+
+                &*core::ptr::from_raw_parts::<Self>(bytes as *const [u8] as *const u8, metadata)
             }
         }
     }

--- a/utils/zerovec/src/cow.rs
+++ b/utils/zerovec/src/cow.rs
@@ -185,8 +185,14 @@ impl<'a, V: VarULE + ?Sized> VarZeroCow<'a, V> {
     /// Construct a new borrowed version of this
     #[cfg(feature = "alloc")]
     pub fn new_owned(val: Box<V>) -> Self {
-        let val = ManuallyDrop::new(val);
-        let buf: NonNull<[u8]> = val.as_bytes().into();
+        let len = val.as_bytes().len();
+        let raw_v = Box::into_raw(val) as *mut V;
+        // disallowed?
+        // let raw_u8: *mut u8 = raw_v as *mut [u8] as *mut u8;
+        let raw_u8: *mut u8 = raw_v as *mut () as *mut u8;
+
+        let buf: NonNull<[u8]> =
+            unsafe { NonNull::new_unchecked(core::ptr::slice_from_raw_parts_mut(raw_u8, len)) };
         let raw = RawVarZeroCow {
             // Invariants upheld:
             // 1 & 3: The bytes came from `val` so they're a valid value and byte slice

--- a/utils/zerovec/src/lib.rs
+++ b/utils/zerovec/src/lib.rs
@@ -2,6 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+#![feature(ptr_metadata)]
 //! Zero-copy vector abstractions for arbitrary types, backed by byte slices.
 //!
 //! `zerovec` enables a far wider range of types — beyond just `&[u8]` and `&str` — to participate in

--- a/utils/zerovec/src/ule/mod.rs
+++ b/utils/zerovec/src/ule/mod.rs
@@ -362,13 +362,16 @@ pub unsafe trait VarULE: 'static {
         use alloc::boxed::Box;
         use core::alloc::Layout;
         let bytesvec = self.as_bytes().to_owned().into_boxed_slice();
-        let bytesvec = mem::ManuallyDrop::new(bytesvec);
+
         unsafe {
             // Get the pointer representation
-            let ptr: *mut Self = Self::from_bytes_unchecked(&bytesvec) as *const Self as *mut Self;
-            assert_eq!(Layout::for_value(&*ptr), Layout::for_value(&**bytesvec));
+            let ptr = Self::from_bytes_unchecked(&bytesvec) as *const Self;
+            let metadata = core::ptr::metadata(ptr);
             // Transmute the pointer to an owned pointer
-            Box::from_raw(ptr)
+            Box::from_raw(core::ptr::from_raw_parts_mut(
+                Box::into_raw(bytesvec) as *mut [u8] as *mut u8,
+                metadata,
+            ))
         }
     }
 }


### PR DESCRIPTION
#6723

WIP demo showing miri-cleanliness of zerovec, using pointer metadata APIs.

Currently it is not possible to fix VarZeroCow