### PR TITLE
Testing date-time-zone formatting for locales with nondefault appendItems

### DIFF
--- a/components/datetime/tests/fixtures/tests/components_with_zones.json
+++ b/components/datetime/tests/fixtures/tests/components_with_zones.json
@@ -170,7 +170,7 @@
             }
         }
     },
-{
+    {
         "description": "Full date time example with long generic time zone. For locale with non-default timezone appendItem (zh, {1}{0} rather than {1} {0}).",
         "input": {
             "value": "2020-01-21T08:25:07.000+05:00",


### PR DESCRIPTION
Follow-up on #7416. Adds testing data for 'zh' and 'cv' locales, which have non-default timezone append patterns under the Gregorian calendar.

## Changelog: N/A

