### PR TITLE
Add example for measuring Date::try_from_fields code size

### DIFF
--- a/components/icu/examples/date_try_from_fields.rs
+++ b/components/icu/examples/date_try_from_fields.rs
@@ -6,8 +6,8 @@
 icu_benchmark_macros::instrument!();
 use icu_benchmark_macros::println;
 
-use icu_calendar::types::DateFields;
-use icu_calendar::{AnyCalendar, AnyCalendarKind, Date};
+use icu::calendar::types::DateFields;
+use icu::calendar::{AnyCalendar, AnyCalendarKind, Date};
 
 const CALENDAR_KINDS: &[AnyCalendarKind] = &[
     AnyCalendarKind::Buddhist,


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->

This PR adds a standalone example using release-opt-size and the benchmark macros so we can measure code size separately from the main library changes.

Only the example and its dependencies are included here.


