### PR TITLE
Fix safety issue in ZeroVec::truncated; publish 0.11.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Several crates have had patch releases in the 2.0 stream:
   - (0.11.3) Make ZeroVec.iter().collect() faster (unicode-org#6764)
   - (0.11.3) Implement `ZeroMapKV` for `VarTupleULE` (unicode-org#6750)
   - (0.11.3) Add `ZeroVec::truncated()` (unicode-org#6604)
+  - (0.11.4) Fix safety issue in `ZeroVec::truncated()` (unicode-org#6805)
 
 ## icu4x 2.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3958,7 +3958,7 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "bincode",
  "criterion",

--- a/utils/zerovec/Cargo.toml
+++ b/utils/zerovec/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "zerovec"
 description = "Zero-copy vector backed by a byte array"
-version = "0.11.3"
+version = "0.11.4"
 categories = ["rust-patterns", "memory-management", "caching", "no-std", "data-structures"]
 keywords = ["zerocopy", "serialization", "zero-copy", "serde"]
 

--- a/utils/zerovec/src/zerovec/mod.rs
+++ b/utils/zerovec/src/zerovec/mod.rs
@@ -172,7 +172,7 @@ impl<U> EyepatchHackVector<U> {
         self.buf = unsafe {
             NonNull::new_unchecked(core::ptr::slice_from_raw_parts_mut(
                 self.buf.as_mut().as_mut_ptr(),
-                core::cmp::max(max, self.buf.as_ref().len()),
+                core::cmp::min(max, self.buf.as_ref().len()),
             ))
         };
     }


### PR DESCRIPTION
Introduced by #6604

cc @hsivonen @robertbastian

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->