### PR TITLE
Check semver only for changes in PR

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -577,7 +577,7 @@ jobs:
       # This is the baseline for semver-check. It can be changed
       # if unstable APIs were changed but semver-check
       # didn't know that they were unstable.
-      BASELINE_REF: 3ea9b557fc6cafc03d2100d0629e0ad3ef8c7407 # a commit on main
+      BASELINE_REF: 2f4ecad9b28f68e3f33b11857683aceb5ef26e14 # a commit on main
     steps:
 
     # Checkout baseline revision; required because actions/checkout is shallow

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -573,26 +573,29 @@ jobs:
 
   semver:
     runs-on: ubuntu-latest
-    env:
-      # This is the baseline for semver-check. It can be changed
-      # if unstable APIs were changed but semver-check
-      # didn't know that they were unstable.
-      BASELINE_REF: 2f4ecad9b28f68e3f33b11857683aceb5ef26e14 # a commit on main
     steps:
-
-    # Checkout baseline revision; required because actions/checkout is shallow
-    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      with:
-        ref: ${{ env.BASELINE_REF }}
 
     # Checkout HEAD revision
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+    - name: Fetch base_ref if needed
+      if: ${{ github.event_name == 'pull_request' }}
+      run: git fetch origin ${{ github.base_ref }}
+
     # Actual job
     - name: Check semver
       uses: obi1kenobi/cargo-semver-checks-action@5b298c9520f7096a4683c0bd981a7ac5a7e249ae
+      # On pull requests, run against the base_ref so only violations added in that PR
+      # will trigger
+      if: ${{ github.event_name == 'pull_request' }}
       with:
-        baseline-rev: ${{ env.BASELINE_REF }}
+        baseline-rev: origin/${{ github.base_ref }}
+
+    - name: Show semver violations since last release
+      uses: obi1kenobi/cargo-semver-checks-action@5b298c9520f7096a4683c0bd981a7ac5a7e249ae
+      # On main, run against the last release, but warn only
+      if: ${{ github.event_name != 'pull_request' }}
+      continue-on-error: true
 
 
   # Notify on slack  

--- a/documents/process/release.md
+++ b/documents/process/release.md
@@ -13,6 +13,7 @@ This is a checklist of things that should be done in the weeks leading to the re
 
 * [ ] Verify that the milestone and checklist are complete
 * [ ] Verify with component owners that they're ready for release
+* [ ] Verify that the semver breakages (listed by the build-test job) are acceptable
 * [ ] Take a bird-eye view at:
   * [ ] READMEs
   * [ ] Documentation


### PR DESCRIPTION
This way, once a pull request is merged, we accept the semver changes and don't have to update the base ref every time.

On main, it lists all violations since the last release (but doesn't fail the job).