### PR TITLE
Don't post gemini help text on PRs

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -4,7 +4,7 @@ code_review:
   comment_severity_threshold: MEDIUM
   max_review_comments: -1
   pull_request_opened:
-    help: true
+    help: false
     summary: false
     code_review: false
 ignore_patterns: []


### PR DESCRIPTION
We all know and love Gemini but it doesn't need to poke us on every single PR. I don't think the poke has caused anyone to request a review who wasn't already going to ask for a review.