### PR TITLE
Add TinyAsciiStr::new_decimal_usize

### DIFF
--- a/utils/tinystr/src/ascii.rs
+++ b/utils/tinystr/src/ascii.rs
@@ -256,23 +256,20 @@ impl<const N: usize> TinyAsciiStr<N> {
     /// assert_eq!(str_saturated, tinystr!(2, "99"));
     /// ```
     pub fn new_unsigned_decimal(number: u32) -> Result<Self, Self> {
-        let mut bytes = [0; N];
+        let mut bytes = [AsciiByte::B0; N];
         let mut x = number;
         let mut i = 0usize;
         #[expect(clippy::indexing_slicing)] // in-range: i < N
         while i < N && (x != 0 || i == 0) {
-            bytes[N - i - 1] = ((x % 10) as u8) + b'0';
+            bytes[N - i - 1] = AsciiByte::from_decimal_digit((x % 10) as u8);
             x /= 10;
             i += 1;
         }
         if i < N {
             bytes.copy_within((N - i)..N, 0);
-            bytes[i..N].fill(0);
+            bytes[i..N].fill(AsciiByte::B0);
         }
-        let s = Self {
-            // SAFETY: `out` only contains ASCII bytes and has same size as `self.bytes`
-            bytes: unsafe { AsciiByte::to_ascii_byte_array(&bytes) },
-        };
+        let s = Self { bytes };
         if x != 0 {
             Err(s)
         } else {

--- a/utils/tinystr/src/ascii.rs
+++ b/utils/tinystr/src/ascii.rs
@@ -223,16 +223,19 @@ impl<const N: usize> TinyAsciiStr<N> {
     /// digits are truncated, and the lowest-magnitude digits are returned
     /// as the error.
     ///
+    /// Note: this function takes a u32. Larger integer types should probably
+    /// not be stored in a `TinyAsciiStr`.
+    ///
     /// # Examples
     ///
     /// ```
     /// use tinystr::TinyAsciiStr;
     /// use tinystr::tinystr;
     ///
-    /// let s0_4 = TinyAsciiStr::<4>::new_decimal_usize(0).unwrap();
-    /// let s456_4 = TinyAsciiStr::<4>::new_decimal_usize(456).unwrap();
-    /// let s456_3 = TinyAsciiStr::<3>::new_decimal_usize(456).unwrap();
-    /// let s456_2 = TinyAsciiStr::<2>::new_decimal_usize(456).unwrap_err();
+    /// let s0_4 = TinyAsciiStr::<4>::new_unsigned_decimal(0).unwrap();
+    /// let s456_4 = TinyAsciiStr::<4>::new_unsigned_decimal(456).unwrap();
+    /// let s456_3 = TinyAsciiStr::<3>::new_unsigned_decimal(456).unwrap();
+    /// let s456_2 = TinyAsciiStr::<2>::new_unsigned_decimal(456).unwrap_err();
     ///
     /// assert_eq!(s0_4, tinystr!(4, "0"));
     /// assert_eq!(s456_4, tinystr!(4, "456"));
@@ -246,13 +249,13 @@ impl<const N: usize> TinyAsciiStr<N> {
     /// use tinystr::TinyAsciiStr;
     /// use tinystr::tinystr;
     ///
-    /// let str_truncated = TinyAsciiStr::<2>::new_decimal_usize(456).unwrap_or_else(|s| s);
-    /// let str_saturated = TinyAsciiStr::<2>::new_decimal_usize(456).unwrap_or(tinystr!(2, "99"));
+    /// let str_truncated = TinyAsciiStr::<2>::new_unsigned_decimal(456).unwrap_or_else(|s| s);
+    /// let str_saturated = TinyAsciiStr::<2>::new_unsigned_decimal(456).unwrap_or(tinystr!(2, "99"));
     ///
     /// assert_eq!(str_truncated, tinystr!(2, "56"));
     /// assert_eq!(str_saturated, tinystr!(2, "99"));
     /// ```
-    pub fn new_decimal_usize(number: usize) -> Result<Self, Self> {
+    pub fn new_unsigned_decimal(number: u32) -> Result<Self, Self> {
         let mut bytes = [0; N];
         let mut x = number;
         let mut i = 0usize;

--- a/utils/tinystr/src/ascii.rs
+++ b/utils/tinystr/src/ascii.rs
@@ -220,7 +220,8 @@ impl<const N: usize> TinyAsciiStr<N> {
     /// the given unsigned integer.
     ///
     /// If the number of decimal digits exceeds `N`, the highest-magnitude
-    /// digits are truncated and returned as the error.
+    /// digits are truncated, and the lowest-magnitude digits are returned
+    /// as the error.
     ///
     /// # Examples
     ///

--- a/utils/tinystr/src/ascii.rs
+++ b/utils/tinystr/src/ascii.rs
@@ -262,7 +262,6 @@ impl<const N: usize> TinyAsciiStr<N> {
             x /= 10;
             i += 1;
         }
-        #[expect(clippy::indexing_slicing)] // in-range: i < N
         if i < N {
             bytes.copy_within((N - i)..N, 0);
             bytes[i..N].fill(0);

--- a/utils/tinystr/src/ascii.rs
+++ b/utils/tinystr/src/ascii.rs
@@ -229,13 +229,15 @@ impl<const N: usize> TinyAsciiStr<N> {
     /// use tinystr::TinyAsciiStr;
     /// use tinystr::tinystr;
     ///
-    /// let n456_4 = TinyAsciiStr::<4>::new_decimal_usize(456).unwrap();
-    /// let n456_3 = TinyAsciiStr::<3>::new_decimal_usize(456).unwrap();
-    /// let n456_2 = TinyAsciiStr::<2>::new_decimal_usize(456).unwrap_err();
+    /// let s0_4 = TinyAsciiStr::<4>::new_decimal_usize(0).unwrap();
+    /// let s456_4 = TinyAsciiStr::<4>::new_decimal_usize(456).unwrap();
+    /// let s456_3 = TinyAsciiStr::<3>::new_decimal_usize(456).unwrap();
+    /// let s456_2 = TinyAsciiStr::<2>::new_decimal_usize(456).unwrap_err();
     ///
-    /// assert_eq!(n456_4, tinystr!(4, "456"));
-    /// assert_eq!(n456_3, tinystr!(3, "456"));
-    /// assert_eq!(n456_2, tinystr!(2, "56"));
+    /// assert_eq!(s0_4, tinystr!(4, "0"));
+    /// assert_eq!(s456_4, tinystr!(4, "456"));
+    /// assert_eq!(s456_3, tinystr!(3, "456"));
+    /// assert_eq!(s456_2, tinystr!(2, "56"));
     /// ```
     ///
     /// Example with saturating the value:
@@ -255,7 +257,7 @@ impl<const N: usize> TinyAsciiStr<N> {
         let mut x = number;
         let mut i = 0usize;
         #[expect(clippy::indexing_slicing)] // in-range: i < N
-        while x != 0 && i < N {
+        while i < N && (x != 0 || i == 0) {
             bytes[N - i - 1] = ((x % 10) as u8) + b'0';
             x /= 10;
             i += 1;

--- a/utils/tinystr/src/asciibyte.rs
+++ b/utils/tinystr/src/asciibyte.rs
@@ -137,9 +137,34 @@ pub enum AsciiByte {
 }
 
 impl AsciiByte {
-    // Convert [u8; N] to [AsciiByte; N]
+    /// Convert [u8; N] to [AsciiByte; N]
+    ///
+    /// # Safety
+    ///
+    /// All bytes MUST be in the range 0 to 127 inclusive.
     #[inline]
     pub const unsafe fn to_ascii_byte_array<const N: usize>(bytes: &[u8; N]) -> [AsciiByte; N] {
         *(bytes as *const [u8; N] as *const [AsciiByte; N])
+    }
+
+    #[inline]
+    pub(crate) fn from_decimal_digit(digit: u8) -> AsciiByte {
+        // Note: This code optimizes nicely with no branches.
+        match digit {
+            0 => AsciiByte::B48,
+            1 => AsciiByte::B49,
+            2 => AsciiByte::B50,
+            3 => AsciiByte::B51,
+            4 => AsciiByte::B52,
+            5 => AsciiByte::B53,
+            6 => AsciiByte::B54,
+            7 => AsciiByte::B55,
+            8 => AsciiByte::B56,
+            9 => AsciiByte::B57,
+            _ => {
+                debug_assert!(false, "not a single digit: {digit}");
+                AsciiByte::B32 // Space
+            }
+        }
     }
 }


### PR DESCRIPTION
It requires unwrapping or unsafe code to do it outside of the tinystr crate, so I thought I would add this little helper function.

/gemini review