### PR TITLE
Tweak locale subtags docs

### DIFF
--- a/components/locale_core/src/subtags/language.rs
+++ b/components/locale_core/src/subtags/language.rs
@@ -6,7 +6,8 @@ impl_tinystr_subtag!(
     /// A language subtag (examples: `"en"`, `"csb"`, `"zh"`, `"und"`, etc.)
     ///
     /// [`Language`] represents a Unicode base language code conformant to the
-    /// [`unicode_language_id`] field of the Language and Locale Identifier.
+    /// [`unicode_language_subtag`] field of the Language and Locale Identifier,
+    /// i.e. an [ISO 639] value.
     ///
     /// # Examples
     ///
@@ -32,7 +33,8 @@ impl_tinystr_subtag!(
     /// The specification allows language subtag to optionally also be 5-8 characters
     /// but that form has not been used and ICU4X does not support it right now.
     ///
-    /// [`unicode_language_id`]: https://unicode.org/reports/tr35/#unicode_language_id
+    /// [`unicode_language_subtag`]: https://unicode.org/reports/tr35/#unicode_language_subtag_validity
+    /// [ISO 639]: https://en.wikipedia.org/wiki/ISO_639
     Language,
     subtags,
     language,

--- a/components/locale_core/src/subtags/region.rs
+++ b/components/locale_core/src/subtags/region.rs
@@ -3,10 +3,11 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 impl_tinystr_subtag!(
-    /// A region subtag (examples: `"US"`, `"CN"`, `"AR"` etc.)
+    /// A region subtag (examples: `"US"`, `"CN"`, `"001"` etc.)
     ///
-    /// [`Region`] represents a Unicode base language code conformant to the
-    /// [`unicode_region_id`] field of the Language and Locale Identifier.
+    /// [`Region`] represents a Unicode region code conformant to the
+    /// [`unicode_region_subtag`] field of the Language and Locale Identifier,
+    /// i.e. an [ISO 3166-1 alpha 2] or [UN M.49] (macro regions only) value.
     ///
     /// # Examples
     ///
@@ -17,7 +18,9 @@ impl_tinystr_subtag!(
     ///     "DE".parse().expect("Failed to parse a region subtag.");
     /// ```
     ///
-    /// [`unicode_region_id`]: https://unicode.org/reports/tr35/#unicode_region_id
+    /// [`unicode_region_subtag`]: https://unicode.org/reports/tr35/#unicode_region_subtag_validity
+    /// [ISO 3166-1 alpha 2]: https://en.wikipedia.org/wiki/ISO_3166-1
+    /// [UN M.49]: https://en.wikipedia.org/wiki/UN_M49
     Region,
     subtags,
     region,
@@ -40,7 +43,7 @@ impl_tinystr_subtag!(
         s.is_ascii_numeric()
     },
     InvalidSubtag,
-    ["FR", "123"],
+    ["FR", "009"],
     ["12", "FRA", "b2"],
 );
 

--- a/components/locale_core/src/subtags/script.rs
+++ b/components/locale_core/src/subtags/script.rs
@@ -7,8 +7,9 @@ use crate::subtags::Subtag;
 impl_tinystr_subtag!(
     /// A script subtag (examples: `"Latn"`, `"Arab"`, etc.)
     ///
-    /// [`Script`] represents a Unicode base language code conformant to the
-    /// [`unicode_script_id`] field of the Language and Locale Identifier.
+    /// [`Script`] represents a Unicode script code conformant to the
+    /// [`unicode_script_subtag`] field of the Language and Locale Identifier,
+    /// i.e. an [ISO 15924] value.
     ///
     /// # Examples
     ///
@@ -19,7 +20,8 @@ impl_tinystr_subtag!(
     ///     "Latn".parse().expect("Failed to parse a script subtag.");
     /// ```
     ///
-    /// [`unicode_script_id`]: https://unicode.org/reports/tr35/#unicode_script_id
+    /// [`unicode_script_subtag`]: https://unicode.org/reports/tr35/#unicode_script_subtag_validity
+    /// [ISO 15924]: https://www.unicode.org/iso15924/index.html
     Script,
     subtags,
     script,

--- a/components/locale_core/src/subtags/variant.rs
+++ b/components/locale_core/src/subtags/variant.rs
@@ -6,7 +6,7 @@ impl_tinystr_subtag!(
     /// A variant subtag (examples: `"macos"`, `"posix"`, `"1996"` etc.)
     ///
     /// [`Variant`] represents a Unicode base language code conformant to the
-    /// [`unicode_variant_id`] field of the Language and Locale Identifier.
+    /// [`unicode_variant_subtag`] field of the Language and Locale Identifier.
     ///
     /// # Examples
     ///
@@ -17,7 +17,7 @@ impl_tinystr_subtag!(
     ///     "macos".parse().expect("Failed to parse a variant subtag.");
     /// ```
     ///
-    /// [`unicode_variant_id`]: https://unicode.org/reports/tr35/#unicode_variant_id
+    /// [`unicode_variant_subtag`]: https://unicode.org/reports/tr35/#unicode_variant_subtag_validity
     Variant,
     subtags,
     variant,


### PR DESCRIPTION
Some copy paste errors and dead links. Also linked more directly to relevant subtag standards.