### PR TITLE
Use checked arithmetic in dense ZeroTrie

### DIFF
--- a/utils/zerotrie/src/dense.rs
+++ b/utils/zerotrie/src/dense.rs
@@ -209,7 +209,15 @@ impl<'a> ZeroAsciiDenseSparse2dTrieBorrowed<'a> {
             // There is an entry in the dense matrix but it is a None value
             return None;
         }
-        usize::from(offset).checked_add(row_value_offset)
+        let Some(result) = usize::from(offset).checked_add(row_value_offset) else {
+            debug_assert!(
+                false,
+                "overflow: offset={}, row_value_offset={}",
+                offset, row_value_offset
+            );
+            return None;
+        };
+        Some(result)
     }
 
     /// Borrows the structure for encoding into [`zerovec`].


### PR DESCRIPTION
Closes #7442 
Adds overflow protection to `ZeroAsciiDenseSparse2dTrieBorrowed::get()` using checked arithmetic operations.

### Changes

**File**: utils/zerotrie/src/dense.rs

1. **Matrix indexing** now uses `checked_mul()` and `checked_add()`
2. **Final value calculation** uses `checked_add()` which perevents overflow when adding offset to row_value_offset

## Changelog: N/A

This is a new unreleased type.