### PR TITLE
Make CollationKeySink public

### DIFF
--- a/components/collator/src/lib.rs
+++ b/components/collator/src/lib.rs
@@ -326,6 +326,7 @@ pub mod provider;
 pub use comparison::Collator;
 pub use comparison::CollatorBorrowed;
 pub use comparison::CollatorPreferences;
+pub use comparison::CollationKeySink;
 
 /// Locale preferences used by this crate
 pub mod preferences {


### PR DESCRIPTION
Split out of https://github.com/unicode-org/icu4x/pull/7173

Part of #7170