### PR TITLE
Rename subdivision types

### DIFF
--- a/components/locale_core/src/data.rs
+++ b/components/locale_core/src/data.rs
@@ -220,12 +220,12 @@ impl DataLocale {
         Ok(())
     }
 
-    fn region_and_subdivision(&self) -> Option<unicode_ext::SubdivisionId> {
+    fn region_and_subdivision(&self) -> Option<unicode_ext::RegionAndSubdivision> {
         self.subdivision
-            .and_then(|s| unicode_ext::SubdivisionId::try_from_str(s.as_str()).ok())
-            .or(self.region.map(|region| unicode_ext::SubdivisionId {
+            .and_then(|s| unicode_ext::RegionAndSubdivision::try_from_str(s.as_str()).ok())
+            .or(self.region.map(|region| unicode_ext::RegionAndSubdivision {
                 region,
-                suffix: unicode_ext::SubdivisionSuffix::UNKNOWN,
+                suffix: unicode_ext::Subdivision::UNKNOWN,
             }))
     }
 
@@ -234,7 +234,7 @@ impl DataLocale {
     ) -> (
         Language,
         Option<Script>,
-        Option<unicode_ext::SubdivisionId>,
+        Option<unicode_ext::RegionAndSubdivision>,
         Option<Variant>,
     ) {
         (
@@ -248,7 +248,7 @@ impl DataLocale {
     pub(crate) fn from_parts(
         language: Language,
         script: Option<Script>,
-        region: Option<unicode_ext::SubdivisionId>,
+        region: Option<unicode_ext::RegionAndSubdivision>,
         variant: Option<Variant>,
     ) -> Self {
         Self {

--- a/components/locale_core/src/extensions/unicode/mod.rs
+++ b/components/locale_core/src/extensions/unicode/mod.rs
@@ -44,7 +44,12 @@ pub use attributes::Attributes;
 pub use key::{key, Key};
 pub use keywords::Keywords;
 #[doc(inline)]
-pub use subdivision::{subdivision_suffix, SubdivisionId, SubdivisionSuffix};
+pub use subdivision::{subdivision, RegionAndSubdivision, Subdivision};
+#[deprecated]
+pub use subdivision::{
+    subdivision as subdivision_suffix, RegionAndSubdivision as SubdivisionId,
+    Subdivision as SubdivisionSuffix,
+};
 #[doc(inline)]
 pub use value::{value, Value};
 

--- a/components/locale_core/src/extensions/unicode/subdivision.rs
+++ b/components/locale_core/src/extensions/unicode/subdivision.rs
@@ -8,34 +8,34 @@ use crate::parser::ParseError;
 use crate::subtags::{Region, Subtag};
 
 impl_tinystr_subtag!(
-    /// A subdivision suffix used in [`SubdivisionId`].
+    /// A subdivision used in [`RegionAndSubdivision`].
     ///
-    /// This suffix represents a specific subdivision code under a given [`Region`].
-    /// For example the value of [`SubdivisionId`] may be `gbsct`, where the [`SubdivisionSuffix`]
+    /// This subtag represents a specific subdivision code under a given [`Region`].
+    /// For example the value of [`RegionAndSubdivision`] may be `gbsct`, where the [`Subdivision`]
     /// is `sct` for Scotland.
     ///
     /// Such a value associated with a key `rg` means that the locale should use Unit Preferences
     /// (default calendar, currency, week data, time cycle, measurement system) for Scotland, even if the
     /// [`LanguageIdentifier`](crate::LanguageIdentifier) is `en-US`.
     ///
-    /// A subdivision suffix has to be a sequence of alphanumerical characters no
+    /// A subdivision has to be a sequence of alphanumerical characters no
     /// shorter than one and no longer than four characters.
     ///
     ///
     /// # Examples
     ///
     /// ```
-    /// use icu::locale::extensions::unicode::{subdivision_suffix, SubdivisionSuffix};
+    /// use icu::locale::extensions::unicode::{subdivision, Subdivision};
     ///
-    /// let ss: SubdivisionSuffix =
-    ///     "sct".parse().expect("Failed to parse a SubdivisionSuffix.");
+    /// let ss: Subdivision =
+    ///     "sct".parse().expect("Failed to parse a Subdivision.");
     ///
-    /// assert_eq!(ss, subdivision_suffix!("sct"));
+    /// assert_eq!(ss, subdivision!("sct"));
     /// ```
-    SubdivisionSuffix,
+    Subdivision,
     extensions::unicode,
-    subdivision_suffix,
-    extensions_unicode_subdivision_suffix,
+    subdivision,
+    extensions_unicode_subdivision,
     1..=4,
     s,
     s.is_ascii_alphanumeric(),
@@ -46,21 +46,21 @@ impl_tinystr_subtag!(
     ["toolooong"],
 );
 
-impl SubdivisionSuffix {
-    pub(crate) const UNKNOWN: Self = subdivision_suffix!("zzzz");
+impl Subdivision {
+    pub(crate) const UNKNOWN: Self = subdivision!("zzzz");
 
     pub(crate) fn is_unknown(self) -> bool {
         self == Self::UNKNOWN
     }
 }
 
-/// A Subivision Id as defined in [`Unicode Locale Identifier`].
+/// A [`RegionAndSubdivision`] represents a `unicode_subdivision_id` as defined in [`Unicode Locale Identifier`].
 ///
-/// Subdivision Id is used in [`Unicode`] extensions:
+/// It is used in [`Unicode`] extensions:
 ///  * `rg` - Regional Override
 ///  * `sd` - Regional Subdivision
 ///
-/// In both cases the subdivision is composed of a [`Region`] and a [`SubdivisionSuffix`] which represents
+/// In both cases it is composed of a [`Region`] and a [`Subdivision`] which represents
 /// different meaning depending on the key.
 ///
 /// [`Unicode Locale Identifier`]: https://unicode.org/reports/tr35/tr35.html#unicode_subdivision_id
@@ -70,50 +70,50 @@ impl SubdivisionSuffix {
 ///
 /// ```
 /// use icu::locale::{
-///     extensions::unicode::{subdivision_suffix, SubdivisionId},
+///     extensions::unicode::{subdivision, RegionAndSubdivision},
 ///     subtags::region,
 /// };
 ///
-/// let ss = subdivision_suffix!("zzzz");
+/// let ss = subdivision!("zzzz");
 /// let region = region!("gb");
 ///
-/// let si = SubdivisionId::new(region, ss);
+/// let si = RegionAndSubdivision::new(region, ss);
 ///
 /// assert_eq!(si.to_string(), "gbzzzz");
 /// ```
 #[derive(Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord, Copy)]
 #[non_exhaustive]
-pub struct SubdivisionId {
-    /// A region field of a Subdivision Id.
+pub struct RegionAndSubdivision {
+    /// A region field of a `unicode_subdivision_id`.
     pub region: Region,
-    /// A subdivision suffix field of a Subdivision Id.
-    pub suffix: SubdivisionSuffix,
+    /// A subdivision suffix field of a `unicode_subdivision_id`.
+    pub suffix: Subdivision,
 }
 
-impl SubdivisionId {
-    /// Returns a new [`SubdivisionId`].
+impl RegionAndSubdivision {
+    /// Returns a new [`RegionAndSubdivision`].
     ///
     /// # Examples
     ///
     /// ```
     /// use icu::locale::{
-    ///     extensions::unicode::{subdivision_suffix, SubdivisionId},
+    ///     extensions::unicode::{subdivision, RegionAndSubdivision},
     ///     subtags::region,
     /// };
     ///
-    /// let ss = subdivision_suffix!("zzzz");
+    /// let ss = subdivision!("zzzz");
     /// let region = region!("gb");
     ///
-    /// let si = SubdivisionId::new(region, ss);
+    /// let si = RegionAndSubdivision::new(region, ss);
     ///
     /// assert_eq!(si.to_string(), "gbzzzz");
     /// ```
-    pub const fn new(region: Region, suffix: SubdivisionSuffix) -> Self {
+    pub const fn new(region: Region, suffix: Subdivision) -> Self {
         Self { region, suffix }
     }
 
     /// A constructor which takes a str slice, parses it and
-    /// produces a well-formed [`SubdivisionId`].
+    /// produces a well-formed [`RegionAndSubdivision`].
     #[inline]
     pub fn try_from_str(s: &str) -> Result<Self, ParseError> {
         Self::try_from_utf8(s.as_bytes())
@@ -135,7 +135,7 @@ impl SubdivisionId {
             .ok_or(ParseError::InvalidExtension)?;
         let region =
             Region::try_from_utf8(region_code_units).map_err(|_| ParseError::InvalidExtension)?;
-        let suffix = SubdivisionSuffix::try_from_utf8(suffix_code_units)?;
+        let suffix = Subdivision::try_from_utf8(suffix_code_units)?;
         Ok(Self { region, suffix })
     }
 
@@ -150,7 +150,7 @@ impl SubdivisionId {
     }
 }
 
-impl writeable::Writeable for SubdivisionId {
+impl writeable::Writeable for RegionAndSubdivision {
     #[inline]
     fn write_to<W: core::fmt::Write + ?Sized>(&self, sink: &mut W) -> core::fmt::Result {
         sink.write_str(self.region.to_tinystr().to_ascii_lowercase().as_str())?;
@@ -163,9 +163,9 @@ impl writeable::Writeable for SubdivisionId {
     }
 }
 
-writeable::impl_display_with_writeable!(SubdivisionId, #[cfg(feature = "alloc")]);
+writeable::impl_display_with_writeable!(RegionAndSubdivision, #[cfg(feature = "alloc")]);
 
-impl FromStr for SubdivisionId {
+impl FromStr for RegionAndSubdivision {
     type Err = ParseError;
 
     #[inline]
@@ -179,14 +179,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_subdivisionid_fromstr() {
-        let si: SubdivisionId = "gbzzzz".parse().expect("Failed to parse SubdivisionId");
+    fn test_RegionAndSubdivision_fromstr() {
+        let si: RegionAndSubdivision = "gbzzzz"
+            .parse()
+            .expect("Failed to parse RegionAndSubdivision");
         assert_eq!(si.region.to_string(), "GB");
         assert_eq!(si.suffix.to_string(), "zzzz");
         assert_eq!(si.to_string(), "gbzzzz");
 
         for sample in ["", "gb", "o"] {
-            let oe: Result<SubdivisionId, _> = sample.parse();
+            let oe: Result<RegionAndSubdivision, _> = sample.parse();
             assert!(oe.is_err(), "Should fail: {sample}");
         }
     }

--- a/components/locale_core/src/preferences/extensions/unicode/keywords/region_override.rs
+++ b/components/locale_core/src/preferences/extensions/unicode/keywords/region_override.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use crate::extensions::unicode::{SubdivisionId, Value};
+use crate::extensions::unicode::{RegionAndSubdivision, Value};
 use crate::preferences::extensions::unicode::errors::PreferencesParseError;
 use crate::preferences::extensions::unicode::struct_keyword;
 
@@ -13,7 +13,7 @@ struct_keyword!(
     [Copy]
     RegionOverride,
     "rg",
-    SubdivisionId,
+    RegionAndSubdivision,
     |input: &Value| {
         input
             .as_single_subtag()

--- a/components/locale_core/src/preferences/extensions/unicode/keywords/regional_subdivision.rs
+++ b/components/locale_core/src/preferences/extensions/unicode/keywords/regional_subdivision.rs
@@ -5,7 +5,7 @@
 use crate::preferences::extensions::unicode::errors::PreferencesParseError;
 use crate::preferences::extensions::unicode::struct_keyword;
 use crate::{
-    extensions::unicode::{SubdivisionId, Value},
+    extensions::unicode::{RegionAndSubdivision, Value},
     subtags::Subtag,
 };
 
@@ -16,7 +16,7 @@ struct_keyword!(
     [Copy]
     RegionalSubdivision,
     "sd",
-    SubdivisionId,
+    RegionAndSubdivision,
     |input: &Value| {
         input
             .as_single_subtag()

--- a/components/locale_core/src/preferences/locale.rs
+++ b/components/locale_core/src/preferences/locale.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use crate::extensions::unicode::{SubdivisionId, SubdivisionSuffix};
+use crate::extensions::unicode::{RegionAndSubdivision, Subdivision};
 use crate::preferences::extensions::unicode::keywords::{RegionOverride, RegionalSubdivision};
 #[cfg(feature = "alloc")]
 use crate::subtags::Variants;
@@ -70,9 +70,9 @@ impl From<&crate::LanguageIdentifier> for LocalePreferences {
             language: lid.language,
             script: lid.script,
             region: lid.region.map(|region| {
-                RegionalSubdivision(SubdivisionId {
+                RegionalSubdivision(RegionAndSubdivision {
                     region,
-                    suffix: SubdivisionSuffix::UNKNOWN,
+                    suffix: Subdivision::UNKNOWN,
                 })
             }),
             variant: lid.variants.iter().copied().next(),
@@ -152,13 +152,13 @@ impl LocalePreferences {
         let region = if let Some(sd) = subdivision {
             if let Some(region) = loc.id.region {
                 // Discard the subdivison if it doesn't match the region
-                Some(RegionalSubdivision(SubdivisionId {
+                Some(RegionalSubdivision(RegionAndSubdivision {
                     region,
                     suffix: if sd.region == region {
                         sd.suffix
                     } else {
                         is_err = true;
-                        SubdivisionSuffix::UNKNOWN
+                        Subdivision::UNKNOWN
                     },
                 }))
             } else {
@@ -167,9 +167,9 @@ impl LocalePreferences {
             }
         } else {
             loc.id.region.map(|region| {
-                RegionalSubdivision(SubdivisionId {
+                RegionalSubdivision(RegionAndSubdivision {
                     region,
-                    suffix: SubdivisionSuffix::UNKNOWN,
+                    suffix: Subdivision::UNKNOWN,
                 })
             })
         };


### PR DESCRIPTION
The LDML `unicode_subdivision_id` expression contains both a region and a subdivision, yet it's just called `SubdivisionId` here. We use it as a region+subdivision type in multiple places, so a more accurate name would be `RegionAndSubdivision`. The current `SubdivisionSuffix`, which is the actual subdivision, can then be `Subdivision`.