### PR TITLE
Add MSRV entry to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Fully filled in up to 30c187f4b7
 - Components
     - General
         - Use HTTPS links in docs (unicode-org#7212)
+        - Update MSRV to 1.86 (unicode-org#7576)
     - `icu_calendar`
         - Introduce a new `Month` type, preferred over using month codes (unicode-org#7147)
         - Restrict the range of valid dates constructed via certain constructors (unicode-org#7219, unicode-org#7227)


### PR DESCRIPTION
GitHub's automerge feature has you confirm the commit message when you enable automerge.

Unfortunately, this means updates to the PR title (e.g. https://github.com/unicode-org/icu4x/pull/7576) will not be incorporated. This is not going to be an issue most of the time, we should just be wary of it.

However, now we have an incorrect commit message in our history. Preemptively updating the changelog to avoid mistakes later.


## Changelog: N/A


