### PR TITLE
fix: overflow  from_epoch_milliseconds_and_utc_offset … (#6512)

### DIFF
--- a/provider/source/src/time_zones/mod.rs
+++ b/provider/source/src/time_zones/mod.rs
@@ -751,6 +751,7 @@ mod tests {
     use icu::time::zone::TimeZoneVariant;
 
     use super::*;
+
     #[test]
     fn basic_cldr_time_zones() {
         use icu::locale::langid;


### PR DESCRIPTION
Added tests confirming integer overflow when combining `i64::MAX/MIN` 
with non-zero UTC offsets. Function panics at `components/time/src/types.rs:378:40` during 
addition operation.

Fixes #6512

## Changelog

icu_time: Fix overflow in `from_epoch_milliseconds_and_utc_offset()`

