### PR TITLE
Rename `SingleUnitVec::Zero` to `SingleUnitVec::Empty` for better naming

### DIFF
--- a/components/experimental/src/measure/parser/mod.rs
+++ b/components/experimental/src/measure/parser/mod.rs
@@ -41,7 +41,7 @@ impl MeasureUnit {
         }
 
         let mut constant_denominator = 0;
-        let mut single_units = SingleUnitVec::Zero;
+        let mut single_units = SingleUnitVec::Empty;
         let mut sign = 1;
         while !code_units.is_empty() {
             // First: extract the power.

--- a/components/experimental/src/measure/single_unit_vec.rs
+++ b/components/experimental/src/measure/single_unit_vec.rs
@@ -11,7 +11,7 @@ use alloc::{vec, vec::Vec};
 // The iter method provides an iterator over the contained SingleUnit instances.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum SingleUnitVec {
-    Zero,
+    Empty,
     One(SingleUnit),
     Two([SingleUnit; 2]),
     Multi(Vec<SingleUnit>),
@@ -22,7 +22,7 @@ impl SingleUnitVec {
     /// within the [`SingleUnitVec`].
     pub(crate) fn as_slice(&self) -> &[SingleUnit] {
         match self {
-            SingleUnitVec::Zero => &[],
+            SingleUnitVec::Empty => &[],
             SingleUnitVec::One(unit) => core::slice::from_ref(unit),
             SingleUnitVec::Two(units) => &units[..],
             SingleUnitVec::Multi(units) => &units[..],
@@ -31,7 +31,7 @@ impl SingleUnitVec {
 
     pub(crate) fn push(&mut self, input_unit: SingleUnit) {
         match self {
-            SingleUnitVec::Zero => *self = SingleUnitVec::One(input_unit),
+            SingleUnitVec::Empty => *self = SingleUnitVec::One(input_unit),
             SingleUnitVec::One(current_unit) => {
                 *self = SingleUnitVec::Two([*current_unit, input_unit])
             }


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->