### PR TITLE
Add allow(unreachable_code) around uses of PatternPlurals::MultipleVariants

### DIFF
--- a/components/datetime/src/provider/fields/components.rs
+++ b/components/datetime/src/provider/fields/components.rs
@@ -182,7 +182,10 @@ impl Bag {
         }
 
         if let Some(week) = self.week {
-            #[allow(unreachable_code)]
+            #[allow(
+                unreachable_code,
+                reason = "Uninhabited MultipleVariants (due to pivot_field), see #7118"
+            )]
             fields.push(Field {
                 symbol: FieldSymbol::Week(match week {
                     Week::WeekOfMonth => unimplemented!("#5643 fields::Week::WeekOfMonth"),

--- a/components/datetime/src/provider/skeleton/plural.rs
+++ b/components/datetime/src/provider/skeleton/plural.rs
@@ -143,6 +143,10 @@ impl From<&PatternPlurals<'_>> for components::Bag {
 
 #[allow(missing_docs)]
 impl<'data> PatternPlurals<'data> {
+    #[allow(
+        unreachable_code,
+        reason = "Uninhabited MultipleVariants (due to pivot_field), see #7118"
+    )]
     pub fn into_owned(self) -> PatternPlurals<'static> {
         match self {
             Self::SinglePattern(pattern) => PatternPlurals::SinglePattern(pattern.into_owned()),


### PR DESCRIPTION
See: https://github.com/unicode-org/icu4x/issues/7118

Fixes nightly CI.
