### PR TITLE
Add BoundLocaleDataProvider and some impls for it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1638,6 +1638,7 @@ dependencies = [
  "icu_properties",
  "icu_properties_data",
  "icu_provider",
+ "icu_provider_blob",
  "litemap",
  "log",
  "num-bigint",

--- a/components/experimental/Cargo.toml
+++ b/components/experimental/Cargo.toml
@@ -71,6 +71,7 @@ icu_provider = { path = "../../provider/core", features = ["std"]}
 icu_locale_data = { workspace = true }
 icu_properties_data = { workspace = true }
 icu_normalizer_data = { workspace = true }
+icu_provider_blob = { workspace = true, features = ["alloc"] }
 
 [features]
 default = ["compiled_data"]
@@ -79,6 +80,11 @@ datagen = ["serde", "dep:databake", "zerovec/databake", "zerotrie/databake", "ti
 ryu = ["fixed_decimal/ryu"]
 log = ["dep:log"]
 serde = ["dep:serde", "icu_locale_core/serde", "zerovec/serde", "potential_utf/serde", "tinystr/serde", "icu_collections/serde", "icu_decimal/serde", "icu_list/serde", "icu_pattern/serde", "icu_plurals/serde", "icu_provider/alloc", "icu_provider/serde", "zerotrie/serde", "icu_normalizer/serde", "icu_casemap/serde"]
+
+[[bench]]
+name = "locale_names"
+path = "benches/locale_names/bench.rs"
+harness = false
 
 [[bench]]
 name = "transliterate"

--- a/components/experimental/benches/locale_names/bench.rs
+++ b/components/experimental/benches/locale_names/bench.rs
@@ -1,0 +1,861 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use criterion::{Criterion, black_box};
+use criterion::{criterion_group, criterion_main};
+
+use icu_experimental::displaynames::provider::{LocaleNamesRegionMediumV1, RegionDisplayNamesV1};
+use icu_experimental::provider::Baked;
+use icu_locale::{DataLocale, locale};
+use icu_provider::buf::{AsDeserializingBufferProvider, DeserializingOwnedBufferProvider};
+use icu_provider::unstable::{
+    BindLocaleDataProvider, BoundLocaleDataProvider, DataAttributesRequest,
+};
+use icu_provider::{
+    DataIdentifierBorrowed, DataMarker, DataMarkerAttributes, DataProvider, DataRequest,
+};
+use icu_provider_blob::BlobDataProvider;
+use tinystr::UnvalidatedTinyAsciiStr;
+
+pub fn criterion_benchmark(criterion: &mut Criterion) {
+    let group_name = "locale_names";
+
+    let mut group = criterion.benchmark_group(group_name);
+
+    let locales = &[
+        DataLocale::from(locale!("af")),
+        DataLocale::from(locale!("ak")),
+        DataLocale::from(locale!("am")),
+        DataLocale::from(locale!("ar")),
+        DataLocale::from(locale!("as")),
+        DataLocale::from(locale!("ast")),
+        DataLocale::from(locale!("az")),
+        DataLocale::from(locale!("ba")),
+        DataLocale::from(locale!("bal-Latn")),
+        DataLocale::from(locale!("be")),
+        DataLocale::from(locale!("bg")),
+        DataLocale::from(locale!("bgc")),
+        DataLocale::from(locale!("bho")),
+        DataLocale::from(locale!("blo")),
+        DataLocale::from(locale!("bn")),
+        DataLocale::from(locale!("br")),
+        DataLocale::from(locale!("brx")),
+        DataLocale::from(locale!("bs")),
+        DataLocale::from(locale!("bs-Cyrl")),
+        DataLocale::from(locale!("bua")),
+        DataLocale::from(locale!("ca")),
+        DataLocale::from(locale!("ceb")),
+        DataLocale::from(locale!("chr")),
+        DataLocale::from(locale!("cs")),
+        DataLocale::from(locale!("csw")),
+        DataLocale::from(locale!("cv")),
+        DataLocale::from(locale!("cy")),
+        DataLocale::from(locale!("da")),
+        DataLocale::from(locale!("de")),
+        DataLocale::from(locale!("doi")),
+        DataLocale::from(locale!("dsb")),
+        DataLocale::from(locale!("ee")),
+        DataLocale::from(locale!("el")),
+        DataLocale::from(locale!("en")),
+        DataLocale::from(locale!("eo")),
+        DataLocale::from(locale!("es")),
+        DataLocale::from(locale!("et")),
+        DataLocale::from(locale!("eu")),
+        DataLocale::from(locale!("fa")),
+        DataLocale::from(locale!("ff-Adlm")),
+        DataLocale::from(locale!("fi")),
+        DataLocale::from(locale!("fil")),
+        DataLocale::from(locale!("fo")),
+        DataLocale::from(locale!("fr")),
+        DataLocale::from(locale!("fy")),
+        DataLocale::from(locale!("ga")),
+        DataLocale::from(locale!("gaa")),
+        DataLocale::from(locale!("gd")),
+        DataLocale::from(locale!("gl")),
+        DataLocale::from(locale!("gu")),
+        DataLocale::from(locale!("ha")),
+        DataLocale::from(locale!("he")),
+        DataLocale::from(locale!("hi")),
+        DataLocale::from(locale!("hi-Latn")),
+        DataLocale::from(locale!("hr")),
+        DataLocale::from(locale!("hsb")),
+        DataLocale::from(locale!("hu")),
+        DataLocale::from(locale!("hy")),
+        DataLocale::from(locale!("ia")),
+        DataLocale::from(locale!("id")),
+        DataLocale::from(locale!("ie")),
+        DataLocale::from(locale!("ig")),
+        DataLocale::from(locale!("ii")),
+        DataLocale::from(locale!("is")),
+        DataLocale::from(locale!("it")),
+        DataLocale::from(locale!("ja")),
+        DataLocale::from(locale!("jv")),
+        DataLocale::from(locale!("ka")),
+        DataLocale::from(locale!("kea")),
+        DataLocale::from(locale!("kgp")),
+        DataLocale::from(locale!("kk")),
+        DataLocale::from(locale!("kk-Arab")),
+        DataLocale::from(locale!("km")),
+        DataLocale::from(locale!("kn")),
+        DataLocale::from(locale!("ko")),
+        DataLocale::from(locale!("kok")),
+        DataLocale::from(locale!("kok-Latn")),
+        DataLocale::from(locale!("ks")),
+        DataLocale::from(locale!("ks-Deva")),
+        DataLocale::from(locale!("ku")),
+        DataLocale::from(locale!("kxv")),
+        DataLocale::from(locale!("kxv-Deva")),
+        DataLocale::from(locale!("kxv-Orya")),
+        DataLocale::from(locale!("kxv-Telu")),
+        DataLocale::from(locale!("ky")),
+        DataLocale::from(locale!("lb")),
+        DataLocale::from(locale!("lij")),
+        DataLocale::from(locale!("lmo")),
+        DataLocale::from(locale!("lo")),
+        DataLocale::from(locale!("lt")),
+        DataLocale::from(locale!("lv")),
+        DataLocale::from(locale!("mai")),
+        DataLocale::from(locale!("mi")),
+        DataLocale::from(locale!("mk")),
+        DataLocale::from(locale!("ml")),
+        DataLocale::from(locale!("mn")),
+        DataLocale::from(locale!("mni")),
+        DataLocale::from(locale!("mr")),
+        DataLocale::from(locale!("ms")),
+        DataLocale::from(locale!("mt")),
+        DataLocale::from(locale!("my")),
+        DataLocale::from(locale!("nds")),
+        DataLocale::from(locale!("ne")),
+        DataLocale::from(locale!("nl")),
+        DataLocale::from(locale!("nn")),
+        DataLocale::from(locale!("no")),
+        DataLocale::from(locale!("nqo")),
+        DataLocale::from(locale!("nso")),
+        DataLocale::from(locale!("oc")),
+        DataLocale::from(locale!("om")),
+        DataLocale::from(locale!("or")),
+        DataLocale::from(locale!("pa")),
+        DataLocale::from(locale!("pcm")),
+        DataLocale::from(locale!("pl")),
+        DataLocale::from(locale!("pms")),
+        DataLocale::from(locale!("ps")),
+        DataLocale::from(locale!("pt")),
+        DataLocale::from(locale!("qu")),
+        DataLocale::from(locale!("raj")),
+        DataLocale::from(locale!("rm")),
+        DataLocale::from(locale!("ro")),
+        DataLocale::from(locale!("ru")),
+        DataLocale::from(locale!("rw")),
+        DataLocale::from(locale!("sa")),
+        DataLocale::from(locale!("sah")),
+        DataLocale::from(locale!("sat")),
+        DataLocale::from(locale!("sc")),
+        DataLocale::from(locale!("scn")),
+        DataLocale::from(locale!("sd")),
+        DataLocale::from(locale!("sd-Deva")),
+        DataLocale::from(locale!("shn")),
+        DataLocale::from(locale!("si")),
+        DataLocale::from(locale!("sk")),
+        DataLocale::from(locale!("sl")),
+        DataLocale::from(locale!("so")),
+        DataLocale::from(locale!("sq")),
+        DataLocale::from(locale!("sr")),
+        DataLocale::from(locale!("sr-Latn")),
+        DataLocale::from(locale!("st")),
+        DataLocale::from(locale!("su")),
+        DataLocale::from(locale!("sv")),
+        DataLocale::from(locale!("sw")),
+        DataLocale::from(locale!("syr")),
+        DataLocale::from(locale!("szl")),
+        DataLocale::from(locale!("ta")),
+        DataLocale::from(locale!("te")),
+        DataLocale::from(locale!("tg")),
+        DataLocale::from(locale!("th")),
+        DataLocale::from(locale!("ti")),
+        DataLocale::from(locale!("tk")),
+        DataLocale::from(locale!("tn")),
+        DataLocale::from(locale!("to")),
+        DataLocale::from(locale!("tr")),
+        DataLocale::from(locale!("tt")),
+        DataLocale::from(locale!("tyv")),
+        DataLocale::from(locale!("ug")),
+        DataLocale::from(locale!("uk")),
+        DataLocale::from(locale!("ur")),
+        DataLocale::from(locale!("uz")),
+        DataLocale::from(locale!("uz-Cyrl")),
+        DataLocale::from(locale!("vec")),
+        DataLocale::from(locale!("vi")),
+        DataLocale::from(locale!("vmw")),
+        DataLocale::from(locale!("wo")),
+        DataLocale::from(locale!("xh")),
+        DataLocale::from(locale!("xnr")),
+        DataLocale::from(locale!("yo")),
+        DataLocale::from(locale!("yrl")),
+        DataLocale::from(locale!("yue")),
+        DataLocale::from(locale!("yue-Hans")),
+        DataLocale::from(locale!("za")),
+        DataLocale::from(locale!("zh")),
+        DataLocale::from(locale!("zh-Hant")),
+        DataLocale::from(locale!("zu")),
+    ];
+
+    let attributeses = &[
+        DataMarkerAttributes::try_from_str("001").unwrap(),
+        DataMarkerAttributes::try_from_str("002").unwrap(),
+        DataMarkerAttributes::try_from_str("003").unwrap(),
+        DataMarkerAttributes::try_from_str("005").unwrap(),
+        DataMarkerAttributes::try_from_str("009").unwrap(),
+        DataMarkerAttributes::try_from_str("011").unwrap(),
+        DataMarkerAttributes::try_from_str("013").unwrap(),
+        DataMarkerAttributes::try_from_str("014").unwrap(),
+        DataMarkerAttributes::try_from_str("015").unwrap(),
+        DataMarkerAttributes::try_from_str("017").unwrap(),
+        DataMarkerAttributes::try_from_str("018").unwrap(),
+        DataMarkerAttributes::try_from_str("019").unwrap(),
+        DataMarkerAttributes::try_from_str("021").unwrap(),
+        DataMarkerAttributes::try_from_str("029").unwrap(),
+        DataMarkerAttributes::try_from_str("030").unwrap(),
+        DataMarkerAttributes::try_from_str("034").unwrap(),
+        DataMarkerAttributes::try_from_str("035").unwrap(),
+        DataMarkerAttributes::try_from_str("039").unwrap(),
+        DataMarkerAttributes::try_from_str("053").unwrap(),
+        DataMarkerAttributes::try_from_str("054").unwrap(),
+        DataMarkerAttributes::try_from_str("057").unwrap(),
+        DataMarkerAttributes::try_from_str("061").unwrap(),
+        DataMarkerAttributes::try_from_str("142").unwrap(),
+        DataMarkerAttributes::try_from_str("143").unwrap(),
+        DataMarkerAttributes::try_from_str("145").unwrap(),
+        DataMarkerAttributes::try_from_str("150").unwrap(),
+        DataMarkerAttributes::try_from_str("151").unwrap(),
+        DataMarkerAttributes::try_from_str("154").unwrap(),
+        DataMarkerAttributes::try_from_str("155").unwrap(),
+        DataMarkerAttributes::try_from_str("202").unwrap(),
+        DataMarkerAttributes::try_from_str("419").unwrap(),
+        DataMarkerAttributes::try_from_str("AC").unwrap(),
+        DataMarkerAttributes::try_from_str("AD").unwrap(),
+        DataMarkerAttributes::try_from_str("AE").unwrap(),
+        DataMarkerAttributes::try_from_str("AF").unwrap(),
+        DataMarkerAttributes::try_from_str("AG").unwrap(),
+        DataMarkerAttributes::try_from_str("AI").unwrap(),
+        DataMarkerAttributes::try_from_str("AL").unwrap(),
+        DataMarkerAttributes::try_from_str("AM").unwrap(),
+        DataMarkerAttributes::try_from_str("AO").unwrap(),
+        DataMarkerAttributes::try_from_str("AQ").unwrap(),
+        DataMarkerAttributes::try_from_str("AR").unwrap(),
+        DataMarkerAttributes::try_from_str("AS").unwrap(),
+        DataMarkerAttributes::try_from_str("AT").unwrap(),
+        DataMarkerAttributes::try_from_str("AU").unwrap(),
+        DataMarkerAttributes::try_from_str("AW").unwrap(),
+        DataMarkerAttributes::try_from_str("AX").unwrap(),
+        DataMarkerAttributes::try_from_str("AZ").unwrap(),
+        DataMarkerAttributes::try_from_str("BA").unwrap(),
+        DataMarkerAttributes::try_from_str("BA").unwrap(),
+        DataMarkerAttributes::try_from_str("BB").unwrap(),
+        DataMarkerAttributes::try_from_str("BD").unwrap(),
+        DataMarkerAttributes::try_from_str("BE").unwrap(),
+        DataMarkerAttributes::try_from_str("BF").unwrap(),
+        DataMarkerAttributes::try_from_str("BG").unwrap(),
+        DataMarkerAttributes::try_from_str("BH").unwrap(),
+        DataMarkerAttributes::try_from_str("BI").unwrap(),
+        DataMarkerAttributes::try_from_str("BJ").unwrap(),
+        DataMarkerAttributes::try_from_str("BL").unwrap(),
+        DataMarkerAttributes::try_from_str("BM").unwrap(),
+        DataMarkerAttributes::try_from_str("BN").unwrap(),
+        DataMarkerAttributes::try_from_str("BO").unwrap(),
+        DataMarkerAttributes::try_from_str("BQ").unwrap(),
+        DataMarkerAttributes::try_from_str("BR").unwrap(),
+        DataMarkerAttributes::try_from_str("BS").unwrap(),
+        DataMarkerAttributes::try_from_str("BT").unwrap(),
+        DataMarkerAttributes::try_from_str("BV").unwrap(),
+        DataMarkerAttributes::try_from_str("BW").unwrap(),
+        DataMarkerAttributes::try_from_str("BY").unwrap(),
+        DataMarkerAttributes::try_from_str("BZ").unwrap(),
+        DataMarkerAttributes::try_from_str("CA").unwrap(),
+        DataMarkerAttributes::try_from_str("CC").unwrap(),
+        DataMarkerAttributes::try_from_str("CC").unwrap(),
+        DataMarkerAttributes::try_from_str("CD").unwrap(),
+        DataMarkerAttributes::try_from_str("CD").unwrap(),
+        DataMarkerAttributes::try_from_str("CF").unwrap(),
+        DataMarkerAttributes::try_from_str("CG").unwrap(),
+        DataMarkerAttributes::try_from_str("CG").unwrap(),
+        DataMarkerAttributes::try_from_str("CH").unwrap(),
+        DataMarkerAttributes::try_from_str("CI").unwrap(),
+        DataMarkerAttributes::try_from_str("CI").unwrap(),
+        DataMarkerAttributes::try_from_str("CK").unwrap(),
+        DataMarkerAttributes::try_from_str("CL").unwrap(),
+        DataMarkerAttributes::try_from_str("CM").unwrap(),
+        DataMarkerAttributes::try_from_str("CN").unwrap(),
+        DataMarkerAttributes::try_from_str("CO").unwrap(),
+        DataMarkerAttributes::try_from_str("CP").unwrap(),
+        DataMarkerAttributes::try_from_str("CQ").unwrap(),
+        DataMarkerAttributes::try_from_str("CR").unwrap(),
+        DataMarkerAttributes::try_from_str("CU").unwrap(),
+        DataMarkerAttributes::try_from_str("CV").unwrap(),
+        DataMarkerAttributes::try_from_str("CV").unwrap(),
+        DataMarkerAttributes::try_from_str("CW").unwrap(),
+        DataMarkerAttributes::try_from_str("CX").unwrap(),
+        DataMarkerAttributes::try_from_str("CY").unwrap(),
+        DataMarkerAttributes::try_from_str("CZ").unwrap(),
+        DataMarkerAttributes::try_from_str("CZ").unwrap(),
+        DataMarkerAttributes::try_from_str("DE").unwrap(),
+        DataMarkerAttributes::try_from_str("DG").unwrap(),
+        DataMarkerAttributes::try_from_str("DJ").unwrap(),
+        DataMarkerAttributes::try_from_str("DK").unwrap(),
+        DataMarkerAttributes::try_from_str("DM").unwrap(),
+        DataMarkerAttributes::try_from_str("DO").unwrap(),
+        DataMarkerAttributes::try_from_str("DZ").unwrap(),
+        DataMarkerAttributes::try_from_str("EA").unwrap(),
+        DataMarkerAttributes::try_from_str("EC").unwrap(),
+        DataMarkerAttributes::try_from_str("EE").unwrap(),
+        DataMarkerAttributes::try_from_str("EG").unwrap(),
+        DataMarkerAttributes::try_from_str("EH").unwrap(),
+        DataMarkerAttributes::try_from_str("ER").unwrap(),
+        DataMarkerAttributes::try_from_str("ES").unwrap(),
+        DataMarkerAttributes::try_from_str("ET").unwrap(),
+        DataMarkerAttributes::try_from_str("EU").unwrap(),
+        DataMarkerAttributes::try_from_str("EZ").unwrap(),
+        DataMarkerAttributes::try_from_str("FI").unwrap(),
+        DataMarkerAttributes::try_from_str("FJ").unwrap(),
+        DataMarkerAttributes::try_from_str("FK").unwrap(),
+        DataMarkerAttributes::try_from_str("FK").unwrap(),
+        DataMarkerAttributes::try_from_str("FM").unwrap(),
+        DataMarkerAttributes::try_from_str("FO").unwrap(),
+        DataMarkerAttributes::try_from_str("FR").unwrap(),
+        DataMarkerAttributes::try_from_str("GA").unwrap(),
+        DataMarkerAttributes::try_from_str("GB").unwrap(),
+        DataMarkerAttributes::try_from_str("GB").unwrap(),
+        DataMarkerAttributes::try_from_str("GD").unwrap(),
+        DataMarkerAttributes::try_from_str("GE").unwrap(),
+        DataMarkerAttributes::try_from_str("GF").unwrap(),
+        DataMarkerAttributes::try_from_str("GG").unwrap(),
+        DataMarkerAttributes::try_from_str("GH").unwrap(),
+        DataMarkerAttributes::try_from_str("GI").unwrap(),
+        DataMarkerAttributes::try_from_str("GL").unwrap(),
+        DataMarkerAttributes::try_from_str("GM").unwrap(),
+        DataMarkerAttributes::try_from_str("GN").unwrap(),
+        DataMarkerAttributes::try_from_str("GP").unwrap(),
+        DataMarkerAttributes::try_from_str("GQ").unwrap(),
+        DataMarkerAttributes::try_from_str("GR").unwrap(),
+        DataMarkerAttributes::try_from_str("GS").unwrap(),
+        DataMarkerAttributes::try_from_str("GT").unwrap(),
+        DataMarkerAttributes::try_from_str("GU").unwrap(),
+        DataMarkerAttributes::try_from_str("GW").unwrap(),
+        DataMarkerAttributes::try_from_str("GY").unwrap(),
+        DataMarkerAttributes::try_from_str("HK").unwrap(),
+        DataMarkerAttributes::try_from_str("HK").unwrap(),
+        DataMarkerAttributes::try_from_str("HM").unwrap(),
+        DataMarkerAttributes::try_from_str("HN").unwrap(),
+        DataMarkerAttributes::try_from_str("HR").unwrap(),
+        DataMarkerAttributes::try_from_str("HT").unwrap(),
+        DataMarkerAttributes::try_from_str("HU").unwrap(),
+        DataMarkerAttributes::try_from_str("IC").unwrap(),
+        DataMarkerAttributes::try_from_str("ID").unwrap(),
+        DataMarkerAttributes::try_from_str("IE").unwrap(),
+        DataMarkerAttributes::try_from_str("IL").unwrap(),
+        DataMarkerAttributes::try_from_str("IM").unwrap(),
+        DataMarkerAttributes::try_from_str("IN").unwrap(),
+        DataMarkerAttributes::try_from_str("IO").unwrap(),
+        DataMarkerAttributes::try_from_str("IO").unwrap(),
+        DataMarkerAttributes::try_from_str("IQ").unwrap(),
+        DataMarkerAttributes::try_from_str("IR").unwrap(),
+        DataMarkerAttributes::try_from_str("IS").unwrap(),
+        DataMarkerAttributes::try_from_str("IT").unwrap(),
+        DataMarkerAttributes::try_from_str("JE").unwrap(),
+        DataMarkerAttributes::try_from_str("JM").unwrap(),
+        DataMarkerAttributes::try_from_str("JO").unwrap(),
+        DataMarkerAttributes::try_from_str("JP").unwrap(),
+        DataMarkerAttributes::try_from_str("KE").unwrap(),
+        DataMarkerAttributes::try_from_str("KG").unwrap(),
+        DataMarkerAttributes::try_from_str("KH").unwrap(),
+        DataMarkerAttributes::try_from_str("KI").unwrap(),
+        DataMarkerAttributes::try_from_str("KM").unwrap(),
+        DataMarkerAttributes::try_from_str("KN").unwrap(),
+        DataMarkerAttributes::try_from_str("KP").unwrap(),
+        DataMarkerAttributes::try_from_str("KR").unwrap(),
+        DataMarkerAttributes::try_from_str("KW").unwrap(),
+        DataMarkerAttributes::try_from_str("KY").unwrap(),
+        DataMarkerAttributes::try_from_str("KZ").unwrap(),
+        DataMarkerAttributes::try_from_str("LA").unwrap(),
+        DataMarkerAttributes::try_from_str("LB").unwrap(),
+        DataMarkerAttributes::try_from_str("LC").unwrap(),
+        DataMarkerAttributes::try_from_str("LI").unwrap(),
+        DataMarkerAttributes::try_from_str("LK").unwrap(),
+        DataMarkerAttributes::try_from_str("LR").unwrap(),
+        DataMarkerAttributes::try_from_str("LS").unwrap(),
+        DataMarkerAttributes::try_from_str("LT").unwrap(),
+        DataMarkerAttributes::try_from_str("LU").unwrap(),
+        DataMarkerAttributes::try_from_str("LV").unwrap(),
+        DataMarkerAttributes::try_from_str("LY").unwrap(),
+        DataMarkerAttributes::try_from_str("MA").unwrap(),
+        DataMarkerAttributes::try_from_str("MC").unwrap(),
+        DataMarkerAttributes::try_from_str("MD").unwrap(),
+        DataMarkerAttributes::try_from_str("ME").unwrap(),
+        DataMarkerAttributes::try_from_str("MF").unwrap(),
+        DataMarkerAttributes::try_from_str("MG").unwrap(),
+        DataMarkerAttributes::try_from_str("MH").unwrap(),
+        DataMarkerAttributes::try_from_str("MK").unwrap(),
+        DataMarkerAttributes::try_from_str("ML").unwrap(),
+        DataMarkerAttributes::try_from_str("MM").unwrap(),
+        DataMarkerAttributes::try_from_str("MM").unwrap(),
+        DataMarkerAttributes::try_from_str("MN").unwrap(),
+        DataMarkerAttributes::try_from_str("MO").unwrap(),
+        DataMarkerAttributes::try_from_str("MO").unwrap(),
+        DataMarkerAttributes::try_from_str("MP").unwrap(),
+        DataMarkerAttributes::try_from_str("MQ").unwrap(),
+        DataMarkerAttributes::try_from_str("MR").unwrap(),
+        DataMarkerAttributes::try_from_str("MS").unwrap(),
+        DataMarkerAttributes::try_from_str("MT").unwrap(),
+        DataMarkerAttributes::try_from_str("MU").unwrap(),
+        DataMarkerAttributes::try_from_str("MV").unwrap(),
+        DataMarkerAttributes::try_from_str("MW").unwrap(),
+        DataMarkerAttributes::try_from_str("MX").unwrap(),
+        DataMarkerAttributes::try_from_str("MY").unwrap(),
+        DataMarkerAttributes::try_from_str("MZ").unwrap(),
+        DataMarkerAttributes::try_from_str("NA").unwrap(),
+        DataMarkerAttributes::try_from_str("NC").unwrap(),
+        DataMarkerAttributes::try_from_str("NE").unwrap(),
+        DataMarkerAttributes::try_from_str("NF").unwrap(),
+        DataMarkerAttributes::try_from_str("NG").unwrap(),
+        DataMarkerAttributes::try_from_str("NI").unwrap(),
+        DataMarkerAttributes::try_from_str("NL").unwrap(),
+        DataMarkerAttributes::try_from_str("NO").unwrap(),
+        DataMarkerAttributes::try_from_str("NP").unwrap(),
+        DataMarkerAttributes::try_from_str("NR").unwrap(),
+        DataMarkerAttributes::try_from_str("NU").unwrap(),
+        DataMarkerAttributes::try_from_str("NZ").unwrap(),
+        DataMarkerAttributes::try_from_str("NZ").unwrap(),
+        DataMarkerAttributes::try_from_str("OM").unwrap(),
+        DataMarkerAttributes::try_from_str("PA").unwrap(),
+        DataMarkerAttributes::try_from_str("PE").unwrap(),
+        DataMarkerAttributes::try_from_str("PF").unwrap(),
+        DataMarkerAttributes::try_from_str("PG").unwrap(),
+        DataMarkerAttributes::try_from_str("PH").unwrap(),
+        DataMarkerAttributes::try_from_str("PK").unwrap(),
+        DataMarkerAttributes::try_from_str("PL").unwrap(),
+        DataMarkerAttributes::try_from_str("PM").unwrap(),
+        DataMarkerAttributes::try_from_str("PN").unwrap(),
+        DataMarkerAttributes::try_from_str("PN").unwrap(),
+        DataMarkerAttributes::try_from_str("PR").unwrap(),
+        DataMarkerAttributes::try_from_str("PS").unwrap(),
+        DataMarkerAttributes::try_from_str("PS").unwrap(),
+        DataMarkerAttributes::try_from_str("PT").unwrap(),
+        DataMarkerAttributes::try_from_str("PW").unwrap(),
+        DataMarkerAttributes::try_from_str("PY").unwrap(),
+        DataMarkerAttributes::try_from_str("QA").unwrap(),
+        DataMarkerAttributes::try_from_str("QO").unwrap(),
+        DataMarkerAttributes::try_from_str("RE").unwrap(),
+        DataMarkerAttributes::try_from_str("RO").unwrap(),
+        DataMarkerAttributes::try_from_str("RS").unwrap(),
+        DataMarkerAttributes::try_from_str("RU").unwrap(),
+        DataMarkerAttributes::try_from_str("RW").unwrap(),
+        DataMarkerAttributes::try_from_str("SA").unwrap(),
+        DataMarkerAttributes::try_from_str("SB").unwrap(),
+        DataMarkerAttributes::try_from_str("SC").unwrap(),
+        DataMarkerAttributes::try_from_str("SD").unwrap(),
+        DataMarkerAttributes::try_from_str("SE").unwrap(),
+        DataMarkerAttributes::try_from_str("SG").unwrap(),
+        DataMarkerAttributes::try_from_str("SH").unwrap(),
+        DataMarkerAttributes::try_from_str("SI").unwrap(),
+        DataMarkerAttributes::try_from_str("SJ").unwrap(),
+        DataMarkerAttributes::try_from_str("SK").unwrap(),
+        DataMarkerAttributes::try_from_str("SL").unwrap(),
+        DataMarkerAttributes::try_from_str("SM").unwrap(),
+        DataMarkerAttributes::try_from_str("SN").unwrap(),
+        DataMarkerAttributes::try_from_str("SO").unwrap(),
+        DataMarkerAttributes::try_from_str("SR").unwrap(),
+        DataMarkerAttributes::try_from_str("SS").unwrap(),
+        DataMarkerAttributes::try_from_str("ST").unwrap(),
+        DataMarkerAttributes::try_from_str("SV").unwrap(),
+        DataMarkerAttributes::try_from_str("SX").unwrap(),
+        DataMarkerAttributes::try_from_str("SY").unwrap(),
+        DataMarkerAttributes::try_from_str("SZ").unwrap(),
+        DataMarkerAttributes::try_from_str("SZ").unwrap(),
+        DataMarkerAttributes::try_from_str("TA").unwrap(),
+        DataMarkerAttributes::try_from_str("TC").unwrap(),
+        DataMarkerAttributes::try_from_str("TD").unwrap(),
+        DataMarkerAttributes::try_from_str("TF").unwrap(),
+        DataMarkerAttributes::try_from_str("TG").unwrap(),
+        DataMarkerAttributes::try_from_str("TH").unwrap(),
+        DataMarkerAttributes::try_from_str("TJ").unwrap(),
+        DataMarkerAttributes::try_from_str("TK").unwrap(),
+        DataMarkerAttributes::try_from_str("TL").unwrap(),
+        DataMarkerAttributes::try_from_str("TL").unwrap(),
+        DataMarkerAttributes::try_from_str("TM").unwrap(),
+        DataMarkerAttributes::try_from_str("TN").unwrap(),
+        DataMarkerAttributes::try_from_str("TO").unwrap(),
+        DataMarkerAttributes::try_from_str("TR").unwrap(),
+        DataMarkerAttributes::try_from_str("TR").unwrap(),
+        DataMarkerAttributes::try_from_str("TT").unwrap(),
+        DataMarkerAttributes::try_from_str("TV").unwrap(),
+        DataMarkerAttributes::try_from_str("TW").unwrap(),
+        DataMarkerAttributes::try_from_str("TZ").unwrap(),
+        DataMarkerAttributes::try_from_str("UA").unwrap(),
+        DataMarkerAttributes::try_from_str("UG").unwrap(),
+        DataMarkerAttributes::try_from_str("UM").unwrap(),
+        DataMarkerAttributes::try_from_str("UN").unwrap(),
+        DataMarkerAttributes::try_from_str("UN").unwrap(),
+        DataMarkerAttributes::try_from_str("US").unwrap(),
+        DataMarkerAttributes::try_from_str("US").unwrap(),
+        DataMarkerAttributes::try_from_str("UY").unwrap(),
+        DataMarkerAttributes::try_from_str("UZ").unwrap(),
+        DataMarkerAttributes::try_from_str("VA").unwrap(),
+        DataMarkerAttributes::try_from_str("VC").unwrap(),
+        DataMarkerAttributes::try_from_str("VE").unwrap(),
+        DataMarkerAttributes::try_from_str("VG").unwrap(),
+        DataMarkerAttributes::try_from_str("VI").unwrap(),
+        DataMarkerAttributes::try_from_str("VN").unwrap(),
+        DataMarkerAttributes::try_from_str("VU").unwrap(),
+        DataMarkerAttributes::try_from_str("WF").unwrap(),
+        DataMarkerAttributes::try_from_str("WS").unwrap(),
+        DataMarkerAttributes::try_from_str("XA").unwrap(),
+        DataMarkerAttributes::try_from_str("XB").unwrap(),
+        DataMarkerAttributes::try_from_str("XK").unwrap(),
+        DataMarkerAttributes::try_from_str("YE").unwrap(),
+        DataMarkerAttributes::try_from_str("YT").unwrap(),
+        DataMarkerAttributes::try_from_str("ZA").unwrap(),
+        DataMarkerAttributes::try_from_str("ZM").unwrap(),
+        DataMarkerAttributes::try_from_str("ZW").unwrap(),
+        DataMarkerAttributes::try_from_str("ZZ").unwrap(),
+    ];
+
+    group.bench_function("region/baked/all/1by1", |bencher| {
+        bencher.iter(|| {
+            let mut sum = 0;
+            for locale in black_box(locales) {
+                for attributes in black_box(attributeses) {
+                    let req = DataRequest {
+                        metadata: Default::default(),
+                        id: DataIdentifierBorrowed::for_marker_attributes_and_locale(
+                            *attributes,
+                            locale,
+                        ),
+                    };
+                    sum += DataProvider::<LocaleNamesRegionMediumV1>::load(&Baked, req)
+                        .map(|resp| resp.payload.get().len())
+                        .unwrap_or_default();
+                }
+            }
+            assert_eq!(sum, 801535);
+            sum
+        });
+    });
+
+    group.bench_function("region/baked/10x10pct/1by1", |bencher| {
+        bencher.iter(|| {
+            let mut sum = 0;
+            let mut i = 0;
+            for locale in black_box(locales) {
+                i += 1;
+                if i % 10 != 0 {
+                    continue;
+                }
+                let mut j = 0;
+                for attributes in black_box(attributeses) {
+                    j += 1;
+                    if j % 10 != 0 {
+                        continue;
+                    }
+                    let req = DataRequest {
+                        metadata: Default::default(),
+                        id: DataIdentifierBorrowed::for_marker_attributes_and_locale(
+                            *attributes,
+                            locale,
+                        ),
+                    };
+                    sum += DataProvider::<LocaleNamesRegionMediumV1>::load(&Baked, req)
+                        .map(|resp| resp.payload.get().len())
+                        .unwrap_or_default();
+                }
+            }
+            assert_eq!(sum, 6965);
+            sum
+        });
+    });
+
+    group.bench_function("region/baked/all/old_map_struct", |bencher| {
+        bencher.iter(|| {
+            let mut sum = 0;
+            for locale in black_box(locales) {
+                let req = DataRequest {
+                    metadata: Default::default(),
+                    id: DataIdentifierBorrowed::for_locale(locale),
+                };
+                let Ok(payload) = DataProvider::<RegionDisplayNamesV1>::load(&Baked, req) else {
+                    continue;
+                };
+                let payload = payload.payload.get();
+                for attributes in black_box(attributeses) {
+                    let id_for_lookup =
+                        UnvalidatedTinyAsciiStr::try_from_utf8(attributes.as_bytes())
+                            .unwrap_or(UnvalidatedTinyAsciiStr::DEFAULT);
+                    sum += payload
+                        .names
+                        .get(&id_for_lookup)
+                        .map(|s| s.len())
+                        .unwrap_or_default();
+                }
+            }
+            assert_eq!(sum, 801535);
+            sum
+        });
+    });
+
+    group.bench_function("region/baked/10x10pct/old_map_struct", |bencher| {
+        bencher.iter(|| {
+            let mut sum = 0;
+            let mut i = 0;
+            for locale in black_box(locales) {
+                i += 1;
+                if i % 10 != 0 {
+                    continue;
+                }
+                let req = DataRequest {
+                    metadata: Default::default(),
+                    id: DataIdentifierBorrowed::for_locale(locale),
+                };
+                let Ok(payload) = DataProvider::<RegionDisplayNamesV1>::load(&Baked, req) else {
+                    continue;
+                };
+                let payload = payload.payload.get();
+                let mut j = 0;
+                for attributes in black_box(attributeses) {
+                    j += 1;
+                    if j % 10 != 0 {
+                        continue;
+                    }
+                    let id_for_lookup =
+                        UnvalidatedTinyAsciiStr::try_from_utf8(attributes.as_bytes())
+                            .unwrap_or(UnvalidatedTinyAsciiStr::DEFAULT);
+                    sum += payload
+                        .names
+                        .get(&id_for_lookup)
+                        .map(|s| s.len())
+                        .unwrap_or_default();
+                }
+            }
+            assert_eq!(sum, 6965);
+            sum
+        });
+    });
+
+    if let Ok(path) = std::env::var("ICU4X_REGION_POSTCARD_PATH") {
+        group.bench_function("region/postcard/all/1by1", |bencher| {
+            let postcard = std::fs::read(&path).unwrap().into_boxed_slice();
+            let provider = BlobDataProvider::try_new_from_blob(postcard).unwrap();
+            let provider = provider.as_deserializing();
+            bencher.iter(|| {
+                let mut sum = 0;
+                for locale in black_box(locales) {
+                    for attributes in black_box(attributeses) {
+                        let req = DataRequest {
+                            metadata: Default::default(),
+                            id: DataIdentifierBorrowed::for_marker_attributes_and_locale(
+                                *attributes,
+                                locale,
+                            ),
+                        };
+                        sum += DataProvider::<LocaleNamesRegionMediumV1>::load(&provider, req)
+                            .map(|resp| resp.payload.get().len())
+                            .unwrap_or_default();
+                    }
+                }
+                assert_eq!(sum, 801535);
+                sum
+            });
+        });
+
+        group.bench_function("region/postcard/10x10pct/1by1", |bencher| {
+            let postcard = std::fs::read(&path).unwrap().into_boxed_slice();
+            let provider = BlobDataProvider::try_new_from_blob(postcard).unwrap();
+            let provider = provider.as_deserializing();
+            bencher.iter(|| {
+                let mut sum = 0;
+                let mut i = 0;
+                for locale in black_box(locales) {
+                    i += 1;
+                    if i % 10 != 0 {
+                        continue;
+                    }
+                    let mut j = 0;
+                    for attributes in black_box(attributeses) {
+                        j += 1;
+                        if j % 10 != 0 {
+                            continue;
+                        }
+                        let req = DataRequest {
+                            metadata: Default::default(),
+                            id: DataIdentifierBorrowed::for_marker_attributes_and_locale(
+                                *attributes,
+                                locale,
+                            ),
+                        };
+                        sum += DataProvider::<LocaleNamesRegionMediumV1>::load(&provider, req)
+                            .map(|resp| resp.payload.get().len())
+                            .unwrap_or_default();
+                    }
+                }
+                assert_eq!(sum, 6965);
+                sum
+            });
+        });
+
+        group.bench_function("region/postcard/all/boundlocale/typed", |bencher| {
+            let postcard = std::fs::read(&path).unwrap().into_boxed_slice();
+            let provider = BlobDataProvider::try_new_from_blob(postcard).unwrap();
+            bencher.iter(|| {
+                let mut sum = 0;
+                for locale in black_box(locales) {
+                    let req = DataRequest {
+                        metadata: Default::default(),
+                        id: DataIdentifierBorrowed::for_locale(locale),
+                    };
+                    let Ok(provider) = provider.bind_locale(LocaleNamesRegionMediumV1::INFO, req)
+                    else {
+                        continue;
+                    };
+                    let provider = DeserializingOwnedBufferProvider::new(provider.bound_provider);
+                    for attributes in black_box(attributeses) {
+                        sum += BoundLocaleDataProvider::<LocaleNamesRegionMediumV1>::load_bound(
+                            &provider,
+                            DataAttributesRequest {
+                                metadata: Default::default(),
+                                marker_attributes: *attributes,
+                            },
+                        )
+                        .map(|resp| resp.payload.len())
+                        .unwrap_or_default();
+                    }
+                }
+                assert_eq!(sum, 801535);
+                sum
+            });
+        });
+
+        group.bench_function("region/postcard/10x10pct/boundlocale/typed", |bencher| {
+            let postcard = std::fs::read(&path).unwrap().into_boxed_slice();
+            let provider = BlobDataProvider::try_new_from_blob(postcard).unwrap();
+            bencher.iter(|| {
+                let mut sum = 0;
+                let mut i = 0;
+                for locale in black_box(locales) {
+                    i += 1;
+                    if i % 10 != 0 {
+                        continue;
+                    }
+                    let req = DataRequest {
+                        metadata: Default::default(),
+                        id: DataIdentifierBorrowed::for_locale(locale),
+                    };
+                    let Ok(provider) = provider.bind_locale(LocaleNamesRegionMediumV1::INFO, req)
+                    else {
+                        continue;
+                    };
+                    let provider = DeserializingOwnedBufferProvider::new(provider.bound_provider);
+                    let mut j = 0;
+                    for attributes in black_box(attributeses) {
+                        j += 1;
+                        if j % 10 != 0 {
+                            continue;
+                        }
+                        sum += BoundLocaleDataProvider::<LocaleNamesRegionMediumV1>::load_bound(
+                            &provider,
+                            DataAttributesRequest {
+                                metadata: Default::default(),
+                                marker_attributes: *attributes,
+                            },
+                        )
+                        .map(|resp| resp.payload.len())
+                        .unwrap_or_default();
+                    }
+                }
+                assert_eq!(sum, 6965);
+                sum
+            });
+        });
+
+        group.bench_function("region/postcard/all/boundlocale/boxdyn", |bencher| {
+            let postcard = std::fs::read(&path).unwrap().into_boxed_slice();
+            let provider = BlobDataProvider::try_new_from_blob(postcard).unwrap();
+            bencher.iter(|| {
+                let mut sum = 0;
+                for locale in black_box(locales) {
+                    let req = DataRequest {
+                        metadata: Default::default(),
+                        id: DataIdentifierBorrowed::for_locale(locale),
+                    };
+                    let Ok(provider) = provider.bind_locale(LocaleNamesRegionMediumV1::INFO, req)
+                    else {
+                        continue;
+                    };
+                    let provider = DeserializingOwnedBufferProvider::new(provider.bound_provider);
+                    let provider: Box<dyn BoundLocaleDataProvider<LocaleNamesRegionMediumV1>> =
+                        Box::new(black_box(provider));
+                    for attributes in black_box(attributeses) {
+                        sum += BoundLocaleDataProvider::<LocaleNamesRegionMediumV1>::load_bound(
+                            &*provider,
+                            DataAttributesRequest {
+                                metadata: Default::default(),
+                                marker_attributes: *attributes,
+                            },
+                        )
+                        .map(|resp| resp.payload.len())
+                        .unwrap_or_default();
+                    }
+                }
+                assert_eq!(sum, 801535);
+                sum
+            });
+        });
+
+        group.bench_function("region/postcard/10x10pct/boundlocale/boxdyn", |bencher| {
+            let postcard = std::fs::read(&path).unwrap().into_boxed_slice();
+            let provider = BlobDataProvider::try_new_from_blob(postcard).unwrap();
+            bencher.iter(|| {
+                let mut sum = 0;
+                let mut i = 0;
+                for locale in black_box(locales) {
+                    i += 1;
+                    if i % 10 != 0 {
+                        continue;
+                    }
+                    let req = DataRequest {
+                        metadata: Default::default(),
+                        id: DataIdentifierBorrowed::for_locale(locale),
+                    };
+                    let Ok(provider) = provider.bind_locale(LocaleNamesRegionMediumV1::INFO, req)
+                    else {
+                        continue;
+                    };
+                    let provider = DeserializingOwnedBufferProvider::new(provider.bound_provider);
+                    let provider: Box<dyn BoundLocaleDataProvider<LocaleNamesRegionMediumV1>> =
+                        Box::new(black_box(provider));
+                    let mut j = 0;
+                    for attributes in black_box(attributeses) {
+                        j += 1;
+                        if j % 10 != 0 {
+                            continue;
+                        }
+                        sum += BoundLocaleDataProvider::<LocaleNamesRegionMediumV1>::load_bound(
+                            &*provider,
+                            DataAttributesRequest {
+                                metadata: Default::default(),
+                                marker_attributes: *attributes,
+                            },
+                        )
+                        .map(|resp| resp.payload.len())
+                        .unwrap_or_default();
+                    }
+                }
+                assert_eq!(sum, 6965);
+                sum
+            });
+        });
+    } // if let Ok(path) = std::env::var("ICU4X_REGION_POSTCARD_PATH")
+
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark,);
+
+criterion_main!(benches);

--- a/components/experimental/src/displaynames/single/mod.rs
+++ b/components/experimental/src/displaynames/single/mod.rs
@@ -33,7 +33,7 @@ pub use script::{ScriptDisplayName, ScriptDisplayNameOwned};
 pub use variant::{VariantDisplayName, VariantDisplayNameOwned};
 
 use crate::displaynames::DisplayNamesPreferences;
-use icu_provider::prelude::*;
+use icu_provider::{prelude::*, unstable::BindLocaleDataProvider};
 use zerovec::VarZeroCow;
 
 pub(crate) fn try_new_unstable<M, D>(
@@ -53,6 +53,25 @@ where
         })?
         .payload;
     Ok(payload)
+}
+
+pub(crate) fn try_new_unstable_bind<M, D>(
+    provider: &D,
+    prefs: DisplayNamesPreferences,
+) -> Result<D::BoundLocaleDataProvider, DataError>
+where
+    D: BindLocaleDataProvider<M>,
+    M: DataMarker<DataStruct = VarZeroCow<'static, str>>,
+{
+    let locale = M::INFO.make_locale(prefs.locale_preferences);
+    let response = provider.bind_locale(
+        M::INFO,
+        DataRequest {
+            id: DataIdentifierBorrowed::for_locale(&locale),
+            metadata: Default::default(),
+        },
+    )?;
+    Ok(response.bound_provider)
 }
 
 pub(crate) fn try_new_short_unstable<MShort, MLong, D>(

--- a/components/experimental/src/displaynames/single/region.rs
+++ b/components/experimental/src/displaynames/single/region.rs
@@ -9,6 +9,9 @@ use crate::displaynames::DisplayNamesPreferences;
 use crate::displaynames::provider::*;
 use icu_locale_core::subtags::Region;
 use icu_provider::prelude::*;
+use icu_provider::unstable::BindLocaleDataProvider;
+use icu_provider::unstable::BoundLocaleDataProvider;
+use icu_provider::unstable::DataAttributesRequest;
 
 /// A localized display name for a single region, owned version.
 ///
@@ -118,6 +121,41 @@ impl RegionDisplayNameOwned {
 }
 
 impl_writeable_for_single_display_name_owned!(RegionDisplayNameOwned);
+
+pub struct RegionDisplayNames<P> {
+    pub(crate) provider: P,
+}
+
+impl<P> RegionDisplayNames<P>
+where
+    P: BoundLocaleDataProvider<LocaleNamesRegionMediumV1>,
+{
+    pub fn try_new_unstable<P0>(
+        provider: &P0,
+        prefs: DisplayNamesPreferences,
+    ) -> Result<Self, DataError>
+    where
+        P0: BindLocaleDataProvider<LocaleNamesRegionMediumV1, BoundLocaleDataProvider = P>,
+    {
+        super::try_new_unstable_bind(provider, prefs).map(|provider| Self { provider })
+    }
+
+    pub fn of(&self, region: Region) -> Result<Option<RegionDisplayName<'_>>, DataError> {
+        let Some(response) = self
+            .provider
+            .load_bound(DataAttributesRequest {
+                marker_attributes: LocaleNamesRegionMediumV1::make_attributes(&region),
+                metadata: Default::default(),
+            })
+            .allow_identifier_not_found()?
+        else {
+            return Ok(None);
+        };
+        Ok(Some(RegionDisplayName {
+            value: &response.payload,
+        }))
+    }
+}
 
 /// A localized display name for a single region.
 #[derive(Debug, Clone, Copy)]

--- a/provider/blob/src/blob_data_provider.rs
+++ b/provider/blob/src/blob_data_provider.rs
@@ -3,7 +3,8 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::blob_schema::BlobBoundLocaleSchema;
-use crate::blob_schema::BlobSchema;
+use crate::blob_schema::RawBlob;
+use crate::blob_schema::ValidatedBlobSchema;
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;
 use icu_provider::Cart;
@@ -89,7 +90,7 @@ use yoke::*;
 /// ```
 #[derive(Clone)]
 pub struct BlobDataProvider {
-    pub(crate) data: Yoke<BlobSchema<'static>, Option<Cart>>,
+    pub(crate) data: Yoke<ValidatedBlobSchema<'static>, Option<Cart>>,
 }
 
 impl core::fmt::Debug for BlobDataProvider {
@@ -108,7 +109,7 @@ impl BlobDataProvider {
     pub fn try_new_from_blob(blob: Box<[u8]>) -> Result<Self, DataError> {
         Ok(Self {
             data: Cart::try_make_yoke(blob, |bytes| {
-                BlobSchema::deserialize_and_check(&mut postcard::Deserializer::from_bytes(bytes))
+                ValidatedBlobSchema::deserialize_and_check(&mut postcard::Deserializer::from_bytes(bytes))
             })?,
         })
     }
@@ -117,7 +118,7 @@ impl BlobDataProvider {
     /// [`try_new_from_blob`](BlobDataProvider::try_new_from_blob) and is allocation-free.
     pub fn try_new_from_static_blob(blob: &'static [u8]) -> Result<Self, DataError> {
         Ok(Self {
-            data: Yoke::new_owned(BlobSchema::deserialize_and_check(
+            data: Yoke::new_owned(ValidatedBlobSchema::deserialize_and_check(
                 &mut postcard::Deserializer::from_bytes(blob),
             )?),
         })
@@ -125,7 +126,7 @@ impl BlobDataProvider {
 
     #[doc(hidden)] // for testing purposes only: checks if it is using the Bigger format
     pub fn internal_is_using_bigger_format(&self) -> bool {
-        matches!(self.data.get(), BlobSchema::V003Bigger(..))
+        matches!(self.data.get(), ValidatedBlobSchema::V004Bigger(..))
     }
 }
 
@@ -135,15 +136,17 @@ impl DynamicDataProvider<BufferMarker> for BlobDataProvider {
         marker: DataMarkerInfo,
         req: DataRequest,
     ) -> Result<DataResponse<BufferMarker>, DataError> {
-        let payload: Yoke<(&[u8], Option<u64>), Option<Cart>> = self
+        let payload: Yoke<RawBlob, Option<Cart>> = self
             .data
             .try_map_project_cloned(|blob, _| blob.load(marker, req))?;
         let mut metadata = DataResponseMetadata::default();
-        metadata.buffer_format = Some(BufferFormat::Postcard1);
-        metadata.checksum = payload.get().1;
+        metadata.buffer_format = Some(payload.get().kind.into_buffer_format());
+        metadata.checksum = payload.get().checksum;
         Ok(DataResponse {
             metadata,
-            payload: DataPayload::from_yoked_buffer(payload.map_project(|(bytes, _), _| bytes)),
+            payload: DataPayload::from_yoked_buffer(
+                payload.map_project(|raw_blob, _| raw_blob.bytes),
+            ),
         })
     }
 }
@@ -204,17 +207,17 @@ pub struct BlobBoundLocaleDataProvider {
 }
 
 impl BindLocaleDataProvider<BufferMarker> for BlobDataProvider {
-    type BoundLocaleDataProvider<'data> = BlobBoundLocaleDataProvider;
+    type BoundLocaleDataProvider = BlobBoundLocaleDataProvider;
     fn bind_locale(
         &self,
         marker: DataMarkerInfo,
         req: DataRequest,
-    ) -> Result<BindLocaleResponse<Self::BoundLocaleDataProvider<'static>>, DataError> {
+    ) -> Result<BindLocaleResponse<Self::BoundLocaleDataProvider>, DataError> {
         let payload: Yoke<(BlobBoundLocaleSchema, Option<u64>), Option<Cart>> = self
             .data
             .try_map_project_cloned(|blob, _| blob.bind_locale(marker, req))?;
         let mut metadata = DataResponseMetadata::default();
-        metadata.buffer_format = Some(BufferFormat::Postcard1);
+        metadata.buffer_format = Some(payload.get().0.kind.into_buffer_format());
         metadata.checksum = payload.get().1;
         Ok(BindLocaleResponse {
             metadata,
@@ -233,7 +236,7 @@ impl BoundLocaleDataProvider<BufferMarker> for BlobBoundLocaleDataProvider {
         let blob = self.data.get();
         let payload = blob.load(req)?;
         let mut metadata = DataResponseMetadata::default();
-        metadata.buffer_format = Some(BufferFormat::Postcard1);
+        metadata.buffer_format = Some(blob.kind.into_buffer_format());
         // Note: the checksum is returned by `bind_locale()` instead of `load_bound()`
         Ok(BoundLocaleDataResponse { metadata, payload })
     }

--- a/provider/blob/src/blob_data_provider.rs
+++ b/provider/blob/src/blob_data_provider.rs
@@ -2,13 +2,19 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use crate::blob_schema::BlobBoundLocaleSchema;
 use crate::blob_schema::BlobSchema;
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;
-use icu_provider::Cart;
-use icu_provider::DynamicDryDataProvider;
 use icu_provider::buf::BufferFormat;
 use icu_provider::prelude::*;
+use icu_provider::unstable::BindLocaleDataProvider;
+use icu_provider::unstable::BindLocaleResponse;
+use icu_provider::unstable::BoundLocaleDataProvider;
+use icu_provider::unstable::BoundLocaleDataResponse;
+use icu_provider::unstable::DataAttributesRequest;
+use icu_provider::Cart;
+use icu_provider::DynamicDryDataProvider;
 use yoke::*;
 
 /// A data provider that reads from serialized blobs of data.
@@ -163,6 +169,73 @@ impl IterableDynamicDataProvider<BufferMarker> for BlobDataProvider {
         marker: DataMarkerInfo,
     ) -> Result<alloc::collections::BTreeSet<DataIdentifierCow<'_>>, DataError> {
         self.data.get().iter_ids(marker)
+    }
+}
+
+/// A [`BlobDataProvider`] that returns data for a specific marker and locale.
+///
+/// # Examples
+///
+/// ```
+/// use icu_locale_core::locale;
+/// use icu_provider::hello_world::HelloWorldAttributeFormatter;
+/// use icu_provider_blob::BlobDataProvider;
+/// use writeable::assert_writeable_eq;
+///
+/// // Read an ICU4X data blob statically:
+/// const HELLO_WORLD_BLOB: &[u8] = include_bytes!("../tests/data/v3.postcard");
+///
+/// // Create a DataProvider from it:
+/// let provider = BlobDataProvider::try_new_from_static_blob(HELLO_WORLD_BLOB)
+///     .expect("Deserialization should succeed");
+///
+/// // Use it to query a HelloWorld formatter:
+/// let formatter = HelloWorldAttributeFormatter::try_new_with_buffer_provider(
+///     &provider,
+///     locale!("en").into()
+/// ).unwrap();
+///
+/// assert_writeable_eq!(formatter.format("reverse").unwrap(), "Olleh Dlrow");
+/// assert_writeable_eq!(formatter.format_for_prefix("rev").unwrap(), "Olleh Dlrow");
+/// ```
+#[derive(Debug)]
+pub struct BlobBoundLocaleDataProvider {
+    pub(crate) data: Yoke<BlobBoundLocaleSchema<'static>, Option<Cart>>,
+}
+
+impl BindLocaleDataProvider<BufferMarker> for BlobDataProvider {
+    type BoundLocaleDataProvider<'data> = BlobBoundLocaleDataProvider;
+    fn bind_locale(
+        &self,
+        marker: DataMarkerInfo,
+        req: DataRequest,
+    ) -> Result<BindLocaleResponse<Self::BoundLocaleDataProvider<'static>>, DataError> {
+        let payload: Yoke<(BlobBoundLocaleSchema, Option<u64>), Option<Cart>> = self
+            .data
+            .try_map_project_cloned(|blob, _| blob.bind_locale(marker, req))?;
+        let mut metadata = DataResponseMetadata::default();
+        metadata.buffer_format = Some(BufferFormat::Postcard1);
+        metadata.checksum = payload.get().1;
+        Ok(BindLocaleResponse {
+            metadata,
+            bound_provider: BlobBoundLocaleDataProvider {
+                data: payload.map_project(|(inner, _), _| inner),
+            },
+        })
+    }
+}
+
+impl BoundLocaleDataProvider<BufferMarker> for BlobBoundLocaleDataProvider {
+    fn load_bound<'data>(
+        &'data self,
+        req: DataAttributesRequest,
+    ) -> Result<BoundLocaleDataResponse<'data, BufferMarker>, DataError> {
+        let blob = self.data.get();
+        let payload = blob.load(req)?;
+        let mut metadata = DataResponseMetadata::default();
+        metadata.buffer_format = Some(BufferFormat::Postcard1);
+        // Note: the checksum is returned by `bind_locale()` instead of `load_bound()`
+        Ok(BoundLocaleDataResponse { metadata, payload })
     }
 }
 

--- a/provider/blob/src/blob_data_provider.rs
+++ b/provider/blob/src/blob_data_provider.rs
@@ -6,6 +6,8 @@ use crate::blob_schema::BlobBoundLocaleSchema;
 use crate::blob_schema::BlobSchema;
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;
+use icu_provider::Cart;
+use icu_provider::DynamicDryDataProvider;
 use icu_provider::buf::BufferFormat;
 use icu_provider::prelude::*;
 use icu_provider::unstable::BindLocaleDataProvider;
@@ -13,8 +15,6 @@ use icu_provider::unstable::BindLocaleResponse;
 use icu_provider::unstable::BoundLocaleDataProvider;
 use icu_provider::unstable::BoundLocaleDataResponse;
 use icu_provider::unstable::DataAttributesRequest;
-use icu_provider::Cart;
-use icu_provider::DynamicDryDataProvider;
 use yoke::*;
 
 /// A data provider that reads from serialized blobs of data.

--- a/provider/blob/src/blob_schema.rs
+++ b/provider/blob/src/blob_schema.rs
@@ -3,10 +3,12 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use core::fmt::Write;
-use icu_provider::{marker::DataMarkerIdHash, prelude::*};
+use icu_provider::marker::DataMarkerIdHash;
+use icu_provider::prelude::*;
+use icu_provider::unstable::DataAttributesRequest;
 use serde::Deserialize;
 use writeable::Writeable;
-use zerotrie::ZeroTrieSimpleAscii;
+use zerotrie::{cursor::ZeroTrieSimpleAsciiCursor, ZeroTrieSimpleAscii};
 use zerovec::vecs::{Index16, Index32, VarZeroSlice, VarZeroVecFormat, ZeroSlice};
 
 /// A versioned Serde schema for ICU4X data blobs.
@@ -49,6 +51,20 @@ impl<'data> BlobSchema<'data> {
             }
             BlobSchema::V003(s) => s.load(marker, req),
             BlobSchema::V003Bigger(s) => s.load(marker, req),
+        }
+    }
+
+    pub(crate) fn bind_locale(
+        &self,
+        marker: DataMarkerInfo,
+        req: DataRequest,
+    ) -> Result<(BlobBoundLocaleSchema<'data>, Option<u64>), DataError> {
+        match self {
+            BlobSchema::V001(..) | BlobSchema::V002(..) | BlobSchema::V002Bigger(..) => {
+                unreachable!("Unreachable blob schema")
+            }
+            BlobSchema::V003(s) => s.bind_locale(marker, req),
+            BlobSchema::V003Bigger(s) => s.bind_locale(marker, req),
         }
     }
 
@@ -127,15 +143,28 @@ impl<LocaleVecFormat: VarZeroVecFormat> Default for BlobSchemaV1<'_, LocaleVecFo
     }
 }
 
+fn load_attributes(
+    mut cursor: ZeroTrieSimpleAsciiCursor,
+    marker_attributes: &DataMarkerAttributes,
+    metadata: DataRequestMetadata,
+) -> Option<usize> {
+    let _infallible_ascii = marker_attributes.write_to(&mut cursor);
+    loop {
+        let index = cursor.take_value();
+        if index.is_some() || !metadata.attributes_prefix_match {
+            break index;
+        }
+        // Match the shortest attribute sharing a prefix.
+        cursor.probe(0);
+    }
+}
+
 impl<'data, LocaleVecFormat: VarZeroVecFormat> BlobSchemaV1<'data, LocaleVecFormat> {
-    pub fn load(
+    pub(crate) fn get_trie(
         &self,
         marker: DataMarkerInfo,
         req: DataRequest,
-    ) -> Result<(&'data [u8], Option<u64>), DataError> {
-        if marker.is_singleton && !req.id.locale.is_unknown() {
-            return Err(DataErrorKind::InvalidRequest.with_req(marker, req));
-        }
+    ) -> Result<ZeroTrieSimpleAscii<&'data [u8]>, DataError> {
         let marker_index = self
             .markers
             .binary_search(&marker.id.hashed())
@@ -145,22 +174,23 @@ impl<'data, LocaleVecFormat: VarZeroVecFormat> BlobSchemaV1<'data, LocaleVecForm
             .locales
             .get(marker_index)
             .ok_or_else(|| DataError::custom("Invalid blob bytes").with_req(marker, req))?;
-        let mut cursor = ZeroTrieSimpleAscii::from_store(zerotrie).into_cursor();
+        Ok(ZeroTrieSimpleAscii::from_store(zerotrie))
+    }
+
+    pub(crate) fn load(
+        &self,
+        marker: DataMarkerInfo,
+        req: DataRequest,
+    ) -> Result<(&'data [u8], Option<u64>), DataError> {
+        if marker.is_singleton && !req.id.locale.is_unknown() {
+            return Err(DataErrorKind::InvalidRequest.with_req(marker, req));
+        }
+        let zerotrie = self.get_trie(marker, req)?;
+        let mut cursor = zerotrie.into_cursor();
         let _infallible_ascii = req.id.locale.write_to(&mut cursor);
         let blob_index = if !req.id.marker_attributes.is_empty() {
             let _infallible_ascii = cursor.write_char(REQUEST_SEPARATOR);
-            req.id
-                .marker_attributes
-                .write_to(&mut cursor)
-                .map_err(|_| DataErrorKind::IdentifierNotFound.with_req(marker, req))?;
-            loop {
-                if let Some(v) = cursor.take_value() {
-                    break Some(v);
-                }
-                if !req.metadata.attributes_prefix_match || cursor.probe(0).is_none() {
-                    break None;
-                }
-            }
+            load_attributes(cursor, req.id.marker_attributes, req.metadata)
         } else {
             cursor.take_value()
         }
@@ -178,8 +208,36 @@ impl<'data, LocaleVecFormat: VarZeroVecFormat> BlobSchemaV1<'data, LocaleVecForm
         ))
     }
 
-    fn get_checksum(&self, zerotrie: &[u8]) -> Option<u64> {
-        ZeroTrieSimpleAscii::from_store(zerotrie)
+    pub(crate) fn bind_locale(
+        &self,
+        marker: DataMarkerInfo,
+        req: DataRequest,
+    ) -> Result<(BlobBoundLocaleSchema<'data>, Option<u64>), DataError> {
+        // Note: singleton markers do not make sense with this function
+        if marker.is_singleton || req.id.locale.is_unknown() {
+            return Err(DataErrorKind::InvalidRequest.with_req(marker, req));
+        }
+        let zerotrie = self.get_trie(marker, req)?;
+        let mut cursor = zerotrie.into_cursor();
+        let _infallible_ascii = req.id.locale.write_to(&mut cursor);
+        let _infallible_ascii = cursor.write_char(REQUEST_SEPARATOR);
+        if cursor.is_empty() {
+            return Err(DataErrorKind::IdentifierNotFound.with_req(marker, req));
+        }
+        Ok((
+            BlobBoundLocaleSchema {
+                attributes_trie: cursor.into_suffix_trie(),
+                buffers: self.buffers,
+            },
+            marker
+                .has_checksum
+                .then(|| self.get_checksum(zerotrie))
+                .flatten(),
+        ))
+    }
+
+    fn get_checksum(&self, zerotrie: ZeroTrieSimpleAscii<&'data [u8]>) -> Option<u64> {
+        zerotrie
             .get(CHECKSUM_KEY)
             .and_then(|cs| Some(u64::from_le_bytes(self.buffers.get(cs)?.try_into().ok()?)))
     }
@@ -241,5 +299,30 @@ impl<'data, LocaleVecFormat: VarZeroVecFormat> BlobSchemaV1<'data, LocaleVecForm
         }
         debug_assert!(seen_min);
         debug_assert!(seen_max);
+    }
+}
+
+#[derive(Clone, Copy, Debug, yoke::Yokeable)]
+pub(crate) struct BlobBoundLocaleSchema<'data> {
+    attributes_trie: ZeroTrieSimpleAscii<&'data [u8]>,
+    buffers: &'data VarZeroSlice<[u8], Index32>,
+}
+
+impl<'data> BlobBoundLocaleSchema<'data> {
+    pub(crate) fn load(&self, req: DataAttributesRequest) -> Result<&'data [u8], DataError> {
+        let blob_index = load_attributes(
+            self.attributes_trie.cursor(),
+            req.marker_attributes,
+            req.metadata,
+        )
+        .ok_or_else(|| {
+            DataErrorKind::IdentifierNotFound
+                .into_error()
+                .with_debug_context(req.marker_attributes)
+        })?;
+        let buffer = self.buffers.get(blob_index).ok_or_else(|| {
+            DataError::custom("Invalid blob bytes").with_debug_context(req.marker_attributes)
+        })?;
+        Ok(buffer)
     }
 }

--- a/provider/blob/src/blob_schema.rs
+++ b/provider/blob/src/blob_schema.rs
@@ -8,7 +8,7 @@ use icu_provider::prelude::*;
 use icu_provider::unstable::DataAttributesRequest;
 use serde::Deserialize;
 use writeable::Writeable;
-use zerotrie::{cursor::ZeroTrieSimpleAsciiCursor, ZeroTrieSimpleAscii};
+use zerotrie::{ZeroTrieSimpleAscii, cursor::ZeroTrieSimpleAsciiCursor};
 use zerovec::vecs::{Index16, Index32, VarZeroSlice, VarZeroVecFormat, ZeroSlice};
 
 /// A versioned Serde schema for ICU4X data blobs.

--- a/provider/blob/src/blob_schema.rs
+++ b/provider/blob/src/blob_schema.rs
@@ -3,9 +3,10 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use core::fmt::Write;
-use icu_provider::marker::DataMarkerIdHash;
+use icu_provider::buf::BufferFormat;
 use icu_provider::prelude::*;
 use icu_provider::unstable::DataAttributesRequest;
+use icu_provider::{marker::DataMarkerIdHash, prelude::yoke::Yokeable};
 use serde::Deserialize;
 use writeable::Writeable;
 use zerotrie::{ZeroTrieSimpleAscii, cursor::ZeroTrieSimpleAsciiCursor};
@@ -24,17 +25,70 @@ pub(crate) enum BlobSchema<'data> {
     V003(BlobSchemaV1<'data, Index16>),
     #[serde(borrow)]
     V003Bigger(BlobSchemaV1<'data, Index32>),
+    #[serde(borrow)]
+    V004(BlobSchemaV4<'data, Index16>),
+    #[serde(borrow)]
+    V004Bigger(BlobSchemaV4<'data, Index32>),
+}
+
+#[derive(Clone, Yokeable)]
+pub(crate) enum ValidatedBlobSchema<'data> {
+    V004(BlobSchemaV4<'data, Index16>),
+    V004Bigger(BlobSchemaV4<'data, Index32>),
+}
+
+#[derive(Clone, Copy, Debug, Yokeable)]
+pub(crate) enum RawBlobKind {
+    Postcard1,
+    VarULE011,
+}
+
+impl RawBlobKind {
+    pub(crate) fn into_buffer_format(self) -> BufferFormat {
+        match self {
+            Self::Postcard1 => BufferFormat::Postcard1,
+            Self::VarULE011 => BufferFormat::VarULE011,
+        }
+    }
+}
+
+#[derive(Yokeable)]
+pub(crate) struct RawBlob<'data> {
+    pub(crate) bytes: &'data [u8],
+    pub(crate) checksum: Option<u64>,
+    pub(crate) kind: RawBlobKind,
 }
 
 // This is a valid separator as `DataLocale` will never produce it.
 pub(crate) const REQUEST_SEPARATOR: char = '\x1E';
 pub(crate) const CHECKSUM_KEY: &[u8] = b"\0c";
 
-impl<'data> BlobSchema<'data> {
+impl<'data> ValidatedBlobSchema<'data> {
     pub fn deserialize_and_check<D: serde::Deserializer<'data>>(
         de: D,
-    ) -> Result<BlobSchema<'data>, D::Error> {
-        let blob = Self::deserialize(de)?;
+    ) -> Result<ValidatedBlobSchema<'data>, D::Error> {
+        let blob = BlobSchema::deserialize(de)?;
+        let blob = match blob {
+            BlobSchema::V001(..) | BlobSchema::V002(..) | BlobSchema::V002Bigger(..) => {
+                unreachable!("Unreachable blob schema")
+            }
+            BlobSchema::V003(schema) => ValidatedBlobSchema::V004(BlobSchemaV4 {
+                markers_postcard1: schema.markers,
+                markers_varule011: ZeroSlice::new_empty(),
+                locales_postcard1: schema.locales,
+                locales_varule011: VarZeroSlice::new_empty(),
+                buffers: schema.buffers,
+            }),
+            BlobSchema::V003Bigger(schema) => ValidatedBlobSchema::V004Bigger(BlobSchemaV4 {
+                markers_postcard1: schema.markers,
+                markers_varule011: ZeroSlice::new_empty(),
+                locales_postcard1: schema.locales,
+                locales_varule011: VarZeroSlice::new_empty(),
+                buffers: schema.buffers,
+            }),
+            BlobSchema::V004(schema) => ValidatedBlobSchema::V004(schema),
+            BlobSchema::V004Bigger(schema) => ValidatedBlobSchema::V004Bigger(schema),
+        };
         #[cfg(debug_assertions)]
         blob.check_invariants();
         Ok(blob)
@@ -44,13 +98,10 @@ impl<'data> BlobSchema<'data> {
         &self,
         marker: DataMarkerInfo,
         req: DataRequest,
-    ) -> Result<(&'data [u8], Option<u64>), DataError> {
+    ) -> Result<RawBlob<'data>, DataError> {
         match self {
-            BlobSchema::V001(..) | BlobSchema::V002(..) | BlobSchema::V002Bigger(..) => {
-                unreachable!("Unreachable blob schema")
-            }
-            BlobSchema::V003(s) => s.load(marker, req),
-            BlobSchema::V003Bigger(s) => s.load(marker, req),
+            Self::V004(s) => s.load(marker, req),
+            Self::V004Bigger(s) => s.load(marker, req),
         }
     }
 
@@ -60,11 +111,8 @@ impl<'data> BlobSchema<'data> {
         req: DataRequest,
     ) -> Result<(BlobBoundLocaleSchema<'data>, Option<u64>), DataError> {
         match self {
-            BlobSchema::V001(..) | BlobSchema::V002(..) | BlobSchema::V002Bigger(..) => {
-                unreachable!("Unreachable blob schema")
-            }
-            BlobSchema::V003(s) => s.bind_locale(marker, req),
-            BlobSchema::V003Bigger(s) => s.bind_locale(marker, req),
+            Self::V004(s) => s.bind_locale(marker, req),
+            Self::V004Bigger(s) => s.bind_locale(marker, req),
         }
     }
 
@@ -74,20 +122,16 @@ impl<'data> BlobSchema<'data> {
         marker: DataMarkerInfo,
     ) -> Result<alloc::collections::BTreeSet<DataIdentifierCow<'_>>, DataError> {
         match self {
-            BlobSchema::V001(..) | BlobSchema::V002(..) | BlobSchema::V002Bigger(..) => {
-                unreachable!("Unreachable blob schema")
-            }
-            BlobSchema::V003(s) => s.iter_ids(marker),
-            BlobSchema::V003Bigger(s) => s.iter_ids(marker),
+            Self::V004(s) => s.iter_ids(marker),
+            Self::V004Bigger(s) => s.iter_ids(marker),
         }
     }
 
     #[cfg(debug_assertions)]
     fn check_invariants(&self) {
         match self {
-            BlobSchema::V001(..) | BlobSchema::V002(..) | BlobSchema::V002Bigger(..) => (),
-            BlobSchema::V003(s) => s.check_invariants(),
-            BlobSchema::V003Bigger(s) => s.check_invariants(),
+            Self::V004(s) => s.check_invariants(),
+            Self::V004Bigger(s) => s.check_invariants(),
         }
     }
 }
@@ -107,6 +151,7 @@ impl<'de> Deserialize<'de> for NeverSchema {
         ))
     }
 }
+
 /// Version 3 of the ICU4X data blob schema.
 ///
 /// This itself has two modes, using [`Index16`] or [`Index32`] buffers for the locales array.
@@ -133,11 +178,51 @@ pub(crate) struct BlobSchemaV1<'data, LocaleVecFormat: VarZeroVecFormat> {
     pub buffers: &'data VarZeroSlice<[u8], Index32>,
 }
 
-impl<LocaleVecFormat: VarZeroVecFormat> Default for BlobSchemaV1<'_, LocaleVecFormat> {
+/// Version 4 of the ICU4X data blob schema.
+///
+/// This itself has two modes, using [`Index16`] or [`Index32`] buffers for the locales array.
+///
+/// The exporter will autoupgrade to the larger buffer as needed.
+#[derive(Clone, Copy, Debug, serde::Deserialize, yoke::Yokeable)]
+#[yoke(prove_covariance_manually)]
+#[cfg_attr(feature = "export", derive(serde::Serialize))]
+#[serde(bound = "")] // Override the autogenerated `LocaleVecFormat: Serialize/Deserialize` bound
+pub(crate) struct BlobSchemaV4<'data, LocaleVecFormat: VarZeroVecFormat> {
+    /// Map from marker hash to locale trie.
+    /// Contains markers serialized as postcard.
+    /// Weak invariant: should be sorted.
+    #[serde(borrow)]
+    pub markers_postcard1: &'data ZeroSlice<DataMarkerIdHash>,
+    /// Map from marker hash to locale trie.
+    /// Contains markers serialized as VarULE.
+    /// Same invariants as `markers_postcard1`
+    #[serde(borrow)]
+    pub markers_varule011: &'data ZeroSlice<DataMarkerIdHash>,
+    /// Map from locale to buffer index.
+    /// Contains markers serialized as postcard.
+    /// Weak invariant: the `usize` values are valid indices into `self.buffers`
+    /// Weak invariant: there is at least one value for every integer in `0..self.buffers.len()`
+    /// Weak invariant: markers and locales are the same length
+    // TODO: Make ZeroTrieSimpleAscii<[u8]> work when in this position.
+    #[serde(borrow)]
+    pub locales_postcard1: &'data VarZeroSlice<[u8], LocaleVecFormat>,
+    /// Map from locale to buffer index.
+    /// Contains markers serialized as VarULE.
+    /// Same invariants as `locales_postcard1`
+    #[serde(borrow)]
+    pub locales_varule011: &'data VarZeroSlice<[u8], LocaleVecFormat>,
+    /// Vector of buffers
+    #[serde(borrow)]
+    pub buffers: &'data VarZeroSlice<[u8], Index32>,
+}
+
+impl<LocaleVecFormat: VarZeroVecFormat> Default for BlobSchemaV4<'_, LocaleVecFormat> {
     fn default() -> Self {
         Self {
-            markers: ZeroSlice::new_empty(),
-            locales: VarZeroSlice::new_empty(),
+            markers_postcard1: ZeroSlice::new_empty(),
+            markers_varule011: ZeroSlice::new_empty(),
+            locales_postcard1: VarZeroSlice::new_empty(),
+            locales_varule011: VarZeroSlice::new_empty(),
             buffers: VarZeroSlice::new_empty(),
         }
     }
@@ -159,33 +244,42 @@ fn load_attributes(
     }
 }
 
-impl<'data, LocaleVecFormat: VarZeroVecFormat> BlobSchemaV1<'data, LocaleVecFormat> {
+impl<'data, LocaleVecFormat: VarZeroVecFormat> BlobSchemaV4<'data, LocaleVecFormat> {
     pub(crate) fn get_trie(
         &self,
         marker: DataMarkerInfo,
-        req: DataRequest,
-    ) -> Result<ZeroTrieSimpleAscii<&'data [u8]>, DataError> {
+    ) -> Result<(ZeroTrieSimpleAscii<&'data [u8]>, RawBlobKind), DataError> {
+        // Try to find in the varule table first
+        if marker.has_varule {
+            if let Ok(marker_index) = self.markers_varule011.binary_search(&marker.id.hashed()) {
+                let zerotrie = self
+                    .locales_varule011
+                    .get(marker_index)
+                    .ok_or_else(|| DataError::custom("Invalid blob bytes"))?;
+                return Ok((ZeroTrieSimpleAscii::from_store(zerotrie), RawBlobKind::VarULE011));
+            }
+        }
         let marker_index = self
-            .markers
+            .markers_postcard1
             .binary_search(&marker.id.hashed())
             .ok()
-            .ok_or_else(|| DataErrorKind::MarkerNotFound.with_req(marker, req))?;
+            .ok_or_else(|| DataErrorKind::MarkerNotFound.into_error())?;
         let zerotrie = self
-            .locales
+            .locales_postcard1
             .get(marker_index)
-            .ok_or_else(|| DataError::custom("Invalid blob bytes").with_req(marker, req))?;
-        Ok(ZeroTrieSimpleAscii::from_store(zerotrie))
+            .ok_or_else(|| DataError::custom("Invalid blob bytes"))?;
+        Ok((ZeroTrieSimpleAscii::from_store(zerotrie), RawBlobKind::Postcard1))
     }
 
     pub(crate) fn load(
         &self,
         marker: DataMarkerInfo,
         req: DataRequest,
-    ) -> Result<(&'data [u8], Option<u64>), DataError> {
+    ) -> Result<RawBlob<'data>, DataError> {
         if marker.is_singleton && !req.id.locale.is_unknown() {
             return Err(DataErrorKind::InvalidRequest.with_req(marker, req));
         }
-        let zerotrie = self.get_trie(marker, req)?;
+        let (zerotrie, kind) = self.get_trie(marker).map_err(|err| err.with_req(marker, req))?;
         let mut cursor = zerotrie.into_cursor();
         let _infallible_ascii = req.id.locale.write_to(&mut cursor);
         let blob_index = if !req.id.marker_attributes.is_empty() {
@@ -199,13 +293,14 @@ impl<'data, LocaleVecFormat: VarZeroVecFormat> BlobSchemaV1<'data, LocaleVecForm
             .buffers
             .get(blob_index)
             .ok_or_else(|| DataError::custom("Invalid blob bytes").with_req(marker, req))?;
-        Ok((
-            buffer,
-            marker
+        Ok(RawBlob {
+            bytes: buffer,
+            checksum: marker
                 .has_checksum
                 .then(|| self.get_checksum(zerotrie))
                 .flatten(),
-        ))
+            kind,
+        })
     }
 
     pub(crate) fn bind_locale(
@@ -217,7 +312,7 @@ impl<'data, LocaleVecFormat: VarZeroVecFormat> BlobSchemaV1<'data, LocaleVecForm
         if marker.is_singleton || req.id.locale.is_unknown() {
             return Err(DataErrorKind::InvalidRequest.with_req(marker, req));
         }
-        let zerotrie = self.get_trie(marker, req)?;
+        let (zerotrie, kind) = self.get_trie(marker).map_err(|err| err.with_req(marker, req))?;
         let mut cursor = zerotrie.into_cursor();
         let _infallible_ascii = req.id.locale.write_to(&mut cursor);
         let _infallible_ascii = cursor.write_char(REQUEST_SEPARATOR);
@@ -228,6 +323,7 @@ impl<'data, LocaleVecFormat: VarZeroVecFormat> BlobSchemaV1<'data, LocaleVecForm
             BlobBoundLocaleSchema {
                 attributes_trie: cursor.into_suffix_trie(),
                 buffers: self.buffers,
+                kind,
             },
             marker
                 .has_checksum
@@ -247,16 +343,8 @@ impl<'data, LocaleVecFormat: VarZeroVecFormat> BlobSchemaV1<'data, LocaleVecForm
         &self,
         marker: DataMarkerInfo,
     ) -> Result<alloc::collections::BTreeSet<DataIdentifierCow<'_>>, DataError> {
-        let marker_index = self
-            .markers
-            .binary_search(&marker.id.hashed())
-            .ok()
-            .ok_or_else(|| DataErrorKind::MarkerNotFound.with_marker(marker))?;
-        let zerotrie = self
-            .locales
-            .get(marker_index)
-            .ok_or_else(|| DataError::custom("Invalid blob bytes").with_marker(marker))?;
-        Ok(ZeroTrieSimpleAscii::from_store(zerotrie)
+        let (zerotrie, _kind) = self.get_trie(marker).map_err(|err| err.with_marker(marker))?;
+        Ok(zerotrie
             .iter()
             .filter_map(|(s, _)| {
                 #[allow(unused_imports)]
@@ -278,15 +366,16 @@ impl<'data, LocaleVecFormat: VarZeroVecFormat> BlobSchemaV1<'data, LocaleVecForm
     /// Verifies the weak invariants using debug assertions
     #[cfg(debug_assertions)]
     fn check_invariants(&self) {
-        if self.markers.is_empty() && self.locales.is_empty() && self.buffers.is_empty() {
+        if self.markers_postcard1.is_empty() && self.markers_varule011.is_empty() && self.locales_postcard1.is_empty() && self.locales_varule011.is_empty() && self.buffers.is_empty() {
             return;
         }
-        debug_assert_eq!(self.markers.len(), self.locales.len());
+        debug_assert_eq!(self.markers_postcard1.len(), self.locales_postcard1.len());
+        debug_assert_eq!(self.markers_varule011.len(), self.locales_varule011.len());
         // Note: We could check that every index occurs at least once, but that's a more expensive
         // operation, so we will just check for the min and max index.
         let mut seen_min = self.buffers.is_empty();
         let mut seen_max = self.buffers.is_empty();
-        for zerotrie in self.locales.iter() {
+        for zerotrie in self.locales_postcard1.iter().chain(self.locales_varule011.iter()) {
             for (_locale, idx) in ZeroTrieSimpleAscii::from_store(zerotrie).iter() {
                 debug_assert!(idx < self.buffers.len());
                 if idx == 0 {
@@ -304,8 +393,9 @@ impl<'data, LocaleVecFormat: VarZeroVecFormat> BlobSchemaV1<'data, LocaleVecForm
 
 #[derive(Clone, Copy, Debug, yoke::Yokeable)]
 pub(crate) struct BlobBoundLocaleSchema<'data> {
-    attributes_trie: ZeroTrieSimpleAscii<&'data [u8]>,
-    buffers: &'data VarZeroSlice<[u8], Index32>,
+    pub(crate) attributes_trie: ZeroTrieSimpleAscii<&'data [u8]>,
+    pub(crate) buffers: &'data VarZeroSlice<[u8], Index32>,
+    pub(crate) kind: RawBlobKind,
 }
 
 impl<'data> BlobBoundLocaleSchema<'data> {

--- a/provider/blob/src/lib.rs
+++ b/provider/blob/src/lib.rs
@@ -38,3 +38,8 @@ mod blob_schema;
 pub mod export;
 
 pub use blob_data_provider::BlobDataProvider;
+
+/// Additional types for mostly internal usage.
+pub mod unstable {
+    pub use super::blob_data_provider::BlobBoundLocaleDataProvider;
+}

--- a/provider/core/src/buf.rs
+++ b/provider/core/src/buf.rs
@@ -108,6 +108,8 @@ pub enum BufferFormat {
     Bincode1,
     /// Serialize using the [`postcard`] crate, version 1.
     Postcard1,
+    /// Serialize using a [`VarULE`](zerovec::ule::VarULE) encoding, version 0.11.
+    VarULE011,
 }
 
 impl BufferFormat {
@@ -128,6 +130,8 @@ impl BufferFormat {
             BufferFormat::Postcard1 => Ok(()),
             #[cfg(not(feature = "deserialize_postcard_1"))]
             BufferFormat::Postcard1 => Err(DataErrorKind::Deserialize.with_str_context("deserializing `BufferFormat::Postcard1` requires the `deserialize_postcard_1` Cargo feature")),
+
+            BufferFormat::VarULE011 => Ok(()),
         }
     }
 }

--- a/provider/core/src/buf/serde.rs
+++ b/provider/core/src/buf/serde.rs
@@ -14,8 +14,10 @@
 use crate::DryDataProvider;
 use crate::buf::BufferFormat;
 use crate::buf::BufferProvider;
+use crate::data_provider::BoundLocaleDataResponse;
 use crate::data_provider::DynamicDryDataProvider;
 use crate::prelude::*;
+use crate::unstable::BoundLocaleDataProvider;
 use serde::de::Deserialize;
 use yoke::Yokeable;
 
@@ -56,6 +58,26 @@ where
     /// ✨ *Enabled with the `serde` Cargo feature.*
     fn as_deserializing(&self) -> DeserializingBufferProvider<'_, Self> {
         DeserializingBufferProvider(self)
+    }
+}
+
+/// A [`BufferProvider`] that deserializes its data using Serde.
+#[derive(Debug)]
+pub struct DeserializingOwnedBufferProvider<P>(P);
+
+impl<P> DeserializingOwnedBufferProvider<P> {
+    /// Wraps the given provider in a [`DeserializingOwnedBufferProvider`].
+    ///
+    /// This requires enabling the deserialization Cargo feature
+    /// for the expected format(s):
+    ///
+    /// - `deserialize_json`
+    /// - `deserialize_postcard_1`
+    /// - `deserialize_bincode_1`
+    ///
+    /// ✨ *Enabled with the `serde` Cargo feature.*
+    pub fn new(inner: P) -> Self {
+        Self(inner)
     }
 }
 
@@ -227,6 +249,30 @@ where
 {
     fn dry_load(&self, req: DataRequest) -> Result<DataResponseMetadata, DataError> {
         self.0.dry_load_data(M::INFO, req)
+    }
+}
+
+impl<P, M> BoundLocaleDataProvider<M> for DeserializingOwnedBufferProvider<P>
+where
+    M: DynamicDataMarker,
+    P: BoundLocaleDataProvider<BufferMarker>,
+    for<'de> <M::DataStruct as Yokeable<'de>>::Output: Deserialize<'de>,
+{
+    fn load_bound(
+        &self,
+        req: crate::request::DataAttributesRequest,
+    ) -> Result<BoundLocaleDataResponse<'_, M>, DataError> {
+        let buffer_response = self.0.load_bound(req)?;
+        let buffer_format = buffer_response.metadata.buffer_format.ok_or_else(|| {
+            DataErrorKind::Deserialize
+                .with_str_context("BufferProvider didn't set BufferFormat")
+                .with_debug_context(&req)
+        })?;
+        Ok(BoundLocaleDataResponse {
+            metadata: buffer_response.metadata,
+            payload: deserialize_impl::<M>(buffer_response.payload, buffer_format)
+                .map_err(|e| e.with_debug_context(&req))?,
+        })
     }
 }
 

--- a/provider/core/src/buf/serde.rs
+++ b/provider/core/src/buf/serde.rs
@@ -17,6 +17,7 @@ use crate::buf::BufferProvider;
 use crate::data_provider::BoundLocaleDataResponse;
 use crate::data_provider::DynamicDryDataProvider;
 use crate::prelude::*;
+use crate::ule::MaybeAsVarULE;
 use crate::unstable::BoundLocaleDataProvider;
 use serde::de::Deserialize;
 use yoke::Yokeable;
@@ -88,6 +89,7 @@ fn deserialize_impl<'data, M>(
 ) -> Result<<M::DataStruct as Yokeable<'data>>::Output, DataError>
 where
     M: DynamicDataMarker,
+    M::DataStruct: MaybeAsVarULE,
     for<'de> <M::DataStruct as Yokeable<'de>>::Output: Deserialize<'de>,
 {
     match buffer_format {
@@ -111,6 +113,19 @@ where
         BufferFormat::Postcard1 => {
             let mut d = postcard::Deserializer::from_bytes(bytes);
             Ok(Deserialize::deserialize(&mut d)?)
+        }
+
+        BufferFormat::VarULE011 => {
+            use zerovec::ule::VarULE;
+            let varule = <M::DataStruct as MaybeAsVarULE>::EncodedStruct::parse_bytes(bytes)?;
+            todo!()
+            // <M::DataStruct as MaybeAsVarULE>::maybe_zero_from_encoded_struct(&varule).ok_or_else(
+            //     || {
+            //         DataErrorKind::Deserialize.with_str_context(
+            //             "VarULE data struct missing maybe_zero_from_encoded_struct",
+            //         )
+            //     },
+            // )
         }
 
         // Allowed for cases in which all features are enabled
@@ -162,6 +177,7 @@ impl DataPayload<BufferMarker> {
     ) -> Result<DataPayload<M>, DataError>
     where
         M: DynamicDataMarker,
+        M::DataStruct: MaybeAsVarULE,
         for<'de> <M::DataStruct as Yokeable<'de>>::Output: Deserialize<'de>,
     {
         self.try_map_project(|bytes, _| deserialize_impl::<M>(bytes, buffer_format))
@@ -172,6 +188,7 @@ impl<P, M> DynamicDataProvider<M> for DeserializingBufferProvider<'_, P>
 where
     M: DynamicDataMarker,
     P: BufferProvider + ?Sized,
+    M::DataStruct: MaybeAsVarULE,
     for<'de> <M::DataStruct as Yokeable<'de>>::Output: Deserialize<'de>,
 {
     /// Converts a buffer into a concrete type by deserializing from a supported buffer format.
@@ -209,6 +226,7 @@ impl<P, M> DynamicDryDataProvider<M> for DeserializingBufferProvider<'_, P>
 where
     M: DynamicDataMarker,
     P: DynamicDryDataProvider<BufferMarker> + ?Sized,
+    M::DataStruct: MaybeAsVarULE,
     for<'de> <M::DataStruct as Yokeable<'de>>::Output: Deserialize<'de>,
 {
     fn dry_load_data(
@@ -224,6 +242,7 @@ impl<P, M> DataProvider<M> for DeserializingBufferProvider<'_, P>
 where
     M: DataMarker,
     P: DynamicDataProvider<BufferMarker> + ?Sized,
+    M::DataStruct: MaybeAsVarULE,
     for<'de> <M::DataStruct as Yokeable<'de>>::Output: Deserialize<'de>,
 {
     /// Converts a buffer into a concrete type by deserializing from a supported buffer format.
@@ -245,6 +264,7 @@ impl<P, M> DryDataProvider<M> for DeserializingBufferProvider<'_, P>
 where
     M: DataMarker,
     P: DynamicDryDataProvider<BufferMarker> + ?Sized,
+    M::DataStruct: MaybeAsVarULE,
     for<'de> <M::DataStruct as Yokeable<'de>>::Output: Deserialize<'de>,
 {
     fn dry_load(&self, req: DataRequest) -> Result<DataResponseMetadata, DataError> {
@@ -255,6 +275,7 @@ where
 impl<P, M> BoundLocaleDataProvider<M> for DeserializingOwnedBufferProvider<P>
 where
     M: DynamicDataMarker,
+    M::DataStruct: MaybeAsVarULE,
     P: BoundLocaleDataProvider<BufferMarker>,
     for<'de> <M::DataStruct as Yokeable<'de>>::Output: Deserialize<'de>,
 {
@@ -262,16 +283,28 @@ where
         &self,
         req: crate::request::DataAttributesRequest,
     ) -> Result<BoundLocaleDataResponse<'_, M>, DataError> {
+        use zerovec::ule::VarULE;
         let buffer_response = self.0.load_bound(req)?;
         let buffer_format = buffer_response.metadata.buffer_format.ok_or_else(|| {
             DataErrorKind::Deserialize
                 .with_str_context("BufferProvider didn't set BufferFormat")
                 .with_debug_context(&req)
         })?;
+        if buffer_format != BufferFormat::VarULE011 {
+            return Err(DataErrorKind::Deserialize
+                .with_str_context("BoundLocaleDataProvider requires VarULE"));
+        }
+        let payload =
+            <M::DataStruct as MaybeAsVarULE>::EncodedStruct::parse_bytes(buffer_response.payload)
+                .map_err(|ule_err| {
+                DataErrorKind::Deserialize
+                    .with_type_context::<M>()
+                    .with_debug_context(&req)
+                    .with_display_context(&ule_err)
+            })?;
         Ok(BoundLocaleDataResponse {
             metadata: buffer_response.metadata,
-            payload: deserialize_impl::<M>(buffer_response.payload, buffer_format)
-                .map_err(|e| e.with_debug_context(&req))?,
+            payload,
         })
     }
 }
@@ -299,6 +332,14 @@ impl From<postcard::Error> for DataError {
     fn from(e: postcard::Error) -> Self {
         DataErrorKind::Deserialize
             .with_str_context("postcard")
+            .with_display_context(&e)
+    }
+}
+
+impl From<zerovec::ule::UleError> for DataError {
+    fn from(e: zerovec::ule::UleError) -> Self {
+        DataErrorKind::Deserialize
+            .with_str_context("VarULE parsing")
             .with_display_context(&e)
     }
 }

--- a/provider/core/src/data_provider.rs
+++ b/provider/core/src/data_provider.rs
@@ -2,6 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use core::fmt::Debug;
 use core::marker::PhantomData;
 use yoke::Yokeable;
 
@@ -9,6 +10,7 @@ use yoke::Yokeable;
 use alloc::boxed::Box;
 
 use crate::prelude::*;
+use crate::request::DataAttributesRequest;
 
 /// A data provider that loads data for a specific [`DataMarkerInfo`].
 pub trait DataProvider<M>
@@ -457,6 +459,93 @@ where
     #[inline]
     fn bound_marker(&self) -> DataMarkerInfo {
         M::INFO
+    }
+}
+
+/// The result of [`BindLocaleDataProvider::bind_locale`].
+#[derive(Debug)]
+#[allow(clippy::exhaustive_structs)] // exported in an unstable module
+pub struct BindLocaleResponse<T> {
+    /// Metadata from the data bind operation.
+    pub metadata: DataResponseMetadata,
+    /// The provider on which attributes can be loaded.
+    pub bound_provider: T,
+}
+
+/// A data provider that can be bound to a particular marker and locale.
+///
+/// See [`BoundLocaleDataProvider`].
+pub trait BindLocaleDataProvider<M>
+where
+    M: DynamicDataMarker,
+{
+    /// Type of the [`BoundLocaleDataProvider`].
+    type BoundLocaleDataProvider<'data>: BoundLocaleDataProvider<M> + 'data
+    where
+        Self: 'data;
+    /// Bind this provider to the given marker and locale.
+    ///
+    /// This performs a data load for the marker and locale, but not attributes.
+    fn bind_locale<'data>(
+        &'data self,
+        marker: DataMarkerInfo,
+        req: DataRequest,
+    ) -> Result<BindLocaleResponse<Self::BoundLocaleDataProvider<'data>>, DataError>;
+}
+
+/// Like [`DataResponse`] but for [`BoundLocaleDataProvider`].
+#[allow(clippy::exhaustive_structs)] // exported in an unstable module
+pub struct BoundLocaleDataResponse<'data, M>
+where
+    M: DynamicDataMarker,
+{
+    /// Metadata about the returned object.
+    pub metadata: DataResponseMetadata,
+    /// The object itself
+    pub payload: <M::DataStruct as Yokeable<'data>>::Output,
+}
+
+impl<'data, M> Debug for BoundLocaleDataResponse<'data, M>
+where
+    M: DynamicDataMarker,
+    <M::DataStruct as Yokeable<'data>>::Output: Debug,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "DataResponse {{ metadata: {:?}, payload: {:?} }}",
+            self.metadata, self.payload
+        )
+    }
+}
+
+/// A data provider that is bound to a particular marker locale. Can be queried for
+/// different marker attributes within that marker and locale.
+pub trait BoundLocaleDataProvider<M>
+where
+    M: DynamicDataMarker,
+{
+    /// Query the provider for data, returning the result.
+    ///
+    /// Returns [`Ok`] if the request successfully loaded data. If data failed to load, returns an
+    /// Error with more information.
+    fn load_bound(
+        &self,
+        req: DataAttributesRequest,
+    ) -> Result<BoundLocaleDataResponse<'_, M>, DataError>;
+}
+
+impl<M, P> BoundLocaleDataProvider<M> for &P
+where
+    M: DynamicDataMarker,
+    P: BoundLocaleDataProvider<M> + ?Sized,
+{
+    #[inline]
+    fn load_bound(
+        &self,
+        req: DataAttributesRequest,
+    ) -> Result<BoundLocaleDataResponse<'_, M>, DataError> {
+        (**self).load_bound(req)
     }
 }
 

--- a/provider/core/src/data_provider.rs
+++ b/provider/core/src/data_provider.rs
@@ -11,6 +11,7 @@ use alloc::boxed::Box;
 
 use crate::prelude::*;
 use crate::request::DataAttributesRequest;
+use crate::ule::MaybeAsVarULE;
 
 /// A data provider that loads data for a specific [`DataMarkerInfo`].
 pub trait DataProvider<M>
@@ -478,19 +479,18 @@ pub struct BindLocaleResponse<T> {
 pub trait BindLocaleDataProvider<M>
 where
     M: DynamicDataMarker,
+    M::DataStruct: MaybeAsVarULE,
 {
     /// Type of the [`BoundLocaleDataProvider`].
-    type BoundLocaleDataProvider<'data>: BoundLocaleDataProvider<M> + 'data
-    where
-        Self: 'data;
+    type BoundLocaleDataProvider: BoundLocaleDataProvider<M>;
     /// Bind this provider to the given marker and locale.
     ///
     /// This performs a data load for the marker and locale, but not attributes.
-    fn bind_locale<'data>(
-        &'data self,
+    fn bind_locale(
+        &self,
         marker: DataMarkerInfo,
         req: DataRequest,
-    ) -> Result<BindLocaleResponse<Self::BoundLocaleDataProvider<'data>>, DataError>;
+    ) -> Result<BindLocaleResponse<Self::BoundLocaleDataProvider>, DataError>;
 }
 
 /// Like [`DataResponse`] but for [`BoundLocaleDataProvider`].
@@ -498,17 +498,19 @@ where
 pub struct BoundLocaleDataResponse<'data, M>
 where
     M: DynamicDataMarker,
+    M::DataStruct: MaybeAsVarULE,
 {
     /// Metadata about the returned object.
     pub metadata: DataResponseMetadata,
     /// The object itself
-    pub payload: <M::DataStruct as Yokeable<'data>>::Output,
+    pub payload: &'data <M::DataStruct as MaybeAsVarULE>::EncodedStruct,
 }
 
 impl<'data, M> Debug for BoundLocaleDataResponse<'data, M>
 where
     M: DynamicDataMarker,
-    <M::DataStruct as Yokeable<'data>>::Output: Debug,
+    M::DataStruct: MaybeAsVarULE,
+    <M::DataStruct as MaybeAsVarULE>::EncodedStruct: Debug,
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(
@@ -524,6 +526,7 @@ where
 pub trait BoundLocaleDataProvider<M>
 where
     M: DynamicDataMarker,
+    M::DataStruct: MaybeAsVarULE,
 {
     /// Query the provider for data, returning the result.
     ///
@@ -538,6 +541,7 @@ where
 impl<M, P> BoundLocaleDataProvider<M> for &P
 where
     M: DynamicDataMarker,
+    M::DataStruct: MaybeAsVarULE,
     P: BoundLocaleDataProvider<M> + ?Sized,
 {
     #[inline]

--- a/provider/core/src/hello_world.rs
+++ b/provider/core/src/hello_world.rs
@@ -7,6 +7,11 @@
 #![allow(clippy::exhaustive_structs)] // data struct module
 
 use crate as icu_provider;
+use crate::buf::DeserializingOwnedBufferProvider;
+use crate::request::DataAttributesRequest;
+use crate::unstable::{BindLocaleDataProvider, BoundLocaleDataProvider};
+#[cfg(feature = "deserialize_json")]
+use crate::unstable::{BindLocaleResponse, BoundLocaleDataResponse};
 
 use crate::prelude::*;
 use alloc::borrow::Cow;
@@ -14,6 +19,8 @@ use alloc::collections::BTreeSet;
 use alloc::string::String;
 use core::fmt::Debug;
 use icu_locale_core::preferences::define_preferences;
+#[cfg(feature = "deserialize_json")]
+use std::collections::BTreeMap;
 use writeable::Writeable;
 use yoke::*;
 use zerofrom::*;
@@ -264,6 +271,76 @@ impl DynamicDataProvider<BufferMarker> for HelloWorldJsonProvider {
     }
 }
 
+/// A data provider returning Hello World strings for attributes in a specific language
+/// as JSON blobs.
+///
+/// Mostly useful for testing.
+#[cfg(feature = "deserialize_json")]
+#[derive(Debug)]
+pub struct HelloWorldJsonBoundLocaleProvider {
+    json_strings: BTreeMap<&'static DataMarkerAttributes, String>,
+}
+
+#[cfg(feature = "deserialize_json")]
+impl BindLocaleDataProvider<BufferMarker> for HelloWorldJsonProvider {
+    type BoundLocaleDataProvider<'data> = HelloWorldJsonBoundLocaleProvider;
+    fn bind_locale(
+        &self,
+        marker: DataMarkerInfo,
+        req: DataRequest,
+    ) -> Result<BindLocaleResponse<Self::BoundLocaleDataProvider<'static>>, DataError> {
+        marker.match_marker(HelloWorldV1::INFO)?;
+        let json_strings = HelloWorldProvider::DATA
+            .iter()
+            .filter_map(|(l, a, v)| {
+                if req.id.locale.strict_cmp(l.as_bytes()).is_eq() && !a.is_empty() {
+                    let attributes = DataMarkerAttributes::from_str_or_panic(a);
+                    #[expect(clippy::unwrap_used)] // HelloWorld::serialize is infallible
+                    let json_string = serde_json::to_string(&HelloWorld {
+                        message: Cow::Borrowed(v),
+                    })
+                    .unwrap();
+                    Some((attributes, json_string))
+                } else {
+                    None
+                }
+            })
+            .collect::<BTreeMap<_, _>>();
+        if json_strings.is_empty() {
+            return Err(DataErrorKind::IdentifierNotFound.with_req(HelloWorldV1::INFO, req));
+        }
+        Ok(BindLocaleResponse {
+            bound_provider: HelloWorldJsonBoundLocaleProvider { json_strings },
+            metadata: Default::default(),
+        })
+    }
+}
+
+#[cfg(feature = "deserialize_json")]
+impl BoundLocaleDataProvider<BufferMarker> for HelloWorldJsonBoundLocaleProvider {
+    fn load_bound<'data>(
+        &'data self,
+        req: DataAttributesRequest,
+    ) -> Result<BoundLocaleDataResponse<'data, BufferMarker>, DataError> {
+        // TODO: Implement logic for attributes_prefix_match
+        let json_string = self
+            .json_strings
+            .get(req.marker_attributes)
+            .ok_or_else(|| {
+                DataErrorKind::IdentifierNotFound
+                    .into_error()
+                    .with_debug_context(&req)
+            })?;
+        Ok(BoundLocaleDataResponse {
+            metadata: DataResponseMetadata {
+                buffer_format: Some(icu_provider::buf::BufferFormat::Json),
+                ..Default::default()
+            },
+            payload: json_string.as_bytes(),
+        })
+    }
+}
+
 impl IterableDataProvider<HelloWorldV1> for HelloWorldProvider {
     fn iter_ids(&self) -> Result<BTreeSet<DataIdentifierCow<'_>>, DataError> {
         #[expect(clippy::unwrap_used)] // hello-world
@@ -312,12 +389,21 @@ pub struct HelloWorldFormatter {
     data: DataPayload<HelloWorldV1>,
 }
 
+/// A type that formats variants of localized "hello world" strings.
+///
+/// This type is intended to take the shape of an ICU4X formatter that lazily
+/// loads data marker attributes.
+#[derive(Debug)]
+pub struct HelloWorldAttributeFormatter<P: BoundLocaleDataProvider<HelloWorldV1>> {
+    provider: P,
+}
+
 /// A formatted hello world message. Implements [`Writeable`].
 ///
 /// For an example, see [`HelloWorldFormatter`].
 #[derive(Debug)]
 pub struct FormattedHelloWorld<'l> {
-    data: &'l HelloWorld<'l>,
+    data: HelloWorld<'l>,
 }
 
 impl HelloWorldFormatter {
@@ -357,13 +443,98 @@ impl HelloWorldFormatter {
     /// Formats a hello world message, returning a [`FormattedHelloWorld`].
     pub fn format<'l>(&'l self) -> FormattedHelloWorld<'l> {
         FormattedHelloWorld {
-            data: self.data.get(),
+            data: self.data.get().clone(), // clones cows whose fields are borrowed
         }
     }
 
     /// Formats a hello world message, returning a [`String`].
     pub fn format_to_string(&self) -> String {
         self.format().write_to_string().into_owned()
+    }
+}
+
+impl<P: BoundLocaleDataProvider<BufferMarker>>
+    HelloWorldAttributeFormatter<DeserializingOwnedBufferProvider<P>>
+{
+    /// Creates one of these formatters from a buffer provider.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu_locale_core::locale;
+    /// use icu_provider::hello_world::{HelloWorldAttributeFormatter, HelloWorldProvider};
+    /// use writeable::assert_writeable_eq;
+    ///
+    /// let fmt = HelloWorldAttributeFormatter::try_new_with_buffer_provider(
+    ///     &HelloWorldProvider.into_json_provider(),
+    ///     locale!("en").into(),
+    /// )
+    /// .expect("locale exists and has attributes");
+    ///
+    /// assert_writeable_eq!(fmt.format("reverse").unwrap(), "Olleh Dlrow");
+    /// ```
+    pub fn try_new_with_buffer_provider<'data, P1>(
+        provider: &'data P1,
+        prefs: HelloWorldFormatterPreferences,
+    ) -> Result<Self, DataError>
+    where
+        P1: BindLocaleDataProvider<BufferMarker, BoundLocaleDataProvider<'data> = P> + ?Sized,
+    {
+        let locale = HelloWorldV1::INFO.make_locale(prefs.locale_preferences);
+        let response = provider.bind_locale(
+            HelloWorldV1::INFO,
+            DataRequest {
+                id: DataIdentifierBorrowed::for_locale(&locale),
+                metadata: Default::default(),
+            },
+        )?;
+        Ok(Self {
+            provider: DeserializingOwnedBufferProvider::new(response.bound_provider),
+        })
+    }
+}
+
+impl<P: BoundLocaleDataProvider<HelloWorldV1>> HelloWorldAttributeFormatter<P> {
+    /// Formats a hello world message with the specified attribute,
+    /// returning a [`FormattedHelloWorld`].
+    pub fn format<'l>(&'l self, attribute: &str) -> Result<FormattedHelloWorld<'l>, DataError> {
+        self.format_internal(attribute, false)
+    }
+
+    /// Formats a hello world message with the attribute best matching a prefix,
+    /// returning a [`FormattedHelloWorld`].
+    pub fn format_for_prefix<'l>(
+        &'l self,
+        prefix: &str,
+    ) -> Result<FormattedHelloWorld<'l>, DataError> {
+        self.format_internal(prefix, true)
+    }
+
+    fn format_internal<'l>(
+        &'l self,
+        attribute: &str,
+        attributes_prefix_match: bool,
+    ) -> Result<FormattedHelloWorld<'l>, DataError> {
+        let marker_attributes = DataMarkerAttributes::try_from_str(attribute)
+            .map_err(|_| DataError::custom("invalid attribute").with_debug_context(attribute))?;
+        let metadata = DataRequestMetadata {
+            attributes_prefix_match,
+            ..Default::default()
+        };
+        let result = self.provider.load_bound(DataAttributesRequest {
+            marker_attributes,
+            metadata,
+        })?;
+        Ok(FormattedHelloWorld {
+            data: result.payload,
+        })
+    }
+
+    /// Formats a hello world message with the specified attribute,
+    /// returning a [`String`].
+    pub fn format_to_string(&self, attribute: &str) -> Result<String, DataError> {
+        self.format(attribute)
+            .map(|ok| ok.write_to_string().into_owned())
     }
 }
 

--- a/provider/core/src/hello_world.rs
+++ b/provider/core/src/hello_world.rs
@@ -278,39 +278,34 @@ impl DynamicDataProvider<BufferMarker> for HelloWorldJsonProvider {
 #[cfg(feature = "deserialize_json")]
 #[derive(Debug)]
 pub struct HelloWorldJsonBoundLocaleProvider {
-    json_strings: BTreeMap<&'static DataMarkerAttributes, String>,
+    message_strings: BTreeMap<&'static DataMarkerAttributes, String>,
 }
 
 #[cfg(feature = "deserialize_json")]
 impl BindLocaleDataProvider<BufferMarker> for HelloWorldJsonProvider {
-    type BoundLocaleDataProvider<'data> = HelloWorldJsonBoundLocaleProvider;
+    type BoundLocaleDataProvider = HelloWorldJsonBoundLocaleProvider;
     fn bind_locale(
         &self,
         marker: DataMarkerInfo,
         req: DataRequest,
-    ) -> Result<BindLocaleResponse<Self::BoundLocaleDataProvider<'static>>, DataError> {
+    ) -> Result<BindLocaleResponse<Self::BoundLocaleDataProvider>, DataError> {
         marker.match_marker(HelloWorldV1::INFO)?;
-        let json_strings = HelloWorldProvider::DATA
+        let message_strings = HelloWorldProvider::DATA
             .iter()
             .filter_map(|(l, a, v)| {
                 if req.id.locale.strict_cmp(l.as_bytes()).is_eq() && !a.is_empty() {
                     let attributes = DataMarkerAttributes::from_str_or_panic(a);
-                    #[expect(clippy::unwrap_used)] // HelloWorld::serialize is infallible
-                    let json_string = serde_json::to_string(&HelloWorld {
-                        message: Cow::Borrowed(v),
-                    })
-                    .unwrap();
-                    Some((attributes, json_string))
+                    Some((attributes, v.to_string()))
                 } else {
                     None
                 }
             })
             .collect::<BTreeMap<_, _>>();
-        if json_strings.is_empty() {
+        if message_strings.is_empty() {
             return Err(DataErrorKind::IdentifierNotFound.with_req(HelloWorldV1::INFO, req));
         }
         Ok(BindLocaleResponse {
-            bound_provider: HelloWorldJsonBoundLocaleProvider { json_strings },
+            bound_provider: HelloWorldJsonBoundLocaleProvider { message_strings },
             metadata: Default::default(),
         })
     }
@@ -323,8 +318,8 @@ impl BoundLocaleDataProvider<BufferMarker> for HelloWorldJsonBoundLocaleProvider
         req: DataAttributesRequest,
     ) -> Result<BoundLocaleDataResponse<'data, BufferMarker>, DataError> {
         // TODO: Implement logic for attributes_prefix_match
-        let json_string = self
-            .json_strings
+        let message_string = self
+            .message_strings
             .get(req.marker_attributes)
             .ok_or_else(|| {
                 DataErrorKind::IdentifierNotFound
@@ -333,10 +328,10 @@ impl BoundLocaleDataProvider<BufferMarker> for HelloWorldJsonBoundLocaleProvider
             })?;
         Ok(BoundLocaleDataResponse {
             metadata: DataResponseMetadata {
-                buffer_format: Some(icu_provider::buf::BufferFormat::Json),
+                buffer_format: Some(icu_provider::buf::BufferFormat::VarULE011),
                 ..Default::default()
             },
-            payload: json_string.as_bytes(),
+            payload: message_string.as_bytes(),
         })
     }
 }
@@ -473,12 +468,12 @@ impl<P: BoundLocaleDataProvider<BufferMarker>>
     ///
     /// assert_writeable_eq!(fmt.format("reverse").unwrap(), "Olleh Dlrow");
     /// ```
-    pub fn try_new_with_buffer_provider<'data, P1>(
-        provider: &'data P1,
+    pub fn try_new_with_buffer_provider<P1>(
+        provider: &P1,
         prefs: HelloWorldFormatterPreferences,
     ) -> Result<Self, DataError>
     where
-        P1: BindLocaleDataProvider<BufferMarker, BoundLocaleDataProvider<'data> = P> + ?Sized,
+        P1: BindLocaleDataProvider<BufferMarker, BoundLocaleDataProvider = P> + ?Sized,
     {
         let locale = HelloWorldV1::INFO.make_locale(prefs.locale_preferences);
         let response = provider.bind_locale(
@@ -526,7 +521,9 @@ impl<P: BoundLocaleDataProvider<HelloWorldV1>> HelloWorldAttributeFormatter<P> {
             metadata,
         })?;
         Ok(FormattedHelloWorld {
-            data: result.payload,
+            data: HelloWorld {
+                message: Cow::Borrowed(result.payload),
+            },
         })
     }
 

--- a/provider/core/src/lib.rs
+++ b/provider/core/src/lib.rs
@@ -120,7 +120,10 @@ mod error;
 pub use error::{DataError, DataErrorKind, ResultDataError};
 
 mod request;
-pub use request::{DataLocale, DataMarkerAttributes, DataRequest, DataRequestMetadata, *};
+pub use request::{
+    AttributeParseError, DataIdentifierBorrowed, DataIdentifierCow, DataLocale,
+    DataMarkerAttributes, DataRequest, DataRequestMetadata,
+};
 
 mod response;
 #[doc(hidden)] // TODO(#4467): establish this as an internal API
@@ -180,6 +183,15 @@ pub mod prelude {
     pub use yoke;
     #[doc(no_inline)]
     pub use zerofrom;
+}
+
+/// Additional traits and types currently being incubated
+pub mod unstable {
+    pub use super::data_provider::{
+        BindLocaleDataProvider, BindLocaleResponse, BoundLocaleDataProvider,
+        BoundLocaleDataResponse,
+    };
+    pub use super::request::DataAttributesRequest;
 }
 
 #[doc(hidden)] // internal

--- a/provider/core/src/marker.rs
+++ b/provider/core/src/marker.rs
@@ -434,6 +434,8 @@ pub struct DataMarkerInfo {
     pub is_singleton: bool,
     /// Whether this data marker uses checksums for integrity purposes.
     pub has_checksum: bool,
+    /// Whether the marker's data struct has a VarULE optimization.
+    pub has_varule: bool,
     /// The fallback to use for this data marker.
     pub fallback_config: LocaleFallbackConfig,
     /// The attributes domain for this data marker. This can be used for filtering marker
@@ -471,6 +473,7 @@ impl DataMarkerInfo {
             fallback_config: LocaleFallbackConfig::default(),
             is_singleton: false,
             has_checksum: false,
+            has_varule: false,
             #[cfg(feature = "export")]
             attributes_domain: "",
             #[cfg(feature = "export")]

--- a/provider/core/src/request.rs
+++ b/provider/core/src/request.rs
@@ -35,6 +35,16 @@ pub struct DataRequest<'a> {
     pub metadata: DataRequestMetadata,
 }
 
+/// A request for data, but with the locale pre-resolved.
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(clippy::exhaustive_structs)] // exported in an unstable module
+pub struct DataAttributesRequest<'a> {
+    /// Marker-specific request attributes
+    pub marker_attributes: &'a DataMarkerAttributes,
+    /// Metadata that may affect the behavior of the data provider.
+    pub metadata: DataRequestMetadata,
+}
+
 /// Metadata for data requests. This is currently empty, but it may be extended with options
 /// for tuning locale fallback, buffer layout, and so forth.
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]

--- a/provider/core/src/varule_traits.rs
+++ b/provider/core/src/varule_traits.rs
@@ -2,6 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use yoke::Yokeable;
 #[cfg(feature = "export")]
 use zerovec::ule::EncodeAsVarULE;
 use zerovec::ule::VarULE;
@@ -24,6 +25,13 @@ pub trait MaybeAsVarULE {
     /// The [`VarULE`] type for this data struct, or `[()]`
     /// if it cannot be represented as [`VarULE`].
     type EncodedStruct: ?Sized + VarULE;
+    // /// Convert the encoded struct to the normal struct.
+    // #[inline]
+    // fn maybe_zero_from_encoded_struct<'a>(
+    //     _encoded_struct: &'a Self::EncodedStruct,
+    // ) -> Option<<Self as Yokeable<'a>>::Output> {
+    //     None
+    // }
 }
 
 /// Export-only trait associated with [`MaybeAsVarULE`]. See that trait
@@ -92,10 +100,12 @@ macro_rules! data_struct {
 //=== Standard impls ===//
 
 #[cfg(feature = "alloc")]
-impl<'a, K0, V> MaybeAsVarULE for ZeroMap<'a, K0, V>
+impl<K0, V> MaybeAsVarULE for ZeroMap<'static, K0, V>
 where
-    K0: ZeroMapKV<'a>,
-    V: ZeroMapKV<'a>,
+    for<'b> K0: ZeroMapKV<'b> + 'static,
+    for<'b> V: ZeroMapKV<'b> + 'static,
+    for<'b> <K0 as ZeroMapKV<'static>>::Container: Yokeable<'b>,
+    for<'b> <V as ZeroMapKV<'static>>::Container: Yokeable<'b>,
     K0: ?Sized,
     V: ?Sized,
 {
@@ -104,10 +114,12 @@ where
 
 #[cfg(feature = "alloc")]
 #[cfg(feature = "export")]
-impl<'a, K0, V> MaybeEncodeAsVarULE for ZeroMap<'a, K0, V>
+impl<K0, V> MaybeEncodeAsVarULE for ZeroMap<'static, K0, V>
 where
-    K0: ZeroMapKV<'a>,
-    V: ZeroMapKV<'a>,
+    for<'b> K0: ZeroMapKV<'b> + 'static,
+    for<'b> V: ZeroMapKV<'b> + 'static,
+    for<'b> <K0 as ZeroMapKV<'static>>::Container: Yokeable<'b>,
+    for<'b> <V as ZeroMapKV<'static>>::Container: Yokeable<'b>,
     K0: ?Sized,
     V: ?Sized,
 {
@@ -166,6 +178,10 @@ impl<T, const N: usize> MaybeEncodeAsVarULE for [T; N] {
     fn maybe_as_encodeable<'a>(&'a self) -> Option<Self::EncodeableStruct<'a>> {
         None
     }
+}
+
+impl<'a, V: VarULE + ?Sized> MaybeAsVarULE for &'a V {
+    type EncodedStruct = V;
 }
 
 impl MaybeAsVarULE for u16 {

--- a/utils/tinystr/src/unvalidated.rs
+++ b/utils/tinystr/src/unvalidated.rs
@@ -27,6 +27,9 @@ impl<const N: usize> fmt::Debug for UnvalidatedTinyAsciiStr<N> {
 }
 
 impl<const N: usize> UnvalidatedTinyAsciiStr<N> {
+    /// The empty string as a default value.
+    pub const DEFAULT: Self = Self([0u8; N]);
+
     #[inline]
     /// Converts into a [`TinyAsciiStr`]. Fails if the bytes are not valid ASCII.
     pub fn try_into_tinystr(self) -> Result<TinyAsciiStr<N>, ParseError> {

--- a/utils/zerotrie/src/cursor.rs
+++ b/utils/zerotrie/src/cursor.rs
@@ -159,7 +159,7 @@ pub struct AsciiProbeResult {
     pub total_siblings: u8,
 }
 
-impl ZeroTrieSimpleAsciiCursor<'_> {
+impl<'a> ZeroTrieSimpleAsciiCursor<'a> {
     /// Steps the cursor one character into the trie based on the character's byte value.
     ///
     /// # Examples
@@ -340,6 +340,31 @@ impl ZeroTrieSimpleAsciiCursor<'_> {
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.trie.is_empty()
+    }
+
+    /// Returns a trie for all suffixes that begin with the previously stepped
+    /// bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zerotrie::ZeroTrieSimpleAscii;
+    ///
+    /// // A trie with two values: "abc" and "abcdef"
+    /// let trie = ZeroTrieSimpleAscii::from_bytes(b"abc\x80def\x81");
+    ///
+    /// // Consume the prefix "ab"
+    /// let mut cursor = trie.cursor();
+    /// cursor.step(b'a');
+    /// cursor.step(b'b');
+    /// let suffix_trie = cursor.into_suffix_trie();
+    ///
+    /// // The suffix trie contains the strings "c" and "cdef"
+    /// assert_eq!(suffix_trie.get("c"), Some(0));
+    /// assert_eq!(suffix_trie.get("cdef"), Some(1));
+    /// ```
+    pub fn into_suffix_trie(self) -> ZeroTrieSimpleAscii<&'a [u8]> {
+        self.trie
     }
 }
 


### PR DESCRIPTION
#3260 

Please take a look at this design for a formatter that retains a piece of the data provider for runtime lookup of data marker attributes, intended for use cases such as currencies, units, and display names.

Reviewable commit-by-commit.

No AI was used when writing this, but I might use one to fix up the clippy and feature warnings in CI.

The docs are somewhat limited. Please focus on the docs tests for the end-to-end usage examples. I will add more docs before merging.