### PR TITLE
Bump ixdtf from 0.6.0-dev to 0.6.0 and release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1883,7 +1883,7 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "ixdtf"
-version = "0.6.0-dev"
+version = "0.6.0"
 dependencies = [
  "criterion",
  "displaydoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,7 +192,7 @@ databake = { version = "0.2.0", path = "utils/databake", default-features = fals
 databake-derive = { version = "0.2.0", path = "utils/databake/derive", default-features = false }
 deduplicating_array = { version = "0.1.6", path = "utils/deduplicating_array", default-features = false }
 fixed_decimal = { version = "0.7.0", path = "utils/fixed_decimal", default-features = false }
-ixdtf = { version = "0.6.0-dev", path = "utils/ixdtf", default-features = false }
+ixdtf = { version = "0.6.0", path = "utils/ixdtf", default-features = false }
 litemap = { version = "0.8.0", path = "utils/litemap", default-features = false }
 potential_utf = { version = "0.1.1", path = "utils/potential_utf", default-features = false }
 tzif = { version = "0.4.0", path = "utils/tzif", default-features = false }

--- a/utils/ixdtf/Cargo.toml
+++ b/utils/ixdtf/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "ixdtf"
 description = "Parser for Internet eXtended DateTime Format"
-version = "0.6.0-dev"
+version = "0.6.0"
 
 authors.workspace = true
 categories.workspace = true


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->

This PR bumps `ixdtf` from 0.6.0-dev to 0.6.0 for release prep. Once merged, it would be great to have a release for use downstream.