### PR TITLE
Fix no-alloc test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2143,12 +2143,6 @@ dependencies = [
 name = "noalloctest"
 version = "2.0.0"
 dependencies = [
- "icu_calendar",
- "icu_collections",
- "icu_locale_core",
- "icu_properties",
- "icu_provider",
- "icu_time",
  "litemap",
  "potential_utf",
  "tinystr",

--- a/tools/make/ffi.toml
+++ b/tools/make/ffi.toml
@@ -112,6 +112,7 @@ toolchain = "${PINNED_CI_NIGHTLY}"
 command = "cargo"
 args = ["rustc", "-p", "noalloctest",
         "--target", "x86_64-unknown-linux-gnu",
+        "-Zbuild-std=core,panic_abort",
         "--",
         "-Clink-arg=-nostartfiles", "-Cpanic=abort",
         "--cfg", "icu4x_noalloctest"]

--- a/tools/noalloctest/Cargo.toml
+++ b/tools/noalloctest/Cargo.toml
@@ -20,12 +20,6 @@ publish = false
 
 [dependencies]
 # Dependencies that should be no-alloc should go here
-icu_calendar = { workspace = true }
-icu_collections = { workspace = true }
-icu_locale_core = { workspace = true }
-icu_properties = { workspace = true }
-icu_provider = { workspace = true, features = ["baked"] }
-icu_time = { workspace = true }
 litemap = { workspace = true }
 potential_utf = { workspace = true }
 tinystr = { workspace = true }


### PR DESCRIPTION
`icu_provider` is not actually no-alloc because `icu_locale_core` and `writeable` are not.