### PR TITLE
Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Reporting a Vulnerability
 
-If you have discovered a security vulnerability in this project, please report it privately. **Do not disclose it as a public issue.**
+If you have discovered a security vulnerability in ICU4X crates or any utility crates maintained in this repository, please report it privately. **Do not disclose it as a public issue.**
 This gives us time to work with you to fix the issue before public exposure, reducing the chance that the exploit will be used before a patch is released.
 
 Please submit the bug report using the [security vulnerability report form](https://github.com/unicode-org/icu4x/security/advisories/new) on GitHub.
@@ -11,8 +11,9 @@ Please provide the following information in your report:
 
  * A description of the vulnerability and its impact
  * How to reproduce the issue
+ * The versions you know are impacted (this list need not be exhaustive)
 
-This project is maintained by volunteers on a reasonable-effort basis. As such, we ask that you give us 90 days to work on a fix before public exposure.
+We ask that you give us 90 days to work on a fix before public exposure.
 
 
 ## Supported Versions


### PR DESCRIPTION
Fixes https://github.com/unicode-org/icu4x/issues/5193


This is modeled after https://github.com/unicode-org/icu, except we can use GitHub for reporting instead of. "Maintainers" on GitHub can see these issues. We could also choose to include icu4x-core as an alternate reporting route.

I arbitrarily picked a sensible policy for past versions, we can iterate on this.

Note that the "security vulnerability report form" looks different for people who are maintainers vs people who are not, so ignore the fact that that link says "Open a draft security advisory", non-maintainers should see something like https://github.com/mozilla/fxa/security/advisories/new.