### PR TITLE
Bump calendrical_calculations to 0.2.2, potential_utf to 0.1.3

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -577,7 +577,7 @@ jobs:
       # This is the baseline for semver-check. It can be changed
       # if unstable APIs were changed but semver-check
       # didn't know that they were unstable.
-      BASELINE_REF: fe588b97f72310dabda1d210444cda0c72cefa26 # a commit on main
+      BASELINE_REF: 7d369fbb651d594322ef44f12ea56066973628e4 # a commit on main
     steps:
 
     # Checkout baseline revision; required because actions/checkout is shallow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ Several crates have had patch releases in the 2.0 stream:
     - (0.2.1) Fix a sign error in `RataDie::until`, add `RataDie::since` (unicode-org#6861)
     - (0.2.2) Make `iso_year_from_fixed`, `day_before_year` public (unicode-org#6871)
     - (0.2.2) Optimise `day_of_provided_year`, `date_from_provided_year_day` for ISO/Gregorian (unicode-org#6883)
-    - (0.2.2) Add Easter holiday to `Gregorian` and `Julian` (unicode-org#6899)
+    - (0.2.2) Add Easter holiday to `iso` and `julian` (unicode-org#6899)
 - `ixdtf`
     - (0.6.0) Add UTF16 handling (unicode-org#6577)
     - (0.6.0) Add TimeZoneParser::parse_identifier for TimeZoneRecord (unicode-org#6584)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ Several crates have had patch releases in the 2.0 stream:
 - `calendrical_calculations`
     - (0.2.1) Fix a sign error in `RataDie::until`, add `RataDie::since` (unicode-org#6861)
     - (0.2.2) Make `iso_year_from_fixed`, `day_before_year` public (unicode-org#6871)
-    - (0.2.2) Optimise `day_of_provided_year`, `date_from_provided_year_day` for ISO/Gregorian (unicode-org#6883)
+    - (0.2.2) Optimise some calculations for `iso` (unicode-org#6883)
     - (0.2.2) Add Easter holiday to `iso` and `julian` (unicode-org#6899)
 - `ixdtf`
     - (0.6.0) Add UTF16 handling (unicode-org#6577)
@@ -54,7 +54,7 @@ Several crates have had patch releases in the 2.0 stream:
     - (0.6.2) Offset must have a sign (#6763)
     - (0.6.2) Correctly handle ambiguous annotations (#6776)
 - `potential_utf`
-    - (0.1.3) Add `.chars()` (unicode-org#6726)
+    - (0.1.3) Add `.chars()` to `PotentialUtf16` (unicode-org#6726)
 - `zerovec`:
   - (0.11.3) Make `VZV::Default` work with non-default index (unicode-org#6661)
   - (0.11.3) Make ZeroVec.iter().collect() faster (unicode-org#6764)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Several crates have had patch releases in the 2.0 stream:
   - (2.0.2) Respect `-u-fw` keyword in `WeekInformation` (unicode-org#6615)
   - (2.0.3) Fix extended year for Roc/Ethiopic (unicode-org#6721)
   - (2.0.3) Fix treatment of None era code for Gregorian (unicode-org#6794)
+  - (2.0.4) Fix a sign error in `RataDie::until`, add `RataDie::since` (unicode-org#6861)
 - `icu_properties`, `icu_properties_data`
   - (2.0.1) Fix a visibility bug in compiled data (unicode-org#6580)
 - `icu_provider_baked`
@@ -41,6 +42,9 @@ Several crates have had patch releases in the 2.0 stream:
   - (2.0.1) Update to tzdb 2025b
 - `calendrical_calculations`
     - (0.2.1) Fix a sign error in `RataDie::until`, add `RataDie::since` (unicode-org#6861)
+    - (0.2.2) Make `iso_year_from_fixed`, `day_before_year` public (unicode-org#6871)
+    - (0.2.2) Optimise `day_of_provided_year`, `date_from_provided_year_day` for ISO/Gregorian (unicode-org#6883)
+    - (0.2.2) Add Easter holiday to `Gregorian` and `Julian` (unicode-org#6899)
 - `ixdtf`
     - (0.6.0) Add UTF16 handling (unicode-org#6577)
     - (0.6.0) Add TimeZoneParser::parse_identifier for TimeZoneRecord (unicode-org#6584)
@@ -49,6 +53,8 @@ Several crates have had patch releases in the 2.0 stream:
     - (0.6.1) Fix is_valid_month_day argument ordering bug (unicode-org#6756)
     - (0.6.2) Offset must have a sign (#6763)
     - (0.6.2) Correctly handle ambiguous annotations (#6776)
+- `potential_utf`
+    - (0.1.3) Add `.chars()` (unicode-org#6726)
 - `zerovec`:
   - (0.11.3) Make `VZV::Default` work with non-default index (unicode-org#6661)
   - (0.11.3) Make ZeroVec.iter().collect() faster (unicode-org#6764)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,7 +335,7 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "calendrical_calculations"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "core_maths",
  "displaydoc",
@@ -1202,7 +1202,7 @@ dependencies = [
 
 [[package]]
 name = "icu_calendar"
-version = "2.0.3"
+version = "2.0.4"
 dependencies = [
  "calendrical_calculations",
  "criterion",
@@ -2392,7 +2392,7 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bincode",
  "databake",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,7 +187,7 @@ icu_experimental_data = { version = "~0.3.0", path = "provider/data/experimental
 
 # Utils
 bies = { version = "0.2.2", path = "utils/bies", default-features = false }
-calendrical_calculations = { version = "0.2.1", path = "utils/calendrical_calculations", default-features = false }
+calendrical_calculations = { version = "0.2.2", path = "utils/calendrical_calculations", default-features = false }
 crlify = { version = "1.0.4", path = "utils/crlify", default-features = false }
 databake = { version = "0.2.0", path = "utils/databake", default-features = false }
 databake-derive = { version = "0.2.0", path = "utils/databake/derive", default-features = false }
@@ -195,7 +195,7 @@ deduplicating_array = { version = "0.1.6", path = "utils/deduplicating_array", d
 fixed_decimal = { version = "0.7.0", path = "utils/fixed_decimal", default-features = false }
 ixdtf = { version = "0.6.0", path = "utils/ixdtf", default-features = false }
 litemap = { version = "0.8.0", path = "utils/litemap", default-features = false }
-potential_utf = { version = "0.1.1", path = "utils/potential_utf", default-features = false }
+potential_utf = { version = "0.1.3", path = "utils/potential_utf", default-features = false }
 resb = { version = "0.1.0", path = "utils/resb", default-features = false }
 tzif = { version = "0.4.0", path = "utils/tzif", default-features = false }
 tinystr = { version = "0.8.0", path = "utils/tinystr", default-features = false }

--- a/components/calendar/Cargo.toml
+++ b/components/calendar/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_calendar"
 description = "Date APIs for Gregorian and non-Gregorian calendars"
-version = "2.0.3"
+version = "2.0.4"
 
 authors.workspace = true
 categories.workspace = true

--- a/utils/calendrical_calculations/Cargo.toml
+++ b/utils/calendrical_calculations/Cargo.toml
@@ -10,7 +10,7 @@
 [package]
 name = "calendrical_calculations"
 description = "Calendrical calculations in Rust"
-version = "0.2.1"
+version = "0.2.2"
 categories = ["rust-patterns", "memory-management", "caching", "no-std", "data-structures"]
 keywords = ["zerocopy", "serialization", "zero-copy", "serde"]
 

--- a/utils/potential_utf/Cargo.toml
+++ b/utils/potential_utf/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "potential_utf"
 description = "Unvalidated string and character types"
-version = "0.1.2"
+version = "0.1.3"
 rust-version.workspace = true
 authors.workspace = true
 edition.workspace = true


### PR DESCRIPTION
We need these for the latest zoneinfo64

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->