### PR TITLE
Expose the UTS 46 virama check using UTS 46 data

### DIFF
--- a/components/normalizer/src/lib.rs
+++ b/components/normalizer/src/lib.rs
@@ -234,6 +234,7 @@ const LOW_ZEROS_MASK: u32 = 0xFFE0;
 /// combining class.
 ///
 /// See trie-value-format.md
+#[inline]
 fn trie_value_has_ccc(trie_value: u32) -> bool {
     (trie_value & 0x3FFFFE00) == 0xD800
 }

--- a/components/normalizer/src/uts46.rs
+++ b/components/normalizer/src/uts46.rs
@@ -62,6 +62,25 @@ impl Uts46MapperBorrowed<'static> {
 }
 
 impl Uts46MapperBorrowed<'_> {
+    /// Returns `true` iff the canonical combining class of `c` is 9 (Virama).
+    ///
+    /// This method uses the UTS 46 data and does not add a dependency on NFD
+    /// data like `CanonicalCombiningClassMapBorrowed` does.
+    #[inline]
+    pub fn is_virama(&self, c: char) -> bool {
+        let trie_val = self
+            .normalizer
+            .decomposing_normalizer
+            .decompositions
+            .trie
+            .get(c);
+        if crate::trie_value_has_ccc(trie_val) {
+            (trie_val as u8) == 9
+        } else {
+            false
+        }
+    }
+
     /// Returns an iterator adaptor that turns an `Iterator` over `char`
     /// into an iterator yielding a `char` sequence that gets the following
     /// operations from the "Map" and "Normalize" steps of the "Processing"


### PR DESCRIPTION
This reduces the optimized wasm size of dependents that don't use icu_normalizer or icu_collator for other purposes by 16.7 KB.

This does not break compat with the current `idna_adapter` but this allows for a new version of `idna_adapter` that uses this and then provides the 16.7 KB size saving.

Let's get this into ICU4X 2.2.


## Changelog

icu_normalizer: Expose the UTS 46 virama check using UTS 46 data
