### PR TITLE
Print warning when multiple filters are applied to same marker

### DIFF
--- a/provider/export/src/lib.rs
+++ b/provider/export/src/lib.rs
@@ -186,7 +186,7 @@ impl ExportDriver {
         .with_additional_collations([])
     }
 
-    /// Adds a filter on a [`DataMarkerAttributes`].
+    /// Sets the filter on a particular `domain` of [`DataMarkerAttributes`].
     ///
     /// These are keyed by a `domain`, which is [`DataMarkerInfo::attributes_domain`] and
     /// can thus apply to multiple data markers at once.


### PR DESCRIPTION
It's unclear from the docs whether calling the function with the same domain multiple times causes the filters to be in a union, intersection, or overridden. I'm adding a warning to be more clear to call it only once.