### PR TITLE
Deprecate convenience constructors of lunisolar calendars

### DIFF
--- a/components/calendar/benches/date.rs
+++ b/components/calendar/benches/date.rs
@@ -152,7 +152,10 @@ fn date_benches(c: &mut Criterion) {
         "calendar/chinese_cached",
         &fxs,
         icu::calendar::cal::LunarChinese::new_china(),
-        |y, m, d, c| Date::try_new_chinese_with_calendar(y, m, d, c).unwrap(),
+        |y, m, d, c| {
+            Date::try_new_from_codes(None, y, types::MonthCode::new_normal(m).unwrap(), d, c)
+                .unwrap()
+        },
     );
 
     bench_calendar(
@@ -160,7 +163,10 @@ fn date_benches(c: &mut Criterion) {
         "calendar/dangi_cached",
         &fxs,
         icu::calendar::cal::LunarChinese::new_korea(),
-        |y, m, d, c| Date::try_new_chinese_with_calendar(y, m, d, c).unwrap(),
+        |y, m, d, c| {
+            Date::try_new_from_codes(None, y, types::MonthCode::new_normal(m).unwrap(), d, c)
+                .unwrap()
+        },
     );
 
     bench_calendar(
@@ -168,7 +174,10 @@ fn date_benches(c: &mut Criterion) {
         "calendar/hebrew",
         &fxs,
         icu::calendar::cal::Hebrew,
-        |y, m, d, _| Date::try_new_hebrew(y, m, d).unwrap(),
+        |y, m, d, c| {
+            Date::try_new_from_codes(None, y, types::MonthCode::new_normal(m).unwrap(), d, c)
+                .unwrap()
+        },
     );
 
     bench_calendar(

--- a/components/calendar/src/cal/hebrew.rs
+++ b/components/calendar/src/cal/hebrew.rs
@@ -364,26 +364,18 @@ impl Calendar for Hebrew {
 }
 
 impl Date<Hebrew> {
-    /// Construct new Hebrew Date.
+    /// This method uses an ordinal month, which is probably not what you want.
     ///
-    /// This date will not use any precomputed calendrical calculations,
-    /// one that loads such data from a provider will be added in the future (#3933)
-    ///
-    ///
-    /// ```rust
-    /// use icu::calendar::Date;
-    ///
-    /// let date_hebrew = Date::try_new_hebrew(3425, 4, 25)
-    ///     .expect("Failed to initialize Hebrew Date instance.");
-    ///
-    /// assert_eq!(date_hebrew.era_year().year, 3425);
-    /// assert_eq!(date_hebrew.month().ordinal, 4);
-    /// assert_eq!(date_hebrew.day_of_month().0, 25);
-    /// ```
-    pub fn try_new_hebrew(year: i32, month: u8, day: u8) -> Result<Date<Hebrew>, RangeError> {
+    /// Use [`Date::try_new_from_codes`]
+    #[deprecated(since = "2.1.0", note = "use `Date::try_new_from_codes`")]
+    pub fn try_new_hebrew(
+        year: i32,
+        ordinal_month: u8,
+        day: u8,
+    ) -> Result<Date<Hebrew>, RangeError> {
         let year = HebrewYearInfo::compute(year);
 
-        ArithmeticDate::try_from_ymd(year, month, day)
+        ArithmeticDate::try_from_ymd(year, ordinal_month, day)
             .map(HebrewDateInner)
             .map(|inner| Date::from_raw(inner, Hebrew))
     }
@@ -497,6 +489,7 @@ mod tests {
                 m
             };
 
+            #[allow(deprecated)] // should still test
             let ordinal_hebrew_date = Date::try_new_hebrew(y, ordinal_month, d)
                 .expect("Construction of date must succeed");
 

--- a/components/calendar/src/tests/continuity_test.rs
+++ b/components/calendar/src/tests/continuity_test.rs
@@ -67,17 +67,17 @@ fn test_buddhist_continuity() {
 #[test]
 fn test_chinese_continuity() {
     let cal = crate::cal::LunarChinese::new_china();
-    let date = Date::try_new_chinese_with_calendar(-10, 1, 1, cal);
+    let date = Date::try_new_from_codes(None, -10, MonthCode::new_normal(1).unwrap(), 1, cal);
     check_continuity(date.unwrap(), 20);
-    let date = Date::try_new_chinese_with_calendar(-300, 1, 1, cal);
+    let date = Date::try_new_from_codes(None, -300, MonthCode::new_normal(1).unwrap(), 1, cal);
     check_every_250_days(date.unwrap(), 2000);
-    let date = Date::try_new_chinese_with_calendar(-10000, 1, 1, cal);
+    let date = Date::try_new_from_codes(None, -10000, MonthCode::new_normal(1).unwrap(), 1, cal);
     check_every_250_days(date.unwrap(), 2000);
 
-    let date = Date::try_new_chinese_with_calendar(1899, 1, 1, cal);
+    let date = Date::try_new_from_codes(None, 1899, MonthCode::new_normal(1).unwrap(), 1, cal);
     check_continuity(date.unwrap(), 20);
 
-    let date = Date::try_new_chinese_with_calendar(2099, 1, 1, cal);
+    let date = Date::try_new_from_codes(None, 2099, MonthCode::new_normal(1).unwrap(), 1, cal);
     check_continuity(date.unwrap(), 20);
 }
 
@@ -91,22 +91,22 @@ fn test_coptic_continuity() {
 
 #[test]
 fn test_korean_continuity() {
-    let cal = crate::cal::LunarChinese::new_korea();
-    let date = Date::try_new_chinese_with_calendar(-10, 1, 1, cal);
+    let cal = cal::LunarChinese::new_korea();
+    let date = Date::try_new_from_codes(None, -10, MonthCode::new_normal(1).unwrap(), 1, cal);
     check_continuity(date.unwrap(), 20);
-    let date = Date::try_new_chinese_with_calendar(-300, 1, 1, cal);
+    let date = Date::try_new_from_codes(None, -300, MonthCode::new_normal(1).unwrap(), 1, cal);
     check_every_250_days(date.unwrap(), 2000);
 
-    let date = Date::try_new_chinese_with_calendar(1900, 1, 1, cal);
+    let date = Date::try_new_from_codes(None, 1900, MonthCode::new_normal(1).unwrap(), 1, cal);
     check_continuity(date.unwrap(), 20);
 
-    let date = Date::try_new_chinese_with_calendar(2100, 1, 1, cal);
+    let date = Date::try_new_from_codes(None, 2100, MonthCode::new_normal(1).unwrap(), 1, cal);
     check_continuity(date.unwrap(), 20);
 }
 
 #[test]
 fn test_ethiopian_continuity() {
-    use crate::cal::EthiopianEraStyle::*;
+    use cal::EthiopianEraStyle::*;
     let date = Date::try_new_ethiopian(AmeteMihret, -10, 1, 1);
     check_continuity(date.unwrap(), 20);
     let date = Date::try_new_ethiopian(AmeteMihret, -300, 1, 1);
@@ -115,7 +115,7 @@ fn test_ethiopian_continuity() {
 
 #[test]
 fn test_ethiopian_amete_alem_continuity() {
-    use crate::cal::EthiopianEraStyle::*;
+    use cal::EthiopianEraStyle::*;
     let date = Date::try_new_ethiopian(AmeteAlem, -10, 1, 1);
     check_continuity(date.unwrap(), 20);
     let date = Date::try_new_ethiopian(AmeteAlem, -300, 1, 1);
@@ -132,9 +132,16 @@ fn test_gregorian_continuity() {
 
 #[test]
 fn test_hebrew_continuity() {
-    let date = Date::try_new_hebrew(-10, 1, 1);
+    let date =
+        Date::try_new_from_codes(None, -10, MonthCode::new_normal(1).unwrap(), 1, cal::Hebrew);
     check_continuity(date.unwrap(), 20);
-    let date = Date::try_new_hebrew(-300, 1, 1);
+    let date = Date::try_new_from_codes(
+        None,
+        -300,
+        MonthCode::new_normal(1).unwrap(),
+        1,
+        cal::Hebrew,
+    );
     check_every_250_days(date.unwrap(), 2000);
 }
 
@@ -148,9 +155,9 @@ fn test_indian_continuity() {
 
 #[test]
 fn test_hijri_civil_continuity() {
-    let cal = crate::cal::Hijri::new_tabular(
-        crate::cal::hijri::TabularAlgorithmLeapYears::TypeII,
-        crate::cal::hijri::TabularAlgorithmEpoch::Friday,
+    let cal = cal::Hijri::new_tabular(
+        cal::hijri::TabularAlgorithmLeapYears::TypeII,
+        cal::hijri::TabularAlgorithmEpoch::Friday,
     );
     let date = Date::try_new_hijri_with_calendar(-10, 1, 1, cal);
     check_continuity(date.unwrap(), 20);
@@ -162,7 +169,7 @@ fn test_hijri_civil_continuity() {
 fn test_hijri_simulated_mecca_continuity() {
     #[cfg(feature = "logging")]
     let _ = simple_logger::SimpleLogger::new().env().init();
-    let cal = crate::cal::Hijri::new_simulated_mecca();
+    let cal = cal::Hijri::new_simulated_mecca();
     let date = Date::try_new_hijri_with_calendar(-10, 1, 1, cal);
     // This test is slow since it is doing astronomical calculations, so check only 3 years
     check_continuity(date.unwrap(), 3);
@@ -173,9 +180,9 @@ fn test_hijri_simulated_mecca_continuity() {
 
 #[test]
 fn test_hijri_tabular_continuity() {
-    let cal = crate::cal::Hijri::new_tabular(
-        crate::cal::hijri::TabularAlgorithmLeapYears::TypeII,
-        crate::cal::hijri::TabularAlgorithmEpoch::Thursday,
+    let cal = cal::Hijri::new_tabular(
+        cal::hijri::TabularAlgorithmLeapYears::TypeII,
+        cal::hijri::TabularAlgorithmEpoch::Thursday,
     );
     let date = Date::try_new_hijri_with_calendar(-10, 1, 1, cal);
     check_continuity(date.unwrap(), 20);
@@ -187,7 +194,7 @@ fn test_hijri_tabular_continuity() {
 fn test_hijri_umm_al_qura_continuity() {
     #[cfg(feature = "logging")]
     let _ = simple_logger::SimpleLogger::new().env().init();
-    let cal = crate::cal::Hijri::new_umm_al_qura();
+    let cal = cal::Hijri::new_umm_al_qura();
     let date = Date::try_new_hijri_with_calendar(-10, 1, 1, cal);
     check_continuity(date.unwrap(), 20);
     let date = Date::try_new_hijri_with_calendar(1290, 1, 1, cal);
@@ -208,7 +215,7 @@ fn test_iso_continuity() {
 
 #[test]
 fn test_japanese_continuity() {
-    let cal = crate::cal::Japanese::new();
+    let cal = cal::Japanese::new();
     let cal = Ref(&cal);
     let date = Date::try_new_japanese_with_calendar("heisei", 20, 1, 1, cal);
     check_continuity(date.unwrap(), 20);
@@ -218,7 +225,7 @@ fn test_japanese_continuity() {
 
 #[test]
 fn test_japanese_extended_continuity() {
-    let cal = crate::cal::JapaneseExtended::new();
+    let cal = cal::JapaneseExtended::new();
     let cal = Ref(&cal);
     let date = Date::try_new_japanese_extended_with_calendar("heisei", 20, 1, 1, cal);
     check_continuity(date.unwrap(), 20);

--- a/components/calendar/tests/arithmetic.rs
+++ b/components/calendar/tests/arithmetic.rs
@@ -143,13 +143,25 @@ fn test_arithmetic_cases() {
 
 #[test]
 fn test_hebrew() {
-    let m06z_20 = Date::try_new_hebrew(5783, 6, 20).unwrap();
-    let m05l_15 = Date::try_new_hebrew(5784, 6, 15).unwrap();
-    let m05l_30 = Date::try_new_hebrew(5784, 6, 30).unwrap();
-    let m06a_29 = Date::try_new_hebrew(5784, 7, 29).unwrap();
-    let m07a_10 = Date::try_new_hebrew(5784, 8, 10).unwrap();
-    let m06b_15 = Date::try_new_hebrew(5785, 6, 15).unwrap();
-    let m07b_20 = Date::try_new_hebrew(5785, 7, 20).unwrap();
+    let m06z_20 =
+        Date::try_new_from_codes(None, 5783, MonthCode::new_normal(6).unwrap(), 20, Hebrew)
+            .unwrap();
+    let m05l_15 =
+        Date::try_new_from_codes(None, 5784, MonthCode::new_leap(5).unwrap(), 15, Hebrew).unwrap();
+    let m05l_30 =
+        Date::try_new_from_codes(None, 5784, MonthCode::new_leap(5).unwrap(), 30, Hebrew).unwrap();
+    let m06a_29 =
+        Date::try_new_from_codes(None, 5784, MonthCode::new_normal(6).unwrap(), 29, Hebrew)
+            .unwrap();
+    let m07a_10 =
+        Date::try_new_from_codes(None, 5784, MonthCode::new_normal(7).unwrap(), 10, Hebrew)
+            .unwrap();
+    let m06b_15 =
+        Date::try_new_from_codes(None, 5785, MonthCode::new_normal(6).unwrap(), 15, Hebrew)
+            .unwrap();
+    let m07b_20 =
+        Date::try_new_from_codes(None, 5785, MonthCode::new_normal(7).unwrap(), 20, Hebrew)
+            .unwrap();
 
     #[rustfmt::skip]
     #[allow(clippy::type_complexity)]


### PR DESCRIPTION
The fact that they use ordinal months is a footgun. They should be replaced by constructors taking `month_code: &str` in the future, but that's not ready yet, so `try_new_from_codes` can be used in the meantime.

Related #7111

Related #7095 