### PR TITLE
Update APIs used in time zone docs

### DIFF
--- a/components/datetime/src/fieldsets.rs
+++ b/components/datetime/src/fieldsets.rs
@@ -935,7 +935,7 @@ macro_rules! impl_zone_marker {
         /// use icu::datetime::input::{Date, DateTime, Time, TimeZone, TimeZoneInfo, UtcOffset};
         /// use icu::datetime::NoCalendarFormatter;
         #[doc = concat!("use icu::datetime::fieldsets::zone::", stringify!($type), ";")]
-        /// use icu::locale::{locale, subtags::subtag};
+        /// use icu::locale::locale;
         /// use writeable::assert_writeable_eq;
         ///
         /// let fmt = NoCalendarFormatter::try_new(
@@ -945,8 +945,8 @@ macro_rules! impl_zone_marker {
         /// .unwrap();
         ///
         /// // Time zone info for America/Chicago in the summer
-        /// let zone = TimeZone(subtag!("uschi"))
-        ///     .with_offset("-05".parse().ok())
+        /// let zone = TimeZone::from_iana_id("America/Chicago")
+        ///     .with_offset(UtcOffset::try_from_seconds(-5 * 3600).ok())
         ///     .at_date_time_iso(DateTime{ date: Date::try_new_iso(2022, 8, 29).unwrap(), time: Time::start_of_day() });
         ///
         /// assert_writeable_eq!(
@@ -1312,12 +1312,12 @@ pub mod zone {
         /// use icu::datetime::input::{Date, DateTime, Time, TimeZone, TimeZoneInfo, UtcOffset};
         /// use icu::datetime::NoCalendarFormatter;
         /// use icu::datetime::fieldsets::zone::SpecificLong;
-        /// use icu::locale::{locale, subtags::subtag};
+        /// use icu::locale::locale;
         /// use writeable::assert_writeable_eq;
         ///
         /// // Time zone info for Europe/Istanbul in the winter
-        /// let zone = TimeZone(subtag!("trist"))
-        ///     .with_offset("+03".parse().ok())
+        /// let zone = TimeZone::from_iana_id("Europe/Istanbul")
+        ///     .with_offset(UtcOffset::try_from_seconds(3 * 3600).ok())
         ///     .at_date_time_iso(DateTime{ date: Date::try_new_iso(2022, 1, 29).unwrap(), time: Time::start_of_day() });
         ///
         /// let fmt = NoCalendarFormatter::try_new(
@@ -1337,12 +1337,12 @@ pub mod zone {
         /// use icu::datetime::input::{Date, DateTime, Time, TimeZone, TimeZoneInfo, UtcOffset};
         /// use icu::datetime::NoCalendarFormatter;
         /// use icu::datetime::fieldsets::zone::SpecificLong;
-        /// use icu::locale::{locale, subtags::subtag};
+        /// use icu::locale::locale;
         /// use writeable::assert_writeable_eq;
         ///
         /// // Time zone info for America/Chicago with a wrong offset
-        /// let wrong_offset = TimeZone(subtag!("uschi"))
-        ///     .with_offset("-04".parse().ok())
+        /// let wrong_offset = TimeZone::from_iana_id("America/Chicago")
+        ///     .with_offset(UtcOffset::try_from_seconds(-4 * 3600).ok())
         ///     .at_date_time_iso(DateTime{ date: Date::try_new_iso(2022, 8, 29).unwrap(), time: Time::start_of_day() });
         ///
         /// let fmt = NoCalendarFormatter::try_new(
@@ -1371,10 +1371,10 @@ pub mod zone {
         /// ```compile_fail,E0271
         /// use icu::datetime::NoCalendarFormatter;
         /// use icu::datetime::fieldsets::zone::SpecificLong;
-        /// use icu::locale::{locale, subtags::subtag};
+        /// use icu::locale::locale;
         /// use icu::datetime::input::{TimeZone, UtcOffset};
         ///
-        /// let time_zone_basic = TimeZone(subtag!("uschi")).without_offset();
+        /// let time_zone_basic = TimeZone::from_iana_id("America/Chicago").without_offset();
         ///
         /// let formatter = NoCalendarFormatter::try_new(
         ///     locale!("en-US").into(),
@@ -1408,12 +1408,12 @@ pub mod zone {
         /// use icu::datetime::input::{Date, DateTime, Time, TimeZone, TimeZoneInfo, UtcOffset};
         /// use icu::datetime::NoCalendarFormatter;
         /// use icu::datetime::fieldsets::zone::SpecificShort;
-        /// use icu::locale::{locale, subtags::subtag};
+        /// use icu::locale::locale;
         /// use writeable::assert_writeable_eq;
         ///
         /// // Time zone info for Asia/Tokyo
-        /// let zone = TimeZone(subtag!("jptyo"))
-        ///     .with_offset("+09".parse().ok())
+        /// let zone = TimeZone::from_iana_id("Asia/Tokyo")
+        ///     .with_offset(UtcOffset::try_from_seconds(9 * 3600).ok())
         ///     .at_date_time_iso(DateTime{ date: Date::try_new_iso(2022, 1, 29).unwrap(), time: Time::start_of_day() });
         ///
         /// let fmt = NoCalendarFormatter::try_new(
@@ -1434,12 +1434,12 @@ pub mod zone {
         /// use icu::datetime::input::{Date, DateTime, Time, TimeZone, TimeZoneInfo, UtcOffset};
         /// use icu::datetime::NoCalendarFormatter;
         /// use icu::datetime::fieldsets::zone::SpecificShort;
-        /// use icu::locale::{locale, subtags::subtag};
+        /// use icu::locale::locale;
         /// use writeable::assert_writeable_eq;
         ///
         /// // Time zone info for America/Chicago with a wrong offset
-        /// let wrong_offset = TimeZone(subtag!("uschi"))
-        ///     .with_offset("-04".parse().ok())
+        /// let wrong_offset = TimeZone::from_iana_id("America/Chicago")
+        ///     .with_offset(UtcOffset::try_from_seconds(-4 * 3600).ok())
         ///     .at_date_time_iso(DateTime{ date: Date::try_new_iso(2022, 8, 29).unwrap(), time: Time::start_of_day() });
         ///
         /// let fmt = NoCalendarFormatter::try_new(
@@ -1469,9 +1469,9 @@ pub mod zone {
         /// use icu::datetime::NoCalendarFormatter;
         /// use icu::datetime::fieldsets::zone::SpecificShort;
         /// use icu::datetime::input::TimeZone;
-        /// use icu::locale::{locale, subtags::subtag};
+        /// use icu::locale::locale;
         ///
-        /// let time_zone_basic = TimeZone(subtag!("uschi")).without_offset();
+        /// let time_zone_basic = TimeZone::from_iana_id("America/Chicago").without_offset();
         ///
         /// let formatter = NoCalendarFormatter::try_new(
         ///     locale!("en-US").into(),
@@ -1502,11 +1502,11 @@ pub mod zone {
         /// use icu::datetime::NoCalendarFormatter;
         /// use icu::datetime::fieldsets::zone::LocalizedOffsetLong;
         /// use icu::datetime::input::{DateTime, Time, TimeZone, UtcOffset};
-        /// use icu::locale::{locale, subtags::subtag};
+        /// use icu::locale::locale;
         /// use writeable::assert_writeable_eq;
         ///
-        /// let utc_offset = "-06".parse().unwrap();
-        /// let time_zone_basic = TimeZone(subtag!("uschi")).with_offset(Some(utc_offset));
+        /// let utc_offset = UtcOffset::try_from_seconds(-6 * 3600).unwrap();
+        /// let time_zone_basic = TimeZone::from_iana_id("America/Chicago").with_offset(Some(utc_offset));
         ///
         /// let date = Date::try_new_iso(2024, 10, 18).unwrap();
         /// let time = Time::start_of_day();
@@ -1549,11 +1549,11 @@ pub mod zone {
         /// use icu::datetime::NoCalendarFormatter;
         /// use icu::datetime::fieldsets::zone::LocalizedOffsetShort;
         /// use icu::datetime::input::{DateTime, Time, TimeZone, UtcOffset};
-        /// use icu::locale::{locale, subtags::subtag};
+        /// use icu::locale::locale;
         /// use writeable::assert_writeable_eq;
         ///
-        /// let utc_offset = "-06".parse().unwrap();
-        /// let time_zone_basic = TimeZone(subtag!("uschi")).with_offset(Some(utc_offset));
+        /// let utc_offset = UtcOffset::try_from_seconds(-6 * 3600).unwrap();
+        /// let time_zone_basic = TimeZone::from_iana_id("America/Chicago").with_offset(Some(utc_offset));
         ///
         /// let date = Date::try_new_iso(2024, 10, 18).unwrap();
         /// let time = Time::start_of_day();
@@ -1595,12 +1595,12 @@ pub mod zone {
         /// use icu::datetime::input::{Date, DateTime, Time, TimeZone, TimeZoneInfo, UtcOffset};
         /// use icu::datetime::NoCalendarFormatter;
         /// use icu::datetime::fieldsets::zone::GenericLong;
-        /// use icu::locale::{locale, subtags::subtag};
+        /// use icu::locale::locale;
         /// use writeable::assert_writeable_eq;
         ///
         /// // Time zone info for Europe/Istanbul in the winter
-        /// let zone = TimeZone(subtag!("trist"))
-        ///     .with_offset("+03".parse().ok())
+        /// let zone = TimeZone::from_iana_id("Europe/Istanbul")
+        ///     .with_offset(UtcOffset::try_from_seconds(3 * 3600).ok())
         ///     .at_date_time_iso(DateTime{ date: Date::try_new_iso(2022, 1, 29).unwrap(), time: Time::start_of_day() });
         ///
         /// let fmt = NoCalendarFormatter::try_new(
@@ -1620,12 +1620,12 @@ pub mod zone {
         /// use icu::datetime::input::{Date, DateTime, Time, TimeZone, TimeZoneInfo, UtcOffset};
         /// use icu::datetime::NoCalendarFormatter;
         /// use icu::datetime::fieldsets::zone::GenericLong;
-        /// use icu::locale::{locale, subtags::subtag};
+        /// use icu::locale::locale;
         /// use writeable::assert_writeable_eq;
         ///
         /// // Time zone info for America/Chicago with a wrong offset
-        /// let wrong_offset = TimeZone(subtag!("uschi"))
-        ///     .with_offset("-04".parse().ok())
+        /// let wrong_offset = TimeZone::from_iana_id("America/Chicago")
+        ///     .with_offset(UtcOffset::try_from_seconds(-4 * 3600).ok())
         ///     .at_date_time_iso(DateTime{ date: Date::try_new_iso(2022, 8, 29).unwrap(), time: Time::start_of_day() });
         ///
         /// let fmt = NoCalendarFormatter::try_new(
@@ -1655,9 +1655,9 @@ pub mod zone {
         /// use icu::datetime::NoCalendarFormatter;
         /// use icu::datetime::fieldsets::zone::GenericLong;
         /// use icu::datetime::input::TimeZone;
-        /// use icu::locale::{locale, subtags::subtag};
+        /// use icu::locale::locale;
         ///
-        /// let time_zone_basic = TimeZone(subtag!("uschi")).without_offset();
+        /// let time_zone_basic = TimeZone::from_iana_id("America/Chicago").without_offset();
         ///
         /// let formatter = NoCalendarFormatter::try_new(
         ///     locale!("en-US").into(),
@@ -1692,12 +1692,12 @@ pub mod zone {
         /// use icu::datetime::input::{Date, DateTime, Time, TimeZone, TimeZoneInfo, UtcOffset};
         /// use icu::datetime::NoCalendarFormatter;
         /// use icu::datetime::fieldsets::zone::GenericShort;
-        /// use icu::locale::{locale, subtags::subtag};
+        /// use icu::locale::locale;
         /// use writeable::assert_writeable_eq;
         ///
         /// // Time zone info for Asia/Tokyo
-        /// let zone = TimeZone(subtag!("jptyo"))
-        ///     .with_offset("+09".parse().ok())
+        /// let zone = TimeZone::from_iana_id("Asia/Tokyo")
+        ///     .with_offset(UtcOffset::try_from_seconds(9 * 3600).ok())
         ///     .at_date_time_iso(DateTime{ date: Date::try_new_iso(2022, 1, 29).unwrap(), time: Time::start_of_day() });
         ///
         /// let fmt = NoCalendarFormatter::try_new(
@@ -1718,12 +1718,12 @@ pub mod zone {
         /// use icu::datetime::input::{Date, DateTime, Time, TimeZone, TimeZoneInfo, UtcOffset};
         /// use icu::datetime::NoCalendarFormatter;
         /// use icu::datetime::fieldsets::zone::GenericShort;
-        /// use icu::locale::{locale, subtags::subtag};
+        /// use icu::locale::locale;
         /// use writeable::assert_writeable_eq;
         ///
         /// // Time zone info for America/Chicago with a wrong offset
-        /// let wrong_offset = TimeZone(subtag!("uschi"))
-        ///     .with_offset("-04".parse().ok())
+        /// let wrong_offset = TimeZone::from_iana_id("America/Chicago")
+        ///     .with_offset(UtcOffset::try_from_seconds(-4 * 3600).ok())
         ///     .at_date_time_iso(DateTime{ date: Date::try_new_iso(2022, 8, 29).unwrap(), time: Time::start_of_day() });
         ///
         /// let fmt = NoCalendarFormatter::try_new(
@@ -1753,9 +1753,9 @@ pub mod zone {
         /// use icu::datetime::NoCalendarFormatter;
         /// use icu::datetime::fieldsets::zone::GenericShort;
         /// use icu::datetime::input::TimeZone;
-        /// use icu::locale::{locale, subtags::subtag};
+        /// use icu::locale::locale;
         ///
-        /// let time_zone_basic = TimeZone(subtag!("uschi")).without_offset();
+        /// let time_zone_basic = TimeZone::from_iana_id("America/Chicago").without_offset();
         ///
         /// let formatter = NoCalendarFormatter::try_new(
         ///     locale!("en-US").into(),
@@ -1792,7 +1792,7 @@ pub mod zone {
         /// use icu::locale::locale;
         /// use writeable::assert_writeable_eq;
         ///
-        /// let utc_offset = UtcOffset::try_from_str("-06").unwrap();
+        /// let utc_offset = UtcOffset::try_from_seconds(-6 * 3600).unwrap();
         ///
         /// let formatter = NoCalendarFormatter::try_new(
         ///     locale!("en-US").into(),
@@ -1827,7 +1827,7 @@ pub mod zone {
         /// use icu::locale::locale;
         /// use writeable::assert_writeable_eq;
         ///
-        /// let utc_offset = UtcOffset::try_from_str("-06").unwrap();
+        /// let utc_offset = UtcOffset::try_from_seconds(-6 * 3600).unwrap();
         ///
         /// let formatter = NoCalendarFormatter::try_new(
         ///     locale!("en-US").into(),

--- a/components/datetime/src/provider/time_zones.rs
+++ b/components/datetime/src/provider/time_zones.rs
@@ -384,7 +384,6 @@ pub(crate) mod legacy {
 
     #[test]
     fn test_metazone_timezone_compat() {
-        use icu_locale::subtags::subtag;
         use icu_time::ZonedDateTime;
 
         let converted = metazone_timezone_compat(
@@ -398,7 +397,7 @@ pub(crate) mod legacy {
         .unwrap()
         .payload;
 
-        let tz = TimeZone(subtag!("aqcas"));
+        let tz = TimeZone::from_iana_id("Antarctica/Casey");
         for timestamp in [
             "1970-01-01 00:00Z",
             "2009-10-17 18:00Z",

--- a/components/time/src/ixdtf.rs
+++ b/components/time/src/ixdtf.rs
@@ -445,10 +445,10 @@ impl<A: AsCalendar> ZonedDateTime<A, TimeZoneInfo<models::AtTime>> {
     /// assert_eq!(zoneddatetime.time.minute.number(), 8);
     /// assert_eq!(zoneddatetime.time.second.number(), 19);
     /// assert_eq!(zoneddatetime.time.subsecond.number(), 0);
-    /// assert_eq!(zoneddatetime.zone.id(), TimeZone(subtag!("uschi")));
+    /// assert_eq!(zoneddatetime.zone.id(), TimeZone::from_iana_id("America/Chicago"));
     /// assert_eq!(
     ///     zoneddatetime.zone.offset(),
-    ///     Some(UtcOffset::try_from_seconds(-18000).unwrap())
+    ///     Some(UtcOffset::try_from_seconds(-5 * 3600).unwrap())
     /// );
     /// let _ = zoneddatetime.zone.zone_name_timestamp();
     /// ```
@@ -475,7 +475,7 @@ impl<A: AsCalendar> ZonedDateTime<A, TimeZoneInfo<models::AtTime>> {
     ///
     /// assert_eq!(
     ///     tz_from_offset.zone,
-    ///     UtcOffset::try_from_seconds(-18000).unwrap()
+    ///     UtcOffset::try_from_seconds(-5 * 3600).unwrap()
     /// );
     /// ```
     ///
@@ -505,7 +505,7 @@ impl<A: AsCalendar> ZonedDateTime<A, TimeZoneInfo<models::AtTime>> {
     ///
     /// assert_eq!(
     ///     tz_from_offset_annotation.zone,
-    ///     UtcOffset::try_from_seconds(-18000).unwrap()
+    ///     UtcOffset::try_from_seconds(-5 * 3600).unwrap()
     /// );
     ///
     /// assert_eq!(
@@ -539,7 +539,7 @@ impl<A: AsCalendar> ZonedDateTime<A, TimeZoneInfo<models::AtTime>> {
     ///
     /// assert_eq!(
     ///     consistent_tz_from_both.zone,
-    ///     UtcOffset::try_from_seconds(-18000).unwrap()
+    ///     UtcOffset::try_from_seconds(-5 * 3600).unwrap()
     /// );
     ///
     /// let inconsistent_tz_from_both = ZonedDateTime::try_offset_only_from_str(
@@ -722,7 +722,7 @@ impl ZonedTime<TimeZoneInfo<models::AtTime>> {
     /// assert_eq!(zonedtime.zone.id(), TimeZone(subtag!("uschi")));
     /// assert_eq!(
     ///     zonedtime.zone.offset(),
-    ///     Some(UtcOffset::try_from_seconds(-18000).unwrap())
+    ///     Some(UtcOffset::try_from_seconds(-5 * 3600).unwrap())
     /// );
     /// let _ = zonedtime.zone.zone_name_timestamp();
     /// ```
@@ -748,7 +748,7 @@ impl ZonedTime<TimeZoneInfo<models::AtTime>> {
     ///
     /// assert_eq!(
     ///     tz_from_offset.zone,
-    ///     UtcOffset::try_from_seconds(-18000).unwrap()
+    ///     UtcOffset::try_from_seconds(-5 * 3600).unwrap()
     /// );
     /// ```
     ///
@@ -776,7 +776,7 @@ impl ZonedTime<TimeZoneInfo<models::AtTime>> {
     ///
     /// assert_eq!(
     ///     tz_from_offset_annotation.zone,
-    ///     UtcOffset::try_from_seconds(-18000).unwrap()
+    ///     UtcOffset::try_from_seconds(-5 * 3600).unwrap()
     /// );
     ///
     /// assert_eq!(
@@ -809,7 +809,7 @@ impl ZonedTime<TimeZoneInfo<models::AtTime>> {
     ///
     /// assert_eq!(
     ///     consistent_tz_from_both.zone,
-    ///     UtcOffset::try_from_seconds(-18000).unwrap()
+    ///     UtcOffset::try_from_seconds(-5 * 3600).unwrap()
     /// );
     ///
     /// let inconsistent_tz_from_both = ZonedTime::try_offset_only_from_str(

--- a/components/time/src/types.rs
+++ b/components/time/src/types.rs
@@ -422,13 +422,13 @@ impl ZonedDateTime<Iso, UtcOffset> {
     /// use icu::time::zone::UtcOffset;
     /// use icu::time::ZonedDateTime;
     ///
-    /// let max_offset = UtcOffset::try_from_seconds(50400).unwrap(); // +14 hours
+    /// let max_offset = UtcOffset::try_from_seconds(14 * 3600).unwrap();
     /// let zdt_max = ZonedDateTime::from_epoch_milliseconds_and_utc_offset(
     ///         i64::MAX,
     ///         max_offset
     ///     );
     ///
-    /// let min_offset = UtcOffset::try_from_seconds(-43200).unwrap(); // -12 hours
+    /// let min_offset = UtcOffset::try_from_seconds(-12 * 3600).unwrap();
     /// let zdt_min = ZonedDateTime::from_epoch_milliseconds_and_utc_offset(
     ///         i64::MIN,
     ///         min_offset

--- a/components/time/src/zone/mod.rs
+++ b/components/time/src/zone/mod.rs
@@ -267,6 +267,7 @@ impl<'a> zerovec::maps::ZeroMapKV<'a> for TimeZone {
 /// use icu::time::DateTime;
 /// use icu::time::Time;
 /// use icu::time::TimeZone;
+/// use icu::time::zone::UtcOffset;
 ///
 /// // Parse the IANA ID
 /// let id = TimeZone::from_iana_id("America/Chicago");
@@ -275,7 +276,7 @@ impl<'a> zerovec::maps::ZeroMapKV<'a> for TimeZone {
 /// let id = TimeZone(subtag!("uschi"));
 ///
 /// // Create a TimeZoneInfo<Base> by associating the ID with an offset
-/// let time_zone = id.with_offset("-0600".parse().ok());
+/// let time_zone = id.with_offset(UtcOffset::try_from_seconds(-6 * 3600).ok());
 ///
 /// // Extend to a TimeZoneInfo<AtTime> by adding a local time
 /// let time_zone_at_time = time_zone.at_date_time_iso(DateTime {
@@ -492,16 +493,16 @@ impl TimeZoneInfo<models::AtTime> {
     /// # Example
     /// ```
     /// use icu::calendar::Date;
-    /// use icu::locale::subtags::subtag;
     /// use icu::time::zone::TimeZoneVariant;
     /// use icu::time::zone::VariantOffsetsCalculator;
     /// use icu::time::DateTime;
     /// use icu::time::Time;
     /// use icu::time::TimeZone;
+    /// use icu::time::zone::UtcOffset;
     ///
     /// // Chicago at UTC-6
-    /// let info = TimeZone(subtag!("uschi"))
-    ///     .with_offset("-0600".parse().ok())
+    /// let info = TimeZone::from_iana_id("America/Chicago")
+    ///     .with_offset(UtcOffset::try_from_seconds(-6 * 3600).ok())
     ///     .at_date_time_iso(DateTime {
     ///         date: Date::try_new_iso(2023, 12, 2).unwrap(),
     ///         time: Time::start_of_day(),
@@ -511,8 +512,8 @@ impl TimeZoneInfo<models::AtTime> {
     /// assert_eq!(info.variant(), TimeZoneVariant::Standard);
     ///
     /// // Chicago at at UTC-5
-    /// let info = TimeZone(subtag!("uschi"))
-    ///     .with_offset("-0500".parse().ok())
+    /// let info = TimeZone::from_iana_id("America/Chicago")
+    ///     .with_offset(UtcOffset::try_from_seconds(-5 * 3600).ok())
     ///     .at_date_time_iso(DateTime {
     ///         date: Date::try_new_iso(2023, 6, 2).unwrap(),
     ///         time: Time::start_of_day(),
@@ -522,8 +523,8 @@ impl TimeZoneInfo<models::AtTime> {
     /// assert_eq!(info.variant(), TimeZoneVariant::Daylight);
     ///
     /// // Chicago at UTC-7
-    /// let info = TimeZone(subtag!("uschi"))
-    ///     .with_offset("-0700".parse().ok())
+    /// let info = TimeZone::from_iana_id("America/Chicago")
+    ///     .with_offset(UtcOffset::try_from_seconds(-7 * 3600).ok())
     ///     .at_date_time_iso(DateTime {
     ///         date: Date::try_new_iso(2023, 12, 2).unwrap(),
     ///         time: Time::start_of_day(),


### PR DESCRIPTION
Instead of constructing `TimeZoneInfo` from BCP-47 subtags and offset strings, we should make our examples construct them from IANA IDs and offset seconds. Those are the actual pieces that clients will have from their TZ arithmetic code.


## Changelog: N/A

