### PR TITLE
Add monotonic_year and tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -334,5 +334,6 @@ debug = true
 
 [workspace.metadata.cargo-semver-checks.lints]
 type_method_marked_deprecated.level = "allow" # allow deprecation in patch releases
+trait_method_marked_deprecated.level = "allow" # allow deprecation in patch releases
 type_marked_deprecated.level = "allow" # allow deprecation in patch releases
 enum_no_repr_variant_discriminant_changed = "allow" # we don't consider this breaking https://github.com/obi1kenobi/cargo-semver-checks/issues/1376

--- a/components/calendar/Cargo.toml
+++ b/components/calendar/Cargo.toml
@@ -64,3 +64,6 @@ harness = false
 [[bench]]
 name = "convert"
 harness = false
+
+[package.metadata.cargo-semver-checks.lints]
+workspace = true

--- a/components/calendar/src/any_calendar.rs
+++ b/components/calendar/src/any_calendar.rs
@@ -1615,7 +1615,7 @@ mod tests {
         } else {
             assert_eq!(
                 year,
-                date.extended_year(),
+                date.monotonic_year(),
                 "Failed to roundtrip year for calendar {}",
                 calendar.debug_name()
             );

--- a/components/calendar/src/any_calendar.rs
+++ b/components/calendar/src/any_calendar.rs
@@ -1588,28 +1588,37 @@ mod tests {
 
         let roundtrip_year = date.year();
         // FIXME: these APIs should be improved
-        let roundtrip_year = roundtrip_year.era_year_or_related_iso();
         let roundtrip_month = date.month().standard_code;
         let roundtrip_day = date.day_of_month().0;
 
         assert_eq!(
-            (year, month, day),
-            (roundtrip_year, roundtrip_month, roundtrip_day),
+            (month, day),
+            (roundtrip_month, roundtrip_day),
             "Failed to roundtrip for calendar {}",
             calendar.debug_name()
         );
 
         if let Some((era_code, era_index)) = era {
             let roundtrip_era_year = date.year().era().expect("year type should be era");
+
+            let roundtrip_year = roundtrip_year.era_year_or_related_iso();
             assert_eq!(
-                (era_code, era_index),
+                (era_code, era_index, year),
                 (
                     roundtrip_era_year.era.as_str(),
-                    roundtrip_era_year.era_index
+                    roundtrip_era_year.era_index,
+                    roundtrip_year
                 ),
                 "Failed to roundtrip era for calendar {}",
                 calendar.debug_name()
             )
+        } else {
+            assert_eq!(
+                year,
+                date.extended_year(),
+                "Failed to roundtrip year for calendar {}",
+                calendar.debug_name()
+            );
         }
 
         let iso = date.to_iso();
@@ -1678,7 +1687,8 @@ mod tests {
         let roc = Ref(&roc);
 
         single_test_roundtrip(buddhist, Some(("be", Some(0))), 100, "M03", 1);
-        single_test_roundtrip(buddhist, None, 2000, "M03", 1);
+        single_test_roundtrip(buddhist, None, 100, "M03", 1);
+        single_test_roundtrip(buddhist, None, -100, "M03", 1);
         single_test_roundtrip(buddhist, Some(("be", Some(0))), -100, "M03", 1);
         single_test_error(
             buddhist,
@@ -1691,6 +1701,7 @@ mod tests {
 
         single_test_roundtrip(coptic, Some(("am", Some(0))), 100, "M03", 1);
         single_test_roundtrip(coptic, None, 2000, "M03", 1);
+        single_test_roundtrip(coptic, None, -100, "M03", 1);
         single_test_roundtrip(coptic, Some(("am", Some(0))), -99, "M03", 1);
         single_test_roundtrip(coptic, Some(("am", Some(0))), 100, "M13", 1);
         single_test_error(
@@ -1704,6 +1715,7 @@ mod tests {
 
         single_test_roundtrip(ethiopian, Some(("am", Some(1))), 100, "M03", 1);
         single_test_roundtrip(ethiopian, None, 2000, "M03", 1);
+        single_test_roundtrip(ethiopian, None, -100, "M03", 1);
         single_test_roundtrip(ethiopian, Some(("am", Some(1))), 2000, "M13", 1);
         single_test_roundtrip(ethiopian, Some(("aa", Some(0))), 5400, "M03", 1);
         single_test_error(
@@ -1743,6 +1755,7 @@ mod tests {
 
         single_test_roundtrip(ethioaa, Some(("aa", Some(0))), 7000, "M13", 1);
         single_test_roundtrip(ethioaa, None, 7000, "M13", 1);
+        single_test_roundtrip(ethioaa, None, -100, "M13", 1);
         single_test_roundtrip(ethioaa, Some(("aa", Some(0))), 100, "M03", 1);
         single_test_error(
             ethiopian,
@@ -1755,6 +1768,7 @@ mod tests {
 
         single_test_roundtrip(gregorian, Some(("ce", Some(1))), 100, "M03", 1);
         single_test_roundtrip(gregorian, None, 2000, "M03", 1);
+        single_test_roundtrip(gregorian, None, -100, "M03", 1);
         single_test_roundtrip(gregorian, Some(("bce", Some(0))), 100, "M03", 1);
         single_test_error(
             gregorian,
@@ -1834,6 +1848,8 @@ mod tests {
         single_test_roundtrip(japanese, Some(("meiji", None)), 10, "M03", 1);
         single_test_roundtrip(japanese, Some(("ce", None)), 1000, "M03", 1);
         single_test_roundtrip(japanese, None, 1000, "M03", 1);
+        single_test_roundtrip(japanese, None, -100, "M03", 1);
+        single_test_roundtrip(japanese, None, 2024, "M03", 1);
         single_test_roundtrip(japanese, Some(("bce", None)), 10, "M03", 1);
         single_test_error(
             japanese,
@@ -1915,6 +1931,7 @@ mod tests {
 
         single_test_roundtrip(persian, Some(("ap", Some(0))), 477, "M03", 1);
         single_test_roundtrip(persian, None, 2083, "M07", 21);
+        single_test_roundtrip(persian, None, -100, "M07", 21);
         single_test_roundtrip(persian, Some(("ap", Some(0))), 1600, "M12", 20);
         single_test_error(
             persian,
@@ -1927,6 +1944,7 @@ mod tests {
 
         single_test_roundtrip(hebrew, Some(("am", Some(0))), 5773, "M03", 1);
         single_test_roundtrip(hebrew, None, 4993, "M07", 21);
+        single_test_roundtrip(hebrew, None, -100, "M07", 21);
         single_test_roundtrip(hebrew, Some(("am", Some(0))), 5012, "M12", 20);
         single_test_error(
             hebrew,
@@ -1940,9 +1958,11 @@ mod tests {
         single_test_roundtrip(roc, Some(("roc", Some(1))), 10, "M05", 3);
         single_test_roundtrip(roc, Some(("broc", Some(0))), 15, "M01", 10);
         single_test_roundtrip(roc, None, 100, "M10", 30);
+        single_test_roundtrip(roc, None, -100, "M10", 30);
 
         single_test_roundtrip(hijri_simulated, Some(("ah", Some(0))), 477, "M03", 1);
         single_test_roundtrip(hijri_simulated, None, 2083, "M07", 21);
+        single_test_roundtrip(hijri_simulated, None, -100, "M07", 21);
         single_test_roundtrip(hijri_simulated, Some(("ah", Some(0))), 1600, "M12", 20);
         single_test_error(
             hijri_simulated,
@@ -1955,6 +1975,7 @@ mod tests {
 
         single_test_roundtrip(hijri_civil, Some(("ah", Some(0))), 477, "M03", 1);
         single_test_roundtrip(hijri_civil, None, 2083, "M07", 21);
+        single_test_roundtrip(hijri_civil, None, -100, "M07", 21);
         single_test_roundtrip(hijri_civil, Some(("ah", Some(0))), 1600, "M12", 20);
         single_test_error(
             hijri_civil,
@@ -1967,6 +1988,7 @@ mod tests {
 
         single_test_roundtrip(hijri_umm_al_qura, Some(("ah", Some(0))), 477, "M03", 1);
         single_test_roundtrip(hijri_umm_al_qura, None, 2083, "M07", 21);
+        single_test_roundtrip(hijri_umm_al_qura, None, -100, "M07", 21);
         single_test_roundtrip(hijri_umm_al_qura, Some(("ah", Some(0))), 1600, "M12", 20);
         single_test_error(
             hijri_umm_al_qura,
@@ -1979,6 +2001,7 @@ mod tests {
 
         single_test_roundtrip(hijri_astronomical, Some(("ah", Some(0))), 477, "M03", 1);
         single_test_roundtrip(hijri_astronomical, None, 2083, "M07", 21);
+        single_test_roundtrip(hijri_astronomical, None, -100, "M07", 21);
         single_test_roundtrip(hijri_astronomical, Some(("ah", Some(0))), 1600, "M12", 20);
         single_test_error(
             hijri_astronomical,

--- a/components/calendar/src/any_calendar.rs
+++ b/components/calendar/src/any_calendar.rs
@@ -473,10 +473,6 @@ impl Calendar for AnyCalendar {
         match_cal_and_date!(match (self, date): (c, d) => c.year_info(d).into())
     }
 
-    fn extended_year(&self, date: &Self::DateInner) -> i32 {
-        match_cal_and_date!(match (self, date): (c, d) => c.extended_year(d))
-    }
-
     /// The calendar-specific check if `date` is in a leap year
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
         match_cal_and_date!(match (self, date): (c, d) => c.is_in_leap_year(d))

--- a/components/calendar/src/any_calendar.rs
+++ b/components/calendar/src/any_calendar.rs
@@ -1583,7 +1583,6 @@ mod tests {
             });
 
         let roundtrip_year = date.year();
-        // FIXME: these APIs should be improved
         let roundtrip_month = date.month().standard_code;
         let roundtrip_day = date.day_of_month().0;
 

--- a/components/calendar/src/cal/buddhist.rs
+++ b/components/calendar/src/cal/buddhist.rs
@@ -116,7 +116,7 @@ impl Calendar for Buddhist {
 
     /// The calendar-specific year represented by `date`
     fn year_info(&self, date: &Self::DateInner) -> Self::Year {
-        let year = date.iso_year() - BUDDHIST_ERA_OFFSET;
+        let year = date.iso_year() + BUDDHIST_ERA_OFFSET;
         types::EraYear {
             era: tinystr!(16, "be"),
             era_index: Some(0),

--- a/components/calendar/src/cal/buddhist.rs
+++ b/components/calendar/src/cal/buddhist.rs
@@ -116,7 +116,7 @@ impl Calendar for Buddhist {
 
     /// The calendar-specific year represented by `date`
     fn year_info(&self, date: &Self::DateInner) -> Self::Year {
-        let year = self.extended_year(date);
+        let year = date.iso_year() - BUDDHIST_ERA_OFFSET;
         types::EraYear {
             era: tinystr!(16, "be"),
             era_index: Some(0),
@@ -124,10 +124,6 @@ impl Calendar for Buddhist {
             monotonic_year: year,
             ambiguity: types::YearAmbiguity::CenturyRequired,
         }
-    }
-
-    fn extended_year(&self, date: &Self::DateInner) -> i32 {
-        Iso.extended_year(date) + BUDDHIST_ERA_OFFSET
     }
 
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {

--- a/components/calendar/src/cal/buddhist.rs
+++ b/components/calendar/src/cal/buddhist.rs
@@ -25,8 +25,8 @@ use tinystr::tinystr;
 
 /// The number of years the Buddhist Era is ahead of C.E. by
 ///
-/// (1 AD = 544 BE)
-const BUDDHIST_ERA_OFFSET: i32 = 543;
+/// (-543 ISO = 544 BCE = 1 BE)
+const BUDDHIST_ERA_OFFSET: i32 = -543;
 
 #[derive(Copy, Clone, Debug, Default)]
 /// The [Thai Solar Buddhist Calendar][cal]
@@ -65,7 +65,7 @@ impl Calendar for Buddhist {
             Some("be") | None => {}
             _ => return Err(DateError::UnknownEra),
         }
-        let year = year - BUDDHIST_ERA_OFFSET;
+        let year = year + BUDDHIST_ERA_OFFSET;
 
         ArithmeticDate::new_from_codes(self, year, month_code, day).map(IsoDateInner)
     }
@@ -116,7 +116,7 @@ impl Calendar for Buddhist {
 
     /// The calendar-specific year represented by `date`
     fn year_info(&self, date: &Self::DateInner) -> Self::Year {
-        let year = date.iso_year() + BUDDHIST_ERA_OFFSET;
+        let year = date.iso_year() - BUDDHIST_ERA_OFFSET;
         types::EraYear {
             era: tinystr!(16, "be"),
             era_index: Some(0),
@@ -170,7 +170,7 @@ impl Date<Buddhist> {
     /// assert_eq!(date_buddhist.day_of_month().0, 2);
     /// ```
     pub fn try_new_buddhist(year: i32, month: u8, day: u8) -> Result<Date<Buddhist>, RangeError> {
-        Date::try_new_iso(year - BUDDHIST_ERA_OFFSET, month, day)
+        Date::try_new_iso(year + BUDDHIST_ERA_OFFSET, month, day)
             .map(|d| Date::new_from_iso(d, Buddhist))
     }
 }

--- a/components/calendar/src/cal/buddhist.rs
+++ b/components/calendar/src/cal/buddhist.rs
@@ -116,10 +116,12 @@ impl Calendar for Buddhist {
 
     /// The calendar-specific year represented by `date`
     fn year_info(&self, date: &Self::DateInner) -> Self::Year {
+        let year = self.extended_year(date);
         types::EraYear {
             era: tinystr!(16, "be"),
             era_index: Some(0),
-            year: self.extended_year(date),
+            year,
+            monotonic_year: year,
             ambiguity: types::YearAmbiguity::CenturyRequired,
         }
     }

--- a/components/calendar/src/cal/chinese.rs
+++ b/components/calendar/src/cal/chinese.rs
@@ -443,6 +443,30 @@ mod test {
                 expected_month: 13,
                 expected_day: 30,
             },
+            TestCase {
+                rd: 0,
+                expected_year: 0,
+                expected_month: 12,
+                expected_day: 20,
+            },
+            TestCase {
+                rd: -1,
+                expected_year: 0,
+                expected_month: 12,
+                expected_day: 19,
+            },
+            TestCase {
+                rd: -365,
+                expected_year: -1,
+                expected_month: 12,
+                expected_day: 9,
+            },
+            TestCase {
+                rd: 100,
+                expected_year: 1,
+                expected_month: 3,
+                expected_day: 1,
+            },
         ];
 
         let chinese_calculating = Chinese::new_always_calculating();

--- a/components/calendar/src/cal/chinese.rs
+++ b/components/calendar/src/cal/chinese.rs
@@ -461,7 +461,7 @@ mod test {
                     let chinese = Date::from_rata_die(rata_die, chinese);
                     assert_eq!(
                         case.expected_year,
-                        chinese.extended_year(),
+                        chinese.monotonic_year(),
                         "[{calendar_type}] Chinese from RD failed, case: {case:?}"
                     );
                     assert_eq!(

--- a/components/calendar/src/cal/chinese.rs
+++ b/components/calendar/src/cal/chinese.rs
@@ -251,10 +251,6 @@ impl Calendar for Chinese {
         }
     }
 
-    fn extended_year(&self, date: &Self::DateInner) -> i32 {
-        date.0.year.related_iso
-    }
-
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
         Self::provided_year_is_leap(date.0.year)
     }

--- a/components/calendar/src/cal/chinese.rs
+++ b/components/calendar/src/cal/chinese.rs
@@ -25,7 +25,6 @@ use crate::error::DateError;
 use crate::provider::chinese_based::CalendarChineseV1;
 use crate::AsCalendar;
 use crate::{types, Calendar, Date, DateDuration, DateDurationUnit};
-use calendrical_calculations::chinese_based;
 use calendrical_calculations::rata_die::RataDie;
 use core::cmp::Ordering;
 use icu_provider::prelude::*;
@@ -253,7 +252,7 @@ impl Calendar for Chinese {
     }
 
     fn extended_year(&self, date: &Self::DateInner) -> i32 {
-        chinese_based::extended_from_iso::<chinese_based::Chinese>(date.0.year.related_iso)
+        date.0.year.related_iso
     }
 
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
@@ -366,85 +365,85 @@ mod test {
         let cases = [
             TestCase {
                 rd: -964192,
-                expected_year: -2,
+                expected_year: -2639,
                 expected_month: 1,
                 expected_day: 1,
             },
             TestCase {
                 rd: -963838,
-                expected_year: -1,
+                expected_year: -2638,
                 expected_month: 1,
                 expected_day: 1,
             },
             TestCase {
                 rd: -963129,
-                expected_year: 0,
+                expected_year: -2637,
                 expected_month: 13,
                 expected_day: 1,
             },
             TestCase {
                 rd: -963100,
-                expected_year: 0,
+                expected_year: -2637,
                 expected_month: 13,
                 expected_day: 30,
             },
             TestCase {
                 rd: -963099,
-                expected_year: 1,
+                expected_year: -2636,
                 expected_month: 1,
                 expected_day: 1,
             },
             TestCase {
                 rd: 738700,
-                expected_year: 4660,
+                expected_year: 2023,
                 expected_month: 6,
                 expected_day: 12,
             },
             TestCase {
                 rd: fixed_from_iso(2319, 2, 20).to_i64_date(),
-                expected_year: 2319 + 2636,
+                expected_year: 2318,
                 expected_month: 13,
                 expected_day: 30,
             },
             TestCase {
                 rd: fixed_from_iso(2319, 2, 21).to_i64_date(),
-                expected_year: 2319 + 2636 + 1,
+                expected_year: 2319,
                 expected_month: 1,
                 expected_day: 1,
             },
             TestCase {
                 rd: 738718,
-                expected_year: 4660,
+                expected_year: 2023,
                 expected_month: 6,
                 expected_day: 30,
             },
             TestCase {
                 rd: 738747,
-                expected_year: 4660,
+                expected_year: 2023,
                 expected_month: 7,
                 expected_day: 29,
             },
             TestCase {
                 rd: 738748,
-                expected_year: 4660,
+                expected_year: 2023,
                 expected_month: 8,
                 expected_day: 1,
             },
             TestCase {
                 rd: 738865,
-                expected_year: 4660,
+                expected_year: 2023,
                 expected_month: 11,
                 expected_day: 29,
             },
             TestCase {
                 rd: 738895,
-                expected_year: 4660,
+                expected_year: 2023,
                 expected_month: 12,
                 expected_day: 29,
             },
             TestCase {
                 rd: 738925,
-                expected_year: 4660,
+                expected_year: 2023,
                 expected_month: 13,
                 expected_day: 30,
             },

--- a/components/calendar/src/cal/coptic.rs
+++ b/components/calendar/src/cal/coptic.rs
@@ -171,7 +171,7 @@ impl Calendar for Coptic {
     }
 
     fn extended_year(&self, date: &Self::DateInner) -> i32 {
-        date.0.extended_year()
+        date.0.monotonic_year()
     }
 
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {

--- a/components/calendar/src/cal/coptic.rs
+++ b/components/calendar/src/cal/coptic.rs
@@ -166,6 +166,7 @@ impl Calendar for Coptic {
             era: tinystr!(16, "am"),
             era_index: Some(0),
             year,
+            monotonic_year: year,
             ambiguity: types::YearAmbiguity::CenturyRequired,
         }
     }

--- a/components/calendar/src/cal/coptic.rs
+++ b/components/calendar/src/cal/coptic.rs
@@ -161,7 +161,7 @@ impl Calendar for Coptic {
     }
 
     fn year_info(&self, date: &Self::DateInner) -> Self::Year {
-        let year = self.extended_year(date);
+        let year = date.0.monotonic_year();
         types::EraYear {
             era: tinystr!(16, "am"),
             era_index: Some(0),
@@ -169,10 +169,6 @@ impl Calendar for Coptic {
             monotonic_year: year,
             ambiguity: types::YearAmbiguity::CenturyRequired,
         }
-    }
-
-    fn extended_year(&self, date: &Self::DateInner) -> i32 {
-        date.0.monotonic_year()
     }
 
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {

--- a/components/calendar/src/cal/dangi.rs
+++ b/components/calendar/src/cal/dangi.rs
@@ -27,7 +27,6 @@ use crate::provider::chinese_based::CalendarDangiV1;
 use crate::types::CyclicYear;
 use crate::AsCalendar;
 use crate::{types, Calendar, Date};
-use calendrical_calculations::chinese_based;
 use calendrical_calculations::rata_die::RataDie;
 use core::cmp::Ordering;
 use icu_provider::prelude::*;
@@ -245,7 +244,7 @@ impl Calendar for Dangi {
     }
 
     fn extended_year(&self, date: &Self::DateInner) -> i32 {
-        chinese_based::extended_from_iso::<chinese_based::Dangi>(date.0.year.related_iso)
+        date.0.year.related_iso
     }
 
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {

--- a/components/calendar/src/cal/dangi.rs
+++ b/components/calendar/src/cal/dangi.rs
@@ -243,10 +243,6 @@ impl Calendar for Dangi {
         }
     }
 
-    fn extended_year(&self, date: &Self::DateInner) -> i32 {
-        date.0.year.related_iso
-    }
-
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
         Self::provided_year_is_leap(date.0.year)
     }

--- a/components/calendar/src/cal/ethiopian.rs
+++ b/components/calendar/src/cal/ethiopian.rs
@@ -199,12 +199,20 @@ impl Calendar for Ethiopian {
     }
 
     fn year_info(&self, date: &Self::DateInner) -> Self::Year {
+        let year = date.0.monotonic_year();
+        let monotonic_year = if self.0 {
+            year
+        } else {
+            year - INCARNATION_OFFSET
+        };
+
         let year = date.0.year;
         if self.0 || year <= INCARNATION_OFFSET {
             types::EraYear {
                 era: tinystr!(16, "aa"),
                 era_index: Some(0),
                 year,
+                monotonic_year,
                 ambiguity: types::YearAmbiguity::CenturyRequired,
             }
         } else {
@@ -212,18 +220,14 @@ impl Calendar for Ethiopian {
                 era: tinystr!(16, "am"),
                 era_index: Some(1),
                 year: year - INCARNATION_OFFSET,
+                monotonic_year,
                 ambiguity: types::YearAmbiguity::CenturyRequired,
             }
         }
     }
 
     fn extended_year(&self, date: &Self::DateInner) -> i32 {
-        let year = date.0.monotonic_year();
-        if self.0 {
-            year
-        } else {
-            year - INCARNATION_OFFSET
-        }
+        self.year_info(date).monotonic_year
     }
 
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {

--- a/components/calendar/src/cal/ethiopian.rs
+++ b/components/calendar/src/cal/ethiopian.rs
@@ -206,7 +206,6 @@ impl Calendar for Ethiopian {
             year - INCARNATION_OFFSET
         };
 
-        let year = date.0.year;
         if self.0 || monotonic_year <= 0 {
             types::EraYear {
                 era: tinystr!(16, "aa"),

--- a/components/calendar/src/cal/ethiopian.rs
+++ b/components/calendar/src/cal/ethiopian.rs
@@ -226,10 +226,6 @@ impl Calendar for Ethiopian {
         }
     }
 
-    fn extended_year(&self, date: &Self::DateInner) -> i32 {
-        self.year_info(date).monotonic_year
-    }
-
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
         Self::provided_year_is_leap(date.0.year)
     }
@@ -362,7 +358,7 @@ mod test {
     }
 
     #[test]
-    fn extended_year() {
+    fn monotonic_year() {
         assert_eq!(
             Date::new_from_iso(
                 Date::try_new_iso(-5500 + 9, 1, 1).unwrap(),

--- a/components/calendar/src/cal/ethiopian.rs
+++ b/components/calendar/src/cal/ethiopian.rs
@@ -65,6 +65,8 @@ pub enum EthiopianEraStyle {
 pub struct Ethiopian(pub(crate) bool);
 
 /// The inner date type used for representing [`Date`]s of [`Ethiopian`]. See [`Date`] and [`Ethiopian`] for more details.
+///
+/// The year is stored as Amete Alem year
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
 pub struct EthiopianDateInner(ArithmeticDate<Ethiopian>);
 

--- a/components/calendar/src/cal/ethiopian.rs
+++ b/components/calendar/src/cal/ethiopian.rs
@@ -218,7 +218,7 @@ impl Calendar for Ethiopian {
     }
 
     fn extended_year(&self, date: &Self::DateInner) -> i32 {
-        let year = date.0.extended_year();
+        let year = date.0.monotonic_year();
         if self.0 {
             year
         } else {
@@ -310,7 +310,7 @@ mod test {
         // 11th September 2023 in gregorian is 6/13/2015 in ethiopian
         let iso_date = Date::try_new_iso(2023, 9, 11).unwrap();
         let date_ethiopian = Date::new_from_iso(iso_date, Ethiopian::new());
-        assert_eq!(date_ethiopian.extended_year(), 2015);
+        assert_eq!(date_ethiopian.monotonic_year(), 2015);
         assert_eq!(date_ethiopian.month().ordinal, 13);
         assert_eq!(date_ethiopian.day_of_month().0, 6);
     }
@@ -320,7 +320,7 @@ mod test {
         let iso_date = Date::try_new_iso(1970, 1, 2).unwrap();
         let date_ethiopian = Date::new_from_iso(iso_date, Ethiopian::new());
 
-        assert_eq!(date_ethiopian.extended_year(), 1962);
+        assert_eq!(date_ethiopian.monotonic_year(), 1962);
         assert_eq!(date_ethiopian.month().ordinal, 4);
         assert_eq!(date_ethiopian.day_of_month().0, 24);
 
@@ -338,7 +338,7 @@ mod test {
             Ethiopian::new_with_era_style(EthiopianEraStyle::AmeteAlem),
         );
 
-        assert_eq!(date_ethiopian.extended_year(), 7462);
+        assert_eq!(date_ethiopian.monotonic_year(), 7462);
         assert_eq!(date_ethiopian.month().ordinal, 4);
         assert_eq!(date_ethiopian.day_of_month().0, 24);
 
@@ -364,7 +364,7 @@ mod test {
                 Date::try_new_iso(-5500 + 9, 1, 1).unwrap(),
                 Ethiopian::new_with_era_style(EthiopianEraStyle::AmeteAlem)
             )
-            .extended_year(),
+            .monotonic_year(),
             1
         );
         assert_eq!(
@@ -372,7 +372,7 @@ mod test {
                 Date::try_new_iso(9, 1, 1).unwrap(),
                 Ethiopian::new_with_era_style(EthiopianEraStyle::AmeteAlem)
             )
-            .extended_year(),
+            .monotonic_year(),
             5501
         );
 
@@ -381,7 +381,7 @@ mod test {
                 Date::try_new_iso(-5500 + 9, 1, 1).unwrap(),
                 Ethiopian::new_with_era_style(EthiopianEraStyle::AmeteMihret)
             )
-            .extended_year(),
+            .monotonic_year(),
             -5499
         );
         assert_eq!(
@@ -389,7 +389,7 @@ mod test {
                 Date::try_new_iso(9, 1, 1).unwrap(),
                 Ethiopian::new_with_era_style(EthiopianEraStyle::AmeteMihret)
             )
-            .extended_year(),
+            .monotonic_year(),
             1
         );
     }

--- a/components/calendar/src/cal/ethiopian.rs
+++ b/components/calendar/src/cal/ethiopian.rs
@@ -207,7 +207,7 @@ impl Calendar for Ethiopian {
         };
 
         let year = date.0.year;
-        if self.0 || year <= INCARNATION_OFFSET {
+        if self.0 || monotonic_year <= 0 {
             types::EraYear {
                 era: tinystr!(16, "aa"),
                 era_index: Some(0),

--- a/components/calendar/src/cal/ethiopian.rs
+++ b/components/calendar/src/cal/ethiopian.rs
@@ -122,9 +122,10 @@ impl Calendar for Ethiopian {
         day: u8,
     ) -> Result<Self::DateInner, DateError> {
         let year = match (self.era_style(), era) {
-            (EthiopianEraStyle::AmeteMihret, Some("am") | None) => {
+            (EthiopianEraStyle::AmeteMihret, Some("am")) => {
                 year_check(year, 1..)? + INCARNATION_OFFSET
             }
+            (EthiopianEraStyle::AmeteMihret, None) => year + INCARNATION_OFFSET,
             (EthiopianEraStyle::AmeteMihret, Some("aa")) => {
                 year_check(year, ..=INCARNATION_OFFSET)?
             }

--- a/components/calendar/src/cal/gregorian.rs
+++ b/components/calendar/src/cal/gregorian.rs
@@ -112,7 +112,7 @@ impl Calendar for Gregorian {
     }
     /// The calendar-specific year represented by `date`
     fn year_info(&self, date: &Self::DateInner) -> Self::Year {
-        let monotonic_year = self.extended_year(date);
+        let monotonic_year = date.0.iso_year();
         if monotonic_year > 0 {
             types::EraYear {
                 era: tinystr!(16, "ce"),
@@ -135,10 +135,6 @@ impl Calendar for Gregorian {
                 ambiguity: types::YearAmbiguity::EraAndCenturyRequired,
             }
         }
-    }
-
-    fn extended_year(&self, date: &Self::DateInner) -> i32 {
-        Iso.extended_year(&date.0)
     }
 
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {

--- a/components/calendar/src/cal/gregorian.rs
+++ b/components/calendar/src/cal/gregorian.rs
@@ -57,7 +57,8 @@ impl Calendar for Gregorian {
     ) -> Result<Self::DateInner, DateError> {
         let year = match era {
             Some("bce" | "bc") => 1 - year_check(year, 1..)?,
-            Some("ad" | "ce") | None => year_check(year, 1..)?,
+            Some("ad" | "ce") => year_check(year, 1..)?,
+            None => year,
             Some(_) => return Err(DateError::UnknownEra),
         };
 

--- a/components/calendar/src/cal/gregorian.rs
+++ b/components/calendar/src/cal/gregorian.rs
@@ -56,9 +56,9 @@ impl Calendar for Gregorian {
         day: u8,
     ) -> Result<Self::DateInner, DateError> {
         let year = match era {
-            Some("bce" | "bc") => 1 - year_check(year, 1..)?,
-            Some("ad" | "ce") => year_check(year, 1..)?,
             None => year,
+            Some("ad" | "ce") => year_check(year, 1..)?,
+            Some("bce" | "bc") => 1 - year_check(year, 1..)?,
             Some(_) => return Err(DateError::UnknownEra),
         };
 

--- a/components/calendar/src/cal/gregorian.rs
+++ b/components/calendar/src/cal/gregorian.rs
@@ -112,13 +112,14 @@ impl Calendar for Gregorian {
     }
     /// The calendar-specific year represented by `date`
     fn year_info(&self, date: &Self::DateInner) -> Self::Year {
-        let extended_year = self.extended_year(date);
-        if extended_year > 0 {
+        let monotonic_year = self.extended_year(date);
+        if monotonic_year > 0 {
             types::EraYear {
                 era: tinystr!(16, "ce"),
                 era_index: Some(1),
-                year: extended_year,
-                ambiguity: match extended_year {
+                year: monotonic_year,
+                monotonic_year,
+                ambiguity: match monotonic_year {
                     ..=999 => types::YearAmbiguity::EraAndCenturyRequired,
                     1000..=1949 => types::YearAmbiguity::CenturyRequired,
                     1950..=2049 => types::YearAmbiguity::Unambiguous,
@@ -129,7 +130,8 @@ impl Calendar for Gregorian {
             types::EraYear {
                 era: tinystr!(16, "bce"),
                 era_index: Some(0),
-                year: 1_i32.saturating_sub(extended_year),
+                year: 1_i32.saturating_sub(monotonic_year),
+                monotonic_year,
                 ambiguity: types::YearAmbiguity::EraAndCenturyRequired,
             }
         }

--- a/components/calendar/src/cal/hebrew.rs
+++ b/components/calendar/src/cal/hebrew.rs
@@ -270,7 +270,7 @@ impl Calendar for Hebrew {
     }
 
     fn extended_year(&self, date: &Self::DateInner) -> i32 {
-        date.0.extended_year()
+        date.0.monotonic_year()
     }
 
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {

--- a/components/calendar/src/cal/hebrew.rs
+++ b/components/calendar/src/cal/hebrew.rs
@@ -261,10 +261,12 @@ impl Calendar for Hebrew {
     }
 
     fn year_info(&self, date: &Self::DateInner) -> Self::Year {
+        let monotonic_year = date.0.monotonic_year();
         types::EraYear {
             era_index: Some(0),
             era: tinystr!(16, "am"),
-            year: self.extended_year(date),
+            year: monotonic_year,
+            monotonic_year,
             ambiguity: types::YearAmbiguity::CenturyRequired,
         }
     }

--- a/components/calendar/src/cal/hebrew.rs
+++ b/components/calendar/src/cal/hebrew.rs
@@ -271,10 +271,6 @@ impl Calendar for Hebrew {
         }
     }
 
-    fn extended_year(&self, date: &Self::DateInner) -> i32 {
-        date.0.monotonic_year()
-    }
-
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
         Self::provided_year_is_leap(date.0.year)
     }

--- a/components/calendar/src/cal/hijri.rs
+++ b/components/calendar/src/cal/hijri.rs
@@ -384,7 +384,8 @@ impl Calendar for HijriSimulated {
         day: u8,
     ) -> Result<Self::DateInner, DateError> {
         let year = match era {
-            Some("ah") | None => year_check(year, 1..)?,
+            Some("ah") => year_check(year, 1..)?,
+            None => year,
             Some("bh") => 1 - year_check(year, 1..)?,
             Some(_) => return Err(DateError::UnknownEra),
         };
@@ -667,7 +668,8 @@ impl Calendar for HijriUmmAlQura {
         day: u8,
     ) -> Result<Self::DateInner, DateError> {
         let year = match era {
-            Some("ah") | None => year_check(year, 1..)?,
+            Some("ah") => year_check(year, 1..)?,
+            None => year,
             Some("bh") => 1 - year_check(year, 1..)?,
             Some(_) => return Err(DateError::UnknownEra),
         };
@@ -892,7 +894,8 @@ impl Calendar for HijriTabular {
         day: u8,
     ) -> Result<Self::DateInner, DateError> {
         let year = match era {
-            Some("ah") | None => year_check(year, 1..)?,
+            Some("ah") => year_check(year, 1..)?,
+            None => year,
             Some("bh") => 1 - year_check(year, 1..)?,
             Some(_) => return Err(DateError::UnknownEra),
         };

--- a/components/calendar/src/cal/hijri.rs
+++ b/components/calendar/src/cal/hijri.rs
@@ -470,11 +470,7 @@ impl Calendar for HijriSimulated {
     }
 
     fn year_info(&self, date: &Self::DateInner) -> Self::Year {
-        era_year(self.extended_year(date))
-    }
-
-    fn extended_year(&self, date: &Self::DateInner) -> i32 {
-        date.0.monotonic_year()
+        era_year(date.0.monotonic_year())
     }
 
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
@@ -754,11 +750,7 @@ impl Calendar for HijriUmmAlQura {
     }
 
     fn year_info(&self, date: &Self::DateInner) -> Self::Year {
-        era_year(self.extended_year(date))
-    }
-
-    fn extended_year(&self, date: &Self::DateInner) -> i32 {
-        date.0.monotonic_year()
+        era_year(date.0.monotonic_year())
     }
 
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
@@ -975,11 +967,7 @@ impl Calendar for HijriTabular {
     }
 
     fn year_info(&self, date: &Self::DateInner) -> Self::Year {
-        era_year(self.extended_year(date))
-    }
-
-    fn extended_year(&self, date: &Self::DateInner) -> i32 {
-        date.0.monotonic_year()
+        era_year(date.0.monotonic_year())
     }
 
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {

--- a/components/calendar/src/cal/hijri.rs
+++ b/components/calendar/src/cal/hijri.rs
@@ -42,6 +42,7 @@ fn era_year(year: i32) -> EraYear {
             era: tinystr!(16, "ah"),
             era_index: Some(0),
             year,
+            monotonic_year: year,
             ambiguity: types::YearAmbiguity::CenturyRequired,
         }
     } else {
@@ -49,6 +50,7 @@ fn era_year(year: i32) -> EraYear {
             era: tinystr!(16, "bh"),
             era_index: Some(1),
             year: 1 - year,
+            monotonic_year: year,
             ambiguity: types::YearAmbiguity::CenturyRequired,
         }
     }

--- a/components/calendar/src/cal/hijri.rs
+++ b/components/calendar/src/cal/hijri.rs
@@ -472,7 +472,7 @@ impl Calendar for HijriSimulated {
     }
 
     fn extended_year(&self, date: &Self::DateInner) -> i32 {
-        date.0.extended_year()
+        date.0.monotonic_year()
     }
 
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
@@ -756,7 +756,7 @@ impl Calendar for HijriUmmAlQura {
     }
 
     fn extended_year(&self, date: &Self::DateInner) -> i32 {
-        date.0.extended_year()
+        date.0.monotonic_year()
     }
 
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
@@ -977,7 +977,7 @@ impl Calendar for HijriTabular {
     }
 
     fn extended_year(&self, date: &Self::DateInner) -> i32 {
-        date.0.extended_year()
+        date.0.monotonic_year()
     }
 
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {

--- a/components/calendar/src/cal/hijri.rs
+++ b/components/calendar/src/cal/hijri.rs
@@ -386,8 +386,8 @@ impl Calendar for HijriSimulated {
         day: u8,
     ) -> Result<Self::DateInner, DateError> {
         let year = match era {
-            Some("ah") => year_check(year, 1..)?,
             None => year,
+            Some("ah") => year_check(year, 1..)?,
             Some("bh") => 1 - year_check(year, 1..)?,
             Some(_) => return Err(DateError::UnknownEra),
         };
@@ -888,8 +888,8 @@ impl Calendar for HijriTabular {
         day: u8,
     ) -> Result<Self::DateInner, DateError> {
         let year = match era {
-            Some("ah") => year_check(year, 1..)?,
             None => year,
+            Some("ah") => year_check(year, 1..)?,
             Some("bh") => 1 - year_check(year, 1..)?,
             Some(_) => return Err(DateError::UnknownEra),
         };

--- a/components/calendar/src/cal/hijri.rs
+++ b/components/calendar/src/cal/hijri.rs
@@ -666,8 +666,8 @@ impl Calendar for HijriUmmAlQura {
         day: u8,
     ) -> Result<Self::DateInner, DateError> {
         let year = match era {
-            Some("ah") => year_check(year, 1..)?,
             None => year,
+            Some("ah") => year_check(year, 1..)?,
             Some("bh") => 1 - year_check(year, 1..)?,
             Some(_) => return Err(DateError::UnknownEra),
         };

--- a/components/calendar/src/cal/indian.rs
+++ b/components/calendar/src/cal/indian.rs
@@ -183,10 +183,12 @@ impl Calendar for Indian {
     }
 
     fn year_info(&self, date: &Self::DateInner) -> Self::Year {
+        let monotonic_year = date.0.monotonic_year();
         types::EraYear {
             era_index: Some(0),
             era: tinystr!(16, "shaka"),
-            year: self.extended_year(date),
+            year: monotonic_year,
+            monotonic_year,
             ambiguity: types::YearAmbiguity::CenturyRequired,
         }
     }

--- a/components/calendar/src/cal/indian.rs
+++ b/components/calendar/src/cal/indian.rs
@@ -193,10 +193,6 @@ impl Calendar for Indian {
         }
     }
 
-    fn extended_year(&self, date: &Self::DateInner) -> i32 {
-        date.0.monotonic_year()
-    }
-
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
         Self::provided_year_is_leap(date.0.year)
     }

--- a/components/calendar/src/cal/indian.rs
+++ b/components/calendar/src/cal/indian.rs
@@ -192,7 +192,7 @@ impl Calendar for Indian {
     }
 
     fn extended_year(&self, date: &Self::DateInner) -> i32 {
-        date.0.extended_year()
+        date.0.monotonic_year()
     }
 
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {

--- a/components/calendar/src/cal/iso.rs
+++ b/components/calendar/src/cal/iso.rs
@@ -42,6 +42,12 @@ pub struct Iso;
 /// The inner date type used for representing [`Date`]s of [`Iso`]. See [`Date`] and [`Iso`] for more details.
 pub struct IsoDateInner(pub(crate) ArithmeticDate<Iso>);
 
+impl IsoDateInner {
+    pub(crate) fn iso_year(&self) -> i32 {
+        self.0.monotonic_year()
+    }
+}
+
 impl CalendarArithmetic for Iso {
     type YearInfo = i32;
 
@@ -152,10 +158,6 @@ impl Calendar for Iso {
             monotonic_year,
             ambiguity: types::YearAmbiguity::Unambiguous,
         }
-    }
-
-    fn extended_year(&self, date: &Self::DateInner) -> i32 {
-        date.0.monotonic_year()
     }
 
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {

--- a/components/calendar/src/cal/iso.rs
+++ b/components/calendar/src/cal/iso.rs
@@ -150,7 +150,7 @@ impl Calendar for Iso {
     }
 
     fn year_info(&self, date: &Self::DateInner) -> Self::Year {
-        let monotonic_year = date.0.monotonic_year();
+        let monotonic_year = date.iso_year();
         types::EraYear {
             era_index: Some(0),
             era: tinystr!(16, "default"),

--- a/components/calendar/src/cal/iso.rs
+++ b/components/calendar/src/cal/iso.rs
@@ -144,10 +144,12 @@ impl Calendar for Iso {
     }
 
     fn year_info(&self, date: &Self::DateInner) -> Self::Year {
+        let monotonic_year = date.0.monotonic_year();
         types::EraYear {
             era_index: Some(0),
             era: tinystr!(16, "default"),
-            year: self.extended_year(date),
+            year: monotonic_year,
+            monotonic_year,
             ambiguity: types::YearAmbiguity::Unambiguous,
         }
     }

--- a/components/calendar/src/cal/iso.rs
+++ b/components/calendar/src/cal/iso.rs
@@ -43,7 +43,7 @@ pub struct Iso;
 pub struct IsoDateInner(pub(crate) ArithmeticDate<Iso>);
 
 impl IsoDateInner {
-    pub(crate) fn iso_year(&self) -> i32 {
+    pub(crate) fn iso_year(self) -> i32 {
         self.0.monotonic_year()
     }
 }

--- a/components/calendar/src/cal/iso.rs
+++ b/components/calendar/src/cal/iso.rs
@@ -153,7 +153,7 @@ impl Calendar for Iso {
     }
 
     fn extended_year(&self, date: &Self::DateInner) -> i32 {
-        date.0.extended_year()
+        date.0.monotonic_year()
     }
 
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {

--- a/components/calendar/src/cal/japanese.rs
+++ b/components/calendar/src/cal/japanese.rs
@@ -641,13 +641,13 @@ impl Japanese {
     ) -> Result<JapaneseDateInner, DateError> {
         let cal = Ref(self);
         let era = match era {
-            Some("ce" | "ad") => {
-                return Ok(Date::try_new_gregorian(year_check(year, 1..)?, month, day)?
+            None => {
+                return Ok(Date::try_new_gregorian(year, month, day)?
                     .to_calendar(cal)
                     .inner);
             }
-            None => {
-                return Ok(Date::try_new_gregorian(year, month, day)?
+            Some("ce" | "ad") => {
+                return Ok(Date::try_new_gregorian(year_check(year, 1..)?, month, day)?
                     .to_calendar(cal)
                     .inner);
             }

--- a/components/calendar/src/cal/japanese.rs
+++ b/components/calendar/src/cal/japanese.rs
@@ -186,7 +186,7 @@ impl Calendar for Japanese {
             return Err(DateError::UnknownMonthCode(month_code));
         }
 
-        self.new_japanese_date_inner(era.unwrap_or("ce"), year, month, day)
+        self.new_japanese_date_inner(era, year, month, day)
     }
 
     fn from_rata_die(&self, rd: RataDie) -> Self::DateInner {
@@ -442,9 +442,10 @@ impl Date<Japanese> {
         day: u8,
         japanese_calendar: A,
     ) -> Result<Date<A>, DateError> {
-        let inner = japanese_calendar
-            .as_calendar()
-            .new_japanese_date_inner(era, year, month, day)?;
+        let inner =
+            japanese_calendar
+                .as_calendar()
+                .new_japanese_date_inner(Some(era), year, month, day)?;
         Ok(Date::from_raw(inner, japanese_calendar))
     }
 }
@@ -490,10 +491,12 @@ impl Date<JapaneseExtended> {
         day: u8,
         japanext_calendar: A,
     ) -> Result<Date<A>, DateError> {
-        let inner = japanext_calendar
-            .as_calendar()
-            .0
-            .new_japanese_date_inner(era, year, month, day)?;
+        let inner = japanext_calendar.as_calendar().0.new_japanese_date_inner(
+            Some(era),
+            year,
+            month,
+            day,
+        )?;
         Ok(Date::from_raw(inner, japanext_calendar))
     }
 }
@@ -638,26 +641,31 @@ impl Japanese {
 
     fn new_japanese_date_inner(
         &self,
-        era: &str,
+        era: Option<&str>,
         year: i32,
         month: u8,
         day: u8,
     ) -> Result<JapaneseDateInner, DateError> {
         let cal = Ref(self);
         let era = match era {
-            "ce" | "ad" => {
+            Some("ce" | "ad") => {
                 return Ok(Date::try_new_gregorian(year_check(year, 1..)?, month, day)?
                     .to_calendar(cal)
                     .inner);
             }
-            "bce" | "bc" => {
+            None => {
+                return Ok(Date::try_new_gregorian(year, month, day)?
+                    .to_calendar(cal)
+                    .inner);
+            }
+            Some("bce" | "bc") => {
                 return Ok(
                     Date::try_new_gregorian(1 - year_check(year, 1..)?, month, day)?
                         .to_calendar(cal)
                         .inner,
                 );
             }
-            e => e.parse().map_err(|_| DateError::UnknownEra)?,
+            Some(e) => e.parse().map_err(|_| DateError::UnknownEra)?,
         };
 
         let (era_start, next_era_start) = self.japanese_era_range_for(era)?;

--- a/components/calendar/src/cal/japanese.rs
+++ b/components/calendar/src/cal/japanese.rs
@@ -252,13 +252,9 @@ impl Calendar for Japanese {
             era: date.era,
             era_index: None,
             year: date.adjusted_year,
-            monotonic_year: date.adjusted_year,
+            monotonic_year: date.inner.0.monotonic_year(),
             ambiguity: types::YearAmbiguity::CenturyRequired,
         }
-    }
-
-    fn extended_year(&self, date: &Self::DateInner) -> i32 {
-        Iso.extended_year(&date.inner)
     }
 
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {
@@ -356,10 +352,6 @@ impl Calendar for JapaneseExtended {
 
     fn year_info(&self, date: &Self::DateInner) -> Self::Year {
         Japanese::year_info(&self.0, date)
-    }
-
-    fn extended_year(&self, date: &Self::DateInner) -> i32 {
-        Japanese::extended_year(&self.0, date)
     }
 
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {

--- a/components/calendar/src/cal/japanese.rs
+++ b/components/calendar/src/cal/japanese.rs
@@ -252,6 +252,7 @@ impl Calendar for Japanese {
             era: date.era,
             era_index: None,
             year: date.adjusted_year,
+            monotonic_year: date.adjusted_year,
             ambiguity: types::YearAmbiguity::CenturyRequired,
         }
     }

--- a/components/calendar/src/cal/julian.rs
+++ b/components/calendar/src/cal/julian.rs
@@ -175,7 +175,7 @@ impl Calendar for Julian {
     }
 
     fn extended_year(&self, date: &Self::DateInner) -> i32 {
-        date.0.extended_year()
+        date.0.monotonic_year()
     }
 
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {

--- a/components/calendar/src/cal/julian.rs
+++ b/components/calendar/src/cal/julian.rs
@@ -156,7 +156,7 @@ impl Calendar for Julian {
     /// The calendar-specific year represented by `date`
     /// Julian has the same era scheme as Gregorian
     fn year_info(&self, date: &Self::DateInner) -> Self::Year {
-        let monotonic_year = self.extended_year(date);
+        let monotonic_year = date.0.monotonic_year();
         if monotonic_year > 0 {
             types::EraYear {
                 era: tinystr!(16, "ce"),
@@ -174,10 +174,6 @@ impl Calendar for Julian {
                 ambiguity: types::YearAmbiguity::EraAndCenturyRequired,
             }
         }
-    }
-
-    fn extended_year(&self, date: &Self::DateInner) -> i32 {
-        date.0.monotonic_year()
     }
 
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {

--- a/components/calendar/src/cal/julian.rs
+++ b/components/calendar/src/cal/julian.rs
@@ -95,7 +95,8 @@ impl Calendar for Julian {
         day: u8,
     ) -> Result<Self::DateInner, DateError> {
         let year = match era {
-            Some("ce" | "ad") | None => year_check(year, 1..)?,
+            Some("ce" | "ad") => year_check(year, 1..)?,
+            None => year,
             Some("bce" | "bc") => 1 - year_check(year, 1..)?,
             Some(_) => return Err(DateError::UnknownEra),
         };

--- a/components/calendar/src/cal/julian.rs
+++ b/components/calendar/src/cal/julian.rs
@@ -156,19 +156,21 @@ impl Calendar for Julian {
     /// The calendar-specific year represented by `date`
     /// Julian has the same era scheme as Gregorian
     fn year_info(&self, date: &Self::DateInner) -> Self::Year {
-        let extended_year = self.extended_year(date);
-        if extended_year > 0 {
+        let monotonic_year = self.extended_year(date);
+        if monotonic_year > 0 {
             types::EraYear {
                 era: tinystr!(16, "ce"),
                 era_index: Some(1),
-                year: extended_year,
+                year: monotonic_year,
+                monotonic_year,
                 ambiguity: types::YearAmbiguity::CenturyRequired,
             }
         } else {
             types::EraYear {
                 era: tinystr!(16, "bce"),
                 era_index: Some(0),
-                year: 1_i32.saturating_sub(extended_year),
+                year: 1_i32.saturating_sub(monotonic_year),
+                monotonic_year,
                 ambiguity: types::YearAmbiguity::EraAndCenturyRequired,
             }
         }

--- a/components/calendar/src/cal/persian.rs
+++ b/components/calendar/src/cal/persian.rs
@@ -158,10 +158,12 @@ impl Calendar for Persian {
     }
 
     fn year_info(&self, date: &Self::DateInner) -> Self::Year {
+        let monotonic_year = self.extended_year(date);
         types::EraYear {
             era: tinystr!(16, "ap"),
             era_index: Some(0),
-            year: self.extended_year(date),
+            year: monotonic_year,
+            monotonic_year,
             ambiguity: types::YearAmbiguity::CenturyRequired,
         }
     }

--- a/components/calendar/src/cal/persian.rs
+++ b/components/calendar/src/cal/persian.rs
@@ -158,7 +158,7 @@ impl Calendar for Persian {
     }
 
     fn year_info(&self, date: &Self::DateInner) -> Self::Year {
-        let monotonic_year = self.extended_year(date);
+        let monotonic_year = date.0.monotonic_year();
         types::EraYear {
             era: tinystr!(16, "ap"),
             era_index: Some(0),
@@ -166,10 +166,6 @@ impl Calendar for Persian {
             monotonic_year,
             ambiguity: types::YearAmbiguity::CenturyRequired,
         }
-    }
-
-    fn extended_year(&self, date: &Self::DateInner) -> i32 {
-        date.0.monotonic_year()
     }
 
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {

--- a/components/calendar/src/cal/persian.rs
+++ b/components/calendar/src/cal/persian.rs
@@ -167,7 +167,7 @@ impl Calendar for Persian {
     }
 
     fn extended_year(&self, date: &Self::DateInner) -> i32 {
-        date.0.extended_year()
+        date.0.monotonic_year()
     }
 
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {

--- a/components/calendar/src/cal/roc.rs
+++ b/components/calendar/src/cal/roc.rs
@@ -133,6 +133,7 @@ impl Calendar for Roc {
                 era: tinystr!(16, "roc"),
                 era_index: Some(1),
                 year: extended_year,
+                monotonic_year: extended_year,
                 ambiguity: types::YearAmbiguity::CenturyRequired,
             }
         } else {
@@ -140,6 +141,7 @@ impl Calendar for Roc {
                 era: tinystr!(16, "broc"),
                 era_index: Some(0),
                 year: 1 - extended_year,
+                monotonic_year: extended_year,
                 ambiguity: types::YearAmbiguity::EraAndCenturyRequired,
             }
         }

--- a/components/calendar/src/cal/roc.rs
+++ b/components/calendar/src/cal/roc.rs
@@ -127,28 +127,24 @@ impl Calendar for Roc {
     }
 
     fn year_info(&self, date: &Self::DateInner) -> Self::Year {
-        let extended_year = self.extended_year(date);
-        if extended_year > 0 {
+        let monotonic_year = date.0.iso_year() - ROC_ERA_OFFSET;
+        if monotonic_year > 0 {
             types::EraYear {
                 era: tinystr!(16, "roc"),
                 era_index: Some(1),
-                year: extended_year,
-                monotonic_year: extended_year,
+                year: monotonic_year,
+                monotonic_year,
                 ambiguity: types::YearAmbiguity::CenturyRequired,
             }
         } else {
             types::EraYear {
                 era: tinystr!(16, "broc"),
                 era_index: Some(0),
-                year: 1 - extended_year,
-                monotonic_year: extended_year,
+                year: 1 - monotonic_year,
+                monotonic_year,
                 ambiguity: types::YearAmbiguity::EraAndCenturyRequired,
             }
         }
-    }
-
-    fn extended_year(&self, date: &Self::DateInner) -> i32 {
-        Iso.extended_year(&date.0) - ROC_ERA_OFFSET
     }
 
     fn is_in_leap_year(&self, date: &Self::DateInner) -> bool {

--- a/components/calendar/src/cal/roc.rs
+++ b/components/calendar/src/cal/roc.rs
@@ -235,7 +235,7 @@ mod test {
             "Failed era check from RD: {case:?}\nISO: {iso_from_rd:?}\nROC: {roc_from_rd:?}"
         );
         assert_eq!(
-            roc_from_rd.extended_year(),
+            roc_from_rd.monotonic_year(),
             if case.expected_era == "roc" {
                 case.expected_year
             } else {

--- a/components/calendar/src/cal/roc.rs
+++ b/components/calendar/src/cal/roc.rs
@@ -67,7 +67,8 @@ impl Calendar for Roc {
         day: u8,
     ) -> Result<Self::DateInner, DateError> {
         let year = match era {
-            Some("roc") | None => ROC_ERA_OFFSET + year_check(year, 1..)?,
+            Some("roc") => ROC_ERA_OFFSET + year_check(year, 1..)?,
+            None => ROC_ERA_OFFSET + year,
             Some("broc") => ROC_ERA_OFFSET + 1 - year_check(year, 1..)?,
             Some(_) => return Err(DateError::UnknownEra),
         };

--- a/components/calendar/src/calendar.rs
+++ b/components/calendar/src/calendar.rs
@@ -72,7 +72,7 @@ pub trait Calendar: crate::cal::scaffold::UnstableSealed {
     ///
     /// "extended year" is an old name, this method should not necessarily match ICU4C extended year,
     /// and instead should attempt to align with
-    /// https://tc39.es/proposal-intl-era-monthcode/ as much as possible.
+    /// <https://tc39.es/proposal-intl-era-monthcode/> as much as possible.
     #[deprecated = "Use the monotonic year instead"]
     fn extended_year(&self, date: &Self::DateInner) -> i32 {
         self.year_info(date).into().monotonic_year()

--- a/components/calendar/src/calendar.rs
+++ b/components/calendar/src/calendar.rs
@@ -32,7 +32,7 @@ pub trait Calendar: crate::cal::scaffold::UnstableSealed {
 
     /// Construct a date from era/month codes and fields
     ///
-    /// The year is the [monotonic year](Date::monotonic_year) if no era is provided
+    /// The year is the [monotonic year](crate::Date::monotonic_year) if no era is provided
     #[expect(clippy::wrong_self_convention)]
     fn from_codes(
         &self,

--- a/components/calendar/src/calendar.rs
+++ b/components/calendar/src/calendar.rs
@@ -32,7 +32,7 @@ pub trait Calendar: crate::cal::scaffold::UnstableSealed {
 
     /// Construct a date from era/month codes and fields
     ///
-    /// The year is the monotonic year if no era is provided
+    /// The year is the [monotonic year](Date::monotonic_year) if no era is provided
     #[expect(clippy::wrong_self_convention)]
     fn from_codes(
         &self,

--- a/components/calendar/src/calendar.rs
+++ b/components/calendar/src/calendar.rs
@@ -73,7 +73,7 @@ pub trait Calendar: crate::cal::scaffold::UnstableSealed {
     /// "extended year" is an old name, this method should not necessarily match ICU4C extended year,
     /// and instead should attempt to align with
     /// <https://tc39.es/proposal-intl-era-monthcode/> as much as possible.
-    #[deprecated = "Use the monotonic year instead"]
+    #[deprecated(since = "2.1.0", note = "Use `Date::monotonic_year` instead")]
     fn extended_year(&self, date: &Self::DateInner) -> i32 {
         self.year_info(date).into().monotonic_year()
     }

--- a/components/calendar/src/calendar.rs
+++ b/components/calendar/src/calendar.rs
@@ -68,12 +68,15 @@ pub trait Calendar: crate::cal::scaffold::UnstableSealed {
 
     /// Information about the year
     fn year_info(&self, date: &Self::DateInner) -> Self::Year;
-    /// The monotonic year value
+    /// (Deprecated)
     ///
     /// "extended year" is an old name, this method should not necessarily match ICU4C extended year,
     /// and instead should attempt to align with
     /// https://tc39.es/proposal-intl-era-monthcode/ as much as possible.
-    fn extended_year(&self, date: &Self::DateInner) -> i32;
+    #[deprecated = "Use the monotonic year instead"]
+    fn extended_year(&self, date: &Self::DateInner) -> i32 {
+        self.year_info(date).into().monotonic_year()
+    }
     /// The calendar-specific month represented by `date`
     fn month(&self, date: &Self::DateInner) -> types::MonthInfo;
     /// The calendar-specific day-of-month represented by `date`

--- a/components/calendar/src/calendar.rs
+++ b/components/calendar/src/calendar.rs
@@ -32,7 +32,7 @@ pub trait Calendar: crate::cal::scaffold::UnstableSealed {
 
     /// Construct a date from era/month codes and fields
     ///
-    /// The year is extended_year if no era is provided
+    /// The year is the monotonic year if no era is provided
     #[expect(clippy::wrong_self_convention)]
     fn from_codes(
         &self,
@@ -68,7 +68,11 @@ pub trait Calendar: crate::cal::scaffold::UnstableSealed {
 
     /// Information about the year
     fn year_info(&self, date: &Self::DateInner) -> Self::Year;
-    /// The extended year value
+    /// The monotonic year value
+    ///
+    /// "extended year" is an old name, this method should not necessarily match ICU4C extended year,
+    /// and instead should attempt to align with
+    /// https://tc39.es/proposal-intl-era-monthcode/ as much as possible.
     fn extended_year(&self, date: &Self::DateInner) -> i32;
     /// The calendar-specific month represented by `date`
     fn month(&self, date: &Self::DateInner) -> types::MonthInfo;

--- a/components/calendar/src/calendar_arithmetic.rs
+++ b/components/calendar/src/calendar_arithmetic.rs
@@ -281,7 +281,7 @@ impl<C: CalendarArithmetic> ArithmeticDate<C> {
         DayOfYear(day_of_year + (self.day as u16))
     }
 
-    pub fn extended_year(&self) -> i32 {
+    pub fn monotonic_year(&self) -> i32 {
         self.year.into()
     }
 

--- a/components/calendar/src/date.rs
+++ b/components/calendar/src/date.rs
@@ -119,7 +119,7 @@ pub struct Date<A: AsCalendar> {
 impl<A: AsCalendar> Date<A> {
     /// Construct a date from from era/month codes and fields, and some calendar representation
     ///
-    /// The year is `extended_year` if no era is provided
+    /// The year is `monotonic_year` if no era is provided
     #[inline]
     pub fn try_new_from_codes(
         era: Option<&str>,
@@ -236,12 +236,25 @@ impl<A: AsCalendar> Date<A> {
         self.calendar.as_calendar().year_info(&self.inner).into()
     }
 
-    /// The "extended year", typically anchored with year 1 as the year 1 of either the most modern or
-    /// otherwise some "major" era for the calendar
+    /// This currently returns the same value as [`Self::monotonic_year()`]
+    #[deprecated = "Please use monotonic_year() instead"]
+    #[inline]
+    pub fn extended_year(&self) -> i32 {
+        self.calendar.as_calendar().extended_year(&self.inner)
+    }
+
+    /// The "monotonic year", typically anchored with year 1 as the year 1 of either the most modern or
+    /// otherwise some "major" era for the calendar.
+    ///
+    /// This year number can be used when you need a simple numeric representation
+    /// of the year.
+    ///
+    /// For calendars defined in Temporal, this will match the "arithmetic year"
+    /// as defined in <https://tc39.es/proposal-intl-era-monthcode/>.
     ///
     /// See [`Self::year()`] for more information about the year.
     #[inline]
-    pub fn extended_year(&self) -> i32 {
+    pub fn monotonic_year(&self) -> i32 {
         self.calendar.as_calendar().extended_year(&self.inner)
     }
 

--- a/components/calendar/src/date.rs
+++ b/components/calendar/src/date.rs
@@ -240,7 +240,7 @@ impl<A: AsCalendar> Date<A> {
     #[deprecated = "Please use monotonic_year() instead"]
     #[inline]
     pub fn extended_year(&self) -> i32 {
-        self.calendar.as_calendar().extended_year(&self.inner)
+        self.monotonic_year()
     }
 
     /// The "monotonic year", typically anchored with year 1 as the year 1 of either the most modern or
@@ -255,7 +255,7 @@ impl<A: AsCalendar> Date<A> {
     /// See [`Self::year()`] for more information about the year.
     #[inline]
     pub fn monotonic_year(&self) -> i32 {
-        self.calendar.as_calendar().extended_year(&self.inner)
+        self.year().monotonic_year()
     }
 
     /// Returns whether `self` is in a calendar-specific leap year

--- a/components/calendar/src/date.rs
+++ b/components/calendar/src/date.rs
@@ -243,14 +243,16 @@ impl<A: AsCalendar> Date<A> {
         self.monotonic_year()
     }
 
-    /// The "monotonic year", typically anchored with year 1 as the year 1 of either the most modern or
-    /// otherwise some "major" era for the calendar.
+    /// The "monotonic year".
     ///
     /// This year number can be used when you need a simple numeric representation
-    /// of the year.
+    /// of the year, and can be meaningfully compared with monotonic years from other
+    /// eras or used in arithmetic.
     ///
     /// For calendars defined in Temporal, this will match the "arithmetic year"
     /// as defined in <https://tc39.es/proposal-intl-era-monthcode/>.
+    /// This is typically anchored with year 1 as the year 1 of either the most modern or
+    /// otherwise some "major" era for the calendar.
     ///
     /// See [`Self::year()`] for more information about the year.
     #[inline]

--- a/components/calendar/src/provider/hijri.rs
+++ b/components/calendar/src/provider/hijri.rs
@@ -71,11 +71,11 @@ pub struct PackedHijriYearInfo(pub u16);
 
 impl PackedHijriYearInfo {
     pub(crate) const fn new(
-        extended_year: i32,
+        monotonic_year: i32,
         month_lengths: [bool; 12],
         start_day: RataDie,
     ) -> Self {
-        let start_offset = start_day.until(Self::mean_synodic_start_day(extended_year));
+        let start_offset = start_day.until(Self::mean_synodic_start_day(monotonic_year));
 
         debug_assert!(
             -8 < start_offset && start_offset < 8,
@@ -101,7 +101,7 @@ impl PackedHijriYearInfo {
         Self(all)
     }
 
-    pub(crate) fn unpack(self, extended_year: i32) -> ([bool; 12], RataDie) {
+    pub(crate) fn unpack(self, monotonic_year: i32) -> ([bool; 12], RataDie) {
         let month_lengths = core::array::from_fn(|i| self.0 & (1 << (i as u8) as u16) != 0);
         let start_offset = if (self.0 & 0b1_0000_0000_0000) != 0 {
             -((self.0 >> 13) as i64)
@@ -110,15 +110,15 @@ impl PackedHijriYearInfo {
         };
         (
             month_lengths,
-            Self::mean_synodic_start_day(extended_year) + start_offset,
+            Self::mean_synodic_start_day(monotonic_year) + start_offset,
         )
     }
 
-    const fn mean_synodic_start_day(extended_year: i32) -> RataDie {
+    const fn mean_synodic_start_day(monotonic_year: i32) -> RataDie {
         // -1 because the epoch is new year of year 1
         // truncating instead of flooring does not matter, as this is used for positive years only
         calendrical_calculations::islamic::ISLAMIC_EPOCH_FRIDAY.add(
-            ((extended_year - 1) as f64 * calendrical_calculations::islamic::MEAN_YEAR_LENGTH)
+            ((monotonic_year - 1) as f64 * calendrical_calculations::islamic::MEAN_YEAR_LENGTH)
                 as i64,
         )
     }

--- a/components/calendar/src/types.rs
+++ b/components/calendar/src/types.rs
@@ -48,13 +48,8 @@ impl YearInfo {
         }
     }
 
-    /// Get the monotonic year
-    ///
-    /// The monotonic year can be meaningfully compared with monotonic years
-    /// from other eras and used for arithmetic.
-    ///
-    /// Typically this is the era year for some "primary" (most modern, or other significant)
-    /// era in the calendar, or related_iso for non-era calendars.
+    /// Get the monotonic year (See [`Date::monotonic_year`](crate::Date::monotonic_year))
+    /// for more information
     pub fn monotonic_year(self) -> i32 {
         match self {
             YearInfo::Era(e) => e.monotonic_year,

--- a/components/calendar/src/types.rs
+++ b/components/calendar/src/types.rs
@@ -48,6 +48,20 @@ impl YearInfo {
         }
     }
 
+    /// Get the monotonic year
+    ///
+    /// The monotonic year can be meaningfully compared with monotonic years
+    /// from other eras and used for arithmetic.
+    ///
+    /// Typically this is the era year for some "primary" (most modern, or other significant)
+    /// era in the calendar, or related_iso for non-era calendars.
+    pub fn monotonic_year(self) -> i32 {
+        match self {
+            YearInfo::Era(e) => e.monotonic_year,
+            YearInfo::Cyclic(c) => c.related_iso,
+        }
+    }
+
     /// Get the era year information, if available
     pub fn era(self) -> Option<EraYear> {
         match self {
@@ -88,6 +102,8 @@ pub enum YearAmbiguity {
 pub struct EraYear {
     /// The numeric year in that era
     pub year: i32,
+    /// See [`YearInfo::monotonic_year()`]
+    pub monotonic_year: i32,
     /// The era code as defined by CLDR, expect for cases where CLDR does not define a code.
     pub era: TinyStr16,
     /// An era index, for calendars with a small set of eras.

--- a/components/calendar/tests/monotonic_year.rs
+++ b/components/calendar/tests/monotonic_year.rs
@@ -1,0 +1,72 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use icu_calendar::AnyCalendar;
+use icu_calendar::AnyCalendarKind;
+use icu_calendar::Date;
+
+#[cfg(test)]
+use std::rc::Rc;
+
+/// Reference: <https://tc39.es/proposal-intl-era-monthcode/#sec-temporal-calendardatearithmeticyear>
+static MONOTONIC_EPOCHS: &[(AnyCalendarKind, i32)] = &[
+    (AnyCalendarKind::Buddhist, -543),
+    (AnyCalendarKind::Chinese, 0),
+    (AnyCalendarKind::Coptic, 283),
+    (AnyCalendarKind::Dangi, 0),
+    (AnyCalendarKind::Ethiopian, 7),
+    (AnyCalendarKind::EthiopianAmeteAlem, -5493),
+    (AnyCalendarKind::Gregorian, 0),
+    (AnyCalendarKind::Hebrew, -3761),
+    (AnyCalendarKind::Indian, 78),
+    (AnyCalendarKind::HijriTabularTypeIIFriday, 621),
+    (AnyCalendarKind::HijriSimulatedMecca, 621),
+    (AnyCalendarKind::HijriTabularTypeIIThursday, 621),
+    (AnyCalendarKind::HijriUmmAlQura, 621),
+    (AnyCalendarKind::Iso, 0),
+    (AnyCalendarKind::Japanese, 0),
+    (AnyCalendarKind::JapaneseExtended, 0),
+    (AnyCalendarKind::Persian, 621),
+    (AnyCalendarKind::Roc, 1911),
+];
+
+#[test]
+fn test_monotonic_year() {
+    for (kind, monotonic_epoch) in MONOTONIC_EPOCHS.iter() {
+        let calendar = Rc::new(AnyCalendar::new(*kind));
+
+        let iso_date_in_epoch_year = Date::try_new_iso(*monotonic_epoch, 12, 31).unwrap();
+        let date_in_epoch_year = iso_date_in_epoch_year.to_calendar(calendar.clone());
+        assert_eq!(
+            date_in_epoch_year.monotonic_year(),
+            0,
+            "Monotonic year for {date_in_epoch_year:?} should be 0"
+        );
+
+        let iso_date_in_2025 = Date::try_new_iso(2025, 12, 31).unwrap();
+        let date_in_2025 = iso_date_in_2025.to_calendar(calendar.clone());
+
+        // The monotonic year should align with the year in the modern era or related ISO.
+        // There is a special case for Japanese since it has a modern era but uses ISO for the monotonic year.
+        if matches!(
+            kind,
+            AnyCalendarKind::Japanese | AnyCalendarKind::JapaneseExtended
+        ) {
+            assert_eq!(
+                date_in_2025.monotonic_year(),
+                2025,
+                "Monotonic year for {date_in_2025:?} should be 2025"
+            );
+        } else {
+            // Note: This code only works because 2025 is in the modern era for all calendars.
+            // These two function calls are not equivalent in general.
+            let expected = date_in_2025.year().era_year_or_related_iso();
+            assert_eq!(
+                date_in_2025.monotonic_year(),
+                expected,
+                "Monotonic year for {date_in_2025:?} should be {expected}"
+            );
+        }
+    }
+}

--- a/components/calendar/tests/monotonic_year.rs
+++ b/components/calendar/tests/monotonic_year.rs
@@ -44,7 +44,7 @@ fn test_monotonic_year() {
             Date::try_new_from_codes(None, 0, m_01, 1, calendar.clone()).unwrap();
         let iso_date_in_epoch_year = date_in_epoch_year.to_calendar(iso);
         assert_eq!(
-            iso_date_in_epoch_year.year().monotonic_year(),
+            iso_date_in_epoch_year.monotonic_year(),
             *monotonic_epoch,
             "Monotonic year for {date_in_epoch_year:?} should be {monotonic_epoch}"
         );

--- a/components/calendar/tests/monotonic_year.rs
+++ b/components/calendar/tests/monotonic_year.rs
@@ -2,6 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use icu_calendar::types::MonthCode;
 use icu_calendar::AnyCalendar;
 use icu_calendar::AnyCalendarKind;
 use icu_calendar::Date;
@@ -33,15 +34,19 @@ static MONOTONIC_EPOCHS: &[(AnyCalendarKind, i32)] = &[
 
 #[test]
 fn test_monotonic_year() {
+    let iso = icu_calendar::cal::Iso;
+    let m_01 = MonthCode::new_normal(1).unwrap();
     for (kind, monotonic_epoch) in MONOTONIC_EPOCHS.iter() {
         let calendar = Rc::new(AnyCalendar::new(*kind));
 
-        let iso_date_in_epoch_year = Date::try_new_iso(*monotonic_epoch, 12, 31).unwrap();
-        let date_in_epoch_year = iso_date_in_epoch_year.to_calendar(calendar.clone());
+        /// Create the first date in the epoch year (monotonic_year = 0)
+        let date_in_epoch_year =
+            Date::try_new_from_codes(None, 0, m_01, 1, calendar.clone()).unwrap();
+        let iso_date_in_epoch_year = date_in_epoch_year.to_calendar(iso);
         assert_eq!(
-            date_in_epoch_year.monotonic_year(),
-            0,
-            "Monotonic year for {date_in_epoch_year:?} should be 0"
+            iso_date_in_epoch_year.year().monotonic_year(),
+            *monotonic_epoch,
+            "Monotonic year for {date_in_epoch_year:?} should be {monotonic_epoch}"
         );
 
         let iso_date_in_2025 = Date::try_new_iso(2025, 12, 31).unwrap();

--- a/components/calendar/tests/monotonic_year.rs
+++ b/components/calendar/tests/monotonic_year.rs
@@ -49,7 +49,15 @@ fn test_monotonic_year() {
             "Monotonic year for {date_in_epoch_year:?} should be {monotonic_epoch}"
         );
 
-        let iso_date_in_2025 = Date::try_new_iso(2025, 12, 31).unwrap();
+        // Test that for all calendars except Japanese, the *current* era is
+        // the same as that used for the monotonic year
+        // This date can be anything as long as it is vaguely modern.
+        //
+        // Note that this property is not *required* by the specification, new
+        // calendars may have epochs that do not follow this property. This
+        // property is strongly suggested by the specification as a rule of thumb
+        // to follow where possible.
+        let iso_date_in_2025 = Date::try_new_iso(2025, 1, 1).unwrap();
         let date_in_2025 = iso_date_in_2025.to_calendar(calendar.clone());
 
         // The monotonic year should align with the year in the modern era or related ISO.

--- a/components/calendar/tests/monotonic_year.rs
+++ b/components/calendar/tests/monotonic_year.rs
@@ -39,7 +39,7 @@ fn test_monotonic_year() {
     for (kind, monotonic_epoch) in MONOTONIC_EPOCHS.iter() {
         let calendar = Rc::new(AnyCalendar::new(*kind));
 
-        /// Create the first date in the epoch year (monotonic_year = 0)
+        // Create the first date in the epoch year (monotonic_year = 0)
         let date_in_epoch_year =
             Date::try_new_from_codes(None, 0, m_01, 1, calendar.clone()).unwrap();
         let iso_date_in_epoch_year = date_in_epoch_year.to_calendar(iso);

--- a/components/icu/examples/iso_date_manipulations.rs
+++ b/components/icu/examples/iso_date_manipulations.rs
@@ -32,7 +32,7 @@ fn main() {
         let date = Date::try_new_iso(year, month, day).expect("date should parse");
         println!(
             "Year: {}, Month: {}, Day: {}",
-            date.extended_year(),
+            date.monotonic_year(),
             date.month().ordinal,
             date.day_of_month().0,
         );

--- a/components/time/src/ixdtf.rs
+++ b/components/time/src/ixdtf.rs
@@ -484,7 +484,7 @@ impl<A: AsCalendar> ZonedDateTime<A, TimeZoneInfo<models::AtTime>> {
     /// )
     /// .unwrap();
     ///
-    /// assert_eq!(zoneddatetime.date.extended_year(), 5784);
+    /// assert_eq!(zoneddatetime.date.monotonic_year(), 5784);
     /// assert_eq!(
     ///     zoneddatetime.date.month().standard_code,
     ///     icu::calendar::types::MonthCode(tinystr::tinystr!(4, "M11"))

--- a/components/time/src/zone/zone_name_timestamp.rs
+++ b/components/time/src/zone/zone_name_timestamp.rs
@@ -184,7 +184,7 @@ impl serde::Serialize for ZoneNameTimestamp {
         #[cfg(feature = "alloc")]
         if serializer.is_human_readable() {
             let date_time = self.to_zoned_date_time_iso();
-            let year = date_time.date.monotonic_year();
+            let year = date_time.date.era_year().year;
             let month = date_time.date.month().month_number();
             let day = date_time.date.day_of_month().0;
             let hour = date_time.time.hour.number();

--- a/components/time/src/zone/zone_name_timestamp.rs
+++ b/components/time/src/zone/zone_name_timestamp.rs
@@ -184,7 +184,7 @@ impl serde::Serialize for ZoneNameTimestamp {
         #[cfg(feature = "alloc")]
         if serializer.is_human_readable() {
             let date_time = self.to_zoned_date_time_iso();
-            let year = date_time.date.extended_year();
+            let year = date_time.date.monotonic_year();
             let month = date_time.date.month().month_number();
             let day = date_time.date.day_of_month().0;
             let hour = date_time.time.hour.number();

--- a/ffi/capi/bindings/c/Date.h
+++ b/ffi/capi/bindings/c/Date.h
@@ -56,6 +56,8 @@ int32_t icu4x_Date_era_year_or_related_iso_mv1(const Date* self);
 
 int32_t icu4x_Date_extended_year_mv1(const Date* self);
 
+int32_t icu4x_Date_monotonic_year_mv1(const Date* self);
+
 void icu4x_Date_era_mv1(const Date* self, DiplomatWrite* write);
 
 uint8_t icu4x_Date_months_in_year_mv1(const Date* self);

--- a/ffi/capi/bindings/cpp/icu4x/Date.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/Date.d.hpp
@@ -163,7 +163,7 @@ public:
   inline int32_t era_year_or_related_iso() const;
 
   /**
-   * Deprecated, use {@link Self::montonic_year}
+   * Deprecated, use {@link Self::monotonic_year}
    *
    * See the [Rust documentation for `extended_year`](https://docs.rs/icu/2.0.0/icu/calendar/struct.Date.html#method.extended_year) for more information.
    */

--- a/ffi/capi/bindings/cpp/icu4x/Date.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/Date.d.hpp
@@ -163,11 +163,18 @@ public:
   inline int32_t era_year_or_related_iso() const;
 
   /**
-   * Returns the extended year in the Date
+   * Deprecated, use {@link Self::montonic_year}
    *
    * See the [Rust documentation for `extended_year`](https://docs.rs/icu/2.0.0/icu/calendar/struct.Date.html#method.extended_year) for more information.
    */
   inline int32_t extended_year() const;
+
+  /**
+   * Returns the monotonic year in the Date
+   *
+   * See the [Rust documentation for `monotonic_year`](https://docs.rs/icu/2.0.0/icu/calendar/struct.Date.html#method.monotonic_year) for more information.
+   */
+  inline int32_t monotonic_year() const;
 
   /**
    * Returns the era for this date, or an empty string

--- a/ffi/capi/bindings/cpp/icu4x/Date.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/Date.hpp
@@ -59,6 +59,8 @@ namespace capi {
 
     int32_t icu4x_Date_extended_year_mv1(const icu4x::capi::Date* self);
 
+    int32_t icu4x_Date_monotonic_year_mv1(const icu4x::capi::Date* self);
+
     void icu4x_Date_era_mv1(const icu4x::capi::Date* self, diplomat::capi::DiplomatWrite* write);
 
     uint8_t icu4x_Date_months_in_year_mv1(const icu4x::capi::Date* self);
@@ -171,6 +173,11 @@ inline int32_t icu4x::Date::era_year_or_related_iso() const {
 
 inline int32_t icu4x::Date::extended_year() const {
   auto result = icu4x::capi::icu4x_Date_extended_year_mv1(this->AsFFI());
+  return result;
+}
+
+inline int32_t icu4x::Date::monotonic_year() const {
+  auto result = icu4x::capi::icu4x_Date_monotonic_year_mv1(this->AsFFI());
   return result;
 }
 

--- a/ffi/capi/bindings/dart/Date.g.dart
+++ b/ffi/capi/bindings/dart/Date.g.dart
@@ -185,7 +185,7 @@ final class Date implements ffi.Finalizable {
     return result;
   }
 
-  /// Deprecated, use [Self::montonic_year]
+  /// Deprecated, use [Self::monotonic_year]
   ///
   /// See the [Rust documentation for `extended_year`](https://docs.rs/icu/2.0.0/icu/calendar/struct.Date.html#method.extended_year) for more information.
   int get extendedYear {

--- a/ffi/capi/bindings/dart/Date.g.dart
+++ b/ffi/capi/bindings/dart/Date.g.dart
@@ -185,11 +185,19 @@ final class Date implements ffi.Finalizable {
     return result;
   }
 
-  /// Returns the extended year in the Date
+  /// Deprecated, use [Self::montonic_year]
   ///
   /// See the [Rust documentation for `extended_year`](https://docs.rs/icu/2.0.0/icu/calendar/struct.Date.html#method.extended_year) for more information.
   int get extendedYear {
     final result = _icu4x_Date_extended_year_mv1(_ffi);
+    return result;
+  }
+
+  /// Returns the monotonic year in the Date
+  ///
+  /// See the [Rust documentation for `monotonic_year`](https://docs.rs/icu/2.0.0/icu/calendar/struct.Date.html#method.monotonic_year) for more information.
+  int get monotonicYear {
+    final result = _icu4x_Date_monotonic_year_mv1(_ffi);
     return result;
   }
 
@@ -322,6 +330,11 @@ external int _icu4x_Date_era_year_or_related_iso_mv1(ffi.Pointer<ffi.Opaque> sel
 @ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Date_extended_year_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_Date_extended_year_mv1(ffi.Pointer<ffi.Opaque> self);
+
+@_DiplomatFfiUse('icu4x_Date_monotonic_year_mv1')
+@ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Date_monotonic_year_mv1')
+// ignore: non_constant_identifier_names
+external int _icu4x_Date_monotonic_year_mv1(ffi.Pointer<ffi.Opaque> self);
 
 @_DiplomatFfiUse('icu4x_Date_era_mv1')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Date_era_mv1')

--- a/ffi/capi/bindings/js/Date.d.ts
+++ b/ffi/capi/bindings/js/Date.d.ts
@@ -142,7 +142,7 @@ export class Date {
     get eraYearOrRelatedIso(): number;
 
     /**
-     * Deprecated, use {@link Self::montonic_year}
+     * Deprecated, use {@link Self::monotonic_year}
      *
      * See the [Rust documentation for `extended_year`](https://docs.rs/icu/2.0.0/icu/calendar/struct.Date.html#method.extended_year) for more information.
      */

--- a/ffi/capi/bindings/js/Date.d.ts
+++ b/ffi/capi/bindings/js/Date.d.ts
@@ -142,11 +142,18 @@ export class Date {
     get eraYearOrRelatedIso(): number;
 
     /**
-     * Returns the extended year in the Date
+     * Deprecated, use {@link Self::montonic_year}
      *
      * See the [Rust documentation for `extended_year`](https://docs.rs/icu/2.0.0/icu/calendar/struct.Date.html#method.extended_year) for more information.
      */
     get extendedYear(): number;
+
+    /**
+     * Returns the monotonic year in the Date
+     *
+     * See the [Rust documentation for `monotonic_year`](https://docs.rs/icu/2.0.0/icu/calendar/struct.Date.html#method.monotonic_year) for more information.
+     */
+    get monotonicYear(): number;
 
     /**
      * Returns the era for this date, or an empty string

--- a/ffi/capi/bindings/js/Date.mjs
+++ b/ffi/capi/bindings/js/Date.mjs
@@ -358,7 +358,7 @@ export class Date {
     }
 
     /**
-     * Deprecated, use {@link Self::montonic_year}
+     * Deprecated, use {@link Self::monotonic_year}
      *
      * See the [Rust documentation for `extended_year`](https://docs.rs/icu/2.0.0/icu/calendar/struct.Date.html#method.extended_year) for more information.
      */

--- a/ffi/capi/bindings/js/Date.mjs
+++ b/ffi/capi/bindings/js/Date.mjs
@@ -358,13 +358,30 @@ export class Date {
     }
 
     /**
-     * Returns the extended year in the Date
+     * Deprecated, use {@link Self::montonic_year}
      *
      * See the [Rust documentation for `extended_year`](https://docs.rs/icu/2.0.0/icu/calendar/struct.Date.html#method.extended_year) for more information.
      */
     get extendedYear() {
 
         const result = wasm.icu4x_Date_extended_year_mv1(this.ffiValue);
+
+        try {
+            return result;
+        }
+
+        finally {
+        }
+    }
+
+    /**
+     * Returns the monotonic year in the Date
+     *
+     * See the [Rust documentation for `monotonic_year`](https://docs.rs/icu/2.0.0/icu/calendar/struct.Date.html#method.monotonic_year) for more information.
+     */
+    get monotonicYear() {
+
+        const result = wasm.icu4x_Date_monotonic_year_mv1(this.ffiValue);
 
         try {
             return result;

--- a/ffi/capi/src/date.rs
+++ b/ffi/capi/src/date.rs
@@ -364,6 +364,7 @@ pub mod ffi {
 
         /// Returns the monotonic year in the Date
         #[diplomat::rust_link(icu::calendar::Date::monotonic_year, FnInStruct)]
+        #[diplomat::rust_link(::calendar::types::YearInfo::monotonic_year, FnInEnum, hidden)]
         #[diplomat::attr(auto, getter)]
         pub fn monotonic_year(&self) -> i32 {
             self.0.monotonic_year()

--- a/ffi/capi/src/date.rs
+++ b/ffi/capi/src/date.rs
@@ -364,7 +364,7 @@ pub mod ffi {
 
         /// Returns the monotonic year in the Date
         #[diplomat::rust_link(icu::calendar::Date::monotonic_year, FnInStruct)]
-        #[diplomat::rust_link(::calendar::types::YearInfo::monotonic_year, FnInEnum, hidden)]
+        #[diplomat::rust_link(icu::calendar::types::YearInfo::monotonic_year, FnInEnum, hidden)]
         #[diplomat::attr(auto, getter)]
         pub fn monotonic_year(&self) -> i32 {
             self.0.monotonic_year()

--- a/ffi/capi/src/date.rs
+++ b/ffi/capi/src/date.rs
@@ -355,7 +355,7 @@ pub mod ffi {
             self.0.year().era_year_or_related_iso()
         }
 
-        /// Deprecated, use [`Self::montonic_year`]
+        /// Deprecated, use [`Self::monotonic_year`]
         #[diplomat::rust_link(icu::calendar::Date::extended_year, FnInStruct)]
         #[diplomat::attr(auto, getter)]
         pub fn extended_year(&self) -> i32 {

--- a/ffi/capi/src/date.rs
+++ b/ffi/capi/src/date.rs
@@ -138,7 +138,7 @@ pub mod ffi {
         #[diplomat::attr(auto, getter)]
         #[diplomat::attr(demo_gen, disable)] // covered by Date
         pub fn year(&self) -> i32 {
-            self.0.extended_year()
+            self.0.monotonic_year()
         }
 
         /// Returns if the year is a leap year for this date
@@ -355,11 +355,18 @@ pub mod ffi {
             self.0.year().era_year_or_related_iso()
         }
 
-        /// Returns the extended year in the Date
+        /// Deprecated, use [`Self::montonic_year`]
         #[diplomat::rust_link(icu::calendar::Date::extended_year, FnInStruct)]
         #[diplomat::attr(auto, getter)]
         pub fn extended_year(&self) -> i32 {
-            self.0.extended_year()
+            self.0.monotonic_year()
+        }
+
+        /// Returns the monotonic year in the Date
+        #[diplomat::rust_link(icu::calendar::Date::monotonic_year, FnInStruct)]
+        #[diplomat::attr(auto, getter)]
+        pub fn monotonic_year(&self) -> i32 {
+            self.0.monotonic_year()
         }
 
         /// Returns the era for this date, or an empty string

--- a/provider/source/src/calendar/eras.rs
+++ b/provider/source/src/calendar/eras.rs
@@ -623,8 +623,8 @@ fn test_calendar_eras() {
                     // Check that the start/end date uses year 1, and minimal/maximal month/day
                     assert_eq!(era_year.year, 1, "Didn't get correct year for {in_era:?}");
                 }
-                // Cyclic calendars use related_iso for their arithmetical years, which won't
-                // work with the ICU4C "default" eras. Skip testing them.
+                // Cyclic calendars use related_iso for their monotonic years, which won't
+                // work with the CLDR "default" eras. Skip testing them.
                 icu::calendar::types::YearInfo::Cyclic(_) => (),
                 _ => unreachable!(),
             }

--- a/provider/source/src/calendar/eras.rs
+++ b/provider/source/src/calendar/eras.rs
@@ -553,7 +553,7 @@ fn test_calendar_eras() {
 
     for (calendar, data) in era_dates_map {
         let kind = match calendar.as_str() {
-            "generic" | "islamic" | "chinese" | "dangi" => continue,
+            "generic" | "islamic" => continue,
             "ethiopic-amete-alem" => AnyCalendarKind::EthiopianAmeteAlem,
             "gregorian" => AnyCalendarKind::Gregorian,
             "japanese" => AnyCalendarKind::JapaneseExtended,
@@ -623,9 +623,9 @@ fn test_calendar_eras() {
                     // Check that the start/end date uses year 1, and minimal/maximal month/day
                     assert_eq!(era_year.year, 1, "Didn't get correct year for {in_era:?}");
                 }
-                icu::calendar::types::YearInfo::Cyclic(_) => {
-                    assert_eq!(in_era.monotonic_year(), 1);
-                }
+                // Cyclic calendars use related_iso for their arithmetical years, which won't
+                // work with the ICU4C "default" eras. Skip testing them.
+                icu::calendar::types::YearInfo::Cyclic(_) => (),
                 _ => unreachable!(),
             }
 

--- a/provider/source/src/calendar/eras.rs
+++ b/provider/source/src/calendar/eras.rs
@@ -236,27 +236,9 @@ fn process_era_dates_map(
             .unwrap()
             .clone();
 
-        data.get_mut("chinese")
-            .unwrap()
-            .eras
-            .get_mut("0")
-            .unwrap()
-            .start = Some(EraStartDate {
-            year: -2636,
-            month: 2,
-            day: 15,
-        });
+        data.remove("chinese");
 
-        data.get_mut("dangi")
-            .unwrap()
-            .eras
-            .get_mut("0")
-            .unwrap()
-            .start = Some(EraStartDate {
-            year: -2332,
-            month: 2,
-            day: 15,
-        });
+        data.remove("dangi");
 
         data.get_mut("hebrew")
             .unwrap()

--- a/provider/source/src/calendar/eras.rs
+++ b/provider/source/src/calendar/eras.rs
@@ -236,9 +236,27 @@ fn process_era_dates_map(
             .unwrap()
             .clone();
 
-        data.remove("chinese");
+        data.get_mut("chinese")
+            .unwrap()
+            .eras
+            .get_mut("0")
+            .unwrap()
+            .start = Some(EraStartDate {
+            year: -2636,
+            month: 2,
+            day: 15,
+        });
 
-        data.remove("dangi");
+        data.get_mut("dangi")
+            .unwrap()
+            .eras
+            .get_mut("0")
+            .unwrap()
+            .start = Some(EraStartDate {
+            year: -2332,
+            month: 2,
+            day: 15,
+        });
 
         data.get_mut("hebrew")
             .unwrap()

--- a/provider/source/src/calendar/eras.rs
+++ b/provider/source/src/calendar/eras.rs
@@ -187,7 +187,7 @@ fn process_era_dates_map(
                 .unwrap()
                 .to_iso();
             *d = EraStartDate {
-                year: date.extended_year(),
+                year: date.monotonic_year(),
                 month: date.month().ordinal,
                 day: date.day_of_month().0,
             };
@@ -553,7 +553,7 @@ fn test_calendar_eras() {
 
     for (calendar, data) in era_dates_map {
         let kind = match calendar.as_str() {
-            "generic" | "islamic" => continue,
+            "generic" | "islamic" | "chinese" | "dangi" => continue,
             "ethiopic-amete-alem" => AnyCalendarKind::EthiopianAmeteAlem,
             "gregorian" => AnyCalendarKind::Gregorian,
             "japanese" => AnyCalendarKind::JapaneseExtended,
@@ -621,10 +621,10 @@ fn test_calendar_eras() {
                     }
 
                     // Check that the start/end date uses year 1, and minimal/maximal month/day
-                    assert_eq!(era_year.year, 1);
+                    assert_eq!(era_year.year, 1, "Didn't get correct year for {in_era:?}");
                 }
                 icu::calendar::types::YearInfo::Cyclic(_) => {
-                    assert_eq!(in_era.extended_year(), 1);
+                    assert_eq!(in_era.monotonic_year(), 1);
                 }
                 _ => unreachable!(),
             }

--- a/tools/web-demo/gen/index.mjs
+++ b/tools/web-demo/gen/index.mjs
@@ -689,6 +689,41 @@ let termini = Object.assign({
         ]
     },
 
+    "Date.monotonicYear": {
+        func: (selfIsoYear, selfIsoMonth, selfIsoDay, selfCalendarKind) => icu.Date.fromIsoInCalendar(selfIsoYear, selfIsoMonth, selfIsoDay, new icu.Calendar(selfCalendarKind)).monotonicYear,
+        // For avoiding webpacking minifying issues:
+        funcName: "Date.monotonicYear",
+        expr: (selfIsoYear, selfIsoMonth, selfIsoDay, selfCalendarKind) => "icu.Date.fromIsoInCalendar(selfIsoYear, selfIsoMonth, selfIsoDay, new icu.Calendar(selfCalendarKind)).monotonicYear".replace(/([\( ])selfIsoYear([,\) \n])/, '$1' + selfIsoYear + '$2').replace(/([\( ])selfIsoMonth([,\) \n])/, '$1' + selfIsoMonth + '$2').replace(/([\( ])selfIsoDay([,\) \n])/, '$1' + selfIsoDay + '$2').replace(/([\( ])selfCalendarKind([,\) \n])/, '$1' + selfCalendarKind + '$2'),
+        parameters: [
+            
+            {
+                name: "self_isoYear",
+                type: "number",
+                typeUse: "number"
+            },
+            
+            {
+                name: "self_isoMonth",
+                type: "number",
+                typeUse: "number"
+            },
+            
+            {
+                name: "self_isoDay",
+                type: "number",
+                typeUse: "number"
+            },
+            
+            {
+                name: "self_calendar_kind",
+                type: "CalendarKind",
+                typeUse: "enumerator",
+                values: ["Iso", "Gregorian", "Buddhist", "Japanese", "JapaneseExtended", "Ethiopian", "EthiopianAmeteAlem", "Indian", "Coptic", "Dangi", "Chinese", "Hebrew", "HijriTabularTypeIIFriday", "HijriSimulatedMecca", "HijriTabularTypeIIThursday", "HijriUmmAlQura", "Persian", "Roc"]
+            }
+            
+        ]
+    },
+
     "Date.era": {
         func: (selfIsoYear, selfIsoMonth, selfIsoDay, selfCalendarKind) => icu.Date.fromIsoInCalendar(selfIsoYear, selfIsoMonth, selfIsoDay, new icu.Calendar(selfCalendarKind)).era,
         // For avoiding webpacking minifying issues:


### PR DESCRIPTION
Supersedes #6762

This also fixes the bug that we were bounds checking extended year: You should be able to do things like `Gregorian::new(year = -100, era = None, ...)`, but we errored here.


In the process; I discovered that Chinese was _accepting_ related_iso as extended year, but _producing_ ICU4C extended year. This is inconsistent.


This serves as another nail in the coffin for any ICU4C-parity guarantee we had for extended_year, because we now have found multiple cases where we are not handling it the ICU4C way already.

The name monotonic_year is to be bikeshed.