### PR TITLE
Remove `PrecomputedDataSource` trait

### DIFF
--- a/components/calendar/src/cal/chinese.rs
+++ b/components/calendar/src/cal/chinese.rs
@@ -3,10 +3,10 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::cal::iso::{Iso, IsoDateInner};
+use crate::calendar_arithmetic::DateFieldsResolver;
 use crate::calendar_arithmetic::{
     ArithmeticDate, ArithmeticDateBuilder, CalendarArithmetic, ToExtendedYear,
 };
-use crate::calendar_arithmetic::{DateFieldsResolver, PrecomputedDataSource};
 use crate::error::DateError;
 use crate::options::{DateAddOptions, DateDifferenceOptions};
 use crate::options::{DateFromFieldsOptions, Overflow};
@@ -531,12 +531,6 @@ impl<R: Rules> CalendarArithmetic for LunarChinese<R> {
     }
 }
 
-impl<R: Rules> PrecomputedDataSource<LunarChineseYearData> for LunarChinese<R> {
-    fn load_or_compute_info(&self, related_iso: i32) -> LunarChineseYearData {
-        self.0.year_data(related_iso)
-    }
-}
-
 impl<R: Rules> DateFieldsResolver for LunarChinese<R> {
     type YearInfo = LunarChineseYearData;
 
@@ -548,7 +542,7 @@ impl<R: Rules> DateFieldsResolver for LunarChinese<R> {
 
     #[inline]
     fn year_info_from_extended(&self, extended_year: i32) -> Self::YearInfo {
-        self.load_or_compute_info(extended_year)
+        self.0.year_data(extended_year)
     }
 
     #[inline]

--- a/components/calendar/src/cal/hebrew.rs
+++ b/components/calendar/src/cal/hebrew.rs
@@ -3,10 +3,10 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::cal::iso::{Iso, IsoDateInner};
+use crate::calendar_arithmetic::ArithmeticDateBuilder;
 use crate::calendar_arithmetic::{
     ArithmeticDate, CalendarArithmetic, DateFieldsResolver, ToExtendedYear,
 };
-use crate::calendar_arithmetic::{ArithmeticDateBuilder, PrecomputedDataSource};
 use crate::error::DateError;
 use crate::options::{DateAddOptions, DateDifferenceOptions};
 use crate::options::{DateFromFieldsOptions, Overflow};
@@ -110,12 +110,6 @@ impl CalendarArithmetic for Hebrew {
 
     fn last_month_day_in_provided_year(info: HebrewYearInfo) -> (u8, u8) {
         info.keviyah.last_month_day_in_year()
-    }
-}
-
-impl PrecomputedDataSource<HebrewYearInfo> for () {
-    fn load_or_compute_info(&self, h_year: i32) -> HebrewYearInfo {
-        HebrewYearInfo::compute(h_year)
     }
 }
 

--- a/components/calendar/src/cal/hijri.rs
+++ b/components/calendar/src/cal/hijri.rs
@@ -3,9 +3,9 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::cal::iso::{Iso, IsoDateInner};
+use crate::calendar_arithmetic::ToExtendedYear;
 use crate::calendar_arithmetic::{ArithmeticDate, CalendarArithmetic};
 use crate::calendar_arithmetic::{ArithmeticDateBuilder, DateFieldsResolver};
-use crate::calendar_arithmetic::{PrecomputedDataSource, ToExtendedYear};
 use crate::error::DateError;
 use crate::options::DateFromFieldsOptions;
 use crate::options::{DateAddOptions, DateDifferenceOptions};
@@ -701,7 +701,7 @@ impl<R: Rules> DateFieldsResolver for Hijri<R> {
 
     #[inline]
     fn year_info_from_extended(&self, extended_year: i32) -> Self::YearInfo {
-        self.load_or_compute_info(extended_year)
+        self.0.year_data(extended_year)
     }
 
     #[inline]
@@ -848,12 +848,6 @@ impl<R: Rules> Calendar for Hijri<R> {
 
     fn calendar_algorithm(&self) -> Option<crate::preferences::CalendarAlgorithm> {
         self.0.calendar_algorithm()
-    }
-}
-
-impl<R: Rules> PrecomputedDataSource<HijriYearData> for Hijri<R> {
-    fn load_or_compute_info(&self, extended_year: i32) -> HijriYearData {
-        self.0.year_data(extended_year)
     }
 }
 

--- a/components/calendar/src/calendar_arithmetic.rs
+++ b/components/calendar/src/calendar_arithmetic.rs
@@ -202,20 +202,6 @@ pub(crate) trait DateFieldsResolver: Calendar {
     }
 }
 
-pub(crate) trait PrecomputedDataSource<YearInfo> {
-    /// Given a calendar year, load (or compute) the YearInfo for it
-    ///
-    /// In the future we may pass in an optional previous YearInfo alongside the year
-    /// it matches to allow code to take shortcuts.
-    fn load_or_compute_info(&self, year: i32) -> YearInfo;
-}
-
-impl PrecomputedDataSource<i32> for () {
-    fn load_or_compute_info(&self, year: i32) -> i32 {
-        year
-    }
-}
-
 impl<C: CalendarArithmetic> ArithmeticDate<C> {
     #[inline]
     pub(crate) const fn new_unchecked(year: C::YearInfo, month: u8, day: u8) -> Self {


### PR DESCRIPTION
This is an internal trait that was used by old offset code, but it's unused now.