### PR TITLE
Fix panic on Chinese construction (move Milliseconds over to being i128s)

### DIFF
--- a/components/calendar/src/cal/chinese.rs
+++ b/components/calendar/src/cal/chinese.rs
@@ -1067,6 +1067,7 @@ mod test {
     use crate::types::DateFields;
     use crate::types::MonthCode;
     use calendrical_calculations::{gregorian::fixed_from_gregorian, rata_die::RataDie};
+    use core::num::NonZero;
     use std::collections::BTreeMap;
     use tinystr::tinystr;
 
@@ -1638,7 +1639,7 @@ mod test {
     #[test]
     fn test_from_fields_constrain() {
         let fields = DateFields {
-            day: core::num::NonZero::new(31),
+            day: NonZero::new(31),
             month_code: Some(MonthCode("M01".parse().unwrap())),
             extended_year: Some(1972),
             ..Default::default()
@@ -1658,7 +1659,7 @@ mod test {
 
         // 2022 did not have M01L, the month should be constrained back down
         let fields = DateFields {
-            day: core::num::NonZero::new(1),
+            day: NonZero::new(1),
             month_code: Some(MonthCode("M01L".parse().unwrap())),
             extended_year: Some(2022),
             ..Default::default()
@@ -1669,6 +1670,23 @@ mod test {
             "M01",
             "Month was successfully constrained"
         );
+    }
+
+    #[test]
+    fn test_from_fields_regress_7049() {
+        let fields = DateFields {
+            extended_year: Some(889192448),
+            ordinal_month: NonZero::new(1),
+            day: NonZero::new(1),
+            ..Default::default()
+        };
+        let options = DateFromFieldsOptions {
+            overflow: Some(Overflow::Reject),
+            ..Default::default()
+        };
+
+        let cal = LunarChinese::new_china();
+        let _date = Date::try_from_fields(fields, options, cal).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
Partially addresses https://github.com/unicode-org/icu4x/issues/7049.