### PR TITLE
Reorder DateDuration methods to group related methods (no API change)

### DIFF
--- a/components/calendar/src/duration.rs
+++ b/components/calendar/src/duration.rs
@@ -246,17 +246,6 @@ pub enum DateDurationParseError {
 }
 
 impl DateDuration {
-    /// Returns a new [`DateDuration`] representing a number of years.
-    pub fn for_years(years: i32) -> Self {
-        Self {
-            is_negative: years.is_negative(),
-            years: years.unsigned_abs(),
-            ..Default::default()
-        }
-    }
-}
-
-impl DateDuration {
     /// Parses an ISO 8601 date-only duration string into a [`DateDuration`].
     ///
     /// This is a wrapper around [`Self::try_from_utf8`] for UTF-8
@@ -366,6 +355,15 @@ impl DateDuration {
             weeks,
             days,
         })
+    }
+
+    /// Returns a new [`DateDuration`] representing a number of years.
+    pub fn for_years(years: i32) -> Self {
+        Self {
+            is_negative: years.is_negative(),
+            years: years.unsigned_abs(),
+            ..Default::default()
+        }
     }
 
     /// Returns a new [`DateDuration`] representing a number of months.


### PR DESCRIPTION
Don't know why it was arranged like that, but this makes the docs look neater.

I think this fixes https://github.com/unicode-org/icu4x/issues/7059 as it was the only issue I found during API review. WG members are encouraged to do their own API review if they want to double check.


## Changelog: N/A
