### PR TITLE
ASCII bytes -> UTF8 code units

### DIFF
--- a/components/calendar/src/types.rs
+++ b/components/calendar/src/types.rs
@@ -100,7 +100,7 @@ pub struct DateFields<'a> {
     /// ```
     pub extended_year: Option<i32>,
     /// The month code representing a valid month in this calendar year,
-    /// represented as UTF-8 code units.
+    /// as a UTF-8 string.
     ///
     /// See [`MonthCode`] for information on the syntax.
     ///


### PR DESCRIPTION
Fixes #7104


I don't think we need to spend time saying that these must be valid ascii too. There's a lot of further validity on these anyway.