### PR TITLE
Move DateFields::month_code over to being a byte slice

### DIFF
--- a/components/calendar/src/cal/chinese.rs
+++ b/components/calendar/src/cal/chinese.rs
@@ -1779,7 +1779,7 @@ mod test {
     fn test_from_fields_constrain() {
         let fields = DateFields {
             day: Some(31),
-            month_code: Some(MonthCode("M01".parse().unwrap())),
+            month_code: Some(b"M01"),
             extended_year: Some(1972),
             ..Default::default()
         };
@@ -1799,7 +1799,7 @@ mod test {
         // 2022 did not have M01L, the month should be constrained back down
         let fields = DateFields {
             day: Some(1),
-            month_code: Some(MonthCode("M01L".parse().unwrap())),
+            month_code: Some(b"M01L"),
             extended_year: Some(2022),
             ..Default::default()
         };

--- a/components/calendar/src/cal/coptic.rs
+++ b/components/calendar/src/cal/coptic.rs
@@ -264,7 +264,7 @@ impl Date<Coptic> {
 mod tests {
     use super::*;
     use crate::options::{DateFromFieldsOptions, MissingFieldsStrategy, Overflow};
-    use crate::types::{DateFields, MonthCode};
+    use crate::types::DateFields;
 
     #[test]
     fn test_coptic_regression() {
@@ -280,7 +280,7 @@ mod tests {
         // M13-7 is not a real day, however this should resolve to M12-6
         // with Overflow::Constrain
         let fields = DateFields {
-            month_code: Some(MonthCode("M13".parse().unwrap())),
+            month_code: Some(b"M13"),
             day: Some(7),
             ..Default::default()
         };

--- a/components/calendar/src/calendar_arithmetic.rs
+++ b/components/calendar/src/calendar_arithmetic.rs
@@ -263,7 +263,7 @@ impl<C: DateFieldsResolver> ArithmeticDate<C> {
                     MissingFieldsStrategy::Ecma => {
                         match (fields.month_code, fields.ordinal_month) {
                             (Some(month_code), None) => {
-                                let validated = month_code.validated()?;
+                                let validated = ValidMonthCode::from_bytes(month_code)?;
                                 valid_month_code = Some(validated);
                                 calendar.reference_year_from_month_day(validated, day)?
                             }
@@ -296,7 +296,7 @@ impl<C: DateFieldsResolver> ArithmeticDate<C> {
             Some(month_code) => {
                 let validated = match valid_month_code {
                     Some(validated) => validated,
-                    None => month_code.validated()?,
+                    None => ValidMonthCode::from_bytes(month_code)?,
                 };
                 let computed_month = calendar.ordinal_month_from_code(&year, validated, options)?;
                 if let Some(ordinal_month) = fields.ordinal_month {

--- a/components/calendar/src/error.rs
+++ b/components/calendar/src/error.rs
@@ -89,11 +89,10 @@ pub enum DateFromFieldsError {
     /// use icu_calendar::Iso;
     /// use icu_calendar::types::MonthCode;
     /// use icu_calendar::types::DateFields;
-    /// use tinystr::tinystr;
     ///
     /// let mut fields = DateFields::default();
     /// fields.extended_year = Some(2000);
-    /// fields.month_code = Some(MonthCode(tinystr!(4, "????")));
+    /// fields.month_code = Some(b"????");
     /// fields.day = Some(1);
     ///
     /// let err = Date::try_from_fields(
@@ -114,12 +113,10 @@ pub enum DateFromFieldsError {
     /// use icu_calendar::error::DateFromFieldsError;
     /// use icu_calendar::cal::Hebrew;
     /// use icu_calendar::types::DateFields;
-    /// use icu_calendar::types::MonthCode;
-    /// use tinystr::tinystr;
     ///
     /// let mut fields = DateFields::default();
     /// fields.extended_year = Some(5783);
-    /// fields.month_code = Some(MonthCode::new_normal(13).unwrap());
+    /// fields.month_code = Some(b"M13");
     /// fields.day = Some(1);
     ///
     /// let err = Date::try_from_fields(
@@ -141,12 +138,10 @@ pub enum DateFromFieldsError {
     /// use icu_calendar::error::DateFromFieldsError;
     /// use icu_calendar::cal::Hebrew;
     /// use icu_calendar::types::DateFields;
-    /// use icu_calendar::types::MonthCode;
-    /// use tinystr::tinystr;
     ///
     /// let mut fields = DateFields::default();
     /// fields.extended_year = Some(5783);
-    /// fields.month_code = Some(MonthCode::new_leap(5).unwrap());
+    /// fields.month_code = Some(b"M05L");
     /// fields.day = Some(1);
     ///
     /// let err = Date::try_from_fields(
@@ -204,12 +199,11 @@ pub enum DateFromFieldsError {
     /// use icu_calendar::error::DateFromFieldsError;
     /// use icu_calendar::cal::Hebrew;
     /// use icu_calendar::types::DateFields;
-    /// use icu_calendar::types::MonthCode;
     /// use tinystr::tinystr;
     ///
     /// let mut fields = DateFields::default();
     /// fields.extended_year = Some(5783);
-    /// fields.month_code = Some(MonthCode(tinystr!(4, "M06")));
+    /// fields.month_code = Some(b"M06");
     /// fields.ordinal_month = Some(6);
     /// fields.day = Some(1);
     ///
@@ -242,7 +236,6 @@ pub enum DateFromFieldsError {
     /// use icu_calendar::error::DateFromFieldsError;
     /// use icu_calendar::cal::Hebrew;
     /// use icu_calendar::types::DateFields;
-    /// use icu_calendar::types::MonthCode;
     /// use tinystr::tinystr;
     ///
     /// let mut fields = DateFields::default();

--- a/components/calendar/src/options.rs
+++ b/components/calendar/src/options.rs
@@ -54,14 +54,13 @@ pub struct DateFromFieldsOptions {
     /// ```
     /// use icu::calendar::Date;
     /// use icu::calendar::types::DateFields;
-    /// use icu::calendar::types::MonthCode;
     /// use icu::calendar::options::MissingFieldsStrategy;
     /// use icu::calendar::options::DateFromFieldsOptions;
     /// use icu::calendar::Iso;
     ///
     /// // These options are missing a year.
     /// let mut fields = DateFields::default();
-    /// fields.month_code = MonthCode::new_normal(2);
+    /// fields.month_code = Some(b"M02");
     /// fields.day = Some(1);
     ///
     /// let options_default = DateFromFieldsOptions::default();
@@ -232,8 +231,6 @@ pub enum Overflow {
     /// use icu_calendar::options::DateFromFieldsOptions;
     /// use icu_calendar::options::Overflow;
     /// use icu_calendar::types::DateFields;
-    /// use icu_calendar::types::MonthCode;
-    /// use tinystr::tinystr;
     ///
     /// let mut options = DateFromFieldsOptions::default();
     /// options.overflow = Some(Overflow::Constrain);
@@ -241,7 +238,7 @@ pub enum Overflow {
     /// // 5784, a leap year, contains M05L, but the day is too big.
     /// let mut fields = DateFields::default();
     /// fields.extended_year = Some(5784);
-    /// fields.month_code = Some(MonthCode(tinystr!(4, "M05L")));
+    /// fields.month_code = Some(b"M05L");
     /// fields.day = Some(50);
     ///
     /// let date = Date::try_from_fields(
@@ -253,7 +250,7 @@ pub enum Overflow {
     ///
     /// // Constrained to the 30th day of M05L of year 5784
     /// assert_eq!(date.year().extended_year(), 5784);
-    /// assert_eq!(date.month().standard_code, MonthCode(tinystr!(4, "M05L")));
+    /// assert_eq!(date.month().standard_code.0, "M05L");
     /// assert_eq!(date.day_of_month().0, 30);
     ///
     /// // 5785, a common year, does not contain M05L.
@@ -268,7 +265,7 @@ pub enum Overflow {
     ///
     /// // Constrained to the 29th day of M06 of year 5785
     /// assert_eq!(date.year().extended_year(), 5785);
-    /// assert_eq!(date.month().standard_code, MonthCode(tinystr!(4, "M06")));
+    /// assert_eq!(date.month().standard_code.0, "M06");
     /// assert_eq!(date.day_of_month().0, 29);
     /// ```
     Constrain,
@@ -283,7 +280,6 @@ pub enum Overflow {
     /// use icu_calendar::options::DateFromFieldsOptions;
     /// use icu_calendar::options::Overflow;
     /// use icu_calendar::types::DateFields;
-    /// use icu_calendar::types::MonthCode;
     /// use tinystr::tinystr;
     ///
     /// let mut options = DateFromFieldsOptions::default();
@@ -292,7 +288,7 @@ pub enum Overflow {
     /// // 5784, a leap year, contains M05L, but the day is too big.
     /// let mut fields = DateFields::default();
     /// fields.extended_year = Some(5784);
-    /// fields.month_code = Some(MonthCode(tinystr!(4, "M05L")));
+    /// fields.month_code = Some(b"M05L");
     /// fields.day = Some(50);
     ///
     /// let err = Date::try_from_fields(
@@ -384,11 +380,7 @@ pub enum MissingFieldsStrategy {
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        error::DateFromFieldsError,
-        types::{DateFields, MonthCode},
-        Date, Gregorian,
-    };
+    use crate::{error::DateFromFieldsError, types::DateFields, Date, Gregorian};
     use itertools::Itertools;
     use std::collections::{BTreeMap, BTreeSet};
 
@@ -462,9 +454,7 @@ mod tests {
         field_fns.insert("era", &|fields| fields.era = Some(b"ad"));
         field_fns.insert("era_year", &|fields| fields.era_year = Some(2000));
         field_fns.insert("extended_year", &|fields| fields.extended_year = Some(2000));
-        field_fns.insert("month_code", &|fields| {
-            fields.month_code = MonthCode::new_normal(4)
-        });
+        field_fns.insert("month_code", &|fields| fields.month_code = Some(b"M04"));
         field_fns.insert("ordinal_month", &|fields| fields.ordinal_month = Some(4));
         field_fns.insert("day", &|fields| fields.day = Some(20));
 

--- a/components/calendar/src/tests/not_enough_fields.rs
+++ b/components/calendar/src/tests/not_enough_fields.rs
@@ -4,7 +4,7 @@
 
 use crate::error::DateFromFieldsError;
 use crate::options::{DateFromFieldsOptions, MissingFieldsStrategy, Overflow};
-use crate::types::{DateFields, MonthCode};
+use crate::types::DateFields;
 use crate::Date;
 
 #[test]
@@ -16,8 +16,8 @@ fn test_from_fields_not_enough_fields() {
     let big_u8 = Some(u8::MAX);
     let small_u8 = Some(1);
     let small_i32 = Some(5000);
-    let valid_month_code = MonthCode::new_normal(1);
-    let invalid_month_code = MonthCode::new_normal(99);
+    let valid_month_code: Option<&[_]> = Some(b"M01");
+    let invalid_month_code: Option<&[_]> = Some(b"M99");
 
     // We want to ensure that most NotEnoughFields cases return NotEnoughFields
     // even when we're providing out-of-range values, so that

--- a/components/calendar/tests/exhaustive.rs
+++ b/components/calendar/tests/exhaustive.rs
@@ -39,6 +39,16 @@ fn check_round_trip() {
 fn check_from_fields() {
     fn test<C: Calendar>(cal: C) {
         let cal = Ref(&cal);
+
+        let codes = (1..19)
+            .flat_map(|i| {
+                [
+                    types::MonthCode::new_normal(i).unwrap(),
+                    types::MonthCode::new_leap(i).unwrap(),
+                ]
+                .into_iter()
+            })
+            .collect::<Vec<_>>();
         for year in -MAGNITUDE..=MAGNITUDE {
             if year % 50000 == 0 {
                 println!("{} {year:?}", cal.as_calendar().debug_name());
@@ -46,17 +56,11 @@ fn check_from_fields() {
             for overflow in [options::Overflow::Constrain, options::Overflow::Reject] {
                 let mut options = options::DateFromFieldsOptions::default();
                 options.overflow = Some(overflow);
-                for mut fields in (1..19)
-                    .flat_map(|i| {
-                        [
-                            types::MonthCode::new_normal(i).unwrap(),
-                            types::MonthCode::new_leap(i).unwrap(),
-                        ]
-                        .into_iter()
-                    })
+                for mut fields in codes
+                    .iter()
                     .map(|m| {
                         let mut fields = types::DateFields::default();
-                        fields.month_code = Some(m);
+                        fields.month_code = Some(m.0.as_bytes());
                         fields
                     })
                     .chain((1..20).map(|m| {

--- a/components/calendar/tests/reference_year.rs
+++ b/components/calendar/tests/reference_year.rs
@@ -27,7 +27,7 @@ where
         let date = Date::from_rata_die(rd, Ref(&cal));
         let month_day = (date.month().standard_code, date.day_of_month().0);
         let mut fields = DateFields::default();
-        fields.month_code = Some(month_day.0);
+        fields.month_code = Some(month_day.0 .0.as_bytes());
         fields.day = Some(month_day.1);
         let mut options = DateFromFieldsOptions::default();
         options.missing_fields_strategy = Some(MissingFieldsStrategy::Ecma);
@@ -50,10 +50,11 @@ where
                     valid_day_number = day_number;
                 }
                 let mut fields = DateFields::default();
-                fields.month_code = match is_leap {
+                let mc = match is_leap {
                     false => MonthCode::new_normal(month_number),
                     true => MonthCode::new_leap(month_number),
                 };
+                fields.month_code = mc.as_ref().map(|m| m.0.as_bytes());
                 fields.day = Some(day_number);
                 let mut options = DateFromFieldsOptions::default();
                 options.overflow = Some(Overflow::Constrain);
@@ -81,7 +82,7 @@ where
                 // Test round-trip (to valid day number)
                 assert_eq!(
                     fields.month_code.unwrap(),
-                    reference_date.month().standard_code,
+                    reference_date.month().standard_code.0.as_bytes(),
                     "{fields:?} {cal:?}"
                 );
                 assert_eq!(


### PR DESCRIPTION
Depends on #7115, depends on #7105

Attempt at fixing #7104.

The user experience of the byte slice is a little bit worse if you want to use MonthCode::new_normal/new_leap since you have to persist those for a while.

Most people will not be creating them for long, though. In theory we could produce byte versions of those methods that produce a limited range of codes. It's more a problem for our tests that need to do things like "create many codes in a loop".

