### PR TITLE
Add a Swedish collation workload

### DIFF
--- a/components/collator/benches/bench.rs
+++ b/components/collator/benches/bench.rs
@@ -124,6 +124,14 @@ pub fn collator_with_locale(criterion: &mut Criterion) {
             .rev()
             .collect::<Vec<&str>>(),
     );
+    let content_swedish: (&str, Vec<&str>) = (
+        "TestNames_Swedish",
+        include_str!("data/TestNames_Swedish.txt")
+            .lines()
+            .filter(|&s| !s.starts_with('#'))
+            .rev()
+            .collect::<Vec<&str>>(),
+    );
     let content_thai: (&str, Vec<&str>) = (
         "TestNames_Thai",
         include_str!("data/TestNames_Thai.txt")
@@ -179,6 +187,11 @@ pub fn collator_with_locale(criterion: &mut Criterion) {
         (
             locale!("ru-RU"),
             vec![&content_latin, &content_russian],
+            &all_strength,
+        ),
+        (
+            locale!("sv"),
+            vec![&content_latin, &content_swedish],
             &all_strength,
         ),
         (

--- a/components/collator/benches/data/TestNames_Swedish.txt
+++ b/components/collator/benches/data/TestNames_Swedish.txt
@@ -1,0 +1,24 @@
+# This file is part of ICU4X. For terms of use, please see the file
+# called LICENSE at the top level of the ICU4X source tree
+# (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+Johansson, Åke
+Johansson, Anna
+Ahlström, Olof
+Hägglund, Frida
+Erikson, Daniel
+Johansson, Andreas
+Lind, Axel
+Johansson, André
+Pettersson, Robert
+Sohlberg, Jonas
+Ericson, Lars
+Johansson, Annika
+Sjöman, Olle
+Åberg, Carita
+Sjöberg, Cecilia
+Palme, Anders
+Håg, Petter
+Erixon, Ida
+Hagelstam, Stina
+Ericsson, Mona


### PR DESCRIPTION
Obviously, the given names are actually irrelevant for benchmarking unless there's a duplicate family name.

This isn't about being truly statistically representative of Swedish names, but the point is to exercise collator behavior that's relevant to pretty much all Latin-script languages other than Vietnamese, German phonebook and the root collation-using languages while doing so in a reasonably realistic way as opposed to using completely unrealistic strings that would only exercise the interesting code paths.

The point of the two names starting with Sjö is to exercise the case of the identical prefix ending with a character that decomposes in NFD.

(Why Swedish? Of the languages that have the collation characteristics that I'm trying to exercise, I can generate fake names off the top of my head for Finnish and Swedish. Swedish has more users and uses two non-ASCII base letters that share the same ASCII base in NFD: å and ä, so Swedish is marginally more interesting technically. Both Swedish and Finnish collation data have the same special cases for å and ä, but Swedish input actually exercises both. Estonian would have both õ and ö, but I don't know how to create realistic fake data that exercises those off the top of my head.)




## Changelog: N/A


