### PR TITLE
Add tcast crate with TransparentCast derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3121,6 +3121,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tcast"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ members = [
     "utils/litemap",
     "utils/resb",
     "utils/tinystr",
+    "utils/tcast",
     "utils/tzif",
     "utils/potential_utf",
     "utils/writeable",
@@ -299,6 +300,7 @@ rand = "0.9"
 rand_distr = "0.5"
 rand_pcg = "0.9"
 rayon = "1.3.0"
+ref_cast = "1.0"
 regex = "1.12.2"
 rkyv = "0.7"
 rmp-serde = "1.2.0"

--- a/utils/tcast/Cargo.toml
+++ b/utils/tcast/Cargo.toml
@@ -1,0 +1,37 @@
+# This file is part of ICU4X. For terms of use, please see the file
+# called LICENSE at the top level of the ICU4X source tree
+# (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+[package]
+name = "tcast"
+description = "Cast transparent wrappers between their inner and outer types"
+version = "0.1.0"
+authors = ["Shane F Carr <shane@unicode.org>"]
+categories = ["rust-patterns", "no-std", "no-std::no-alloc"]
+keywords = ["transparent", "cast", "ref", "box", "dst"]
+
+edition.workspace = true
+include.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version = "1.71.1"
+
+[lib]
+proc-macro = true
+path = "src/lib.rs"
+
+[package.metadata.workspaces]
+independent = true
+
+[package.metadata.docs.rs]
+all-features = true
+
+[dependencies]
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true, features = ["fold"] }
+
+[dev-dependencies]
+
+[lints]
+workspace = true

--- a/utils/tcast/LICENSE
+++ b/utils/tcast/LICENSE
@@ -1,0 +1,46 @@
+UNICODE LICENSE V3
+
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright © 2020-2024 Unicode, Inc.
+
+NOTICE TO USER: Carefully read the following legal agreement. BY
+DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
+SOFTWARE, YOU UNEQUIVOCALLY ACCEPT, AND AGREE TO BE BOUND BY, ALL OF THE
+TERMS AND CONDITIONS OF THIS AGREEMENT. IF YOU DO NOT AGREE, DO NOT
+DOWNLOAD, INSTALL, COPY, DISTRIBUTE OR USE THE DATA FILES OR SOFTWARE.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of data files and any associated documentation (the "Data Files") or
+software and any associated documentation (the "Software") to deal in the
+Data Files or Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, and/or sell
+copies of the Data Files or Software, and to permit persons to whom the
+Data Files or Software are furnished to do so, provided that either (a)
+this copyright and permission notice appear with all copies of the Data
+Files or Software, or (b) this copyright and permission notice appear in
+associated Documentation.
+
+THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+THIRD PARTY RIGHTS.
+
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS NOTICE
+BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES,
+OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THE DATA
+FILES OR SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder shall
+not be used in advertising or otherwise to promote the sale, use or other
+dealings in these Data Files or Software without prior written
+authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
+
+—
+
+Portions of ICU4X may have been adapted from ICU4C and/or ICU4J.
+ICU 1.8.1 to ICU 57.1 © 1995-2016 International Business Machines Corporation and others.

--- a/utils/tcast/README.md
+++ b/utils/tcast/README.md
@@ -17,6 +17,16 @@ users cannot violate any invariants that the outer type imposes.
 You should add your own public functions that call the generated private
 functions after checking for invariants.
 
+## Comparison to Other Popular Crates
+
+Versus `ref-cast`: `tcast` is designed to be more flexible. For example,
+it supports standard pointer wrappers like `Box`, and it is exclusively a
+proc macro with no runtime trait, reducing dependencies and allowing it
+to be used as a dev-dependency (see below).
+
+Versus `bytemuck`, `zerocopy`, `zerovec`: `tcast` is a narrower crate
+focused on the `#[repr(transparent)]` use case.
+
 ## As a Dev-Dependency
 
 The primary purpose of this derive is to check for invariants and reduce

--- a/utils/tcast/README.md
+++ b/utils/tcast/README.md
@@ -1,0 +1,159 @@
+# tcast [![crates.io](https://img.shields.io/crates/v/tcast)](https://crates.io/crates/tcast)
+
+<!-- cargo-rdme start -->
+
+Creates private functions that cast a `repr(transparent)` struct from its
+inner type to its outer type.
+
+The generated functions are:
+
+- `fn tcast_ref(&Inner) -> &Outer`
+- If `tcast(alloc)` or `tcast(std)` is specified:
+    - `fn tcast_box(Box<Inner>) -> Box<Outer>`
+
+The generated functions are always private. This is to ensure external
+users cannot violate any invariants that the outer type imposes.
+
+You should add your own public functions that call the generated private
+functions after checking for invariants.
+
+## As a Dev-Dependency
+
+The primary purpose of this derive is to check for invariants and reduce
+the amount of unsafe code in your crate.
+
+You can avoid depending on this crate at runtime (and the transitive
+dependency on `syn`) by adding this crate as a dev-dependency and adding
+a function with the same signature gated on `#[cfg(not(test))]`:
+
+```rust
+#[cfg_attr(test, derive(TransparentCast))]
+#[repr(transparent)]
+pub struct Wrap<T>(T);
+
+impl<T> Wrap<T> {
+    #[cfg(not(test))]
+    fn tcast_ref(inner: &T) -> &Self {
+        // Safety: the tcast crate guarantees that this is safe
+        unsafe { core::mem::transmute(inner) }
+    }
+}
+```
+
+## Examples
+
+A struct with invariants:
+
+```rust
+mod even {
+    use tcast::TransparentCast;
+
+    #[derive(TransparentCast, Debug, PartialEq)]
+    #[repr(transparent)]
+    pub struct Even(u32);
+
+    impl Even {
+        pub fn from_ref(input: &u32) -> Option<&Self> {
+            if input % 2 == 0 {
+                Some(Self::tcast_ref(input))
+            } else {
+                None
+            }
+        }
+    }
+}
+
+assert!(even::Even::from_ref(&32).is_some());
+assert!(even::Even::from_ref(&33).is_none());
+```
+
+A more complex struct:
+
+```rust
+use core::marker::PhantomData;
+use tcast::TransparentCast;
+
+#[derive(TransparentCast, Debug, PartialEq)]
+#[tcast(std)]
+#[repr(transparent)]
+struct WithMarker<'a, T> {
+    value: &'a str,
+    _marker: PhantomData<T>,
+}
+
+#[derive(Debug, PartialEq)]
+struct MarkerType;
+
+assert_eq!(
+    WithMarker::<MarkerType>::tcast_box(Box::new("hello")),
+    Box::new(WithMarker::<MarkerType> {
+        value: "hello",
+        _marker: PhantomData,
+    })
+);
+```
+
+A dynamically-sized type (DST):
+
+```rust
+use core::marker::PhantomData;
+use tcast::TransparentCast;
+
+#[derive(TransparentCast)]
+#[tcast(std)]
+#[repr(transparent)]
+struct DynamicallySized {
+    value: str,
+}
+
+assert_eq!(
+    DynamicallySized::tcast_ref(&"hello").value,
+    *"hello"
+);
+```
+
+## Incorrect Usage
+
+The struct must be repr(transparent):
+
+```rust
+use tcast::TransparentCast;
+
+#[derive(TransparentCast)]
+struct NotTransparent(u8);
+```
+
+The struct must have at least one field:
+
+```rust
+use tcast::TransparentCast;
+
+#[derive(TransparentCast)]
+#[repr(transparent)]
+struct UnitStruct;
+```
+
+The struct must not have multiple non-zero-sized fields:
+
+```rust
+#[repr(transparent)]
+struct MultipleNonZeroFields(u8, u8, u8);
+```
+
+The struct can be annotated with tcast(alloc) or tcast(std) but not both:
+
+```rust
+use tcast::TransparentCast;
+
+#[derive(TransparentCast)]
+#[tcast(std)]
+#[tcast(alloc)]
+#[repr(transparent)]
+struct TooManyAttributes(u8);
+```
+
+<!-- cargo-rdme end -->
+
+## More Information
+
+For more information on development, authorship, contributing etc. please visit [`ICU4X home page`](https://github.com/unicode-org/icu4x).

--- a/utils/tcast/examples/transparent_cast.rs
+++ b/utils/tcast/examples/transparent_cast.rs
@@ -1,0 +1,16 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use tcast::TransparentCast;
+
+#[derive(Debug, TransparentCast)]
+#[tcast(std)]
+#[repr(transparent)]
+struct Wrap<T: ?Sized>(T);
+
+fn main() {
+    let inner = "hello world";
+    let wrap = Wrap::<str>::tcast_ref(inner);
+    println!("{wrap:?}");
+}

--- a/utils/tcast/src/lib.rs
+++ b/utils/tcast/src/lib.rs
@@ -1,0 +1,355 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+// https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
+// #![cfg_attr(not(any(test, doc)), no_std)]
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::indexing_slicing,
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+    )
+)]
+#![warn(missing_docs)]
+
+//! Creates private functions that cast a `repr(transparent)` struct from its
+//! inner type to its outer type.
+//!
+//! The generated functions are:
+//!
+//! - `fn tcast_ref(&Inner) -> &Outer`
+//! - If `tcast(alloc)` or `tcast(std)` is specified:
+//!     - `fn tcast_box(Box<Inner>) -> Box<Outer>`
+//!
+//! The generated functions are always private. This is to ensure external
+//! users cannot violate any invariants that the outer type imposes.
+//!
+//! You should add your own public functions that call the generated private
+//! functions after checking for invariants.
+//!
+//! # As a Dev-Dependency
+//!
+//! The primary purpose of this derive is to check for invariants and reduce
+//! the amount of unsafe code in your crate.
+//!
+//! You can avoid depending on this crate at runtime (and the transitive
+//! dependency on `syn`) by adding this crate as a dev-dependency and adding
+//! a function with the same signature gated on `#[cfg(not(test))]`:
+//!
+//! ```
+//! #[cfg_attr(test, derive(TransparentCast))]
+//! #[repr(transparent)]
+//! pub struct Wrap<T>(T);
+//!
+//! impl<T> Wrap<T> {
+//!     #[cfg(not(test))]
+//!     fn tcast_ref(inner: &T) -> &Self {
+//!         // Safety: the tcast crate guarantees that this is safe
+//!         unsafe { core::mem::transmute(inner) }
+//!     }
+//! }
+//! ```
+//!
+//! # Examples
+//!
+//! A struct with invariants:
+//!
+//! ```
+//! mod even {
+//!     use tcast::TransparentCast;
+//!
+//!     #[derive(TransparentCast, Debug, PartialEq)]
+//!     #[repr(transparent)]
+//!     pub struct Even(u32);
+//!
+//!     impl Even {
+//!         pub fn from_ref(input: &u32) -> Option<&Self> {
+//!             if input % 2 == 0 {
+//!                 Some(Self::tcast_ref(input))
+//!             } else {
+//!                 None
+//!             }
+//!         }
+//!     }
+//! }
+//!
+//! assert!(even::Even::from_ref(&32).is_some());
+//! assert!(even::Even::from_ref(&33).is_none());
+//! ```
+//!
+//! A more complex struct:
+//!
+//! ```
+//! use core::marker::PhantomData;
+//! use tcast::TransparentCast;
+//!
+//! #[derive(TransparentCast, Debug, PartialEq)]
+//! #[tcast(std)]
+//! #[repr(transparent)]
+//! struct WithMarker<'a, T> {
+//!     value: &'a str,
+//!     _marker: PhantomData<T>,
+//! }
+//!
+//! #[derive(Debug, PartialEq)]
+//! struct MarkerType;
+//!
+//! assert_eq!(
+//!     WithMarker::<MarkerType>::tcast_box(Box::new("hello")),
+//!     Box::new(WithMarker::<MarkerType> {
+//!         value: "hello",
+//!         _marker: PhantomData,
+//!     })
+//! );
+//! ```
+//!
+//! A dynamically-sized type (DST):
+//!
+//! ```
+//! use core::marker::PhantomData;
+//! use tcast::TransparentCast;
+//!
+//! #[derive(TransparentCast)]
+//! #[tcast(std)]
+//! #[repr(transparent)]
+//! struct DynamicallySized {
+//!     value: str,
+//! }
+//!
+//! assert_eq!(
+//!     DynamicallySized::tcast_ref(&"hello").value,
+//!     *"hello"
+//! );
+//! ```
+//!
+//! # Incorrect Usage
+//!
+//! The struct must be repr(transparent):
+//!
+//! ```compile_fail
+//! use tcast::TransparentCast;
+//!
+//! #[derive(TransparentCast)]
+//! struct NotTransparent(u8);
+//! ```
+//!
+//! The struct must have at least one field:
+//!
+//! ```compile_fail
+//! use tcast::TransparentCast;
+//!
+//! #[derive(TransparentCast)]
+//! #[repr(transparent)]
+//! struct UnitStruct;
+//! ```
+//!
+//! The struct must not have multiple non-zero-sized fields:
+//!
+//! ```compile_fail
+//! #[repr(transparent)]
+//! struct MultipleNonZeroFields(u8, u8, u8);
+//! ```
+//!
+//! The struct can be annotated with tcast(alloc) or tcast(std) but not both:
+//!
+//! ```compile_fail
+//! use tcast::TransparentCast;
+//!
+//! #[derive(TransparentCast)]
+//! #[tcast(std)]
+//! #[tcast(alloc)]
+//! #[repr(transparent)]
+//! struct TooManyAttributes(u8);
+//! ```
+
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::{
+    parse_macro_input, punctuated::Punctuated, Attribute, DeriveInput, FieldsNamed, FieldsUnnamed,
+    Meta, Token,
+};
+
+/// Derive macro that adds private transparent cast functions to a type.
+///
+/// See the crate-level docs for more details.
+#[proc_macro_derive(TransparentCast, attributes(tcast))]
+pub fn tcast_derive(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    TokenStream::from(zf_derive_impl(&input))
+}
+
+fn zf_derive_impl(input: &DeriveInput) -> TokenStream2 {
+    if !has_repr_transparent(&input.attrs) {
+        return syn::Error::new_spanned(input, "TransparentCast requires #[repr(transparent)]")
+            .to_compile_error();
+    }
+
+    let ident = &input.ident;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+    let transparent_ty = match transparent_over_type(input) {
+        Ok(ty) => ty,
+        Err(err) => return err.to_compile_error(),
+    };
+
+    let tcast_ref_impl = quote! {
+        /// Casts an inner type reference to an outer type reference.
+        #[allow(dead_code)]
+        fn tcast_ref<'tcast>(inner: &'tcast #transparent_ty) -> &'tcast #ident #ty_generics {
+            // Safety: As verified above, the input type is transparent over transparent_ty.
+            // This is a private function. The caller is responsible for upholding any potential field invariants.
+            unsafe { core::mem::transmute(inner) }
+        }
+    };
+
+    let tcast_box_impl = match tcast_box_mode(&input.attrs) {
+        Ok(Some(TcastBoxMode::Alloc)) => quote! {
+            /// Casts an inner type box to an outer type box.
+            #[allow(dead_code)]
+            fn tcast_box(
+                inner: alloc::boxed::Box<#transparent_ty>,
+            ) -> alloc::boxed::Box<#ident #ty_generics> {
+                // Safety: As verified above, the input type is transparent over transparent_ty.
+                // This is a private function. The caller is responsible for upholding any potential field invariants.
+                unsafe { core::mem::transmute(inner) }
+            }
+        },
+        Ok(Some(TcastBoxMode::Std)) => quote! {
+            /// Casts an inner type box to an outer type box.
+            #[allow(dead_code)]
+            fn tcast_box(
+                inner: std::boxed::Box<#transparent_ty>,
+            ) -> std::boxed::Box<#ident #ty_generics> {
+                // Safety: As verified above, the input type is transparent over transparent_ty.
+                // This is a private function. The caller is responsible for upholding any potential field invariants.
+                unsafe { core::mem::transmute(inner) }
+            }
+        },
+        Ok(None) => TokenStream2::new(),
+        Err(err) => return err.to_compile_error(),
+    };
+
+    quote! {
+        impl #impl_generics #ident #ty_generics #where_clause {
+            #tcast_ref_impl
+            #tcast_box_impl
+        }
+    }
+}
+
+/// Returns whether one of the given attributes is repr(transparent).
+fn has_repr_transparent(attrs: &[Attribute]) -> bool {
+    for attr in attrs {
+        if !attr.path().is_ident("repr") {
+            continue;
+        }
+
+        let parser = Punctuated::<Meta, Token![,]>::parse_terminated;
+        if let Ok(metas) = attr.parse_args_with(parser) {
+            for meta in metas {
+                if let Meta::Path(path) = meta {
+                    if path.is_ident("transparent") {
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+
+    false
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TcastBoxMode {
+    Alloc,
+    Std,
+}
+
+/// Returns the requested tcast box mode, if any.
+fn tcast_box_mode(attrs: &[Attribute]) -> Result<Option<TcastBoxMode>, syn::Error> {
+    let mut mode = None;
+    for attr in attrs {
+        if !attr.path().is_ident("tcast") {
+            continue;
+        }
+
+        let parser = Punctuated::<Meta, Token![,]>::parse_terminated;
+        if let Ok(metas) = attr.parse_args_with(parser) {
+            for meta in metas {
+                if let Meta::Path(path) = meta {
+                    let new_mode = if path.is_ident("alloc") {
+                        TcastBoxMode::Alloc
+                    } else if path.is_ident("std") {
+                        TcastBoxMode::Std
+                    } else {
+                        continue;
+                    };
+                    if mode.is_some() {
+                        return Err(syn::Error::new_spanned(
+                            attr,
+                            "TransparentCast cannot combine tcast(alloc) and tcast(std)",
+                        ));
+                    }
+                    mode = Some(new_mode);
+                }
+            }
+        }
+    }
+
+    Ok(mode)
+}
+
+/// Returns the inner type of a transparent struct.
+fn transparent_over_type(input: &DeriveInput) -> Result<&syn::Type, syn::Error> {
+    match &input.data {
+        syn::Data::Struct(data) => match &data.fields {
+            syn::Fields::Named(FieldsNamed { named: fields, .. })
+            | syn::Fields::Unnamed(FieldsUnnamed {
+                unnamed: fields, ..
+            }) => {
+                let mut non_zero_fields = fields
+                    .into_iter()
+                    .filter(|field| !is_zero_sized_field(&field.ty));
+
+                match (non_zero_fields.next(), non_zero_fields.next()) {
+                    (Some(first), None) => Ok(&first.ty),
+                    _ => Err(syn::Error::new_spanned(
+                        &data.fields,
+                        "TransparentCast requires exactly one non-zero-sized field",
+                    )),
+                }
+            }
+            syn::Fields::Unit => Err(syn::Error::new_spanned(
+                &data.fields,
+                "TransparentCast requires at least one non-zero-sized field",
+            )),
+        },
+        syn::Data::Enum(_) | syn::Data::Union(_) => Err(syn::Error::new_spanned(
+            input,
+            "TransparentCast only supports structs",
+        )),
+    }
+}
+
+/// Returns whether the given field is zero-sized.
+///
+/// Currently this just checks if the field is `PhantomData`.
+/// This should be improved in the future.
+fn is_zero_sized_field(ty: &syn::Type) -> bool {
+    if let syn::Type::Path(type_path) = ty {
+        if let Some(ident) = type_path.path.get_ident() {
+            return ident == "PhantomData";
+        }
+
+        if let Some(segment) = type_path.path.segments.last() {
+            if segment.ident == "PhantomData" {
+                return true;
+            }
+        }
+    }
+
+    false
+}

--- a/utils/tcast/src/lib.rs
+++ b/utils/tcast/src/lib.rs
@@ -30,6 +30,16 @@
 //! You should add your own public functions that call the generated private
 //! functions after checking for invariants.
 //!
+//! # Comparison to Other Popular Crates
+//!
+//! Versus `ref-cast`: `tcast` is designed to be more flexible. For example,
+//! it supports standard pointer wrappers like `Box`, and it is exclusively a
+//! proc macro with no runtime trait, reducing dependencies and allowing it
+//! to be used as a dev-dependency (see below).
+//!
+//! Versus `bytemuck`, `zerocopy`, `zerovec`: `tcast` is a narrower crate
+//! focused on the `#[repr(transparent)]` use case.
+//!
 //! # As a Dev-Dependency
 //!
 //! The primary purpose of this derive is to check for invariants and reduce


### PR DESCRIPTION
Fixes #7607
Replaces #5101
See #6915

I was trying to use `ref_cast`, but found that it had multiple deficiencies:

1. Doesn't support standard pointer wrappers like Box
2. Implements a trait by default, which can violate field invariants
    - Note: it supports a private conversion function via `RefCastCustom`
3. Not highly suited for use as a dev-dependency only

So, I made my own proc macro, `TransparentCast`.

The use cases are the same as `RefCast`, as listed in #7607, but it resolves the deficiencies listed above.

I am as sensitive to dependency bloat as everyone else, so I specifically designed this derive to be usable as a dev-dependency. See the example. However, this PR is not intended to be the place to debate whether we decide to use that strategy in icu4x.