### PR TITLE
reduced the size of arithmetic calendar

### DIFF
--- a/components/calendar/src/calendar_arithmetic.rs
+++ b/components/calendar/src/calendar_arithmetic.rs
@@ -2,6 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+extern crate alloc;
+
 use calendrical_calculations::rata_die::RataDie;
 
 use crate::duration::{DateDuration, DateDurationUnit};
@@ -11,12 +13,14 @@ use crate::error::{
 };
 use crate::options::{DateAddOptions, DateDifferenceOptions};
 use crate::options::{DateFromFieldsOptions, MissingFieldsStrategy, Overflow};
-use crate::types::{DateFields, Month};
+use crate::types::{DateFields, ValidMonthCode};
 use crate::{types, Calendar, DateError, RangeError};
 use core::cmp::Ordering;
 use core::fmt::Debug;
 use core::hash::{Hash, Hasher};
 use core::ops::RangeInclusive;
+use alloc::vec::Vec;
+
 
 /// This is checked by constructors. Internally we don't care about this invariant.
 pub const VALID_YEAR_RANGE: RangeInclusive<i32> = -1_000_000..=1_000_000;
@@ -25,14 +29,22 @@ pub const VALID_YEAR_RANGE: RangeInclusive<i32> = -1_000_000..=1_000_000;
 /// date types. Because this range slightly exceeds the [`VALID_YEAR_RANGE`], only
 /// the valid year range is checked in constructors. Only the `Date::from_rata_die`
 /// constructor actually uses this, but for clamping instead of erroring.
-// This range is the tightest possible range that includes all valid years for all
-// calendars, this is asserted in [`test_validity_ranges`].
+///
+/// The longest average year length is 365.25 (Julian, Coptic). We round up to 366 to make
+/// it round and capture year offsets from the Gregorian calendar, which underlies RD.
 pub const VALID_RD_RANGE: RangeInclusive<RataDie> =
-    RataDie::new(-367256444)..=RataDie::new(365940477);
+    RataDie::new(*VALID_YEAR_RANGE.start() as i64 * 366)
+        ..=RataDie::new(*VALID_YEAR_RANGE.end() as i64 * 366);
 
 // Invariant: VALID_RD_RANGE contains the date
 #[derive(Debug)]
-pub(crate) struct ArithmeticDate<C: DateFieldsResolver>(<C::YearInfo as PackWithMD>::Packed);
+pub(crate) struct ArithmeticDate<C: DateFieldsResolver> {
+    pub year: C::YearInfo,
+    /// 1-based month of year
+    pub month: u8,
+    /// 1-based day of month
+    pub day: u8,
+}
 
 // Manual impls since the derive will introduce a C: Trait bound
 // and only the year value should be compared
@@ -45,9 +57,9 @@ impl<C: DateFieldsResolver> Clone for ArithmeticDate<C> {
 
 impl<C: DateFieldsResolver> PartialEq for ArithmeticDate<C> {
     fn eq(&self, other: &Self) -> bool {
-        self.year().to_extended_year() == other.year().to_extended_year()
-            && self.month() == other.month()
-            && self.day() == other.day()
+        self.year.to_extended_year() == other.year.to_extended_year()
+            && self.month == other.month
+            && self.day == other.day
     }
 }
 
@@ -55,11 +67,11 @@ impl<C: DateFieldsResolver> Eq for ArithmeticDate<C> {}
 
 impl<C: DateFieldsResolver> Ord for ArithmeticDate<C> {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.year()
+        self.year
             .to_extended_year()
-            .cmp(&other.year().to_extended_year())
-            .then(self.month().cmp(&other.month()))
-            .then(self.day().cmp(&other.day()))
+            .cmp(&other.year.to_extended_year())
+            .then(self.month.cmp(&other.month))
+            .then(self.day.cmp(&other.day))
     }
 }
 
@@ -74,9 +86,9 @@ impl<C: DateFieldsResolver> Hash for ArithmeticDate<C> {
     where
         H: Hasher,
     {
-        self.year().to_extended_year().hash(state);
-        self.month().hash(state);
-        self.day().hash(state);
+        self.year.to_extended_year().hash(state);
+        self.month.hash(state);
+        self.day.hash(state);
     }
 }
 
@@ -94,47 +106,15 @@ impl ToExtendedYear for i32 {
     }
 }
 
-pub(crate) trait PackWithMD: Copy {
-    type Packed: Copy + Debug;
-
-    fn pack(self, month: u8, day: u8) -> Self::Packed;
-    fn unpack_year(packed: Self::Packed) -> Self;
-    fn unpack_month(packed: Self::Packed) -> u8;
-    fn unpack_day(packed: Self::Packed) -> u8;
-}
-
-impl PackWithMD for i32 {
-    /// 2 bits unused, 21 bits year (test_validity_ranges),
-    /// 4 bits month (1..13), 5 bits day (1..31)
-    type Packed = [u8; 4];
-
-    fn pack(self, month: u8, day: u8) -> Self::Packed {
-        (self << 9 | (month as i32) << 5 | day as i32).to_le_bytes()
-    }
-
-    fn unpack_year(packed: Self::Packed) -> Self {
-        let packed = i32::from_le_bytes(packed);
-        packed >> 9
-    }
-
-    fn unpack_month(packed: Self::Packed) -> u8 {
-        let packed = i32::from_le_bytes(packed);
-        (packed >> 5 & 0b1111) as u8
-    }
-
-    fn unpack_day(packed: Self::Packed) -> u8 {
-        let packed = i32::from_le_bytes(packed);
-        (packed & 0b11111) as u8
-    }
-}
-
 /// Trait for converting from era codes, month codes, and other fields to year/month/day ordinals.
 pub(crate) trait DateFieldsResolver: Calendar {
     /// This stores the year as either an i32, or a type containing more
     /// useful computational information.
-    type YearInfo: Copy + Debug + PartialEq + ToExtendedYear + PackWithMD;
+    type YearInfo: Copy + Debug + PartialEq + ToExtendedYear;
 
     fn days_in_provided_month(year: Self::YearInfo, month: u8) -> u8;
+
+    fn months_in_provided_year(year: Self::YearInfo) -> u8;
 
     /// Converts the era and era year to a YearInfo. If the calendar does not have eras,
     /// this should always return an Err result.
@@ -155,33 +135,22 @@ pub(crate) trait DateFieldsResolver: Calendar {
     /// day for the given month.
     fn reference_year_from_month_day(
         &self,
-        month: Month,
+        month_code: ValidMonthCode,
         day: u8,
     ) -> Result<Self::YearInfo, EcmaReferenceYearError>;
 
-    /// The number of months for the given year.
-    ///
-    /// The default impl is for non-lunisolar calendars with 12 months!
-    fn months_in_provided_year(_year: Self::YearInfo) -> u8 {
-        12
-    }
-
     /// Calculates the ordinal month for the given year and month code.
     ///
-    /// The default impl is for non-lunisolar calendars!
+    /// The default impl is for non-lunisolar calendars with 12 months!
     #[inline]
-    fn ordinal_from_month(
+    fn ordinal_month_from_code(
         &self,
-        year: Self::YearInfo,
-        month: Month,
+        _year: &Self::YearInfo,
+        month_code: ValidMonthCode,
         _options: DateFromFieldsOptions,
     ) -> Result<u8, MonthCodeError> {
-        match (month.number(), month.is_leap()) {
-            (month_number, false)
-                if (1..=Self::months_in_provided_year(year)).contains(&month_number) =>
-            {
-                Ok(month_number)
-            }
+        match month_code.to_tuple() {
+            (month_number @ 1..=12, false) => Ok(month_number),
             _ => Err(MonthCodeError::NotInCalendar),
         }
     }
@@ -192,54 +161,102 @@ pub(crate) trait DateFieldsResolver: Calendar {
     ///
     /// The default impl is for non-lunisolar calendars!
     #[inline]
-    fn month_from_ordinal(&self, _year: Self::YearInfo, ordinal_month: u8) -> Month {
-        Month::new_unchecked(ordinal_month, types::LeapStatus::Normal)
+    fn month_code_from_ordinal(&self, _year: &Self::YearInfo, ordinal_month: u8) -> ValidMonthCode {
+        ValidMonthCode::new_unchecked(ordinal_month, false)
     }
 }
 
+
+pub(crate) struct SharedFields {
+    pub extended_year: Option<i32>,
+    pub era: Option<Vec<u8>>,
+    pub era_year: Option<i32>,
+    pub validated_month_code: Option<ValidMonthCode>,
+    pub ordinal_month: Option<u8>,
+    pub day: u8,
+}
+
+pub(crate) fn parse_fields_shared(
+    fields: DateFields,
+    options: DateFromFieldsOptions,
+) -> Result<SharedFields, DateFromFieldsError> {
+    let missing_fields_strategy = options.missing_fields_strategy.unwrap_or_default();
+
+    // day
+    let day = match fields.day {
+        Some(day) => day,
+        None => match missing_fields_strategy {
+            MissingFieldsStrategy::Reject => {
+                return Err(DateFromFieldsError::NotEnoughFields)
+            }
+            MissingFieldsStrategy::Ecma => {
+                if fields.extended_year.is_some() || fields.era_year.is_some() {
+                    1
+                } else {
+                    return Err(DateFromFieldsError::NotEnoughFields);
+                }
+            }
+        },
+    };
+
+    if fields.month_code.is_none() && fields.ordinal_month.is_none() {
+        return Err(DateFromFieldsError::NotEnoughFields);
+    }
+
+    let validated_month_code = match fields.month_code {
+        Some(month_code) => {
+            Some(ValidMonthCode::try_from_utf8(month_code)?)
+        }
+        None => None,
+    };
+
+    Ok(SharedFields {
+        extended_year: fields.extended_year,
+        era: fields.era.map(|e| e.to_vec()),
+        era_year: fields.era_year,
+        validated_month_code,
+        ordinal_month: fields.ordinal_month,
+        day,
+    })
+}
+
+
 impl<C: DateFieldsResolver> ArithmeticDate<C> {
-    pub(crate) fn year(self) -> C::YearInfo {
-        C::YearInfo::unpack_year(self.0)
-    }
-
-    pub(crate) fn month(self) -> u8 {
-        C::YearInfo::unpack_month(self.0)
-    }
-
-    pub(crate) fn day(self) -> u8 {
-        C::YearInfo::unpack_day(self.0)
-    }
-
     // Precondition: the date is in the VALID_RD_RANGE
     #[inline]
-    pub(crate) fn new_unchecked(year: C::YearInfo, month: u8, day: u8) -> Self {
-        ArithmeticDate(C::YearInfo::pack(year, month, day))
+    pub(crate) const fn new_unchecked(year: C::YearInfo, month: u8, day: u8) -> Self {
+        ArithmeticDate { year, month, day }
     }
 
-    pub(crate) fn cast<C2: DateFieldsResolver<YearInfo = C::YearInfo>>(self) -> ArithmeticDate<C2> {
-        ArithmeticDate::new_unchecked(self.year(), self.month(), self.day())
+    pub(crate) const fn cast<C2: DateFieldsResolver<YearInfo = C::YearInfo>>(
+        self,
+    ) -> ArithmeticDate<C2> {
+        ArithmeticDate {
+            year: self.year,
+            month: self.month,
+            day: self.day,
+        }
     }
 
-    pub(crate) fn from_era_year_month_code_day(
+    pub(crate) fn from_codes(
         era: Option<&str>,
         year: i32,
         month_code: types::MonthCode,
         day: u8,
         calendar: &C,
     ) -> Result<Self, DateError> {
+        let year = range_check(year, "year", VALID_YEAR_RANGE)?;
         let year = if let Some(era) = era {
-            let year = calendar
-                .year_info_from_era(era.as_bytes(), range_check(year, "year", VALID_YEAR_RANGE)?)?;
-            range_check(year.to_extended_year(), "era_year", VALID_YEAR_RANGE)?;
-            year
+            calendar.year_info_from_era(era.as_bytes(), year)?
         } else {
-            calendar.year_info_from_extended(range_check(year, "extended_year", VALID_YEAR_RANGE)?)
+            calendar.year_info_from_extended(year)
         };
-        let validated = Month::try_from_utf8(month_code.0.as_bytes()).map_err(|e| match e {
-            MonthCodeParseError::InvalidSyntax => DateError::UnknownMonthCode(month_code),
-        })?;
+        let validated =
+            ValidMonthCode::try_from_utf8(month_code.0.as_bytes()).map_err(|e| match e {
+                MonthCodeParseError::InvalidSyntax => DateError::UnknownMonthCode(month_code),
+            })?;
         let month = calendar
-            .ordinal_from_month(year, validated, Default::default())
+            .ordinal_month_from_code(&year, validated, Default::default())
             .map_err(|e| match e {
                 MonthCodeError::NotInCalendar | MonthCodeError::NotInYear => {
                     DateError::UnknownMonthCode(month_code)
@@ -257,162 +274,82 @@ impl<C: DateFieldsResolver> ArithmeticDate<C> {
         options: DateFromFieldsOptions,
         calendar: &C,
     ) -> Result<Self, DateFromFieldsError> {
-        let missing_fields_strategy = options.missing_fields_strategy.unwrap_or_default();
+        let shared = parse_fields_shared(fields, options)?;
 
-        let day = match fields.day {
-            Some(day) => day,
-            None => match missing_fields_strategy {
-                MissingFieldsStrategy::Reject => return Err(DateFromFieldsError::NotEnoughFields),
-                MissingFieldsStrategy::Ecma => {
-                    if fields.extended_year.is_some() || fields.era_year.is_some() {
-                        // The ECMAScript strategy is to pick day 1, always, regardless of whether
-                        // that day exists for the month/year combo
-                        1
-                    } else {
-                        return Err(DateFromFieldsError::NotEnoughFields);
-                    }
-                }
-            },
-        };
+        // year resolution
 
-        if fields.month_code.is_none() && fields.ordinal_month.is_none() {
-            // We're returning this error early so that we return structural type
-            // errors before range errors, see comment in the year code below.
-            return Err(DateFromFieldsError::NotEnoughFields);
-        }
-
-        let mut valid_month_code = None;
-
-        // NOTE: The year/extendedyear range check is important to avoid arithmetic
-        // overflow in `year_info_from_era` and `year_info_from_extended`. It
-        // must happen before they are called.
-        //
-        // To better match the Temporal specification's order of operations, we try
-        // to return structural type errors (`NotEnoughFields`) before checking for range errors.
-        // This isn't behavior we *must* have, but it is not much additional work to maintain
-        // so we make an attempt.
-        let year = match (fields.era, fields.era_year) {
-            (None, None) => match fields.extended_year {
-                Some(extended_year) => calendar.year_info_from_extended(range_check(
-                    extended_year,
+        // Case 1: Era + era_year
+        let year_info = match (&shared.era, shared.era_year) {
+            (Some(era_bytes), Some(era_year)) => {
+                let era_year_checked = range_check(
+                    era_year,
                     "year",
                     VALID_YEAR_RANGE,
-                )?),
-                None => match missing_fields_strategy {
-                    MissingFieldsStrategy::Reject => {
-                        return Err(DateFromFieldsError::NotEnoughFields)
-                    }
-                    MissingFieldsStrategy::Ecma => {
-                        match (fields.month_code, fields.ordinal_month) {
-                            (Some(month_code), None) => {
-                                let validated = Month::try_from_utf8(month_code)?;
-                                valid_month_code = Some(validated);
-                                calendar.reference_year_from_month_day(validated, day)?
-                            }
-                            _ => return Err(DateFromFieldsError::NotEnoughFields),
-                        }
-                    }
-                },
-            },
-            (Some(era), Some(era_year)) => {
-                let year = calendar.year_info_from_era(
-                    era,
-                    range_check(era_year.to_extended_year(), "year", VALID_YEAR_RANGE)?,
                 )?;
-                range_check(year.to_extended_year(), "extended_year", VALID_YEAR_RANGE)?;
-                if let Some(extended_year) = fields.extended_year {
-                    if year.to_extended_year() != extended_year {
-                        return Err(DateFromFieldsError::InconsistentYear);
-                    }
-                }
-                year
+                calendar.year_info_from_era(era_bytes, era_year_checked)?
             }
-            // Era and Era Year must be both or neither
-            (Some(_), None) | (None, Some(_)) => return Err(DateFromFieldsError::NotEnoughFields),
-        };
 
-        let month = match fields.month_code {
-            Some(month_code) => {
-                let validated = match valid_month_code {
-                    Some(validated) => validated,
-                    None => Month::try_from_utf8(month_code)?,
-                };
-                let computed_month = calendar.ordinal_from_month(year, validated, options)?;
-                if let Some(ordinal_month) = fields.ordinal_month {
-                    if computed_month != ordinal_month {
-                        return Err(DateFromFieldsError::InconsistentMonth);
-                    }
-                }
-                computed_month
-            }
-            None => match fields.ordinal_month {
-                Some(month) => month,
-                None => {
-                    debug_assert!(false, "Already checked above");
+            (None, None) => {
+                if let Some(extended_year) = shared.extended_year {
+                    let checked = range_check(
+                        extended_year,
+                        "year",
+                        VALID_YEAR_RANGE,
+                    )?;
+                    calendar.year_info_from_extended(checked)
+                } else {
                     return Err(DateFromFieldsError::NotEnoughFields);
                 }
-            },
+            }
+
+
+            _ => return Err(DateFromFieldsError::NotEnoughFields),
+        };
+
+        // month resolution
+
+        let month = if let Some(valid_mc) = shared.validated_month_code {
+            let computed = calendar.ordinal_month_from_code(&year_info, valid_mc, options)?;
+            if let Some(ord_month) = shared.ordinal_month {
+                if computed != ord_month {
+                    return Err(DateFromFieldsError::InconsistentMonth);
+                }
+            }
+            computed
+        } else if let Some(ordinal) = shared.ordinal_month {
+            ordinal
+        } else {
+            return Err(DateFromFieldsError::NotEnoughFields);
         };
 
         let constrained_month = range_check_with_overflow(
             month,
             "month",
-            1..=C::months_in_provided_year(year),
+            1..=C::months_in_provided_year(year_info),
             options.overflow.unwrap_or_default(),
         )?;
 
-        let day = range_check_with_overflow(
-            day,
+        // day resolution
+
+        let constrained_day = range_check_with_overflow(
+            shared.day,
             "day",
-            1..=C::days_in_provided_month(year, constrained_month),
+            1..=C::days_in_provided_month(year_info, constrained_month),
             options.overflow.unwrap_or_default(),
         )?;
-        // date is in the valid year range, and therefore in the valid RD range
-        Ok(Self::new_unchecked(year, constrained_month, day))
+
+        // result
+
+        Ok(Self::new_unchecked(year_info, constrained_month, constrained_day))
     }
 
-    pub(crate) fn from_year_month_day(
-        year: i32,
-        month: u8,
-        day: u8,
-        cal: &C,
-    ) -> Result<Self, RangeError> {
-        let year_info = cal.year_info_from_extended(range_check(year, "year", VALID_YEAR_RANGE)?);
-        // check the extended year in terms of the year
-        let offset = year - year_info.to_extended_year();
-        range_check(
-            year, // == year_info.to_extended_year() + offset
-            "year",
-            (VALID_YEAR_RANGE.start() + offset)..=(VALID_YEAR_RANGE.end() + offset),
-        )?;
-        range_check(month, "month", 1..=C::months_in_provided_year(year_info))?;
-        range_check(day, "day", 1..=C::days_in_provided_month(year_info, month))?;
-        // date is in the valid year range, and therefore in the valid RD range
-        Ok(ArithmeticDate::new_unchecked(year_info, month, day))
-    }
 
-    pub(crate) fn from_era_year_month_day(
-        era: &str,
-        year: i32,
-        month: u8,
-        day: u8,
-        cal: &C,
-    ) -> Result<Self, DateError> {
-        let year_info = cal.year_info_from_era(
-            era.as_bytes(),
-            range_check(year, "era_year", VALID_YEAR_RANGE)?,
-        )?;
-        // check the extended year in terms of the year
-        let offset = year - year_info.to_extended_year();
-        range_check(
-            year, // == year_info.to_extended_year() + offset
-            "extended_year",
-            (VALID_YEAR_RANGE.start() + offset)..=(VALID_YEAR_RANGE.end() + offset),
-        )?;
-        range_check(month, "month", 1..=C::months_in_provided_year(year_info))?;
-        range_check(day, "day", 1..=C::days_in_provided_month(year_info, month))?;
+    pub(crate) fn try_from_ymd(year: C::YearInfo, month: u8, day: u8) -> Result<Self, RangeError> {
+        range_check(year.to_extended_year(), "year", VALID_YEAR_RANGE)?;
+        range_check(month, "month", 1..=C::months_in_provided_year(year))?;
+        range_check(day, "day", 1..=C::days_in_provided_month(year, month))?;
         // date is in the valid year range, and therefore in the valid RD range
-        Ok(ArithmeticDate::new_unchecked(year_info, month, day))
+        Ok(ArithmeticDate::new_unchecked(year, month, day))
     }
 
     /// Implements the Temporal abstract operation BalanceNonISODate.
@@ -507,14 +444,14 @@ impl<C: DateFieldsResolver> ArithmeticDate<C> {
     ) -> bool {
         // 1. Let _parts_ be CalendarISOToDate(_calendar_, _fromIsoDate_).
         // 1. Let _y0_ be _parts_.[[Year]] + _years_.
-        let y0 = cal.year_info_from_extended(duration.add_years_to(self.year().to_extended_year()));
+        let y0 = cal.year_info_from_extended(duration.add_years_to(self.year.to_extended_year()));
         // 1. Let _m0_ be MonthCodeToOrdinal(_calendar_, _y0_, ! ConstrainMonthCode(_calendar_, _y0_, _parts_.[[MonthCode]], ~constrain~)).
-        let base_month = cal.month_from_ordinal(self.year(), self.month());
+        let base_month_code = cal.month_code_from_ordinal(&self.year, self.month);
         let constrain = DateFromFieldsOptions {
             overflow: Some(Overflow::Constrain),
             ..Default::default()
         };
-        let m0_result = cal.ordinal_from_month(y0, base_month, constrain);
+        let m0_result = cal.ordinal_month_from_code(&y0, base_month_code, constrain);
         let m0 = match m0_result {
             Ok(m0) => m0,
             Err(_) => {
@@ -528,7 +465,7 @@ impl<C: DateFieldsResolver> ArithmeticDate<C> {
         // 1. Let _endOfMonth_ be BalanceNonISODate(_calendar_, _y0_, _m0_ + _months_ + 1, 0).
         let end_of_month = Self::new_balanced(y0, duration.add_months_to(m0) + 1, 0, cal);
         // 1. Let _baseDay_ be _parts_.[[Day]].
-        let base_day = self.day();
+        let base_day = self.day;
         let y1;
         let m1;
         let d1;
@@ -538,31 +475,31 @@ impl<C: DateFieldsResolver> ArithmeticDate<C> {
             //     1. Let _regulatedDay_ be _baseDay_.
             //   1. Else,
             //     1. Let _regulatedDay_ be _endOfMonth_.[[Day]].
-            let regulated_day = if base_day < end_of_month.day() {
+            let regulated_day = if base_day < end_of_month.day {
                 base_day
             } else {
-                end_of_month.day()
+                end_of_month.day
             };
             //   1. Let _balancedDate_ be BalanceNonISODate(_calendar_, _endOfMonth_.[[Year]], _endOfMonth_.[[Month]], _regulatedDay_ + 7 * _weeks_ + _days_).
             //   1. Let _y1_ be _balancedDate_.[[Year]].
             //   1. Let _m1_ be _balancedDate_.[[Month]].
             //   1. Let _d1_ be _balancedDate_.[[Day]].
             let balanced_date = Self::new_balanced(
-                end_of_month.year(),
-                i64::from(end_of_month.month()),
+                end_of_month.year,
+                i64::from(end_of_month.month),
                 duration.add_weeks_and_days_to(regulated_day),
                 cal,
             );
-            y1 = balanced_date.year();
-            m1 = balanced_date.month();
-            d1 = balanced_date.day();
+            y1 = balanced_date.year;
+            m1 = balanced_date.month;
+            d1 = balanced_date.day;
         } else {
             // 1. Else,
             //   1. Let _y1_ be _endOfMonth_.[[Year]].
             //   1. Let _m1_ be _endOfMonth_.[[Month]].
             //   1. Let _d1_ be _baseDay_.
-            y1 = end_of_month.year();
-            m1 = end_of_month.month();
+            y1 = end_of_month.year;
+            m1 = end_of_month.month;
             d1 = base_day;
         }
         // 1. Let _calDate2_ be CalendarISOToDate(_calendar_, _toIsoDate_).
@@ -573,19 +510,18 @@ impl<C: DateFieldsResolver> ArithmeticDate<C> {
         // 1. Else if _d1_ ≠ _calDate2_.[[Day]], then
         //   1. If _sign_ × (_d1_ - _calDate2_.[[Day]]) > 0, return *true*.
         #[allow(clippy::collapsible_if)] // to align with the spec
-        if y1 != other.year() {
-            if sign
-                * (i64::from(y1.to_extended_year()) - i64::from(other.year().to_extended_year()))
+        if y1 != other.year {
+            if sign * (i64::from(y1.to_extended_year()) - i64::from(other.year.to_extended_year()))
                 > 0
             {
                 return true;
             }
-        } else if m1 != other.month() {
-            if sign * (i64::from(m1) - i64::from(other.month())) > 0 {
+        } else if m1 != other.month {
+            if sign * (i64::from(m1) - i64::from(other.month)) > 0 {
                 return true;
             }
-        } else if d1 != other.day() {
-            if sign * (i64::from(d1) - i64::from(other.day())) > 0 {
+        } else if d1 != other.day {
+            if sign * (i64::from(d1) - i64::from(other.day)) > 0 {
                 return true;
             }
         }
@@ -605,29 +541,33 @@ impl<C: DateFieldsResolver> ArithmeticDate<C> {
     ) -> Result<Self, DateError> {
         // 1. Let _parts_ be CalendarISOToDate(_calendar_, _isoDate_).
         // 1. Let _y0_ be _parts_.[[Year]] + _duration_.[[Years]].
-        let y0 = cal.year_info_from_extended(duration.add_years_to(self.year().to_extended_year()));
+        let y0 = cal.year_info_from_extended(duration.add_years_to(self.year.to_extended_year()));
         // 1. Let _m0_ be MonthCodeToOrdinal(_calendar_, _y0_, ! ConstrainMonthCode(_calendar_, _y0_, _parts_.[[MonthCode]], _overflow_)).
-        let base_month = cal.month_from_ordinal(self.year(), self.month());
+        let base_month = cal.month_code_from_ordinal(&self.year, self.month);
         let m0 = cal
-            .ordinal_from_month(
-                y0,
+            .ordinal_month_from_code(
+                &y0,
                 base_month,
                 DateFromFieldsOptions::from_add_options(options),
             )
             .map_err(|e| {
                 // TODO: Use a narrower error type here. For now, convert into DateError.
                 match e {
-                    MonthCodeError::NotInCalendar => DateError::UnknownMonthCode(base_month.code()),
-                    MonthCodeError::NotInYear => DateError::UnknownMonthCode(base_month.code()),
+                    MonthCodeError::NotInCalendar => {
+                        DateError::UnknownMonthCode(base_month.to_month_code())
+                    }
+                    MonthCodeError::NotInYear => {
+                        DateError::UnknownMonthCode(base_month.to_month_code())
+                    }
                 }
             })?;
         // 1. Let _endOfMonth_ be BalanceNonISODate(_calendar_, _y0_, _m0_ + _duration_.[[Months]] + 1, 0).
         let end_of_month = Self::new_balanced(y0, duration.add_months_to(m0) + 1, 0, cal);
         // 1. Let _baseDay_ be _parts_.[[Day]].
-        let base_day = self.day();
-        // 1. If _baseDay_ &le; _endOfMonth_.[[Day]], then
+        let base_day = self.day;
+        // 1. If _baseDay_ &lt; _endOfMonth_.[[Day]], then
         //   1. Let _regulatedDay_ be _baseDay_.
-        let regulated_day = if base_day <= end_of_month.day() {
+        let regulated_day = if base_day < end_of_month.day {
             base_day
         } else {
             // 1. Else,
@@ -638,17 +578,17 @@ impl<C: DateFieldsResolver> ArithmeticDate<C> {
                     field: "day",
                     value: i32::from(base_day),
                     min: 1,
-                    max: i32::from(end_of_month.day()),
+                    max: i32::from(end_of_month.day),
                 });
             }
-            end_of_month.day()
+            end_of_month.day
         };
         // 1. Let _balancedDate_ be BalanceNonISODate(_calendar_, _endOfMonth_.[[Year]], _endOfMonth_.[[Month]], _regulatedDay_ + 7 * _duration_.[[Weeks]] + _duration_.[[Days]]).
         // 1. Let _result_ be ? CalendarIntegersToISO(_calendar_, _balancedDate_.[[Year]], _balancedDate_.[[Month]], _balancedDate_.[[Day]]).
         // 1. Return _result_.
         Ok(Self::new_balanced(
-            end_of_month.year(),
-            i64::from(end_of_month.month()),
+            end_of_month.year,
+            i64::from(end_of_month.month),
             duration.add_weeks_and_days_to(regulated_day),
             cal,
         ))
@@ -792,108 +732,5 @@ mod tests {
         Date::try_new_iso(2024, 0, 1).unwrap_err();
         Date::try_new_iso(2024, 1, 0).unwrap_err();
         Date::try_new_iso(2024, 0, 0).unwrap_err();
-    }
-
-    #[test]
-    fn test_validity_ranges() {
-        use crate::{cal::*, Date};
-
-        #[rustfmt::skip]
-        let lowest_years = [
-            Date::from_rata_die(*VALID_RD_RANGE.start(), Buddhist).year().extended_year(),
-            Date::from_rata_die(*VALID_RD_RANGE.start(), ChineseTraditional::new()).year().extended_year(),
-            Date::from_rata_die(*VALID_RD_RANGE.start(), Coptic).year().extended_year(),
-            Date::from_rata_die(*VALID_RD_RANGE.start(), Ethiopian::new_with_era_style(EthiopianEraStyle::AmeteAlem)).year().extended_year(),
-            Date::from_rata_die(*VALID_RD_RANGE.start(), Ethiopian::new_with_era_style(EthiopianEraStyle::AmeteMihret)).year().extended_year(),
-            Date::from_rata_die(*VALID_RD_RANGE.start(), Gregorian).year().extended_year(),
-            Date::from_rata_die(*VALID_RD_RANGE.start(), Hebrew).year().extended_year(),
-            Date::from_rata_die(*VALID_RD_RANGE.start(), Hijri::new_umm_al_qura()).year().extended_year(),
-            Date::from_rata_die(*VALID_RD_RANGE.start(), Hijri::new_tabular(HijriTabularLeapYears::TypeII, HijriTabularEpoch::Thursday)).year().extended_year(),
-            Date::from_rata_die(*VALID_RD_RANGE.start(), Indian).year().extended_year(),
-            Date::from_rata_die(*VALID_RD_RANGE.start(), Iso).year().extended_year(),
-            Date::from_rata_die(*VALID_RD_RANGE.start(), Japanese::new()).year().extended_year(),
-            Date::from_rata_die(*VALID_RD_RANGE.start(), Julian).year().extended_year(),
-            Date::from_rata_die(*VALID_RD_RANGE.start(), KoreanTraditional::new()).year().extended_year(),
-            Date::from_rata_die(*VALID_RD_RANGE.start(), Persian).year().extended_year(),
-            Date::from_rata_die(*VALID_RD_RANGE.start(), Roc).year().extended_year(),
-        ];
-
-        #[rustfmt::skip]
-        let highest_years = [
-            Date::from_rata_die(*VALID_RD_RANGE.end(), Buddhist).year().extended_year(),
-            Date::from_rata_die(*VALID_RD_RANGE.end(), ChineseTraditional::new()).year().extended_year(),
-            Date::from_rata_die(*VALID_RD_RANGE.end(), Coptic).year().extended_year(),
-            Date::from_rata_die(*VALID_RD_RANGE.end(), Ethiopian::new_with_era_style(EthiopianEraStyle::AmeteAlem)).year().extended_year(),
-            Date::from_rata_die(*VALID_RD_RANGE.end(), Ethiopian::new_with_era_style(EthiopianEraStyle::AmeteMihret)).year().extended_year(),
-            Date::from_rata_die(*VALID_RD_RANGE.end(), Gregorian).year().extended_year(),
-            Date::from_rata_die(*VALID_RD_RANGE.end(), Hebrew).year().extended_year(),
-            Date::from_rata_die(*VALID_RD_RANGE.end(), Hijri::new_umm_al_qura()).year().extended_year(),
-            Date::from_rata_die(*VALID_RD_RANGE.end(), Hijri::new_tabular(HijriTabularLeapYears::TypeII, HijriTabularEpoch::Thursday)).year().extended_year(),
-            Date::from_rata_die(*VALID_RD_RANGE.end(), Indian).year().extended_year(),
-            Date::from_rata_die(*VALID_RD_RANGE.end(), Iso).year().extended_year(),
-            Date::from_rata_die(*VALID_RD_RANGE.end(), Japanese::new()).year().extended_year(),
-            Date::from_rata_die(*VALID_RD_RANGE.end(), Julian).year().extended_year(),
-            Date::from_rata_die(*VALID_RD_RANGE.end(), KoreanTraditional::new()).year().extended_year(),
-            Date::from_rata_die(*VALID_RD_RANGE.end(), Persian).year().extended_year(),
-            Date::from_rata_die(*VALID_RD_RANGE.end(), Roc).year().extended_year(),
-        ];
-
-        #[rustfmt::skip]
-        let lowest_rds = [
-            Date::try_new_from_codes(None, *VALID_YEAR_RANGE.start(), Month::new(1).code(), 1, Buddhist).unwrap().to_rata_die(),
-            Date::try_new_from_codes(None, *VALID_YEAR_RANGE.start(), Month::new(1).code(), 1, ChineseTraditional::new()).unwrap().to_rata_die(),
-            Date::try_new_from_codes(None, *VALID_YEAR_RANGE.start(), Month::new(1).code(), 1, Coptic).unwrap().to_rata_die(),
-            Date::try_new_from_codes(None, *VALID_YEAR_RANGE.start(), Month::new(1).code(), 1, Ethiopian::new_with_era_style(EthiopianEraStyle::AmeteAlem)).unwrap().to_rata_die(),
-            Date::try_new_from_codes(None, *VALID_YEAR_RANGE.start(), Month::new(1).code(), 1, Ethiopian::new_with_era_style(EthiopianEraStyle::AmeteMihret)).unwrap().to_rata_die(),
-            Date::try_new_from_codes(None, *VALID_YEAR_RANGE.start(), Month::new(1).code(), 1, Gregorian).unwrap().to_rata_die(),
-            Date::try_new_from_codes(None, *VALID_YEAR_RANGE.start(), Month::new(1).code(), 1, Hebrew).unwrap().to_rata_die(),
-            Date::try_new_from_codes(None, *VALID_YEAR_RANGE.start(), Month::new(1).code(), 1, Hijri::new_umm_al_qura()).unwrap().to_rata_die(),
-            Date::try_new_from_codes(None, *VALID_YEAR_RANGE.start(), Month::new(1).code(), 1, Hijri::new_tabular(HijriTabularLeapYears::TypeII, HijriTabularEpoch::Thursday)).unwrap().to_rata_die(),
-            Date::try_new_from_codes(None, *VALID_YEAR_RANGE.start(), Month::new(1).code(), 1, Indian).unwrap().to_rata_die(),
-            Date::try_new_from_codes(None, *VALID_YEAR_RANGE.start(), Month::new(1).code(), 1, Iso).unwrap().to_rata_die(),
-            Date::try_new_from_codes(None, *VALID_YEAR_RANGE.start(), Month::new(1).code(), 1, Japanese::new()).unwrap().to_rata_die(),
-            Date::try_new_from_codes(None, *VALID_YEAR_RANGE.start(), Month::new(1).code(), 1, Julian).unwrap().to_rata_die(),
-            Date::try_new_from_codes(None, *VALID_YEAR_RANGE.start(), Month::new(1).code(), 1, KoreanTraditional::new()).unwrap().to_rata_die(),
-            Date::try_new_from_codes(None, *VALID_YEAR_RANGE.start(), Month::new(1).code(), 1, Persian).unwrap().to_rata_die(),
-            Date::try_new_from_codes(None, *VALID_YEAR_RANGE.start(), Month::new(1).code(), 1, Roc).unwrap().to_rata_die(),
-        ];
-
-        #[rustfmt::skip]
-        let highest_rds = [
-            Date::try_new_from_codes(None, *VALID_YEAR_RANGE.end(), Month::new(12).code(), 31, Buddhist).unwrap().to_rata_die(),
-            Date::try_new_from_codes(None, *VALID_YEAR_RANGE.end(), Month::new(12).code(), 30, ChineseTraditional::new()).unwrap().to_rata_die(),
-            Date::try_new_from_codes(None, *VALID_YEAR_RANGE.end(), Month::new(13).code(), 5, Coptic).unwrap().to_rata_die(),
-            Date::try_new_from_codes(None, *VALID_YEAR_RANGE.end(), Month::new(13).code(), 5, Ethiopian::new_with_era_style(EthiopianEraStyle::AmeteAlem)).unwrap().to_rata_die(),
-            Date::try_new_from_codes(None, *VALID_YEAR_RANGE.end(), Month::new(13).code(), 5, Ethiopian::new_with_era_style(EthiopianEraStyle::AmeteMihret)).unwrap().to_rata_die(),
-            Date::try_new_from_codes(None, *VALID_YEAR_RANGE.end(), Month::new(12).code(), 31, Gregorian).unwrap().to_rata_die(),
-            Date::try_new_from_codes(None, *VALID_YEAR_RANGE.end(), Month::new(12).code(), 29, Hebrew).unwrap().to_rata_die(),
-            Date::try_new_from_codes(None, *VALID_YEAR_RANGE.end(), Month::new(12).code(), 30, Hijri::new_umm_al_qura()).unwrap().to_rata_die(),
-            Date::try_new_from_codes(None, *VALID_YEAR_RANGE.end(), Month::new(12).code(), 30, Hijri::new_tabular(HijriTabularLeapYears::TypeII, HijriTabularEpoch::Thursday)).unwrap().to_rata_die(),
-            Date::try_new_from_codes(None, *VALID_YEAR_RANGE.end(), Month::new(12).code(), 30, Indian).unwrap().to_rata_die(),
-            Date::try_new_from_codes(None, *VALID_YEAR_RANGE.end(), Month::new(12).code(), 31, Iso).unwrap().to_rata_die(),
-            Date::try_new_from_codes(None, *VALID_YEAR_RANGE.end(), Month::new(12).code(), 31, Japanese::new()).unwrap().to_rata_die(),
-            Date::try_new_from_codes(None, *VALID_YEAR_RANGE.end(), Month::new(12).code(), 31, Julian).unwrap().to_rata_die(),
-            Date::try_new_from_codes(None, *VALID_YEAR_RANGE.end(), Month::new(12).code(), 30, KoreanTraditional::new()).unwrap().to_rata_die(),
-            Date::try_new_from_codes(None, *VALID_YEAR_RANGE.end(), Month::new(12).code(), 30, Persian).unwrap().to_rata_die(),
-            Date::try_new_from_codes(None, *VALID_YEAR_RANGE.end(), Month::new(12).code(), 31, Roc).unwrap().to_rata_die(),
-        ];
-
-        // RD range is tight
-        assert_eq!(
-            lowest_rds.iter().copied().min().unwrap(),
-            *VALID_RD_RANGE.start()
-        );
-        assert_eq!(
-            highest_rds.iter().copied().max().unwrap(),
-            *VALID_RD_RANGE.end()
-        );
-
-        // Valid RDs can represent all valid years
-        assert!(lowest_years.iter().all(|y| y <= VALID_YEAR_RANGE.start()));
-        assert!(highest_years.iter().all(|y| y >= VALID_YEAR_RANGE.end()));
-
-        // All years are 21-bits
-        assert!(-lowest_years.iter().copied().min().unwrap() < 1 << 20);
-        assert!(highest_years.iter().copied().max().unwrap() < 1 << 20);
     }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->
Fixes #7201 

This pull request refactors the `from_fields()` method in `calendar_arithmetic.rs` as described in the issue. 

The shared parsing logic for day, month, and year fields has been moved into a new helper function `parse_fields_shared()` along with a `SharedFields` struct. 

This keeps the logic in one place and reduces the overall code size. 
