### PR TITLE
Expose a compiled data version of titlecase_segment_with_only_case_data over FFI

### DIFF
--- a/ffi/capi/bindings/c/CaseMapper.h
+++ b/ffi/capi/bindings/c/CaseMapper.h
@@ -35,6 +35,8 @@ void icu4x_CaseMapper_uppercase_with_compiled_data_mv1(DiplomatStringView s, con
 
 void icu4x_CaseMapper_titlecase_segment_with_only_case_data_v1_mv1(const CaseMapper* self, DiplomatStringView s, const Locale* locale, TitlecaseOptionsV1 options, DiplomatWrite* write);
 
+void icu4x_CaseMapper_titlecase_segment_with_only_case_compiled_data_mv1(DiplomatStringView s, const Locale* locale, TitlecaseOptionsV1 options, DiplomatWrite* write);
+
 void icu4x_CaseMapper_fold_mv1(const CaseMapper* self, DiplomatStringView s, DiplomatWrite* write);
 
 void icu4x_CaseMapper_fold_turkic_mv1(const CaseMapper* self, DiplomatStringView s, DiplomatWrite* write);

--- a/ffi/capi/bindings/cpp/icu4x/CaseMapper.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/CaseMapper.d.hpp
@@ -102,6 +102,20 @@ public:
   inline icu4x::diplomat::result<std::monostate, icu4x::diplomat::Utf8Error> titlecase_segment_with_only_case_data_v1_write(std::string_view s, const icu4x::Locale& locale, icu4x::TitlecaseOptionsV1 options, W& writeable_output) const;
 
   /**
+   * Returns the full titlecase mapping of the given string, performing head adjustment without
+   * loading additional data, using compiled data (avoids having to allocate a `CaseMapper` object).
+   *
+   * (if head adjustment is enabled in the options)
+   *
+   * The `v1` refers to the version of the options struct, which may change as we add more options
+   *
+   * See the [Rust documentation for `titlecase_segment_with_only_case_data_to_string`](https://docs.rs/icu/2.1.1/icu/casemap/struct.CaseMapperBorrowed.html#method.titlecase_segment_with_only_case_data_to_string) for more information.
+   */
+  inline static icu4x::diplomat::result<std::string, icu4x::diplomat::Utf8Error> titlecase_segment_with_only_case_compiled_data(std::string_view s, const icu4x::Locale& locale, icu4x::TitlecaseOptionsV1 options);
+  template<typename W>
+  inline static icu4x::diplomat::result<std::monostate, icu4x::diplomat::Utf8Error> titlecase_segment_with_only_case_compiled_data_write(std::string_view s, const icu4x::Locale& locale, icu4x::TitlecaseOptionsV1 options, W& writeable_output);
+
+  /**
    * Case-folds the characters in the given string
    *
    * See the [Rust documentation for `fold`](https://docs.rs/icu/2.1.1/icu/casemap/struct.CaseMapperBorrowed.html#method.fold) for more information.

--- a/ffi/capi/bindings/cpp/icu4x/CaseMapper.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/CaseMapper.hpp
@@ -38,6 +38,8 @@ namespace capi {
 
     void icu4x_CaseMapper_titlecase_segment_with_only_case_data_v1_mv1(const icu4x::capi::CaseMapper* self, icu4x::diplomat::capi::DiplomatStringView s, const icu4x::capi::Locale* locale, icu4x::capi::TitlecaseOptionsV1 options, icu4x::diplomat::capi::DiplomatWrite* write);
 
+    void icu4x_CaseMapper_titlecase_segment_with_only_case_compiled_data_mv1(icu4x::diplomat::capi::DiplomatStringView s, const icu4x::capi::Locale* locale, icu4x::capi::TitlecaseOptionsV1 options, icu4x::diplomat::capi::DiplomatWrite* write);
+
     void icu4x_CaseMapper_fold_mv1(const icu4x::capi::CaseMapper* self, icu4x::diplomat::capi::DiplomatStringView s, icu4x::diplomat::capi::DiplomatWrite* write);
 
     void icu4x_CaseMapper_fold_turkic_mv1(const icu4x::capi::CaseMapper* self, icu4x::diplomat::capi::DiplomatStringView s, icu4x::diplomat::capi::DiplomatWrite* write);
@@ -197,6 +199,31 @@ inline icu4x::diplomat::result<std::monostate, icu4x::diplomat::Utf8Error> icu4x
     icu4x::diplomat::capi::DiplomatWrite write = icu4x::diplomat::WriteTrait<W>::Construct(writeable);
     icu4x::capi::icu4x_CaseMapper_titlecase_segment_with_only_case_data_v1_mv1(this->AsFFI(),
         {s.data(), s.size()},
+        locale.AsFFI(),
+        options.AsFFI(),
+        &write);
+    return icu4x::diplomat::Ok<std::monostate>();
+}
+
+inline icu4x::diplomat::result<std::string, icu4x::diplomat::Utf8Error> icu4x::CaseMapper::titlecase_segment_with_only_case_compiled_data(std::string_view s, const icu4x::Locale& locale, icu4x::TitlecaseOptionsV1 options) {
+    if (!icu4x::diplomat::capi::diplomat_is_str(s.data(), s.size())) {
+    return icu4x::diplomat::Err<icu4x::diplomat::Utf8Error>();
+  }
+    std::string output;
+    icu4x::diplomat::capi::DiplomatWrite write = icu4x::diplomat::WriteFromString(output);
+    icu4x::capi::icu4x_CaseMapper_titlecase_segment_with_only_case_compiled_data_mv1({s.data(), s.size()},
+        locale.AsFFI(),
+        options.AsFFI(),
+        &write);
+    return icu4x::diplomat::Ok<std::string>(std::move(output));
+}
+template<typename W>
+inline icu4x::diplomat::result<std::monostate, icu4x::diplomat::Utf8Error> icu4x::CaseMapper::titlecase_segment_with_only_case_compiled_data_write(std::string_view s, const icu4x::Locale& locale, icu4x::TitlecaseOptionsV1 options, W& writeable) {
+    if (!icu4x::diplomat::capi::diplomat_is_str(s.data(), s.size())) {
+    return icu4x::diplomat::Err<icu4x::diplomat::Utf8Error>();
+  }
+    icu4x::diplomat::capi::DiplomatWrite write = icu4x::diplomat::WriteTrait<W>::Construct(writeable);
+    icu4x::capi::icu4x_CaseMapper_titlecase_segment_with_only_case_compiled_data_mv1({s.data(), s.size()},
         locale.AsFFI(),
         options.AsFFI(),
         &write);

--- a/ffi/capi/src/casemap.rs
+++ b/ffi/capi/src/casemap.rs
@@ -171,6 +171,36 @@ pub mod ffi {
                 .write_to(write);
         }
 
+        /// Returns the full titlecase mapping of the given string, performing head adjustment without
+        /// loading additional data, using compiled data (avoids having to allocate a `CaseMapper` object).
+        ///
+        /// (if head adjustment is enabled in the options)
+        ///
+        /// The `v1` refers to the version of the options struct, which may change as we add more options
+        #[diplomat::rust_link(
+            icu::casemap::CaseMapperBorrowed::titlecase_segment_with_only_case_data_to_string,
+            FnInStruct
+        )]
+        #[diplomat::rust_link(
+            icu::casemap::CaseMapperBorrowed::titlecase_segment_with_only_case_data_to_string,
+            FnInStruct,
+            hidden
+        )]
+        #[cfg(feature = "compiled_data")]
+        #[diplomat::attr(supports = non_exhaustive_structs, rename = "titlecase_segment_with_only_case_compiled_data")]
+        #[diplomat::attr(demo_gen, disable)] // available through Self::create()
+        #[diplomat::attr(kotlin, disable)] // option support (https://github.com/rust-diplomat/diplomat/issues/989)
+        pub fn titlecase_segment_with_only_case_compiled_data(
+            s: &str,
+            locale: &Locale,
+            options: TitlecaseOptionsV1,
+            write: &mut DiplomatWrite,
+        ) {
+            let _infallible = icu_casemap::CaseMapper::new()
+                .titlecase_segment_with_only_case_data(s, &locale.0.id, options.into())
+                .write_to(write);
+        }
+
         /// Case-folds the characters in the given string
         #[diplomat::rust_link(icu::casemap::CaseMapperBorrowed::fold, FnInStruct)]
         #[diplomat::rust_link(icu::casemap::CaseMapperBorrowed::fold_string, FnInStruct, hidden)]

--- a/ffi/dart/lib/src/bindings/CaseMapper.g.dart
+++ b/ffi/dart/lib/src/bindings/CaseMapper.g.dart
@@ -99,6 +99,21 @@ final class CaseMapper implements ffi.Finalizable {
     return write.finalize();
   }
 
+  /// Returns the full titlecase mapping of the given string, performing head adjustment without
+  /// loading additional data, using compiled data (avoids having to allocate a `CaseMapper` object).
+  ///
+  /// (if head adjustment is enabled in the options)
+  ///
+  /// The `v1` refers to the version of the options struct, which may change as we add more options
+  ///
+  /// See the [Rust documentation for `titlecase_segment_with_only_case_data_to_string`](https://docs.rs/icu/2.1.1/icu/casemap/struct.CaseMapperBorrowed.html#method.titlecase_segment_with_only_case_data_to_string) for more information.
+  static String titlecaseSegmentWithOnlyCaseCompiledData(String s, Locale locale, TitlecaseOptions options) {
+    final temp = _FinalizedArena();
+    final write = _Write();
+    _icu4x_CaseMapper_titlecase_segment_with_only_case_compiled_data_mv1(s._utf8AllocIn(temp.arena), locale._ffi, options._toFfi(temp.arena), write._ffi);
+    return write.finalize();
+  }
+
   /// Case-folds the characters in the given string
   ///
   /// See the [Rust documentation for `fold`](https://docs.rs/icu/2.1.1/icu/casemap/struct.CaseMapperBorrowed.html#method.fold) for more information.
@@ -276,6 +291,11 @@ external void _icu4x_CaseMapper_uppercase_with_compiled_data_mv1(_SliceUtf8 s, f
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8, ffi.Pointer<ffi.Opaque>, _TitlecaseOptionsFfi, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CaseMapper_titlecase_segment_with_only_case_data_v1_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_CaseMapper_titlecase_segment_with_only_case_data_v1_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUtf8 s, ffi.Pointer<ffi.Opaque> locale, _TitlecaseOptionsFfi options, ffi.Pointer<ffi.Opaque> write);
+
+@_DiplomatFfiUse('icu4x_CaseMapper_titlecase_segment_with_only_case_compiled_data_mv1')
+@ffi.Native<ffi.Void Function(_SliceUtf8, ffi.Pointer<ffi.Opaque>, _TitlecaseOptionsFfi, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CaseMapper_titlecase_segment_with_only_case_compiled_data_mv1')
+// ignore: non_constant_identifier_names
+external void _icu4x_CaseMapper_titlecase_segment_with_only_case_compiled_data_mv1(_SliceUtf8 s, ffi.Pointer<ffi.Opaque> locale, _TitlecaseOptionsFfi options, ffi.Pointer<ffi.Opaque> write);
 
 @_DiplomatFfiUse('icu4x_CaseMapper_fold_mv1')
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CaseMapper_fold_mv1')

--- a/ffi/npm/lib/CaseMapper.d.ts
+++ b/ffi/npm/lib/CaseMapper.d.ts
@@ -64,6 +64,18 @@ export class CaseMapper {
     titlecaseSegmentWithOnlyCaseData(s: string, locale: Locale, options: TitlecaseOptions_obj): string;
 
     /**
+     * Returns the full titlecase mapping of the given string, performing head adjustment without
+     * loading additional data, using compiled data (avoids having to allocate a `CaseMapper` object).
+     *
+     * (if head adjustment is enabled in the options)
+     *
+     * The `v1` refers to the version of the options struct, which may change as we add more options
+     *
+     * See the [Rust documentation for `titlecase_segment_with_only_case_data_to_string`](https://docs.rs/icu/2.1.1/icu/casemap/struct.CaseMapperBorrowed.html#method.titlecase_segment_with_only_case_data_to_string) for more information.
+     */
+    static titlecaseSegmentWithOnlyCaseCompiledData(s: string, locale: Locale, options: TitlecaseOptions_obj): string;
+
+    /**
      * Case-folds the characters in the given string
      *
      * See the [Rust documentation for `fold`](https://docs.rs/icu/2.1.1/icu/casemap/struct.CaseMapperBorrowed.html#method.fold) for more information.

--- a/ffi/npm/lib/CaseMapper.mjs
+++ b/ffi/npm/lib/CaseMapper.mjs
@@ -216,6 +216,36 @@ export class CaseMapper {
     }
 
     /**
+     * Returns the full titlecase mapping of the given string, performing head adjustment without
+     * loading additional data, using compiled data (avoids having to allocate a `CaseMapper` object).
+     *
+     * (if head adjustment is enabled in the options)
+     *
+     * The `v1` refers to the version of the options struct, which may change as we add more options
+     *
+     * See the [Rust documentation for `titlecase_segment_with_only_case_data_to_string`](https://docs.rs/icu/2.1.1/icu/casemap/struct.CaseMapperBorrowed.html#method.titlecase_segment_with_only_case_data_to_string) for more information.
+     */
+    static titlecaseSegmentWithOnlyCaseCompiledData(s, locale, options) {
+        let functionCleanupArena = new diplomatRuntime.CleanupArena();
+
+        const sSlice = functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.sliceWrapper(wasm, diplomatRuntime.DiplomatBuf.str8(wasm, s)));
+        const write = new diplomatRuntime.DiplomatWriteBuf(wasm);
+
+    wasm.icu4x_CaseMapper_titlecase_segment_with_only_case_compiled_data_mv1(sSlice.ptr, locale.ffiValue, TitlecaseOptions._fromSuppliedValue(diplomatRuntime.internalConstructor, options)._intoFFI(diplomatRuntime.FUNCTION_PARAM_ALLOC.alloc(TitlecaseOptions._sizeBytes), functionCleanupArena, {}, false), write.buffer);
+
+        try {
+            return write.readString8();
+        }
+
+        finally {
+            diplomatRuntime.FUNCTION_PARAM_ALLOC.clean();
+            functionCleanupArena.free();
+
+            write.free();
+        }
+    }
+
+    /**
      * Case-folds the characters in the given string
      *
      * See the [Rust documentation for `fold`](https://docs.rs/icu/2.1.1/icu/casemap/struct.CaseMapperBorrowed.html#method.fold) for more information.


### PR DESCRIPTION
We have compiled data versions of other ones.

This helps reduce binary size for gboard since we can avoid pulling in GC data. GBoard does custom head adjustment.


## Changelog

icu_capi: Expose a compiled data version of `CaseMapper::titlecase_segment_with_only_case_data()`


