### PR TITLE
Make `icu_calendar`, `icu_time` no-alloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2118,6 +2118,7 @@ dependencies = [
  "icu_locale_core",
  "icu_properties",
  "icu_provider",
+ "icu_time",
  "litemap",
  "potential_utf",
  "tinystr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2113,6 +2113,7 @@ dependencies = [
 name = "noalloctest"
 version = "2.0.0"
 dependencies = [
+ "icu_calendar",
  "icu_collections",
  "icu_locale_core",
  "icu_properties",

--- a/components/calendar/Cargo.toml
+++ b/components/calendar/Cargo.toml
@@ -23,13 +23,13 @@ all-features = true
 calendrical_calculations = { workspace = true }
 displaydoc = { workspace = true }
 icu_provider = { workspace = true }
-icu_locale_core = { workspace = true, features = ["alloc"]}
+icu_locale_core = { workspace = true }
 ixdtf = { workspace = true, optional = true }
-tinystr = { workspace = true, features = ["alloc", "zerovec"] }
+tinystr = { workspace = true, features = ["zerovec"] }
 zerovec = { workspace = true, features = ["derive"] }
 
 databake = { workspace = true, features = ["derive"], optional = true }
-serde = { workspace = true, features = ["derive", "alloc"], optional = true }
+serde = { workspace = true, features = ["derive"], optional = true }
 
 icu_calendar_data = { workspace = true, optional = true }
 icu_locale = { workspace = true, optional = true }
@@ -56,7 +56,7 @@ serde = ["dep:serde", "zerovec/serde", "tinystr/serde", "icu_provider/serde"]
 datagen = ["serde", "dep:databake", "zerovec/databake", "tinystr/databake", "alloc", "icu_provider/export"]
 compiled_data = ["dep:icu_calendar_data", "dep:icu_locale", "icu_locale?/compiled_data", "icu_provider/baked"]
 
-alloc = []
+alloc = ["icu_locale_core/alloc", "tinystr/alloc", "serde?/alloc"]
 
 [[bench]]
 name = "date"

--- a/components/calendar/src/provider.rs
+++ b/components/calendar/src/provider.rs
@@ -99,6 +99,7 @@ pub const MARKERS: &[DataMarkerInfo] = &[
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_calendar::provider))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+#[cfg_attr(not(feature = "alloc"), zerovec::skip_derive(ZeroMapKV))]
 pub struct EraStartDate {
     /// The year the era started in
     pub year: i32,

--- a/components/calendar/src/types.rs
+++ b/components/calendar/src/types.rs
@@ -10,7 +10,6 @@ use core::fmt;
 use core::num::NonZeroU8;
 use tinystr::TinyAsciiStr;
 use tinystr::{TinyStr16, TinyStr4};
-use zerovec::maps::ZeroMapKV;
 use zerovec::ule::AsULE;
 
 /// A bag of various ways of expressing the year, month, and/or day.
@@ -256,7 +255,8 @@ impl AsULE for MonthCode {
     }
 }
 
-impl<'a> ZeroMapKV<'a> for MonthCode {
+#[cfg(feature = "alloc")]
+impl<'a> zerovec::maps::ZeroMapKV<'a> for MonthCode {
     type Container = zerovec::ZeroVec<'a, MonthCode>;
     type Slice = zerovec::ZeroSlice<MonthCode>;
     type GetType = <MonthCode as AsULE>::ULE;

--- a/components/locale_core/src/preferences/extensions/unicode/keywords/calendar.rs
+++ b/components/locale_core/src/preferences/extensions/unicode/keywords/calendar.rs
@@ -4,10 +4,8 @@
 
 #![allow(non_snake_case)]
 
-#[cfg(feature = "alloc")]
 use crate::preferences::extensions::unicode::enum_keyword;
 
-#[cfg(feature = "alloc")]
 enum_keyword!(
     /// Hijri Calendar sub-type
     ///
@@ -23,7 +21,6 @@ enum_keyword!(
         Rgsa
 });
 
-#[cfg(feature = "alloc")]
 enum_keyword!(
     /// A Unicode Calendar Identifier defines a type of calendar.
     ///

--- a/components/locale_core/src/preferences/extensions/unicode/keywords/collation.rs
+++ b/components/locale_core/src/preferences/extensions/unicode/keywords/collation.rs
@@ -2,10 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-#[cfg(feature = "alloc")]
 use crate::preferences::extensions::unicode::enum_keyword;
 
-#[cfg(feature = "alloc")]
 enum_keyword!(
     /// A Unicode Collation Identifier defines a type of collation (sort order).
     ///
@@ -43,7 +41,6 @@ enum_keyword!(
         ("zhuyin" => Zhuyin),
 }, "co");
 
-#[cfg(feature = "alloc")]
 enum_keyword!(
     /// Collation parameter key for ordering by case.
     ///
@@ -62,7 +59,6 @@ enum_keyword!(
         ("false" => False),
 }, "kf");
 
-#[cfg(feature = "alloc")]
 enum_keyword!(
     /// Collation parameter key for numeric handling.
     ///

--- a/components/locale_core/src/preferences/extensions/unicode/keywords/currency_format.rs
+++ b/components/locale_core/src/preferences/extensions/unicode/keywords/currency_format.rs
@@ -2,10 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-#[cfg(feature = "alloc")]
 use crate::preferences::extensions::unicode::enum_keyword;
 
-#[cfg(feature = "alloc")]
 enum_keyword!(
     /// A Unicode Currency Format Identifier defines a style for currency formatting.
     ///

--- a/components/locale_core/src/preferences/extensions/unicode/keywords/emoji.rs
+++ b/components/locale_core/src/preferences/extensions/unicode/keywords/emoji.rs
@@ -2,10 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-#[cfg(feature = "alloc")]
 use crate::preferences::extensions::unicode::enum_keyword;
 
-#[cfg(feature = "alloc")]
 enum_keyword!(
     /// A Unicode Emoji Presentation Style Identifier
     ///

--- a/components/locale_core/src/preferences/extensions/unicode/keywords/first_day.rs
+++ b/components/locale_core/src/preferences/extensions/unicode/keywords/first_day.rs
@@ -2,10 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-#[cfg(feature = "alloc")]
 use crate::preferences::extensions::unicode::enum_keyword;
 
-#[cfg(feature = "alloc")]
 enum_keyword!(
     /// A Unicode First Day Identifier defines the preferred first day of the week for calendar display.
     ///

--- a/components/locale_core/src/preferences/extensions/unicode/keywords/hour_cycle.rs
+++ b/components/locale_core/src/preferences/extensions/unicode/keywords/hour_cycle.rs
@@ -2,10 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-#[cfg(feature = "alloc")]
 use crate::preferences::extensions::unicode::enum_keyword;
 
-#[cfg(feature = "alloc")]
 enum_keyword!(
     /// A Unicode Hour Cycle Identifier defines the preferred time cycle. Specifying "hc" in a locale identifier overrides the default value specified by supplemental time data for the region.
     ///

--- a/components/locale_core/src/preferences/extensions/unicode/keywords/line_break.rs
+++ b/components/locale_core/src/preferences/extensions/unicode/keywords/line_break.rs
@@ -2,10 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-#[cfg(feature = "alloc")]
 use crate::preferences::extensions::unicode::enum_keyword;
 
-#[cfg(feature = "alloc")]
 enum_keyword!(
     /// A Unicode Line Break Style Identifier defines a preferred line break style corresponding to the CSS level 3 line-break option.
     ///

--- a/components/locale_core/src/preferences/extensions/unicode/keywords/line_break_word.rs
+++ b/components/locale_core/src/preferences/extensions/unicode/keywords/line_break_word.rs
@@ -2,10 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-#[cfg(feature = "alloc")]
 use crate::preferences::extensions::unicode::enum_keyword;
 
-#[cfg(feature = "alloc")]
 enum_keyword!(
     /// A Unicode Line Break Word Identifier defines preferred line break word handling behavior corresponding to the CSS level 3 word-break option.
     ///

--- a/components/locale_core/src/preferences/extensions/unicode/keywords/measurement_system.rs
+++ b/components/locale_core/src/preferences/extensions/unicode/keywords/measurement_system.rs
@@ -2,10 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-#[cfg(feature = "alloc")]
 use crate::preferences::extensions::unicode::enum_keyword;
 
-#[cfg(feature = "alloc")]
 enum_keyword!(
     /// A Unicode Measurement System Identifier defines a preferred measurement system.
     ///

--- a/components/locale_core/src/preferences/extensions/unicode/keywords/measurement_unit_override.rs
+++ b/components/locale_core/src/preferences/extensions/unicode/keywords/measurement_unit_override.rs
@@ -2,10 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-#[cfg(feature = "alloc")]
 use crate::preferences::extensions::unicode::enum_keyword;
 
-#[cfg(feature = "alloc")]
 enum_keyword!(
     /// A Measurement Unit Preference Override defines an override for measurement unit preference.
     ///

--- a/components/locale_core/src/preferences/extensions/unicode/keywords/sentence_supression.rs
+++ b/components/locale_core/src/preferences/extensions/unicode/keywords/sentence_supression.rs
@@ -2,10 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-#[cfg(feature = "alloc")]
 use crate::preferences::extensions::unicode::enum_keyword;
 
-#[cfg(feature = "alloc")]
 enum_keyword!(
     /// A Unicode Sentence Break Suppressions Identifier defines a set of data to be used for suppressing certain
     /// sentence breaks that would otherwise be found by UAX #14 rules.

--- a/components/locale_core/src/preferences/extensions/unicode/keywords/variant.rs
+++ b/components/locale_core/src/preferences/extensions/unicode/keywords/variant.rs
@@ -2,10 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-#[cfg(feature = "alloc")]
 use crate::preferences::extensions::unicode::enum_keyword;
 
-#[cfg(feature = "alloc")]
 enum_keyword!(
     /// A Unicode Variant Identifier defines a special variant used for locales.
     ///

--- a/components/locale_core/src/preferences/extensions/unicode/macros/mod.rs
+++ b/components/locale_core/src/preferences/extensions/unicode/macros/mod.rs
@@ -2,12 +2,10 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-#[cfg(feature = "alloc")]
 mod enum_keyword;
 mod struct_keyword;
 
 #[doc(inline)]
-#[cfg(feature = "alloc")]
 pub use enum_keyword::enum_keyword;
 #[doc(inline)]
 pub use struct_keyword::struct_keyword;

--- a/components/locale_core/src/shortvec/litemap.rs
+++ b/components/locale_core/src/shortvec/litemap.rs
@@ -45,6 +45,8 @@ impl<K, V> Store<K, V> for ShortBoxSlice<(K, V)> {
             ZeroOne(ref v) => v.as_ref(),
             #[cfg(feature = "alloc")]
             Multi(ref v) => v.last(),
+            #[cfg(not(feature = "alloc"))]
+            Two([_, ref v]) => Some(v),
         }
         .map(|elt| (&elt.0, &elt.1))
     }

--- a/components/time/Cargo.toml
+++ b/components/time/Cargo.toml
@@ -44,10 +44,10 @@ writeable = { workspace = true }
 [features]
 default = ["compiled_data", "ixdtf"]
 ixdtf = ["dep:ixdtf", "icu_calendar/ixdtf"]
-serde = ["dep:serde", "zerovec/serde", "zerotrie/serde", "icu_provider/serde", "icu_locale_core/serde"]
+serde = ["dep:serde", "zerovec/serde", "zerotrie/serde", "icu_provider/serde", "icu_locale_core/serde", "alloc"]
 datagen = ["serde", "dep:databake", "zerovec/databake", "zerotrie/databake", "icu_provider/export", "icu_locale_core/databake", "alloc"]
 compiled_data = ["dep:icu_time_data", "icu_calendar/compiled_data", "icu_provider/baked"]
-alloc = ["zerotrie/alloc", "serde?/alloc"]
+alloc = ["zerotrie/alloc", "serde?/alloc", "zerovec/alloc"]
 
 [package.metadata.cargo-semver-checks.lints]
 workspace = true

--- a/components/time/src/provider/mod.rs
+++ b/components/time/src/provider/mod.rs
@@ -19,7 +19,6 @@
 use crate::zone::{UtcOffset, ZoneNameTimestamp};
 use icu_provider::prelude::*;
 use zerotrie::ZeroTrieSimpleAscii;
-use zerovec::maps::ZeroMapKV;
 use zerovec::ule::vartuple::VarTupleULE;
 use zerovec::ule::{AsULE, NichedOption, RawBytesULE};
 use zerovec::{VarZeroVec, ZeroSlice, ZeroVec};
@@ -71,6 +70,7 @@ const SECONDS_TO_EIGHTS_OF_HOURS: i32 = 60 * 60 / 8;
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_time::provider))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+#[cfg_attr(not(feature = "alloc"), zerovec::skip_derive(ZeroMapKV))]
 #[non_exhaustive]
 pub enum TimeZoneVariant {
     /// The variant corresponding to `"standard"` in CLDR.
@@ -286,7 +286,8 @@ fn offsets_ule() {
     assert_round_trip(UtcOffset::try_from_str("-01:50").unwrap());
 }
 
-impl<'a> ZeroMapKV<'a> for VariantOffsets {
+#[cfg(feature = "alloc")]
+impl<'a> zerovec::maps::ZeroMapKV<'a> for VariantOffsets {
     type Container = ZeroVec<'a, Self>;
     type Slice = ZeroSlice<Self>;
     type GetType = <Self as AsULE>::ULE;
@@ -595,64 +596,65 @@ icu_provider::data_marker!(
     has_checksum = true
 );
 
+impl AsULE for VariantOffsets {
+    type ULE = [i8; 2];
+
+    fn from_unaligned([std, dst]: Self::ULE) -> Self {
+        fn decode(encoded: i8) -> i32 {
+            encoded as i32 * SECONDS_TO_EIGHTS_OF_HOURS
+                + match encoded % 8 {
+                    // 7.5, 37.5, representing 10, 40
+                    1 | 5 => 150,
+                    -1 | -5 => -150,
+                    // 22.5, 52.5, representing 20, 50
+                    3 | 7 => -150,
+                    -3 | -7 => 150,
+                    // 0, 15, 30, 45
+                    _ => 0,
+                }
+        }
+
+        Self {
+            standard: UtcOffset::from_seconds_unchecked(decode(std)),
+            daylight: (dst != 0).then(|| UtcOffset::from_seconds_unchecked(decode(std + dst))),
+        }
+    }
+
+    fn to_unaligned(self) -> Self::ULE {
+        fn encode(offset: i32) -> i8 {
+            debug_assert_eq!(offset.abs() % 60, 0);
+            let scaled = match offset.abs() / 60 % 60 {
+                0 | 15 | 30 | 45 => offset / SECONDS_TO_EIGHTS_OF_HOURS,
+                10 | 40 => {
+                    // stored as 7.5, 37.5, truncating div
+                    offset / SECONDS_TO_EIGHTS_OF_HOURS
+                }
+                20 | 50 => {
+                    // stored as 22.5, 52.5, need to add one
+                    offset / SECONDS_TO_EIGHTS_OF_HOURS + offset.signum()
+                }
+                _ => {
+                    debug_assert!(false, "{offset:?}");
+                    offset / SECONDS_TO_EIGHTS_OF_HOURS
+                }
+            };
+            debug_assert!(i8::MIN as i32 <= scaled && scaled <= i8::MAX as i32);
+            scaled as i8
+        }
+        [
+            encode(self.standard.to_seconds()),
+            self.daylight
+                .map(|d| encode(d.to_seconds() - self.standard.to_seconds()))
+                .unwrap_or_default(),
+        ]
+    }
+}
+
 // remove in 3.0
+#[cfg(feature = "alloc")]
 pub(crate) mod legacy {
     use super::*;
     use zerovec::ZeroMap2d;
-
-    impl AsULE for VariantOffsets {
-        type ULE = [i8; 2];
-
-        fn from_unaligned([std, dst]: Self::ULE) -> Self {
-            fn decode(encoded: i8) -> i32 {
-                encoded as i32 * SECONDS_TO_EIGHTS_OF_HOURS
-                    + match encoded % 8 {
-                        // 7.5, 37.5, representing 10, 40
-                        1 | 5 => 150,
-                        -1 | -5 => -150,
-                        // 22.5, 52.5, representing 20, 50
-                        3 | 7 => -150,
-                        -3 | -7 => 150,
-                        // 0, 15, 30, 45
-                        _ => 0,
-                    }
-            }
-
-            Self {
-                standard: UtcOffset::from_seconds_unchecked(decode(std)),
-                daylight: (dst != 0).then(|| UtcOffset::from_seconds_unchecked(decode(std + dst))),
-            }
-        }
-
-        fn to_unaligned(self) -> Self::ULE {
-            fn encode(offset: i32) -> i8 {
-                debug_assert_eq!(offset.abs() % 60, 0);
-                let scaled = match offset.abs() / 60 % 60 {
-                    0 | 15 | 30 | 45 => offset / SECONDS_TO_EIGHTS_OF_HOURS,
-                    10 | 40 => {
-                        // stored as 7.5, 37.5, truncating div
-                        offset / SECONDS_TO_EIGHTS_OF_HOURS
-                    }
-                    20 | 50 => {
-                        // stored as 22.5, 52.5, need to add one
-                        offset / SECONDS_TO_EIGHTS_OF_HOURS + offset.signum()
-                    }
-                    _ => {
-                        debug_assert!(false, "{offset:?}");
-                        offset / SECONDS_TO_EIGHTS_OF_HOURS
-                    }
-                };
-                debug_assert!(i8::MIN as i32 <= scaled && scaled <= i8::MAX as i32);
-                scaled as i8
-            }
-            [
-                encode(self.standard.to_seconds()),
-                self.daylight
-                    .map(|d| encode(d.to_seconds() - self.standard.to_seconds()))
-                    .unwrap_or_default(),
-            ]
-        }
-    }
 
     icu_provider::data_marker!(
         /// The default mapping between period and offsets. The second level key is a wall-clock time encoded as

--- a/components/time/src/zone/mod.rs
+++ b/components/time/src/zone/mod.rs
@@ -76,7 +76,6 @@ use icu_calendar::Iso;
 use icu_locale_core::subtags::{subtag, Subtag};
 use icu_provider::prelude::yoke;
 use zerovec::ule::{AsULE, ULE};
-use zerovec::{ZeroSlice, ZeroVec};
 
 /// Time zone data model choices.
 pub mod models {
@@ -205,9 +204,10 @@ impl AsULE for TimeZone {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a> zerovec::maps::ZeroMapKV<'a> for TimeZone {
-    type Container = ZeroVec<'a, TimeZone>;
-    type Slice = ZeroSlice<TimeZone>;
+    type Container = zerovec::ZeroVec<'a, TimeZone>;
+    type Slice = zerovec::ZeroSlice<TimeZone>;
     type GetType = TimeZone;
     type OwnedType = TimeZone;
 }

--- a/components/time/src/zone/offset.rs
+++ b/components/time/src/zone/offset.rs
@@ -4,7 +4,9 @@
 
 use core::str::FromStr;
 
-use crate::provider::{legacy::TimezoneVariantsOffsetsV1, TimezonePeriods, TimezonePeriodsV1};
+#[cfg(feature = "alloc")]
+use crate::provider::legacy::TimezoneVariantsOffsetsV1;
+use crate::provider::{TimezonePeriods, TimezonePeriodsV1};
 use crate::TimeZone;
 use icu_provider::prelude::*;
 
@@ -169,12 +171,14 @@ impl FromStr for UtcOffset {
 
 #[derive(Debug)]
 enum OffsetData {
+    #[cfg(feature = "alloc")] // doesn't alloc, but ZeroMap are behind the alloc feature
     Old(DataPayload<TimezoneVariantsOffsetsV1>),
     New(DataPayload<TimezonePeriodsV1>),
 }
 
 #[derive(Debug)]
 enum OffsetDataBorrowed<'a> {
+    #[cfg(feature = "alloc")]
     Old(&'a zerovec::ZeroMap2d<'a, TimeZone, ZoneNameTimestamp, VariantOffsets>),
     New(&'a TimezonePeriods<'a>),
 }
@@ -231,19 +235,25 @@ impl VariantOffsetsCalculator {
         use icu_provider::buf::AsDeserializingBufferProvider;
         {
             Ok(Self {
-                offset_period: if let Ok(payload) = DataProvider::<TimezonePeriodsV1>::load(
+                offset_period: match DataProvider::<TimezonePeriodsV1>::load(
                     &provider.as_deserializing(),
                     Default::default(),
                 ) {
-                    OffsetData::New(payload.payload)
-                } else {
-                    OffsetData::Old(
-                        DataProvider::<TimezoneVariantsOffsetsV1>::load(
-                            &provider.as_deserializing(),
-                            Default::default(),
-                        )?
-                        .payload,
-                    )
+                    Ok(payload) => OffsetData::New(payload.payload),
+                    Err(_e) => {
+                        #[cfg(feature = "alloc")]
+                        {
+                            OffsetData::Old(
+                                DataProvider::<TimezoneVariantsOffsetsV1>::load(
+                                    &provider.as_deserializing(),
+                                    Default::default(),
+                                )?
+                                .payload,
+                            )
+                        }
+                        #[cfg(not(feature = "alloc"))]
+                        return Err(_e);
+                    }
                 },
             })
         }
@@ -266,6 +276,7 @@ impl VariantOffsetsCalculator {
         VariantOffsetsCalculatorBorrowed {
             offset_period: match self.offset_period {
                 OffsetData::New(ref payload) => OffsetDataBorrowed::New(payload.get()),
+                #[cfg(feature = "alloc")]
                 OffsetData::Old(ref payload) => OffsetDataBorrowed::Old(payload.get()),
             },
         }
@@ -297,6 +308,7 @@ impl VariantOffsetsCalculatorBorrowed<'static> {
         VariantOffsetsCalculator {
             offset_period: match self.offset_period {
                 OffsetDataBorrowed::New(p) => OffsetData::New(DataPayload::from_static_ref(p)),
+                #[cfg(feature = "alloc")]
                 OffsetDataBorrowed::Old(p) => OffsetData::Old(DataPayload::from_static_ref(p)),
             },
         }
@@ -354,11 +366,12 @@ impl VariantOffsetsCalculatorBorrowed<'_> {
         time_zone_id: TimeZone,
         timestamp: ZoneNameTimestamp,
     ) -> Option<VariantOffsets> {
-        use zerovec::ule::AsULE;
-        let mut offsets = None;
         match self.offset_period {
             OffsetDataBorrowed::New(p) => p.get(time_zone_id, timestamp).map(|(os, _)| os),
+            #[cfg(feature = "alloc")]
             OffsetDataBorrowed::Old(p) => {
+                use zerovec::ule::AsULE;
+                let mut offsets = None;
                 for (bytes, id) in p.get0(&time_zone_id)?.iter1_copied().rev() {
                     if timestamp >= ZoneNameTimestamp::from_unaligned(*bytes) {
                         offsets = Some(id);

--- a/components/time/src/zone/zone_name_timestamp.rs
+++ b/components/time/src/zone/zone_name_timestamp.rs
@@ -5,7 +5,7 @@
 use core::fmt;
 
 use icu_calendar::Iso;
-use zerovec::{maps::ZeroMapKV, ule::AsULE, ZeroSlice, ZeroVec};
+use zerovec::ule::AsULE;
 
 use crate::{zone::UtcOffset, DateTime, ZonedDateTime};
 
@@ -193,9 +193,10 @@ impl AsULE for ZoneNameTimestamp {
     }
 }
 
-impl<'a> ZeroMapKV<'a> for ZoneNameTimestamp {
-    type Container = ZeroVec<'a, Self>;
-    type Slice = ZeroSlice<Self>;
+#[cfg(feature = "alloc")]
+impl<'a> zerovec::maps::ZeroMapKV<'a> for ZoneNameTimestamp {
+    type Container = zerovec::ZeroVec<'a, Self>;
+    type Slice = zerovec::ZeroSlice<Self>;
     type GetType = <Self as AsULE>::ULE;
     type OwnedType = Self;
 }

--- a/tools/noalloctest/Cargo.toml
+++ b/tools/noalloctest/Cargo.toml
@@ -25,6 +25,7 @@ icu_collections = { workspace = true }
 icu_locale_core = { workspace = true, features = ["serde"] }
 icu_properties = { workspace = true, features = ["compiled_data"] }
 icu_provider = { workspace = true, features = ["baked", "logging", "sync", "serde", "deserialize_postcard_1"] }
+icu_time = { workspace = true, features = ["ixdtf"] }
 litemap = { workspace = true, features = ["yoke"] }
 potential_utf = { workspace = true, features = ["serde", "writeable", "zerovec"] }
 tinystr = { workspace = true, features = ["serde", "zerovec"] }

--- a/tools/noalloctest/Cargo.toml
+++ b/tools/noalloctest/Cargo.toml
@@ -20,6 +20,7 @@ publish = false
 
 [dependencies]
 # Dependencies that should be no-alloc should go here
+icu_calendar = { workspace = true, features = ["ixdtf", "logging"] }
 icu_collections = { workspace = true }
 icu_locale_core = { workspace = true, features = ["serde"] }
 icu_properties = { workspace = true, features = ["compiled_data"] }

--- a/tools/noalloctest/src/main.rs
+++ b/tools/noalloctest/src/main.rs
@@ -11,6 +11,7 @@ use icu_collections as _;
 use icu_locale_core as _;
 use icu_properties as _;
 use icu_provider as _;
+use icu_time as _;
 use litemap as _;
 use potential_utf as _;
 use tinystr as _;

--- a/tools/noalloctest/src/main.rs
+++ b/tools/noalloctest/src/main.rs
@@ -6,6 +6,7 @@
 #![cfg_attr(icu4x_noalloctest, no_std)]
 #![cfg_attr(icu4x_noalloctest, no_main)]
 
+use icu_calendar as _;
 use icu_collections as _;
 use icu_locale_core as _;
 use icu_properties as _;

--- a/utils/ixdtf/src/lib.rs
+++ b/utils/ixdtf/src/lib.rs
@@ -393,8 +393,6 @@ mod error;
 pub mod parsers;
 pub mod records;
 
-extern crate alloc;
-
 pub use error::ParseError;
 
 /// This module contains the supported encoding for `ixdtf` parsing.


### PR DESCRIPTION
Fixes #6984

`icu_calendar` requires `CalendarAlgorithm`, which requires construction of `icu::locale::extensions::unicode::Value`s of length two (`enum_preferences!` supports at most length 2, which is used by extensions such as `-islamic-tbla`). To support this, I added a new constructor to `ShortBoxSlice` for constructing from two elements, and a no-alloc-only variant `::Two([T; 2])`.