### PR TITLE
fix(normalizer): Add missing backticks to doc comment

### DIFF
--- a/components/normalizer/src/lib.rs
+++ b/components/normalizer/src/lib.rs
@@ -170,8 +170,8 @@ fn likely(b: bool) -> bool {
     b
 }
 
-/// This type exists as a shim for `icu_properties` `CanonicalCombiningClass` when the crate is disabled
-/// It should not be exposed to users.
+// This type exists as a shim for `icu_properties` `CanonicalCombiningClass` when the crate is disabled
+// It should not be exposed to users.
 #[cfg(not(feature = "icu_properties"))]
 #[derive(Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
 struct CanonicalCombiningClass(pub(crate) u8);


### PR DESCRIPTION
Fixes #7632. This PR suppresses `clippy::doc-markdown` warnings in `components/normalizer/src/lib.rs` by wrapping `icu_properties` and `CanonicalCombiningClass` in backticks.


## Changelog: N/A

