### PR TITLE
Fix unused_crate_dependencies

### DIFF
--- a/components/properties/src/provider/names.rs
+++ b/components/properties/src/provider/names.rs
@@ -13,7 +13,7 @@
 //! Read more about data providers: [`icu_provider`]
 
 use icu_locale_core::subtags::Script;
-use icu_provider::prelude::*;
+use icu_provider::prelude::{yoke, zerofrom};
 
 use zerotrie::ZeroTrieSimpleAscii;
 use zerovec::ule::NichedOption;

--- a/tools/make/tidy.toml
+++ b/tools/make/tidy.toml
@@ -269,7 +269,7 @@ script = '''
 exit_on_error true
 
 set_env "RUSTFLAGS" "-D unused_crate_dependencies"
-exec --fail-on-error cargo +stable check --all-features # https://github.com/rust-lang/rust/issues/147069
+exec --fail-on-error cargo check --all-features
 unset_env "RUSTFLAGS"
 exec --fail-on-error cargo run --manifest-path tools/make/depcheck/Cargo.toml
 '''


### PR DESCRIPTION
It triggers in beta because `icu_locale_core` is also imported through `icu_provider::prelude::*`

https://github.com/rust-lang/rust/issues/147069#issuecomment-3386119494