### PR TITLE
Auto-install `cargo-tidy` and remove from contributing.md

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -469,12 +469,6 @@ jobs:
     - name: Show the selected Rust toolchain
       run: rustup show
 
-    # Job-specific dependencies
-    - name: Install cargo-rdme
-      uses: taiki-e/install-action@64e4e2f995104968c78bd697b253d55bf557af66 # v2.41.11
-      with:
-        tool: cargo-rdme@1.4.2
-
     # Actual job
     - name: Tidy
       run: cargo make ci-job-tidy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,11 +14,9 @@ In most cases, the first step is to find or file a new issue related to your pla
 
 ### Installing dependencies
 
-To build ICU4X, you will need the following dependencies:
+ICU4X is written in Rust, so you will need a [Rust toolchain](https://rust-lang.org/tools/install/).
 
- - Rust (and Cargo) installed [via `rustup`](https://doc.rust-lang.org/book/ch01-01-installation.html)
- - `cargo-make` installed via `cargo install cargo-make`
- - `cargo-rdme` installed via `cargo install cargo-rdme`
+We use `cargo-make` for development scripts, install via `cargo install cargo-make`.
 
 Certain tests may need further dependencies, these are documented below in the [Testing](#testing) section.
 

--- a/tools/make/tidy.toml
+++ b/tools/make/tidy.toml
@@ -132,6 +132,7 @@ echo "License header check complete"
 
 [tasks.generate-readmes]
 description = "Automatically generate README.md for each component."
+install_crate = { crate_name = "cargo-rdme", test_arg = ["--help"] }
 category = "ICU4X Development"
 script_runner = "@duckscript"
 script = '''


### PR DESCRIPTION
Not a critical tool that should block onboarding.