### PR TITLE
Allow consumers to determine bindings directories

### DIFF
--- a/ffi/capi/Cargo.toml
+++ b/ffi/capi/Cargo.toml
@@ -24,6 +24,10 @@ repository.workspace = true
 rust-version.workspace = true
 version = "1.5.1"
 
+# This exists to workaround a limitation in cargo:
+# https://github.com/rust-lang/cargo/issues/3544
+links = "icu_capi1"
+
 [package.metadata.docs.rs]
 all-features = true
 

--- a/ffi/capi/build.rs
+++ b/ffi/capi/build.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 
 /// Inform cargo of the include directories as metadata key value pairs
 ///
-/// Cargo will make the values available to consumers via `DEP_ICU_CAPI_<KEY>`.
+/// Cargo will make the values available to consumers via `DEP_ICU_CAPI1_<KEY>`.
 /// See <https://doc.rust-lang.org/cargo/reference/build-scripts.html#the-links-manifest-key>
 /// for more information.
 fn add_bindings_to_cargo_metadata() {


### PR DESCRIPTION
Port of https://github.com/unicode-org/icu4x/pull/6887 to 1.5 as we would benefit from it in servo. To support an older MSRV this PR uses older syntax, see the MSRV note in the [cargo documentation](https://doc.rust-lang.org/cargo/reference/build-scripts.html#the-links-manifest-key))

This allows consumers of icu_capi to determine the location of the include directories by reading the DEP_ environment variable cargo will set.
Currently, consumers need to invoke cargo metadata to determine the header file location, which can be quite expensive. After this PR, consumers could directly read the environment variable that cargo sets.
This approach is already used in other bindings libraries, e.g. [in libz-sys](https://github.com/rust-lang/libz-sys/blob/1c2c7b04f585f86d9bd203bccf631a5dc2bdabc4/build.rs#L171).