### PR TITLE
Update Diplomat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - FFI
     - `icu_capi`
         - All C++ enums now default to a valid value; which is the `Default` impl where there is one, and some semi-logical value otherwise. This has changed defaults in some cases and may cause a behavioral change for people relying on C++ default constructors. (unicode-org#6692)
+        - `ListFormatter::format` now takes a `diplomat::span<const diplomat::string_view_for_slice>` instead of a `diplomat::span<std::string_view>` to handle soundness issues on some platforms (unicode-org#6974)
 - Utils
     - `yoke`
         - Add four `map_with_cart` methods to `yoke::Yoke`, similar to `Yoke::map_project` but

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "diplomat"
 version = "0.12.0"
-source = "git+https://github.com/Manishearth/diplomat?rev=0fd371d03cb11866a87782762e3fd445e13a3800#0fd371d03cb11866a87782762e3fd445e13a3800"
+source = "git+https://github.com/Manishearth/diplomat?rev=9739cb1a2cb615c930cafce52a02aa465a50e293#9739cb1a2cb615c930cafce52a02aa465a50e293"
 dependencies = [
  "diplomat_core",
  "proc-macro2",
@@ -742,7 +742,7 @@ dependencies = [
 [[package]]
 name = "diplomat-runtime"
 version = "0.12.0"
-source = "git+https://github.com/Manishearth/diplomat?rev=0fd371d03cb11866a87782762e3fd445e13a3800#0fd371d03cb11866a87782762e3fd445e13a3800"
+source = "git+https://github.com/Manishearth/diplomat?rev=9739cb1a2cb615c930cafce52a02aa465a50e293#9739cb1a2cb615c930cafce52a02aa465a50e293"
 dependencies = [
  "log",
 ]
@@ -750,7 +750,7 @@ dependencies = [
 [[package]]
 name = "diplomat-tool"
 version = "0.12.1"
-source = "git+https://github.com/Manishearth/diplomat?rev=0fd371d03cb11866a87782762e3fd445e13a3800#0fd371d03cb11866a87782762e3fd445e13a3800"
+source = "git+https://github.com/Manishearth/diplomat?rev=9739cb1a2cb615c930cafce52a02aa465a50e293#9739cb1a2cb615c930cafce52a02aa465a50e293"
 dependencies = [
  "askama",
  "clap",
@@ -771,7 +771,7 @@ dependencies = [
 [[package]]
 name = "diplomat_core"
 version = "0.12.1"
-source = "git+https://github.com/Manishearth/diplomat?rev=0fd371d03cb11866a87782762e3fd445e13a3800#0fd371d03cb11866a87782762e3fd445e13a3800"
+source = "git+https://github.com/Manishearth/diplomat?rev=9739cb1a2cb615c930cafce52a02aa465a50e293#9739cb1a2cb615c930cafce52a02aa465a50e293"
 dependencies = [
  "displaydoc",
  "either",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,10 +215,10 @@ icu_benchmark_macros = { path = "tools/benchmark/macros" }
 
 # The version here can either be a `version = ".."` spec or `git = "https://github.com/rust-diplomat/diplomat", rev = ".."`
 # Diplomat must be published preceding a new ICU4X release but may use git versions in between
-diplomat = { git = "https://github.com/Manishearth/diplomat", rev = "0fd371d03cb11866a87782762e3fd445e13a3800", default-features = false }
-diplomat-runtime = { git = "https://github.com/Manishearth/diplomat", rev = "0fd371d03cb11866a87782762e3fd445e13a3800", default-features = false }
-diplomat_core = { git = "https://github.com/Manishearth/diplomat", rev = "0fd371d03cb11866a87782762e3fd445e13a3800", default-features = false }
-diplomat-tool = { git = "https://github.com/Manishearth/diplomat", rev = "0fd371d03cb11866a87782762e3fd445e13a3800", default-features = false }
+diplomat = { git = "https://github.com/Manishearth/diplomat", rev = "9739cb1a2cb615c930cafce52a02aa465a50e293", default-features = false }
+diplomat-runtime = { git = "https://github.com/Manishearth/diplomat", rev = "9739cb1a2cb615c930cafce52a02aa465a50e293", default-features = false }
+diplomat_core = { git = "https://github.com/Manishearth/diplomat", rev = "9739cb1a2cb615c930cafce52a02aa465a50e293", default-features = false }
+diplomat-tool = { git = "https://github.com/Manishearth/diplomat", rev = "9739cb1a2cb615c930cafce52a02aa465a50e293", default-features = false }
 
 # EXTERNAL DEPENDENCIES
 #

--- a/ffi/capi/bindings/cpp/icu4x/ListFormatter.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/ListFormatter.d.hpp
@@ -81,16 +81,16 @@ public:
   /**
    * See the [Rust documentation for `format`](https://docs.rs/icu/2.0.0/icu/list/struct.ListFormatter.html#method.format) for more information.
    */
-  inline std::string format(icu4x::diplomat::span<const std::string_view> list) const;
+  inline std::string format(icu4x::diplomat::span<const diplomat::string_view_for_slice> list) const;
   template<typename W>
-  inline void format_write(icu4x::diplomat::span<const std::string_view> list, W& writeable_output) const;
+  inline void format_write(icu4x::diplomat::span<const diplomat::string_view_for_slice> list, W& writeable_output) const;
 
   /**
    * See the [Rust documentation for `format`](https://docs.rs/icu/2.0.0/icu/list/struct.ListFormatter.html#method.format) for more information.
    */
-  inline std::string format16(icu4x::diplomat::span<const std::u16string_view> list) const;
+  inline std::string format16(icu4x::diplomat::span<const diplomat::u16string_view_for_slice> list) const;
   template<typename W>
-  inline void format16_write(icu4x::diplomat::span<const std::u16string_view> list, W& writeable_output) const;
+  inline void format16_write(icu4x::diplomat::span<const diplomat::u16string_view_for_slice> list, W& writeable_output) const;
 
     inline const icu4x::capi::ListFormatter* AsFFI() const;
     inline icu4x::capi::ListFormatter* AsFFI();

--- a/ffi/capi/bindings/cpp/icu4x/ListFormatter.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/ListFormatter.hpp
@@ -89,7 +89,7 @@ inline icu4x::diplomat::result<std::unique_ptr<icu4x::ListFormatter>, icu4x::Dat
     return result.is_ok ? icu4x::diplomat::result<std::unique_ptr<icu4x::ListFormatter>, icu4x::DataError>(icu4x::diplomat::Ok<std::unique_ptr<icu4x::ListFormatter>>(std::unique_ptr<icu4x::ListFormatter>(icu4x::ListFormatter::FromFFI(result.ok)))) : icu4x::diplomat::result<std::unique_ptr<icu4x::ListFormatter>, icu4x::DataError>(icu4x::diplomat::Err<icu4x::DataError>(icu4x::DataError::FromFFI(result.err)));
 }
 
-inline std::string icu4x::ListFormatter::format(icu4x::diplomat::span<const std::string_view> list) const {
+inline std::string icu4x::ListFormatter::format(icu4x::diplomat::span<const diplomat::string_view_for_slice> list) const {
     std::string output;
     icu4x::diplomat::capi::DiplomatWrite write = icu4x::diplomat::WriteFromString(output);
     icu4x::capi::icu4x_ListFormatter_format_utf8_mv1(this->AsFFI(),
@@ -98,14 +98,14 @@ inline std::string icu4x::ListFormatter::format(icu4x::diplomat::span<const std:
     return output;
 }
 template<typename W>
-inline void icu4x::ListFormatter::format_write(icu4x::diplomat::span<const std::string_view> list, W& writeable) const {
+inline void icu4x::ListFormatter::format_write(icu4x::diplomat::span<const diplomat::string_view_for_slice> list, W& writeable) const {
     icu4x::diplomat::capi::DiplomatWrite write = icu4x::diplomat::WriteTrait<W>::Construct(writeable);
     icu4x::capi::icu4x_ListFormatter_format_utf8_mv1(this->AsFFI(),
         {reinterpret_cast<const icu4x::diplomat::capi::DiplomatStringView*>(list.data()), list.size()},
         &write);
 }
 
-inline std::string icu4x::ListFormatter::format16(icu4x::diplomat::span<const std::u16string_view> list) const {
+inline std::string icu4x::ListFormatter::format16(icu4x::diplomat::span<const diplomat::u16string_view_for_slice> list) const {
     std::string output;
     icu4x::diplomat::capi::DiplomatWrite write = icu4x::diplomat::WriteFromString(output);
     icu4x::capi::icu4x_ListFormatter_format_utf16_mv1(this->AsFFI(),
@@ -114,7 +114,7 @@ inline std::string icu4x::ListFormatter::format16(icu4x::diplomat::span<const st
     return output;
 }
 template<typename W>
-inline void icu4x::ListFormatter::format16_write(icu4x::diplomat::span<const std::u16string_view> list, W& writeable) const {
+inline void icu4x::ListFormatter::format16_write(icu4x::diplomat::span<const diplomat::u16string_view_for_slice> list, W& writeable) const {
     icu4x::diplomat::capi::DiplomatWrite write = icu4x::diplomat::WriteTrait<W>::Construct(writeable);
     icu4x::capi::icu4x_ListFormatter_format_utf16_mv1(this->AsFFI(),
         {reinterpret_cast<const icu4x::diplomat::capi::DiplomatStringView*>(list.data()), list.size()},

--- a/ffi/capi/bindings/cpp/icu4x/diplomat_runtime.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/diplomat_runtime.hpp
@@ -282,6 +282,68 @@ private:
 
 #endif // __cplusplus >= 202002L
 
+// An ABI stable std::basic_string_view equivalent for the case of string
+// views in slices
+template <class CharT, class Traits = std::char_traits<CharT>>
+class basic_string_view_for_slice {
+public:
+  using std_string_view           = std::basic_string_view<CharT, Traits>;
+  using traits_type               = typename std_string_view::traits_type;
+  using value_type                = typename std_string_view::value_type;
+  using pointer                   = typename std_string_view::pointer;
+  using const_pointer             = typename std_string_view::const_pointer;
+  using size_type                 = typename std_string_view::size_type;
+  using difference_type           = typename std_string_view::difference_type;
+
+  constexpr basic_string_view_for_slice() noexcept
+    : basic_string_view_for_slice{std_string_view{}} {}
+
+  constexpr basic_string_view_for_slice(const basic_string_view_for_slice& other) noexcept = default;
+
+  constexpr basic_string_view_for_slice(const const_pointer s, const size_type count)
+    : basic_string_view_for_slice{std_string_view{s, count}} {}
+
+  constexpr basic_string_view_for_slice(const const_pointer s)
+    : basic_string_view_for_slice{std_string_view{s}} {}
+
+  constexpr basic_string_view_for_slice& operator=(const basic_string_view_for_slice& view) noexcept = default;
+
+  constexpr basic_string_view_for_slice(const std_string_view& s) noexcept
+    : data_{s.data(), s.size()} {}
+
+  constexpr basic_string_view_for_slice& operator=(const std_string_view& s) noexcept {
+    data_ = {s.data(), s.size()};
+    return *this;
+  }
+
+  constexpr operator std_string_view() const noexcept { return {data(), size()}; }
+  constexpr std_string_view as_sv() const noexcept { return *this; }
+
+  constexpr const_pointer data() const noexcept { return data_.data; }
+  constexpr size_type size() const noexcept { return data_.len; }
+
+private:
+  using capi_type =
+    std::conditional_t<std::is_same_v<value_type, char>,
+      capi::DiplomatStringView,
+    std::conditional_t<std::is_same_v<value_type, char16_t>,
+      capi::DiplomatString16View,
+      void>>;
+
+  static_assert(!std::is_void_v<capi_type>,
+    "ABI compatible string_views are only supported for char and char16_t");
+
+  capi_type data_;
+};
+
+// We only implement these specialisations as diplomat doesn't provide c abi
+// types for others
+using string_view_for_slice = basic_string_view_for_slice<char>;
+using u16string_view_for_slice = basic_string_view_for_slice<char16_t>;
+
+using string_view_span = span<const string_view_for_slice>;
+using u16string_view_span = span<const u16string_view_for_slice>;
+
 // Interop between std::function & our C Callback wrapper type
 
 template <typename T, typename = void>


### PR DESCRIPTION
This includes https://github.com/rust-diplomat/diplomat/pull/964, which is a soundness fix.

This does change the C++ API a little bit for ListFormatter, but it's a soundness fix so that takes precedence.

Doing this separately so it can be tested and show up in the changelog; we'll be cutting a Diplomat release soon.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->