### PR TITLE
Add Swedish collator benchmark #7559

### DIFF
--- a/components/collator/benches/bench.rs
+++ b/components/collator/benches/bench.rs
@@ -132,6 +132,14 @@ pub fn collator_with_locale(criterion: &mut Criterion) {
             .rev()
             .collect::<Vec<&str>>(),
     );
+    let content_swedish: (&str, Vec<&str>) = (
+        "TestNames_Swedish",
+        include_str!("data/TestNames_Swedish.txt")
+            .lines()
+            .filter(|&s| !s.starts_with('#'))
+            .rev()
+            .collect::<Vec<&str>>(),
+    );
 
     // hsivonen@ : All five strengths are benched.
     // The default is tertiary, so it makes sense to bench that.
@@ -189,6 +197,11 @@ pub fn collator_with_locale(criterion: &mut Criterion) {
         (
             locale!("ko-KR"),
             vec![&content_latin, &content_korean],
+            &all_strength,
+        ),
+        (
+            locale!("sv"),
+            vec![&content_latin, &content_swedish],
             &all_strength,
         ),
     ];

--- a/components/collator/benches/data/TestNames_Swedish.txt
+++ b/components/collator/benches/data/TestNames_Swedish.txt
@@ -1,0 +1,52 @@
+# This file is part of ICU4X. For terms of use, please see the file
+# called LICENSE at the top level of the ICU4X source tree
+# (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+Abba
+Abbe
+Agda
+Ahlin
+Akra
+Alin
+Andersson, Anna
+Andersson, Agda
+Andersson, Ärta
+Andersson, Åsa
+Bengtsson, Bengt
+Berg, Anna
+Berg, Änne
+Berg, Åke
+Ericsen
+Ericson
+Ericsson
+Ericsun
+Eriksen
+Erikson
+Eriksson
+Eriksun
+Erixon
+Lundström, Bo
+Lundstrom, Bo
+Olofsson, Olle
+Olofsson, Örjan
+Sjöberg, Östen
+Sjoberg, Osten
+Åberg, Anders
+Ärlandsson, Bengt
+Öberg, Clara
+Åberg, Berit
+Ärlandsson, Anna
+Öberg, Anders
+Andersson, Åke
+Andersson, Ärlige
+Olofsson, Olov
+Olofsson, Östen
+Lundqvist, Åke
+Lundqvist, Anders
+Sjöberg, Anders
+Sjoberg, Anders
+Ericsson, Anders
+Ericson, Anders
+Eriksson, Anders
+Erikson, Anders
+Erixon, Anders


### PR DESCRIPTION
This PR adds a new benchmark for the Swedish locale to expand the language coverage of the collator benchmarks and test specific tailoring cases.

Fixes #7559