### PR TITLE
Avoid get32 in the collator

### DIFF
--- a/components/collator/src/provider.rs
+++ b/components/collator/src/provider.rs
@@ -209,7 +209,7 @@ icu_provider::data_struct!(
 
 impl<'data> CollationData<'data> {
     pub(crate) fn ce32_for_char(&self, c: char) -> CollationElement32 {
-        CollationElement32::new(self.trie.get32(c as u32))
+        CollationElement32::new(self.trie.get(c))
     }
     pub(crate) fn get_ce32(&'data self, index: usize) -> CollationElement32 {
         CollationElement32::new(if let Some(u) = self.ce32s.get(index) {


### PR DESCRIPTION
This avoids an unnecessary check for the argument being within the Unicode range, since we already know that it is.