### PR TITLE
Re-remove range-check from Gregorian calendars

### DIFF
--- a/components/calendar/src/cal/gregorian.rs
+++ b/components/calendar/src/cal/gregorian.rs
@@ -4,7 +4,6 @@
 
 use crate::cal::abstract_gregorian::{impl_with_abstract_gregorian, GregorianYears};
 use crate::calendar_arithmetic::ArithmeticDate;
-use crate::error::range_check;
 use crate::preferences::CalendarAlgorithm;
 use crate::{types, Date, DateError, RangeError};
 use tinystr::tinystr;
@@ -18,8 +17,8 @@ impl GregorianYears for CeBce {
     fn extended_from_era_year(&self, era: Option<&str>, year: i32) -> Result<i32, DateError> {
         match era {
             None => Ok(year),
-            Some("ad" | "ce") => Ok(range_check(year, "year", 1..)?),
-            Some("bce" | "bc") => Ok(1 - range_check(year, "year", 1..)?),
+            Some("ad" | "ce") => Ok(year),
+            Some("bce" | "bc") => Ok(1 - year),
             Some(_) => Err(DateError::UnknownEra),
         }
     }

--- a/components/calendar/src/cal/japanese.rs
+++ b/components/calendar/src/cal/japanese.rs
@@ -5,7 +5,7 @@
 use crate::cal::abstract_gregorian::{impl_with_abstract_gregorian, GregorianYears};
 use crate::cal::iso::IsoEra;
 use crate::calendar_arithmetic::ArithmeticDate;
-use crate::error::{range_check, DateError};
+use crate::error::DateError;
 use crate::provider::{
     CalendarJapaneseExtendedV1, CalendarJapaneseModernV1, EraStartDate, JapaneseEras,
 };
@@ -458,14 +458,12 @@ impl JapaneseEras<'_> {
             }
             Some("ce" | "ad") => {
                 return Ok(JapaneseDateInner(ArithmeticDate::new_gregorian::<IsoEra>(
-                    range_check(year, "year", 1..)?,
-                    month,
-                    day,
+                    year, month, day,
                 )?));
             }
             Some("bce" | "bc") => {
                 return Ok(JapaneseDateInner(ArithmeticDate::new_gregorian::<IsoEra>(
-                    1 - range_check(year, "year", 1..)?,
+                    1 - year,
                     month,
                     day,
                 )?));

--- a/components/calendar/src/cal/roc.rs
+++ b/components/calendar/src/cal/roc.rs
@@ -4,7 +4,6 @@
 
 use crate::cal::abstract_gregorian::{impl_with_abstract_gregorian, GregorianYears};
 use crate::calendar_arithmetic::ArithmeticDate;
-use crate::error::range_check;
 use crate::preferences::CalendarAlgorithm;
 use crate::{types, Date, DateError, RangeError};
 use tinystr::tinystr;
@@ -42,8 +41,8 @@ impl GregorianYears for RocEra {
     fn extended_from_era_year(&self, era: Option<&str>, year: i32) -> Result<i32, DateError> {
         match era {
             None => Ok(year),
-            Some("roc") => Ok(range_check(year, "year", 1..)?),
-            Some("broc") => Ok(1 - range_check(year, "year", 1..)?),
+            Some("roc") => Ok(year),
+            Some("broc") => Ok(1 - year),
             Some(_) => Err(DateError::UnknownEra),
         }
     }


### PR DESCRIPTION
This is a regression from https://github.com/unicode-org/icu4x/pull/6975 and breaks Temporal.

`from_fields` allows for years to be outside their era, and this is generally considered a good idea because it prevents surprise errors when eras change in Japanese.


If the year-checking behavior is desired in from_codes we can add a simple "check if the returned era was the original era" check.


This was briefly discussed in https://github.com/unicode-org/icu4x/pull/6910#discussion_r2363290327

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->