### PR TITLE
Undo my change to lunisolar error matching

### DIFF
--- a/components/calendar/src/calendar_arithmetic.rs
+++ b/components/calendar/src/calendar_arithmetic.rs
@@ -363,7 +363,11 @@ impl<C: DateFieldsResolver> ArithmeticDate<C> {
         }
         let year = calendar.year_info_from_extended(year);
 
-        let month = calendar.ordinal_from_month(year, month, Default::default())?;
+        let month = match calendar.ordinal_from_month(year, month, Default::default()) {
+            Ok(month) => month,
+            Err(MonthError::NotInCalendar) => return Err(LunisolarDateError::MonthNotInCalendar),
+            Err(MonthError::NotInYear) => return Err(LunisolarDateError::MonthNotInYear),
+        };
 
         let max_day = C::days_in_provided_month(year, month);
         if !(1..=max_day).contains(&day) {

--- a/components/calendar/src/error.rs
+++ b/components/calendar/src/error.rs
@@ -627,16 +627,6 @@ impl From<MonthError> for DateFromFieldsError {
     }
 }
 
-impl From<MonthError> for LunisolarDateError {
-    #[inline]
-    fn from(value: MonthError) -> Self {
-        match value {
-            MonthError::NotInCalendar => LunisolarDateError::MonthNotInCalendar,
-            MonthError::NotInYear => LunisolarDateError::MonthNotInYear,
-        }
-    }
-}
-
 mod inner {
     /// Internal narrow error type for calculating the ECMA reference year
     ///


### PR DESCRIPTION
In https://github.com/unicode-org/icu4x/pull/7676 I moved lunisolar errors over to a `?` operator.

Robert disagrees: https://github.com/unicode-org/icu4x/pull/7676#discussion_r2841888168

I landed that PR in the interest of unblocking future work, but I don't mind undoing it. I still have a slight preference to not have error matches in this (rather large) file, but I don't care enough in this case since it's a simple function.

## Changelog: N/A

