### PR TITLE
renamed from_vec_unchecked to from_vec

### DIFF
--- a/components/locale_core/src/extensions/private/mod.rs
+++ b/components/locale_core/src/extensions/private/mod.rs
@@ -63,7 +63,7 @@ pub(crate) const PRIVATE_EXT_STR: &str = "x";
 /// let subtag1: Subtag = "foo".parse().expect("Failed to parse a Subtag.");
 /// let subtag2: Subtag = "bar".parse().expect("Failed to parse a Subtag.");
 ///
-/// let private = Private::from_vec_unchecked(vec![subtag1, subtag2]);
+/// let private = Private::from_vec(vec![subtag1, subtag2]);
 /// assert_eq!(&private.to_string(), "x-foo-bar");
 /// ```
 ///
@@ -124,11 +124,11 @@ impl Private {
     /// let subtag1: Subtag = "foo".parse().expect("Failed to parse a Subtag.");
     /// let subtag2: Subtag = "bar".parse().expect("Failed to parse a Subtag.");
     ///
-    /// let private = Private::from_vec_unchecked(vec![subtag1, subtag2]);
+    /// let private = Private::from_vec(vec![subtag1, subtag2]);
     /// assert_eq!(&private.to_string(), "x-foo-bar");
     /// ```
     #[cfg(feature = "alloc")]
-    pub fn from_vec_unchecked(input: Vec<Subtag>) -> Self {
+    pub fn from_vec(input: Vec<Subtag>) -> Self {
         Self(input.into())
     }
 
@@ -157,7 +157,7 @@ impl Private {
     ///
     /// let subtag1: Subtag = "foo".parse().expect("Failed to parse a Subtag.");
     /// let subtag2: Subtag = "bar".parse().expect("Failed to parse a Subtag.");
-    /// let mut private = Private::from_vec_unchecked(vec![subtag1, subtag2]);
+    /// let mut private = Private::from_vec(vec![subtag1, subtag2]);
     ///
     /// assert_eq!(&private.to_string(), "x-foo-bar");
     ///

--- a/components/locale_core/tests/fixtures/mod.rs
+++ b/components/locale_core/tests/fixtures/mod.rs
@@ -94,7 +94,7 @@ impl TryFrom<LocaleExtensions> for Extensions {
             .iter()
             .map(|v| private::Subtag::try_from_str(v).expect("Failed to add field."))
             .collect();
-        ext.private = private::Private::from_vec_unchecked(v);
+        ext.private = private::Private::from_vec(v);
         Ok(ext)
     }
 }


### PR DESCRIPTION
Fixes #7671 
Renames `icu::locid::extensions::private::Private::from_vec_unchecked` to `from_vec`.