### PR TITLE
Use better types in `LocalePreferences`

### DIFF
--- a/components/locale_core/src/data.rs
+++ b/components/locale_core/src/data.rs
@@ -3,9 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::extensions::unicode as unicode_ext;
-use crate::preferences::{
-    extensions::unicode::keywords::RegionalSubdivision, LocalePreferences, PreferenceKey,
-};
+use crate::preferences::{extensions::unicode::keywords::RegionalSubdivision, LocalePreferences};
 use crate::subtags::{Language, Region, Script, Subtag, Variant};
 #[cfg(feature = "alloc")]
 use crate::ParseError;
@@ -173,14 +171,13 @@ impl DataLocale {
 
         let unicode_extensions_count = locale.extensions.unicode.keywords.iter().count();
 
-        #[allow(clippy::unwrap_used)] // RegionalSubdivision has a unicode_extension_key
         if unicode_extensions_count != 0
             && (unicode_extensions_count != 1
                 || !locale
                     .extensions
                     .unicode
                     .keywords
-                    .contains_key(&RegionalSubdivision::unicode_extension_key().unwrap()))
+                    .contains_key(&RegionalSubdivision::UNICODE_EXTENSION_KEY))
         {
             return Err(ParseError::InvalidExtension);
         }
@@ -358,11 +355,10 @@ impl DataLocale {
     }
 
     fn extensions(&self) -> Option<crate::extensions::Extensions> {
-        #[allow(clippy::unwrap_used)] // RegionalSubdivision has a unicode_extension_key
         Some(crate::extensions::Extensions {
             unicode: unicode_ext::Unicode {
                 keywords: unicode_ext::Keywords::new_single(
-                    RegionalSubdivision::unicode_extension_key().unwrap(),
+                    RegionalSubdivision::UNICODE_EXTENSION_KEY,
                     RegionalSubdivision(
                         unicode_ext::SubdivisionId::try_from_str(self.subdivision?.as_str())
                             .ok()?,

--- a/components/locale_core/src/preferences/extensions/unicode/macros/enum_keyword.rs
+++ b/components/locale_core/src/preferences/extensions/unicode/macros/enum_keyword.rs
@@ -104,14 +104,14 @@ macro_rules! __enum_keyword {
 
         impl $crate::preferences::PreferenceKey for $name {
             fn unicode_extension_key() -> Option<$crate::extensions::unicode::Key> {
-                Some($crate::extensions::unicode::key!($ext_key))
+                Some(Self::UNICODE_EXTENSION_KEY)
             }
 
             fn try_from_key_value(
                 key: &$crate::extensions::unicode::Key,
                 value: &$crate::extensions::unicode::Value,
             ) -> Result<Option<Self>, $crate::preferences::extensions::unicode::errors::PreferencesParseError> {
-                if Self::unicode_extension_key() == Some(*key) {
+                if Self::UNICODE_EXTENSION_KEY == *key {
                     Self::try_from(value).map(Some)
                 } else {
                     Ok(None)
@@ -121,6 +121,10 @@ macro_rules! __enum_keyword {
             fn unicode_extension_value(&self) -> Option<$crate::extensions::unicode::Value> {
                 Some((*self).into())
             }
+        }
+
+        impl $name {
+            pub(crate) const UNICODE_EXTENSION_KEY: $crate::extensions::unicode::Key = $crate::extensions::unicode::key!($ext_key);
         }
 
         impl TryFrom<&$crate::extensions::unicode::Value> for $name {

--- a/components/locale_core/src/preferences/extensions/unicode/macros/struct_keyword.rs
+++ b/components/locale_core/src/preferences/extensions/unicode/macros/struct_keyword.rs
@@ -53,14 +53,14 @@ macro_rules! __struct_keyword {
 
         impl $crate::preferences::PreferenceKey for $name {
             fn unicode_extension_key() -> Option<$crate::extensions::unicode::Key> {
-                Some($crate::extensions::unicode::key!($ext_key))
+                Some(Self::UNICODE_EXTENSION_KEY)
             }
 
             fn try_from_key_value(
                 key: &$crate::extensions::unicode::Key,
                 value: &$crate::extensions::unicode::Value,
             ) -> Result<Option<Self>, $crate::preferences::extensions::unicode::errors::PreferencesParseError> {
-                if Self::unicode_extension_key() == Some(*key) {
+                if Self::UNICODE_EXTENSION_KEY == *key {
                     let result = Self::try_from(value.clone())?;
                     Ok(Some(result))
                 } else {
@@ -73,6 +73,10 @@ macro_rules! __struct_keyword {
             ) -> Option<$crate::extensions::unicode::Value> {
                 Some(self.clone().into())
             }
+        }
+
+        impl $name {
+            pub(crate) const UNICODE_EXTENSION_KEY: $crate::extensions::unicode::Key = $crate::extensions::unicode::key!($ext_key);
         }
 
         impl core::ops::Deref for $name {

--- a/components/locale_core/src/preferences/locale.rs
+++ b/components/locale_core/src/preferences/locale.rs
@@ -3,7 +3,6 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::preferences::extensions::unicode::keywords::{RegionOverride, RegionalSubdivision};
-use crate::preferences::PreferenceKey;
 #[cfg(feature = "alloc")]
 use crate::subtags::Variants;
 use crate::subtags::{Language, Region, Script, Variant};
@@ -67,19 +66,17 @@ impl From<&crate::Locale> for LocalePreferences {
             script: loc.id.script,
             region: loc.id.region,
             variant: loc.id.variants.iter().copied().next(),
-            #[allow(clippy::unwrap_used)] // RegionalSubdivision has a unicode_extension_key
             subdivision: loc
                 .extensions
                 .unicode
                 .keywords
-                .get(&RegionalSubdivision::unicode_extension_key().unwrap())
+                .get(&RegionalSubdivision::UNICODE_EXTENSION_KEY)
                 .and_then(|v| RegionalSubdivision::try_from(v.clone()).ok()),
-            #[allow(clippy::unwrap_used)] // RegionOverride has a unicode_extension_key
             region_override: loc
                 .extensions
                 .unicode
                 .keywords
-                .get(&RegionOverride::unicode_extension_key().unwrap())
+                .get(&RegionOverride::UNICODE_EXTENSION_KEY)
                 .and_then(|v| RegionOverride::try_from(v.clone()).ok()),
         }
     }
@@ -114,19 +111,17 @@ impl From<LocalePreferences> for crate::Locale {
             },
             extensions: {
                 let mut extensions = crate::extensions::Extensions::default();
-                #[allow(clippy::unwrap_used)] // RegionalSubdivision has a unicode_extension_key
                 if let Some(sd) = prefs.subdivision {
-                    extensions.unicode.keywords.set(
-                        RegionalSubdivision::unicode_extension_key().unwrap(),
-                        sd.into(),
-                    );
+                    extensions
+                        .unicode
+                        .keywords
+                        .set(RegionalSubdivision::UNICODE_EXTENSION_KEY, sd.into());
                 }
-                #[allow(clippy::unwrap_used)] // RegionOverride has a unicode_extension_key
                 if let Some(rg) = prefs.region_override {
                     extensions
                         .unicode
                         .keywords
-                        .set(RegionOverride::unicode_extension_key().unwrap(), rg.into());
+                        .set(RegionOverride::UNICODE_EXTENSION_KEY, rg.into());
                 }
                 extensions
             },


### PR DESCRIPTION
Split off from #7341

The existing types `RegionalSubdivision` and `RegionOverride` already have functionality to convert from/to `Value`s, so we don't need to duplicate that.