### PR TITLE
Fix dart

### DIFF
--- a/ffi/dart/hook/link.dart
+++ b/ffi/dart/hook/link.dart
@@ -65,10 +65,13 @@ const _diplomatFfiUseIdentifier = record_use.Identifier(
 
 extension on LinkInput {
   record_use.RecordedUsages? get usages {
-    if (recordedUsagesFile == null) {
+    // the hooks package is pinned
+    // ignore: experimental_member_use
+    final records = recordedUsagesFile;
+    if (records == null) {
       return null;
     }
-    final usagesContent = File.fromUri(recordedUsagesFile!).readAsStringSync();
+    final usagesContent = File.fromUri(records).readAsStringSync();
     final usagesJson = jsonDecode(usagesContent) as Map<String, dynamic>;
     return record_use.RecordedUsages.fromJson(usagesJson);
   }

--- a/ffi/dart/pubspec.yaml
+++ b/ffi/dart/pubspec.yaml
@@ -21,16 +21,17 @@ environment:
 
 dependencies:
   args: ^2.7.0
-  code_assets: ^0.19.7
+  code_assets: ^0.19.9
   collection: ^1.19.1
   crypto: ^3.0.6
   ffi: ^2.1.4
-  hooks: ^0.20.1
+  # Pinned as we use unstable APIs
+  hooks: '>=0.20.4 <0.20.5'
   logging: ^1.3.0
   meta: ^1.17.0
-  native_toolchain_c: ^0.17.1
+  native_toolchain_c: ^0.17.2
   path: ^1.9.1
-  record_use: ^0.4.1
+  record_use: ^0.4.2
 
 dev_dependencies:
   dart_flutter_team_lints: ^3.5.2

--- a/tools/make/ffi.toml
+++ b/tools/make/ffi.toml
@@ -60,6 +60,14 @@ args = ["-C", "examples/js-tiny", "test"]
 [tasks.test-dart]
 description = "Run Dart tests"
 category = "ICU4X Development"
+dependencies = [
+    "test-dart-lib",
+    "test-dart-example",
+]
+
+[tasks.test-dart-lib]
+description = "Run Dart tests"
+category = "ICU4X Development"
 script_runner = "@duckscript"
 script = '''
 cd ffi/dart
@@ -67,8 +75,13 @@ exec --fail-on-error dart pub get
 exec --fail-on-error dart format --set-exit-if-changed .
 exec --fail-on-error dart analyze
 exec --fail-on-error dart --enable-experiment=record-use test
-cd ../..
+'''
 
+[tasks.test-dart-example]
+description = "Run Dart tests"
+category = "ICU4X Development"
+script_runner = "@duckscript"
+script = '''
 cd examples/dart
 exec --fail-on-error dart pub get
 exec --fail-on-error dart format --set-exit-if-changed .


### PR DESCRIPTION
Latest `dev` introduces a new lint that complains on experimental APIs. Pin the `hooks` package and suppress the lint

Also splits the make task into `test-dart-lib` and `test-dart-example`.