### PR TITLE
Bump zoneinfo64 to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,6 @@
         - Add `Yoke::with_mut_return`, similar to `Yoke::with_mut` but with a callback that may
             return any `'static` type. (unicode-org#6827)
     - `zoneinfo64`
-        - Remove `icu_time` dependency (unicode-org#6914)
-        - Add gap offset data to `PossibleOffset::None` to help resolve forward transitions (unicode-org#6913)
 
 ## icu4x 2.0.x
 
@@ -32,6 +30,7 @@ Several crates have had patch releases in the 2.0 stream:
   - (2.0.3) Fix extended year for Roc/Ethiopic (unicode-org#6721)
   - (2.0.3) Fix treatment of None era code for Gregorian (unicode-org#6794)
   - (2.0.4) Fix a sign error in `RataDie::until`, add `RataDie::since` (unicode-org#6861)
+  - (2.0.5) Fix calendrical-calculations dependency (unicode-org#6919)
 - `icu_properties`, `icu_properties_data`
   - (2.0.1) Fix a visibility bug in compiled data (unicode-org#6580)
 - `icu_provider_baked`
@@ -59,11 +58,15 @@ Several crates have had patch releases in the 2.0 stream:
 - `potential_utf`
     - (0.1.3) Add `.chars()` to `PotentialUtf16` (unicode-org#6726)
 - `zerovec`:
-  - (0.11.3) Make `VZV::Default` work with non-default index (unicode-org#6661)
-  - (0.11.3) Make ZeroVec.iter().collect() faster (unicode-org#6764)
-  - (0.11.3) Implement `ZeroMapKV` for `VarTupleULE` (unicode-org#6750)
-  - (0.11.3) Add `ZeroVec::truncated()` (unicode-org#6604)
-  - (0.11.4) Fix safety issue in `ZeroVec::truncated()` (unicode-org#6805)
+    - (0.11.3) Make `VZV::Default` work with non-default index (unicode-org#6661)
+    - (0.11.3) Make ZeroVec.iter().collect() faster (unicode-org#6764)
+    - (0.11.3) Implement `ZeroMapKV` for `VarTupleULE` (unicode-org#6750)
+    - (0.11.3) Add `ZeroVec::truncated()` (unicode-org#6604)
+    - (0.11.4) Fix safety issue in `ZeroVec::truncated()` (unicode-org#6805)
+- `zoneinfo64`
+    - (0.1.0) New crate
+    - (0.2.0) Remove `icu_time` dependency (unicode-org#6914)
+    - (0.2.0) Add gap offset data to `PossibleOffset::None` to help resolve forward transitions (unicode-org#6913)
 
 ## icu4x 2.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4012,7 +4012,7 @@ dependencies = [
 
 [[package]]
 name = "zoneinfo64"
-version = "0.2.0-dev"
+version = "0.2.0"
 dependencies = [
  "calendrical_calculations",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -207,7 +207,7 @@ zerofrom-derive = { version = "0.1.3", path = "utils/zerofrom/derive", default-f
 zerotrie = { version = "0.2.0", path = "utils/zerotrie", default-features = false }
 zerovec = { version = "0.11.3", path = "utils/zerovec", default-features = false }
 zerovec-derive = { version = "0.11.1", path = "utils/zerovec/derive", default-features = false }
-zoneinfo64 = { version = "0.1.0", path = "utils/zoneinfo64", default-features = false }
+zoneinfo64 = { version = "0.2.0", path = "utils/zoneinfo64", default-features = false }
 
 # Tools
 icu_benchmark_macros = { path = "tools/benchmark/macros" }

--- a/utils/zoneinfo64/Cargo.toml
+++ b/utils/zoneinfo64/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "zoneinfo64"
 description = "Working with ICU zoneinfo64.res timezone data bundles"
-version = "0.2.0-dev"
+version = "0.2.0"
 
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION
I don't think we'll need any more breaking changes; the integration works already. I suspect we will need some minor non-breaking fixes once I have it all hooked up end to end (this is tricky and will take some time).

(If we do end up needing more breaking changes, this is a utils crate, no big deal. Most of our utils crates had some rapid breakage cycles initially)


<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->