### PR TITLE
Adapt `UnicodeSet` builder warning

### DIFF
--- a/components/collections/src/codepointinvlist/builder.rs
+++ b/components/collections/src/codepointinvlist/builder.rs
@@ -13,7 +13,7 @@ use zerovec::{ule::AsULE, ZeroVec};
 /// A builder for [`CodePointInversionList`].
 ///
 /// Provides exposure to builder functions and conversion to [`CodePointInversionList`]
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct CodePointInversionListBuilder {
     // A sorted list of even length, with values <= char::MAX + 1
     intervals: Vec<u32>,

--- a/components/experimental/src/unicodeset_parse/parse.rs
+++ b/components/experimental/src/unicodeset_parse/parse.rs
@@ -1207,10 +1207,18 @@ where
         if self.inverted {
             // code point inversion; removes all strings
             #[cfg(feature = "log")]
-            if !self.string_set.is_empty() {
-                log::info!(
-                    "Inverting a unicode set with strings. This removes all strings entirely."
-                );
+            {
+                let single_set = self.single_set.clone().build();
+                if !self
+                    .string_set
+                    .iter()
+                    // if the string starts with a cp in the cp-set, then it'll be rejected through that
+                    .all(|s| s.chars().next().is_some_and(|c| single_set.contains(c)))
+                {
+                    log::info!(
+                        "Inverting a unicode set with strings. This removes all strings entirely."
+                    );
+                }
             }
             self.string_set.clear();
             self.single_set.complement();


### PR DESCRIPTION
Currently the set `[^ [i ɪ e {e̞}] j ʝ]` triggers this warning. However, the "e̞" string is excluded from the inverted set because the 'e' code point is as well, so that's fine.