### PR TITLE
Change debug output of PluralElementsPackedULE

### DIFF
--- a/components/plurals/src/provider.rs
+++ b/components/plurals/src/provider.rs
@@ -395,7 +395,7 @@ pub struct PluralElementsPackedCow<'data, V: VarULE + ?Sized> {
 /// A bitpacked DST for [`PluralElements`].
 ///
 /// Can be put in a [`Cow`] or a [`VarZeroSlice`].
-#[derive(Debug, PartialEq, Eq)]
+#[derive(PartialEq, Eq)]
 #[repr(transparent)]
 pub struct PluralElementsPackedULE<V: VarULE + ?Sized> {
     _v: PhantomData<V>,
@@ -414,6 +414,16 @@ pub struct PluralElementsPackedULE<V: VarULE + ?Sized> {
     /// - Bytes 2..(2+L): the default (plural "other") value `V`
     /// - Remainder: [`PluralElementsTupleSliceVarULE`]
     bytes: [u8],
+}
+
+impl<V: VarULE + fmt::Debug + ?Sized> fmt::Debug for PluralElementsPackedULE<V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let unpacked = self.as_parts();
+        f.debug_struct("PluralElementsPackedULE")
+            .field("parts", &unpacked)
+            .field("bytes", &&self.bytes)
+            .finish()
+    }
 }
 
 impl<V: VarULE + ?Sized> ToOwned for PluralElementsPackedULE<V> {
@@ -755,6 +765,7 @@ struct PluralElementsPackedBuilder<'a, T> {
 }
 
 /// Internal unpacked and deserialized values from a [`PluralElementsPackedULE`].
+#[derive(Debug)]
 struct PluralElementsUnpacked<'a, V: VarULE + ?Sized> {
     pub default: PluralElementWithMetadata<'a, V>,
     pub specials: Option<&'a PluralElementsTupleSliceVarULE<V>>,


### PR DESCRIPTION
```rust
    let mut prefs = DateTimeFormatterPreferences::from(locale!("th-TH"));
    prefs.hour_cycle = Some(HourCycle::H12);
    let formatter = NoCalendarFormatter::try_new(prefs, fieldsets::T::hms().with_length(Length::Long)).unwrap();
    println!("{formatter:?}");
```

Old output:

> FixedCalendarDateTimeFormatter { selection: DateTimeZonePatternSelectionData { options: RawOptions { length: Some(Long), date_fields: None, alignment: None, year_style: None, time_precision: Some(Second) }, prefs: RawPreferences { hour_cycle: Some(H12) }, date: DatePatternSelectionData { payload: () }, time: TimePatternSelectionData { payload: PackedPatterns { header: 898192, elements: [PluralElementsPackedULE { _v: PhantomData<zerovec::zerovec::slice::ZeroSlice<icu_datetime::provider::pattern::item::PatternItem>>, bytes: [1, 128, 113, 1, 0, 32, 47, 128, 96, 1] }, PluralElementsPackedULE { _v: PhantomData<zerovec::zerovec::slice::ZeroSlice<icu_datetime::provider::pattern::item::PatternItem>>, bytes: [2, 128, 113, 1, 0, 0, 58, 128, 128, 2, 0, 0, 32, 128, 96, 1] }, PluralElementsPackedULE { _v: PhantomData<zerovec::zerovec::slice::ZeroSlice<icu_datetime::provider::pattern::item::PatternItem>>, bytes: [3, 128, 113, 1, 0, 0, 58, 128, 128, 2, 0, 0, 58, 128, 144, 2, 0, 0, 32, 128, 96, 1] }] } }, zone: None, glue: None }, names: RawDateTimeNames { year_names: (), month_names: (), weekday_names: (), dayperiod_names: SingleLength { variables: Abbreviated, payload: LinearNames { names: ["AM", "PM", "เท\u{e35}\u{e48}ยง", "เท\u{e35}\u{e48}ยงค\u{e37}น"] } }, zone_essentials: (), locations_root: (), locations: (), exemplars_root: (), exemplars: (), mz_generic_long: (), mz_generic_short: (), mz_standard_long: (), mz_specific_long: (), mz_specific_short: (), mz_periods: (), decimal_formatter: Some(DecimalFormatter { options: DecimalFormatterOptions { grouping_strategy: Some(Never) }, symbols: DecimalSymbols { strings: DecimalSymbolStrsBuilder { minus_sign_prefix: "-", minus_sign_suffix: "", plus_sign_prefix: "+", plus_sign_suffix: "", decimal_separator: ".", grouping_separator: ",", numsys: "latn" }, grouping_sizes: GroupingSizes { primary: 3, secondary: 3, min_grouping: 1 } }, digits: ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'] }) }, _calendar: PhantomData<()> }

New output:

> FixedCalendarDateTimeFormatter { selection: DateTimeZonePatternSelectionData { options: RawOptions { length: Some(Long), date_fields: None, alignment: None, year_style: None, time_precision: Some(Second) }, prefs: RawPreferences { hour_cycle: Some(H12) }, date: DatePatternSelectionData { payload: () }, time: TimePatternSelectionData { payload: PackedPatterns { header: 898192, elements: [PluralElementsPackedULE { parts: PluralElementsUnpacked { default: (FourBitMetadata(1), ZeroVec([Field(Field { symbol: Hour(H12), length: One }), Literal('\u{202f}'), Field(Field { symbol: DayPeriod(AmPm), length: One })])), specials: None }, bytes: [1, 128, 113, 1, 0, 32, 47, 128, 96, 1] }, PluralElementsPackedULE { parts: PluralElementsUnpacked { default: (FourBitMetadata(2), ZeroVec([Field(Field { symbol: Hour(H12), length: One }), Literal(':'), Field(Field { symbol: Minute, length: Two }), Literal(' '), Field(Field { symbol: DayPeriod(AmPm), length: One })])), specials: None }, bytes: [2, 128, 113, 1, 0, 0, 58, 128, 128, 2, 0, 0, 32, 128, 96, 1] }, PluralElementsPackedULE { parts: PluralElementsUnpacked { default: (FourBitMetadata(3), ZeroVec([Field(Field { symbol: Hour(H12), length: One }), Literal(':'), Field(Field { symbol: Minute, length: Two }), Literal(':'), Field(Field { symbol: Second(Second), length: Two }), Literal(' '), Field(Field { symbol: DayPeriod(AmPm), length: One })])), specials: None }, bytes: [3, 128, 113, 1, 0, 0, 58, 128, 128, 2, 0, 0, 58, 128, 144, 2, 0, 0, 32, 128, 96, 1] }] } }, zone: None, glue: None }, names: RawDateTimeNames { year_names: (), month_names: (), weekday_names: (), dayperiod_names: SingleLength { variables: Abbreviated, payload: LinearNames { names: ["AM", "PM", "เท\u{e35}\u{e48}ยง", "เท\u{e35}\u{e48}ยงค\u{e37}น"] } }, zone_essentials: (), locations_root: (), locations: (), exemplars_root: (), exemplars: (), mz_generic_long: (), mz_generic_short: (), mz_standard_long: (), mz_specific_long: (), mz_specific_short: (), mz_periods: (), decimal_formatter: Some(DecimalFormatter { options: DecimalFormatterOptions { grouping_strategy: Some(Never) }, symbols: DecimalSymbols { strings: DecimalSymbolStrsBuilder { minus_sign_prefix: "-", minus_sign_suffix: "", plus_sign_prefix: "+", plus_sign_suffix: "", decimal_separator: ".", grouping_separator: ",", numsys: "latn" }, grouping_sizes: GroupingSizes { primary: 3, secondary: 3, min_grouping: 1 } }, digits: ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'] }) }, _calendar: PhantomData<()> }

Do you think it's better? You can see the pattern parts, but it is more verbose.