### PR TITLE
Don't fall back from specific non-location to specific location

### DIFF
--- a/components/datetime/src/format/datetime.rs
+++ b/components/datetime/src/format/datetime.rs
@@ -432,7 +432,6 @@ where
                 field,
                 &[
                     TimeZoneFormatterUnit::SpecificNonLocation(FieldLength::Four),
-                    TimeZoneFormatterUnit::SpecificLocation,
                     TimeZoneFormatterUnit::LocalizedOffset(FieldLength::Four),
                 ],
             )?

--- a/components/datetime/src/format/time_zone.rs
+++ b/components/datetime/src/format/time_zone.rs
@@ -23,7 +23,6 @@ pub(super) enum TimeZoneFormatterUnit {
     GenericNonLocation(FieldLength),
     SpecificNonLocation(FieldLength),
     GenericLocation,
-    SpecificLocation,
     ExemplarCity,
     #[allow(dead_code)]
     GenericPartialLocation(FieldLength),
@@ -68,9 +67,6 @@ impl FormatTimeZone for TimeZoneFormatterUnit {
                 SpecificNonLocationFormat(length).format(sink, input, data_payloads, fdf)
             }
             Self::GenericLocation => GenericLocationFormat.format(sink, input, data_payloads, fdf),
-            Self::SpecificLocation => {
-                SpecificLocationFormat.format(sink, input, data_payloads, fdf)
-            }
             Self::ExemplarCity => ExemplarCityFormat.format(sink, input, data_payloads, fdf),
             Self::GenericPartialLocation(length) => {
                 GenericPartialLocationFormat(length).format(sink, input, data_payloads, fdf)
@@ -267,24 +263,49 @@ impl FormatTimeZone for SpecificNonLocationFormat {
             };
             if specific.use_standard.binary_search(&mz.id).is_ok() {
                 if let Some(n) = standard_names.defaults.get(&mz.id) {
-                    n
+                    Some(n)
                 } else {
                     // The only reason why the name is not in GenericStandard even though we expect it
                     // to be, is that it was deduplicated against the generic location format.
                     return GenericLocationFormat.format(sink, input, data_payloads, _fdf);
                 }
-            } else if let Some(n) = specific.defaults.get(&(mz.id, TimeZoneVariant::Standard)) {
-                n
             } else {
-                return Ok(Err(FormatTimeZoneError::Fallback));
+                None
             }
-        } else if let Some(n) = specific.defaults.get(&(mz.id, variant)) {
-            n
+        } else {
+            None
+        }
+        .or_else(|| specific.defaults.get(&(mz.id, variant)));
+
+        if let Some(name) = name {
+            sink.write_str(name)?;
+        } else if self.0 == FieldLength::Four {
+            // We expect a metazone name but didn't find one. This is because
+            // the names are deduplicated against the specific location patterns.
+            let Some(locations) = data_payloads.locations else {
+                return Ok(Err(FormatTimeZoneError::NamesNotLoaded));
+            };
+            let Some(locations_root) = data_payloads.locations_root else {
+                return Ok(Err(FormatTimeZoneError::NamesNotLoaded));
+            };
+            let Some(location) = locations
+                .locations
+                .get(&time_zone_id)
+                .or_else(|| locations_root.locations.get(&time_zone_id))
+            else {
+                return Ok(Err(FormatTimeZoneError::Fallback));
+            };
+
+            match variant {
+                TimeZoneVariant::Standard => &locations.pattern_standard,
+                TimeZoneVariant::Daylight => &locations.pattern_daylight,
+                _ => return Ok(Err(FormatTimeZoneError::Fallback)),
+            }
+            .interpolate([location])
+            .write_to(sink)?;
         } else {
             return Ok(Err(FormatTimeZoneError::Fallback));
-        };
-
-        sink.write_str(name)?;
+        }
 
         Ok(Ok(()))
     }
@@ -436,70 +457,6 @@ impl FormatTimeZone for GenericLocationFormat {
             .pattern_generic
             .interpolate([location])
             .write_to(sink)?;
-
-        Ok(Ok(()))
-    }
-}
-
-// Los Angeles Daylight Time
-struct SpecificLocationFormat;
-
-impl FormatTimeZone for SpecificLocationFormat {
-    /// Writes the time zone in a specific location format as defined by the UTS-35 spec.
-    /// e.g. France Time
-    /// <https://unicode.org/reports/tr35/tr35-dates.html#Time_Zone_Format_Terminology>
-    fn format<W: writeable::PartsWrite + ?Sized>(
-        &self,
-        sink: &mut W,
-        input: &DateTimeInputUnchecked,
-        data_payloads: TimeZoneDataPayloadsBorrowed,
-        _decimal_formatter: Option<&DecimalFormatter>,
-    ) -> Result<Result<(), FormatTimeZoneError>, fmt::Error> {
-        let Some(time_zone_id) = input.zone_id else {
-            return Ok(Err(FormatTimeZoneError::MissingInputField(
-                MissingInputFieldKind::TimeZoneId,
-            )));
-        };
-        let Some(offset) = input.zone_offset else {
-            // We don't require the offset, this will eventually hit GMT+?
-            return Ok(Err(FormatTimeZoneError::Fallback));
-        };
-        let Some(timestamp) = input.zone_name_timestamp else {
-            return Ok(Err(FormatTimeZoneError::MissingInputField(
-                MissingInputFieldKind::TimeZoneNameTimestamp,
-            )));
-        };
-
-        let Some(locations) = data_payloads.locations else {
-            return Ok(Err(FormatTimeZoneError::NamesNotLoaded));
-        };
-        let Some(locations_root) = data_payloads.locations_root else {
-            return Ok(Err(FormatTimeZoneError::NamesNotLoaded));
-        };
-        let Some(metazone_period) = data_payloads.mz_periods else {
-            return Ok(Err(FormatTimeZoneError::NamesNotLoaded));
-        };
-        let Some((offsets, _)) = metazone_period.get(time_zone_id, timestamp) else {
-            return Ok(Err(FormatTimeZoneError::Fallback));
-        };
-
-        let Some(location) = locations
-            .locations
-            .get(&time_zone_id)
-            .or_else(|| locations_root.locations.get(&time_zone_id))
-        else {
-            return Ok(Err(FormatTimeZoneError::Fallback));
-        };
-
-        if offset == offsets.standard {
-            &locations.pattern_standard
-        } else if Some(offset) == offsets.daylight {
-            &locations.pattern_daylight
-        } else {
-            return Ok(Err(FormatTimeZoneError::Fallback));
-        }
-        .interpolate([location])
-        .write_to(sink)?;
 
         Ok(Ok(()))
     }

--- a/components/datetime/tests/patterns/tests/time_zones.json
+++ b/components/datetime/tests/patterns/tests/time_zones.json
@@ -187,7 +187,7 @@
     "datetime": "2021-07-11T12:00:00.000+01[Africa/Casablanca]",
     "expectations": {
       "z": "GMT+1",
-      "zzzz": "Morocco Daylight Time",
+      "zzzz": "GMT+01:00",
 
       "v": "Morocco Time",
       "vvvv": "Morocco Time"
@@ -198,7 +198,7 @@
     "datetime": "2021-07-11T12:00:00.000+00[Africa/Casablanca]",
     "expectations": {
       "z": "GMT+0",
-      "zzzz": "Morocco Standard Time",
+      "zzzz": "GMT+00:00",
 
       "v": "Morocco Time",
       "vvvv": "Morocco Time"
@@ -209,7 +209,7 @@
     "datetime": "2008-02-21T12:00:00.000-04:00[America/Argentina/San_Luis]",
     "expectations": {
       "z": "GMT-4",
-      "zzzz": "San Luis Standard Time",
+      "zzzz": "GMT-04:00",
 
       "v": "San Luis Time",
       "vvvv": "San Luis Time",

--- a/components/datetime/tests/patterns/tests/time_zones.json
+++ b/components/datetime/tests/patterns/tests/time_zones.json
@@ -182,6 +182,27 @@
       "O": "GMT\u200e+3\u200e",
       "OOOO": "GMT\u200e+03:00\u200e"
     }
+  },{
+    "locale": "en-GB",
+    "datetime": "2021-07-11T12:00:00.000+01[Africa/Casablanca]",
+    "expectations": {
+      "z": "GMT+1",
+      "zzzz": "Morocco Daylight Time",
+
+      "v": "Morocco Time",
+      "vvvv": "Morocco Time"
+    }
+  },
+  {
+    "locale": "en-GB",
+    "datetime": "2021-07-11T12:00:00.000+00[Africa/Casablanca]",
+    "expectations": {
+      "z": "GMT+0",
+      "zzzz": "Morocco Standard Time",
+
+      "v": "Morocco Time",
+      "vvvv": "Morocco Time"
+    }
   },
   {
     "locale": "en",


### PR DESCRIPTION
https://github.com/unicode-org/icu4x/pull/5792 deduplicated specific-non-location values against specific location, but introduced specific location as a fall back step if specific-non-location fails. I came up with this in [CLDR-18074](https://unicode-org.atlassian.net/browse/CLDR-18074) but now realise that this is flawed (variants don't make much sense outside a metazone).

This PR does not undo the deduplication, however it only uses the specific location format if we expect to find a specific non-location format, i.e. if we are in a metazone. In particular, it will not produce "Morroco Standard Time" or "Morocco Daylight Time" anymore, (those terms didn't make any sense).