### PR TITLE
Encapsulate Date fields

### DIFF
--- a/components/calendar/src/any_calendar.rs
+++ b/components/calendar/src/any_calendar.rs
@@ -1411,8 +1411,8 @@ impl<C: IntoAnyCalendar> Date<C> {
     /// Type-erase the date, converting it to a date for [`AnyCalendar`]
     pub fn to_any(self) -> Date<AnyCalendar> {
         Date::from_raw(
-            self.calendar.date_to_any(&self.inner),
-            self.calendar.to_any(),
+            self.calendar().date_to_any(self.inner()),
+            self.into_calendar().to_any(),
         )
     }
 }

--- a/components/calendar/src/cal/hebrew.rs
+++ b/components/calendar/src/cal/hebrew.rs
@@ -534,13 +534,13 @@ mod tests {
     fn test_negative_era_years() {
         let greg_date = Date::try_new_gregorian(-5000, 1, 1).unwrap();
         let greg_year = greg_date.era_year();
-        assert_eq!(greg_date.inner.0.year(), -5000);
+        assert_eq!(greg_year.extended_year, -5000);
         assert_eq!(greg_year.era, "bce");
         // In Gregorian, era year is 1 - extended year
         assert_eq!(greg_year.year, 5001);
         let hebr_date = greg_date.to_calendar(Hebrew);
         let hebr_year = hebr_date.era_year();
-        assert_eq!(hebr_date.inner.0.year().value, -1240);
+        assert_eq!(hebr_year.extended_year, -1240);
         assert_eq!(hebr_year.era, "am");
         // In Hebrew, there is no inverse era, so negative extended years are negative era years
         assert_eq!(hebr_year.year, -1240);

--- a/components/calendar/src/cal/julian.rs
+++ b/components/calendar/src/cal/julian.rs
@@ -486,7 +486,7 @@ mod test {
 
                 assert_eq!(
                     i.cmp(&j),
-                    julian_i.inner.0.cmp(&julian_j.inner.0),
+                    julian_i.inner().0.cmp(&julian_j.inner().0),
                     "Julian directionality inconsistent with directionality for i: {i}, j: {j}"
                 );
             }

--- a/components/calendar/src/date.rs
+++ b/components/calendar/src/date.rs
@@ -115,8 +115,8 @@ impl<C> Deref for Ref<'_, C> {
 /// assert_eq!(date_iso.day_of_month().0, 2);
 /// ```
 pub struct Date<A: AsCalendar> {
-    pub(crate) inner: <A::Calendar as Calendar>::DateInner,
-    pub(crate) calendar: A,
+    inner: <A::Calendar as Calendar>::DateInner,
+    calendar: A,
 }
 
 impl<A: AsCalendar> Date<A> {
@@ -137,7 +137,7 @@ impl<A: AsCalendar> Date<A> {
         let inner = calendar
             .as_calendar()
             .from_codes(era, year, month_code, day)?;
-        Ok(Date { inner, calendar })
+        Ok(Date::from_raw(inner, calendar))
     }
 
     /// Construct a [`Date`] from from a bag of fields and a calendar.
@@ -186,7 +186,7 @@ impl<A: AsCalendar> Date<A> {
         calendar: A,
     ) -> Result<Self, DateFromFieldsError> {
         let inner = calendar.as_calendar().from_fields(fields, options)?;
-        Ok(Date { inner, calendar })
+        Ok(Date::from_raw(inner, calendar))
     }
 
     /// Construct a date from a [`RataDie`] and a calendar.
@@ -202,10 +202,7 @@ impl<A: AsCalendar> Date<A> {
     #[inline]
     pub fn from_rata_die(rd: RataDie, calendar: A) -> Self {
         let rd = rd.clamp(*VALID_RD_RANGE.start(), *VALID_RD_RANGE.end());
-        Date {
-            inner: calendar.as_calendar().from_rata_die(rd),
-            calendar,
-        }
+        Date::from_raw(calendar.as_calendar().from_rata_die(rd), calendar)
     }
 
     /// Convert the date to a [`RataDie`]
@@ -241,7 +238,7 @@ impl<A: AsCalendar> Date<A> {
             // `from_rata_die` precondition is satified by `to_rata_die`
             c2.from_rata_die(c1.to_rata_die(self.inner()))
         };
-        Date { inner, calendar }
+        Date::from_raw(inner, calendar)
     }
 
     /// The day-of-month of this date.
@@ -432,6 +429,11 @@ impl<A: AsCalendar> Date<A> {
     #[inline]
     pub fn calendar(&self) -> &A::Calendar {
         self.calendar.as_calendar()
+    }
+
+    #[inline]
+    pub(crate) fn into_calendar(self) -> A {
+        self.calendar
     }
 
     /// Get a reference to the contained calendar wrapper


### PR DESCRIPTION
All construction should go through `Date::from_raw`, and `Date.inner` should not be mutable. This gives more peace of mind wrt to calendar bounds.

## Changelog: N/A

