### PR TITLE
Implement `PartialOrd` for `Date` unconditionally

### DIFF
--- a/components/calendar/src/any_calendar.rs
+++ b/components/calendar/src/any_calendar.rs
@@ -149,6 +149,32 @@ pub enum AnyDateInner {
     Roc(<Roc as Calendar>::DateInner),
 }
 
+impl PartialOrd for AnyDateInner {
+    #[rustfmt::skip]
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        use AnyDateInner::*;
+        match (self, other) {
+            (Buddhist(d1), Buddhist(d2)) => d1.partial_cmp(d2),
+            (Chinese(d1), Chinese(d2)) => d1.partial_cmp(d2),
+            (Coptic(d1), Coptic(d2)) => d1.partial_cmp(d2),
+            (Dangi(d1), Dangi(d2)) => d1.partial_cmp(d2),
+            (Ethiopian(d1), Ethiopian(d2)) => d1.partial_cmp(d2),
+            (Gregorian(d1), Gregorian(d2)) => d1.partial_cmp(d2),
+            (Hebrew(d1), Hebrew(d2)) => d1.partial_cmp(d2),
+            (Indian(d1), Indian(d2)) => d1.partial_cmp(d2),
+            (&HijriTabular(ref d1, s1), &HijriTabular(ref d2, s2)) if s1 == s2 => d1.partial_cmp(d2),
+            (HijriSimulated(d1), HijriSimulated(d2)) => d1.partial_cmp(d2),
+            (HijriUmmAlQura(d1), HijriUmmAlQura(d2)) => d1.partial_cmp(d2),
+            (Iso(d1), Iso(d2)) => d1.partial_cmp(d2),
+            (Japanese(d1), Japanese(d2)) => d1.partial_cmp(d2),
+            (JapaneseExtended(d1), JapaneseExtended(d2)) => d1.partial_cmp(d2),
+            (Persian(d1), Persian(d2)) => d1.partial_cmp(d2),
+            (Roc(d1), Roc(d2)) => d1.partial_cmp(d2),
+            _ => None,
+        }
+    }
+}
+
 macro_rules! match_cal_and_date {
     (match ($cal:ident, $date:ident): ($cal_matched:ident, $date_matched:ident) => $e:expr) => {
         match ($cal, $date) {

--- a/components/calendar/src/cal/chinese.rs
+++ b/components/calendar/src/cal/chinese.rs
@@ -467,6 +467,16 @@ impl<S: Rules> PartialEq for ChineseDateInner<S> {
     }
 }
 impl<S: Rules> Eq for ChineseDateInner<S> {}
+impl<R: Rules> PartialOrd for ChineseDateInner<R> {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl<R: Rules> Ord for ChineseDateInner<R> {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.0.cmp(&other.0)
+    }
+}
 
 impl LunarChinese<China> {
     /// Creates a new calendar using [`China`] rules.

--- a/components/calendar/src/cal/hijri.rs
+++ b/components/calendar/src/cal/hijri.rs
@@ -668,6 +668,16 @@ impl<R: Rules> PartialEq for HijriDateInner<R> {
     }
 }
 impl<R: Rules> Eq for HijriDateInner<R> {}
+impl<R: Rules> PartialOrd for HijriDateInner<R> {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl<R: Rules> Ord for HijriDateInner<R> {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.0.cmp(&other.0)
+    }
+}
 
 impl<R: Rules> CalendarArithmetic for Hijri<R> {
     fn days_in_provided_month(year: Self::YearInfo, month: u8) -> u8 {

--- a/components/calendar/src/cal/julian.rs
+++ b/components/calendar/src/cal/julian.rs
@@ -65,7 +65,7 @@ use tinystr::tinystr;
 pub struct Julian;
 
 /// The inner date type used for representing [`Date`]s of [`Julian`]. See [`Date`] and [`Julian`] for more details.
-#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
 // The inner date type used for representing Date<Julian>
 pub struct JulianDateInner(pub(crate) ArithmeticDate<Julian>);
 

--- a/components/calendar/src/calendar.rs
+++ b/components/calendar/src/calendar.rs
@@ -28,7 +28,9 @@ use core::fmt;
 /// </div>
 pub trait Calendar: crate::cal::scaffold::UnstableSealed {
     /// The internal type used to represent dates
-    type DateInner: Eq + Copy + fmt::Debug;
+    ///
+    /// Equality and ordering should observe normal calendar semantics.
+    type DateInner: Eq + Copy + PartialOrd + fmt::Debug;
     /// The type of YearInfo returned by the date
     type Year: fmt::Debug + Into<types::YearInfo>;
     /// The type of error returned by `until`

--- a/components/calendar/src/date.rs
+++ b/components/calendar/src/date.rs
@@ -517,7 +517,6 @@ impl<A: AsCalendar> Eq for Date<A> {}
 impl<C, A, B> PartialOrd<Date<B>> for Date<A>
 where
     C: Calendar,
-    C::DateInner: PartialOrd,
     A: AsCalendar<Calendar = C>,
     B: AsCalendar<Calendar = C>,
 {


### PR DESCRIPTION
Clients shouldn't need to add a `C::DateInner: PartialOrd` bound when writing generic code.

https://github.com/unicode-org/icu4x/issues/3469