### PR TITLE
Write a proper safety comment for ZeroVec::truncate

### DIFF
--- a/utils/zerovec/src/zerovec/mod.rs
+++ b/utils/zerovec/src/zerovec/mod.rs
@@ -167,8 +167,12 @@ impl<U> EyepatchHackVector<U> {
     }
 
     fn truncate(&mut self, max: usize) {
-        // SAFETY: The elements in buf are `ULE`, so they don't need to be dropped
-        // even if we own them.
+        // SAFETY:
+        // - The elements in buf are `ULE`, so they don't need to be dropped even if we own them.
+        // - self.buf is a valid, nonnull slice pointer, since it comes from a NonNull and the struct
+        //   invariant requires validity.
+        // - Because of the `min`, we are guaranteed to be constructing a slice of the same length or
+        //   smaller, from the same pointer, so it will be valid as well, and similarly non-null.
         self.buf = unsafe {
             NonNull::new_unchecked(core::ptr::slice_from_raw_parts_mut(
                 self.buf.as_mut().as_mut_ptr(),


### PR DESCRIPTION
Fixes #6808

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->