### PR TITLE
Don't allow pushing a `true` tag into `Value`

### DIFF
--- a/components/locale_core/src/extensions/unicode/value.rs
+++ b/components/locale_core/src/extensions/unicode/value.rs
@@ -139,6 +139,8 @@ impl Value {
     ///
     /// let mut v = Value::default();
     /// v.push_subtag(subtag!("foo"));
+    /// // The `true` subtag is ignored
+    /// v.push_subtag(subtag!("true"));
     /// v.push_subtag(subtag!("bar"));
     /// assert_eq!(v, "foo-bar");
     /// ```


### PR DESCRIPTION
That breaks the invariant that the `Value` is in canonical form.

See #6698 