### PR TITLE
2 digit yearstyle for buddhist calender

### DIFF
--- a/components/calendar/src/cal/buddhist.rs
+++ b/components/calendar/src/cal/buddhist.rs
@@ -55,7 +55,13 @@ impl GregorianYears for BuddhistEra {
             era_index: Some(0),
             year: extended_year,
             extended_year,
-            ambiguity: types::YearAmbiguity::CenturyRequired,
+            // Buddhist year = Gregorian year + 543
+            ambiguity: match extended_year {
+                ..=0 => types::YearAmbiguity::EraAndCenturyRequired,
+                1..=2492 => types::YearAmbiguity::CenturyRequired,
+                2493..=2592 => types::YearAmbiguity::Unambiguous,
+                2593.. => types::YearAmbiguity::CenturyRequired,
+            },
         }
     }
 


### PR DESCRIPTION
Fixes #6840 

```rust
ambiguity: match extended_year {
                    ..=999 => types::YearAmbiguity::EraAndCenturyRequired,
                    1000..=1949 => types::YearAmbiguity::CenturyRequired,
                    1950..=2049 => types::YearAmbiguity::Unambiguous,
                    2050.. => types::YearAmbiguity::CenturyRequired,
                },
```
This is in [`era_year_from_extended()`](https://github.com/unicode-org/icu4x/blob/main/components/calendar/src/cal/gregorian.rs#L40-L45) function in `Gregorian calender`, the years marked as `Unambiguous` enables `YearStyle::Auto` to select the 2 digit year pattern for these years. Did something similar with `Buddhist calender` by converting the same match statement years according to buddist calender years.

```rust
            // Buddhist year = Gregorian year + 543
            ambiguity: match extended_year {
                ..=0 => types::YearAmbiguity::EraAndCenturyRequired,
                1..=2492 => types::YearAmbiguity::CenturyRequired,
                2493..=2592 => types::YearAmbiguity::Unambiguous,
                2593.. => types::YearAmbiguity::CenturyRequired,
            },
```
