### PR TITLE
Fix panic when constraining out-of-range months

### DIFF
--- a/components/calendar/src/calendar_arithmetic.rs
+++ b/components/calendar/src/calendar_arithmetic.rs
@@ -383,18 +383,19 @@ impl<C: CalendarArithmetic> ArithmeticDate<C> {
         options: DateFromFieldsOptions,
     ) -> Result<Self, RangeError> {
         let ArithmeticDateBuilder { year, month, day } = builder;
+        let constrained_month = range_check_with_overflow(
+            month,
+            "month",
+            1..=C::months_in_provided_year(year),
+            options.overflow.unwrap_or_default(),
+        )?;
         Ok(Self::new_unchecked(
             year,
-            range_check_with_overflow(
-                month,
-                "month",
-                1..=C::months_in_provided_year(year),
-                options.overflow.unwrap_or_default(),
-            )?,
+            constrained_month,
             range_check_with_overflow(
                 day,
                 "day",
-                1..=C::days_in_provided_month(year, month),
+                1..=C::days_in_provided_month(year, constrained_month),
                 options.overflow.unwrap_or_default(),
             )?,
         ))

--- a/components/calendar/src/options.rs
+++ b/components/calendar/src/options.rs
@@ -328,4 +328,20 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn test_constrain_large_months() {
+        let fields = DateFields {
+            extended_year: Some(2004),
+            ordinal_month: NonZeroU8::new(15),
+            day: NonZeroU8::new(1),
+            ..Default::default()
+        };
+        let options = DateFromFieldsOptions {
+            overflow: Some(Overflow::Constrain),
+            ..Default::default()
+        };
+
+        let _ = Date::try_from_fields(fields, options, crate::cal::Persian).unwrap();
+    }
 }


### PR DESCRIPTION
Otherwise the day check panics since range.contains() doesn't like checking backwards ranges, and `days_in_provided_month(year, invalid_month)` produces 0.