### PR TITLE
Remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1187,7 +1187,6 @@ name = "icu_benchmark_memory"
 version = "0.0.0"
 dependencies = [
  "clap",
- "libc",
  "serde_json",
 ]
 
@@ -1211,7 +1210,6 @@ dependencies = [
  "simple_logger",
  "tinystr",
  "ureq",
- "writeable",
  "zerovec",
 ]
 
@@ -1246,9 +1244,7 @@ dependencies = [
  "icu_segmenter",
  "icu_time",
  "libc_alloc",
- "log",
  "potential_utf",
- "serde",
  "simple_logger",
  "tinystr",
  "unicode-bidi",
@@ -1262,7 +1258,6 @@ version = "2.0.0"
 dependencies = [
  "criterion",
  "databake",
- "displaydoc",
  "icu",
  "icu_casemap_data",
  "icu_collections",
@@ -1299,7 +1294,6 @@ dependencies = [
  "atoi",
  "criterion",
  "databake",
- "displaydoc",
  "icu",
  "icu_collator_data",
  "icu_collections",
@@ -1314,7 +1308,6 @@ dependencies = [
  "smallvec",
  "utf16_iter",
  "utf8_iter",
- "write16",
  "zerovec",
 ]
 
@@ -1385,7 +1378,6 @@ version = "2.0.0"
 dependencies = [
  "criterion",
  "databake",
- "displaydoc",
  "fixed_decimal",
  "getrandom 0.3.2",
  "icu",
@@ -1398,7 +1390,6 @@ dependencies = [
  "rand_distr",
  "rand_pcg",
  "serde",
- "tinystr",
  "writeable",
  "zerovec",
 ]
@@ -1465,7 +1456,6 @@ dependencies = [
 name = "icu_harfbuzz"
 version = "0.3.0"
 dependencies = [
- "displaydoc",
  "harfbuzz-traits",
  "icu_normalizer",
  "icu_properties",
@@ -1477,7 +1467,6 @@ name = "icu_list"
 version = "2.0.0"
 dependencies = [
  "databake",
- "displaydoc",
  "icu",
  "icu_list_data",
  "icu_locale",
@@ -1501,7 +1490,6 @@ version = "2.0.0"
 dependencies = [
  "criterion",
  "databake",
- "displaydoc",
  "icu",
  "icu_collections",
  "icu_locale_core",
@@ -1549,7 +1537,6 @@ dependencies = [
  "criterion",
  "databake",
  "detone",
- "displaydoc",
  "icu",
  "icu_collections",
  "icu_normalizer_data",
@@ -1596,7 +1583,6 @@ dependencies = [
  "icu",
  "icu_locale",
  "icu_locale_core",
- "icu_normalizer_data",
  "icu_plurals_data",
  "icu_provider",
  "postcard",
@@ -1614,13 +1600,11 @@ name = "icu_properties"
 version = "2.0.1"
 dependencies = [
  "databake",
- "displaydoc",
  "icu",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "potential_utf",
  "serde",
  "unicode-bidi",
  "zerotrie",
@@ -1649,7 +1633,6 @@ dependencies = [
  "serde",
  "serde_json",
  "stable_deref_trait",
- "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
@@ -1661,13 +1644,9 @@ dependencies = [
 name = "icu_provider_adapters"
 version = "2.0.0"
 dependencies = [
- "databake",
  "icu_locale",
  "icu_provider",
- "serde",
- "tinystr",
  "writeable",
- "zerovec",
 ]
 
 [[package]]
@@ -1681,8 +1660,6 @@ dependencies = [
  "icu_provider_export",
  "icu_provider_registry",
  "log",
- "proc-macro2",
- "writeable",
  "zerotrie",
  "zerovec",
 ]
@@ -1734,11 +1711,9 @@ dependencies = [
  "bincode",
  "criterion",
  "crlify",
- "displaydoc",
  "icu_locale_core",
  "icu_provider",
  "icu_provider_export",
- "log",
  "postcard",
  "serde",
  "serde-json-core",
@@ -1760,16 +1735,12 @@ version = "2.0.2"
 dependencies = [
  "calendrical_calculations",
  "displaydoc",
- "either",
  "elsa",
  "flate2",
  "icu",
  "icu_codepointtrie_builder",
- "icu_collections",
- "icu_experimental",
  "icu_pattern",
  "icu_provider",
- "icu_provider_adapters",
  "icu_provider_export",
  "icu_provider_registry",
  "icu_segmenter",
@@ -1806,7 +1777,6 @@ dependencies = [
  "core_maths",
  "criterion",
  "databake",
- "displaydoc",
  "icu",
  "icu_collections",
  "icu_locale",

--- a/components/calendar/Cargo.toml
+++ b/components/calendar/Cargo.toml
@@ -27,7 +27,6 @@ icu_locale_core = { workspace = true, features = ["alloc"]}
 ixdtf = { workspace = true, optional = true }
 tinystr = { workspace = true, features = ["alloc", "zerovec"] }
 zerovec = { workspace = true, features = ["derive"] }
-writeable = { workspace = true }
 
 databake = { workspace = true, features = ["derive"], optional = true }
 serde = { workspace = true, features = ["derive", "alloc"], optional = true }

--- a/components/casemap/Cargo.toml
+++ b/components/casemap/Cargo.toml
@@ -20,7 +20,6 @@ version.workspace = true
 all-features = true
 
 [dependencies]
-displaydoc = { workspace = true }
 icu_collections = { workspace = true, features = ["alloc"] }
 icu_locale_core = { workspace = true, features = ["alloc"] }
 icu_properties = { workspace = true }

--- a/components/collator/Cargo.toml
+++ b/components/collator/Cargo.toml
@@ -19,7 +19,6 @@ rust-version.workspace = true
 all-features = true
 
 [dependencies]
-displaydoc = { workspace = true }
 icu_collections = { workspace = true }
 icu_normalizer = { workspace = true, features = ["utf8_iter", "utf16_iter"] }
 icu_locale_core = { workspace = true, features = ["alloc"] }
@@ -28,7 +27,6 @@ icu_provider = { workspace = true }
 utf8_iter = { workspace = true }
 utf16_iter = { workspace = true }
 smallvec = { workspace = true, features = ["union", "const_generics", "const_new"] } # alloc
-write16 = { workspace = true }
 zerovec = { workspace = true }
 
 databake = { workspace = true, optional = true, features = ["derive"] }

--- a/components/collections/codepointtrie_builder/Cargo.toml
+++ b/components/collections/codepointtrie_builder/Cargo.toml
@@ -31,16 +31,16 @@ independent = true
 [features]
 # Use the wasm builder
 default = ["wasm"]
-wasm = ["dep:wasmi", "dep:wat"]
+wasm = ["dep:wasmi", "dep:wat", "dep:zerovec"]
 # Use the ICU4C builder
 # needs the ICU4C_LIB_PATH variable set and pointing to an ICU4C lib folder
 # containing dylibs. If you want to use staticlibs, set ICU4C_LINK_STATICALLY.
 # Will be silently disabled if the wasm feature is enabled
-icu4c = []
+icu4c = ["dep:zerovec"]
 
 [dependencies]
 icu_collections = { workspace = true, features = ["serde"] }
-zerovec = { workspace = true }
+zerovec = { workspace = true, optional = true }
 wasmi = { workspace = true, optional = true }
 wat = { workspace = true, optional = true }
 

--- a/components/datetime/Cargo.toml
+++ b/components/datetime/Cargo.toml
@@ -21,7 +21,6 @@ all-features = true
 
 [dependencies]
 displaydoc = { workspace = true }
-either = { workspace = true }
 fixed_decimal = { workspace = true }
 icu_calendar = { workspace = true }
 icu_decimal = { workspace = true }
@@ -30,7 +29,6 @@ icu_pattern = { workspace = true, features = ["zerovec", "alloc"] }
 icu_plurals = { workspace = true }
 icu_provider = { workspace = true }
 icu_time = { workspace = true, features = ["alloc"] }
-smallvec = { workspace = true }
 tinystr = { workspace = true, features = ["alloc", "zerovec"] }
 potential_utf = { workspace = true, features = ["alloc", "zerovec"] }
 writeable = { workspace = true }
@@ -39,12 +37,13 @@ zerovec = { workspace = true, features = ["alloc", "yoke"] }
 serde = { workspace = true, features = ["derive", "alloc"], optional = true }
 zerotrie = { workspace = true, features = ["alloc"], optional = true }
 databake = { workspace = true, features = ["derive"], optional = true}
+either = { workspace = true, optional = true }
+smallvec = { workspace = true, optional = true }
+litemap = { workspace = true, optional = true }
 
 icu_datetime_data = { workspace = true, optional = true }
 icu_locale = { workspace = true, optional = true }
 
-# Experimental
-litemap = { workspace = true, optional = true }
 
 [dev-dependencies]
 icu = { path = "../../components/icu", default-features = false }
@@ -74,7 +73,7 @@ serde = [
     "icu_provider/serde",
     "icu_time/serde",
     "litemap?/serde",
-    "smallvec/serde",
+    "smallvec?/serde",
     "tinystr/serde",
     "potential_utf/serde",
     "zerovec/serde",
@@ -82,7 +81,9 @@ serde = [
 ]
 datagen = [
     "dep:databake",
+    "dep:either",
     "dep:litemap",
+    "dep:smallvec",
     "icu_calendar/datagen",
     "icu_pattern/databake",
     "icu_plurals/datagen",
@@ -91,7 +92,7 @@ datagen = [
     "serde",
 ]
 logging = ["icu_calendar/logging"]
-experimental = ["dep:litemap"]
+experimental = []
 compiled_data = ["dep:icu_datetime_data", "icu_calendar/compiled_data", "icu_decimal/compiled_data", "icu_plurals/compiled_data", "icu_time/compiled_data", "dep:icu_locale", "icu_locale?/compiled_data", "icu_provider/baked"]
 ixdtf = ["icu_time/ixdtf", "icu_calendar/ixdtf"]
 

--- a/components/decimal/Cargo.toml
+++ b/components/decimal/Cargo.toml
@@ -20,7 +20,6 @@ version.workspace = true
 all-features = true
 
 [dependencies]
-displaydoc = { workspace = true }
 fixed_decimal = { workspace = true }
 icu_provider = { workspace = true }
 icu_locale_core = { workspace = true }
@@ -28,7 +27,6 @@ writeable = { workspace = true }
 zerovec = { workspace = true }
 databake = { workspace = true, features = ["derive"], optional = true}
 serde = { workspace = true, features = ["derive"], optional = true }
-tinystr = { workspace = true }
 
 icu_decimal_data = { workspace = true, optional = true }
 icu_locale = { workspace = true, optional = true }
@@ -46,8 +44,8 @@ criterion = { workspace = true }
 
 [features]
 default = ["compiled_data"]
-serde = ["dep:serde", "icu_provider/serde", "zerovec/serde", "tinystr/serde"]
-datagen = ["serde", "dep:databake", "zerovec/databake", "tinystr/databake", "icu_provider/export", "alloc"]
+serde = ["dep:serde", "icu_provider/serde", "zerovec/serde"]
+datagen = ["serde", "dep:databake", "zerovec/databake", "icu_provider/export", "alloc"]
 compiled_data = ["dep:icu_decimal_data", "dep:icu_locale", "icu_locale?/compiled_data", "icu_provider/baked"]
 ryu = ["fixed_decimal/ryu"]
 alloc = ["serde?/alloc", "zerovec/alloc"]

--- a/components/icu/src/lib.rs
+++ b/components/icu/src/lib.rs
@@ -138,9 +138,8 @@
 )]
 #![warn(missing_docs)]
 
-#[cfg(doc)]
 // Needed for intra-doc link to work, since icu_provider is otherwise never mentioned in this crate
-extern crate icu_provider;
+use icu_provider as _;
 
 #[doc(inline)]
 pub use icu_calendar as calendar;

--- a/components/list/Cargo.toml
+++ b/components/list/Cargo.toml
@@ -19,7 +19,6 @@ version.workspace = true
 all-features = true
 
 [dependencies]
-displaydoc = { workspace = true }
 icu_provider = { workspace = true }
 regex-automata = { workspace = true, features = ["dfa-search"] }
 writeable = { workspace = true }

--- a/components/locale/Cargo.toml
+++ b/components/locale/Cargo.toml
@@ -24,7 +24,6 @@ all-features = true
 
 [dependencies]
 databake = { workspace = true, optional = true, features = ["derive"] }
-displaydoc = { workspace = true }
 icu_locale_core = { workspace = true, features = ["alloc", "zerovec"] }
 icu_provider = { workspace = true }
 serde = { workspace = true, features = ["derive", "alloc"], optional = true }

--- a/components/normalizer/Cargo.toml
+++ b/components/normalizer/Cargo.toml
@@ -20,7 +20,6 @@ license.workspace = true
 all-features = true
 
 [dependencies]
-displaydoc = { workspace = true }
 icu_collections = { workspace = true }
 icu_properties = { workspace = true, optional = true }
 icu_provider = { workspace = true }
@@ -56,9 +55,12 @@ experimental = []
 compiled_data = ["dep:icu_normalizer_data", "icu_properties?/compiled_data", "icu_provider/baked"]
 icu_properties = ["dep:icu_properties"]
 # For dealing with UTF16 strings
-utf16_iter = ["dep:utf16_iter", "write16"]
+utf16_iter = ["dep:utf16_iter", "dep:write16"]
 # For dealing with potentially ill-formed UTF8 strings
 utf8_iter = ["dep:utf8_iter"]
+
+# added by accident
+write16 = []
 
 [[bench]]
 name = "bench"

--- a/components/pattern/Cargo.toml
+++ b/components/pattern/Cargo.toml
@@ -25,10 +25,10 @@ either = { workspace = true }
 displaydoc = { workspace = true }
 writeable = { workspace = true, features = ["either"] }
 databake = { workspace = true, features = ["derive"], optional = true }
-litemap = { workspace = true, default-features = false, optional = true }
+litemap = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive", "alloc"], optional = true }
 yoke = { workspace = true, features = ["derive"], optional = true }
-zerovec = { workspace = true, default-features = false, optional = true }
+zerovec = { workspace = true, optional = true }
 
 [dev-dependencies]
 litemap = { workspace = true, features = ["alloc"] }
@@ -45,4 +45,4 @@ databake = ["dep:databake"]
 litemap = ["dep:litemap"]
 serde = ["alloc", "dep:serde"]
 yoke = ["dep:yoke"]
-zerovec = ["dep:zerovec"]
+zerovec = ["dep:zerovec", "alloc"]

--- a/components/pattern/src/frontend/mod.rs
+++ b/components/pattern/src/frontend/mod.rs
@@ -6,7 +6,7 @@
 mod databake;
 #[cfg(feature = "serde")]
 pub(crate) mod serde;
-#[cfg(all(feature = "zerovec", feature = "alloc"))]
+#[cfg(feature = "zerovec")]
 mod zerovec;
 
 use crate::common::*;

--- a/components/plurals/Cargo.toml
+++ b/components/plurals/Cargo.toml
@@ -20,16 +20,15 @@ version.workspace = true
 all-features = true
 
 [dependencies]
-displaydoc = { workspace = true }
 fixed_decimal = { workspace = true }
 icu_provider = { workspace = true, features = ["alloc"] }
 zerovec = { workspace = true, features = ["alloc", "yoke"] }
 
 databake = { workspace = true, features = ["derive"], optional = true}
 serde = { workspace = true, features = ["derive", "alloc"], optional = true }
+displaydoc = { workspace = true, optional = true }
 
 icu_plurals_data = { workspace = true, optional = true }
-icu_normalizer_data = { workspace = true, optional = true }
 icu_locale = { workspace = true, optional = true }
 
 [dev-dependencies]
@@ -44,10 +43,13 @@ criterion = { workspace = true }
 
 [features]
 default = ["compiled_data"]
-serde = ["dep:serde", "zerovec/serde", "icu_locale_core/serde", "icu_provider/serde"]
+serde = ["dep:serde", "zerovec/serde", "icu_locale_core/serde", "icu_provider/serde", "dep:displaydoc"]
 datagen = ["serde", "zerovec/databake", "dep:databake", "icu_provider/export"]
 experimental = []
 compiled_data = ["dep:icu_plurals_data", "dep:icu_locale", "icu_locale?/compiled_data", "icu_provider/baked"]
+
+# added by accident
+icu_normalizer_data = []
 
 [lib]
 bench = false  # This option is required for Benchmark CI

--- a/components/properties/Cargo.toml
+++ b/components/properties/Cargo.toml
@@ -20,7 +20,6 @@ rust-version.workspace = true
 all-features = true
 
 [dependencies]
-displaydoc = { workspace = true }
 icu_collections = { workspace = true }
 icu_provider = { workspace = true }
 zerovec = { workspace = true, features = ["derive", "yoke"] }
@@ -28,7 +27,6 @@ zerotrie = { workspace = true, features = ["yoke", "zerofrom"] }
 databake = { workspace = true, features = ["derive"], optional = true}
 serde = { workspace = true, features = ["derive", "alloc"], optional = true }
 icu_locale_core = { workspace = true, features = ["zerovec"] }
-potential_utf = { workspace = true, features = ["zerovec"]}
 
 unicode-bidi = { workspace = true, optional = true }
 
@@ -39,8 +37,8 @@ icu = { path = "../../components/icu", default-features = false }
 
 [features]
 default = ["compiled_data"]
-serde = ["dep:serde", "icu_locale_core/serde", "potential_utf/serde", "zerovec/serde", "icu_collections/serde", "icu_provider/serde", "zerotrie/serde"]
-datagen = ["serde", "dep:databake", "potential_utf/databake", "zerovec/databake", "icu_collections/databake", "icu_locale_core/databake", "zerotrie/databake", "icu_provider/export"]
+serde = ["dep:serde", "icu_locale_core/serde", "zerovec/serde", "icu_collections/serde", "icu_provider/serde", "zerotrie/serde"]
+datagen = ["serde", "dep:databake", "zerovec/databake", "icu_collections/databake", "icu_locale_core/databake", "zerotrie/databake", "icu_provider/export"]
 unicode_bidi = [ "dep:unicode-bidi" ]
 compiled_data = ["dep:icu_properties_data", "icu_provider/baked"]
 alloc = ["zerovec/alloc", "icu_collections/alloc"]

--- a/components/segmenter/Cargo.toml
+++ b/components/segmenter/Cargo.toml
@@ -20,7 +20,6 @@ version.workspace = true
 all-features = true
 
 [dependencies]
-displaydoc = { workspace = true }
 icu_collections = { workspace = true }
 icu_locale_core = { workspace = true }
 icu_provider = { workspace = true }

--- a/components/time/Cargo.toml
+++ b/components/time/Cargo.toml
@@ -26,10 +26,8 @@ icu_calendar = { workspace = true }
 icu_provider = { workspace = true }
 icu_locale_core = { workspace = true, features = ["zerovec"] }
 ixdtf = { workspace = true, optional = true }
-tinystr = { workspace = true, features = ["zerovec"] }
 zerotrie = { workspace = true, features = ["yoke", "zerofrom"] }
 zerovec = { workspace = true, features = ["derive", "yoke"] }
-writeable = { workspace = true }
 
 databake = { workspace = true, optional = true, features = ["derive"] }
 serde = { workspace = true, features = ["derive"], optional = true }
@@ -40,14 +38,16 @@ icu_time_data = { workspace = true, optional = true }
 icu = { path = "../../components/icu", default-features = false }
 icu_datetime = { path = "../../components/datetime", features = ["compiled_data"] }
 icu_provider_blob = { path = "../../provider/blob" }
+tinystr = { workspace = true }
+writeable = { workspace = true }
 
 [features]
 default = ["compiled_data", "ixdtf"]
 ixdtf = ["dep:ixdtf", "icu_calendar/ixdtf"]
-serde = ["dep:serde", "zerovec/serde", "zerotrie/serde", "tinystr/serde", "icu_provider/serde", "icu_locale_core/serde"]
-datagen = ["serde", "dep:databake", "zerovec/databake", "zerotrie/databake", "tinystr/databake", "icu_provider/export", "icu_locale_core/databake", "alloc"]
+serde = ["dep:serde", "zerovec/serde", "zerotrie/serde", "icu_provider/serde", "icu_locale_core/serde"]
+datagen = ["serde", "dep:databake", "zerovec/databake", "zerotrie/databake", "icu_provider/export", "icu_locale_core/databake", "alloc"]
 compiled_data = ["dep:icu_time_data", "icu_calendar/compiled_data", "icu_provider/baked"]
-alloc = ["tinystr/alloc", "zerotrie/alloc", "serde?/alloc"]
+alloc = ["zerotrie/alloc", "serde?/alloc"]
 
 [package.metadata.cargo-semver-checks.lints]
 workspace = true

--- a/ffi/capi/Cargo.toml
+++ b/ffi/capi/Cargo.toml
@@ -38,7 +38,6 @@ default = ["compiled_data", "default_components", "logging", "simple_logger", "s
 any_provider = []
 buffer_provider = [
     "dep:icu_provider_blob",
-    "dep:serde",
     "icu_calendar?/serde",
     "icu_casemap?/serde",
     "icu_collator?/serde",
@@ -51,13 +50,12 @@ buffer_provider = [
     "icu_plurals?/serde",
     "icu_properties?/serde",
     "icu_provider/serde",
-    "icu_provider_adapters/serde",
     "icu_segmenter?/serde",
     "icu_time?/serde",
     "icu_experimental?/serde",
 ]
 provider_fs = ["dep:icu_provider_fs", "buffer_provider", "std"]
-logging = ["icu_provider/logging", "dep:log", "diplomat-runtime/log", "std"]
+logging = ["icu_provider/logging", "diplomat-runtime/log", "std"]
 simple_logger = ["dep:simple_logger", "logging"]
 
 # Components
@@ -76,20 +74,20 @@ default_components = [
     "timezone"
 ]
 
-calendar = ["dep:icu_calendar", "dep:icu_time"]
+calendar = ["dep:icu_calendar", "dep:icu_time", "dep:tinystr"]
 casemap = ["dep:icu_casemap"]
 collator = ["dep:icu_collator"]
 # collections = ["dep:icu_collections"] # Not useful on its own: use properties
-datetime = ["dep:icu_datetime", "dep:icu_calendar", "dep:icu_time", "dep:icu_decimal", "dep:icu_plurals", "icu_datetime?/experimental"]
-decimal = ["dep:icu_decimal", "dep:fixed_decimal"]
+datetime = ["calendar", "dep:icu_datetime", "icu_datetime/experimental"]
+decimal = ["dep:icu_decimal", "dep:fixed_decimal", "dep:zerovec"]
 experimental = ["dep:icu_experimental"]
-list = ["dep:icu_list"]
+list = ["dep:icu_list", "dep:potential_utf"]
 locale = ["dep:icu_locale"]
 normalizer = ["dep:icu_normalizer", "icu_normalizer?/utf8_iter", "icu_normalizer?/utf16_iter"]
 plurals = ["dep:icu_plurals", "dep:fixed_decimal"]
 properties = ["dep:icu_properties", "dep:icu_collections", "dep:unicode-bidi"]
 segmenter = ["dep:icu_segmenter"]
-timezone = ["dep:icu_time", "dep:icu_calendar"]
+timezone = ["calendar"]
 
 compiled_data = [
     "icu_calendar?/compiled_data",
@@ -115,12 +113,8 @@ libc_alloc = ["dep:libc_alloc"]
 
 [dependencies]
 # Mandatory ICU4X components and utils
-icu_locale_core = { workspace = true }
+icu_locale_core = { workspace = true, features = ["alloc"] }
 icu_provider = { workspace = true }
-icu_provider_adapters = { workspace = true }
-
-tinystr = { workspace = true }
-potential_utf = { workspace = true, features = ["writeable"]}
 writeable = { workspace = true }
 
 # Diplomat
@@ -145,11 +139,13 @@ icu_time = { workspace = true, features = ["alloc", "ixdtf"], optional = true }
 icu_experimental = { workspace = true, optional = true }
 
 # Optional ICU4X features (not components)
+icu_provider_adapters = { workspace = true, features = ["serde"] } # should be optional
 icu_provider_blob = { workspace = true, features = ["alloc"], optional = true }
-serde = { workspace = true, optional = true }
+# log = { workspace = true, optional = true }
+potential_utf = { workspace = true, features = ["writeable"], optional = true }
+tinystr = { workspace = true, optional = true }
 unicode-bidi = { workspace = true, optional = true }
-log = { workspace = true, optional = true }
-zerovec = { workspace = true }
+zerovec = { workspace = true, optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # Logging uses diplomat_runtime bindings in wasm, we only need this for native

--- a/ffi/capi/src/errors.rs
+++ b/ffi/capi/src/errors.rs
@@ -61,7 +61,7 @@ pub mod ffi {
     #[repr(C)]
     #[diplomat::rust_link(icu::calendar::RangeError, Struct, compact)]
     #[diplomat::rust_link(icu::calendar::DateError, Enum, compact)]
-    #[cfg(any(feature = "datetime", feature = "timezone", feature = "calendar"))]
+    #[cfg(feature = "calendar")]
     #[non_exhaustive]
     pub enum CalendarError {
         Unknown = 0x00,
@@ -74,7 +74,7 @@ pub mod ffi {
     #[repr(C)]
     #[diplomat::rust_link(icu::calendar::ParseError, Enum, compact)]
     #[diplomat::rust_link(icu::time::ParseError, Enum, compact)]
-    #[cfg(any(feature = "datetime", feature = "timezone", feature = "calendar"))]
+    #[cfg(feature = "calendar")]
     #[non_exhaustive]
     pub enum Rfc9557ParseError {
         Unknown = 0x00,
@@ -86,7 +86,7 @@ pub mod ffi {
 
     #[derive(Debug, PartialEq, Eq)]
     #[diplomat::rust_link(icu::time::zone::InvalidOffsetError, Struct, compact)]
-    #[cfg(any(feature = "datetime", feature = "timezone"))]
+    #[cfg(feature = "datetime")]
     pub struct TimeZoneInvalidOffsetError;
 
     #[derive(Debug, PartialEq, Eq)]
@@ -160,14 +160,14 @@ impl From<icu_provider::DataError> for DataError {
     }
 }
 
-#[cfg(any(feature = "datetime", feature = "timezone", feature = "calendar"))]
+#[cfg(feature = "calendar")]
 impl From<icu_calendar::RangeError> for CalendarError {
     fn from(_: icu_calendar::RangeError) -> Self {
         Self::OutOfRange
     }
 }
 
-#[cfg(any(feature = "datetime", feature = "timezone", feature = "calendar"))]
+#[cfg(feature = "calendar")]
 impl From<icu_calendar::DateError> for CalendarError {
     fn from(e: icu_calendar::DateError) -> Self {
         match e {
@@ -179,7 +179,7 @@ impl From<icu_calendar::DateError> for CalendarError {
     }
 }
 
-#[cfg(any(feature = "datetime", feature = "timezone", feature = "calendar"))]
+#[cfg(feature = "calendar")]
 impl From<icu_calendar::ParseError> for Rfc9557ParseError {
     fn from(e: icu_calendar::ParseError) -> Self {
         match e {
@@ -192,7 +192,7 @@ impl From<icu_calendar::ParseError> for Rfc9557ParseError {
     }
 }
 
-#[cfg(any(feature = "datetime", feature = "timezone", feature = "calendar"))]
+#[cfg(feature = "calendar")]
 impl From<icu_time::ParseError> for Rfc9557ParseError {
     fn from(e: icu_time::ParseError) -> Self {
         match e {
@@ -316,7 +316,7 @@ impl From<icu_locale_core::ParseError> for LocaleParseError {
     }
 }
 
-#[cfg(any(feature = "timezone", feature = "datetime"))]
+#[cfg(feature = "datetime")]
 impl From<icu_time::zone::InvalidOffsetError> for TimeZoneInvalidOffsetError {
     fn from(_: icu_time::zone::InvalidOffsetError) -> Self {
         Self

--- a/ffi/capi/src/lib.rs
+++ b/ffi/capi/src/lib.rs
@@ -23,6 +23,8 @@
     clippy::result_unit_err,
     clippy::should_implement_trait
 )]
+// libc is behind a negative feature
+#![allow(unused_crate_dependencies)]
 
 //! This crate contains the `extern "C"` FFI for ICU4X, as well as the [Diplomat](https://github.com/rust-diplomat/diplomat)-generated
 //! C, C++, Dart, JavaScript, and TypeScript bindings.
@@ -81,7 +83,7 @@ pub mod unstable {
 
     #[cfg(feature = "properties")]
     pub mod bidi;
-    #[cfg(any(feature = "datetime", feature = "timezone", feature = "calendar"))]
+    #[cfg(feature = "calendar")]
     pub mod calendar;
     #[cfg(feature = "casemap")]
     pub mod casemap;
@@ -89,13 +91,13 @@ pub mod unstable {
     pub mod collator;
     #[cfg(feature = "properties")]
     pub mod collections_sets;
-    #[cfg(any(feature = "datetime", feature = "timezone", feature = "calendar"))]
+    #[cfg(feature = "calendar")]
     pub mod date;
     #[cfg(feature = "datetime")]
     pub mod date_formatter;
     #[cfg(feature = "datetime")]
     pub mod date_time_formatter;
-    #[cfg(any(feature = "datetime", feature = "timezone", feature = "calendar"))]
+    #[cfg(feature = "calendar")]
     pub mod datetime;
     #[cfg(feature = "datetime")]
     pub mod datetime_options;
@@ -109,7 +111,7 @@ pub mod unstable {
     pub mod fallbacker;
     #[cfg(feature = "decimal")]
     pub mod fixed_decimal;
-    #[cfg(any(feature = "datetime", feature = "timezone"))]
+    #[cfg(feature = "datetime")]
     pub mod iana_parser;
     #[cfg(feature = "list")]
     pub mod list;
@@ -147,19 +149,19 @@ pub mod unstable {
     pub mod segmenter_sentence;
     #[cfg(feature = "segmenter")]
     pub mod segmenter_word;
-    #[cfg(any(feature = "datetime", feature = "timezone", feature = "calendar"))]
+    #[cfg(feature = "calendar")]
     pub mod time;
     #[cfg(feature = "datetime")]
     pub mod time_formatter;
-    #[cfg(any(feature = "datetime", feature = "timezone"))]
+    #[cfg(feature = "datetime")]
     pub mod timezone;
     #[cfg(feature = "datetime")]
     pub mod timezone_formatter;
-    #[cfg(any(feature = "datetime", feature = "timezone"))]
+    #[cfg(feature = "datetime")]
     pub mod variant_offset;
     #[cfg(feature = "calendar")]
     pub mod week;
-    #[cfg(any(feature = "datetime", feature = "timezone"))]
+    #[cfg(feature = "datetime")]
     pub mod windows_parser;
     #[cfg(feature = "datetime")]
     pub mod zoned_date_formatter;

--- a/ffi/freertos/src/lib.rs
+++ b/ffi/freertos/src/lib.rs
@@ -43,6 +43,7 @@ mod stuff {
     extern crate alloc;
 
     use core::panic::PanicInfo;
+    use cortex_m as _;
     use freertos_rust::FreeRtosAllocator;
 
     #[global_allocator]

--- a/ffi/harfbuzz/Cargo.toml
+++ b/ffi/harfbuzz/Cargo.toml
@@ -34,7 +34,6 @@ harfbuzz-traits = { version = "0.6.0" }
 icu_normalizer = { workspace = true }
 icu_properties = { workspace = true }
 icu_provider = {workspace = true }
-displaydoc = { workspace = true }
 
 [features]
 default = []

--- a/provider/adapters/Cargo.toml
+++ b/provider/adapters/Cargo.toml
@@ -19,11 +19,6 @@ version.workspace = true
 [dependencies]
 icu_locale = { workspace = true }
 icu_provider = { workspace = true, features = ["alloc"] }
-tinystr = { workspace = true, features = ["zerovec"] }
-zerovec = { workspace = true, features = ["yoke"] }
-
-databake = { workspace = true, features = ["derive"], optional = true}
-serde = { workspace = true, features = ["derive", "alloc"], optional = true }
 
 [dev-dependencies]
 icu_provider = { path = "../../provider/core", features = ["deserialize_json"] }
@@ -32,3 +27,7 @@ writeable = { path = "../../utils/writeable" }
 
 [features]
 export = ["icu_provider/export"]
+serde = []
+
+# added by accident
+databake = []

--- a/provider/baked/Cargo.toml
+++ b/provider/baked/Cargo.toml
@@ -18,16 +18,14 @@ include.workspace = true
 
 [dependencies]
 icu_provider = { workspace = true, features = ["export", "baked"] }
-writeable = { workspace = true }
-zerotrie = { workspace = true, features = ["alloc", "databake"] }
-zerovec = { workspace = true }
 
 crlify = { workspace = true }
-databake = { workspace = true}
+databake = { workspace = true }
 icu_provider_registry = { workspace = true }
 log = { workspace = true }
-proc-macro2 = { workspace = true }
 heck = { workspace = true }
+zerotrie = { workspace = true, features = ["databake"] }
 
 [dev-dependencies]
 icu_provider_export = { path = "../export" }
+zerovec = { workspace = true }

--- a/provider/baked/src/export.rs
+++ b/provider/baked/src/export.rs
@@ -606,8 +606,8 @@ impl DataExporter for BakedExporter {
 
             // Safety invariant upheld: the only values being added to the trie are `index`
             // values, which come from enumerating `values`
-            let trie = icu_provider::baked::zerotrie::ZeroTrieSimpleAscii::from_iter(
-                values.clone().flat_map(|(index, (_payload, ids))| {
+            let trie = zerotrie::ZeroTrieSimpleAscii::from_iter(values.clone().flat_map(
+                |(index, (_payload, ids))| {
                     ids.iter().map(move |id| {
                         let mut encoded = id.locale.to_string().into_bytes();
                         if !id.marker_attributes.is_empty() {
@@ -616,8 +616,8 @@ impl DataExporter for BakedExporter {
                         }
                         (encoded, index)
                     })
-                }),
-            );
+                },
+            ));
 
             stats.lookup_struct_size = core::mem::size_of::<
                 icu_provider::baked::zerotrie::Data<icu_provider::hello_world::HelloWorldV1>,

--- a/provider/blob/Cargo.toml
+++ b/provider/blob/Cargo.toml
@@ -44,10 +44,13 @@ criterion = { workspace = true }
 [features]
 export = [
     "icu_provider/export",
-    "log",
+    "dep:log",
     "alloc",
 ]
 alloc = ["icu_provider/alloc", "postcard/alloc", "zerotrie/alloc", "serde/alloc"]
+
+# added by accident
+log = []
 
 [lib]
 bench = false  # This option is required for Benchmark CI

--- a/provider/core/Cargo.toml
+++ b/provider/core/Cargo.toml
@@ -22,9 +22,8 @@ all-features = true
 [dependencies]
 displaydoc = { workspace = true }
 icu_locale_core = { workspace = true }
-stable_deref_trait = { workspace = true }
-writeable = { workspace = true }
-tinystr = { workspace = true }
+stable_deref_trait = { workspace = true, optional = true }
+writeable = { workspace = true, optional = true }
 yoke = { workspace = true, features = ["alloc", "derive"] }
 zerofrom = { workspace = true, features = ["alloc", "derive"] }
 zerovec = { workspace = true, features = ["derive"]}
@@ -54,7 +53,7 @@ criterion = { workspace = true }
 
 [features]
 std = ["alloc"]
-alloc = ["icu_locale_core/alloc", "zerovec/alloc", "zerotrie/alloc"]
+alloc = ["icu_locale_core/alloc", "zerovec/alloc", "zerotrie?/alloc", "dep:stable_deref_trait", "dep:writeable"]
 sync = []
 # Enable logging of additional context of data errors
 logging = ["dep:log"]
@@ -68,10 +67,13 @@ deserialize_bincode_1 = ["serde", "dep:bincode", "std"]
 deserialize_postcard_1 = ["serde", "dep:postcard"]
 
 # Dependencies for baked provider scaffolding
-baked = ["zerotrie"]
+baked = ["dep:zerotrie", "dep:writeable"]
 
 # Dependencies for running data generation
 export = ["serde", "dep:erased-serde", "dep:databake", "std", "sync", "dep:postcard", "zerovec/databake"]
+
+# added by accident
+zerotrie = []
 
 [package.metadata.cargo-all-features]
 denylist = ["macros"]

--- a/provider/fs/Cargo.toml
+++ b/provider/fs/Cargo.toml
@@ -20,7 +20,6 @@ version.workspace = true
 all-features = true
 
 [dependencies]
-displaydoc = { workspace = true }
 icu_provider = { workspace = true, features = ["serde", "std", "export"] }
 serde = { workspace = true, features = ["derive", "alloc"] }
 serde-json-core = { workspace = true, features = ["std"] }
@@ -28,7 +27,6 @@ serde-json-core = { workspace = true, features = ["std"] }
 # Dependencies for the export feature
 bincode = { workspace = true, optional = true }
 crlify = { workspace = true, optional = true }
-log = {workspace = true, optional = true }
 postcard = { workspace = true, features = ["alloc"], optional = true }
 serde_json = { workspace = true, features = ["std"], optional = true }
 
@@ -46,7 +44,6 @@ criterion = { workspace = true }
 export = [
     "dep:bincode",
     "dep:crlify",
-    "dep:log",
     "dep:postcard",
     "dep:serde_json",
     "icu_provider/export",

--- a/provider/source/Cargo.toml
+++ b/provider/source/Cargo.toml
@@ -39,10 +39,8 @@ icu_time = { workspace = true, features = ["ixdtf"] }
 # ICU infrastructure
 calendrical_calculations = { workspace = true }
 icu_codepointtrie_builder = { workspace = true }
-icu_collections = { workspace = true, features = ["serde"] }
 icu_pattern = { workspace = true, features = ["alloc", "serde"] }
 icu_provider = { workspace = true, features = ["std", "logging", "export"]}
-icu_provider_adapters = { workspace = true }
 icu_provider_registry = { workspace = true }
 litemap = { workspace = true, features = ["serde"] }
 tinystr = { workspace = true, features = ["alloc", "serde", "zerovec"] }
@@ -53,7 +51,6 @@ zerovec = { workspace = true, features = ["serde", "yoke", "alloc"] }
 
 # External dependencies
 displaydoc = { workspace = true }
-either = { workspace = true }
 elsa = { workspace = true }
 flate2 = { workspace = true }
 itertools = { workspace = true }
@@ -72,9 +69,6 @@ zip = { workspace = true, features = ["deflate"] }
 ureq = { workspace = true, optional = true}
 
 # `experimental` feature 
-icu_experimental = { workspace = true, features = ["datagen"], optional = true }
-num-bigint = { workspace = true, optional = true }
-num-rational = { workspace = true, optional = true }
 num-traits = { workspace = true, optional = true }
 
 [dev-dependencies]
@@ -84,6 +78,8 @@ icu_provider = { workspace = true, features = ["deserialize_postcard_1"] }
 icu_segmenter = { path = "../../components/segmenter", features = ["lstm"] }
 simple_logger = { workspace = true }
 icu = { path = "../../components/icu", default-features = false, features = ["experimental"] }
+num-bigint = { workspace = true }
+num-rational = { workspace = true }
 
 [features]
 default = ["use_wasm", "networking"]
@@ -97,10 +93,11 @@ use_icu4c = ["icu_codepointtrie_builder/icu4c"]
 networking = ["dep:ureq"]
 experimental = [
     "icu/experimental",
-    "dep:num-bigint",
-    "dep:num-rational",
     "dep:num-traits",
 ]
+
+# added by accident
+icu_experimental = []
 
 [package.metadata.cargo-all-features]
 # We don't need working CPT builders for check

--- a/provider/source/src/properties/bidi.rs
+++ b/provider/source/src/properties/bidi.rs
@@ -37,10 +37,10 @@ impl DataProvider<PropertyEnumBidiMirroringGlyphV1> for SourceDataProvider {
         use icu::collections::codepointinvlist::CodePointInversionListBuilder;
         use icu::collections::codepointtrie::CodePointTrie;
         use icu::collections::codepointtrie::TrieType;
+        use icu::collections::codepointtrie::TrieValue;
         use icu::properties::props::BidiMirroringGlyph;
         use icu::properties::props::BidiPairedBracketType;
         use icu_codepointtrie_builder::{CodePointTrieBuilder, CodePointTrieBuilderData};
-        use icu_collections::codepointtrie::TrieValue;
 
         self.check_req::<PropertyEnumBidiMirroringGlyphV1>(req)?;
 

--- a/tools/benchmark/memory/Cargo.toml
+++ b/tools/benchmark/memory/Cargo.toml
@@ -11,4 +11,3 @@ edition = "2021"
 [dependencies]
 serde_json = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
-libc = "0.2"

--- a/tools/make/tidy.toml
+++ b/tools/make/tidy.toml
@@ -263,8 +263,14 @@ end
 [tasks.depcheck]
 description = "Run the dependency checker"
 category = "ICU4X Development"
-command = "cargo"
-args = ["run", "--manifest-path", "tools/make/depcheck/Cargo.toml"]
+script_runner = "@duckscript"
+env = { "RUSTFLAGS" = "-D unused_crate_dependencies" }
+script = '''
+exit_on_error true
+
+exec --fail-on-error cargo check --all-features
+exec --fail-on-error cargo run --manifest-path tools/make/depcheck/Cargo.toml
+'''
 
 [tasks.codegen]
 description = "Run the codegen tool"

--- a/tools/noalloctest/src/main.rs
+++ b/tools/noalloctest/src/main.rs
@@ -6,6 +6,14 @@
 #![cfg_attr(icu4x_noalloctest, no_std)]
 #![cfg_attr(icu4x_noalloctest, no_main)]
 
+use litemap as _;
+use potential_utf as _;
+use tinystr as _;
+use yoke as _;
+use zerofrom as _;
+use zerotrie as _;
+use zerovec as _;
+
 #[cfg(icu4x_noalloctest)]
 mod real {
     #[panic_handler]

--- a/utils/env_preferences/Cargo.toml
+++ b/utils/env_preferences/Cargo.toml
@@ -22,7 +22,8 @@ displaydoc = { workspace = true }
 icu_locale_core = { workspace = true, features = ["alloc"] }
 libc = "0.2.155"
 
-[dependencies.windows]
+
+[target.'cfg(target_os = "windows")'.dependencies.windows]
 version = "0.60.0"
 features = [
     "System",
@@ -35,5 +36,5 @@ features = [
     "Win32_Globalization",
 ]
 
-[dev-dependencies]
+[target.'cfg(target_os = "windows")'.dev-dependencies]
 windows-core = "0.60.1"

--- a/utils/env_preferences/src/lib.rs
+++ b/utils/env_preferences/src/lib.rs
@@ -18,6 +18,11 @@ pub mod parse;
 
 pub use error::{LocaleError, ParseError, RetrievalError};
 
+// doc
+use core_foundation_sys as _;
+#[cfg(target_os = "windows")]
+use libc as _;
+
 #[cfg(any(doc, target_os = "macos"))]
 pub mod apple;
 #[cfg(any(doc, target_os = "linux"))]

--- a/utils/yoke/Cargo.toml
+++ b/utils/yoke/Cargo.toml
@@ -22,8 +22,8 @@ independent = true
 [features]
 default = ["alloc", "zerofrom"]
 derive = ["dep:yoke-derive", "zerofrom/derive"]
-alloc = ["stable_deref_trait/alloc", "serde?/alloc", "zerofrom/alloc"]
-serde = ["dep:serde"]
+alloc = ["stable_deref_trait/alloc", "zerofrom/alloc"]
+serde = []
 zerofrom = ["dep:zerofrom"]
 
 [package.metadata.docs.rs]
@@ -38,7 +38,6 @@ stable_deref_trait = { workspace = true }
 
 yoke-derive = { workspace = true, optional = true }
 
-serde = { workspace = true, optional = true }
 zerofrom = { workspace = true, optional = true}
 
 [dev-dependencies]


### PR DESCRIPTION
This runs the `unused_crate_dependencies` lint in the `depcheck` job.

Unfortunately it's hard to globally enable this lint (i.e. in our lint boilerplate in each crate, or in `clippy-all`), as it triggers a lot of false positives for dev targets (examples/benches/tests) if they don't use all dependencies and all dev dependencies (https://github.com/rust-lang/rust/issues/95513). It also triggers with `-Zbuild-std` (https://github.com/rust-lang/rust/issues/122105), so the FFI jobs would fail.