### PR TITLE
Make trivial constructors for Char16Trie / Char16TrieIterator inline-eligible

### DIFF
--- a/components/collections/src/char16trie/trie.rs
+++ b/components/collections/src/char16trie/trie.rs
@@ -88,11 +88,13 @@ pub struct Char16Trie<'data> {
 
 impl<'data> Char16Trie<'data> {
     /// Returns a new [`Char16Trie`] with ownership of the provided data.
+    #[inline]
     pub fn new(data: ZeroVec<'data, u16>) -> Self {
         Self { data }
     }
 
     /// Returns a new [`Char16TrieIterator`] backed by borrowed data from the `trie` data
+    #[inline]
     pub fn iter(&self) -> Char16TrieIterator<'_> {
         Char16TrieIterator::new(&self.data)
     }
@@ -164,6 +166,7 @@ macro_rules! trie_unwrap {
 
 impl<'a> Char16TrieIterator<'a> {
     /// Returns a new [`Char16TrieIterator`] backed by borrowed data for the `trie` array
+    #[inline]
     pub fn new(trie: &'a ZeroSlice<u16>) -> Self {
         Self {
             trie,


### PR DESCRIPTION
This seems to make code that uses these a bit faster, and these are so small as to be harmless for code size.