### PR TITLE
Add missing error variant conversion

### DIFF
--- a/components/time/src/ixdtf.rs
+++ b/components/time/src/ixdtf.rs
@@ -105,6 +105,10 @@ impl From<icu_calendar::ParseError> for ParseError {
             icu_calendar::ParseError::Range(r) => Self::Range(r),
             icu_calendar::ParseError::Syntax(s) => Self::Syntax(s),
             icu_calendar::ParseError::UnknownCalendar => Self::UnknownCalendar,
+            icu_calendar::ParseError::MismatchedCalendar(a, b) => Self::MismatchedCalendar(
+                a.try_into().unwrap_or(AnyCalendarKind::Iso),
+                b.try_into().unwrap_or(AnyCalendarKind::Iso),
+            ),
             _ => unreachable!(),
         }
     }


### PR DESCRIPTION
This would have been caught by https://github.com/rust-lang/rust/issues/89554.

Unfortunately, because this conversion was missing, the change from `AnyCalendarKind` to `CalendarAlgorithm` in `icu_calendar::ParseError` was not applied to `icu_time::ParseError`. 

## Changelog: N/A

