### PR TITLE
Use string interpolation instead of token streams to generate Baked mod.rs

### DIFF
--- a/provider/baked/tests/data/mod.rs
+++ b/provider/baked/tests/data/mod.rs
@@ -1,5 +1,7 @@
 // @generated
 include!("hello_world_v1.rs.data");
+
+
 /// Marks a type as a data provider. You can then use macros like
 /// `impl_core_helloworld_v1` to add implementations.
 ///
@@ -14,7 +16,7 @@ include!("hello_world_v1.rs.data");
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __make_provider {
-    ($ name : ty) => {
+    ($name:ty) => {
         #[clippy::msrv = "1.83"]
         impl $name {
             #[allow(dead_code)]
@@ -23,8 +25,11 @@ macro_rules! __make_provider {
         icu_provider::marker::impl_data_provider_never_marker!($name);
     };
 }
+
 #[doc(inline)]
 pub use __make_provider as make_provider;
+
+// Not public as it will only work locally due to needing access to the other macros.
 /// This macro requires the following crates:
 /// * `icu`
 /// * `icu_provider`
@@ -32,8 +37,9 @@ pub use __make_provider as make_provider;
 /// * `zerovec`
 #[allow(unused_macros)]
 macro_rules! impl_data_provider {
-    ($ provider : ty) => {
+    ($provider:ty) => {
         make_provider!($provider);
         impl_hello_world_v1!($provider);
+
     };
 }

--- a/provider/data/calendar/data/mod.rs
+++ b/provider/data/calendar/data/mod.rs
@@ -2,6 +2,8 @@
 include!("calendar_japanese_extended_v1.rs.data");
 include!("calendar_japanese_modern_v1.rs.data");
 include!("calendar_week_v1.rs.data");
+
+
 /// Marks a type as a data provider. You can then use macros like
 /// `impl_core_helloworld_v1` to add implementations.
 ///
@@ -16,7 +18,7 @@ include!("calendar_week_v1.rs.data");
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __make_provider {
-    ($ name : ty) => {
+    ($name:ty) => {
         #[clippy::msrv = "1.83"]
         impl $name {
             #[allow(dead_code)]
@@ -25,8 +27,11 @@ macro_rules! __make_provider {
         icu_provider::marker::impl_data_provider_never_marker!($name);
     };
 }
+
 #[doc(inline)]
 pub use __make_provider as make_provider;
+
+// Not public as it will only work locally due to needing access to the other macros.
 /// This macro requires the following crates:
 /// * `icu`
 /// * `icu_provider`
@@ -34,10 +39,11 @@ pub use __make_provider as make_provider;
 /// * `zerovec`
 #[allow(unused_macros)]
 macro_rules! impl_data_provider {
-    ($ provider : ty) => {
+    ($provider:ty) => {
         make_provider!($provider);
         impl_calendar_japanese_extended_v1!($provider);
         impl_calendar_japanese_modern_v1!($provider);
         impl_calendar_week_v1!($provider);
+
     };
 }

--- a/provider/data/calendar/stubdata/mod.rs
+++ b/provider/data/calendar/stubdata/mod.rs
@@ -2,6 +2,8 @@
 include!("calendar_japanese_extended_v1.rs.data");
 include!("calendar_japanese_modern_v1.rs.data");
 include!("calendar_week_v1.rs.data");
+
+
 /// Marks a type as a data provider. You can then use macros like
 /// `impl_core_helloworld_v1` to add implementations.
 ///
@@ -16,7 +18,7 @@ include!("calendar_week_v1.rs.data");
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __make_provider {
-    ($ name : ty) => {
+    ($name:ty) => {
         #[clippy::msrv = "1.83"]
         impl $name {
             #[allow(dead_code)]
@@ -25,18 +27,22 @@ macro_rules! __make_provider {
         icu_provider::marker::impl_data_provider_never_marker!($name);
     };
 }
+
 #[doc(inline)]
 pub use __make_provider as make_provider;
+
+// Not public as it will only work locally due to needing access to the other macros.
 /// This macro requires the following crates:
 /// * `icu`
 /// * `icu_provider`
 /// * `zerovec`
 #[allow(unused_macros)]
 macro_rules! impl_data_provider {
-    ($ provider : ty) => {
+    ($provider:ty) => {
         make_provider!($provider);
         impl_calendar_japanese_extended_v1!($provider);
         impl_calendar_japanese_modern_v1!($provider);
         impl_calendar_week_v1!($provider);
+
     };
 }

--- a/provider/data/casemap/data/mod.rs
+++ b/provider/data/casemap/data/mod.rs
@@ -1,6 +1,8 @@
 // @generated
 include!("case_map_unfold_v1.rs.data");
 include!("case_map_v1.rs.data");
+
+
 /// Marks a type as a data provider. You can then use macros like
 /// `impl_core_helloworld_v1` to add implementations.
 ///
@@ -15,7 +17,7 @@ include!("case_map_v1.rs.data");
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __make_provider {
-    ($ name : ty) => {
+    ($name:ty) => {
         #[clippy::msrv = "1.83"]
         impl $name {
             #[allow(dead_code)]
@@ -24,17 +26,21 @@ macro_rules! __make_provider {
         icu_provider::marker::impl_data_provider_never_marker!($name);
     };
 }
+
 #[doc(inline)]
 pub use __make_provider as make_provider;
+
+// Not public as it will only work locally due to needing access to the other macros.
 /// This macro requires the following crates:
 /// * `icu`
 /// * `icu_provider`
 /// * `zerovec`
 #[allow(unused_macros)]
 macro_rules! impl_data_provider {
-    ($ provider : ty) => {
+    ($provider:ty) => {
         make_provider!($provider);
         impl_case_map_unfold_v1!($provider);
         impl_case_map_v1!($provider);
+
     };
 }

--- a/provider/data/casemap/stubdata/mod.rs
+++ b/provider/data/casemap/stubdata/mod.rs
@@ -1,6 +1,8 @@
 // @generated
 include!("case_map_unfold_v1.rs.data");
 include!("case_map_v1.rs.data");
+
+
 /// Marks a type as a data provider. You can then use macros like
 /// `impl_core_helloworld_v1` to add implementations.
 ///
@@ -15,7 +17,7 @@ include!("case_map_v1.rs.data");
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __make_provider {
-    ($ name : ty) => {
+    ($name:ty) => {
         #[clippy::msrv = "1.83"]
         impl $name {
             #[allow(dead_code)]
@@ -24,17 +26,21 @@ macro_rules! __make_provider {
         icu_provider::marker::impl_data_provider_never_marker!($name);
     };
 }
+
 #[doc(inline)]
 pub use __make_provider as make_provider;
+
+// Not public as it will only work locally due to needing access to the other macros.
 /// This macro requires the following crates:
 /// * `icu`
 /// * `icu_provider`
 /// * `zerovec`
 #[allow(unused_macros)]
 macro_rules! impl_data_provider {
-    ($ provider : ty) => {
+    ($provider:ty) => {
         make_provider!($provider);
         impl_case_map_unfold_v1!($provider);
         impl_case_map_v1!($provider);
+
     };
 }

--- a/provider/data/collator/data/mod.rs
+++ b/provider/data/collator/data/mod.rs
@@ -6,6 +6,8 @@ include!("collation_metadata_v1.rs.data");
 include!("collation_tailoring_v1.rs.data");
 include!("collation_special_primaries_v1.rs.data");
 include!("collation_root_v1.rs.data");
+
+
 /// Marks a type as a data provider. You can then use macros like
 /// `impl_core_helloworld_v1` to add implementations.
 ///
@@ -20,7 +22,7 @@ include!("collation_root_v1.rs.data");
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __make_provider {
-    ($ name : ty) => {
+    ($name:ty) => {
         #[clippy::msrv = "1.83"]
         impl $name {
             #[allow(dead_code)]
@@ -29,8 +31,11 @@ macro_rules! __make_provider {
         icu_provider::marker::impl_data_provider_never_marker!($name);
     };
 }
+
 #[doc(inline)]
 pub use __make_provider as make_provider;
+
+// Not public as it will only work locally due to needing access to the other macros.
 /// This macro requires the following crates:
 /// * `icu`
 /// * `icu_provider`
@@ -38,7 +43,7 @@ pub use __make_provider as make_provider;
 /// * `zerovec`
 #[allow(unused_macros)]
 macro_rules! impl_data_provider {
-    ($ provider : ty) => {
+    ($provider:ty) => {
         make_provider!($provider);
         impl_collation_reordering_v1!($provider);
         impl_collation_diacritics_v1!($provider);
@@ -47,5 +52,6 @@ macro_rules! impl_data_provider {
         impl_collation_tailoring_v1!($provider);
         impl_collation_special_primaries_v1!($provider);
         impl_collation_root_v1!($provider);
+
     };
 }

--- a/provider/data/collator/stubdata/mod.rs
+++ b/provider/data/collator/stubdata/mod.rs
@@ -6,6 +6,8 @@ include!("collation_metadata_v1.rs.data");
 include!("collation_tailoring_v1.rs.data");
 include!("collation_special_primaries_v1.rs.data");
 include!("collation_root_v1.rs.data");
+
+
 /// Marks a type as a data provider. You can then use macros like
 /// `impl_core_helloworld_v1` to add implementations.
 ///
@@ -20,7 +22,7 @@ include!("collation_root_v1.rs.data");
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __make_provider {
-    ($ name : ty) => {
+    ($name:ty) => {
         #[clippy::msrv = "1.83"]
         impl $name {
             #[allow(dead_code)]
@@ -29,15 +31,18 @@ macro_rules! __make_provider {
         icu_provider::marker::impl_data_provider_never_marker!($name);
     };
 }
+
 #[doc(inline)]
 pub use __make_provider as make_provider;
+
+// Not public as it will only work locally due to needing access to the other macros.
 /// This macro requires the following crates:
 /// * `icu`
 /// * `icu_provider`
 /// * `zerovec`
 #[allow(unused_macros)]
 macro_rules! impl_data_provider {
-    ($ provider : ty) => {
+    ($provider:ty) => {
         make_provider!($provider);
         impl_collation_reordering_v1!($provider);
         impl_collation_diacritics_v1!($provider);
@@ -46,5 +51,6 @@ macro_rules! impl_data_provider {
         impl_collation_tailoring_v1!($provider);
         impl_collation_special_primaries_v1!($provider);
         impl_collation_root_v1!($provider);
+
     };
 }

--- a/provider/data/datetime/data/mod.rs
+++ b/provider/data/datetime/data/mod.rs
@@ -52,6 +52,8 @@ include!("datetime_names_year_japanext_v1.rs.data");
 include!("datetime_patterns_date_dangi_v1.rs.data");
 include!("datetime_names_month_roc_v1.rs.data");
 include!("datetime_names_year_japanese_v1.rs.data");
+
+
 /// Marks a type as a data provider. You can then use macros like
 /// `impl_core_helloworld_v1` to add implementations.
 ///
@@ -66,7 +68,7 @@ include!("datetime_names_year_japanese_v1.rs.data");
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __make_provider {
-    ($ name : ty) => {
+    ($name:ty) => {
         #[clippy::msrv = "1.83"]
         impl $name {
             #[allow(dead_code)]
@@ -75,8 +77,11 @@ macro_rules! __make_provider {
         icu_provider::marker::impl_data_provider_never_marker!($name);
     };
 }
+
 #[doc(inline)]
 pub use __make_provider as make_provider;
+
+// Not public as it will only work locally due to needing access to the other macros.
 /// This macro requires the following crates:
 /// * `alloc`
 /// * `icu`
@@ -86,7 +91,7 @@ pub use __make_provider as make_provider;
 /// * `zerovec`
 #[allow(unused_macros)]
 macro_rules! impl_data_provider {
-    ($ provider : ty) => {
+    ($provider:ty) => {
         make_provider!($provider);
         impl_datetime_names_year_ethiopian_v1!($provider);
         impl_datetime_patterns_date_ethiopian_v1!($provider);
@@ -141,5 +146,6 @@ macro_rules! impl_data_provider {
         impl_datetime_patterns_date_dangi_v1!($provider);
         impl_datetime_names_month_roc_v1!($provider);
         impl_datetime_names_year_japanese_v1!($provider);
+
     };
 }

--- a/provider/data/datetime/stubdata/mod.rs
+++ b/provider/data/datetime/stubdata/mod.rs
@@ -52,6 +52,8 @@ include!("datetime_names_year_japanext_v1.rs.data");
 include!("datetime_patterns_date_dangi_v1.rs.data");
 include!("datetime_names_month_roc_v1.rs.data");
 include!("datetime_names_year_japanese_v1.rs.data");
+
+
 /// Marks a type as a data provider. You can then use macros like
 /// `impl_core_helloworld_v1` to add implementations.
 ///
@@ -66,7 +68,7 @@ include!("datetime_names_year_japanese_v1.rs.data");
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __make_provider {
-    ($ name : ty) => {
+    ($name:ty) => {
         #[clippy::msrv = "1.83"]
         impl $name {
             #[allow(dead_code)]
@@ -75,14 +77,17 @@ macro_rules! __make_provider {
         icu_provider::marker::impl_data_provider_never_marker!($name);
     };
 }
+
 #[doc(inline)]
 pub use __make_provider as make_provider;
+
+// Not public as it will only work locally due to needing access to the other macros.
 /// This macro requires the following crates:
 /// * `icu`
 /// * `icu_provider`
 #[allow(unused_macros)]
 macro_rules! impl_data_provider {
-    ($ provider : ty) => {
+    ($provider:ty) => {
         make_provider!($provider);
         impl_datetime_names_year_ethiopian_v1!($provider);
         impl_datetime_patterns_date_ethiopian_v1!($provider);
@@ -137,5 +142,6 @@ macro_rules! impl_data_provider {
         impl_datetime_patterns_date_dangi_v1!($provider);
         impl_datetime_names_month_roc_v1!($provider);
         impl_datetime_names_year_japanese_v1!($provider);
+
     };
 }

--- a/provider/data/decimal/data/mod.rs
+++ b/provider/data/decimal/data/mod.rs
@@ -1,6 +1,8 @@
 // @generated
 include!("decimal_symbols_v1.rs.data");
 include!("decimal_digits_v1.rs.data");
+
+
 /// Marks a type as a data provider. You can then use macros like
 /// `impl_core_helloworld_v1` to add implementations.
 ///
@@ -15,7 +17,7 @@ include!("decimal_digits_v1.rs.data");
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __make_provider {
-    ($ name : ty) => {
+    ($name:ty) => {
         #[clippy::msrv = "1.83"]
         impl $name {
             #[allow(dead_code)]
@@ -24,8 +26,11 @@ macro_rules! __make_provider {
         icu_provider::marker::impl_data_provider_never_marker!($name);
     };
 }
+
 #[doc(inline)]
 pub use __make_provider as make_provider;
+
+// Not public as it will only work locally due to needing access to the other macros.
 /// This macro requires the following crates:
 /// * `icu`
 /// * `icu_provider`
@@ -33,9 +38,10 @@ pub use __make_provider as make_provider;
 /// * `zerovec`
 #[allow(unused_macros)]
 macro_rules! impl_data_provider {
-    ($ provider : ty) => {
+    ($provider:ty) => {
         make_provider!($provider);
         impl_decimal_symbols_v1!($provider);
         impl_decimal_digits_v1!($provider);
+
     };
 }

--- a/provider/data/decimal/stubdata/mod.rs
+++ b/provider/data/decimal/stubdata/mod.rs
@@ -1,6 +1,8 @@
 // @generated
 include!("decimal_symbols_v1.rs.data");
 include!("decimal_digits_v1.rs.data");
+
+
 /// Marks a type as a data provider. You can then use macros like
 /// `impl_core_helloworld_v1` to add implementations.
 ///
@@ -15,7 +17,7 @@ include!("decimal_digits_v1.rs.data");
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __make_provider {
-    ($ name : ty) => {
+    ($name:ty) => {
         #[clippy::msrv = "1.83"]
         impl $name {
             #[allow(dead_code)]
@@ -24,16 +26,20 @@ macro_rules! __make_provider {
         icu_provider::marker::impl_data_provider_never_marker!($name);
     };
 }
+
 #[doc(inline)]
 pub use __make_provider as make_provider;
+
+// Not public as it will only work locally due to needing access to the other macros.
 /// This macro requires the following crates:
 /// * `icu`
 /// * `icu_provider`
 #[allow(unused_macros)]
 macro_rules! impl_data_provider {
-    ($ provider : ty) => {
+    ($provider:ty) => {
         make_provider!($provider);
         impl_decimal_symbols_v1!($provider);
         impl_decimal_digits_v1!($provider);
+
     };
 }

--- a/provider/data/experimental/data/mod.rs
+++ b/provider/data/experimental/data/mod.rs
@@ -59,6 +59,8 @@ include!("units_names_duration_core_v1.rs.data");
 include!("currency_fractions_v1.rs.data");
 include!("units_info_v1.rs.data");
 include!("narrow_year_relative_v1.rs.data");
+
+
 /// Marks a type as a data provider. You can then use macros like
 /// `impl_core_helloworld_v1` to add implementations.
 ///
@@ -73,7 +75,7 @@ include!("narrow_year_relative_v1.rs.data");
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __make_provider {
-    ($ name : ty) => {
+    ($name:ty) => {
         #[clippy::msrv = "1.83"]
         impl $name {
             #[allow(dead_code)]
@@ -82,8 +84,11 @@ macro_rules! __make_provider {
         icu_provider::marker::impl_data_provider_never_marker!($name);
     };
 }
+
 #[doc(inline)]
 pub use __make_provider as make_provider;
+
+// Not public as it will only work locally due to needing access to the other macros.
 /// This macro requires the following crates:
 /// * `alloc`
 /// * `icu`
@@ -93,7 +98,7 @@ pub use __make_provider as make_provider;
 /// * `zerovec`
 #[allow(unused_macros)]
 macro_rules! impl_data_provider {
-    ($ provider : ty) => {
+    ($provider:ty) => {
         make_provider!($provider);
         impl_short_day_relative_v1!($provider);
         impl_long_second_relative_v1!($provider);
@@ -155,5 +160,6 @@ macro_rules! impl_data_provider {
         impl_currency_fractions_v1!($provider);
         impl_units_info_v1!($provider);
         impl_narrow_year_relative_v1!($provider);
+
     };
 }

--- a/provider/data/experimental/stubdata/mod.rs
+++ b/provider/data/experimental/stubdata/mod.rs
@@ -59,6 +59,8 @@ include!("units_names_duration_core_v1.rs.data");
 include!("currency_fractions_v1.rs.data");
 include!("units_info_v1.rs.data");
 include!("narrow_year_relative_v1.rs.data");
+
+
 /// Marks a type as a data provider. You can then use macros like
 /// `impl_core_helloworld_v1` to add implementations.
 ///
@@ -73,7 +75,7 @@ include!("narrow_year_relative_v1.rs.data");
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __make_provider {
-    ($ name : ty) => {
+    ($name:ty) => {
         #[clippy::msrv = "1.83"]
         impl $name {
             #[allow(dead_code)]
@@ -82,8 +84,11 @@ macro_rules! __make_provider {
         icu_provider::marker::impl_data_provider_never_marker!($name);
     };
 }
+
 #[doc(inline)]
 pub use __make_provider as make_provider;
+
+// Not public as it will only work locally due to needing access to the other macros.
 /// This macro requires the following crates:
 /// * `icu`
 /// * `icu_provider`
@@ -91,7 +96,7 @@ pub use __make_provider as make_provider;
 /// * `zerovec`
 #[allow(unused_macros)]
 macro_rules! impl_data_provider {
-    ($ provider : ty) => {
+    ($provider:ty) => {
         make_provider!($provider);
         impl_short_day_relative_v1!($provider);
         impl_long_second_relative_v1!($provider);
@@ -153,5 +158,6 @@ macro_rules! impl_data_provider {
         impl_currency_fractions_v1!($provider);
         impl_units_info_v1!($provider);
         impl_narrow_year_relative_v1!($provider);
+
     };
 }

--- a/provider/data/list/data/mod.rs
+++ b/provider/data/list/data/mod.rs
@@ -2,6 +2,8 @@
 include!("list_or_v1.rs.data");
 include!("list_and_v1.rs.data");
 include!("list_unit_v1.rs.data");
+
+
 /// Marks a type as a data provider. You can then use macros like
 /// `impl_core_helloworld_v1` to add implementations.
 ///
@@ -16,7 +18,7 @@ include!("list_unit_v1.rs.data");
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __make_provider {
-    ($ name : ty) => {
+    ($name:ty) => {
         #[clippy::msrv = "1.83"]
         impl $name {
             #[allow(dead_code)]
@@ -25,8 +27,11 @@ macro_rules! __make_provider {
         icu_provider::marker::impl_data_provider_never_marker!($name);
     };
 }
+
 #[doc(inline)]
 pub use __make_provider as make_provider;
+
+// Not public as it will only work locally due to needing access to the other macros.
 /// This macro requires the following crates:
 /// * `icu`
 /// * `icu_provider`
@@ -34,10 +39,11 @@ pub use __make_provider as make_provider;
 /// * `zerovec`
 #[allow(unused_macros)]
 macro_rules! impl_data_provider {
-    ($ provider : ty) => {
+    ($provider:ty) => {
         make_provider!($provider);
         impl_list_or_v1!($provider);
         impl_list_and_v1!($provider);
         impl_list_unit_v1!($provider);
+
     };
 }

--- a/provider/data/list/stubdata/mod.rs
+++ b/provider/data/list/stubdata/mod.rs
@@ -2,6 +2,8 @@
 include!("list_or_v1.rs.data");
 include!("list_and_v1.rs.data");
 include!("list_unit_v1.rs.data");
+
+
 /// Marks a type as a data provider. You can then use macros like
 /// `impl_core_helloworld_v1` to add implementations.
 ///
@@ -16,7 +18,7 @@ include!("list_unit_v1.rs.data");
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __make_provider {
-    ($ name : ty) => {
+    ($name:ty) => {
         #[clippy::msrv = "1.83"]
         impl $name {
             #[allow(dead_code)]
@@ -25,17 +27,21 @@ macro_rules! __make_provider {
         icu_provider::marker::impl_data_provider_never_marker!($name);
     };
 }
+
 #[doc(inline)]
 pub use __make_provider as make_provider;
+
+// Not public as it will only work locally due to needing access to the other macros.
 /// This macro requires the following crates:
 /// * `icu`
 /// * `icu_provider`
 #[allow(unused_macros)]
 macro_rules! impl_data_provider {
-    ($ provider : ty) => {
+    ($provider:ty) => {
         make_provider!($provider);
         impl_list_or_v1!($provider);
         impl_list_and_v1!($provider);
         impl_list_unit_v1!($provider);
+
     };
 }

--- a/provider/data/locale/data/mod.rs
+++ b/provider/data/locale/data/mod.rs
@@ -10,6 +10,8 @@ include!("locale_likely_subtags_extended_v1.rs.data");
 include!("locale_script_direction_v1.rs.data");
 include!("locale_likely_subtags_script_region_v1.rs.data");
 include!("locale_exemplar_characters_punctuation_v1.rs.data");
+
+
 /// Marks a type as a data provider. You can then use macros like
 /// `impl_core_helloworld_v1` to add implementations.
 ///
@@ -24,7 +26,7 @@ include!("locale_exemplar_characters_punctuation_v1.rs.data");
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __make_provider {
-    ($ name : ty) => {
+    ($name:ty) => {
         #[clippy::msrv = "1.83"]
         impl $name {
             #[allow(dead_code)]
@@ -33,8 +35,11 @@ macro_rules! __make_provider {
         icu_provider::marker::impl_data_provider_never_marker!($name);
     };
 }
+
 #[doc(inline)]
 pub use __make_provider as make_provider;
+
+// Not public as it will only work locally due to needing access to the other macros.
 /// This macro requires the following crates:
 /// * `icu`
 /// * `icu_locale_core`
@@ -43,7 +48,7 @@ pub use __make_provider as make_provider;
 /// * `zerovec`
 #[allow(unused_macros)]
 macro_rules! impl_data_provider {
-    ($ provider : ty) => {
+    ($provider:ty) => {
         make_provider!($provider);
         impl_locale_likely_subtags_language_v1!($provider);
         impl_locale_parents_v1!($provider);
@@ -56,5 +61,6 @@ macro_rules! impl_data_provider {
         impl_locale_script_direction_v1!($provider);
         impl_locale_likely_subtags_script_region_v1!($provider);
         impl_locale_exemplar_characters_punctuation_v1!($provider);
+
     };
 }

--- a/provider/data/locale/stubdata/mod.rs
+++ b/provider/data/locale/stubdata/mod.rs
@@ -10,6 +10,8 @@ include!("locale_likely_subtags_extended_v1.rs.data");
 include!("locale_script_direction_v1.rs.data");
 include!("locale_likely_subtags_script_region_v1.rs.data");
 include!("locale_exemplar_characters_punctuation_v1.rs.data");
+
+
 /// Marks a type as a data provider. You can then use macros like
 /// `impl_core_helloworld_v1` to add implementations.
 ///
@@ -24,7 +26,7 @@ include!("locale_exemplar_characters_punctuation_v1.rs.data");
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __make_provider {
-    ($ name : ty) => {
+    ($name:ty) => {
         #[clippy::msrv = "1.83"]
         impl $name {
             #[allow(dead_code)]
@@ -33,8 +35,11 @@ macro_rules! __make_provider {
         icu_provider::marker::impl_data_provider_never_marker!($name);
     };
 }
+
 #[doc(inline)]
 pub use __make_provider as make_provider;
+
+// Not public as it will only work locally due to needing access to the other macros.
 /// This macro requires the following crates:
 /// * `icu`
 /// * `icu_locale_core`
@@ -42,7 +47,7 @@ pub use __make_provider as make_provider;
 /// * `zerovec`
 #[allow(unused_macros)]
 macro_rules! impl_data_provider {
-    ($ provider : ty) => {
+    ($provider:ty) => {
         make_provider!($provider);
         impl_locale_likely_subtags_language_v1!($provider);
         impl_locale_parents_v1!($provider);
@@ -55,5 +60,6 @@ macro_rules! impl_data_provider {
         impl_locale_script_direction_v1!($provider);
         impl_locale_likely_subtags_script_region_v1!($provider);
         impl_locale_exemplar_characters_punctuation_v1!($provider);
+
     };
 }

--- a/provider/data/normalizer/data/mod.rs
+++ b/provider/data/normalizer/data/mod.rs
@@ -6,6 +6,8 @@ include!("normalizer_nfkd_tables_v1.rs.data");
 include!("normalizer_nfc_v1.rs.data");
 include!("normalizer_nfd_data_v1.rs.data");
 include!("normalizer_uts46_data_v1.rs.data");
+
+
 /// Marks a type as a data provider. You can then use macros like
 /// `impl_core_helloworld_v1` to add implementations.
 ///
@@ -20,7 +22,7 @@ include!("normalizer_uts46_data_v1.rs.data");
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __make_provider {
-    ($ name : ty) => {
+    ($name:ty) => {
         #[clippy::msrv = "1.83"]
         impl $name {
             #[allow(dead_code)]
@@ -29,15 +31,18 @@ macro_rules! __make_provider {
         icu_provider::marker::impl_data_provider_never_marker!($name);
     };
 }
+
 #[doc(inline)]
 pub use __make_provider as make_provider;
+
+// Not public as it will only work locally due to needing access to the other macros.
 /// This macro requires the following crates:
 /// * `icu`
 /// * `icu_provider`
 /// * `zerovec`
 #[allow(unused_macros)]
 macro_rules! impl_data_provider {
-    ($ provider : ty) => {
+    ($provider:ty) => {
         make_provider!($provider);
         impl_normalizer_nfd_tables_v1!($provider);
         impl_normalizer_nfd_supplement_v1!($provider);
@@ -46,5 +51,6 @@ macro_rules! impl_data_provider {
         impl_normalizer_nfc_v1!($provider);
         impl_normalizer_nfd_data_v1!($provider);
         impl_normalizer_uts46_data_v1!($provider);
+
     };
 }

--- a/provider/data/normalizer/stubdata/mod.rs
+++ b/provider/data/normalizer/stubdata/mod.rs
@@ -6,6 +6,8 @@ include!("normalizer_nfkd_tables_v1.rs.data");
 include!("normalizer_nfc_v1.rs.data");
 include!("normalizer_nfd_data_v1.rs.data");
 include!("normalizer_uts46_data_v1.rs.data");
+
+
 /// Marks a type as a data provider. You can then use macros like
 /// `impl_core_helloworld_v1` to add implementations.
 ///
@@ -20,7 +22,7 @@ include!("normalizer_uts46_data_v1.rs.data");
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __make_provider {
-    ($ name : ty) => {
+    ($name:ty) => {
         #[clippy::msrv = "1.83"]
         impl $name {
             #[allow(dead_code)]
@@ -29,15 +31,18 @@ macro_rules! __make_provider {
         icu_provider::marker::impl_data_provider_never_marker!($name);
     };
 }
+
 #[doc(inline)]
 pub use __make_provider as make_provider;
+
+// Not public as it will only work locally due to needing access to the other macros.
 /// This macro requires the following crates:
 /// * `icu`
 /// * `icu_provider`
 /// * `zerovec`
 #[allow(unused_macros)]
 macro_rules! impl_data_provider {
-    ($ provider : ty) => {
+    ($provider:ty) => {
         make_provider!($provider);
         impl_normalizer_nfd_tables_v1!($provider);
         impl_normalizer_nfd_supplement_v1!($provider);
@@ -46,5 +51,6 @@ macro_rules! impl_data_provider {
         impl_normalizer_nfc_v1!($provider);
         impl_normalizer_nfd_data_v1!($provider);
         impl_normalizer_uts46_data_v1!($provider);
+
     };
 }

--- a/provider/data/plurals/data/mod.rs
+++ b/provider/data/plurals/data/mod.rs
@@ -2,6 +2,8 @@
 include!("plurals_ordinal_v1.rs.data");
 include!("plurals_cardinal_v1.rs.data");
 include!("plurals_ranges_v1.rs.data");
+
+
 /// Marks a type as a data provider. You can then use macros like
 /// `impl_core_helloworld_v1` to add implementations.
 ///
@@ -16,7 +18,7 @@ include!("plurals_ranges_v1.rs.data");
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __make_provider {
-    ($ name : ty) => {
+    ($name:ty) => {
         #[clippy::msrv = "1.83"]
         impl $name {
             #[allow(dead_code)]
@@ -25,8 +27,11 @@ macro_rules! __make_provider {
         icu_provider::marker::impl_data_provider_never_marker!($name);
     };
 }
+
 #[doc(inline)]
 pub use __make_provider as make_provider;
+
+// Not public as it will only work locally due to needing access to the other macros.
 /// This macro requires the following crates:
 /// * `icu`
 /// * `icu_provider`
@@ -34,10 +39,11 @@ pub use __make_provider as make_provider;
 /// * `zerovec`
 #[allow(unused_macros)]
 macro_rules! impl_data_provider {
-    ($ provider : ty) => {
+    ($provider:ty) => {
         make_provider!($provider);
         impl_plurals_ordinal_v1!($provider);
         impl_plurals_cardinal_v1!($provider);
         impl_plurals_ranges_v1!($provider);
+
     };
 }

--- a/provider/data/plurals/stubdata/mod.rs
+++ b/provider/data/plurals/stubdata/mod.rs
@@ -2,6 +2,8 @@
 include!("plurals_ordinal_v1.rs.data");
 include!("plurals_cardinal_v1.rs.data");
 include!("plurals_ranges_v1.rs.data");
+
+
 /// Marks a type as a data provider. You can then use macros like
 /// `impl_core_helloworld_v1` to add implementations.
 ///
@@ -16,7 +18,7 @@ include!("plurals_ranges_v1.rs.data");
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __make_provider {
-    ($ name : ty) => {
+    ($name:ty) => {
         #[clippy::msrv = "1.83"]
         impl $name {
             #[allow(dead_code)]
@@ -25,17 +27,21 @@ macro_rules! __make_provider {
         icu_provider::marker::impl_data_provider_never_marker!($name);
     };
 }
+
 #[doc(inline)]
 pub use __make_provider as make_provider;
+
+// Not public as it will only work locally due to needing access to the other macros.
 /// This macro requires the following crates:
 /// * `icu`
 /// * `icu_provider`
 #[allow(unused_macros)]
 macro_rules! impl_data_provider {
-    ($ provider : ty) => {
+    ($provider:ty) => {
         make_provider!($provider);
         impl_plurals_ordinal_v1!($provider);
         impl_plurals_cardinal_v1!($provider);
         impl_plurals_ranges_v1!($provider);
+
     };
 }

--- a/provider/data/properties/data/mod.rs
+++ b/provider/data/properties/data/mod.rs
@@ -136,6 +136,8 @@ include!("property_binary_default_ignorable_code_point_v1.rs.data");
 include!("property_binary_extended_pictographic_v1.rs.data");
 include!("property_name_parse_vertical_orientation_v1.rs.data");
 include!("property_name_parse_canonical_combining_class_v1.rs.data");
+
+
 /// Marks a type as a data provider. You can then use macros like
 /// `impl_core_helloworld_v1` to add implementations.
 ///
@@ -150,7 +152,7 @@ include!("property_name_parse_canonical_combining_class_v1.rs.data");
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __make_provider {
-    ($ name : ty) => {
+    ($name:ty) => {
         #[clippy::msrv = "1.83"]
         impl $name {
             #[allow(dead_code)]
@@ -159,8 +161,11 @@ macro_rules! __make_provider {
         icu_provider::marker::impl_data_provider_never_marker!($name);
     };
 }
+
 #[doc(inline)]
 pub use __make_provider as make_provider;
+
+// Not public as it will only work locally due to needing access to the other macros.
 /// This macro requires the following crates:
 /// * `icu`
 /// * `icu_provider`
@@ -168,7 +173,7 @@ pub use __make_provider as make_provider;
 /// * `zerovec`
 #[allow(unused_macros)]
 macro_rules! impl_data_provider {
-    ($ provider : ty) => {
+    ($provider:ty) => {
         make_provider!($provider);
         impl_property_enum_indic_syllabic_category_v1!($provider);
         impl_property_binary_pattern_syntax_v1!($provider);
@@ -307,5 +312,6 @@ macro_rules! impl_data_provider {
         impl_property_binary_extended_pictographic_v1!($provider);
         impl_property_name_parse_vertical_orientation_v1!($provider);
         impl_property_name_parse_canonical_combining_class_v1!($provider);
+
     };
 }

--- a/provider/data/properties/stubdata/mod.rs
+++ b/provider/data/properties/stubdata/mod.rs
@@ -136,6 +136,8 @@ include!("property_binary_default_ignorable_code_point_v1.rs.data");
 include!("property_binary_extended_pictographic_v1.rs.data");
 include!("property_name_parse_vertical_orientation_v1.rs.data");
 include!("property_name_parse_canonical_combining_class_v1.rs.data");
+
+
 /// Marks a type as a data provider. You can then use macros like
 /// `impl_core_helloworld_v1` to add implementations.
 ///
@@ -150,7 +152,7 @@ include!("property_name_parse_canonical_combining_class_v1.rs.data");
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __make_provider {
-    ($ name : ty) => {
+    ($name:ty) => {
         #[clippy::msrv = "1.83"]
         impl $name {
             #[allow(dead_code)]
@@ -159,8 +161,11 @@ macro_rules! __make_provider {
         icu_provider::marker::impl_data_provider_never_marker!($name);
     };
 }
+
 #[doc(inline)]
 pub use __make_provider as make_provider;
+
+// Not public as it will only work locally due to needing access to the other macros.
 /// This macro requires the following crates:
 /// * `icu`
 /// * `icu_provider`
@@ -168,7 +173,7 @@ pub use __make_provider as make_provider;
 /// * `zerovec`
 #[allow(unused_macros)]
 macro_rules! impl_data_provider {
-    ($ provider : ty) => {
+    ($provider:ty) => {
         make_provider!($provider);
         impl_property_enum_indic_syllabic_category_v1!($provider);
         impl_property_binary_pattern_syntax_v1!($provider);
@@ -307,5 +312,6 @@ macro_rules! impl_data_provider {
         impl_property_binary_extended_pictographic_v1!($provider);
         impl_property_name_parse_vertical_orientation_v1!($provider);
         impl_property_name_parse_canonical_combining_class_v1!($provider);
+
     };
 }

--- a/provider/data/segmenter/data/mod.rs
+++ b/provider/data/segmenter/data/mod.rs
@@ -8,6 +8,8 @@ include!("segmenter_lstm_auto_v1.rs.data");
 include!("segmenter_break_word_v1.rs.data");
 include!("segmenter_break_word_override_v1.rs.data");
 include!("segmenter_break_sentence_override_v1.rs.data");
+
+
 /// Marks a type as a data provider. You can then use macros like
 /// `impl_core_helloworld_v1` to add implementations.
 ///
@@ -22,7 +24,7 @@ include!("segmenter_break_sentence_override_v1.rs.data");
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __make_provider {
-    ($ name : ty) => {
+    ($name:ty) => {
         #[clippy::msrv = "1.83"]
         impl $name {
             #[allow(dead_code)]
@@ -31,8 +33,11 @@ macro_rules! __make_provider {
         icu_provider::marker::impl_data_provider_never_marker!($name);
     };
 }
+
 #[doc(inline)]
 pub use __make_provider as make_provider;
+
+// Not public as it will only work locally due to needing access to the other macros.
 /// This macro requires the following crates:
 /// * `icu`
 /// * `icu_provider`
@@ -40,7 +45,7 @@ pub use __make_provider as make_provider;
 /// * `zerovec`
 #[allow(unused_macros)]
 macro_rules! impl_data_provider {
-    ($ provider : ty) => {
+    ($provider:ty) => {
         make_provider!($provider);
         impl_segmenter_break_sentence_v1!($provider);
         impl_segmenter_dictionary_auto_v1!($provider);
@@ -51,5 +56,6 @@ macro_rules! impl_data_provider {
         impl_segmenter_break_word_v1!($provider);
         impl_segmenter_break_word_override_v1!($provider);
         impl_segmenter_break_sentence_override_v1!($provider);
+
     };
 }

--- a/provider/data/segmenter/stubdata/mod.rs
+++ b/provider/data/segmenter/stubdata/mod.rs
@@ -8,6 +8,8 @@ include!("segmenter_lstm_auto_v1.rs.data");
 include!("segmenter_break_word_v1.rs.data");
 include!("segmenter_break_word_override_v1.rs.data");
 include!("segmenter_break_sentence_override_v1.rs.data");
+
+
 /// Marks a type as a data provider. You can then use macros like
 /// `impl_core_helloworld_v1` to add implementations.
 ///
@@ -22,7 +24,7 @@ include!("segmenter_break_sentence_override_v1.rs.data");
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __make_provider {
-    ($ name : ty) => {
+    ($name:ty) => {
         #[clippy::msrv = "1.83"]
         impl $name {
             #[allow(dead_code)]
@@ -31,15 +33,18 @@ macro_rules! __make_provider {
         icu_provider::marker::impl_data_provider_never_marker!($name);
     };
 }
+
 #[doc(inline)]
 pub use __make_provider as make_provider;
+
+// Not public as it will only work locally due to needing access to the other macros.
 /// This macro requires the following crates:
 /// * `icu`
 /// * `icu_provider`
 /// * `zerovec`
 #[allow(unused_macros)]
 macro_rules! impl_data_provider {
-    ($ provider : ty) => {
+    ($provider:ty) => {
         make_provider!($provider);
         impl_segmenter_break_sentence_v1!($provider);
         impl_segmenter_dictionary_auto_v1!($provider);
@@ -50,5 +55,6 @@ macro_rules! impl_data_provider {
         impl_segmenter_break_word_v1!($provider);
         impl_segmenter_break_word_override_v1!($provider);
         impl_segmenter_break_sentence_override_v1!($provider);
+
     };
 }

--- a/provider/data/time/data/mod.rs
+++ b/provider/data/time/data/mod.rs
@@ -3,6 +3,8 @@ include!("timezone_identifiers_iana_extended_v1.rs.data");
 include!("timezone_identifiers_windows_v1.rs.data");
 include!("timezone_periods_v1.rs.data");
 include!("timezone_identifiers_iana_core_v1.rs.data");
+
+
 /// Marks a type as a data provider. You can then use macros like
 /// `impl_core_helloworld_v1` to add implementations.
 ///
@@ -17,7 +19,7 @@ include!("timezone_identifiers_iana_core_v1.rs.data");
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __make_provider {
-    ($ name : ty) => {
+    ($name:ty) => {
         #[clippy::msrv = "1.83"]
         impl $name {
             #[allow(dead_code)]
@@ -26,8 +28,11 @@ macro_rules! __make_provider {
         icu_provider::marker::impl_data_provider_never_marker!($name);
     };
 }
+
 #[doc(inline)]
 pub use __make_provider as make_provider;
+
+// Not public as it will only work locally due to needing access to the other macros.
 /// This macro requires the following crates:
 /// * `icu`
 /// * `icu_provider`
@@ -35,11 +40,12 @@ pub use __make_provider as make_provider;
 /// * `zerovec`
 #[allow(unused_macros)]
 macro_rules! impl_data_provider {
-    ($ provider : ty) => {
+    ($provider:ty) => {
         make_provider!($provider);
         impl_timezone_identifiers_iana_extended_v1!($provider);
         impl_timezone_identifiers_windows_v1!($provider);
         impl_timezone_periods_v1!($provider);
         impl_timezone_identifiers_iana_core_v1!($provider);
+
     };
 }

--- a/provider/data/time/stubdata/mod.rs
+++ b/provider/data/time/stubdata/mod.rs
@@ -3,6 +3,8 @@ include!("timezone_identifiers_iana_extended_v1.rs.data");
 include!("timezone_identifiers_windows_v1.rs.data");
 include!("timezone_periods_v1.rs.data");
 include!("timezone_identifiers_iana_core_v1.rs.data");
+
+
 /// Marks a type as a data provider. You can then use macros like
 /// `impl_core_helloworld_v1` to add implementations.
 ///
@@ -17,7 +19,7 @@ include!("timezone_identifiers_iana_core_v1.rs.data");
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __make_provider {
-    ($ name : ty) => {
+    ($name:ty) => {
         #[clippy::msrv = "1.83"]
         impl $name {
             #[allow(dead_code)]
@@ -26,8 +28,11 @@ macro_rules! __make_provider {
         icu_provider::marker::impl_data_provider_never_marker!($name);
     };
 }
+
 #[doc(inline)]
 pub use __make_provider as make_provider;
+
+// Not public as it will only work locally due to needing access to the other macros.
 /// This macro requires the following crates:
 /// * `icu`
 /// * `icu_provider`
@@ -35,11 +40,12 @@ pub use __make_provider as make_provider;
 /// * `zerovec`
 #[allow(unused_macros)]
 macro_rules! impl_data_provider {
-    ($ provider : ty) => {
+    ($provider:ty) => {
         make_provider!($provider);
         impl_timezone_identifiers_iana_extended_v1!($provider);
         impl_timezone_identifiers_windows_v1!($provider);
         impl_timezone_periods_v1!($provider);
         impl_timezone_identifiers_iana_core_v1!($provider);
+
     };
 }


### PR DESCRIPTION
Baked data is set up to run rustfmt on generated files, if available.

In Google's build system, we don't do that, because the hermetic build won't have a rustfmt binary available. This might be fixable with some work.

Either way, this isn't usually a big deal: baked data isn't meant to be legible anyway.

However, the mod.rs file is useful: you might need to edit it when adding a more markers. It's nice for it to always be formatted to make this easy.

Also, mod.rs is not that interesting a file from a codegen point of view anyway: the benefit of using token streams is slight to nonexistant.