### PR TITLE
Bump baseline ref

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -553,7 +553,7 @@ jobs:
       # This is the baseline for semver-check. It can be changed
       # if unstable APIs were changed but semver-check
       # didn't know that they were unstable.
-      BASELINE_REF: 2ddba9c1ffc918946c7e7b23f0c5bf6feeb71a3a # a commit on main
+      BASELINE_REF: e87f4d55ba4785228fded1abada2bce93e34b680 # a commit on main
     steps:
 
     # Checkout baseline revision; required because actions/checkout is shallow


### PR DESCRIPTION
The failure on the new baseline commit is in a provider module.