### PR TITLE
Respect `-u-rg` in calendar resolution

### DIFF
--- a/components/calendar/src/any_calendar.rs
+++ b/components/calendar/src/any_calendar.rs
@@ -711,6 +711,18 @@ pub enum AnyCalendarKind {
 
 impl CalendarPreferences {
     /// Selects the [`CalendarAlgorithm`] appropriate for the given [`CalendarPreferences`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use icu::calendar::preferences::{CalendarAlgorithm, CalendarPreferences};
+    /// use icu::locale::locale;
+    ///
+    /// assert_eq!(CalendarPreferences::from(&locale!("und")).resolved_algorithm(), CalendarAlgorithm::Gregory);
+    /// assert_eq!(CalendarPreferences::from(&locale!("und-US-u-ca-hebrew")).resolved_algorithm(), CalendarAlgorithm::Hebrew);
+    /// assert_eq!(CalendarPreferences::from(&locale!("und-AF")).resolved_algorithm(), CalendarAlgorithm::Persian);
+    /// assert_eq!(CalendarPreferences::from(&locale!("und-US-u-rg-thxxxx")).resolved_algorithm(), CalendarAlgorithm::Buddhist);
+    /// ```
     pub fn resolved_algorithm(self) -> CalendarAlgorithm {
         let region = self.locale_preferences.region();
         let region = region.as_ref().map(|r| r.as_str());

--- a/components/locale_core/src/preferences/locale.rs
+++ b/components/locale_core/src/preferences/locale.rs
@@ -163,8 +163,15 @@ impl LocalePreferences {
     }
 
     /// Preference of Region
+    ///
+    /// This respects the [`RegionOverride`], and should only be used
+    /// for [data that is region-specific](https://github.com/unicode-org/cldr/blob/main/common/supplemental/rgScope.xml).
     pub const fn region(&self) -> Option<Region> {
-        self.region
+        if let Some(rg) = self.region_override {
+            Some(rg.0.region)
+        } else {
+            self.region
+        }
     }
 
     /// Extends the preferences with the values from another set of preferences.


### PR DESCRIPTION
#4413 

Should respect `-u-rg` per https://github.com/unicode-org/cldr/blob/main/common/supplemental/rgScope.xml