### PR TITLE
Reduce checks in `ZonedDateTime` parsing

### DIFF
--- a/components/calendar/src/date.rs
+++ b/components/calendar/src/date.rs
@@ -233,6 +233,7 @@ impl<A: AsCalendar> Date<A> {
         let c1 = self.calendar.as_calendar();
         let c2 = calendar.as_calendar();
         let inner = if c1.has_cheap_iso_conversion() && c2.has_cheap_iso_conversion() {
+            // no-op
             c2.from_iso(c1.to_iso(self.inner()))
         } else {
             // `from_rata_die` precondition is satified by `to_rata_die`

--- a/components/time/src/types.rs
+++ b/components/time/src/types.rs
@@ -179,6 +179,10 @@ impl Time {
             subsecond: nanosecond.try_into()?,
         })
     }
+
+    pub(crate) const fn seconds_since_midnight(self) -> u32 {
+        (self.hour.0 as u32 * 60 + self.minute.0 as u32) * 60 + self.second.0 as u32
+    }
 }
 
 /// A date and time for a given calendar.
@@ -310,8 +314,47 @@ const UNIX_EPOCH: RataDie = calendrical_calculations::gregorian::fixed_from_greg
 
 impl Ord for ZonedDateTime<Iso, UtcOffset> {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-        self.to_epoch_milliseconds_utc()
-            .cmp(&other.to_epoch_milliseconds_utc())
+        let mut srd = self.date.to_rata_die();
+        let mut ord = other.date.to_rata_die();
+
+        // If the RDs are three days apart, even with maximum/minimum
+        // times and offsets, the UTC days will still be at at least
+        // one day apart
+        if srd + 3 <= ord {
+            return core::cmp::Ordering::Less;
+        }
+        if srd - 3 >= ord {
+            return core::cmp::Ordering::Greater;
+        }
+
+        let mut ss = self.time.seconds_since_midnight() as i32 - self.zone.to_seconds();
+        let mut os = other.time.seconds_since_midnight() as i32 - other.zone.to_seconds();
+
+        // the seconds can wrap into the day
+
+        if ss < 0 {
+            srd -= 1;
+            ss += 24 * 60 * 60;
+        }
+        if ss > 24 * 60 * 60 {
+            srd += 1;
+            ss -= 24 * 60 * 60;
+        }
+
+        if os < 0 {
+            ord -= 1;
+            os += 24 * 60 * 60;
+        }
+        if os > 24 * 60 * 60 {
+            ord += 1;
+            os -= 24 * 60 * 60;
+        }
+
+        // the subseconds cannot wrap into the seconds
+
+        srd.cmp(&ord)
+            .then(ss.cmp(&os))
+            .then(self.time.subsecond.cmp(&other.time.subsecond))
     }
 }
 impl PartialOrd for ZonedDateTime<Iso, UtcOffset> {
@@ -417,17 +460,5 @@ impl ZonedDateTime<Iso, UtcOffset> {
             time,
             zone: utc_offset,
         }
-    }
-
-    pub(crate) fn to_epoch_milliseconds_utc(self) -> i64 {
-        let ZonedDateTime { date, time, zone } = self;
-        let days = date.to_rata_die() - UNIX_EPOCH;
-        let hours = time.hour.number() as i64;
-        let minutes = time.minute.number() as i64;
-        let seconds = time.second.number() as i64;
-        let nanos = time.subsecond.number() as i64;
-        let offset_seconds = zone.to_seconds() as i64;
-        (((days * 24 + hours) * 60 + minutes) * 60 + seconds - offset_seconds) * 1000
-            + nanos / 1_000_000
     }
 }

--- a/components/time/src/zone/zone_name_timestamp.rs
+++ b/components/time/src/zone/zone_name_timestamp.rs
@@ -4,9 +4,11 @@
 
 use core::fmt;
 
+use icu_calendar::types::RataDie;
 use icu_calendar::Iso;
 use zerovec::ule::AsULE;
 
+use crate::Time;
 use crate::{zone::UtcOffset, DateTime, ZonedDateTime};
 
 /// The moment in time for resolving a time zone name.
@@ -66,6 +68,8 @@ use crate::{zone::UtcOffset, DateTime, ZonedDateTime};
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ZoneNameTimestamp(u32);
 
+const RD_EPOCH: RataDie = calendrical_calculations::gregorian::fixed_from_gregorian(1970, 1, 1);
+
 impl ZoneNameTimestamp {
     /// Recovers the UTC datetime for this [`ZoneNameTimestamp`].
     ///
@@ -123,21 +127,31 @@ impl ZoneNameTimestamp {
     /// assert_eq!(recovered_zoned_date_time.time.subsecond.number(), 0); // always zero
     /// ```
     pub fn from_zoned_date_time_iso(zoned_date_time: ZonedDateTime<Iso, UtcOffset>) -> Self {
-        let ms = match zoned_date_time.to_epoch_milliseconds_utc() {
+        Self::from_rd_time_zone(
+            zoned_date_time.date.to_rata_die(),
+            zoned_date_time.time,
+            zoned_date_time.zone,
+        )
+    }
+
+    pub(crate) fn from_rd_time_zone(rd: RataDie, time: Time, zone: UtcOffset) -> Self {
+        let seconds = (rd - RD_EPOCH) * 24 * 60 * 60 + time.seconds_since_midnight() as i64
+            - zone.to_seconds() as i64;
+        let seconds = match seconds {
             // Values that are not multiples of 15, that we map to the next multiple
             // of 15 (which is always 00:15 or 00:45, values that are otherwise unused).
-            63593070000..63593100000 => 63593100000,
-            307622400000..307622700000 => 307622700000,
-            576041460000..576042300000 => 576042300000,
-            576043260000..576044100000 => 576044100000,
-            594180060000..594180900000 => 594180900000,
-            607491060000..607491900000 => 607491900000,
-            1601740860000..1601741700000 => 1601741700000,
-            1633190460000..1633191300000 => 1633191300000,
-            1664640060000..1664640900000 => 1664640900000,
-            ms => ms,
+            63593070..63593100 => 63593100,
+            307622400..307622700 => 307622700,
+            576041460..576042300 => 576042300,
+            576043260..576044100 => 576044100,
+            594180060..594180900 => 594180900,
+            607491060..607491900 => 607491900,
+            1601740860..1601741700 => 1601741700,
+            1633190460..1633191300 => 1633191300,
+            1664640060..1664640900 => 1664640900,
+            s => s,
         };
-        let qh = ms / 1000 / 60 / 15;
+        let qh = seconds / 60 / 15;
         let qh_clamped = qh.clamp(Self::far_in_past().0 as i64, Self::far_in_future().0 as i64);
         // Valid cast as the value is clamped to u32 values.
         Self(qh_clamped as u32)
@@ -261,7 +275,7 @@ impl<'de> serde::Deserialize<'de> for ZoneNameTimestamp {
             let minute = parts[14..16].parse::<u8>().map_err(e1)?;
             return Ok(Self::from_zoned_date_time_iso(ZonedDateTime {
                 date: icu_calendar::Date::try_new_iso(year, month, day).map_err(e2)?,
-                time: crate::Time::try_new(hour, minute, 0, 0).map_err(e3)?,
+                time: Time::try_new(hour, minute, 0, 0).map_err(e3)?,
                 zone: UtcOffset::zero(),
             }));
         }


### PR DESCRIPTION
Currently the date and time are reparsed to populate the time zone timestamp.

Also fixes the `PartialOrd` impl for `ZonedDateTime<Iso, UtcOffset>`, which previously only used millisecond accuracy, whereas `Time` has nanosecond.

Also simplifies `ZoneNameTimestamp` construction, which only needs second-level accuracy.


## Changelog

icu_time: Reduce unnecessary checks during `ZonedDateTime` parsing.
