### PR TITLE
Deprecate `Date::extended_year`

### DIFF
--- a/components/calendar/fuzz/fuzz_targets/construction.rs
+++ b/components/calendar/fuzz/fuzz_targets/construction.rs
@@ -25,7 +25,6 @@ fuzz_target!(|data: FuzzInput| {
         let _ = date.day_of_year();
         let _ = date.days_in_month();
         let _ = date.days_in_year();
-        let _ = date.extended_year();
         let _ = date.is_in_leap_year();
         let _ = date.month();
         let _ = date.months_in_year();

--- a/components/calendar/src/any_calendar.rs
+++ b/components/calendar/src/any_calendar.rs
@@ -1364,7 +1364,7 @@ mod tests {
         } else {
             assert_eq!(
                 year,
-                date.extended_year(),
+                date.year().extended_year(),
                 "Failed to roundtrip year for calendar {}",
                 calendar.debug_name()
             );

--- a/components/calendar/src/cal/east_asian_traditional.rs
+++ b/components/calendar/src/cal/east_asian_traditional.rs
@@ -1208,7 +1208,7 @@ mod test {
             let chinese = Date::from_rata_die(rata_die, ChineseTraditional::new());
             assert_eq!(
                 case.expected_year,
-                chinese.extended_year(),
+                chinese.year().extended_year(),
                 "Chinese from RD failed, case: {case:?}"
             );
             assert_eq!(
@@ -1871,21 +1871,21 @@ mod test {
                     'outer: for long in [false, true] {
                         for (start_year, start_month, end_year, end_month, by) in [
                             (
-                                reference_year_end.extended_year(),
+                                reference_year_end.year().extended_year(),
                                 reference_year_end.month().number(),
-                                year_1900_start.extended_year(),
+                                year_1900_start.year().extended_year(),
                                 year_1900_start.month().number(),
                                 -1,
                             ),
                             (
-                                reference_year_end.extended_year(),
+                                reference_year_end.year().extended_year(),
                                 reference_year_end.month().number(),
-                                year_2035_end.extended_year(),
+                                year_2035_end.year().extended_year(),
                                 year_2035_end.month().number(),
                                 1,
                             ),
                             (
-                                year_1900_start.extended_year(),
+                                year_1900_start.year().extended_year(),
                                 year_1900_start.month().number(),
                                 -10000,
                                 1,

--- a/components/calendar/src/cal/ethiopian.rs
+++ b/components/calendar/src/cal/ethiopian.rs
@@ -321,7 +321,7 @@ mod test {
         // 2023-09-11 ISO is 2025-13-06 Ethiopian
         let rd = Date::try_new_iso(2023, 9, 11).unwrap().to_rata_die();
         let date_ethiopian = Date::from_rata_die(rd, Ethiopian::new());
-        assert_eq!(date_ethiopian.extended_year(), 2015);
+        assert_eq!(date_ethiopian.year().extended_year(), 2015);
         assert_eq!(date_ethiopian.month().ordinal, 13);
         assert_eq!(date_ethiopian.day_of_month().0, 6);
     }
@@ -331,7 +331,7 @@ mod test {
         let rd = Date::try_new_iso(1970, 1, 2).unwrap().to_rata_die();
         let date_ethiopian = Date::from_rata_die(rd, Ethiopian::new());
 
-        assert_eq!(date_ethiopian.extended_year(), 1962);
+        assert_eq!(date_ethiopian.year().extended_year(), 1962);
         assert_eq!(date_ethiopian.month().ordinal, 4);
         assert_eq!(date_ethiopian.day_of_month().0, 24);
 
@@ -343,7 +343,7 @@ mod test {
         let rd = Date::try_new_iso(1970, 1, 2).unwrap().to_rata_die();
         let date_ethiopian = Date::from_rata_die(rd, Ethiopian(EthiopianEraStyle::AmeteAlem));
 
-        assert_eq!(date_ethiopian.extended_year(), 7462);
+        assert_eq!(date_ethiopian.year().extended_year(), 7462);
         assert_eq!(date_ethiopian.month().ordinal, 4);
         assert_eq!(date_ethiopian.day_of_month().0, 24);
 
@@ -364,6 +364,7 @@ mod test {
             Date::try_new_iso(-5500 + 9, 1, 1)
                 .unwrap()
                 .to_calendar(Ethiopian(EthiopianEraStyle::AmeteAlem))
+                .year()
                 .extended_year(),
             1
         );
@@ -371,6 +372,7 @@ mod test {
             Date::try_new_iso(9, 1, 1)
                 .unwrap()
                 .to_calendar(Ethiopian(EthiopianEraStyle::AmeteAlem))
+                .year()
                 .extended_year(),
             5501
         );
@@ -379,6 +381,7 @@ mod test {
             Date::try_new_iso(-5500 + 9, 1, 1)
                 .unwrap()
                 .to_calendar(Ethiopian(EthiopianEraStyle::AmeteMihret))
+                .year()
                 .extended_year(),
             -5499
         );
@@ -386,6 +389,7 @@ mod test {
             Date::try_new_iso(9, 1, 1)
                 .unwrap()
                 .to_calendar(Ethiopian(EthiopianEraStyle::AmeteMihret))
+                .year()
                 .extended_year(),
             1
         );

--- a/components/calendar/src/cal/roc.rs
+++ b/components/calendar/src/cal/roc.rs
@@ -146,7 +146,7 @@ mod test {
             "Failed era check from RD: {case:?}\nROC: {roc_from_rd:?}"
         );
         assert_eq!(
-            roc_from_rd.extended_year(),
+            roc_from_rd.year().extended_year(),
             if case.era == "roc" {
                 case.year
             } else {
@@ -166,7 +166,7 @@ mod test {
         );
 
         let roc_from_case = Date::try_new_roc(
-            roc_from_rd.extended_year(),
+            roc_from_rd.year().extended_year(),
             roc_from_rd.month().ordinal,
             roc_from_rd.day_of_month().0,
         )

--- a/components/calendar/src/date.rs
+++ b/components/calendar/src/date.rs
@@ -286,19 +286,9 @@ impl<A: AsCalendar> Date<A> {
         self.calendar.as_calendar().year_info(&self.inner).into()
     }
 
-    /// The "extended year" of this date.
-    ///
-    /// This year number can be used when you need a simple numeric representation
-    /// of the year, and can be meaningfully compared with extended years from other
-    /// eras or used in arithmetic.
-    ///
-    /// For calendars defined in Temporal, this will match the "arithmetic year"
-    /// as defined in <https://tc39.es/proposal-intl-era-monthcode/>.
-    /// This is typically anchored with year 1 as the year 1 of either the most modern or
-    /// otherwise some "major" era for the calendar.
-    ///
-    /// See [`Self::year()`] for more information about the year.
+    /// Use [`YearInfo::extended_year`](types::YearInfo::extended_year)
     #[inline]
+    #[deprecated(since = "2.2.0", note = "use `date.year().extended_year()`")]
     pub fn extended_year(&self) -> i32 {
         self.year().extended_year()
     }

--- a/components/calendar/src/types.rs
+++ b/components/calendar/src/types.rs
@@ -70,7 +70,7 @@ mod unstable {
         ///
         /// For an example, see [`Self::extended_year`].
         pub era_year: Option<i32>,
-        /// See [`Date::extended_year()`](crate::Date::extended_year).
+        /// See [`YearInfo::extended_year()`](crate::types::YearInfo::extended_year).
         ///
         /// If both this and [`Self::era`]/[`Self::era_year`] are set, they must
         /// refer to the same year.
@@ -259,8 +259,16 @@ impl YearInfo {
         }
     }
 
-    /// Get the extended year (See [`Date::extended_year`](crate::Date::extended_year))
-    /// for more information
+    /// The "extended year".
+    ///
+    /// This year number can be used when you need a simple numeric representation
+    /// of the year, and can be meaningfully compared with extended years from other
+    /// eras or used in arithmetic.
+    ///
+    /// For calendars defined in Temporal, this will match the "arithmetic year"
+    /// as defined in <https://tc39.es/proposal-intl-era-monthcode/>.
+    /// This is typically anchored with year 1 as the year 1 of either the most modern or
+    /// otherwise some "major" era for the calendar.
     pub fn extended_year(self) -> i32 {
         match self {
             YearInfo::Era(e) => e.extended_year,

--- a/components/calendar/tests/extended_year.rs
+++ b/components/calendar/tests/extended_year.rs
@@ -44,7 +44,7 @@ fn test_extended_year() {
             Date::try_new_from_codes(None, 0, m_01.code(), 1, calendar.clone()).unwrap();
         let iso_date_in_epoch_year = date_in_epoch_year.to_calendar(iso);
         assert_eq!(
-            iso_date_in_epoch_year.extended_year(),
+            iso_date_in_epoch_year.year().extended_year(),
             *extended_epoch,
             "Extended year for {date_in_epoch_year:?} should be {extended_epoch}"
         );
@@ -67,7 +67,7 @@ fn test_extended_year() {
             AnyCalendarKind::Japanese | AnyCalendarKind::JapaneseExtended
         ) {
             assert_eq!(
-                date_in_2025.extended_year(),
+                date_in_2025.year().extended_year(),
                 2025,
                 "Extended year for {date_in_2025:?} should be 2025"
             );
@@ -76,7 +76,7 @@ fn test_extended_year() {
             // These two function calls are not equivalent in general.
             let expected = date_in_2025.year().era_year_or_related_iso();
             assert_eq!(
-                date_in_2025.extended_year(),
+                date_in_2025.year().extended_year(),
                 expected,
                 "Extended year for {date_in_2025:?} should be {expected}"
             );

--- a/components/icu/examples/iso_date_manipulations.rs
+++ b/components/icu/examples/iso_date_manipulations.rs
@@ -32,7 +32,7 @@ fn main() {
         let date = Date::try_new_iso(year, month, day).expect("date should parse");
         println!(
             "Year: {}, Month: {}, Day: {}",
-            date.extended_year(),
+            date.year().extended_year(),
             date.month().ordinal,
             date.day_of_month().0,
         );

--- a/components/time/src/ixdtf.rs
+++ b/components/time/src/ixdtf.rs
@@ -469,7 +469,7 @@ impl<A: AsCalendar> ZonedDateTime<A, TimeZoneInfo<models::AtTime>> {
     /// )
     /// .unwrap();
     ///
-    /// assert_eq!(zoneddatetime.date.extended_year(), 5784);
+    /// assert_eq!(zoneddatetime.date.year().extended_year(), 5784);
     /// assert_eq!(
     ///     zoneddatetime.date.month().standard_code,
     ///     icu::calendar::types::MonthCode(tinystr::tinystr!(4, "M11"))

--- a/ffi/capi/bindings/cpp/icu4x/Date.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/Date.d.hpp
@@ -198,7 +198,7 @@ public:
    * of the year, and can be meaningfully compared with extended years from other
    * eras or used in arithmetic.
    *
-   * See the [Rust documentation for `extended_year`](https://docs.rs/icu/2.1.1/icu/calendar/struct.Date.html#method.extended_year) for more information.
+   * See the [Rust documentation for `extended_year`](https://docs.rs/icu/2.1.1/icu/calendar/types/enum.YearInfo.html#method.extended_year) for more information.
    */
   inline int32_t extended_year() const;
 

--- a/ffi/capi/bindings/cpp/icu4x/IsoDate.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/IsoDate.d.hpp
@@ -135,7 +135,7 @@ public:
    *
    * For calendars without an era, returns the extended year
    *
-   * See the [Rust documentation for `year`](https://docs.rs/icu/2.1.1/icu/calendar/struct.Date.html#method.year) for more information.
+   * See the [Rust documentation for `extended_year`](https://docs.rs/icu/2.1.1/icu/calendar/types/enum.YearInfo.html#method.extended_year) for more information.
    */
   inline int32_t year() const;
 

--- a/ffi/capi/src/date.rs
+++ b/ffi/capi/src/date.rs
@@ -148,11 +148,11 @@ pub mod ffi {
         /// Returns the year number in the current era for this date
         ///
         /// For calendars without an era, returns the extended year
-        #[diplomat::rust_link(icu::calendar::Date::year, FnInStruct)]
+        #[diplomat::rust_link(icu::calendar::types::YearInfo::extended_year, FnInEnum)]
         #[diplomat::attr(auto, getter)]
         #[diplomat::attr(demo_gen, disable)] // covered by Date
         pub fn year(&self) -> i32 {
-            self.0.extended_year()
+            self.0.year().extended_year()
         }
 
         /// Returns if the year is a leap year for this date
@@ -459,11 +459,11 @@ pub mod ffi {
         /// This year number can be used when you need a simple numeric representation
         /// of the year, and can be meaningfully compared with extended years from other
         /// eras or used in arithmetic.
-        #[diplomat::rust_link(icu::calendar::Date::extended_year, FnInStruct)]
-        #[diplomat::rust_link(icu::calendar::types::YearInfo::extended_year, FnInEnum, hidden)]
+        #[diplomat::rust_link(icu::calendar::types::YearInfo::extended_year, FnInEnum)]
+        #[diplomat::rust_link(icu::calendar::Date::extended_year, FnInStruct, hidden)]
         #[diplomat::attr(auto, getter)]
         pub fn extended_year(&self) -> i32 {
-            self.0.extended_year()
+            self.0.year().extended_year()
         }
 
         /// Returns the era for this date, or an empty string

--- a/ffi/dart/lib/src/bindings/Date.g.dart
+++ b/ffi/dart/lib/src/bindings/Date.g.dart
@@ -223,7 +223,7 @@ final class Date implements ffi.Finalizable {
   /// of the year, and can be meaningfully compared with extended years from other
   /// eras or used in arithmetic.
   ///
-  /// See the [Rust documentation for `extended_year`](https://docs.rs/icu/2.1.1/icu/calendar/struct.Date.html#method.extended_year) for more information.
+  /// See the [Rust documentation for `extended_year`](https://docs.rs/icu/2.1.1/icu/calendar/types/enum.YearInfo.html#method.extended_year) for more information.
   int get extendedYear {
     final result = _icu4x_Date_extended_year_mv1(_ffi);
     return result;

--- a/ffi/dart/lib/src/bindings/IsoDate.g.dart
+++ b/ffi/dart/lib/src/bindings/IsoDate.g.dart
@@ -141,7 +141,7 @@ final class IsoDate implements ffi.Finalizable {
   ///
   /// For calendars without an era, returns the extended year
   ///
-  /// See the [Rust documentation for `year`](https://docs.rs/icu/2.1.1/icu/calendar/struct.Date.html#method.year) for more information.
+  /// See the [Rust documentation for `extended_year`](https://docs.rs/icu/2.1.1/icu/calendar/types/enum.YearInfo.html#method.extended_year) for more information.
   int get year {
     final result = _icu4x_IsoDate_year_mv1(_ffi);
     return result;

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/Date.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/Date.kt
@@ -293,7 +293,7 @@ class Date internal constructor (
     *of the year, and can be meaningfully compared with extended years from other
     *eras or used in arithmetic.
     *
-    *See the [Rust documentation for `extended_year`](https://docs.rs/icu/2.1.1/icu/calendar/struct.Date.html#method.extended_year) for more information.
+    *See the [Rust documentation for `extended_year`](https://docs.rs/icu/2.1.1/icu/calendar/types/enum.YearInfo.html#method.extended_year) for more information.
     */
     fun extendedYear(): Int {
         

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/IsoDate.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/IsoDate.kt
@@ -209,7 +209,7 @@ class IsoDate internal constructor (
     *
     *For calendars without an era, returns the extended year
     *
-    *See the [Rust documentation for `year`](https://docs.rs/icu/2.1.1/icu/calendar/struct.Date.html#method.year) for more information.
+    *See the [Rust documentation for `extended_year`](https://docs.rs/icu/2.1.1/icu/calendar/types/enum.YearInfo.html#method.extended_year) for more information.
     */
     fun year(): Int {
         

--- a/ffi/npm/lib/Date.d.ts
+++ b/ffi/npm/lib/Date.d.ts
@@ -178,7 +178,7 @@ export class Date {
      * of the year, and can be meaningfully compared with extended years from other
      * eras or used in arithmetic.
      *
-     * See the [Rust documentation for `extended_year`](https://docs.rs/icu/2.1.1/icu/calendar/struct.Date.html#method.extended_year) for more information.
+     * See the [Rust documentation for `extended_year`](https://docs.rs/icu/2.1.1/icu/calendar/types/enum.YearInfo.html#method.extended_year) for more information.
      */
     get extendedYear(): number;
 

--- a/ffi/npm/lib/Date.mjs
+++ b/ffi/npm/lib/Date.mjs
@@ -423,7 +423,7 @@ export class Date {
      * of the year, and can be meaningfully compared with extended years from other
      * eras or used in arithmetic.
      *
-     * See the [Rust documentation for `extended_year`](https://docs.rs/icu/2.1.1/icu/calendar/struct.Date.html#method.extended_year) for more information.
+     * See the [Rust documentation for `extended_year`](https://docs.rs/icu/2.1.1/icu/calendar/types/enum.YearInfo.html#method.extended_year) for more information.
      */
     get extendedYear() {
 

--- a/ffi/npm/lib/IsoDate.d.ts
+++ b/ffi/npm/lib/IsoDate.d.ts
@@ -106,7 +106,7 @@ export class IsoDate {
      *
      * For calendars without an era, returns the extended year
      *
-     * See the [Rust documentation for `year`](https://docs.rs/icu/2.1.1/icu/calendar/struct.Date.html#method.year) for more information.
+     * See the [Rust documentation for `extended_year`](https://docs.rs/icu/2.1.1/icu/calendar/types/enum.YearInfo.html#method.extended_year) for more information.
      */
     get year(): number;
 

--- a/ffi/npm/lib/IsoDate.mjs
+++ b/ffi/npm/lib/IsoDate.mjs
@@ -282,7 +282,7 @@ export class IsoDate {
      *
      * For calendars without an era, returns the extended year
      *
-     * See the [Rust documentation for `year`](https://docs.rs/icu/2.1.1/icu/calendar/struct.Date.html#method.year) for more information.
+     * See the [Rust documentation for `extended_year`](https://docs.rs/icu/2.1.1/icu/calendar/types/enum.YearInfo.html#method.extended_year) for more information.
      */
     get year() {
 


### PR DESCRIPTION
We should make people get the extended year through `YearInfo`, so that they are aware of the other year values that are not the extended year. This is also currently the only method from `YearInfo` that's also exposed on `Date`.


## Changelog

icu_calendar: Deprecate `Date::extended_year()` (use `Date::year().extended_year()`)

