### PR TITLE
Add RataDie::in_well_behaved_astronomical_range(), use to avoid panics

### DIFF
--- a/components/calendar/src/cal/chinese_based.rs
+++ b/components/calendar/src/cal/chinese_based.rs
@@ -153,12 +153,18 @@ impl ChineseBasedYearInfo {
             chinese_based::month_structure_for_year::<CB>(new_year, next_new_year);
 
         let ny_offset = new_year - calendrical_calculations::iso::fixed_from_iso(related_iso, 1, 1);
+
+        #[cfg(debug_assertions)]
+        let out_of_valid_astronomical_range =
+            !WELL_BEHAVED_ASTRONOMICAL_YEAR_RANGE.contains(&i64::from(related_iso));
+        #[cfg(not(debug_assertions))]
+        let out_of_valid_astronomical_range = false;
         Self {
             packed_data: PackedChineseBasedYearInfo::new(
                 month_lengths,
                 leap_month,
                 ny_offset,
-                !WELL_BEHAVED_ASTRONOMICAL_YEAR_RANGE.contains(&i64::from(related_iso)),
+                out_of_valid_astronomical_range,
             ),
             related_iso,
         }

--- a/components/calendar/src/provider/chinese_based.rs
+++ b/components/calendar/src/provider/chinese_based.rs
@@ -105,11 +105,17 @@ impl PackedChineseBasedYearInfo {
             "Last month length should not be set for non-leap years"
         );
         let mut ny_offset = ny_offset - Self::FIRST_NY;
+
         if out_of_valid_astronomical_range {
-            ny_offset = cmp::min(33, cmp::max(0, ny_offset));
+            // When out of range, just clamp to something we can represent
+            // We can store up to 6 bytes for ny_offset, even if our
+            // maximum asserted value is otherwise 33
+            ny_offset = cmp::min(0x40, cmp::max(0, ny_offset));
+        } else {
+            debug_assert!(ny_offset >= 0, "Year offset too small to store");
+            // The maximum new-year's offset we have found is 33
+            debug_assert!(ny_offset < 34, "Year offset too big to store");
         }
-        debug_assert!(ny_offset >= 0, "Year offset too small to store");
-        debug_assert!(ny_offset < 34, "Year offset too big to store");
         // Also an API correctness assertion
         debug_assert!(
             leap_month_idx.map(|l| l <= 13).unwrap_or(true),

--- a/components/calendar/src/provider/chinese_based.rs
+++ b/components/calendar/src/provider/chinese_based.rs
@@ -91,6 +91,8 @@ impl PackedChineseBasedYearInfo {
     /// out_of_valid_astronomical_range is true when the data is for a date that is well
     /// outside calendrical_calculations::chinese_based::WELL_BEHAVED_ASTRONOMICAL_RANGE.
     /// It clamps some values to avoid debug assertions on calendrical invariants.
+    ///
+    /// It only needs to be set in debug-assertions mode, and is ignored in release.
     pub(crate) fn new(
         month_lengths: [bool; 13],
         leap_month_idx: Option<u8>,

--- a/components/calendar/src/provider/chinese_based.rs
+++ b/components/calendar/src/provider/chinese_based.rs
@@ -12,7 +12,6 @@
 //!
 //! Read more about data providers: [`icu_provider`]
 
-use core::cmp;
 use icu_provider::prelude::*;
 use zerovec::ule::{AsULE, ULE};
 use zerovec::ZeroVec;
@@ -110,7 +109,7 @@ impl PackedChineseBasedYearInfo {
             // When out of range, just clamp to something we can represent
             // We can store up to 6 bytes for ny_offset, even if our
             // maximum asserted value is otherwise 33
-            ny_offset = cmp::min(0x40, cmp::max(0, ny_offset));
+            ny_offset = ny_offset.clamp(0, 0x40);
         } else {
             debug_assert!(ny_offset >= 0, "Year offset too small to store");
             // The maximum new-year's offset we have found is 33

--- a/components/calendar/src/tests/extrema.rs
+++ b/components/calendar/src/tests/extrema.rs
@@ -22,6 +22,9 @@ fn check_extrema<C: Calendar>(cal: C) {
     );
 }
 
+// Test all calendars that have any amount of tricky mathematics
+// to ensure that they do not trigger debug assertions for large dates.
+
 #[test]
 fn check_extrema_chinese() {
     check_extrema(Chinese::new())
@@ -40,4 +43,26 @@ fn check_extrema_hijri_simulated_mecca() {
 #[test]
 fn check_extrema_hijri_uaq() {
     check_extrema(HijriUmmAlQura::new())
+}
+
+#[test]
+fn check_extrema_hijri_tabular() {
+    check_extrema(HijriTabular::new(
+        HijriTabularLeapYears::TypeII,
+        HijriTabularEpoch::Thursday,
+    ));
+    check_extrema(HijriTabular::new(
+        HijriTabularLeapYears::TypeII,
+        HijriTabularEpoch::Friday,
+    ));
+}
+
+#[test]
+fn check_extrema_hebrew() {
+    check_extrema(Hebrew::new())
+}
+
+#[test]
+fn check_extrema_persian() {
+    check_extrema(Persian::new())
 }

--- a/components/calendar/src/tests/extrema.rs
+++ b/components/calendar/src/tests/extrema.rs
@@ -7,6 +7,7 @@ use crate::Calendar;
 use crate::Date;
 use crate::Ref;
 
+#[track_caller]
 fn check_extrema<C: Calendar>(cal: C) {
     // Minimum and maximum dates allowed in ECMA-262 Temporal.
     let min_date_iso = Date::try_new_iso(-271821, 4, 19).unwrap();

--- a/components/calendar/src/tests/extrema.rs
+++ b/components/calendar/src/tests/extrema.rs
@@ -1,3 +1,7 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
 use crate::cal::*;
 use crate::Date;
 use crate::Ref;

--- a/components/calendar/src/tests/extrema.rs
+++ b/components/calendar/src/tests/extrema.rs
@@ -1,0 +1,66 @@
+use crate::cal::*;
+use crate::Date;
+use crate::Ref;
+
+#[test]
+fn check_extrema() {
+    // Minimum and maximum dates allowed in ECMA-262 Temporal.
+    let min_date_iso = Date::try_new_iso(-271821, 4, 19).unwrap();
+    let max_date_iso = Date::try_new_iso(275760, 9, 13).unwrap();
+
+    // Assertion failure:
+    // > Month should be in range of u8! Value -1428 failed for RD RataDie(-99280838)
+    {
+        let cal = Chinese::new();
+        let min_date = min_date_iso.to_calendar(Ref(&cal));
+        let max_date = max_date_iso.to_calendar(Ref(&cal));
+
+        println!(
+            "min.year = {:?}, max.year = {:?}",
+            min_date.year(),
+            max_date.year()
+        );
+    }
+
+    // Assertion failure:
+    // > Month should be in range of u8! Value -1428 failed for RD RataDie(-99280838)
+    {
+        let cal = Dangi::new();
+        let min_date = min_date_iso.to_calendar(Ref(&cal));
+        let max_date = max_date_iso.to_calendar(Ref(&cal));
+
+        println!(
+            "min.year = {:?}, max.year = {:?}",
+            min_date.year(),
+            max_date.year()
+        );
+    }
+
+    // Assertion failure:
+    // > assertion failed: Date::try_new_observational_islamic_date(y, m, d, IslamicObservational::new_always_calculating()).is_ok()
+    {
+        let cal = HijriSimulated::new_mecca();
+        let min_date = min_date_iso.to_calendar(Ref(&cal));
+        let max_date = max_date_iso.to_calendar(Ref(&cal));
+
+        println!(
+            "min.year = {:?}, max.year = {:?}",
+            min_date.year(),
+            max_date.year()
+        );
+    }
+
+    // Assertion failure:
+    // > assertion failed: Date::try_new_ummalqura_date(y, m, d, IslamicUmmAlQura::new_always_calculating()).is_ok()
+    {
+        let cal = HijriUmmAlQura::new();
+        let min_date = min_date_iso.to_calendar(Ref(&cal));
+        let max_date = max_date_iso.to_calendar(Ref(&cal));
+
+        println!(
+            "min.year = {:?}, max.year = {:?}",
+            min_date.year(),
+            max_date.year()
+        );
+    }
+}

--- a/components/calendar/src/tests/extrema.rs
+++ b/components/calendar/src/tests/extrema.rs
@@ -12,59 +12,41 @@ fn check_extrema() {
     let min_date_iso = Date::try_new_iso(-271821, 4, 19).unwrap();
     let max_date_iso = Date::try_new_iso(275760, 9, 13).unwrap();
 
-    // Assertion failure:
-    // > Month should be in range of u8! Value -1428 failed for RD RataDie(-99280838)
-    {
-        let cal = Chinese::new();
-        let min_date = min_date_iso.to_calendar(Ref(&cal));
-        let max_date = max_date_iso.to_calendar(Ref(&cal));
+    let cal = Chinese::new();
+    let min_date = min_date_iso.to_calendar(Ref(&cal));
+    let max_date = max_date_iso.to_calendar(Ref(&cal));
 
-        println!(
-            "min.year = {:?}, max.year = {:?}",
-            min_date.year(),
-            max_date.year()
-        );
-    }
+    println!(
+        "min.year = {:?}, max.year = {:?}",
+        min_date.year(),
+        max_date.year()
+    );
 
-    // Assertion failure:
-    // > Month should be in range of u8! Value -1428 failed for RD RataDie(-99280838)
-    {
-        let cal = Dangi::new();
-        let min_date = min_date_iso.to_calendar(Ref(&cal));
-        let max_date = max_date_iso.to_calendar(Ref(&cal));
+    let cal = Dangi::new();
+    let min_date = min_date_iso.to_calendar(Ref(&cal));
+    let max_date = max_date_iso.to_calendar(Ref(&cal));
 
-        println!(
-            "min.year = {:?}, max.year = {:?}",
-            min_date.year(),
-            max_date.year()
-        );
-    }
+    println!(
+        "min.year = {:?}, max.year = {:?}",
+        min_date.year(),
+        max_date.year()
+    );
+    let cal = HijriSimulated::new_mecca();
+    let min_date = min_date_iso.to_calendar(Ref(&cal));
+    let max_date = max_date_iso.to_calendar(Ref(&cal));
 
-    // Assertion failure:
-    // > assertion failed: Date::try_new_observational_islamic_date(y, m, d, IslamicObservational::new_always_calculating()).is_ok()
-    {
-        let cal = HijriSimulated::new_mecca();
-        let min_date = min_date_iso.to_calendar(Ref(&cal));
-        let max_date = max_date_iso.to_calendar(Ref(&cal));
+    println!(
+        "min.year = {:?}, max.year = {:?}",
+        min_date.year(),
+        max_date.year()
+    );
+    let cal = HijriUmmAlQura::new();
+    let min_date = min_date_iso.to_calendar(Ref(&cal));
+    let max_date = max_date_iso.to_calendar(Ref(&cal));
 
-        println!(
-            "min.year = {:?}, max.year = {:?}",
-            min_date.year(),
-            max_date.year()
-        );
-    }
-
-    // Assertion failure:
-    // > assertion failed: Date::try_new_ummalqura_date(y, m, d, IslamicUmmAlQura::new_always_calculating()).is_ok()
-    {
-        let cal = HijriUmmAlQura::new();
-        let min_date = min_date_iso.to_calendar(Ref(&cal));
-        let max_date = max_date_iso.to_calendar(Ref(&cal));
-
-        println!(
-            "min.year = {:?}, max.year = {:?}",
-            min_date.year(),
-            max_date.year()
-        );
-    }
+    println!(
+        "min.year = {:?}, max.year = {:?}",
+        min_date.year(),
+        max_date.year()
+    );
 }

--- a/components/calendar/src/tests/extrema.rs
+++ b/components/calendar/src/tests/extrema.rs
@@ -3,50 +3,41 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::cal::*;
+use crate::Calendar;
 use crate::Date;
 use crate::Ref;
 
-#[test]
-fn check_extrema() {
+fn check_extrema<C: Calendar>(cal: C) {
     // Minimum and maximum dates allowed in ECMA-262 Temporal.
     let min_date_iso = Date::try_new_iso(-271821, 4, 19).unwrap();
     let max_date_iso = Date::try_new_iso(275760, 9, 13).unwrap();
-
-    let cal = Chinese::new();
     let min_date = min_date_iso.to_calendar(Ref(&cal));
     let max_date = max_date_iso.to_calendar(Ref(&cal));
 
     println!(
-        "min.year = {:?}, max.year = {:?}",
+        "min.year = {:?}, max.year = {:?} (cal = {})",
         min_date.year(),
-        max_date.year()
+        max_date.year(),
+        cal.debug_name()
     );
+}
 
-    let cal = Dangi::new();
-    let min_date = min_date_iso.to_calendar(Ref(&cal));
-    let max_date = max_date_iso.to_calendar(Ref(&cal));
+#[test]
+fn check_extrema_chinese() {
+    check_extrema(Chinese::new())
+}
 
-    println!(
-        "min.year = {:?}, max.year = {:?}",
-        min_date.year(),
-        max_date.year()
-    );
-    let cal = HijriSimulated::new_mecca();
-    let min_date = min_date_iso.to_calendar(Ref(&cal));
-    let max_date = max_date_iso.to_calendar(Ref(&cal));
+#[test]
+fn check_extrema_dangi() {
+    check_extrema(Dangi::new())
+}
 
-    println!(
-        "min.year = {:?}, max.year = {:?}",
-        min_date.year(),
-        max_date.year()
-    );
-    let cal = HijriUmmAlQura::new();
-    let min_date = min_date_iso.to_calendar(Ref(&cal));
-    let max_date = max_date_iso.to_calendar(Ref(&cal));
+#[test]
+fn check_extrema_hijri_simulated_mecca() {
+    check_extrema(HijriSimulated::new_mecca())
+}
 
-    println!(
-        "min.year = {:?}, max.year = {:?}",
-        min_date.year(),
-        max_date.year()
-    );
+#[test]
+fn check_extrema_hijri_uaq() {
+    check_extrema(HijriUmmAlQura::new())
 }

--- a/components/calendar/src/tests/mod.rs
+++ b/components/calendar/src/tests/mod.rs
@@ -3,3 +3,4 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 mod continuity_test;
+mod extrema;

--- a/utils/calendrical_calculations/src/chinese_based.rs
+++ b/utils/calendrical_calculations/src/chinese_based.rs
@@ -3,11 +3,32 @@ use crate::helpers::i64_to_i32;
 use crate::iso::{fixed_from_iso, iso_from_fixed};
 use crate::rata_die::{Moment, RataDie};
 use core::num::NonZeroU8;
+use core::ops::Range;
 #[allow(unused_imports)]
 use core_maths::*;
 
 // Don't iterate more than 14 times (which accounts for checking for 13 months)
 const MAX_ITERS_FOR_MONTHS_OF_YEAR: u8 = 14;
+
+/// For astronomical calendars in this module, the range in which they are expected to be well-behaved.
+///
+/// With astronomical calendars, for dates in the far past or far future, floating point error, algorithm inaccuracies,
+/// and other issues may cause the calendar algorithm to behave unexpectedly.
+///
+/// Our code has a number of debug assertions for various calendrical invariants (for example, lunar calendar months
+/// must be 29 or 30 days), but it will turn these off outside of these ranges.
+///
+/// Consumers of this code are encouraged to disallow such out-of-range values; or, if allowing them, not expect too
+/// much in terms of calendrical invariants. Once we have proleptic approximations of these calendars (#5778),
+/// developers will be encouraged to use them when dates are out of range.
+///
+/// This value is not stable and may change. It's currently somewhat arbitrarily chosen to be
+/// approximately ±10,000 years from 0 CE.
+//
+// NOTE: this value is doc(inline)d in islamic.rs; if you wish to change this consider if you wish to also
+// change the value there, or if it should be split.
+pub const WELL_BEHAVED_ASTRONOMICAL_RANGE: Range<RataDie> =
+    RataDie::new(365 * -10_000)..RataDie::new(365 * 10_000);
 
 /// The trait ChineseBased is used by Chinese-based calendars to perform computations shared by such calendar.
 /// To do so, calendars should:
@@ -213,10 +234,16 @@ pub(crate) fn new_year_in_sui<C: ChineseBased>(prior_solstice: RataDie) -> (Rata
     let following_solstice =
         bind_winter_solstice::<C>(winter_solstice_on_or_before::<C>(prior_solstice + 370)); // s2
     let month_after_eleventh = new_moon_on_or_after::<C>((prior_solstice + 1).as_moment()); // m12
-    debug_assert!(month_after_eleventh - prior_solstice >= 0);
+    debug_assert!(
+        month_after_eleventh - prior_solstice >= 0
+            || !WELL_BEHAVED_ASTRONOMICAL_RANGE.contains(&prior_solstice)
+    );
     let month_after_twelfth = new_moon_on_or_after::<C>((month_after_eleventh + 1).as_moment()); // m13
     let month_after_thirteenth = new_moon_on_or_after::<C>((month_after_twelfth + 1).as_moment());
-    debug_assert!(month_after_twelfth - month_after_eleventh >= 29);
+    debug_assert!(
+        month_after_twelfth - month_after_eleventh >= 29
+            || !WELL_BEHAVED_ASTRONOMICAL_RANGE.contains(&prior_solstice)
+    );
     let next_eleventh_month = new_moon_before::<C>((following_solstice + 1).as_moment()); // next-m11
     let lhs_argument =
         ((next_eleventh_month - month_after_eleventh) as f64 / MEAN_SYNODIC_MONTH).round() as i64;
@@ -289,7 +316,7 @@ pub(crate) fn winter_solstice_on_or_before<C: ChineseBased>(date: RataDie) -> Ra
         day += 1.0;
     }
     debug_assert!(
-        iters < MAX_ITERS_FOR_MONTHS_OF_YEAR,
+        iters < MAX_ITERS_FOR_MONTHS_OF_YEAR || !WELL_BEHAVED_ASTRONOMICAL_RANGE.contains(&date),
         "Number of iterations was higher than expected"
     );
     day.as_rata_die()
@@ -479,7 +506,9 @@ pub fn days_in_month<C: ChineseBased>(
     };
     let next_new_moon = new_moon_on_or_after::<C>((approx + 15).as_moment());
     let result = (next_new_moon - prev_new_moon) as u8;
-    debug_assert!(result == 29 || result == 30);
+    debug_assert!(
+        result == 29 || result == 30 || !WELL_BEHAVED_ASTRONOMICAL_RANGE.contains(&new_year)
+    );
     (result, next_new_moon)
 }
 
@@ -513,7 +542,9 @@ pub fn month_structure_for_year<C: ChineseBased>(
         }
 
         let diff = next_month_start - current_month_start;
-        debug_assert!(diff == 29 || diff == 30);
+        debug_assert!(
+            diff == 29 || diff == 30 || !WELL_BEHAVED_ASTRONOMICAL_RANGE.contains(&new_year)
+        );
         #[expect(clippy::indexing_slicing)] // array is of length 13, we iterate till i=11
         if diff == 30 {
             ret[usize::from(i)] = true;
@@ -536,7 +567,9 @@ pub fn month_structure_for_year<C: ChineseBased>(
         leap_month_index = None;
     } else {
         let diff = next_new_year - current_month_start;
-        debug_assert!(diff == 29 || diff == 30);
+        debug_assert!(
+            diff == 29 || diff == 30 || !WELL_BEHAVED_ASTRONOMICAL_RANGE.contains(&new_year)
+        );
         if diff == 30 {
             ret[12] = true;
         }
@@ -544,7 +577,8 @@ pub fn month_structure_for_year<C: ChineseBased>(
     if current_month_start != next_new_year && leap_month_index.is_none() {
         leap_month_index = Some(13); // The last month is a leap month
         debug_assert!(
-            major_solar_term_from_fixed::<C>(current_month_start) == current_month_major_solar_term,
+            major_solar_term_from_fixed::<C>(current_month_start) == current_month_major_solar_term
+                || !WELL_BEHAVED_ASTRONOMICAL_RANGE.contains(&new_year),
             "A leap month is required here, but it had a major solar term!"
         );
     }

--- a/utils/calendrical_calculations/src/islamic.rs
+++ b/utils/calendrical_calculations/src/islamic.rs
@@ -17,6 +17,10 @@ pub const ISLAMIC_EPOCH_FRIDAY: RataDie = crate::julian::fixed_from_julian(622, 
 /// Lisp code reference: <https://github.com/EdReingold/calendar-code2/blob/main/calendar.l#L2066>
 pub const ISLAMIC_EPOCH_THURSDAY: RataDie = crate::julian::fixed_from_julian(622, 7, 15);
 
+// Inline to copy over docs. This can be made into a separate value as per need.
+#[doc(inline)]
+pub use crate::chinese_based::WELL_BEHAVED_ASTRONOMICAL_RANGE;
+
 /// Lisp code reference: <https://github.com/EdReingold/calendar-code2/blob/main/calendar.l#L6898>
 pub const CAIRO: Location = Location {
     latitude: 30.1,
@@ -185,7 +189,7 @@ pub fn saudi_islamic_month_days(year: i32, month: u8) -> u8 {
 
     let diff = next_month_start - month_start;
     debug_assert!(
-        diff <= 30,
+        diff <= 30 || !WELL_BEHAVED_ASTRONOMICAL_RANGE.contains(&month_start),
         "umm-al-qura months must not be more than 30 days"
     );
     u8::try_from(diff).unwrap_or(30)


### PR DESCRIPTION
Attempting to address https://github.com/unicode-org/icu4x/issues/4917, https://github.com/unicode-org/icu4x/issues/5068, https://issues.chromium.org/issues/439624688.

Related: https://github.com/unicode-org/icu4x/issues/5778

https://github.com/tc39/proposal-temporal/issues/2869 has told us that we are allowed to break calendar-internal invariants outside of the useful range of the calendar.

We currently hit debug assertions for some of these dates. This patches it up by 

This is a partial PR, I haven't fixed all of the assertions. We'll likely have to make the function in calendrical_calculations pub+hidden (or make a copy in `icu_calendar`) and use it.

I would like feedback on the approach.





<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->