### PR TITLE
Safely handle panics in the replace_cart callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,7 @@ Fully filled in up to 30c187f4b7
     - `yoke`, `yoke_derive`: `0.8.1 -> ???`
         - impl common traits (Display, PartialEq/Eq, PartialOrd/Ord) (#7400)
         - derive: Allow trait bounds in `where` clauses (unicode-org#7230)
+        - Safely handle panics in the `replace_cart` callback, additionally fixing OOM safety issue in `wrap_cart_in_*` (unicode-org#7456)
     - `zerofrom`: No change (`0.1.6`)
     - `zerotrie`: `0.2.3 -> ???`
         - Add `ZeroAsciiDenseSparse2dTrie` for more efficient storage of data keys with many attributes (unicode-org#7264, unicode-org#7304, unicode-org#7305)

--- a/utils/yoke/src/yoke.rs
+++ b/utils/yoke/src/yoke.rs
@@ -10,6 +10,7 @@ use crate::kinda_sorta_dangling::KindaSortaDangling;
 use crate::utils;
 use crate::Yokeable;
 use core::marker::PhantomData;
+use core::mem::ManuallyDrop;
 use core::ops::Deref;
 use stable_deref_trait::StableDeref;
 
@@ -453,7 +454,6 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
     ///
     /// # Safety
     ///
-    /// - `f()` must not panic
     /// - References from the yokeable `Y` should still be valid for the lifetime of the
     ///   returned cart type `C`.
     ///
@@ -468,18 +468,25 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
     ///   I.e., if C contains an `fn(&'a u8)`, it cannot be replaced with `fn(&'static u8),
     ///   even though that is typically safe.
     ///
+    /// Note: `f` *is* allowed to panic.
+    ///
     /// Typically, this means implementing `f` as something which _wraps_ the inner cart type `C`.
     /// `Yoke` only really cares about destructors for its carts so it's fine to erase other
     /// information about the cart, as long as the backing data will still be destroyed at the
     /// same time.
     #[inline]
     pub unsafe fn replace_cart<C2>(self, f: impl FnOnce(C) -> C2) -> Yoke<Y, C2> {
+        let yokeable = ManuallyDrop::new(self.yokeable);
+        let cart = f(self.cart);
         Yoke {
             // Safety note: the safety invariant of this function guarantees that
             // the data that the yokeable references has its ownership (if any)
-            // transferred to the new cart before self.cart is dropped.
-            yokeable: self.yokeable,
-            cart: f(self.cart),
+            // transferred to the new cart before self.cart is dropped, unless
+            // `f` panics, in which case the above `ManuallyDrop` ensures that
+            // the yokeable is leaked (preventing any UB from dropping the
+            // yokeable after its cart).
+            yokeable: ManuallyDrop::into_inner(yokeable),
+            cart,
         }
     }
 
@@ -1560,6 +1567,7 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
     #[inline]
     pub fn wrap_cart_in_box(self) -> Yoke<Y, Box<C>> {
         // Safety: safe because the cart is preserved, as it is just wrapped.
+        // `replace_cart()` explicitly allows panics.
         unsafe { self.replace_cart(Box::new) }
     }
     /// Helper function allowing one to wrap the cart type `C` in an `Rc<T>`.
@@ -1569,7 +1577,8 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
     /// ✨ *Enabled with the `alloc` Cargo feature.*
     #[inline]
     pub fn wrap_cart_in_rc(self) -> Yoke<Y, Rc<C>> {
-        // Safety: safe because the cart is preserved, as it is just wrapped
+        // Safety: safe because the cart is preserved, as it is just wrapped.
+        // `replace_cart()` explicitly allows panics.
         unsafe { self.replace_cart(Rc::new) }
     }
     /// Helper function allowing one to wrap the cart type `C` in an `Arc<T>`.
@@ -1579,7 +1588,8 @@ impl<Y: for<'a> Yokeable<'a>, C> Yoke<Y, C> {
     /// ✨ *Enabled with the `alloc` Cargo feature.*
     #[inline]
     pub fn wrap_cart_in_arc(self) -> Yoke<Y, Arc<C>> {
-        // Safety: safe because the cart is preserved, as it is just wrapped
+        // Safety: safe because the cart is preserved, as it is just wrapped.
+        // `replace_cart()` explicitly allows panics.
         unsafe { self.replace_cart(Arc::new) }
     }
 }


### PR DESCRIPTION
Fixes #7431


## Changelog

yoke: Handle potential UB around panicky callbacks in `replace_cart`