### PR TITLE
Add buffer ctors for properties APIs

### DIFF
--- a/components/properties/src/code_point_map.rs
+++ b/components/properties/src/code_point_map.rs
@@ -40,6 +40,18 @@ impl<T: TrieValue> CodePointMapData<T> {
         CodePointMapDataBorrowed::new()
     }
 
+    #[cfg(feature = "serde")]
+    #[doc = icu_provider::gen_buffer_unstable_docs!(BUFFER, Self::new)]
+    pub fn try_new_with_buffer_provider(
+        provider: &(impl icu_provider::buf::BufferProvider + ?Sized),
+    ) -> Result<Self, DataError>
+    where
+        T: EnumeratedProperty + for<'a> serde::Deserialize<'a>,
+    {
+        use icu_provider::buf::AsDeserializingBufferProvider;
+        Self::try_new_unstable(&provider.as_deserializing())
+    }
+
     #[doc = icu_provider::gen_buffer_unstable_docs!(UNSTABLE, Self::new)]
     pub fn try_new_unstable(
         provider: &(impl DataProvider<T::DataMarker> + ?Sized),

--- a/components/properties/src/code_point_set.rs
+++ b/components/properties/src/code_point_set.rs
@@ -40,6 +40,15 @@ impl CodePointSetData {
         CodePointSetDataBorrowed::new::<P>()
     }
 
+    #[cfg(feature = "serde")]
+    #[doc = icu_provider::gen_buffer_unstable_docs!(BUFFER, Self::new)]
+    pub fn try_new_with_buffer_provider<P: BinaryProperty>(
+        provider: &(impl icu_provider::buf::BufferProvider + ?Sized),
+    ) -> Result<CodePointSetData, DataError> {
+        use icu_provider::buf::AsDeserializingBufferProvider;
+        Self::try_new_unstable::<P>(&provider.as_deserializing())
+    }
+
     #[doc = icu_provider::gen_buffer_unstable_docs!(UNSTABLE, Self::new)]
     pub fn try_new_unstable<P: BinaryProperty>(
         provider: &(impl DataProvider<P::DataMarker> + ?Sized),

--- a/components/properties/src/emoji.rs
+++ b/components/properties/src/emoji.rs
@@ -27,6 +27,15 @@ impl EmojiSetData {
         EmojiSetDataBorrowed::new::<P>()
     }
 
+    #[cfg(feature = "serde")]
+    #[doc = icu_provider::gen_buffer_unstable_docs!(BUFFER, Self::new)]
+    pub fn try_new_with_buffer_provider<P: EmojiSet>(
+        provider: &(impl icu_provider::buf::BufferProvider + ?Sized),
+    ) -> Result<EmojiSetData, DataError> {
+        use icu_provider::buf::AsDeserializingBufferProvider;
+        Self::try_new_unstable::<P>(&provider.as_deserializing())
+    }
+
     /// A version of `new()` that uses custom data provided by a [`DataProvider`].
     ///
     /// Note that this will return an owned version of the data. Functionality is available on


### PR DESCRIPTION
Fixes the issue found in https://github.com/unicode-org/icu4x/discussions/7374

This was an oversight when we did new properties.

## Changelog

icu_properties: Add buffer provider constructors for all property APIs
 - New methods: `CodePointMapData::try_new_with_buffer_provider()`, `CodePointSetData::try_new_with_buffer_provider()`, `EmojiSetData::try_new_with_buffer_provider()`

