### PR TITLE
Improve safety comment and test for PLURAL_PATTERN_0

### DIFF
--- a/components/experimental/src/compactdecimal/provider.rs
+++ b/components/experimental/src/compactdecimal/provider.rs
@@ -14,7 +14,6 @@
 use icu_pattern::SinglePlaceholderPattern;
 use icu_plurals::provider::PluralElementsPackedULE;
 use icu_provider::prelude::*;
-use zerovec::ule::encode_varule_to_box;
 use zerovec::ule::vartuple::VarTupleULE;
 use zerovec::VarZeroVec;
 
@@ -92,6 +91,7 @@ impl CompactDecimalPatternData<'_> {
 #[test]
 fn validate_plural_pattern_0_map() {
     use icu_plurals::{provider::FourBitMetadata, PluralElements};
+    use zerovec::ule::encode_varule_to_box;
 
     assert_eq!(
         CompactDecimalPatternData::PLURAL_PATTERN_0,


### PR DESCRIPTION
Follow-up to https://github.com/unicode-org/icu4x/pull/7388#discussion_r2677221388

It might not be safe to call `.decode()`. We should test equality in VarULE space.

Also, added a `// Safety` comment. Clippy should have caught that.