### PR TITLE
Fix rearguard difference detection logic

### DIFF
--- a/tools/make/bakeddata/src/main.rs
+++ b/tools/make/bakeddata/src/main.rs
@@ -83,7 +83,9 @@ fn main() {
             .collect()
     };
 
-    let source = SourceDataProvider::new();
+    let source = SourceDataProvider::new()
+        .with_tzdb(Path::new("provider/source/tests/data/tzdb"))
+        .unwrap();
 
     let driver = ExportDriver::new(
         source


### PR DESCRIPTION
There's a period in Namibia that is a single period in main, but two periods in rearguard, with the second period agreeing with main. The current code says the whole main period disagrees with rearguard (and logs a warning), but it should be split into two periods with only the first disagreeing.