### PR TITLE
Add some zoneinfo docs

### DIFF
--- a/utils/zoneinfo64/src/lib.rs
+++ b/utils/zoneinfo64/src/lib.rs
@@ -37,11 +37,21 @@ enum TzZone<'a> {
 }
 
 struct TzZoneData<'a> {
+    /// Transitions before the epoch of i32::MIN
     trans_pre32: &'a [(i32, i32)],
+    /// Transitions with epoch values that can fit in an i32
     trans: &'a [i32],
+    /// Transitions after the epoch of i32::MAX
     trans_post32: &'a [(i32, i32)],
+    /// Map to offset from transitions. Treat [trans_pre32, trans, trans_post32]
+    /// as a single array and use its corresponding index into this to get the index
+    /// in type_offsets. The index in type_offsets is the *new* offset after the
+    /// matching transition
     type_map: &'a [u8],
+    /// Offsets. First entry is standard time, second entry is offset from standard time (if any)
     type_offsets: &'a [(i32, i32)],
+    /// An index into the Rules table,
+    /// its standard_offset_seconds, and its starting year.
     final_rule_offset_year: Option<(u32, i32, u32)>,
     #[allow(dead_code)]
     links: &'a [u32],
@@ -419,7 +429,9 @@ pub struct Zone<'a> {
 
 #[derive(Debug, Clone, Copy)]
 struct Rule<'a> {
+    /// The year the rule starts applying
     start_year: u32,
+    /// The offset of standard time
     standard_offset_seconds: i32,
     inner: &'a TzRule,
 }

--- a/utils/zoneinfo64/src/rule.rs
+++ b/utils/zoneinfo64/src/rule.rs
@@ -9,7 +9,7 @@ pub(crate) struct TzRule {
     pub(crate) additional_offset_secs: i32,
     /// The yearly start date of the rule
     pub(crate) start: TzRuleDate,
-    /// The end date of Daylight Savings
+    /// The yearly end date of the rule
     pub(crate) end: TzRuleDate,
 }
 

--- a/utils/zoneinfo64/src/rule.rs
+++ b/utils/zoneinfo64/src/rule.rs
@@ -5,7 +5,7 @@
 #[derive(Debug)]
 pub(crate) struct TzRule {
     /// The amount of seconds to add to standard_offset_seconds
-    /// to get the offset in daylight time
+    /// to get the total offset
     pub(crate) additional_offset_secs: i32,
     /// The start date of Daylight Savings
     pub(crate) start: TzRuleDate,

--- a/utils/zoneinfo64/src/rule.rs
+++ b/utils/zoneinfo64/src/rule.rs
@@ -4,35 +4,91 @@
 
 #[derive(Debug)]
 pub(crate) struct TzRule {
-    additional_offset_secs: i32,
-    start: TzRuleDate,
-    end: TzRuleDate,
+    /// The amount of seconds to add to standard_offset_seconds
+    /// to get the offset in daylight time
+    pub(crate) additional_offset_secs: i32,
+    /// The start date of Daylight Savings
+    pub(crate) start: TzRuleDate,
+    /// The end date of Daylight Savings
+    pub(crate) end: TzRuleDate,
 }
 
 #[derive(Debug)]
-struct TzRuleDate {
-    day: i8,
-    day_of_week: i8,
-    month: u8,
-    millis_of_day: u32,
-    time_mode: TimeMode,
-    mode: RuleMode,
+pub(crate) struct TzRuleDate {
+    /// A 1-indexed day number
+    pub(crate) day: i8,
+    /// A 1-indexed day of the week (1 = Sunday)
+    pub(crate) day_of_week: i8,
+    /// A 0-indexed month number
+    pub(crate) month: u8,
+    /// The time in the day that the transition occurs
+    pub(crate) millis_of_day: u32,
+    /// How to interpret millis_of_day
+    pub(crate) time_mode: TimeMode,
+    /// How to interpret day, day_of_week, and month
+    pub(crate) mode: RuleMode,
 }
 
 #[derive(Debug)]
-enum TimeMode {
+pub(crate) enum TimeMode {
+    /// {millis_of_day} is local wall clock time in the time zone
+    /// *before* the transition
+    ///
+    /// i.e. if the transition between LST and LDT is to happen at 02:00,
+    /// the time that *would be* 02:00 LST would be the first time of LDT.
+    ///
+    /// This means that `{local_wall_clock_time}` may never actually be the
+    /// wall clock time! The America/Los_Angeles transition occurs at Wall 02:00,
+    /// however the transition from PST to PDT is
+    /// `2025-03-09T01:59:59-08:00[America/Los_Angeles]` to
+    /// 2025-03-09T03:00:00-07:00[America/Los_Angeles],
+    /// so 2025-03-09T02:00:00 never occurs.
+    ///
+    /// This can be turned into Standard by subtracting the offset-from-standard
+    /// of the time zone *before* this transition
     Wall = 0,
+    /// {millis_of_day} is local standard time
+    ///
+    /// Will produce different results from Wall=0 for DST-to-STD transitions
+    ///
+    /// This can be turned into Wall by adding the offset-from-standard of the time zone
+    /// *before* this transition.
     Standard = 1,
+    /// {millis_of_day} is UTC time
+    ///
+    /// This is UTC time *on the UTC day* identified by this rule; which may
+    /// end up on a different local day.
+    ///
+    /// For example, America/Santiago transitions to STD on the first Sunday after April 2.
+    /// at UTC 03:00:00, which is `2025-04-06T03:00:00+00:00[UTC]`. This ends up being
+    /// a transition from`2025-04-05T23:59:59-03:00[America/Santiago]` to
+    /// `2025-04-05T23:00:00-04:00[America/Santiago]`).
+    ///
+    /// This can be turned into Standard by subtracting the standard-offset-from-UTC of the
+    /// time zone. It can be turned into Wall by subtracting the offset-from-UTC of the time zone
+    /// before this transition.
     Utc = 2,
 }
 
 #[derive(Debug, PartialEq)]
 #[allow(non_camel_case_types, clippy::upper_case_acronyms)]
-enum RuleMode {
+/// How to interpret `{day}` `{day_of_week}` and `{month}`
+pub(crate) enum RuleMode {
+    /// The {day}th {day_of_week} in {month}
+    ///
+    /// Current zoneinfo64 does not use this, instead
+    /// choosing to represent this as DOW_GEQ_DOM with day = 1/8/15/22
     DOW_IN_MONTH,
+    /// {month} {day}
+    ///
+    /// Current zoneinfo64 does not use this
     DOM,
-    DOW_GE_DOM,
-    DOW_LE_DOM,
+    /// The first {day_of_week} on or after {month} {day}
+    DOW_GEQ_DOM,
+    /// The first {day_of_week} on or before {month} {day}
+    ///
+    /// Typically, this represents rules like "Last Sunday in March" (Europe/London)
+    DOW_LEQ_DOM,
 }
 
 impl TzRule {
@@ -96,10 +152,10 @@ impl TzRuleDate {
             } else {
                 day_of_week = -day_of_week;
                 if day > 0 {
-                    mode = RuleMode::DOW_GE_DOM;
+                    mode = RuleMode::DOW_GEQ_DOM;
                 } else {
                     day = -day;
-                    mode = RuleMode::DOW_LE_DOM;
+                    mode = RuleMode::DOW_LEQ_DOM;
                 }
             }
             if day_of_week > 7 {

--- a/utils/zoneinfo64/src/rule.rs
+++ b/utils/zoneinfo64/src/rule.rs
@@ -7,7 +7,7 @@ pub(crate) struct TzRule {
     /// The amount of seconds to add to standard_offset_seconds
     /// to get the total offset
     pub(crate) additional_offset_secs: i32,
-    /// The start date of Daylight Savings
+    /// The yearly start date of the rule
     pub(crate) start: TzRuleDate,
     /// The end date of Daylight Savings
     pub(crate) end: TzRuleDate,

--- a/utils/zoneinfo64/src/rule.rs
+++ b/utils/zoneinfo64/src/rule.rs
@@ -5,7 +5,7 @@
 #[derive(Debug)]
 pub(crate) struct TzRule {
     /// The amount of seconds to add to standard_offset_seconds
-    /// to get the total offset
+    /// to get the rule offset
     pub(crate) additional_offset_secs: i32,
     /// The yearly start date of the rule
     pub(crate) start: TzRuleDate,
@@ -34,7 +34,7 @@ pub(crate) enum TimeMode {
     /// {millis_of_day} is local wall clock time in the time zone
     /// *before* the transition
     ///
-    /// i.e. if the transition between LST and LDT is to happen at 02:00,
+    /// e.g. if the transition between LST and LDT is to happen at 02:00,
     /// the time that *would be* 02:00 LST would be the first time of LDT.
     ///
     /// This means that `{local_wall_clock_time}` may never actually be the


### PR DESCRIPTION
Does it make sense to have these fields be public? I was hoping to write a zoneinfo64-inspect tool similar to tzif-inspect.


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->