### PR TITLE
Start producing Meiji era only after Meiji 6

### DIFF
--- a/provider/source/src/calendar/eras.rs
+++ b/provider/source/src/calendar/eras.rs
@@ -185,7 +185,13 @@ fn test_calendar_eras() {
         for (idx, (_, era)) in data.eras.iter().enumerate() {
             let (in_era_iso, not_in_era_iso) = match (era.start, era.end) {
                 (Some(start), None) => {
-                    let start = Date::try_new_iso(start.year, start.month, start.day).unwrap();
+                    let year = if era.code == "meiji" {
+                        // Meiji starts roundtripping only after Meiji 6
+                        start.year + 5
+                    } else {
+                        start.year
+                    };
+                    let start = Date::try_new_iso(year, start.month, start.day).unwrap();
                     (start, Date::from_rata_die(start.to_rata_die() - 1, Iso))
                 }
                 (None, Some(end)) => {
@@ -233,7 +239,16 @@ fn test_calendar_eras() {
             }
 
             // Check that the start/end date uses year 1, and minimal/maximal month/day
-            assert_eq!(era_year.year, 1, "Didn't get correct year for {in_era:?}");
+            let expected_year = if era.code == "meiji" {
+                // We started at Meiji 6 for Meiji only, above
+                6
+            } else {
+                1
+            };
+            assert_eq!(
+                era_year.year, expected_year,
+                "Didn't get correct year for {in_era:?}"
+            );
 
             if calendar == "japanese" {
                 // Japanese is the only calendar that doesn't start eras on a new year


### PR DESCRIPTION
See https://github.com/tc39/proposal-intl-era-monthcode/pull/102

We already have a note about this in our docs, but the calendar switchover happened in Meiji 6, which means dates specified as Meiji 1-5 are unambiguously lunisolar. We're already liberal in accepting eraYears that are not in range of the era, which means we can't (and shouldn't) do much about people plugging dates specified as Meiji 1-5, but we can avoid producing such dates.

Matching Temporal seems like the right call to me here.

If matching Temporal here is not desired this can in theory be patched over in temporal_rs and Firefox (@hsivonen), but I feel convinced by the Temporal discussions.


## Changelog

icu_calendar: Start producing Meiji era only after Meiji 6

