### PR TITLE
Fix crate name references in the README for potential_utf

### DIFF
--- a/utils/potential_utf/README.md
+++ b/utils/potential_utf/README.md
@@ -1,4 +1,4 @@
-# unvalidated_utf [![crates.io](https://img.shields.io/crates/v/unvalidated_utf)](https://crates.io/crates/unvalidated_utf)
+# potential_utf [![crates.io](https://img.shields.io/crates/v/potential_utf)](https://crates.io/crates/potential_utf)
 
 <!-- cargo-rdme start -->
 


### PR DESCRIPTION
The README.md file incorrectly reflected a crate name of `unvalidated_utf` instead of `potential_utf`.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->