### PR TITLE
Make ZeroVec.iter().collect() faster

### DIFF
--- a/utils/zerovec/src/zerovec/slice.rs
+++ b/utils/zerovec/src/zerovec/slice.rs
@@ -410,6 +410,10 @@ impl<'a, T: AsULE> Iterator for ZeroSliceIter<'a, T> {
     fn next(&mut self) -> Option<T> {
         self.0.next().copied().map(T::from_unaligned)
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
 }
 
 impl<'a, T: AsULE> ExactSizeIterator for ZeroSliceIter<'a, T> {


### PR DESCRIPTION
Original issue is https://bugzilla.mozilla.org/show_bug.cgi?id=1974993

Segmenter's LSTM data model uses ZeroVec.iter().collect() to extract a model data. But this is slower after
https://github.com/unicode-org/icu4x/pull/5924.

`collect()` still uses `Iterator.size_hint()` even if `ExactSizeIterator`. So we should implement it.

After applying this fix, this makes LSTM data model faster, like the following:

```
Line Break/UTF8/Th/auto time:   [288.58 µs 288.88 µs 289.19 µs]
                        change: [-14.597% -12.338% -10.010%] (p = 0.00 < 0.05)
                        Performance has improved.
Line Break/UTF8/Th/lstm time:   [298.69 µs 300.79 µs 302.90 µs]
                        change: [-10.057% -8.6718% -6.7929%] (p = 0.00 < 0.05)
                        Performance has improved.
``