### PR TITLE
added tlh-001 fallback test

### DIFF
--- a/provider/source/tests/locales.rs.data
+++ b/provider/source/tests/locales.rs.data
@@ -32,7 +32,7 @@ const LOCALES: &[LanguageIdentifier] = &[
     //  - South American dialect
     //  - Has context dependent list fragments
     langid!("es"),
-    langid!("es-AR"),   
+    langid!("es-AR"),
     // French:
     // - Often the first non-English locale to receive new data in CLDR
     langid!("fr"),


### PR DESCRIPTION
Addresses #6541 

This PR adds `tlh-001` (klingon) to the test locale set as an unsupported locale so as to improve test coverage for fallback behavior.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->