### PR TITLE
Mark all FFI enums as `#[non_exhaustive]`

### DIFF
--- a/ffi/capi/src/bidi.rs
+++ b/ffi/capi/src/bidi.rs
@@ -13,6 +13,7 @@ pub mod ffi {
     #[cfg(feature = "buffer_provider")]
     use crate::unstable::{errors::ffi::DataError, provider::ffi::DataProvider};
 
+    #[non_exhaustive]
     pub enum BidiDirection {
         // This is an output type, so the default mostly impacts deferred initialization.
         // We pick Ltr since the algorithm defaults to Ltr in the absence of other info.

--- a/ffi/capi/src/calendar.rs
+++ b/ffi/capi/src/calendar.rs
@@ -18,6 +18,7 @@ pub mod ffi {
     /// The various calendar types currently supported by [`Calendar`]
     #[diplomat::enum_convert(icu_calendar::AnyCalendarKind, needs_wildcard)]
     #[diplomat::rust_link(icu::calendar::AnyCalendarKind, Enum)]
+    #[non_exhaustive]
     pub enum CalendarKind {
         /// The kind of an Iso calendar
         // AnyCalendarKind in Rust doesn't have a default, but it is useful to have one

--- a/ffi/capi/src/casemap.rs
+++ b/ffi/capi/src/casemap.rs
@@ -21,6 +21,7 @@ pub mod ffi {
 
     #[diplomat::enum_convert(icu_casemap::options::LeadingAdjustment, needs_wildcard)]
     #[diplomat::rust_link(icu::casemap::options::LeadingAdjustment, Enum)]
+    #[non_exhaustive]
     pub enum LeadingAdjustment {
         #[diplomat::attr(auto, default)]
         Auto,
@@ -30,6 +31,7 @@ pub mod ffi {
 
     #[diplomat::enum_convert(icu_casemap::options::TrailingCase, needs_wildcard)]
     #[diplomat::rust_link(icu::casemap::options::TrailingCase, Enum)]
+    #[non_exhaustive]
     pub enum TrailingCase {
         #[diplomat::attr(auto, default)]
         Lower,

--- a/ffi/capi/src/collator.rs
+++ b/ffi/capi/src/collator.rs
@@ -49,6 +49,7 @@ pub mod ffi {
     #[diplomat::rust_link(icu::collator::options::Strength, Enum)]
     #[derive(Eq, PartialEq, Debug, PartialOrd, Ord)]
     #[diplomat::enum_convert(icu_collator::options::Strength, needs_wildcard)]
+    #[non_exhaustive]
     pub enum CollatorStrength {
         Primary = 0,
         Secondary = 1,
@@ -60,6 +61,7 @@ pub mod ffi {
     #[diplomat::rust_link(icu::collator::options::AlternateHandling, Enum)]
     #[derive(Eq, PartialEq, Debug, PartialOrd, Ord)]
     #[diplomat::enum_convert(icu_collator::options::AlternateHandling, needs_wildcard)]
+    #[non_exhaustive]
     pub enum CollatorAlternateHandling {
         NonIgnorable = 0,
         Shifted = 1,
@@ -67,6 +69,7 @@ pub mod ffi {
 
     #[diplomat::rust_link(icu::collator::preferences::CollationCaseFirst, Enum)]
     #[derive(Eq, PartialEq, Debug, PartialOrd, Ord)]
+    #[non_exhaustive]
     pub enum CollatorCaseFirst {
         Off = 0,
         Lower = 1,
@@ -76,6 +79,7 @@ pub mod ffi {
     #[diplomat::rust_link(icu::collator::options::MaxVariable, Enum)]
     #[derive(Eq, PartialEq, Debug, PartialOrd, Ord)]
     #[diplomat::enum_convert(icu_collator::options::MaxVariable, needs_wildcard)]
+    #[non_exhaustive]
     pub enum CollatorMaxVariable {
         Space = 0,
         Punctuation = 1,
@@ -86,6 +90,7 @@ pub mod ffi {
     #[diplomat::rust_link(icu::collator::options::CaseLevel, Enum)]
     #[derive(Eq, PartialEq, Debug, PartialOrd, Ord)]
     #[diplomat::enum_convert(icu_collator::options::CaseLevel, needs_wildcard)]
+    #[non_exhaustive]
     pub enum CollatorCaseLevel {
         Off = 0,
         On = 1,
@@ -93,6 +98,7 @@ pub mod ffi {
 
     #[diplomat::rust_link(icu::collator::preferences::CollationNumericOrdering, Enum)]
     #[derive(Eq, PartialEq, Debug, PartialOrd, Ord)]
+    #[non_exhaustive]
     pub enum CollatorNumericOrdering {
         Off = 0,
         On = 1,

--- a/ffi/capi/src/date.rs
+++ b/ffi/capi/src/date.rs
@@ -19,6 +19,7 @@ pub mod ffi {
     use tinystr::TinyAsciiStr;
 
     #[diplomat::enum_convert(icu_calendar::types::Weekday)]
+    #[non_exhaustive]
     pub enum Weekday {
         Monday = 1,
         Tuesday,

--- a/ffi/capi/src/datetime_options.rs
+++ b/ffi/capi/src/datetime_options.rs
@@ -8,6 +8,7 @@
 pub mod ffi {
     #[diplomat::enum_convert(icu_datetime::options::Length, needs_wildcard)]
     #[diplomat::rust_link(icu::datetime::options::Length, Enum)]
+    #[non_exhaustive]
     pub enum DateTimeLength {
         Long,
         #[diplomat::attr(auto, default)]
@@ -17,6 +18,7 @@ pub mod ffi {
 
     #[diplomat::enum_convert(icu_datetime::options::Alignment, needs_wildcard)]
     #[diplomat::rust_link(icu::datetime::options::Alignment, Enum)]
+    #[non_exhaustive]
     pub enum DateTimeAlignment {
         #[diplomat::attr(auto, default)]
         Auto,
@@ -25,6 +27,7 @@ pub mod ffi {
 
     #[diplomat::enum_convert(icu_datetime::options::YearStyle, needs_wildcard)]
     #[diplomat::rust_link(icu::datetime::options::YearStyle, Enum)]
+    #[non_exhaustive]
     pub enum YearStyle {
         #[diplomat::attr(auto, default)]
         Auto,
@@ -34,6 +37,7 @@ pub mod ffi {
 
     #[diplomat::rust_link(icu::datetime::options::TimePrecision, Enum)]
     #[diplomat::rust_link(icu::datetime::options::SubsecondDigits, Enum)]
+    #[non_exhaustive]
     pub enum TimePrecision {
         Hour,
         Minute,

--- a/ffi/capi/src/decimal.rs
+++ b/ffi/capi/src/decimal.rs
@@ -27,6 +27,7 @@ pub mod ffi {
 
     #[diplomat::rust_link(icu::decimal::options::GroupingStrategy, Enum)]
     #[diplomat::enum_convert(icu_decimal::options::GroupingStrategy, needs_wildcard)]
+    #[non_exhaustive]
     pub enum DecimalGroupingStrategy {
         #[diplomat::attr(auto, default)]
         Auto,

--- a/ffi/capi/src/displaynames.rs
+++ b/ffi/capi/src/displaynames.rs
@@ -42,6 +42,7 @@ pub mod ffi {
 
     #[diplomat::rust_link(icu::experimental::displaynames::Style, Enum)]
     #[diplomat::enum_convert(icu_experimental::displaynames::Style, needs_wildcard)]
+    #[non_exhaustive]
     pub enum DisplayNamesStyle {
         Narrow,
         Short,
@@ -51,6 +52,7 @@ pub mod ffi {
 
     #[diplomat::rust_link(icu::experimental::displaynames::Fallback, Enum)]
     #[diplomat::enum_convert(icu_experimental::displaynames::Fallback, needs_wildcard)]
+    #[non_exhaustive]
     pub enum DisplayNamesFallback {
         #[diplomat::attr(auto, default)]
         Code,
@@ -59,6 +61,7 @@ pub mod ffi {
 
     #[diplomat::rust_link(icu::experimental::displaynames::LanguageDisplay, Enum)]
     #[diplomat::enum_convert(icu_experimental::displaynames::LanguageDisplay, needs_wildcard)]
+    #[non_exhaustive]
     pub enum LanguageDisplay {
         #[diplomat::attr(auto, default)]
         Dialect,

--- a/ffi/capi/src/errors.rs
+++ b/ffi/capi/src/errors.rs
@@ -18,6 +18,7 @@ pub mod ffi {
     #[repr(C)]
     #[diplomat::rust_link(icu_provider::DataError, Struct, compact)]
     #[diplomat::rust_link(icu_provider::DataErrorKind, Enum, compact)]
+    #[non_exhaustive]
     pub enum DataError {
         Unknown = 0x00,
         MarkerNotFound = 0x01,
@@ -33,6 +34,7 @@ pub mod ffi {
     #[derive(Debug, PartialEq, Eq)]
     #[repr(C)]
     #[diplomat::rust_link(icu::locale::ParseError, Enum, compact)]
+    #[non_exhaustive]
     pub enum LocaleParseError {
         Unknown = 0x00,
         Language = 0x01,
@@ -44,6 +46,7 @@ pub mod ffi {
     #[repr(C)]
     #[diplomat::rust_link(fixed_decimal::ParseError, Enum, compact)]
     #[cfg(any(feature = "decimal", feature = "plurals"))]
+    #[non_exhaustive]
     pub enum DecimalParseError {
         Unknown = 0x00,
         Limit = 0x01,
@@ -60,6 +63,7 @@ pub mod ffi {
     #[diplomat::rust_link(icu::calendar::RangeError, Struct, compact)]
     #[diplomat::rust_link(icu::calendar::DateError, Enum, compact)]
     #[cfg(any(feature = "datetime", feature = "timezone", feature = "calendar"))]
+    #[non_exhaustive]
     pub enum CalendarError {
         Unknown = 0x00,
         OutOfRange = 0x01,
@@ -72,6 +76,7 @@ pub mod ffi {
     #[diplomat::rust_link(icu::calendar::ParseError, Enum, compact)]
     #[diplomat::rust_link(icu::time::ParseError, Enum, compact)]
     #[cfg(any(feature = "datetime", feature = "timezone", feature = "calendar"))]
+    #[non_exhaustive]
     pub enum Rfc9557ParseError {
         Unknown = 0x00,
         InvalidSyntax = 0x01,
@@ -91,6 +96,7 @@ pub mod ffi {
     #[diplomat::rust_link(icu::datetime::pattern::PatternLoadError, Enum, compact)]
     #[diplomat::rust_link(icu_provider::DataError, Struct, compact)]
     #[diplomat::rust_link(icu_provider::DataErrorKind, Enum, compact)]
+    #[non_exhaustive]
     pub enum DateTimeFormatterLoadError {
         Unknown = 0x00,
 
@@ -128,6 +134,7 @@ pub mod ffi {
         Enum,
         compact
     )]
+    #[non_exhaustive]
     pub enum DateTimeWriteError {
         Unknown = 0x00,
         MissingTimeZoneVariant = 0x01,

--- a/ffi/capi/src/fallbacker.rs
+++ b/ffi/capi/src/fallbacker.rs
@@ -26,6 +26,7 @@ pub mod ffi {
         FnInEnum,
         hidden
     )]
+    #[non_exhaustive]
     pub enum LocaleFallbackPriority {
         #[diplomat::attr(auto, default)]
         Language = 0,

--- a/ffi/capi/src/fixed_decimal.rs
+++ b/ffi/capi/src/fixed_decimal.rs
@@ -21,6 +21,7 @@ pub mod ffi {
     /// The sign of a Decimal, as shown in formatting.
     #[diplomat::rust_link(fixed_decimal::Sign, Enum)]
     #[diplomat::enum_convert(fixed_decimal::Sign, needs_wildcard)]
+    #[non_exhaustive]
     pub enum DecimalSign {
         /// No sign (implicitly positive, e.g., 1729).
         #[diplomat::attr(auto, default)]
@@ -34,6 +35,7 @@ pub mod ffi {
     /// ECMA-402 compatible sign display preference.
     #[diplomat::rust_link(fixed_decimal::SignDisplay, Enum)]
     #[diplomat::enum_convert(fixed_decimal::SignDisplay, needs_wildcard)]
+    #[non_exhaustive]
     pub enum DecimalSignDisplay {
         #[diplomat::attr(auto, default)]
         Auto,
@@ -46,6 +48,7 @@ pub mod ffi {
     /// Increment used in a rounding operation.
     #[diplomat::rust_link(fixed_decimal::RoundingIncrement, Enum)]
     #[diplomat::enum_convert(fixed_decimal::RoundingIncrement, needs_wildcard)]
+    #[non_exhaustive]
     pub enum DecimalRoundingIncrement {
         #[diplomat::attr(auto, default)]
         MultiplesOf1,
@@ -56,6 +59,7 @@ pub mod ffi {
 
     /// Mode used in a rounding operation for signed numbers.
     #[diplomat::rust_link(fixed_decimal::SignedRoundingMode, Enum)]
+    #[non_exhaustive]
     pub enum DecimalSignedRoundingMode {
         Expand,
         Trunc,

--- a/ffi/capi/src/lib.rs
+++ b/ffi/capi/src/lib.rs
@@ -11,7 +11,10 @@
         clippy::unwrap_used,
         clippy::expect_used,
         clippy::panic,
-        // Exhaustiveness and Debug is not required for Diplomat types
+        // Enums should be non-exhaustive, as exhaustive enums don't exist in other languages anyway
+        clippy::exhaustive_enums,
+        // Structs should be exhaustive, as they are exhaustive in C/C++
+        // Debug is not required as there is no stable Rust API
     )
 )]
 // Diplomat limitations

--- a/ffi/capi/src/list.rs
+++ b/ffi/capi/src/list.rs
@@ -20,6 +20,7 @@ pub mod ffi {
 
     #[diplomat::rust_link(icu::list::options::ListLength, Enum)]
     #[diplomat::enum_convert(icu_list::options::ListLength, needs_wildcard)]
+    #[non_exhaustive]
     pub enum ListLength {
         #[diplomat::attr(auto, default)]
         Wide,

--- a/ffi/capi/src/locale.rs
+++ b/ffi/capi/src/locale.rs
@@ -14,6 +14,7 @@ pub mod ffi {
 
     #[diplomat::rust_link(icu::locale::TransformResult, Enum)]
     #[diplomat::enum_convert(icu_locale::TransformResult)]
+    #[non_exhaustive]
     pub enum TransformResult {
         Modified,
         // This is an output type, so the default mostly impacts deferred initialization.

--- a/ffi/capi/src/locale_directionality.rs
+++ b/ffi/capi/src/locale_directionality.rs
@@ -16,6 +16,7 @@ pub mod ffi {
     use crate::unstable::locale_core::ffi::Locale;
 
     #[diplomat::rust_link(icu::locale::Direction, Enum)]
+    #[non_exhaustive]
     pub enum LocaleDirection {
         LeftToRight,
         RightToLeft,

--- a/ffi/capi/src/pluralrules.rs
+++ b/ffi/capi/src/pluralrules.rs
@@ -18,6 +18,7 @@ pub mod ffi {
 
     #[diplomat::rust_link(icu::plurals::PluralCategory, Enum)]
     #[diplomat::enum_convert(icu_plurals::PluralCategory)]
+    #[non_exhaustive]
     pub enum PluralCategory {
         Zero,
         One,

--- a/ffi/capi/src/properties_bidi.rs
+++ b/ffi/capi/src/properties_bidi.rs
@@ -21,6 +21,7 @@ pub mod ffi {
 
     #[diplomat::rust_link(icu::properties::props::BidiPairedBracketType, Enum)]
     #[diplomat::enum_convert(props::BidiPairedBracketType, needs_wildcard)]
+    #[non_exhaustive]
     pub enum BidiPairedBracketType {
         /// Represents Bidi_Paired_Bracket_Type=Open.
         Open,

--- a/ffi/capi/src/properties_enums.rs
+++ b/ffi/capi/src/properties_enums.rs
@@ -13,6 +13,7 @@ pub mod ffi {
 
     #[diplomat::rust_link(icu::properties::props::BidiClass, Struct)]
     #[diplomat::enum_convert(icu_properties::props::BidiClass, needs_wildcard)]
+    #[non_exhaustive]
     pub enum BidiClass {
         #[diplomat::rust_link(
             icu::properties::props::BidiClass::LeftToRight,
@@ -212,6 +213,7 @@ pub mod ffi {
 
     #[diplomat::rust_link(icu::properties::props::Script, Struct)]
     #[diplomat::enum_convert(icu_properties::props::Script, needs_wildcard)]
+    #[non_exhaustive]
     pub enum Script {
         #[diplomat::rust_link(icu::properties::props::Script::Adlam, AssociatedConstantInStruct)]
         Adlam = 167,
@@ -987,6 +989,7 @@ pub mod ffi {
 
     #[diplomat::rust_link(icu::properties::props::HangulSyllableType, Struct)]
     #[diplomat::enum_convert(icu_properties::props::HangulSyllableType, needs_wildcard)]
+    #[non_exhaustive]
     pub enum HangulSyllableType {
         #[diplomat::rust_link(
             icu::properties::props::HangulSyllableType::NotApplicable,
@@ -1058,6 +1061,7 @@ pub mod ffi {
 
     #[diplomat::rust_link(icu::properties::props::EastAsianWidth, Struct)]
     #[diplomat::enum_convert(icu_properties::props::EastAsianWidth, needs_wildcard)]
+    #[non_exhaustive]
     pub enum EastAsianWidth {
         #[diplomat::rust_link(
             icu::properties::props::EastAsianWidth::Neutral,
@@ -1139,6 +1143,7 @@ pub mod ffi {
 
     #[diplomat::rust_link(icu::properties::props::LineBreak, Struct)]
     #[diplomat::enum_convert(icu_properties::props::LineBreak, needs_wildcard)]
+    #[non_exhaustive]
     pub enum LineBreak {
         #[diplomat::rust_link(
             icu::properties::props::LineBreak::Unknown,
@@ -1449,6 +1454,7 @@ pub mod ffi {
 
     #[diplomat::rust_link(icu::properties::props::GraphemeClusterBreak, Struct)]
     #[diplomat::enum_convert(icu_properties::props::GraphemeClusterBreak, needs_wildcard)]
+    #[non_exhaustive]
     pub enum GraphemeClusterBreak {
         #[diplomat::rust_link(
             icu::properties::props::LineBreak::Other,
@@ -1568,6 +1574,7 @@ pub mod ffi {
 
     #[diplomat::rust_link(icu::properties::props::WordBreak, Struct)]
     #[diplomat::enum_convert(icu_properties::props::WordBreak, needs_wildcard)]
+    #[non_exhaustive]
     pub enum WordBreak {
         #[diplomat::rust_link(
             icu::properties::props::WordBreak::Other,
@@ -1740,6 +1747,7 @@ pub mod ffi {
 
     #[diplomat::rust_link(icu::properties::props::SentenceBreak, Struct)]
     #[diplomat::enum_convert(icu_properties::props::SentenceBreak, needs_wildcard)]
+    #[non_exhaustive]
     pub enum SentenceBreak {
         #[diplomat::rust_link(
             icu::properties::props::SentenceBreak::Other,
@@ -1875,6 +1883,7 @@ pub mod ffi {
 
     #[diplomat::rust_link(icu::properties::props::CanonicalCombiningClass, Struct)]
     #[diplomat::enum_convert(icu_properties::props::CanonicalCombiningClass, needs_wildcard)]
+    #[non_exhaustive]
     pub enum CanonicalCombiningClass {
         #[diplomat::rust_link(
             icu::properties::props::CanonicalCombiningClass::NotReordered,
@@ -2258,6 +2267,7 @@ pub mod ffi {
 
     #[diplomat::rust_link(icu::properties::props::IndicSyllabicCategory, Struct)]
     #[diplomat::enum_convert(icu_properties::props::IndicSyllabicCategory, needs_wildcard)]
+    #[non_exhaustive]
     pub enum IndicSyllabicCategory {
         #[diplomat::rust_link(
             icu::properties::props::IndicSyllabicCategory::Other,
@@ -2515,6 +2525,7 @@ pub mod ffi {
 
     #[diplomat::rust_link(icu::properties::props::JoiningType, Struct)]
     #[diplomat::enum_convert(icu_properties::props::JoiningType, needs_wildcard)]
+    #[non_exhaustive]
     pub enum JoiningType {
         #[diplomat::rust_link(
             icu::properties::props::JoiningType::NonJoining,
@@ -2594,6 +2605,7 @@ pub mod ffi {
 
     #[diplomat::rust_link(icu::properties::props::GeneralCategory, Enum)]
     #[diplomat::enum_convert(icu_properties::props::GeneralCategory)]
+    #[non_exhaustive]
     pub enum GeneralCategory {
         #[diplomat::rust_link(icu::properties::props::GeneralCategory::Unassigned, EnumVariant)]
         Unassigned = 0,
@@ -2898,6 +2910,7 @@ pub mod ffi {
 
     #[diplomat::rust_link(icu::properties::props::VerticalOrientation, Struct)]
     #[diplomat::enum_convert(icu_properties::props::VerticalOrientation, needs_wildcard)]
+    #[non_exhaustive]
     pub enum VerticalOrientation {
         #[diplomat::rust_link(
             icu::properties::props::VerticalOrientation::Rotated,

--- a/ffi/capi/src/segmenter_line.rs
+++ b/ffi/capi/src/segmenter_line.rs
@@ -25,6 +25,7 @@ pub mod ffi {
 
     #[diplomat::rust_link(icu::segmenter::options::LineBreakStrictness, Enum)]
     #[diplomat::enum_convert(icu_segmenter::options::LineBreakStrictness, needs_wildcard)]
+    #[non_exhaustive]
     pub enum LineBreakStrictness {
         Loose,
         Normal,
@@ -35,6 +36,7 @@ pub mod ffi {
 
     #[diplomat::rust_link(icu::segmenter::options::LineBreakWordOption, Enum)]
     #[diplomat::enum_convert(icu_segmenter::options::LineBreakWordOption, needs_wildcard)]
+    #[non_exhaustive]
     pub enum LineBreakWordOption {
         #[diplomat::attr(auto, default)]
         Normal,

--- a/ffi/capi/src/segmenter_word.rs
+++ b/ffi/capi/src/segmenter_word.rs
@@ -16,6 +16,7 @@ pub mod ffi {
 
     #[diplomat::enum_convert(icu_segmenter::options::WordType, needs_wildcard)]
     #[diplomat::rust_link(icu::segmenter::options::WordType, Enum)]
+    #[non_exhaustive]
     pub enum SegmenterWordType {
         // This is an output type, so the default mostly impacts deferred initialization.
         #[diplomat::attr(auto, default)]

--- a/ffi/capi/src/timezone.rs
+++ b/ffi/capi/src/timezone.rs
@@ -62,6 +62,7 @@ pub mod ffi {
     }
 
     #[diplomat::enum_convert(icu_time::zone::TimeZoneVariant, needs_wildcard)]
+    #[non_exhaustive]
     pub enum TimeZoneVariant {
         // TimeZoneVariant in Rust doesn't have a default, but it is useful to have one
         // here for consistent behavior.


### PR DESCRIPTION
They effectively already are, because the Rust API is unstable and there is no such thing as an exhaustive enum in other languages.

This lets us add variants in the future without semver complaining.