### PR TITLE
Reduce the size of `Zone` by deferring lookups

### DIFF
--- a/utils/zoneinfo64/src/deserialize.rs
+++ b/utils/zoneinfo64/src/deserialize.rs
@@ -30,6 +30,10 @@ pub(crate) fn deserialize<'a>(resb: &'a [u32]) -> Result<ZoneInfo64<'a>, BinaryD
     let raw_zones = zones;
     let mut zones = Vec::with_capacity(raw_zones.len());
 
+    if zones.capacity() == 0 {
+        return Err(BinaryDeserializerError::unknown("at least one zone is required"));
+    }
+
     for zone in &raw_zones {
         match *zone {
             TzZoneRaw::Int(i) => {

--- a/utils/zoneinfo64/src/deserialize.rs
+++ b/utils/zoneinfo64/src/deserialize.rs
@@ -31,7 +31,9 @@ pub(crate) fn deserialize<'a>(resb: &'a [u32]) -> Result<ZoneInfo64<'a>, BinaryD
     let mut zones = Vec::with_capacity(raw_zones.len());
 
     if zones.capacity() == 0 {
-        return Err(BinaryDeserializerError::unknown("at least one zone is required"));
+        return Err(BinaryDeserializerError::unknown(
+            "at least one zone is required",
+        ));
     }
 
     for zone in &raw_zones {

--- a/utils/zoneinfo64/src/rule.rs
+++ b/utils/zoneinfo64/src/rule.rs
@@ -7,7 +7,7 @@ use calendrical_calculations::iso;
 use calendrical_calculations::rata_die::RataDie;
 use icu_time::zone::UtcOffset;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) struct Rule<'a> {
     /// The year the rule starts applying
     pub(crate) start_year: i32,
@@ -16,7 +16,7 @@ pub(crate) struct Rule<'a> {
     pub(crate) inner: &'a TzRule,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub(crate) struct TzRule {
     /// The amount of seconds to add to standard_offset_seconds
     /// to get the rule offset
@@ -27,7 +27,7 @@ pub(crate) struct TzRule {
     end: TzRuleDate,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 struct TzRuleDate {
     /// A 1-indexed day number
     day: u8,
@@ -43,7 +43,7 @@ struct TzRuleDate {
     mode: RuleMode,
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 enum TimeMode {
     /// {transition_time} is local wall clock time in the time zone
     /// *before* the transition

--- a/utils/zoneinfo64/src/rule.rs
+++ b/utils/zoneinfo64/src/rule.rs
@@ -454,9 +454,9 @@ mod tests {
     fn test_last_transition_not_in_rule_year() {
         for chrono in crate::tests::time_zones_to_test() {
             let iana = chrono.name();
-            let zoneinfo64 = TZDB.get(iana).unwrap();
+            let zoneinfo64 = TZDB.get(iana).unwrap().simple();
 
-            if let Some(rule) = zoneinfo64.final_rule {
+            if let Some(rule) = zoneinfo64.final_rule(&TZDB.rules) {
                 let transition = zoneinfo64.transition_offset_at(zoneinfo64.transition_count() - 1);
                 let utc_year =
                     iso::iso_year_from_fixed(EPOCH + (transition.since / SECONDS_IN_UTC_DAY))
@@ -476,9 +476,9 @@ mod tests {
     fn test_rule_stays_inside_year() {
         for chrono in crate::tests::time_zones_to_test() {
             let iana = chrono.name();
-            let zoneinfo64 = TZDB.get(iana).unwrap();
+            let zoneinfo64 = TZDB.get(iana).unwrap().simple();
 
-            if let Some(rule) = zoneinfo64.final_rule {
+            if let Some(rule) = zoneinfo64.final_rule(&TZDB.rules) {
                 let max_delta = core::cmp::max(
                     rule.standard_offset_seconds.unsigned_abs(),
                     (rule.standard_offset_seconds + rule.inner.additional_offset_secs)
@@ -508,9 +508,9 @@ mod tests {
     fn test_rule_offset_positive() {
         for chrono in crate::tests::time_zones_to_test() {
             let iana = chrono.name();
-            let zoneinfo64 = TZDB.get(iana).unwrap();
+            let zoneinfo64 = TZDB.get(iana).unwrap().simple();
 
-            if let Some(rule) = zoneinfo64.final_rule {
+            if let Some(rule) = zoneinfo64.final_rule(&TZDB.rules) {
                 assert!(
                     rule.inner.additional_offset_secs > 0,
                     "additional offset should be positive, is {} ({iana})",
@@ -524,9 +524,9 @@ mod tests {
     fn test_offset_before_rule_is_second_offset() {
         for chrono in crate::tests::time_zones_to_test() {
             let iana = chrono.name();
-            let zoneinfo64 = TZDB.get(iana).unwrap();
+            let zoneinfo64 = TZDB.get(iana).unwrap().simple();
 
-            if let Some(rule) = zoneinfo64.final_rule {
+            if let Some(rule) = zoneinfo64.final_rule(&TZDB.rules) {
                 let last_transition =
                     zoneinfo64.transition_offset_at(zoneinfo64.transition_count() - 1);
 


### PR DESCRIPTION
Alternative to #6902

This defers the lookups in `zones`, `names`, `rules`, and `regions` from the constructor, only storing the index in the `Zone` struct.

This will cost an additional lookup at the beginning of each zone operation, but these are fairly lookup-heavy already anyway. It also saves the lookups for name and region, which are probably only needed very rarely. In exchange, the size of `Zone` gets significantly decreased.

Also adds a `RawZone` abstraction which can be GIGO converted to and from `Zone`, with the invariant being that the same `ZoneInfo64` instance is used throughout. Users like temporal can combine this with a static `LazyLock<ZoneInfo64>` to provide a safe wrapper with minimal size.