### PR TITLE
icu_capi: Allow consumers to determine bindings directories

### DIFF
--- a/examples/gn/Cargo.toml
+++ b/examples/gn/Cargo.toml
@@ -15,6 +15,9 @@ icu = { version = "2.0.0", default-features = false }
 icu_provider = { version = "2.0.0" }
 
 # We need to explicitly specify versions here because these have build scripts and/or we wish to supply flags
+[gn.package.icu_capi."2.0.2"]
+rustflags = []
+
 [gn.package.proc-macro2."1.0.91"]
 rustflags = ["--cfg=use_proc_macro", "--cfg=wrap_proc_macro", "--cfg=proc_macro_span"]
 

--- a/ffi/capi/Cargo.toml
+++ b/ffi/capi/Cargo.toml
@@ -159,3 +159,5 @@ libc_alloc = { workspace = true, features = ["global"], optional = true }
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "none")))'.dependencies]
 icu_provider_fs = { workspace = true, optional = true }
 
+[gn]
+rustflags = []

--- a/ffi/capi/Cargo.toml
+++ b/ffi/capi/Cargo.toml
@@ -159,5 +159,3 @@ libc_alloc = { workspace = true, features = ["global"], optional = true }
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "none")))'.dependencies]
 icu_provider_fs = { workspace = true, optional = true }
 
-[gn]
-rustflags = []

--- a/ffi/capi/build.rs
+++ b/ffi/capi/build.rs
@@ -1,0 +1,34 @@
+use std::env;
+use std::path::PathBuf;
+
+/// Inform cargo of the include directories as metadata key value pairs
+///
+/// Cargo will make the values available to consumers via `DEP_ICU_CAPI_<KEY>`.
+/// See <https://doc.rust-lang.org/cargo/reference/build-scripts.html#the-links-manifest-key>
+/// for more information.
+fn add_bindings_to_cargo_metadata() {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let bindings_dir = PathBuf::from(manifest_dir).join("bindings");
+    let c_bindings_dir = bindings_dir.join("c");
+    let cpp_bindings_dir = bindings_dir.join("cpp");
+    let dart_bindings_dir = bindings_dir.join("dart");
+    let js_bindings_dir = bindings_dir.join("js");
+
+    println!("cargo::metadata=c_include_dir={}", c_bindings_dir.display());
+    println!(
+        "cargo::metadata=cpp_include_dir={}",
+        cpp_bindings_dir.display()
+    );
+    println!(
+        "cargo::metadata=dart_include_dir={}",
+        dart_bindings_dir.display()
+    );
+    println!(
+        "cargo::metadata=js_include_dir={}",
+        js_bindings_dir.display()
+    );
+}
+
+fn main() {
+    add_bindings_to_cargo_metadata();
+}

--- a/ffi/capi/build.rs
+++ b/ffi/capi/build.rs
@@ -1,3 +1,7 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
 use std::env;
 use std::path::PathBuf;
 


### PR DESCRIPTION
This allows consumers of `icu_capi` to determine the location of the include directories by reading the `DEP_` environment variable cargo will set.
Currently, consumers need to invoke `cargo metadata` to determine the header file location, which can be quite expensive. After this PR, consumers could directly read the environment variable that cargo sets. 
This approach is already used in other bindings libraries, e.g. [in libz-sys](https://github.com/rust-lang/libz-sys/blob/1c2c7b04f585f86d9bd203bccf631a5dc2bdabc4/build.rs#L171) (the syntax is a little different, since they support an older MSRV, see the MSRV note in the [cargo documentation](https://doc.rust-lang.org/cargo/reference/build-scripts.html#the-links-manifest-key))

Fixes #6769