### PR TITLE
Update Diplomat to new opaque_mut annotations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,7 +746,7 @@ dependencies = [
 [[package]]
 name = "diplomat"
 version = "0.14.0"
-source = "git+https://github.com/rust-diplomat/diplomat?rev=f71e1b6c562237f9e6059dbf54bfce626936dd35#f71e1b6c562237f9e6059dbf54bfce626936dd35"
+source = "git+https://github.com/rust-diplomat/diplomat?rev=c10e39694cae1026c906111fa2c6c791d7cc6935#c10e39694cae1026c906111fa2c6c791d7cc6935"
 dependencies = [
  "diplomat_core",
  "proc-macro2",
@@ -777,7 +777,7 @@ dependencies = [
 [[package]]
 name = "diplomat-runtime"
 version = "0.14.0"
-source = "git+https://github.com/rust-diplomat/diplomat?rev=f71e1b6c562237f9e6059dbf54bfce626936dd35#f71e1b6c562237f9e6059dbf54bfce626936dd35"
+source = "git+https://github.com/rust-diplomat/diplomat?rev=c10e39694cae1026c906111fa2c6c791d7cc6935#c10e39694cae1026c906111fa2c6c791d7cc6935"
 dependencies = [
  "log",
 ]
@@ -785,7 +785,7 @@ dependencies = [
 [[package]]
 name = "diplomat-tool"
 version = "0.14.1"
-source = "git+https://github.com/rust-diplomat/diplomat?rev=f71e1b6c562237f9e6059dbf54bfce626936dd35#f71e1b6c562237f9e6059dbf54bfce626936dd35"
+source = "git+https://github.com/rust-diplomat/diplomat?rev=c10e39694cae1026c906111fa2c6c791d7cc6935#c10e39694cae1026c906111fa2c6c791d7cc6935"
 dependencies = [
  "askama",
  "clap",
@@ -806,7 +806,7 @@ dependencies = [
 [[package]]
 name = "diplomat_core"
 version = "0.14.0"
-source = "git+https://github.com/rust-diplomat/diplomat?rev=f71e1b6c562237f9e6059dbf54bfce626936dd35#f71e1b6c562237f9e6059dbf54bfce626936dd35"
+source = "git+https://github.com/rust-diplomat/diplomat?rev=c10e39694cae1026c906111fa2c6c791d7cc6935#c10e39694cae1026c906111fa2c6c791d7cc6935"
 dependencies = [
  "displaydoc",
  "either",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,10 +213,10 @@ icu_benchmark_macros = { path = "tools/benchmark/macros" }
 
 # The version here can either be a `version = ".."` spec or `git = "https://github.com/rust-diplomat/diplomat", rev = ".."`
 # Diplomat must be published preceding a new ICU4X release but may use git versions in between
-diplomat = { git = "https://github.com/rust-diplomat/diplomat", rev = "f71e1b6c562237f9e6059dbf54bfce626936dd35", default-features = false }
-diplomat-runtime = { git = "https://github.com/rust-diplomat/diplomat", rev = "f71e1b6c562237f9e6059dbf54bfce626936dd35", default-features = false }
-diplomat_core = { git = "https://github.com/rust-diplomat/diplomat", rev = "f71e1b6c562237f9e6059dbf54bfce626936dd35", default-features = false }
-diplomat-tool = { git = "https://github.com/rust-diplomat/diplomat", rev = "f71e1b6c562237f9e6059dbf54bfce626936dd35" }
+diplomat = { git = "https://github.com/rust-diplomat/diplomat", rev = "c10e39694cae1026c906111fa2c6c791d7cc6935", default-features = false }
+diplomat-runtime = { git = "https://github.com/rust-diplomat/diplomat", rev = "c10e39694cae1026c906111fa2c6c791d7cc6935", default-features = false }
+diplomat_core = { git = "https://github.com/rust-diplomat/diplomat", rev = "c10e39694cae1026c906111fa2c6c791d7cc6935", default-features = false }
+diplomat-tool = { git = "https://github.com/rust-diplomat/diplomat", rev = "c10e39694cae1026c906111fa2c6c791d7cc6935" }
 
 # EXTERNAL DEPENDENCIES
 #

--- a/ffi/capi/bindings/c/TimeZoneInfo.h
+++ b/ffi/capi/bindings/c/TimeZoneInfo.h
@@ -40,7 +40,7 @@ TimeZoneInfo* icu4x_TimeZoneInfo_with_variant_mv1(const TimeZoneInfo* self, Time
 UtcOffset* icu4x_TimeZoneInfo_offset_mv1(const TimeZoneInfo* self);
 
 typedef struct icu4x_TimeZoneInfo_infer_variant_mv1_result { bool is_ok;} icu4x_TimeZoneInfo_infer_variant_mv1_result;
-icu4x_TimeZoneInfo_infer_variant_mv1_result icu4x_TimeZoneInfo_infer_variant_mv1(TimeZoneInfo* self, const VariantOffsetsCalculator* _offset_calculator);
+icu4x_TimeZoneInfo_infer_variant_mv1_result icu4x_TimeZoneInfo_infer_variant_mv1(const TimeZoneInfo* self, const VariantOffsetsCalculator* _offset_calculator);
 
 typedef struct icu4x_TimeZoneInfo_variant_mv1_result {union {TimeZoneVariant ok; }; bool is_ok;} icu4x_TimeZoneInfo_variant_mv1_result;
 icu4x_TimeZoneInfo_variant_mv1_result icu4x_TimeZoneInfo_variant_mv1(const TimeZoneInfo* self);

--- a/ffi/capi/bindings/cpp/icu4x/TimeZoneInfo.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/TimeZoneInfo.d.hpp
@@ -121,7 +121,7 @@ public:
    * \deprecated does nothing
    */
   [[deprecated("does nothing")]]
-  inline std::optional<std::monostate> infer_variant(const icu4x::VariantOffsetsCalculator& _offset_calculator);
+  inline std::optional<std::monostate> infer_variant(const icu4x::VariantOffsetsCalculator& _offset_calculator) const;
 
   /**
    * See the [Rust documentation for `variant`](https://docs.rs/icu/2.1.1/icu/time/struct.TimeZoneInfo.html#method.variant) for more information.

--- a/ffi/capi/bindings/cpp/icu4x/TimeZoneInfo.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/TimeZoneInfo.hpp
@@ -43,7 +43,7 @@ namespace capi {
     icu4x::capi::UtcOffset* icu4x_TimeZoneInfo_offset_mv1(const icu4x::capi::TimeZoneInfo* self);
 
     typedef struct icu4x_TimeZoneInfo_infer_variant_mv1_result { bool is_ok;} icu4x_TimeZoneInfo_infer_variant_mv1_result;
-    icu4x_TimeZoneInfo_infer_variant_mv1_result icu4x_TimeZoneInfo_infer_variant_mv1(icu4x::capi::TimeZoneInfo* self, const icu4x::capi::VariantOffsetsCalculator* _offset_calculator);
+    icu4x_TimeZoneInfo_infer_variant_mv1_result icu4x_TimeZoneInfo_infer_variant_mv1(const icu4x::capi::TimeZoneInfo* self, const icu4x::capi::VariantOffsetsCalculator* _offset_calculator);
 
     typedef struct icu4x_TimeZoneInfo_variant_mv1_result {union {icu4x::capi::TimeZoneVariant ok; }; bool is_ok;} icu4x_TimeZoneInfo_variant_mv1_result;
     icu4x_TimeZoneInfo_variant_mv1_result icu4x_TimeZoneInfo_variant_mv1(const icu4x::capi::TimeZoneInfo* self);
@@ -100,7 +100,7 @@ inline std::unique_ptr<icu4x::UtcOffset> icu4x::TimeZoneInfo::offset() const {
     return std::unique_ptr<icu4x::UtcOffset>(icu4x::UtcOffset::FromFFI(result));
 }
 
-inline std::optional<std::monostate> icu4x::TimeZoneInfo::infer_variant(const icu4x::VariantOffsetsCalculator& _offset_calculator) {
+inline std::optional<std::monostate> icu4x::TimeZoneInfo::infer_variant(const icu4x::VariantOffsetsCalculator& _offset_calculator) const {
     auto result = icu4x::capi::icu4x_TimeZoneInfo_infer_variant_mv1(this->AsFFI(),
         _offset_calculator.AsFFI());
     return result.is_ok ? std::optional<std::monostate>() : std::nullopt;

--- a/ffi/capi/src/bidi.rs
+++ b/ffi/capi/src/bidi.rs
@@ -229,7 +229,7 @@ pub mod ffi {
     }
 
     /// Bidi information for a single processed paragraph
-    #[diplomat::opaque]
+    #[diplomat::opaque_mut]
     #[diplomat::attr(demo_gen, disable)] // TODO needs custom page
     pub struct BidiParagraph<'info>(pub unicode_bidi::Paragraph<'info, 'info>);
 

--- a/ffi/capi/src/collections_sets.rs
+++ b/ffi/capi/src/collections_sets.rs
@@ -9,7 +9,7 @@ pub mod ffi {
 
     use crate::unstable::properties_sets::ffi::CodePointSetData;
 
-    #[diplomat::opaque]
+    #[diplomat::opaque_mut]
     #[diplomat::rust_link(
         icu::collections::codepointinvlist::CodePointInversionListBuilder,
         Struct

--- a/ffi/capi/src/fallbacker.rs
+++ b/ffi/capi/src/fallbacker.rs
@@ -53,7 +53,7 @@ pub mod ffi {
     );
 
     /// An iterator over the locale under fallback.
-    #[diplomat::opaque]
+    #[diplomat::opaque_mut]
     #[diplomat::rust_link(icu::locale::fallback::LocaleFallbackIterator, Struct)]
     pub struct LocaleFallbackIterator<'a>(pub icu_locale::fallback::LocaleFallbackIterator<'a>);
 

--- a/ffi/capi/src/fixed_decimal.rs
+++ b/ffi/capi/src/fixed_decimal.rs
@@ -13,7 +13,7 @@ pub mod ffi {
 
     use writeable::Writeable;
 
-    #[diplomat::opaque]
+    #[diplomat::opaque_mut]
     #[diplomat::rust_link(fixed_decimal::Decimal, Typedef)]
     pub struct Decimal(pub fixed_decimal::Decimal);
 

--- a/ffi/capi/src/iana_parser.rs
+++ b/ffi/capi/src/iana_parser.rs
@@ -59,7 +59,7 @@ pub mod ffi {
         }
     }
 
-    #[diplomat::opaque]
+    #[diplomat::opaque_mut]
     #[diplomat::rust_link(icu::time::zone::iana::TimeZoneIter, Struct)]
     pub struct TimeZoneIterator<'a>(icu_time::zone::iana::TimeZoneIter<'a>);
 
@@ -160,7 +160,7 @@ pub mod ffi {
         canonical: DiplomatUtf8StrSlice<'a>,
     }
 
-    #[diplomat::opaque]
+    #[diplomat::opaque_mut]
     #[diplomat::rust_link(icu::time::zone::iana::TimeZoneAndCanonicalIter, Struct)]
     pub struct TimeZoneAndCanonicalIterator<'a>(icu_time::zone::iana::TimeZoneAndCanonicalIter<'a>);
 
@@ -188,7 +188,7 @@ pub mod ffi {
         normalized: DiplomatUtf8StrSlice<'a>,
     }
 
-    #[diplomat::opaque]
+    #[diplomat::opaque_mut]
     #[diplomat::rust_link(icu::time::zone::iana::TimeZoneAndCanonicalAndNormalizedIter, Struct)]
     pub struct TimeZoneAndCanonicalAndNormalizedIterator<'a>(
         icu_time::zone::iana::TimeZoneAndCanonicalAndNormalizedIter<'a>,

--- a/ffi/capi/src/locale_core.rs
+++ b/ffi/capi/src/locale_core.rs
@@ -11,7 +11,7 @@ pub mod ffi {
 
     use writeable::Writeable;
 
-    #[diplomat::opaque]
+    #[diplomat::opaque_mut]
     /// An ICU4X Locale, capable of representing strings like `"en-US"`.
     #[diplomat::rust_link(icu::locale::Locale, Struct)]
     #[diplomat::rust_link(icu::locale::DataLocale, Struct, hidden)]

--- a/ffi/capi/src/properties_iter.rs
+++ b/ffi/capi/src/properties_iter.rs
@@ -24,7 +24,7 @@ pub mod ffi {
 
     /// An iterator over code point ranges, produced by `CodePointSetData` or
     /// one of the `CodePointMapData` types
-    #[diplomat::opaque]
+    #[diplomat::opaque_mut]
     pub struct CodePointRangeIterator<'a>(
         pub Box<dyn Iterator<Item = RangeInclusive<DiplomatChar>> + 'a>,
     );

--- a/ffi/capi/src/provider.rs
+++ b/ffi/capi/src/provider.rs
@@ -12,7 +12,7 @@ pub mod ffi {
 
     use crate::unstable::errors::ffi::DataError;
 
-    #[diplomat::opaque]
+    #[diplomat::opaque_mut]
     /// An ICU4X data provider, capable of loading ICU4X data keys from some source.
     ///
     /// Currently the only source supported is loading from "blob" formatted data from a bytes buffer or the file system.

--- a/ffi/capi/src/segmenter_grapheme.rs
+++ b/ffi/capi/src/segmenter_grapheme.rs
@@ -18,21 +18,21 @@ pub mod ffi {
     #[diplomat::rust_link(icu::segmenter::GraphemeClusterSegmenterBorrowed, Struct, hidden)]
     pub struct GraphemeClusterSegmenter(icu_segmenter::GraphemeClusterSegmenter);
 
-    #[diplomat::opaque]
+    #[diplomat::opaque_mut]
     #[diplomat::rust_link(icu::segmenter::iterators::GraphemeClusterBreakIterator, Struct)]
     #[diplomat::attr(demo_gen, disable)] // iterator type
     pub struct GraphemeClusterBreakIteratorUtf8<'a>(
         icu_segmenter::iterators::GraphemeClusterBreakIterator<'a, 'a, PotentiallyIllFormedUtf8>,
     );
 
-    #[diplomat::opaque]
+    #[diplomat::opaque_mut]
     #[diplomat::rust_link(icu::segmenter::iterators::GraphemeClusterBreakIterator, Struct)]
     #[diplomat::attr(demo_gen, disable)] // iterator type
     pub struct GraphemeClusterBreakIteratorUtf16<'a>(
         icu_segmenter::iterators::GraphemeClusterBreakIterator<'a, 'a, Utf16>,
     );
 
-    #[diplomat::opaque]
+    #[diplomat::opaque_mut]
     #[diplomat::rust_link(icu::segmenter::iterators::GraphemeClusterBreakIterator, Struct)]
     #[diplomat::attr(demo_gen, disable)] // iterator type
     pub struct GraphemeClusterBreakIteratorLatin1<'a>(

--- a/ffi/capi/src/segmenter_line.rs
+++ b/ffi/capi/src/segmenter_line.rs
@@ -16,7 +16,7 @@ pub mod ffi {
     #[cfg(any(feature = "compiled_data", feature = "buffer_provider"))]
     use icu_segmenter::options::LineBreakOptions;
 
-    #[diplomat::opaque]
+    #[diplomat::opaque_mut] // TODO (#7704): This is unsound
     /// An ICU4X line-break segmenter, capable of finding breakpoints in strings.
     #[diplomat::rust_link(icu::segmenter::LineSegmenter, Struct)]
     #[diplomat::rust_link(icu::segmenter::LineSegmenterBorrowed, Struct, hidden)]
@@ -52,21 +52,21 @@ pub mod ffi {
         pub word_option: DiplomatOption<LineBreakWordOption>,
     }
 
-    #[diplomat::opaque]
+    #[diplomat::opaque_mut]
     #[diplomat::rust_link(icu::segmenter::iterators::LineBreakIterator, Struct)]
     #[diplomat::attr(demo_gen, disable)] // iterator type
     pub struct LineBreakIteratorUtf8<'a>(
         icu_segmenter::iterators::LineBreakIterator<'a, 'a, PotentiallyIllFormedUtf8>,
     );
 
-    #[diplomat::opaque]
+    #[diplomat::opaque_mut]
     #[diplomat::rust_link(icu::segmenter::iterators::LineBreakIterator, Struct)]
     #[diplomat::attr(demo_gen, disable)] // iterator type
     pub struct LineBreakIteratorUtf16<'a>(
         icu_segmenter::iterators::LineBreakIterator<'a, 'a, Utf16>,
     );
 
-    #[diplomat::opaque]
+    #[diplomat::opaque_mut]
     #[diplomat::rust_link(icu::segmenter::iterators::LineBreakIterator, Struct)]
     #[diplomat::attr(demo_gen, disable)] // iterator type
     pub struct LineBreakIteratorLatin1<'a>(

--- a/ffi/capi/src/segmenter_sentence.rs
+++ b/ffi/capi/src/segmenter_sentence.rs
@@ -19,21 +19,21 @@ pub mod ffi {
     #[diplomat::rust_link(icu::segmenter::SentenceSegmenterBorrowed, Struct, hidden)]
     pub struct SentenceSegmenter(icu_segmenter::SentenceSegmenter);
 
-    #[diplomat::opaque]
+    #[diplomat::opaque_mut]
     #[diplomat::rust_link(icu::segmenter::iterators::SentenceBreakIterator, Struct)]
     #[diplomat::attr(demo_gen, disable)] // iterator type
     pub struct SentenceBreakIteratorUtf8<'a>(
         icu_segmenter::iterators::SentenceBreakIterator<'a, 'a, PotentiallyIllFormedUtf8>,
     );
 
-    #[diplomat::opaque]
+    #[diplomat::opaque_mut]
     #[diplomat::rust_link(icu::segmenter::iterators::SentenceBreakIterator, Struct)]
     #[diplomat::attr(demo_gen, disable)] // iterator type
     pub struct SentenceBreakIteratorUtf16<'a>(
         icu_segmenter::iterators::SentenceBreakIterator<'a, 'a, Utf16>,
     );
 
-    #[diplomat::opaque]
+    #[diplomat::opaque_mut]
     #[diplomat::rust_link(icu::segmenter::iterators::SentenceBreakIterator, Struct)]
     #[diplomat::attr(demo_gen, disable)] // iterator type
     pub struct SentenceBreakIteratorLatin1<'a>(

--- a/ffi/capi/src/segmenter_word.rs
+++ b/ffi/capi/src/segmenter_word.rs
@@ -24,27 +24,27 @@ pub mod ffi {
         Letter = 2,
     }
 
-    #[diplomat::opaque]
+    #[diplomat::opaque_mut] // TODO (#7704): This is unsound
     /// An ICU4X word-break segmenter, capable of finding word breakpoints in strings.
     #[diplomat::rust_link(icu::segmenter::WordSegmenter, Struct)]
     #[diplomat::rust_link(icu::segmenter::WordSegmenterBorrowed, Struct, hidden)]
     #[diplomat::demo(custom_func = "../../../tools/web-demo/custom/WordSegmenter.mjs")]
     pub struct WordSegmenter(icu_segmenter::WordSegmenter);
 
-    #[diplomat::opaque]
+    #[diplomat::opaque_mut]
     #[diplomat::rust_link(icu::segmenter::iterators::WordBreakIterator, Struct)]
     #[diplomat::attr(demo_gen, disable)] // iterator type
     pub struct WordBreakIteratorUtf8<'a>(
         icu_segmenter::iterators::WordBreakIterator<'a, 'a, PotentiallyIllFormedUtf8>,
     );
 
-    #[diplomat::opaque]
+    #[diplomat::opaque_mut]
     #[diplomat::rust_link(icu::segmenter::iterators::WordBreakIterator, Struct)]
     #[diplomat::attr(demo_gen, disable)] // iterator type
     pub struct WordBreakIteratorUtf16<'a>(
         icu_segmenter::iterators::WordBreakIterator<'a, 'a, Utf16>,
     );
-    #[diplomat::opaque]
+    #[diplomat::opaque_mut]
     #[diplomat::rust_link(icu::segmenter::iterators::WordBreakIterator, Struct)]
     #[diplomat::attr(demo_gen, disable)] // iterator type
     pub struct WordBreakIteratorLatin1<'a>(

--- a/ffi/capi/src/timezone.rs
+++ b/ffi/capi/src/timezone.rs
@@ -283,7 +283,7 @@ pub mod ffi {
         #[diplomat::rust_link(icu::time::zone::TimeZoneVariant, Enum, compact)]
         #[allow(deprecated)]
         pub fn infer_variant(
-            &mut self,
+            &self,
             _offset_calculator: &crate::unstable::variant_offset::ffi::VariantOffsetsCalculator,
         ) -> Option<()> {
             Some(())

--- a/ffi/capi/src/week.rs
+++ b/ffi/capi/src/week.rs
@@ -70,7 +70,7 @@ pub mod ffi {
 
     /// Documents which days of the week are considered to be a part of the weekend
     #[diplomat::rust_link(icu::calendar::week::WeekdaySetIterator, Struct)]
-    #[diplomat::opaque]
+    #[diplomat::opaque_mut]
     pub struct WeekdaySetIterator(icu_calendar::week::WeekdaySetIterator);
 
     impl WeekdaySetIterator {


### PR DESCRIPTION
https://github.com/rust-diplomat/diplomat/pull/1065 made Diplomat start enforcing `opaque_mut`. Diplomat doesn't use this to check anything yet, but it's step 1 of the process in making FFI sound.

## Changelog: N/A

