### PR TITLE
Non-breaking updates to `Yoke` and `Yokeable`

### DIFF
--- a/utils/yoke/src/cartable_ptr.rs
+++ b/utils/yoke/src/cartable_ptr.rs
@@ -318,6 +318,7 @@ where
     ///
     /// - If `true`, the instance is `None`
     /// - If `false`, the instance is a valid `SelectedRc`
+    #[must_use]
     #[inline]
     pub fn is_none(&self) -> bool {
         self.inner == sentinel_for::<C::Raw>()

--- a/utils/yoke/src/lib.rs
+++ b/utils/yoke/src/lib.rs
@@ -52,6 +52,7 @@ pub mod either;
 pub mod erased;
 mod kinda_sorta_dangling;
 mod macro_impls;
+pub mod utils;
 mod yoke;
 mod yokeable;
 #[cfg(feature = "zerofrom")]

--- a/utils/yoke/src/utils.rs
+++ b/utils/yoke/src/utils.rs
@@ -39,7 +39,8 @@ pub const fn cast_yokeable<Y: Yokeable<'static>>(from: Y::Output) -> Y {
 /// This method casts `yokeable` between `&'a mut Y<'static>` and `&'a mut Y<'a>`,
 /// and passes it to `f`.
 ///
-/// See [`Yokeable::transform_mut`] and [`Yokeable::transform_mut_return`] for why this is safe.
+/// See [`Yokeable::transform_mut`] for why this is safe, noting that the same reasoning about
+/// the `'static` return type applies beyond `()` to `R: 'static`.
 #[inline]
 pub fn transform_mut_yokeable<'a, Y, F, R>(yokeable: &'a mut Y, f: F) -> R
 where
@@ -50,7 +51,6 @@ where
 {
     // Cast away the lifetime of `Y`
     // Safety: this is equivalent to f(transmute(yokeable)), and the documentation of
-    // [`Yokeable::transform_mut`] and [`Yokeable::transform_mut_return`]
-    // explain why doing so is sound.
+    // [`Yokeable::transform_mut`] and this function explain why doing so is sound.
     unsafe { f(mem::transmute::<&'a mut Y, &'a mut Y::Output>(yokeable)) }
 }

--- a/utils/yoke/src/utils.rs
+++ b/utils/yoke/src/utils.rs
@@ -1,0 +1,56 @@
+use crate::Yokeable;
+use core::{mem, ptr};
+use core::mem::ManuallyDrop;
+
+
+/// This method can be used to cast away the `Yokeable<'a>`'s lifetime.
+///
+/// # Safety
+///
+/// The returned value must be destroyed before the data `from` was borrowing from is.
+#[inline]
+pub const unsafe fn make_yokeable<'a, Y: Yokeable<'a>>(from: Y::Output) -> Y {
+    // Unfortunately, Rust doesn't think `mem::transmute` is possible since it's not sure the sizes
+    // are the same.
+    const {
+        assert!(mem::size_of::<Y::Output>() == mem::size_of::<Y>());
+    }
+    let from_ptr: *const Y = (&from as *const Y::Output).cast();
+    let _ = ManuallyDrop::new(from);
+    // Safety: `ptr` is certainly valid, aligned and points to a properly initialized value, as
+    // it comes from a value that was moved into a ManuallyDrop.
+    unsafe { ptr::read(from_ptr) }
+}
+
+/// Cast from the [`Output`] of a `Yokeable<'static>` to the [`Yokeable`] itself.
+///
+/// For any implementation that follows the safety contract of `Yokeable<'static>`,
+/// `Y` and `Y::Output` are the same type.
+///
+/// [`Output`]: Yokeable::Output
+#[inline]
+pub const fn cast_yokeable<Y: Yokeable<'static>>(from: Y::Output) -> Y {
+    // SAFETY:
+    // `from` is `'static`, and thus anything it borrows won't be destroyed
+    // (at least, not before the returned `Y` is).
+    unsafe { self::make_yokeable(from) }
+}
+
+/// This method casts `yokeable` between `&'a mut Y<'static>` and `&'a mut Y<'a>`,
+/// and passes it to `f`.
+///
+/// See [`Yokeable::transform_mut`] and [`Yokeable::transform_mut_return`] for why this is safe.
+#[inline]
+pub fn transform_mut_yokeable<'a, Y, F, R>(yokeable: &'a mut Y, f: F) -> R
+where
+    Y: Yokeable<'a>,
+    // be VERY CAREFUL changing this signature, it is very nuanced
+    F: 'static + for<'b> FnOnce(&'b mut Y::Output) -> R,
+    R: 'static,
+{
+    // Cast away the lifetime of `Y`
+    // Safety: this is equivalent to f(transmute(yokeable)), and the documentation of
+    // [`Yokeable::transform_mut`] and [`Yokeable::transform_mut_return`]
+    // explain why doing so is sound.
+    unsafe { f(mem::transmute::<&'a mut Y, &'a mut Y::Output>(yokeable)) }
+}

--- a/utils/yoke/src/utils.rs
+++ b/utils/yoke/src/utils.rs
@@ -8,6 +8,7 @@ use core::mem::ManuallyDrop;
 /// # Safety
 ///
 /// The returned value must be destroyed before the data `from` was borrowing from is.
+#[must_use]
 #[inline]
 pub const unsafe fn make_yokeable<'a, Y: Yokeable<'a>>(from: Y::Output) -> Y {
     // Unfortunately, Rust doesn't think `mem::transmute` is possible since it's not sure the sizes
@@ -28,6 +29,7 @@ pub const unsafe fn make_yokeable<'a, Y: Yokeable<'a>>(from: Y::Output) -> Y {
 /// `Y` and `Y::Output` are the same type.
 ///
 /// [`Output`]: Yokeable::Output
+#[must_use]
 #[inline]
 pub const fn cast_yokeable<Y: Yokeable<'static>>(from: Y::Output) -> Y {
     // SAFETY:

--- a/utils/yoke/src/utils.rs
+++ b/utils/yoke/src/utils.rs
@@ -13,7 +13,8 @@ use core::{mem, ptr};
 /// The returned value must be destroyed before the data `from` was borrowing from is.
 #[must_use]
 #[inline]
-pub const unsafe fn make_yokeable<'a, Y: Yokeable<'a>>(from: Y::Output) -> Y {
+// Can likely be made `const` starting with 1.83.0
+pub unsafe fn make_yokeable<'a, Y: Yokeable<'a>>(from: Y::Output) -> Y {
     // Unfortunately, Rust doesn't think `mem::transmute` is possible since it's not sure the sizes
     // are the same.
     const {
@@ -34,7 +35,8 @@ pub const unsafe fn make_yokeable<'a, Y: Yokeable<'a>>(from: Y::Output) -> Y {
 /// [`Output`]: Yokeable::Output
 #[must_use]
 #[inline]
-pub const fn cast_yokeable<Y: Yokeable<'static>>(from: Y::Output) -> Y {
+// Can likely be made `const` starting with 1.83.0
+pub fn cast_yokeable<Y: Yokeable<'static>>(from: Y::Output) -> Y {
     // SAFETY:
     // `from` is `'static`, and thus anything it borrows won't be destroyed
     // (at least, not before the returned `Y` is).

--- a/utils/yoke/src/utils.rs
+++ b/utils/yoke/src/utils.rs
@@ -1,7 +1,10 @@
-use crate::Yokeable;
-use core::{mem, ptr};
-use core::mem::ManuallyDrop;
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use crate::Yokeable;
+use core::mem::ManuallyDrop;
+use core::{mem, ptr};
 
 /// This method can be used to cast away the `Yokeable<'a>`'s lifetime.
 ///

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -392,6 +392,10 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
 
     /// Mutate the stored [`Yokeable`] data.
     ///
+    /// If the callback needs to return `'static` data, then [`Yoke::with_mut_return`] can be
+    /// used until the next breaking release of `yoke`, at which time the callback to this
+    /// function will be able to return any `'static` data.
+    ///
     /// See [`Yokeable::transform_mut()`] for why this operation is safe.
     ///
     /// # Example
@@ -453,6 +457,23 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
         F: 'static + for<'b> FnOnce(&'b mut <Y as Yokeable<'a>>::Output),
     {
         self.yokeable.transform_mut(f);
+    }
+
+    /// Mutate the stored [`Yokeable`] data, and return `'static` data (possibly just `()`).
+    ///
+    /// See [`Yokeable::transform_mut()`] and [`utils::transform_mut_yokeable`] for why this
+    /// operation is safe.
+    ///
+    /// ### Will be removed
+    /// This method will be removed on the next breaking release of `yoke`, when the callback of
+    /// [`Yoke::with_mut`] will gain the ability to return any `R: 'static` and supersede this
+    /// method.
+    pub fn with_mut_return<'a, F, R>(&'a mut self, f: F) -> R
+    where
+        F: 'static + for<'b> FnOnce(&'b mut <Y as Yokeable<'a>>::Output) -> R,
+        R: 'static,
+    {
+        utils::transform_mut_yokeable(&mut *self.yokeable, f)
     }
 
     /// Helper function allowing one to wrap the cart type `C` in an `Option<T>`.

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -1139,7 +1139,7 @@ impl<Y: for<'a> Yokeable<'a>, C: 'static + Sized + Send + Sync> Yoke<Y, Arc<C>> 
     ///
     /// // Now erased1 and erased2 have the same type!
     /// ```
-   #[must_use]
+    #[must_use]
     pub fn erase_arc_cart(self) -> Yoke<Y, ErasedArcCart> {
         // Safety: safe because the cart is preserved, as it is just type-erased
         unsafe { self.replace_cart(|c| c as ErasedArcCart) }

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -421,7 +421,7 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
     /// #     })
     /// # }
     ///
-    /// // also implements Yokeable
+    /// #[derive(Yokeable)]
     /// struct Bar<'a> {
     ///     numbers: Cow<'a, [u8]>,
     ///     string: Cow<'a, str>,
@@ -447,29 +447,6 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
     /// // Unchanged and still Cow::Borrowed
     /// assert_eq!(&*bar.get().numbers, &[0x68, 0x65, 0x6c, 0x6c, 0x6f]);
     /// assert!(matches!(bar.get().numbers, Cow::Borrowed(_)));
-    ///
-    /// # unsafe impl<'a> Yokeable<'a> for Bar<'static> {
-    /// #     type Output = Bar<'a>;
-    /// #     fn transform(&'a self) -> &'a Bar<'a> {
-    /// #         self
-    /// #     }
-    /// #
-    /// #     fn transform_owned(self) -> Bar<'a> {
-    /// #         // covariant lifetime cast, can be done safely
-    /// #         self
-    /// #     }
-    /// #
-    /// #     unsafe fn make(from: Bar<'a>) -> Self {
-    /// #         unsafe { mem::transmute(from) }
-    /// #     }
-    /// #
-    /// #     fn transform_mut<F>(&'a mut self, f: F)
-    /// #     where
-    /// #         F: 'static + FnOnce(&'a mut Self::Output),
-    /// #     {
-    /// #         unsafe { f(mem::transmute(self)) }
-    /// #     }
-    /// # }
     /// ```
     pub fn with_mut<'a, F>(&'a mut self, f: F)
     where
@@ -777,7 +754,7 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
     /// # use std::mem;
     /// # use std::rc::Rc;
     /// #
-    /// // also safely implements Yokeable<'a>
+    /// #[derive(Yokeable)]
     /// struct Bar<'a> {
     ///     string_1: &'a str,
     ///     string_2: &'a str,
@@ -788,30 +765,6 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
     /// ) -> Yoke<&'static str, Rc<[u8]>> {
     ///     bar.map_project(|bar, _| bar.string_1)
     /// }
-    ///
-    /// #
-    /// # unsafe impl<'a> Yokeable<'a> for Bar<'static> {
-    /// #     type Output = Bar<'a>;
-    /// #     fn transform(&'a self) -> &'a Bar<'a> {
-    /// #         self
-    /// #     }
-    /// #
-    /// #     fn transform_owned(self) -> Bar<'a> {
-    /// #         // covariant lifetime cast, can be done safely
-    /// #         self
-    /// #     }
-    /// #
-    /// #     unsafe fn make(from: Bar<'a>) -> Self {
-    /// #         unsafe { mem::transmute(from) }
-    /// #     }
-    /// #
-    /// #     fn transform_mut<F>(&'a mut self, f: F)
-    /// #     where
-    /// #         F: 'static + FnOnce(&'a mut Self::Output),
-    /// #     {
-    /// #         unsafe { f(mem::transmute(self)) }
-    /// #     }
-    /// # }
     /// ```
     //
     // Safety docs can be found at the end of the file.
@@ -884,7 +837,7 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
     /// # use std::rc::Rc;
     /// # use std::str::{self, Utf8Error};
     /// #
-    /// // also safely implements Yokeable<'a>
+    /// #[derive(Yokeable)]
     /// struct Bar<'a> {
     ///     bytes_1: &'a [u8],
     ///     string_2: &'a str,
@@ -895,30 +848,6 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
     /// ) -> Result<Yoke<&'static str, Rc<[u8]>>, Utf8Error> {
     ///     bar.try_map_project(|bar, _| str::from_utf8(bar.bytes_1))
     /// }
-    ///
-    /// #
-    /// # unsafe impl<'a> Yokeable<'a> for Bar<'static> {
-    /// #     type Output = Bar<'a>;
-    /// #     fn transform(&'a self) -> &'a Bar<'a> {
-    /// #         self
-    /// #     }
-    /// #
-    /// #     fn transform_owned(self) -> Bar<'a> {
-    /// #         // covariant lifetime cast, can be done safely
-    /// #         self
-    /// #     }
-    /// #
-    /// #     unsafe fn make(from: Bar<'a>) -> Self {
-    /// #         unsafe { mem::transmute(from) }
-    /// #     }
-    /// #
-    /// #     fn transform_mut<F>(&'a mut self, f: F)
-    /// #     where
-    /// #         F: 'static + FnOnce(&'a mut Self::Output),
-    /// #     {
-    /// #         unsafe { f(mem::transmute(self)) }
-    /// #     }
-    /// # }
     /// ```
     pub fn try_map_project<P, F, E>(self, f: F) -> Result<Yoke<P, C>, E>
     where
@@ -1333,7 +1262,7 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
 /// # use std::mem;
 /// # use std::rc::Rc;
 /// #
-/// // also safely implements Yokeable<'a>
+/// #[derive(Yokeable)]
 /// struct Bar<'a> {
 ///     owned: String,
 ///     string_2: &'a str,
@@ -1343,32 +1272,6 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
 ///     // ERROR (but works if you replace owned with string_2)
 ///     bar.map_project_cloned(|bar, _| &*bar.owned)
 /// }
-///
-/// #
-/// # unsafe impl<'a> Yokeable<'a> for Bar<'static> {
-/// #     type Output = Bar<'a>;
-/// #     fn transform(&'a self) -> &'a Bar<'a> {
-/// #         self
-/// #     }
-/// #
-/// #     fn transform_owned(self) -> Bar<'a> {
-/// #         // covariant lifetime cast, can be done safely
-/// #         self
-/// #     }
-/// #
-/// #     unsafe fn make(from: Bar<'a>) -> Self {
-/// #         let ret = mem::transmute_copy(&from);
-/// #         mem::forget(from);
-/// #         ret
-/// #     }
-/// #
-/// #     fn transform_mut<F>(&'a mut self, f: F)
-/// #     where
-/// #         F: 'static + FnOnce(&'a mut Self::Output),
-/// #     {
-/// #         unsafe { f(mem::transmute(self)) }
-/// #     }
-/// # }
 /// ```
 ///
 /// Borrowed data from `Y` similarly cannot escape with the wrong lifetime because of the `for<'a>`, since

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -190,6 +190,7 @@ where
     /// assert!(matches!(yoke.get(), &Cow::Borrowed(_)));
     /// assert_eq!(bytes_remaining, 3);
     /// ```
+    #[must_use]
     pub fn attach_to_cart<F>(cart: C, f: F) -> Self
     where
         // safety note: This works by enforcing that the *only* place the return value of F
@@ -238,6 +239,7 @@ where
     /// Use [`Yoke::attach_to_cart()`].
     ///
     /// This was needed because the pre-1.61 compiler couldn't always handle the FnOnce trait bound.
+    #[must_use]
     #[deprecated]
     pub fn attach_to_cart_badly(
         cart: C,
@@ -288,6 +290,7 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
     /// let yoke: Yoke<Cow<str>, _> = load_object("filename.bincode");
     /// assert_eq!(yoke.get(), "hello");
     /// ```
+    #[must_use]
     #[inline]
     pub fn get<'a>(&'a self) -> &'a <Y as Yokeable<'a>>::Output {
         self.yokeable.transform()
@@ -297,6 +300,7 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
     ///
     /// This can be useful when building caches, etc. However, if you plan to store the cart
     /// separately from the yoke, read the note of caution below in [`Yoke::into_backing_cart`].
+    #[must_use]
     pub fn backing_cart(&self) -> &C {
         &self.cart
     }
@@ -350,6 +354,7 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
     /// let cart = yoke.into_backing_cart();
     /// assert_eq!(&*cart, "foo"); // WHOOPS!
     /// ```
+    #[must_use]
     pub fn into_backing_cart(self) -> C {
         self.cart
     }
@@ -379,6 +384,7 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
     /// `Yoke` only really cares about destructors for its carts so it's fine to erase other
     /// information about the cart, as long as the backing data will still be destroyed at the
     /// same time.
+    #[must_use]
     #[inline]
     pub unsafe fn replace_cart<C2>(self, f: impl FnOnce(C) -> C2) -> Yoke<Y, C2> {
         Yoke {
@@ -477,6 +483,7 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
     }
 
     /// Helper function allowing one to wrap the cart type `C` in an `Option<T>`.
+    #[must_use]
     #[inline]
     pub fn wrap_cart_in_option(self) -> Yoke<Y, Option<C>> {
         // Safety: the cart is preserved (since it is just wrapped into a Some),
@@ -507,6 +514,7 @@ impl<Y: for<'a> Yokeable<'a>> Yoke<Y, ()> {
     ///
     /// assert_eq!(yoke.get(), "hello");
     /// ```
+    #[must_use]
     pub fn new_always_owned(yokeable: Y) -> Self {
         Self {
             // Safety note: this `yokeable` certainly does not reference data owned by (), so we do
@@ -521,6 +529,7 @@ impl<Y: for<'a> Yokeable<'a>> Yoke<Y, ()> {
     /// For most `Yoke` types this would be unsafe but it's
     /// fine for `Yoke<Y, ()>` since there are no actual internal
     /// references
+    #[must_use]
     pub fn into_yokeable(self) -> Y {
         // Safety note: since `yokeable` cannot reference data owned by `()`, this is certainly
         // safe.
@@ -555,6 +564,7 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, Option<C>> {
     ///
     /// assert_eq!(yoke.get(), "hello");
     /// ```
+    #[must_use]
     pub const fn new_owned(yokeable: Y) -> Self {
         Self {
             // Safety note: this `yokeable` is known not to borrow from the cart.
@@ -625,6 +635,7 @@ impl<Y: for<'a> Yokeable<'a>, C: CartablePointerLike> Yoke<Y, Option<C>> {
     /// }
     /// assert_eq!(W * 7, size_of::<StaticOrYoke2>());
     /// ```
+    #[must_use]
     #[inline]
     pub fn convert_cart_into_option_pointer(self) -> Yoke<Y, CartableOptionPointer<C>> {
         match self.cart {
@@ -789,6 +800,7 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
     /// ```
     //
     // Safety docs can be found at the end of the file.
+    #[must_use]
     pub fn map_project<P, F>(self, f: F) -> Yoke<P, C>
     where
         P: for<'a> Yokeable<'a>,
@@ -814,6 +826,7 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
     ///
     /// This is a bit more efficient than cloning the [`Yoke`] and then calling [`Yoke::map_project`]
     /// because then it will not clone fields that are going to be discarded.
+    #[must_use]
     pub fn map_project_cloned<'this, P, F>(&'this self, f: F) -> Yoke<P, C>
     where
         P: for<'a> Yokeable<'a>,
@@ -920,6 +933,7 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
     /// See [#1061](https://github.com/unicode-org/icu4x/issues/1061).
     ///
     /// See the docs of [`Yoke::map_project`] for how this works.
+    #[must_use]
     pub fn map_project_with_explicit_capture<P, T>(
         self,
         capture: T,
@@ -1081,6 +1095,7 @@ impl<Y: for<'a> Yokeable<'a>, C: 'static + Sized> Yoke<Y, Rc<C>> {
     ///
     /// // Now erased1 and erased2 have the same type!
     /// ```
+    #[must_use]
     pub fn erase_rc_cart(self) -> Yoke<Y, ErasedRcCart> {
         // Safety: safe because the cart is preserved, as it is just type-erased
         unsafe { self.replace_cart(|c| c as ErasedRcCart) }
@@ -1124,6 +1139,7 @@ impl<Y: for<'a> Yokeable<'a>, C: 'static + Sized + Send + Sync> Yoke<Y, Arc<C>> 
     ///
     /// // Now erased1 and erased2 have the same type!
     /// ```
+   #[must_use]
     pub fn erase_arc_cart(self) -> Yoke<Y, ErasedArcCart> {
         // Safety: safe because the cart is preserved, as it is just type-erased
         unsafe { self.replace_cart(|c| c as ErasedArcCart) }
@@ -1167,6 +1183,7 @@ impl<Y: for<'a> Yokeable<'a>, C: 'static + Sized> Yoke<Y, Box<C>> {
     ///
     /// // Now erased1 and erased2 have the same type!
     /// ```
+    #[must_use]
     pub fn erase_box_cart(self) -> Yoke<Y, ErasedBoxCart> {
         // Safety: safe because the cart is preserved, as it is just type-erased
         unsafe { self.replace_cart(|c| c as ErasedBoxCart) }
@@ -1179,6 +1196,7 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
     /// Can be paired with [`Yoke::erase_box_cart()`]
     ///
     /// ✨ *Enabled with the `alloc` Cargo feature.*
+    #[must_use]
     #[inline]
     pub fn wrap_cart_in_box(self) -> Yoke<Y, Box<C>> {
         // Safety: safe because the cart is preserved, as it is just wrapped.
@@ -1189,6 +1207,7 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
     /// to make the [`Yoke`] cloneable.
     ///
     /// ✨ *Enabled with the `alloc` Cargo feature.*
+    #[must_use]
     #[inline]
     pub fn wrap_cart_in_rc(self) -> Yoke<Y, Rc<C>> {
         // Safety: safe because the cart is preserved, as it is just wrapped
@@ -1199,6 +1218,7 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
     /// to make the [`Yoke`] cloneable.
     ///
     /// ✨ *Enabled with the `alloc` Cargo feature.*
+    #[must_use]
     #[inline]
     pub fn wrap_cart_in_arc(self) -> Yoke<Y, Arc<C>> {
         // Safety: safe because the cart is preserved, as it is just wrapped
@@ -1213,6 +1233,7 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
     /// `B` variant, use [`Self::wrap_cart_in_either_b()`].
     ///
     /// For an example, see [`EitherCart`].
+    #[must_use]
     #[inline]
     pub fn wrap_cart_in_either_a<B>(self) -> Yoke<Y, EitherCart<C, B>> {
         // Safety: safe because the cart is preserved, as it is just wrapped.
@@ -1224,6 +1245,7 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
     /// `A` variant, use [`Self::wrap_cart_in_either_a()`].
     ///
     /// For an example, see [`EitherCart`].
+    #[must_use]
     #[inline]
     pub fn wrap_cart_in_either_b<A>(self) -> Yoke<Y, EitherCart<A, C>> {
         // Safety: safe because the cart is preserved, as it is just wrapped.

--- a/utils/yoke/src/yokeable.rs
+++ b/utils/yoke/src/yokeable.rs
@@ -239,6 +239,9 @@ pub unsafe trait Yokeable<'a>: Sized + 'static {
     ///  - one of f's captures: since F: 'static, the resulting reference must refer
     ///    to 'static data.
     ///  - a static or thread_local variable: ditto.
+    ///
+    /// Additionally, the return type `()` of `f` is `'static`, so it cannot expose non-`'static`
+    /// data that could be unexpectedly invalidated by the `Yokeable` or its cart.
     #[inline]
     fn transform_mut<F>(&'a mut self, f: F)
     where

--- a/utils/yoke/src/yokeable.rs
+++ b/utils/yoke/src/yokeable.rs
@@ -247,32 +247,6 @@ pub unsafe trait Yokeable<'a>: Sized + 'static {
     {
         utils::transform_mut_yokeable(self, f);
     }
-
-    /// This method must cast `self` between `&'a mut Self<'static>` and `&'a mut Self<'a>`,
-    /// and pass it to `f`.
-    ///
-    /// # Implementation safety
-    ///
-    /// A safe implementation of this method must be equivalent to a pointer cast/transmute between
-    /// `&mut Self<'a>` and `&mut Self<'static>` being passed to `f`.
-    ///
-    /// In other words, a safe implementation must be equivalent to the default implementation,
-    /// so it is unlikely that a manual implementation is worthwhile.
-    ///
-    /// # Why is this safe?
-    ///
-    /// See [`Yokeable::transform_mut`]. The added ability to return `'static` data is incapable
-    /// of leaking out non-`'static` data that would be unexpectedly invalidated too early,
-    /// unless `f` uses unsound `unsafe` code.
-    #[inline]
-    fn transform_mut_return<F, R>(&'a mut self, f: F) -> R
-    where
-        // be VERY CAREFUL changing this signature, it is very nuanced (see above)
-        F: 'static + for<'b> FnOnce(&'b mut Self::Output) -> R,
-        R: 'static,
-    {
-        utils::transform_mut_yokeable(self, f)
-    }
 }
 
 #[cfg(feature = "alloc")]

--- a/utils/yoke/src/yokeable.rs
+++ b/utils/yoke/src/yokeable.rs
@@ -94,6 +94,7 @@ pub unsafe trait Yokeable<'a>: Sized + 'static {
     /// If the invariants of [`Yokeable`] are being satisfied, the body of this method
     /// should simply be `{ self }`, though it's acceptable to include additional assertions
     /// if desired.
+    #[must_use]
     fn transform(&'a self) -> &'a Self::Output;
 
     /// This method must cast `self` between `Self<'static>` and `Self<'a>`.
@@ -103,6 +104,7 @@ pub unsafe trait Yokeable<'a>: Sized + 'static {
     /// If the invariants of [`Yokeable`] are being satisfied, the body of this method
     /// should simply be `{ self }`, though it's acceptable to include additional assertions
     /// if desired.
+    #[must_use]
     fn transform_owned(self) -> Self::Output;
 
     /// This method can be used to cast away `Self<'a>`'s lifetime.
@@ -116,6 +118,7 @@ pub unsafe trait Yokeable<'a>: Sized + 'static {
     /// A safe implementation of this method must be equivalent to a transmute between
     /// `Self<'a>` and `Self<'static>`
     #[deprecated(since = "0.8.1", note = "use `yoke::utils::make_yokeable` instead")]
+    #[must_use]
     #[inline]
     unsafe fn make(from: Self::Output) -> Self {
         utils::make_yokeable(from)

--- a/utils/yoke/src/yokeable.rs
+++ b/utils/yoke/src/yokeable.rs
@@ -83,7 +83,7 @@ use core::marker::PhantomData;
 ///     }
 /// }
 /// ```
-pub unsafe trait Yokeable<'a>: Sized + 'static {
+pub unsafe trait Yokeable<'a>: 'static {
     /// This type MUST be `Self` with the `'static` replaced with `'a`, i.e. `Self<'a>`
     type Output: 'a;
 
@@ -117,10 +117,14 @@ pub unsafe trait Yokeable<'a>: Sized + 'static {
     ///
     /// A safe implementation of this method must be equivalent to a transmute between
     /// `Self<'a>` and `Self<'static>`
-    #[deprecated(since = "0.8.1", note = "use `yoke::utils::make_yokeable` instead")]
+    // TODO: actually deprecate this, and move the rest of ICU4X to `yoke::utils::make_yokeable`.
+    // #[deprecated(since = "0.8.1", note = "use `yoke::utils::make_yokeable` instead")]
     #[must_use]
     #[inline]
-    unsafe fn make(from: Self::Output) -> Self {
+    unsafe fn make(from: Self::Output) -> Self
+    where
+        Self: Sized,
+    {
         utils::make_yokeable(from)
     }
 
@@ -250,6 +254,7 @@ pub unsafe trait Yokeable<'a>: Sized + 'static {
     where
         // be VERY CAREFUL changing this signature, it is very nuanced (see above)
         F: 'static + for<'b> FnOnce(&'b mut Self::Output),
+        Self: Sized,
     {
         utils::transform_mut_yokeable(self, f);
     }

--- a/utils/yoke/tests/bincode.rs
+++ b/utils/yoke/tests/bincode.rs
@@ -6,7 +6,6 @@
 // since `cargo miri test` doesn't work on doctests yet
 
 use std::borrow::Cow;
-use std::mem;
 use std::rc::Rc;
 use yoke::{Yoke, Yokeable};
 
@@ -36,26 +35,15 @@ struct Bar<'a> {
 
 unsafe impl<'a> Yokeable<'a> for Bar<'static> {
     type Output = Bar<'a>;
+
     #[inline]
     fn transform(&'a self) -> &'a Bar<'a> {
         self
     }
+
     #[inline]
     fn transform_owned(self) -> Bar<'a> {
         self
-    }
-    #[inline]
-    unsafe fn make(from: Bar<'a>) -> Self {
-        let ret = mem::transmute_copy(&from);
-        mem::forget(from);
-        ret
-    }
-    #[inline]
-    fn transform_mut<F>(&'a mut self, f: F)
-    where
-        F: 'static + FnOnce(&'a mut Self::Output),
-    {
-        unsafe { f(mem::transmute::<&mut Bar<'_>, &mut Bar<'a>>(self)) }
     }
 }
 


### PR DESCRIPTION
Closes #3507 and #6786.

Progress towards #5368 and #6784 but doesn't do the breaking parts of those issues.

# Changes 
- Add three free functions in a new, public `yoke::utils` module (name to-be-bikeshed) 
- Add `Yoke::with_mut_return`, and document that it will be removed on the next breaking release of `yoke`.
- Add default impls to `Yokeable::make` and `Yokeable::transform_mut`. 
- Utilize those default impls throughout `yoke` and `yoke_derive` (i.e., delete impls of those functions). This removes the need for allowing a bunch of lints in some `yoke_derive` functions. 
- Use `derive(Yokeable)` in doctests
- Add `#[must_use]` to public functions where reasonable. (Not strictly necessary, but I prefer it.)
  
##   Changes I'm unsure of 
- Transition `yoke` to using the corresponding free function instead of `Yokeable::make`
- Deprecate `Yokeable::make`; note that this has not yet been done. In order to avoid breaking `cargo quick` while limiting the scope of this PR to `yoke`, if we decided to proceed with deprecating it, I think it's best to have a dedicated PR that deprecates `Yokeable::make` at the same time as updating its usage in other ICU4X crates.

   Not sure if it's the right call to deprecate it. `Yokeable::make` didn't benefit from method-call syntax, but perhaps it would still make sense to leave it un-deprecated with a default impl that simply uses the free function. Might be marginally more convenient for people to use.  
   
- Add `where Self: Sized` to `Yokeable::make` and `Yokeable::transform_mut` - see [my comment on #6784](https://github.com/unicode-org/icu4x/issues/6784#issuecomment-3141770043). This is necessary to add default impls to those methods, though there's an alternative of adding a non-supertrait/`Self` where-bound that asserts the `Sized`ness of `Self`.
  
# Things which need naming
- the three free functions for handling `Yokeable`s (personally I'm satisfied with their names)
  - `make_yokeable`
  - `cast_yokeable`
  - `transform_mut_yokeable`
- the module where those functions are, currently `yoke::utils` (better ideas are very, very welcome)
- the temporary `Yoke::with_mut_return` function. Adding the `_return` suffix makes sense to me.
  
# Todo's
- Give a better name to `yoke::utils`, if nothing else
- Update `CHANGELOG.md`

Note again that `Yokeable::make` will not be deprecated in this PR, a followup PR seems suitable for that, if we go through with it.