### PR TITLE
Special-case hebrew months in names data struct

### DIFF
--- a/components/calendar/src/cal/hebrew.rs
+++ b/components/calendar/src/cal/hebrew.rs
@@ -214,9 +214,6 @@ impl DateFieldsResolver for Hebrew {
             ordinal_month - (is_leap && ordinal_month >= 6) as u8,
             if ordinal_month == 6 && is_leap {
                 LeapStatus::Leap
-            } else if ordinal_month == 7 && is_leap {
-                // Use the leap name for Adar in a leap year
-                LeapStatus::FormattingLeap
             } else {
                 LeapStatus::Normal
             },
@@ -357,13 +354,13 @@ impl Date<Hebrew> {
     /// use icu::calendar::Date;
     /// use icu::calendar::types::Month;
     ///
-    /// let date = Date::try_new_hebrew_v2(5782, Month::new(6), 7)
+    /// let date = Date::try_new_hebrew_v2(5782, Month::leap(5), 7)
     ///     .expect("Failed to initialize Date instance.");
     ///
     /// assert_eq!(date.era_year().year, 5782);
     /// // Adar I
-    /// assert_eq!(date.month().number(), 6);
-    /// assert_eq!(date.month().is_formatting_leap(), true);
+    /// assert_eq!(date.month().number(), 5);
+    /// assert_eq!(date.month().is_leap(), true);
     /// assert_eq!(date.day_of_month().0, 7);
     /// ```
     pub fn try_new_hebrew_v2(

--- a/components/calendar/src/calendar_arithmetic.rs
+++ b/components/calendar/src/calendar_arithmetic.rs
@@ -582,13 +582,12 @@ impl<C: DateFieldsResolver> ArithmeticDate<C> {
         } else {
             let target_month = cal.month_from_ordinal(target.year(), target.month());
             if month != target_month {
-                let ordering = month.cmp_lexicographic(target_month);
                 if sign > 0 {
-                    if ordering.is_gt() {
+                    if month > target_month {
                         return true;
                     }
                 } else {
-                    if ordering.reverse().is_gt() {
+                    if month <= target_month {
                         return true;
                     }
                 }

--- a/components/datetime/src/format/datetime.rs
+++ b/components/datetime/src/format/datetime.rs
@@ -286,15 +286,11 @@ where
                 }
                 Err(e) => {
                     w.with_part(PART, |w| {
-                        w.with_part(Part::ERROR, |w| {
-                            w.write_str(&month.value.formatting_code().0)
-                        })
+                        w.with_part(Part::ERROR, |w| w.write_str(&month.value.code().0))
                     })?;
                     Err(match e {
                         GetNameForMonthError::InvalidMonthCode => {
-                            FormattedDateTimePatternError::InvalidMonthCode(
-                                month.value.formatting_code(),
-                            )
+                            FormattedDateTimePatternError::InvalidMonthCode(month.value.code())
                         }
                         GetNameForMonthError::InvalidFieldLength => {
                             FormattedDateTimePatternError::UnsupportedLength(ErrorField(field))

--- a/components/datetime/src/pattern/names.rs
+++ b/components/datetime/src/pattern/names.rs
@@ -3773,25 +3773,37 @@ impl RawDateTimeNamesBorrowed<'_> {
         let month_index = usize::from(month.number() - 1);
         let name = match month_names {
             MonthNames::Linear(linear) => {
-                if month.is_formatting_leap() {
+                if month.is_leap() {
                     None
                 } else {
                     linear.get(month_index)
                 }
             }
+            MonthNames::LeapLinear(hebrew) if hebrew.get(12).unwrap_or_default().is_empty() => {
+                if month.number() == 5 && month.is_leap() {
+                    // Adar I name in position 16
+                    hebrew.get(16)
+                } else if month.number() == 6 && month.ordinal == 7 {
+                    // Adar II name in position 17
+                    hebrew.get(17)
+                } else if month_index < 12 {
+                    hebrew.get(month_index)
+                } else {
+                    None
+                }
+            }
             MonthNames::LeapLinear(leap_linear) => {
                 let num_months = leap_linear.len() / 2;
-                if month.is_formatting_leap() {
+                if month.is_leap() {
                     leap_linear.get(month_index + num_months)
                 } else if month_index < num_months {
                     leap_linear.get(month_index)
                 } else {
                     None
                 }
-                .filter(|s| !s.is_empty())
             }
             MonthNames::LeapNumeric(leap_numeric) => {
-                if month.is_formatting_leap() {
+                if month.is_leap() {
                     return Ok(MonthPlaceholderValue::NumericPattern(leap_numeric));
                 } else {
                     return Ok(MonthPlaceholderValue::Numeric);


### PR DESCRIPTION
This moves the "membrane" between `icu_calendar` and `icu_datetime` to not having to expose the non-standard "formatting month code".

#7149 