### PR TITLE
Use <= not < when checking if a day is out of range after addition

### DIFF
--- a/components/calendar/src/calendar_arithmetic.rs
+++ b/components/calendar/src/calendar_arithmetic.rs
@@ -625,9 +625,9 @@ impl<C: DateFieldsResolver> ArithmeticDate<C> {
         let end_of_month = Self::new_balanced(y0, duration.add_months_to(m0) + 1, 0, cal);
         // 1. Let _baseDay_ be _parts_.[[Day]].
         let base_day = self.day();
-        // 1. If _baseDay_ &lt; _endOfMonth_.[[Day]], then
+        // 1. If _baseDay_ &le; _endOfMonth_.[[Day]], then
         //   1. Let _regulatedDay_ be _baseDay_.
-        let regulated_day = if base_day < end_of_month.day() {
+        let regulated_day = if base_day <= end_of_month.day() {
             base_day
         } else {
             // 1. Else,

--- a/components/calendar/tests/arithmetic.rs
+++ b/components/calendar/tests/arithmetic.rs
@@ -186,6 +186,16 @@ fn test_hebrew() {
 }
 
 #[test]
+fn test_gregory_leap_addition() {
+    let leap_day = Date::try_new_gregorian(2020, 2, 29).unwrap();
+    let mut options = DateAddOptions::default();
+    options.overflow = Some(Overflow::Reject);
+    let y4 = DateDuration::for_years(4);
+    let result = leap_day.try_added_with_options(y4, options).unwrap();
+    assert_eq!(result, Date::try_new_gregorian(2024, 2, 29).unwrap());
+}
+
+#[test]
 fn test_tricky_leap_months() {
     let mut add_options = DateAddOptions::default();
     add_options.overflow = Some(Overflow::Constrain);


### PR DESCRIPTION
The spec is wrong here: https://github.com/tc39/proposal-intl-era-monthcode/pull/98
