### PR TITLE
Added tlh-001 to test-options

### DIFF
--- a/provider/export/tests/test-options.rs
+++ b/provider/export/tests/test-options.rs
@@ -469,7 +469,7 @@ fn explicit_runtime_retain_base() {
         // "ru-Cyrl-RU", (same as 'ru')
         "sr-Latn",
         // "sr-ME", (same as 'sr-Latn')
-        "tlh-001", // no data for any ancestor, but retained as an explicit base language
+        "tlh-001", // no matching ancestor locale in responses before 'und'; retained since RetainBaseLanguages does not deduplicate against 'und'
         "und",
     ];
 


### PR DESCRIPTION
Fixes #6541

This follows up on the previous closed PR by moving the `tlh-001` coverage into `provider/export/tests/test-options.rs` and updating only the expected test output. No fallback logic changes. So, this just aligns the tests with current exporter behavior.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->


## Changelog: N/A

