### PR TITLE
Let prop map lookups reach the trie code with char range info and inlining

### DIFF
--- a/components/properties/src/code_point_map.rs
+++ b/components/properties/src/code_point_map.rs
@@ -162,11 +162,13 @@ impl<'a, T: TrieValue> CodePointMapDataBorrowed<'a, T> {
     /// assert_eq!(gc.get('木'), GeneralCategory::OtherLetter);  // U+6728
     /// assert_eq!(gc.get('🎃'), GeneralCategory::OtherSymbol);  // U+1F383 JACK-O-LANTERN
     /// ```
+    #[inline]
     pub fn get(self, ch: char) -> T {
-        self.map.get32(ch as u32)
+        self.map.get(ch)
     }
 
     /// See [`Self::get`].
+    #[inline]
     pub fn get32(self, ch: u32) -> T {
         self.map.get32(ch)
     }

--- a/components/properties/src/provider.rs
+++ b/components/properties/src/provider.rs
@@ -934,6 +934,13 @@ impl<'data, T: TrieValue> PropertyCodePointMap<'data, T> {
     }
 
     #[inline]
+    pub(crate) fn get(&self, c: char) -> T {
+        match *self {
+            Self::CodePointTrie(ref t) => t.get(c),
+        }
+    }
+
+    #[inline]
     #[cfg(feature = "alloc")]
     pub(crate) fn try_into_converted<P>(
         self,


### PR DESCRIPTION
We shouldn't be inhibiting inlining here and we shouldn't be throwing away `char` range information.