### PR TITLE
reexport stable-deref-trait from yoke.

### DIFF
--- a/utils/yoke/src/lib.rs
+++ b/utils/yoke/src/lib.rs
@@ -63,6 +63,7 @@ pub use yoke_derive::Yokeable;
 
 pub use crate::yoke::{CloneableCart, Yoke};
 pub use crate::yokeable::Yokeable;
+pub use stable_deref_trait;
 
 #[cfg(feature = "zerofrom")]
 use zerofrom::ZeroFrom;


### PR DESCRIPTION
Using custom type as cart needs implementing the StableDeref trait, which is not reexported from Yoke.

reexport stable-deref-trait, so that user don't have find the correct version of stable-deref-trait themselves before implementing it.