### PR TITLE
Add birds-eye view of open PRs to release checklist

### DIFF
--- a/documents/process/release.md
+++ b/documents/process/release.md
@@ -14,8 +14,8 @@ This is a checklist of things that should be done in the weeks leading to the re
 * [ ] Verify that the milestone and checklist are complete
 * [ ] Verify with component owners that they're ready for release
 * [ ] Verify that the semver breakages (listed by the build-test job) are acceptable
+* [ ] A week before the planned release, go through each open PR and consult with the author to decide the timeline for landing it and whether it should make the release. PRs in draft status or with a "waiting-on-author" label can be skipped.
 * [ ] Take a bird-eye view at:
-  * [ ] Open Pull Requests. Try not to leave high-quality contributions to lower-priority components hanging across a release.
   * [ ] READMEs
   * [ ] Documentation
   * [ ] Coverage ([coveralls](https://coveralls.io/github/unicode-org/icu4x?branch=main) and [codecov](https://app.codecov.io/gh/unicode-org/icu4x/tree/main))


### PR DESCRIPTION
Explicitly stating another thing that I considered part of the release duty but wasn't explicit.