### PR TITLE
Add Swedish lines that got accidentally deleted by shuf

### DIFF
--- a/components/collator/benches/data/README.md
+++ b/components/collator/benches/data/README.md
@@ -13,7 +13,7 @@ sed -i '/^$/d' ${filename}
 ## Shuffling the file
 
 ```shell
-shuf -n 20 ${filename} -o ${filename}
+shuf ${filename} -o ${filename}
 ```
 
 ## Add back the header (if you plan on submitting the files)

--- a/components/collator/benches/data/TestNames_Swedish.txt
+++ b/components/collator/benches/data/TestNames_Swedish.txt
@@ -2,23 +2,27 @@
 # called LICENSE at the top level of the ICU4X source tree
 # (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-Johansson, Åke
-Johansson, Anna
-Ahlström, Olof
-Hägglund, Frida
-Erikson, Daniel
-Johansson, Andreas
-Lind, Axel
-Johansson, André
+Söderholm, Carl
 Pettersson, Robert
-Sohlberg, Jonas
-Ericson, Lars
-Johansson, Annika
+Håg, Petter
+Erikson, Daniel
+Ericsson, Marie
 Sjöman, Olle
 Åberg, Carita
-Sjöberg, Cecilia
-Palme, Anders
-Håg, Petter
-Erixon, Ida
-Hagelstam, Stina
+Ericson, Lars
 Ericsson, Mona
+Hägglund, Frida
+Eriksson, John
+Palmén, Thomas
+Johansson, Åke
+Hagelstam, Stina
+Sjöberg, Cecilia
+Johansson, Andreas
+Johansson, André
+Palme, Anders
+Erixon, Ida
+Ahlström, Olof
+Lind, Axel
+Johansson, Annika
+Sohlberg, Jonas
+Johansson, Anna


### PR DESCRIPTION
Also adjusting the `shuf` command example in the README not to result in data loss.


## Changelog: N/A


