### PR TITLE
Fix relativetime preferences to observe numbering system

### DIFF
--- a/components/experimental/src/relativetime/mod.rs
+++ b/components/experimental/src/relativetime/mod.rs
@@ -15,3 +15,4 @@ pub use format::FormattedRelativeTime;
 pub use options::RelativeTimeFormatterOptions;
 pub use relativetime::RelativeTimeFormatter;
 pub use relativetime::RelativeTimeFormatterPreferences;
+pub use relativetime::preferences;

--- a/components/experimental/src/relativetime/mod.rs
+++ b/components/experimental/src/relativetime/mod.rs
@@ -13,6 +13,6 @@ mod relativetime;
 
 pub use format::FormattedRelativeTime;
 pub use options::RelativeTimeFormatterOptions;
+pub use relativetime::preferences;
 pub use relativetime::RelativeTimeFormatter;
 pub use relativetime::RelativeTimeFormatterPreferences;
-pub use relativetime::preferences;

--- a/components/experimental/src/relativetime/relativetime.rs
+++ b/components/experimental/src/relativetime/relativetime.rs
@@ -21,13 +21,29 @@ define_preferences!(
     /// The preferences for relative time formatting.
     [Copy]
     RelativeTimeFormatterPreferences,
-    {}
+    {
+        /// The user's preferred numbering system.
+        ///
+        /// Corresponds to the `-u-nu` in Unicode Locale Identifier.
+        ///
+        /// To get the resolved numbering system, you can inspect the data provider.
+        /// See the [`provider`] module for an example.
+        numbering_system: preferences::NumberingSystem
+    }
 );
 prefs_convert!(
     RelativeTimeFormatterPreferences,
-    DecimalFormatterPreferences
+    DecimalFormatterPreferences,
+    { numbering_system }
 );
 prefs_convert!(RelativeTimeFormatterPreferences, PluralRulesPreferences);
+
+/// Locale preferences used by this crate
+pub mod preferences {
+    /// **This is a reexport of a type in [`icu::locale`](icu_locale_core::preferences::extensions::unicode::keywords)**.
+    #[doc = "\n"] // prevent autoformatting
+    pub use icu_locale_core::preferences::extensions::unicode::keywords::NumberingSystem;
+}
 
 /// A formatter to render locale-sensitive relative time.
 ///

--- a/components/experimental/tests/relativetime/tests.rs
+++ b/components/experimental/tests/relativetime/tests.rs
@@ -4,9 +4,10 @@
 
 use fixed_decimal::Decimal;
 use icu_experimental::relativetime::{
-    options::Numeric, RelativeTimeFormatter, RelativeTimeFormatterOptions, RelativeTimeFormatterPreferences
+    options::Numeric, RelativeTimeFormatter, RelativeTimeFormatterOptions,
+    RelativeTimeFormatterPreferences,
 };
-use icu_locale_core::{locale, extensions::unicode::value};
+use icu_locale_core::{extensions::unicode::value, locale};
 use writeable::assert_writeable_eq;
 
 macro_rules! generate_test {

--- a/components/experimental/tests/relativetime/tests.rs
+++ b/components/experimental/tests/relativetime/tests.rs
@@ -4,9 +4,9 @@
 
 use fixed_decimal::Decimal;
 use icu_experimental::relativetime::{
-    options::Numeric, RelativeTimeFormatter, RelativeTimeFormatterOptions,
+    options::Numeric, RelativeTimeFormatter, RelativeTimeFormatterOptions, RelativeTimeFormatterPreferences
 };
-use icu_locale_core::locale;
+use icu_locale_core::{locale, extensions::unicode::value};
 use writeable::assert_writeable_eq;
 
 macro_rules! generate_test {
@@ -1243,3 +1243,14 @@ generate_test!(
         (10, "خلال ١٠ سنوات")
     ]
 );
+
+#[test]
+fn test_numbering_system_latn() {
+    let mut prefs = RelativeTimeFormatterPreferences::from(locale!("bn"));
+    let options = RelativeTimeFormatterOptions::default();
+    let formatter_bn = RelativeTimeFormatter::try_new_long_day(prefs, options).unwrap();
+    prefs.numbering_system = Some(value!("latn").try_into().unwrap());
+    let formatter_bn_latn = RelativeTimeFormatter::try_new_long_day(prefs, options).unwrap();
+    assert_writeable_eq!(formatter_bn.format(55.into()), "৫৫ দিনের মধ্যে");
+    assert_writeable_eq!(formatter_bn_latn.format(55.into()), "55 দিনের মধ্যে");
+}


### PR DESCRIPTION
Found by conformance testing: https://github.com/unicode-org/conformance/issues/530