### PR TITLE
Add FixedLengthVarULE and user in icu_plurals

### DIFF
--- a/components/pattern/src/lib.rs
+++ b/components/pattern/src/lib.rs
@@ -134,6 +134,12 @@ impl SinglePlaceholderPattern {
     /// ```
     pub const PASS_THROUGH: &'static SinglePlaceholderPattern =
         SinglePlaceholderPattern::from_ref_store_unchecked("\x01");
+
+    #[doc(hidden)] // for macro to_sized_varule_bytes
+    pub const fn as_bytes(&self) -> &[u8] {
+        // TODO: Add safety note
+        self.store.as_bytes()
+    }
 }
 
 /// # Examples

--- a/components/plurals/src/provider.rs
+++ b/components/plurals/src/provider.rs
@@ -482,7 +482,7 @@ where
         core::mem::transmute(bytes)
     }
 
-    /// Creates a singleton [`PluralElementsPackedULE`] in a const context.
+    /// Creates a [`PluralElementsPackedULE`] with an "other" variant in a const context.
     ///
     /// Const parameters:
     ///
@@ -508,7 +508,7 @@ where
     /// let value = "hello, world!"; // 13 bytes long
     /// let metadata = FourBitMetadata::try_from_byte(11).unwrap();
     /// let inner_ule = SizedVarULEBytes::<13, str>::try_from_encodeable(value).unwrap();
-    /// let plural_ule = PluralElementsPackedULE::new_singleton_mn::<13, 14>(inner_ule, metadata);
+    /// let plural_ule = PluralElementsPackedULE::new_mn::<13, 14>(inner_ule, metadata);
     /// let rules = PluralRules::try_new(locale!("en").into(), Default::default()).unwrap();
     ///
     /// assert_eq!(plural_ule.as_varule().get(0.into(), &rules).1, "hello, world!");
@@ -530,7 +530,7 @@ where
     /// use zerovec::ule::SizedVarULEBytes;
     ///
     /// const plural_ule: SizedVarULEBytes<1, PluralElementsPackedULE<str>> =
-    ///     PluralElementsPackedULE::new_singleton_mn::<0, 1>(SizedVarULEBytes::EMPTY_STR, FourBitMetadata::zero());
+    ///     PluralElementsPackedULE::new_mn::<0, 1>(SizedVarULEBytes::EMPTY_STR, FourBitMetadata::zero());
     ///
     /// let rules = PluralRules::try_new(locale!("en").into(), Default::default()).unwrap();
     ///
@@ -540,14 +540,14 @@ where
     /// ```
     ///
     /// [generic_const_exprs]: https://doc.rust-lang.org/beta/unstable-book/language-features/generic-const-exprs.html#generic_const_exprs
-    pub const fn new_singleton_mn<const M: usize, const N: usize>(
+    pub const fn new_mn<const M: usize, const N: usize>(
         input: SizedVarULEBytes<M, V>,
         metadata: FourBitMetadata,
     ) -> SizedVarULEBytes<N, PluralElementsPackedULE<V>> {
         #[allow(clippy::panic)] // for safety, and documented
         if N != M + 1 {
             panic!(concat!(
-                "new_singleton_mn: N (",
+                "new_mn: N (",
                 stringify!(N),
                 ") != 1 + M (",
                 stringify!(M),

--- a/components/plurals/src/provider.rs
+++ b/components/plurals/src/provider.rs
@@ -31,7 +31,7 @@ use zerovec::ule::EncodeAsVarULE;
 use zerovec::ule::UleError;
 use zerovec::ule::VarULE;
 use zerovec::ule::ULE;
-use zerovec::ule::{AsULE, ConstStackVarULE};
+use zerovec::ule::{AsULE, SizedVarULEBytes};
 use zerovec::VarZeroSlice;
 
 pub mod rules;
@@ -502,10 +502,10 @@ where
     /// use icu::plurals::provider::PluralElementsPackedULE;
     /// use icu::plurals::PluralRules;
     /// use icu::locale::locale;
-    /// use zerovec::ule::ConstStackVarULE;
+    /// use zerovec::ule::SizedVarULEBytes;
     ///
     /// let value = "hello, world!"; // 13 bytes long
-    /// let inner_ule = ConstStackVarULE::<13, str>::try_from_encodeable(value).unwrap();
+    /// let inner_ule = SizedVarULEBytes::<13, str>::try_from_encodeable(value).unwrap();
     /// let plural_ule = PluralElementsPackedULE::new_singleton_mn::<13, 14>(inner_ule);
     /// let rules = PluralRules::try_new(locale!("en").into(), Default::default()).unwrap();
     ///
@@ -520,10 +520,10 @@ where
     /// use icu::plurals::provider::PluralElementsPackedULE;
     /// use icu::plurals::PluralRules;
     /// use icu::locale::locale;
-    /// use zerovec::ule::ConstStackVarULE;
+    /// use zerovec::ule::SizedVarULEBytes;
     ///
-    /// const plural_ule: ConstStackVarULE<1, PluralElementsPackedULE<str>> =
-    ///     PluralElementsPackedULE::new_singleton_mn::<0, 1>(ConstStackVarULE::EMPTY_STR);
+    /// const plural_ule: SizedVarULEBytes<1, PluralElementsPackedULE<str>> =
+    ///     PluralElementsPackedULE::new_singleton_mn::<0, 1>(SizedVarULEBytes::EMPTY_STR);
     ///
     /// let rules = PluralRules::try_new(locale!("en").into(), Default::default()).unwrap();
     ///
@@ -534,8 +534,8 @@ where
     ///
     /// [generic_const_exprs]: https://doc.rust-lang.org/beta/unstable-book/language-features/generic-const-exprs.html#generic_const_exprs
     pub const fn new_singleton_mn<const M: usize, const N: usize>(
-        input: ConstStackVarULE<M, V>,
-    ) -> ConstStackVarULE<N, PluralElementsPackedULE<V>> {
+        input: SizedVarULEBytes<M, V>,
+    ) -> SizedVarULEBytes<N, PluralElementsPackedULE<V>> {
         #[allow(clippy::panic)] // for safety, and documented
         if N != M + 1 {
             panic!(concat!(
@@ -561,7 +561,7 @@ where
         // Safety: bytes are a valid representation of this type:
         // 1. The first byte is 0 which indicates a singleton
         // 2. The remainder is a valid V by invariant of the input parameter
-        unsafe { ConstStackVarULE::new_unchecked(bytes) }
+        unsafe { SizedVarULEBytes::new_unchecked(bytes) }
     }
 
     /// Returns a tuple with:

--- a/components/plurals/src/provider.rs
+++ b/components/plurals/src/provider.rs
@@ -508,7 +508,7 @@ where
     /// let value = "hello, world!"; // 13 bytes long
     /// let metadata = FourBitMetadata::try_from_byte(11).unwrap();
     /// let inner_ule = SizedVarULEBytes::<13, str>::try_from_encodeable(value).unwrap();
-    /// let plural_ule = PluralElementsPackedULE::new_mn::<13, 14>(metadata, inner_ule);
+    /// let plural_ule = PluralElementsPackedULE::new_mn::<_, 14>(metadata, inner_ule);
     /// let rules = PluralRules::try_new(locale!("en").into(), Default::default()).unwrap();
     ///
     /// assert_eq!(plural_ule.as_varule().get(0.into(), &rules), (metadata, "hello, world!"));
@@ -527,7 +527,7 @@ where
     ///
     /// const metadata: FourBitMetadata = FourBitMetadata::zero();
     /// let plural_ule = const {
-    ///     PluralElementsPackedULE::new_mn::<0, 1>(metadata, SizedVarULEBytes::EMPTY_STR)
+    ///     PluralElementsPackedULE::new_mn::<_, 1>(metadata, SizedVarULEBytes::EMPTY_STR)
     /// };
     ///
     /// let rules = PluralRules::try_new(locale!("en").into(), Default::default()).unwrap();

--- a/components/plurals/src/provider.rs
+++ b/components/plurals/src/provider.rs
@@ -514,6 +514,24 @@ where
     /// assert_eq!(plural_ule.as_varule().get(2.into(), &rules).1, "hello, world!");
     /// ```
     ///
+    /// In a const context:
+    ///
+    /// ```
+    /// use icu::plurals::provider::PluralElementsPackedULE;
+    /// use icu::plurals::PluralRules;
+    /// use icu::locale::locale;
+    /// use zerovec::ule::FixedLengthVarULE;
+    ///
+    /// const plural_ule: FixedLengthVarULE<1, PluralElementsPackedULE<str>> =
+    ///     PluralElementsPackedULE::new_singleton_mn::<0, 1>(FixedLengthVarULE::EMPTY_STR);
+    ///
+    /// let rules = PluralRules::try_new(locale!("en").into(), Default::default()).unwrap();
+    ///
+    /// assert_eq!(plural_ule.as_varule().get(0.into(), &rules).1, "");
+    /// assert_eq!(plural_ule.as_varule().get(1.into(), &rules).1, "");
+    /// assert_eq!(plural_ule.as_varule().get(2.into(), &rules).1, "");
+    /// ```
+    ///
     /// [generic_const_exprs]: https://doc.rust-lang.org/beta/unstable-book/language-features/generic-const-exprs.html#generic_const_exprs
     pub const fn new_singleton_mn<const M: usize, const N: usize>(
         input: FixedLengthVarULE<M, V>,

--- a/components/plurals/src/provider.rs
+++ b/components/plurals/src/provider.rs
@@ -518,6 +518,7 @@ where
     pub const fn new_singleton_mn<const M: usize, const N: usize>(
         input: FixedLengthVarULE<M, V>,
     ) -> FixedLengthVarULE<N, PluralElementsPackedULE<V>> {
+        #[allow(clippy::panic)] // for safety, and documented
         if N != M + 1 {
             panic!(concat!(
                 "new_singleton_mn: N (",

--- a/components/plurals/src/provider.rs
+++ b/components/plurals/src/provider.rs
@@ -556,6 +556,7 @@ where
             remainder[i] = input.as_bytes()[i];
             i += 1;
         }
+        // First byte = 0 for a singleton
         *start = 0;
         // Safety: bytes are a valid representation of this type:
         // 1. The first byte is 0 which indicates a singleton

--- a/components/plurals/src/provider.rs
+++ b/components/plurals/src/provider.rs
@@ -508,7 +508,7 @@ where
     /// let value = "hello, world!"; // 13 bytes long
     /// let metadata = FourBitMetadata::try_from_byte(11).unwrap();
     /// let inner_ule = SizedVarULEBytes::<13, str>::try_from_encodeable(value).unwrap();
-    /// let plural_ule = PluralElementsPackedULE::new_mn::<13, 14>(inner_ule, metadata);
+    /// let plural_ule = PluralElementsPackedULE::new_mn::<13, 14>(metadata, inner_ule);
     /// let rules = PluralRules::try_new(locale!("en").into(), Default::default()).unwrap();
     ///
     /// assert_eq!(plural_ule.as_varule().get(0.into(), &rules).1, "hello, world!");
@@ -530,7 +530,7 @@ where
     /// use zerovec::ule::SizedVarULEBytes;
     ///
     /// const plural_ule: SizedVarULEBytes<1, PluralElementsPackedULE<str>> =
-    ///     PluralElementsPackedULE::new_mn::<0, 1>(SizedVarULEBytes::EMPTY_STR, FourBitMetadata::zero());
+    ///     PluralElementsPackedULE::new_mn::<0, 1>(FourBitMetadata::zero(), SizedVarULEBytes::EMPTY_STR);
     ///
     /// let rules = PluralRules::try_new(locale!("en").into(), Default::default()).unwrap();
     ///
@@ -541,8 +541,8 @@ where
     ///
     /// [generic_const_exprs]: https://doc.rust-lang.org/beta/unstable-book/language-features/generic-const-exprs.html#generic_const_exprs
     pub const fn new_mn<const M: usize, const N: usize>(
-        input: SizedVarULEBytes<M, V>,
         metadata: FourBitMetadata,
+        input: SizedVarULEBytes<M, V>,
     ) -> SizedVarULEBytes<N, PluralElementsPackedULE<V>> {
         #[allow(clippy::panic)] // for safety, and documented
         if N != M + 1 {

--- a/components/plurals/src/provider.rs
+++ b/components/plurals/src/provider.rs
@@ -511,13 +511,9 @@ where
     /// let plural_ule = PluralElementsPackedULE::new_mn::<13, 14>(metadata, inner_ule);
     /// let rules = PluralRules::try_new(locale!("en").into(), Default::default()).unwrap();
     ///
-    /// assert_eq!(plural_ule.as_varule().get(0.into(), &rules).1, "hello, world!");
-    /// assert_eq!(plural_ule.as_varule().get(1.into(), &rules).1, "hello, world!");
-    /// assert_eq!(plural_ule.as_varule().get(2.into(), &rules).1, "hello, world!");
-    ///
-    /// assert_eq!(plural_ule.as_varule().get(0.into(), &rules).0, metadata);
-    /// assert_eq!(plural_ule.as_varule().get(1.into(), &rules).0, metadata);
-    /// assert_eq!(plural_ule.as_varule().get(2.into(), &rules).0, metadata);
+    /// assert_eq!(plural_ule.as_varule().get(0.into(), &rules), (metadata, "hello, world!"));
+    /// assert_eq!(plural_ule.as_varule().get(1.into(), &rules), (metadata, "hello, world!"));
+    /// assert_eq!(plural_ule.as_varule().get(2.into(), &rules), (metadata, "hello, world!"));
     /// ```
     ///
     /// In a const context:
@@ -529,14 +525,15 @@ where
     /// use icu::locale::locale;
     /// use zerovec::ule::SizedVarULEBytes;
     ///
+    /// const metadata: FourBitMetadata = FourBitMetadata::zero();
     /// const plural_ule: SizedVarULEBytes<1, PluralElementsPackedULE<str>> =
-    ///     PluralElementsPackedULE::new_mn::<0, 1>(FourBitMetadata::zero(), SizedVarULEBytes::EMPTY_STR);
+    ///     PluralElementsPackedULE::new_mn::<0, 1>(metadata, SizedVarULEBytes::EMPTY_STR);
     ///
     /// let rules = PluralRules::try_new(locale!("en").into(), Default::default()).unwrap();
     ///
-    /// assert_eq!(plural_ule.as_varule().get(0.into(), &rules).1, "");
-    /// assert_eq!(plural_ule.as_varule().get(1.into(), &rules).1, "");
-    /// assert_eq!(plural_ule.as_varule().get(2.into(), &rules).1, "");
+    /// assert_eq!(plural_ule.as_varule().get(0.into(), &rules), (metadata, ""));
+    /// assert_eq!(plural_ule.as_varule().get(1.into(), &rules), (metadata, ""));
+    /// assert_eq!(plural_ule.as_varule().get(2.into(), &rules), (metadata, ""));
     /// ```
     ///
     /// [generic_const_exprs]: https://doc.rust-lang.org/beta/unstable-book/language-features/generic-const-exprs.html#generic_const_exprs

--- a/components/plurals/src/provider.rs
+++ b/components/plurals/src/provider.rs
@@ -531,7 +531,13 @@ where
         let mut bytes = [0u8; N];
         #[allow(clippy::unwrap_used)] // the bytes are nonempty because N > 0
         let (start, remainder) = bytes.split_first_mut().unwrap();
-        remainder.copy_from_slice(input.as_bytes());
+        // TODO(1.87): use copy_from_slice
+        let mut i = 0;
+        #[allow(clippy::indexing_slicing)] // both remainder and input are length M
+        while i < M {
+            remainder[i] = input.as_bytes()[i];
+            i += 1;
+        }
         *start = 0;
         // Safety: bytes are a valid representation of this type:
         // 1. The first byte is 0 which indicates a singleton

--- a/components/plurals/src/provider.rs
+++ b/components/plurals/src/provider.rs
@@ -31,7 +31,7 @@ use zerovec::ule::EncodeAsVarULE;
 use zerovec::ule::UleError;
 use zerovec::ule::VarULE;
 use zerovec::ule::ULE;
-use zerovec::ule::{AsULE, FixedLengthVarULE};
+use zerovec::ule::{AsULE, ConstStackVarULE};
 use zerovec::VarZeroSlice;
 
 pub mod rules;
@@ -502,10 +502,10 @@ where
     /// use icu::plurals::provider::PluralElementsPackedULE;
     /// use icu::plurals::PluralRules;
     /// use icu::locale::locale;
-    /// use zerovec::ule::FixedLengthVarULE;
+    /// use zerovec::ule::ConstStackVarULE;
     ///
     /// let value = "hello, world!"; // 13 bytes long
-    /// let inner_ule = FixedLengthVarULE::<13, str>::try_from_encodeable(value).unwrap();
+    /// let inner_ule = ConstStackVarULE::<13, str>::try_from_encodeable(value).unwrap();
     /// let plural_ule = PluralElementsPackedULE::new_singleton_mn::<13, 14>(inner_ule);
     /// let rules = PluralRules::try_new(locale!("en").into(), Default::default()).unwrap();
     ///
@@ -520,10 +520,10 @@ where
     /// use icu::plurals::provider::PluralElementsPackedULE;
     /// use icu::plurals::PluralRules;
     /// use icu::locale::locale;
-    /// use zerovec::ule::FixedLengthVarULE;
+    /// use zerovec::ule::ConstStackVarULE;
     ///
-    /// const plural_ule: FixedLengthVarULE<1, PluralElementsPackedULE<str>> =
-    ///     PluralElementsPackedULE::new_singleton_mn::<0, 1>(FixedLengthVarULE::EMPTY_STR);
+    /// const plural_ule: ConstStackVarULE<1, PluralElementsPackedULE<str>> =
+    ///     PluralElementsPackedULE::new_singleton_mn::<0, 1>(ConstStackVarULE::EMPTY_STR);
     ///
     /// let rules = PluralRules::try_new(locale!("en").into(), Default::default()).unwrap();
     ///
@@ -534,8 +534,8 @@ where
     ///
     /// [generic_const_exprs]: https://doc.rust-lang.org/beta/unstable-book/language-features/generic-const-exprs.html#generic_const_exprs
     pub const fn new_singleton_mn<const M: usize, const N: usize>(
-        input: FixedLengthVarULE<M, V>,
-    ) -> FixedLengthVarULE<N, PluralElementsPackedULE<V>> {
+        input: ConstStackVarULE<M, V>,
+    ) -> ConstStackVarULE<N, PluralElementsPackedULE<V>> {
         #[allow(clippy::panic)] // for safety, and documented
         if N != M + 1 {
             panic!(concat!(
@@ -561,7 +561,7 @@ where
         // Safety: bytes are a valid representation of this type:
         // 1. The first byte is 0 which indicates a singleton
         // 2. The remainder is a valid V by invariant of the input parameter
-        unsafe { FixedLengthVarULE::new_unchecked(bytes) }
+        unsafe { ConstStackVarULE::new_unchecked(bytes) }
     }
 
     /// Returns a tuple with:

--- a/components/plurals/src/provider.rs
+++ b/components/plurals/src/provider.rs
@@ -719,7 +719,7 @@ pub struct FourBitMetadata(u8);
 impl FourBitMetadata {
     /// Creates a [`FourBitMetadata`] if the given value fits in 4 bits.
     pub fn try_from_byte(byte: u8) -> Option<Self> {
-        if byte < 0x80 {
+        if byte <= 0x0F {
             Some(Self(byte))
         } else {
             None
@@ -727,12 +727,12 @@ impl FourBitMetadata {
     }
 
     /// Creates a [`FourBitMetadata`] with a zero value.
-    pub fn zero() -> Self {
+    pub const fn zero() -> Self {
         Self(0)
     }
 
     /// Gets the value out of a [`FourBitMetadata`].
-    pub fn get(self) -> u8 {
+    pub const fn get(self) -> u8 {
         self.0
     }
 }

--- a/components/plurals/src/provider.rs
+++ b/components/plurals/src/provider.rs
@@ -526,8 +526,9 @@ where
     /// use zerovec::ule::SizedVarULEBytes;
     ///
     /// const metadata: FourBitMetadata = FourBitMetadata::zero();
-    /// const plural_ule: SizedVarULEBytes<1, PluralElementsPackedULE<str>> =
-    ///     PluralElementsPackedULE::new_mn::<0, 1>(metadata, SizedVarULEBytes::EMPTY_STR);
+    /// let plural_ule = const {
+    ///     PluralElementsPackedULE::new_mn::<0, 1>(metadata, SizedVarULEBytes::EMPTY_STR)
+    /// };
     ///
     /// let rules = PluralRules::try_new(locale!("en").into(), Default::default()).unwrap();
     ///

--- a/utils/zerovec/src/ule/fixed_length.rs
+++ b/utils/zerovec/src/ule/fixed_length.rs
@@ -1,0 +1,95 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use crate::ule::{EncodeAsVarULE, UleError, VarULE};
+use core::fmt;
+use core::marker::PhantomData;
+use core::ops::Deref;
+
+/// A container for a [`VarULE`] with a fixed byte length.
+///
+/// This container may be useful if the length of your VarULE is known at compile-time.
+///
+/// # Examples
+///
+/// ```
+/// use zerovec::ule::FixedLengthVarULE;
+///
+/// let container = FixedLengthVarULE::<13, str>::try_from_encodeable("hello, world!").unwrap();
+///
+/// assert_eq!(&*container, "hello, world!");
+///
+/// // Returns an error if the container is not the correct size:
+/// FixedLengthVarULE::<20, str>::try_from_encodeable("hello, world!").unwrap_err();
+/// ```
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub struct FixedLengthVarULE<const N: usize, V: VarULE + ?Sized> {
+    /// Invariant: The bytes MUST be a valid VarULE representation of `V`.
+    bytes: [u8; N],
+    _marker: PhantomData<V>,
+}
+
+impl<const N: usize, V: VarULE + ?Sized> FixedLengthVarULE<N, V> {
+    /// Creates one of these from an [`EncodeAsVarULE`].
+    ///
+    /// Returns an error if the byte length in the container is not the correct length
+    /// for the encodeable object.
+    pub fn try_from_encodeable(input: impl EncodeAsVarULE<V>) -> Result<Self, UleError> {
+        let len = input.encode_var_ule_len();
+        if len != N {
+            return Err(UleError::length::<V>(len));
+        }
+        let mut bytes = [0u8; N];
+        input.encode_var_ule_write(&mut bytes);
+        // Safety: the bytes were just written from an EncodeAsVarULE impl
+        unsafe { Ok(Self::new_unchecked(bytes)) }
+    }
+
+    /// Creates one of these directly from bytes.
+    ///
+    /// # Safety
+    ///
+    /// The bytes MUST be a valid VarULE representation of `V`.
+    pub const unsafe fn new_unchecked(bytes: [u8; N]) -> Self {
+        Self {
+            bytes,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Returns the bytes backing this [`FixedLengthVarULE`], which are
+    /// guaranteed to be a valid VarULE representation of `V`.
+    pub const fn as_bytes(&self) -> &[u8; N] {
+        &self.bytes
+    }
+
+    /// Returns the container as an instance of `V`.
+    pub fn as_varule(&self) -> &V {
+        debug_assert!(V::validate_bytes(&self.bytes).is_ok());
+        // Safety: self.bytes are a valid VarULE representation of `V`.
+        unsafe { V::from_bytes_unchecked(&self.bytes) }
+    }
+}
+
+impl<const N: usize, V: VarULE + ?Sized> fmt::Debug for FixedLengthVarULE<N, V>
+where
+    V: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_varule().fmt(f)
+    }
+}
+
+impl<const N: usize, V: VarULE + ?Sized> AsRef<V> for FixedLengthVarULE<N, V> {
+    fn as_ref(&self) -> &V {
+        self.as_varule()
+    }
+}
+
+impl<const N: usize, V: VarULE + ?Sized> Deref for FixedLengthVarULE<N, V> {
+    type Target = V;
+    fn deref(&self) -> &Self::Target {
+        self.as_varule()
+    }
+}

--- a/utils/zerovec/src/ule/fixed_length.rs
+++ b/utils/zerovec/src/ule/fixed_length.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use crate::ule::{EncodeAsVarULE, ULE, UleError, VarULE};
+use crate::ule::{EncodeAsVarULE, UleError, VarULE, ULE};
 use core::fmt;
 use core::marker::PhantomData;
 use core::ops::Deref;
@@ -14,23 +14,23 @@ use core::ops::Deref;
 /// # Examples
 ///
 /// ```
-/// use zerovec::ule::FixedLengthVarULE;
+/// use zerovec::ule::ConstStackVarULE;
 ///
-/// let container = FixedLengthVarULE::<13, str>::try_from_encodeable("hello, world!").unwrap();
+/// let container = ConstStackVarULE::<13, str>::try_from_encodeable("hello, world!").unwrap();
 ///
 /// assert_eq!(&*container, "hello, world!");
 ///
 /// // Returns an error if the container is not the correct size:
-/// FixedLengthVarULE::<20, str>::try_from_encodeable("hello, world!").unwrap_err();
+/// ConstStackVarULE::<20, str>::try_from_encodeable("hello, world!").unwrap_err();
 /// ```
 #[derive(Copy, Clone, PartialEq, Eq)]
-pub struct FixedLengthVarULE<const N: usize, V: VarULE + ?Sized> {
+pub struct ConstStackVarULE<const N: usize, V: VarULE + ?Sized> {
     /// Invariant: The bytes MUST be a valid VarULE representation of `V`.
     bytes: [u8; N],
     _marker: PhantomData<V>,
 }
 
-impl<const N: usize, V: VarULE + ?Sized> FixedLengthVarULE<N, V> {
+impl<const N: usize, V: VarULE + ?Sized> ConstStackVarULE<N, V> {
     /// Creates one of these from an [`EncodeAsVarULE`].
     ///
     /// Returns an error if the byte length in the container is not the correct length
@@ -58,7 +58,7 @@ impl<const N: usize, V: VarULE + ?Sized> FixedLengthVarULE<N, V> {
         }
     }
 
-    /// Returns the bytes backing this [`FixedLengthVarULE`], which are
+    /// Returns the bytes backing this [`ConstStackVarULE`], which are
     /// guaranteed to be a valid VarULE representation of `V`.
     pub const fn as_bytes(&self) -> &[u8; N] {
         &self.bytes
@@ -72,7 +72,7 @@ impl<const N: usize, V: VarULE + ?Sized> FixedLengthVarULE<N, V> {
     }
 }
 
-impl<const N: usize, V: VarULE + ?Sized> fmt::Debug for FixedLengthVarULE<N, V>
+impl<const N: usize, V: VarULE + ?Sized> fmt::Debug for ConstStackVarULE<N, V>
 where
     V: fmt::Debug,
 {
@@ -81,27 +81,27 @@ where
     }
 }
 
-impl<const N: usize, V: VarULE + ?Sized> AsRef<V> for FixedLengthVarULE<N, V> {
+impl<const N: usize, V: VarULE + ?Sized> AsRef<V> for ConstStackVarULE<N, V> {
     fn as_ref(&self) -> &V {
         self.as_varule()
     }
 }
 
-impl<const N: usize, V: VarULE + ?Sized> Deref for FixedLengthVarULE<N, V> {
+impl<const N: usize, V: VarULE + ?Sized> Deref for ConstStackVarULE<N, V> {
     type Target = V;
     fn deref(&self) -> &Self::Target {
         self.as_varule()
     }
 }
 
-impl FixedLengthVarULE<0, str> {
-    /// The empty string as a [`FixedLengthVarULE`].
+impl ConstStackVarULE<0, str> {
+    /// The empty string as a [`ConstStackVarULE`].
     // Safety: the empty slice is a valid str
     pub const EMPTY_STR: Self = unsafe { Self::new_unchecked([]) };
 }
 
-impl<T: ULE> FixedLengthVarULE<0, [T]> {
-    /// The empty slice as a [`FixedLengthVarULE`].
+impl<T: ULE> ConstStackVarULE<0, [T]> {
+    /// The empty slice as a [`ConstStackVarULE`].
     // Safety: the empty slice is a valid str
     pub const EMPTY_SLICE: Self = unsafe { Self::new_unchecked([]) };
 }

--- a/utils/zerovec/src/ule/fixed_length.rs
+++ b/utils/zerovec/src/ule/fixed_length.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use crate::ule::{EncodeAsVarULE, UleError, VarULE};
+use crate::ule::{EncodeAsVarULE, ULE, UleError, VarULE};
 use core::fmt;
 use core::marker::PhantomData;
 use core::ops::Deref;
@@ -92,4 +92,16 @@ impl<const N: usize, V: VarULE + ?Sized> Deref for FixedLengthVarULE<N, V> {
     fn deref(&self) -> &Self::Target {
         self.as_varule()
     }
+}
+
+impl FixedLengthVarULE<0, str> {
+    /// The empty string as a [`FixedLengthVarULE`].
+    // Safety: the empty slice is a valid str
+    pub const EMPTY_STR: Self = unsafe { Self::new_unchecked([]) };
+}
+
+impl<T: ULE> FixedLengthVarULE<0, [T]> {
+    /// The empty slice as a [`FixedLengthVarULE`].
+    // Safety: the empty slice is a valid str
+    pub const EMPTY_SLICE: Self = unsafe { Self::new_unchecked([]) };
 }

--- a/utils/zerovec/src/ule/fixed_length.rs
+++ b/utils/zerovec/src/ule/fixed_length.rs
@@ -14,23 +14,23 @@ use core::ops::Deref;
 /// # Examples
 ///
 /// ```
-/// use zerovec::ule::ConstStackVarULE;
+/// use zerovec::ule::SizedVarULEBytes;
 ///
-/// let container = ConstStackVarULE::<13, str>::try_from_encodeable("hello, world!").unwrap();
+/// let container = SizedVarULEBytes::<13, str>::try_from_encodeable("hello, world!").unwrap();
 ///
 /// assert_eq!(&*container, "hello, world!");
 ///
 /// // Returns an error if the container is not the correct size:
-/// ConstStackVarULE::<20, str>::try_from_encodeable("hello, world!").unwrap_err();
+/// SizedVarULEBytes::<20, str>::try_from_encodeable("hello, world!").unwrap_err();
 /// ```
 #[derive(Copy, Clone, PartialEq, Eq)]
-pub struct ConstStackVarULE<const N: usize, V: VarULE + ?Sized> {
+pub struct SizedVarULEBytes<const N: usize, V: VarULE + ?Sized> {
     /// Invariant: The bytes MUST be a valid VarULE representation of `V`.
     bytes: [u8; N],
     _marker: PhantomData<V>,
 }
 
-impl<const N: usize, V: VarULE + ?Sized> ConstStackVarULE<N, V> {
+impl<const N: usize, V: VarULE + ?Sized> SizedVarULEBytes<N, V> {
     /// Creates one of these from an [`EncodeAsVarULE`].
     ///
     /// Returns an error if the byte length in the container is not the correct length
@@ -58,7 +58,7 @@ impl<const N: usize, V: VarULE + ?Sized> ConstStackVarULE<N, V> {
         }
     }
 
-    /// Returns the bytes backing this [`ConstStackVarULE`], which are
+    /// Returns the bytes backing this [`SizedVarULEBytes`], which are
     /// guaranteed to be a valid VarULE representation of `V`.
     pub const fn as_bytes(&self) -> &[u8; N] {
         &self.bytes
@@ -72,7 +72,7 @@ impl<const N: usize, V: VarULE + ?Sized> ConstStackVarULE<N, V> {
     }
 }
 
-impl<const N: usize, V: VarULE + ?Sized> fmt::Debug for ConstStackVarULE<N, V>
+impl<const N: usize, V: VarULE + ?Sized> fmt::Debug for SizedVarULEBytes<N, V>
 where
     V: fmt::Debug,
 {
@@ -81,27 +81,27 @@ where
     }
 }
 
-impl<const N: usize, V: VarULE + ?Sized> AsRef<V> for ConstStackVarULE<N, V> {
+impl<const N: usize, V: VarULE + ?Sized> AsRef<V> for SizedVarULEBytes<N, V> {
     fn as_ref(&self) -> &V {
         self.as_varule()
     }
 }
 
-impl<const N: usize, V: VarULE + ?Sized> Deref for ConstStackVarULE<N, V> {
+impl<const N: usize, V: VarULE + ?Sized> Deref for SizedVarULEBytes<N, V> {
     type Target = V;
     fn deref(&self) -> &Self::Target {
         self.as_varule()
     }
 }
 
-impl ConstStackVarULE<0, str> {
-    /// The empty string as a [`ConstStackVarULE`].
+impl SizedVarULEBytes<0, str> {
+    /// The empty string as a [`SizedVarULEBytes`].
     // Safety: the empty slice is a valid str
     pub const EMPTY_STR: Self = unsafe { Self::new_unchecked([]) };
 }
 
-impl<T: ULE> ConstStackVarULE<0, [T]> {
-    /// The empty slice as a [`ConstStackVarULE`].
+impl<T: ULE> SizedVarULEBytes<0, [T]> {
+    /// The empty slice as a [`SizedVarULEBytes`].
     // Safety: the empty slice is a valid str
     pub const EMPTY_SLICE: Self = unsafe { Self::new_unchecked([]) };
 }

--- a/utils/zerovec/src/ule/mod.rs
+++ b/utils/zerovec/src/ule/mod.rs
@@ -31,7 +31,7 @@ pub use chars::CharULE;
 #[cfg(feature = "alloc")]
 pub use encode::encode_varule_to_box;
 pub use encode::EncodeAsVarULE;
-pub use fixed_length::SizedVarULEBytes;
+pub use fixed_length::{to_sized_varule_bytes, SizedVarULEBytes};
 pub use multi::MultiFieldsULE;
 pub use niche::{NicheBytes, NichedOption, NichedOptionULE};
 pub use option::{OptionULE, OptionVarULE};

--- a/utils/zerovec/src/ule/mod.rs
+++ b/utils/zerovec/src/ule/mod.rs
@@ -31,7 +31,7 @@ pub use chars::CharULE;
 #[cfg(feature = "alloc")]
 pub use encode::encode_varule_to_box;
 pub use encode::EncodeAsVarULE;
-pub use fixed_length::FixedLengthVarULE;
+pub use fixed_length::ConstStackVarULE;
 pub use multi::MultiFieldsULE;
 pub use niche::{NicheBytes, NichedOption, NichedOptionULE};
 pub use option::{OptionULE, OptionVarULE};

--- a/utils/zerovec/src/ule/mod.rs
+++ b/utils/zerovec/src/ule/mod.rs
@@ -14,6 +14,7 @@ mod chars;
 #[cfg(doc)]
 pub mod custom;
 mod encode;
+mod fixed_length;
 mod macros;
 mod multi;
 mod niche;
@@ -30,6 +31,7 @@ pub use chars::CharULE;
 #[cfg(feature = "alloc")]
 pub use encode::encode_varule_to_box;
 pub use encode::EncodeAsVarULE;
+pub use fixed_length::FixedLengthVarULE;
 pub use multi::MultiFieldsULE;
 pub use niche::{NicheBytes, NichedOption, NichedOptionULE};
 pub use option::{OptionULE, OptionVarULE};
@@ -441,6 +443,8 @@ impl UleError {
     }
 
     /// Construct an "invalid length" error for the given type and length
+    ///
+    /// The length is of the input bytes, not the expected length.
     pub fn length<T: ?Sized + 'static>(len: usize) -> UleError {
         UleError::InvalidLength {
             ty: any::type_name::<T>(),

--- a/utils/zerovec/src/ule/mod.rs
+++ b/utils/zerovec/src/ule/mod.rs
@@ -31,7 +31,7 @@ pub use chars::CharULE;
 #[cfg(feature = "alloc")]
 pub use encode::encode_varule_to_box;
 pub use encode::EncodeAsVarULE;
-pub use fixed_length::ConstStackVarULE;
+pub use fixed_length::SizedVarULEBytes;
 pub use multi::MultiFieldsULE;
 pub use niche::{NicheBytes, NichedOption, NichedOptionULE};
 pub use option::{OptionULE, OptionVarULE};


### PR DESCRIPTION
See #7391
Depends on #7399

I was making a PR that got a bit bigger than I wanted, so I split this out into a standalone change.

We finally have `VarZeroCow`, a heap-or-reference container for a VarULE. Another reasonable container to want is what I'm proposing in this PR, a `FixedLengthVarULE`, which stores the VarULE on the stack with a fixed number of bytes.

This can be used to compose ULEs and VarULEs in const contexts, as I show with the PluralElementsPackedULE example.