### PR TITLE
Fix swapped new/try_new in WordSegmenter comments

### DIFF
--- a/components/segmenter/src/word.rs
+++ b/components/segmenter/src/word.rs
@@ -174,9 +174,9 @@ impl<Y: RuleBreakType> Iterator for WordBreakIteratorWithWordType<'_, '_, Y> {
 /// have information on the language of the text being segmented, providing this hint can
 /// produce higher-quality results.
 ///
-/// If you have a content locale, use [`WordBreakOptions`] and a constructor begining with `new`.
+/// If you have a content locale, use [`WordBreakOptions`] and a constructor beginning with `try_new`.
 /// If you do not have a content locale use [`WordBreakInvariantOptions`] and a constructor
-/// beginning with `try_new`.
+/// beginning with `new`.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->
The documentation for `WordSegmenter` appeared to have the `new` and `try_new` constructors swapped.

- `WordBreakOptions` (with locale) typically involves fallible data loading (`try_new`).
- `WordBreakInvariantOptions` implies infallible/const construction (`new`).

Also fixed a typo: `begining` -> `beginning`.


## Changelog: N/A


