### PR TITLE
Reduce year validity range to 500,000

### DIFF
--- a/components/calendar/src/cal/buddhist.rs
+++ b/components/calendar/src/cal/buddhist.rs
@@ -72,7 +72,7 @@ impl Date<Buddhist> {
     /// Construct a new Buddhist [`Date`].
     ///
     /// Years are arithmetic, meaning there is a year 0 preceded by negative years, with a
-    /// valid range of `-1,000,000..=1,000,000`.
+    /// valid range of `-500,000..=500,000`.
     ///
     /// ```rust
     /// use icu::calendar::Date;

--- a/components/calendar/src/cal/coptic.rs
+++ b/components/calendar/src/cal/coptic.rs
@@ -238,7 +238,7 @@ impl Date<Coptic> {
     /// Construct new Coptic [`Date`].
     ///
     /// Years are arithmetic, meaning there is a year 0 preceded by negative years, with a
-    /// valid range of `-1,000,000..=1,000,000`.
+    /// valid range of `-500,000..=500,000`.
     ///
     /// ```rust
     /// use icu::calendar::Date;

--- a/components/calendar/src/cal/east_asian_traditional.rs
+++ b/components/calendar/src/cal/east_asian_traditional.rs
@@ -487,7 +487,7 @@ impl Date<KoreanTraditional> {
     /// Construct a new traditional Korean [`Date`].
     ///
     /// Years are arithmetic, meaning there is a year 0 preceded by negative years, with a
-    /// valid range of `-1,000,000..=1,000,000`.
+    /// valid range of `-500,000..=500,000`.
     ///
     /// ```rust
     /// use icu::calendar::Date;
@@ -830,7 +830,7 @@ impl Date<ChineseTraditional> {
     /// Construct a new traditional Chinese [`Date`].
     ///
     /// Years are arithmetic, meaning there is a year 0 preceded by negative years, with a
-    /// valid range of `-1,000,000..=1,000,000`.
+    /// valid range of `-500,000..=500,000`.
     ///
     /// ```rust
     /// use icu::calendar::Date;

--- a/components/calendar/src/cal/ethiopian.rs
+++ b/components/calendar/src/cal/ethiopian.rs
@@ -282,7 +282,7 @@ impl Date<Ethiopian> {
     /// Construct new Ethiopian [`Date`].
     ///
     /// Years are arithmetic, meaning there is a year 0 preceded by negative years, with a
-    /// valid range of `-1,000,000..=1,000,000`.
+    /// valid range of `-500,000..=500,000`.
     ///
     /// Years are interpreted according to the provided `era_style`.
     ///

--- a/components/calendar/src/cal/gregorian.rs
+++ b/components/calendar/src/cal/gregorian.rs
@@ -123,7 +123,7 @@ impl Date<Gregorian> {
     /// Construct a new Gregorian [`Date`].
     ///
     /// Years are arithmetic, meaning there is a year 0 preceded by negative years, with a
-    /// valid range of `-1,000,000..=1,000,000`.
+    /// valid range of `-500,000..=500,000`.
     ///
     /// ```rust
     /// use icu::calendar::Date;

--- a/components/calendar/src/cal/hebrew.rs
+++ b/components/calendar/src/cal/hebrew.rs
@@ -351,7 +351,7 @@ impl Date<Hebrew> {
     /// Construct a new Hebrew [`Date`].
     ///
     /// Years are arithmetic, meaning there is a year 0 preceded by negative years, with a
-    /// valid range of `-1,000,000..=1,000,000`.
+    /// valid range of `-500,000..=500,000`.
     ///
     /// ```rust
     /// use icu::calendar::Date;

--- a/components/calendar/src/cal/hijri.rs
+++ b/components/calendar/src/cal/hijri.rs
@@ -989,7 +989,7 @@ impl<A: AsCalendar<Calendar = Hijri<R>>, R: Rules> Date<A> {
     /// Construct new Hijri [`Date`].
     ///
     /// Years are arithmetic, meaning there is a year 0 preceded by negative years, with a
-    /// valid range of `-1,000,000..=1,000,000`.
+    /// valid range of `-500,000..=500,000`.
     ///
     /// ```rust
     /// use icu::calendar::cal::Hijri;

--- a/components/calendar/src/cal/indian.rs
+++ b/components/calendar/src/cal/indian.rs
@@ -293,7 +293,7 @@ impl Date<Indian> {
     /// Construct new Indian [`Date`].
     ///
     /// Years are arithmetic, meaning there is a year 0 preceded by negative years, with a
-    /// valid range of `-1,000,000..=1,000,000`.
+    /// valid range of `-500,000..=500,000`.
     ///
     /// ```rust
     /// use icu::calendar::Date;

--- a/components/calendar/src/cal/iso.rs
+++ b/components/calendar/src/cal/iso.rs
@@ -60,7 +60,7 @@ impl Date<Iso> {
     /// Construct a new ISO [`Date`].
     ///
     /// Years are arithmetic, meaning there is a year 0 preceded by negative years, with a
-    /// valid range of `-1,000,000..=1,000,000`.
+    /// valid range of `-500,000..=500,000`.
     ///
     /// ```rust
     /// use icu::calendar::Date;
@@ -109,18 +109,18 @@ mod test {
         let cases = [
             // Clamping RD
             TestCase {
-                year: -1005513,
-                month: 1,
-                day: 3,
+                year: -505503,
+                month: 4,
+                day: 10,
                 rd: *VALID_RD_RANGE.start() - 100000,
                 invalid_ymd: true,
                 clamping_rd: true,
             },
             // Lowest allowed RD
             TestCase {
-                year: -1005513,
-                month: 1,
-                day: 3,
+                year: -505503,
+                month: 4,
+                day: 10,
                 rd: *VALID_RD_RANGE.start(),
                 invalid_ymd: true,
                 clamping_rd: false,
@@ -130,7 +130,7 @@ mod test {
                 year: *VALID_YEAR_RANGE.start(),
                 month: 1,
                 day: 1,
-                rd: RataDie::new(-365242865),
+                rd: RataDie::new(-182621615),
                 invalid_ymd: false,
                 clamping_rd: false,
             },
@@ -139,13 +139,13 @@ mod test {
                 year: *VALID_YEAR_RANGE.end(),
                 month: 12,
                 day: 31,
-                rd: RataDie::new(365242500),
+                rd: RataDie::new(182621250),
                 invalid_ymd: false,
                 clamping_rd: false,
             },
             // Highest allowed RD
             TestCase {
-                year: 1001911,
+                year: 501911,
                 month: 12,
                 day: 31,
                 rd: *VALID_RD_RANGE.end(),
@@ -154,7 +154,7 @@ mod test {
             },
             // Clamping RD
             TestCase {
-                year: 1001911,
+                year: 501911,
                 month: 12,
                 day: 31,
                 rd: *VALID_RD_RANGE.end() + 100000,
@@ -168,9 +168,9 @@ mod test {
             let date_from_ymd = Date::try_new_iso(case.year, case.month, case.day);
 
             if !case.clamping_rd {
-                assert_eq!(date_from_rd.to_rata_die(), case.rd);
+                assert_eq!(date_from_rd.to_rata_die(), case.rd, "{case:?}");
             } else {
-                assert_ne!(date_from_rd.to_rata_die(), case.rd);
+                assert_ne!(date_from_rd.to_rata_die(), case.rd, "{case:?}");
             }
 
             if !case.invalid_ymd {

--- a/components/calendar/src/cal/japanese.rs
+++ b/components/calendar/src/cal/japanese.rs
@@ -200,8 +200,8 @@ impl Date<Japanese> {
     ///
     /// However, dates may always be specified in "bce" or "ce" and they will be adjusted as necessary.
     ///
-    /// This function accepts years in the range `-1,000,000..=1,000,000`, where the Gregorian year
-    /// is also in the range `-1,000,000..=1,000,000`.
+    /// This function accepts years in the range `-500,000..=500,000`, where the Gregorian year
+    /// is also in the range `-500,000..=500,000`.
     ///
     /// ```rust
     /// use icu::calendar::cal::Japanese;

--- a/components/calendar/src/cal/julian.rs
+++ b/components/calendar/src/cal/julian.rs
@@ -274,7 +274,7 @@ impl Date<Julian> {
     /// Construct new Julian [`Date`].
     ///
     /// Years are arithmetic, meaning there is a year 0 preceded by negative years, with a
-    /// valid range of `-1,000,000..=1,000,000`.
+    /// valid range of `-500,000..=500,000`.
     ///
     /// ```rust
     /// use icu::calendar::Date;

--- a/components/calendar/src/cal/persian.rs
+++ b/components/calendar/src/cal/persian.rs
@@ -232,7 +232,7 @@ impl Date<Persian> {
     /// Construct new Persian [`Date`].
     ///
     /// Years are arithmetic, meaning there is a year 0 preceded by negative years, with a
-    /// valid range of `-1,000,000..=1,000,000`.
+    /// valid range of `-500,000..=500,000`.
     ///
     /// ```rust
     /// use icu::calendar::Date;

--- a/components/calendar/src/cal/roc.rs
+++ b/components/calendar/src/cal/roc.rs
@@ -87,7 +87,7 @@ impl Date<Roc> {
     /// Construct a new Republic of China calendar [`Date`].
     ///
     /// Years are arithmetic, meaning there is a year 0 preceded by negative years, with a
-    /// valid range of `-1,000,000..=1,000,000`.
+    /// valid range of `-500,000..=500,000`.
     ///
     /// ```rust
     /// use icu::calendar::Date;

--- a/components/calendar/src/calendar_arithmetic.rs
+++ b/components/calendar/src/calendar_arithmetic.rs
@@ -19,7 +19,18 @@ use core::hash::{Hash, Hasher};
 use core::ops::RangeInclusive;
 
 /// This is checked by constructors. Internally we don't care about this invariant.
-pub const VALID_YEAR_RANGE: RangeInclusive<i32> = -1_000_000..=1_000_000;
+///
+/// The values selected here affect `VALID_RD_RANGE`, which we do care about internally.
+/// If changing this, this should be changed first, and then `test_validity_ranges` can
+/// be used to figure out the new RD range.
+///
+/// Some things to consider when changing this:
+///
+/// - Temporal's IXDTF only supports up to 6-digit years (ISO 8601 requires expanded years to
+///   specify a digit count, Temporal [specifies](https://tc39.es/proposal-temporal/#sec-temporal-iso8601grammar)
+///   it as six digits)
+/// - The Temporal range is 271821-04-20 to +275760-09-13.
+pub const VALID_YEAR_RANGE: RangeInclusive<i32> = -500_000..=500_000;
 
 /// This is a fundamental invariant of `ArithmeticDate` and by extension all our
 /// date types. Because this range slightly exceeds the [`VALID_YEAR_RANGE`], only
@@ -27,8 +38,10 @@ pub const VALID_YEAR_RANGE: RangeInclusive<i32> = -1_000_000..=1_000_000;
 /// constructor actually uses this, but for clamping instead of erroring.
 // This range is the tightest possible range that includes all valid years for all
 // calendars, this is asserted in [`test_validity_ranges`].
+//
+// This range is -505503-04-10 to 501911-12-31
 pub const VALID_RD_RANGE: RangeInclusive<RataDie> =
-    RataDie::new(-367256444)..=RataDie::new(365940477);
+    RataDie::new(-184631444)..=RataDie::new(183319227);
 
 // Invariant: VALID_RD_RANGE contains the date
 #[derive(Debug)]
@@ -981,22 +994,23 @@ mod tests {
             Date::try_new_from_codes(None, *VALID_YEAR_RANGE.start(), Month::new(1).code(), 1, Roc).unwrap().to_rata_die(),
         ];
 
+        // TODO: this test should use try_new_from_fields with Constrain so it doesn't have to hardcode month lengths
         #[rustfmt::skip]
         let highest_rds = [
             Date::try_new_from_codes(None, *VALID_YEAR_RANGE.end(), Month::new(12).code(), 31, Buddhist).unwrap().to_rata_die(),
-            Date::try_new_from_codes(None, *VALID_YEAR_RANGE.end(), Month::new(12).code(), 30, ChineseTraditional::new()).unwrap().to_rata_die(),
+            Date::try_new_from_codes(None, *VALID_YEAR_RANGE.end(), Month::new(12).code(), 29, ChineseTraditional::new()).unwrap().to_rata_die(),
             Date::try_new_from_codes(None, *VALID_YEAR_RANGE.end(), Month::new(13).code(), 5, Coptic).unwrap().to_rata_die(),
             Date::try_new_from_codes(None, *VALID_YEAR_RANGE.end(), Month::new(13).code(), 5, Ethiopian::new_with_era_style(EthiopianEraStyle::AmeteAlem)).unwrap().to_rata_die(),
             Date::try_new_from_codes(None, *VALID_YEAR_RANGE.end(), Month::new(13).code(), 5, Ethiopian::new_with_era_style(EthiopianEraStyle::AmeteMihret)).unwrap().to_rata_die(),
             Date::try_new_from_codes(None, *VALID_YEAR_RANGE.end(), Month::new(12).code(), 31, Gregorian).unwrap().to_rata_die(),
             Date::try_new_from_codes(None, *VALID_YEAR_RANGE.end(), Month::new(12).code(), 29, Hebrew).unwrap().to_rata_die(),
-            Date::try_new_from_codes(None, *VALID_YEAR_RANGE.end(), Month::new(12).code(), 30, Hijri::new_umm_al_qura()).unwrap().to_rata_die(),
-            Date::try_new_from_codes(None, *VALID_YEAR_RANGE.end(), Month::new(12).code(), 30, Hijri::new_tabular(HijriTabularLeapYears::TypeII, HijriTabularEpoch::Thursday)).unwrap().to_rata_die(),
+            Date::try_new_from_codes(None, *VALID_YEAR_RANGE.end(), Month::new(12).code(), 29, Hijri::new_umm_al_qura()).unwrap().to_rata_die(),
+            Date::try_new_from_codes(None, *VALID_YEAR_RANGE.end(), Month::new(12).code(), 29, Hijri::new_tabular(HijriTabularLeapYears::TypeII, HijriTabularEpoch::Thursday)).unwrap().to_rata_die(),
             Date::try_new_from_codes(None, *VALID_YEAR_RANGE.end(), Month::new(12).code(), 30, Indian).unwrap().to_rata_die(),
             Date::try_new_from_codes(None, *VALID_YEAR_RANGE.end(), Month::new(12).code(), 31, Iso).unwrap().to_rata_die(),
             Date::try_new_from_codes(None, *VALID_YEAR_RANGE.end(), Month::new(12).code(), 31, Japanese::new()).unwrap().to_rata_die(),
             Date::try_new_from_codes(None, *VALID_YEAR_RANGE.end(), Month::new(12).code(), 31, Julian).unwrap().to_rata_die(),
-            Date::try_new_from_codes(None, *VALID_YEAR_RANGE.end(), Month::new(12).code(), 30, KoreanTraditional::new()).unwrap().to_rata_die(),
+            Date::try_new_from_codes(None, *VALID_YEAR_RANGE.end(), Month::new(12).code(), 29, KoreanTraditional::new()).unwrap().to_rata_die(),
             Date::try_new_from_codes(None, *VALID_YEAR_RANGE.end(), Month::new(12).code(), 30, Persian).unwrap().to_rata_die(),
             Date::try_new_from_codes(None, *VALID_YEAR_RANGE.end(), Month::new(12).code(), 31, Roc).unwrap().to_rata_die(),
         ];

--- a/components/calendar/src/date.rs
+++ b/components/calendar/src/date.rs
@@ -124,8 +124,8 @@ impl<A: AsCalendar> Date<A> {
     ///
     /// The year is interpreted as an [`extended_year`](Date::extended_year) if no era is provided.
     ///
-    /// This function accepts years in the range `-1,000,000..=1,000,000`, where the `extended_year`
-    /// is also in the range `-1,000,000..=1,000,000`.
+    /// This function accepts years in the range `-500,000..=500,000`, where the `extended_year`
+    /// is also in the range `-500,000..=500,000`.
     #[inline]
     pub fn try_new_from_codes(
         era: Option<&str>,
@@ -146,8 +146,8 @@ impl<A: AsCalendar> Date<A> {
     /// and the month as either ordinal or month code. It can constrain out-of-bounds values
     /// and fill in missing fields. See [`DateFromFieldsOptions`] for more information.
     ///
-    /// This function accepts years in the range `-1,000,000..=1,000,000`, where the `extended_year`
-    /// is also in the range `-1,000,000..=1,000,000`.
+    /// This function accepts years in the range `-500,000..=500,000`, where the `extended_year`
+    /// is also in the range `-500,000..=500,000`.
     ///
     /// # Examples
     ///

--- a/components/calendar/src/types.rs
+++ b/components/calendar/src/types.rs
@@ -66,8 +66,8 @@ mod unstable {
         /// If set, [`Self::era`] must also be set.
         ///
         /// [`Date::try_from_fields`](crate::Date::try_from_fields)  accepts years in
-        /// the range `-1,000,000..=1,000,000`, where the `extended_year` is also in
-        /// the range `-1,000,000..=1,000,000`.
+        /// the range `-500,000..=500,000`, where the `extended_year` is also in
+        /// the range `-500,000..=500,000`.
         ///
         /// For an example, see [`Self::extended_year`].
         pub era_year: Option<i32>,
@@ -77,7 +77,7 @@ mod unstable {
         /// refer to the same year.
         ///
         /// [`Date::try_from_fields`](crate::Date::try_from_fields) accepts extended years
-        /// in the range `-1,000,000..=1,000,000`.
+        /// in the range `-500,000..=500,000`.
         ///
         /// # Examples
         ///


### PR DESCRIPTION
We discovered that 7-digit years do not work in IXDTF. Reducing to 500k, instead, which has a decent buffer between the Temporal lower bound and the IXDTF upper bound.

900k would also probably be acceptable if we want to reduce slowly.