### PR TITLE
Update ixdtf to 0.6.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1918,7 +1918,7 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "ixdtf"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "criterion",
  "displaydoc",

--- a/utils/ixdtf/Cargo.toml
+++ b/utils/ixdtf/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "ixdtf"
 description = "Parser for Internet eXtended DateTime Format"
-version = "0.6.2"
+version = "0.6.3"
 
 authors.workspace = true
 categories.workspace = true


### PR DESCRIPTION
Was holding off on this until I knew I didn't need further ixdtf changes; which I think is now true.


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->