### PR TITLE
fix(docs): clarify normalize_utf8 example uses &[u8]

### DIFF
--- a/components/locale_core/src/locale.rs
+++ b/components/locale_core/src/locale.rs
@@ -171,8 +171,9 @@ impl Locale {
     /// ```
     /// use icu::locale::Locale;
     ///
+    /// let bytes = b"pL-latn-pl-U-HC-H12";
     /// assert_eq!(
-    ///     Locale::normalize_utf8(b"pL-latn-pl-U-HC-H12").as_deref(),
+    ///     Locale::normalize_utf8(bytes).as_deref(),
     ///     Ok("pl-Latn-PL-u-hc-h12")
     /// );
     /// ```


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->


The issue is that the example for `normalize_utf8` uses the same pattern as `normalize`, which doesn't clearly show that `normalize_utf8` accepts `&[u8]` (byte slices) rather than `&str`.

I've fixed this by updating the example to extract the byte string literal into a variable:
ust
let bytes = b"pL-latn-pl-U-HC-H12";
assert_eq!(
    Locale::normalize_utf8(bytes).as_deref(),
    Ok("pl-Latn-PL-u-hc-h12")
);