### PR TITLE
Fix binsize CI

### DIFF
--- a/tools/make/wasm.toml
+++ b/tools/make/wasm.toml
@@ -20,8 +20,8 @@ exit_on_error true
 
 # 100 KiB, working around a bug in older rustc
 # https://github.com/unicode-org/icu4x/issues/2753
-set_env RUSTFLAGS "-Clink-args=-zstack-size=100000 --cfg getrandom_backend=\"wasm_js\" -Zwasm-c-abi=spec"
-command = set "build -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target wasm32-unknown-unknown --profile=release-opt-size --examples --workspace --features serde --exclude icu_provider_export --exclude icu_capi"
+set_env RUSTFLAGS "-Zunstable-options -Cpanic=immediate-abort -Clink-args=-zstack-size=100000 --cfg getrandom_backend=\"wasm_js\" -Zwasm-c-abi=spec"
+command = set "build -Z build-std=std,panic_abort --target wasm32-unknown-unknown --profile=release-opt-size --examples --workspace --features serde --exclude icu_provider_export --exclude icu_capi"
 exec --fail-on-error cargo +${PINNED_CI_NIGHTLY} %{command}
 # Re-run the build command only to generate the JSON output
 output = exec --fail-on-error cargo +${PINNED_CI_NIGHTLY} %{command} --message-format=json


### PR DESCRIPTION
Fixes the bug introduced by #7003

Unfortunately, binsize CI was already broken: The introduction of a `ureq` dev-dep to `icu_calendar` pulled in `getrandom 0.2` which needs a speial feature to build in wasm, but simply adding `getrandom = {version = 0.2, features = ["js"]}` starts causing compile errors in rustls. I don't intend to investigate further.

A potential fix would be to move the networky test to `tools/networky_tests` or something.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->