### PR TITLE
Add shared helper to assert consistency across collator comparison paths

### DIFF
--- a/components/collator/tests/tests.rs
+++ b/components/collator/tests/tests.rs
@@ -119,13 +119,9 @@ fn check_expectations(
     right: &[&str],
     expectations: &[Ordering],
 ) {
-    let mut left_iter = left.iter();
-    let mut right_iter = right.iter();
-    let mut expect_iter = expectations.iter();
-    while let (Some(left_str), Some(right_str), Some(expectation)) =
-        (left_iter.next(), right_iter.next(), expect_iter.next())
+    for ((left_str, right_str), expected) in left.iter().zip(right.iter()).zip(expectations.iter())
     {
-        assert_eq!(collator.compare(left_str, right_str), *expectation);
+        assert_all_comparisons(collator, left_str, right_str, *expected);
     }
 }
 
@@ -1561,11 +1557,7 @@ fn test_basics() {
     {
         let collator = Collator::try_new(Default::default(), options).unwrap();
 
-        for ((left_str, right_str), expected) in
-            left.iter().zip(right.iter()).zip(expectations.iter())
-        {
-            assert_all_comparisons(&collator, left_str, right_str, *expected);
-        }
+        check_expectations(&collator, &left, &right, &expectations);
     }
 }
 


### PR DESCRIPTION
Fixes #6855 

This PR adds a small shared test helper `assert_all_comparisons` that verifies all supported comparison paths (utf-8, utf-16, and sort keys) and ensure consistent ordering results.

The helper is placed alongside existing test utilities and is used in a few tests to reduce duplication and improve coverage of comparison invariants.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->


## Changelog: N/A


