### PR TITLE
Fix treatment of None era code for Gregorian

### DIFF
--- a/components/calendar/src/cal/gregorian.rs
+++ b/components/calendar/src/cal/gregorian.rs
@@ -56,8 +56,8 @@ impl Calendar for Gregorian {
         day: u8,
     ) -> Result<Self::DateInner, DateError> {
         let year = match era {
-            Some("bce" | "bc") | None => 1 - year_check(year, 1..)?,
-            Some("ad" | "ce") => year_check(year, 1..)?,
+            Some("bce" | "bc") => 1 - year_check(year, 1..)?,
+            Some("ad" | "ce") | None => year_check(year, 1..)?,
             Some(_) => return Err(DateError::UnknownEra),
         };
 


### PR DESCRIPTION
None sets the default era, which is not BC


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->