### PR TITLE
Mark CollationKeySink as unstable

### DIFF
--- a/components/collator/Cargo.toml
+++ b/components/collator/Cargo.toml
@@ -52,6 +52,7 @@ serde = ["dep:serde", "zerovec/serde", "icu_properties/serde", "icu_normalizer/s
 datagen = ["serde", "dep:databake", "zerovec/databake", "icu_properties/datagen", "icu_normalizer/datagen", "icu_collections/databake", "icu_provider/export"]
 compiled_data = ["dep:icu_collator_data", "icu_normalizer/compiled_data", "dep:icu_locale", "icu_locale?/compiled_data", "icu_provider/baked"]
 latin1 = []
+unstable = []
 
 [[bench]]
 name = "bench"

--- a/components/collator/src/comparison.rs
+++ b/components/collator/src/comparison.rs
@@ -1809,6 +1809,10 @@ impl CollatorBorrowed<'_> {
 
     /// Given valid UTF-8, write the sort key bytes up to the collator's strength.
     ///
+    /// The bytes are written to an implementor of [`CollationKeySink`], a no-std version of `std::io::Write`.
+    /// This trait is currently unstable, but it is implemented by `Vec<u8>`, `VecDeque<u8>`,
+    /// `SmallVec<[u8; N]>`, and `&mut [u8]` (returning an error if the slice is too small).
+    ///
     /// If two sort keys generated at the same strength are compared bytewise, the result is
     /// the same as a collation comparison of the original strings at that strength.
     ///
@@ -2340,6 +2344,16 @@ impl TooSmall {
 /// A [`std::io::Write`]-like trait for writing to a buffer-like object.
 ///
 /// (This crate does not have access to [`std`].)
+///
+/// <div class="stab unstable">
+/// 🚧 This code is considered unstable; it may change at any time, in breaking or non-breaking ways,
+/// including in SemVer minor releases. Do not implement or call methods on this trait
+/// unless you are prepared for things to occasionally break.
+///
+/// Graduation tracking issue: [issue #7178](https://github.com/unicode-org/icu4x/issues/7178).
+/// </div>
+///
+/// ✨ *Enabled with the `unstable` Cargo feature.*
 pub trait CollationKeySink {
     /// The type of error the sink may return.
     type Error;

--- a/components/collator/src/lib.rs
+++ b/components/collator/src/lib.rs
@@ -327,6 +327,9 @@ pub use comparison::Collator;
 pub use comparison::CollatorBorrowed;
 pub use comparison::CollatorPreferences;
 
+#[cfg(feature = "unstable")]
+pub use comparison::CollationKeySink;
+
 /// Locale preferences used by this crate
 pub mod preferences {
     /// **This is a reexport of a type in [`icu::locale`](icu_locale_core::preferences::extensions::unicode::keywords)**.

--- a/ffi/capi/tests/missing_apis.txt
+++ b/ffi/capi/tests/missing_apis.txt
@@ -26,6 +26,9 @@ icu::calendar::types::DateDuration::for_months#FnInStruct
 icu::calendar::types::DateDuration::for_weeks#FnInStruct
 icu::calendar::types::DateDuration::for_years#FnInStruct
 icu::calendar::types::DateDurationUnit#Enum
+icu::collator::CollationKeySink::finish#FnInTrait
+icu::collator::CollationKeySink::write#FnInTrait
+icu::collator::CollationKeySink::write_byte#FnInTrait
 icu::collator::CollatorBorrowed::compare_latin1#FnInStruct
 icu::collator::CollatorBorrowed::compare_latin1_utf16#FnInStruct
 icu::collator::CollatorBorrowed::write_sort_key_to#FnInStruct


### PR DESCRIPTION
Related: https://github.com/unicode-org/icu4x/issues/7178

Alternative to https://github.com/unicode-org/icu4x/pull/7176/

This type is already unreachable on main, this PR makes it reachable with the unstable feature. 


@hsivonen has stated his intent was to graduate this, but Ideally we should wait until we have figured out the collator sort key FFI story (https://github.com/unicode-org/icu4x/issues/7177) before marking this trait as public. Furthermore, I don't want to snap-graduate something this close to the 2.1 release.


I used the same unstable scheme used for experimental types in icu_calendar, based on the design in https://github.com/unicode-org/icu4x/issues/6659