### PR TITLE
Update Dart toolchain to `3.10.0-22.0.dev`

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -347,7 +347,7 @@ jobs:
     # Job-specific dependencies
     - uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672 # v1.6.5
       with:
-        sdk: ${{ github.event_name != 'schedule' && '3.9.0-138.0.dev' || 'dev' }}
+        sdk: ${{ github.event_name != 'schedule' && '3.10.0-22.0.dev' || 'dev' }}
     - name: Install yq if Windows
       if: ${{ matrix.os == 'windows-latest' }}
       run: choco install yq

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -358,7 +358,7 @@ jobs:
 
     - name: Run `cargo make ci-job-test-dart` in local mode
       run: |
-        cp ffi/dart/.dart_tool/native_assets/lib/* dylib
+        cp ffi/dart/.dart_tool/lib/* dylib
         yq -i ".hooks.user_defines.icu4x.buildMode = \"local\"" ffi/dart/pubspec.yaml
         yq -i ".hooks.user_defines.icu4x.localPath = \"file://$(realpath dylib)\"" ffi/dart/pubspec.yaml
         yq -i ".hooks.user_defines.icu4x.buildMode = \"local\"" examples/dart/pubspec.yaml

--- a/examples/dart/.gitignore
+++ b/examples/dart/.gitignore
@@ -1,4 +1,4 @@
 # https://dart.dev/guides/libraries/private-files
 # Created by `dart pub`
 .dart_tool/
-bin/example/
+build/

--- a/tools/make/ffi.toml
+++ b/tools/make/ffi.toml
@@ -73,9 +73,11 @@ cd examples/dart
 exec --fail-on-error dart pub get
 exec --fail-on-error dart format --set-exit-if-changed .
 exec --fail-on-error dart analyze
-exec --fail-on-error dart --enable-experiment=native-assets --enable-experiment=record-use build bin/example.dart
-exec --fail-on-error bin/example/example.exe
-libs = glob_array ./bin/example/lib/*
+exec --fail-on-error dart --enable-experiment=native-assets --enable-experiment=record-use build cli bin/example.dart
+bins = glob_array ./build/cli/*/bundle/bin/example
+bin = array_pop ${bins}
+exec --fail-on-error ${bin}
+libs = glob_array ./build/cli/*/bundle/lib/*
 lib = array_pop ${libs}
 size = filesize ${lib}
 println ${size} "bytes"

--- a/tools/make/ffi.toml
+++ b/tools/make/ffi.toml
@@ -74,7 +74,7 @@ exec --fail-on-error dart pub get
 exec --fail-on-error dart format --set-exit-if-changed .
 exec --fail-on-error dart analyze
 exec --fail-on-error dart --enable-experiment=native-assets --enable-experiment=record-use build cli bin/example.dart
-bins = glob_array ./build/cli/*/bundle/bin/example
+bins = glob_array ./build/cli/*/bundle/bin/*
 bin = array_pop ${bins}
 exec --fail-on-error ${bin}
 libs = glob_array ./build/cli/*/bundle/lib/*


### PR DESCRIPTION
This is the latest toolchain that works on Mac (https://github.com/dart-lang/sdk/issues/61235)