### PR TITLE
Optimized get_u8 by avoiding char->u32 conversion

### DIFF
--- a/components/normalizer/src/properties.rs
+++ b/components/normalizer/src/properties.rs
@@ -571,7 +571,12 @@ impl CanonicalCombiningClassMapBorrowed<'_> {
     /// `CanonicalCombiningClass`.
     #[inline(always)]
     pub fn get_u8(&self, c: char) -> u8 {
-        self.get32_u8(u32::from(c))
+        let trie_value = self.decompositions.trie.get(c);
+        if trie_value_has_ccc(trie_value) {
+            trie_value as u8
+        } else {
+            ccc!(NotReordered, 0).to_icu4c_value()
+        }
     }
 
     /// Look up the canonical combining class for a scalar value


### PR DESCRIPTION
Fixes #7506 

Summary :- 
In `CanonicalCombiningClassMapBorrowed::get_u8()`, it was converting a `char` to `<u32>` and then calling `get32_u8()`, which throws away range information that the trie can use for optimization.
This PR changes `get_u8()` to query the trie directly by char using `trie.get(c)` instead of first converting to `<u32>`. This preserves the range information and avoids having to re establish it internally in the trie lookup.


## Changelog: N/A
