### PR TITLE
Allow clippy::mem_forget in yoke_derive

### DIFF
--- a/utils/yoke/derive/src/lib.rs
+++ b/utils/yoke/derive/src/lib.rs
@@ -198,7 +198,7 @@ fn yokeable_derive_impl(input: &DeriveInput) -> TokenStream2 {
                         // are the same
                         debug_assert!(mem::size_of::<Self::Output>() == mem::size_of::<Self>());
                         let ptr: *const Self = (&this as *const Self::Output).cast();
-                        #[allow(forgetting_copy_types, clippy::forget_copy, clippy::forget_non_drop)] // This is a noop if the struct is copy, which Clippy doesn't like
+                        #[allow(forgetting_copy_types, clippy::forget_copy, clippy::forget_non_drop, clippy::mem_forget)] // This is a noop if the struct is copy, which Clippy doesn't like
                         mem::forget(this);
                         ptr::read(ptr)
                     }
@@ -237,7 +237,7 @@ fn yokeable_derive_impl(input: &DeriveInput) -> TokenStream2 {
                     // are the same
                     debug_assert!(mem::size_of::<Self::Output>() == mem::size_of::<Self>());
                     let ptr: *const Self = (&this as *const Self::Output).cast();
-                    #[allow(forgetting_copy_types, clippy::forget_copy, clippy::forget_non_drop)] // This is a noop if the struct is copy, which Clippy doesn't like
+                    #[allow(forgetting_copy_types, clippy::forget_copy, clippy::forget_non_drop, clippy::mem_forget)] // This is a noop if the struct is copy, which Clippy doesn't like
                     mem::forget(this);
                     ptr::read(ptr)
                 }


### PR DESCRIPTION
Fixes #6786

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->