### PR TITLE
Clarify docs on `extensions::Private`

### DIFF
--- a/components/locale_core/src/extensions/private/mod.rs
+++ b/components/locale_core/src/extensions/private/mod.rs
@@ -114,8 +114,6 @@ impl Private {
 
     /// A constructor which takes a list of [`Subtag`]s.
     ///
-    /// The subtags should be in canonical form (lowercase).
-    ///
     /// ✨ *Enabled with the `alloc` Cargo feature.*
     ///
     /// # Examples


### PR DESCRIPTION
Fixes #4149 

Summary :- 

- Added clear documentation stating the caller must provide sorted subtags, deduplicated subtags, canonical form ( lowercase ) subtags

- Updated all examples to show properly sorted input which is "bar" before "foo"


## Changelog: N/A

