### PR TITLE
Fix Tabular behavior when estimating boundary years

### DIFF
--- a/components/calendar/src/cal/hijri.rs
+++ b/components/calendar/src/cal/hijri.rs
@@ -734,7 +734,7 @@ impl<R: Rules> Calendar for Hijri<R> {
 
     fn from_rata_die(&self, rd: RataDie) -> Self::DateInner {
         // (354 * 30 + 11) / 30 is the mean year length for a tabular year
-        // This is slightly different from the MEAN_YEAR_LENGTH, which is based on
+        // This is slightly different from the `calendrical_calculations::islamic::MEAN_YEAR_LENGTH`, which is based on
         // the (current) synodic month length.
         // This does not need to be accurate, it's just a performance optimisation
         // to avoid a long linear search. `Rules` also don't need to use this


### PR DESCRIPTION
Fixes https://github.com/unicode-org/icu4x/issues/7056

We have a case where the estimated year is two years off.

I'm not sure if there's an underlying bug in the logic here. Perhaps the +1 in `extended_year` estimation code is wrong?