### PR TITLE
Avoid claiming that HijriSimulated corresponds to islamic-rgsa

### DIFF
--- a/components/calendar/src/any_calendar.rs
+++ b/components/calendar/src/any_calendar.rs
@@ -774,8 +774,6 @@ pub enum AnyCalendarKind {
     /// This corresponds to the `"hebrew"` [CLDR calendar](https://unicode.org/reports/tr35/#UnicodeCalendarIdentifier).
     Hebrew,
     /// The kind of an [`HijriSimulated`], Mecca calendar
-    ///
-    /// This corresponds to the `"islamic-rgsa"` [CLDR calendar](https://unicode.org/reports/tr35/#UnicodeCalendarIdentifier).
     HijriSimulatedMecca,
     /// The kind of an [`HijriTabular`] calendar using [`HijriTabularLeapYears::TypeII`] and [`HijriTabularEpoch::Friday`]
     ///


### PR DESCRIPTION
Publicly-available information about how the islamic-rgsa identifier was minted for JDK purposes, how JDK acknowledges past-sighting-data-only calendar possibility, the context of minting the identifier together with islamic-umalqura (an SA simulation), and the CLDR display name for islamic-rgsa all indicate that islamic-rgsa is supposed to denote sighting
data (that can be past only), so we shouldn't be saying that a simulation corresponds to it.