### PR TITLE
Simplify FFI time zone timestamp code

### DIFF
--- a/components/datetime/src/format/input.rs
+++ b/components/datetime/src/format/input.rs
@@ -9,8 +9,9 @@ use crate::scaffold::*;
 use icu_calendar::types::{DayOfYear, RataDie};
 use icu_calendar::{AsCalendar, Calendar};
 use icu_time::scaffold::IntoOption;
+use icu_time::zone::models::{AtTime, Base};
 use icu_time::zone::ZoneNameTimestamp;
-use icu_time::{Hour, Minute, Nanosecond, Second};
+use icu_time::{Hour, Minute, Nanosecond, Second, TimeZoneInfo};
 
 use icu_calendar::Date;
 use icu_time::{zone::UtcOffset, Time, TimeZone};
@@ -86,6 +87,19 @@ impl DateTimeInputUnchecked {
     /// Sets the time zone UTC offset.
     pub fn set_time_zone_utc_offset(&mut self, utc_offset: UtcOffset) {
         self.zone_offset = Some(utc_offset);
+    }
+
+    /// Sets all fields from a [`TimeZoneInfo<Base>`] input.
+    pub fn set_time_zone_info_base_fields(&mut self, info: TimeZoneInfo<Base>) {
+        self.zone_id = Some(info.id());
+        self.zone_offset = self.zone_offset.or_else(|| info.offset());
+    }
+
+    /// Sets all fields from a [`TimeZoneInfo<AtTime>`] input.
+    pub fn set_time_zone_info_at_time_fields(&mut self, info: TimeZoneInfo<AtTime>) {
+        self.zone_id = Some(info.id());
+        self.zone_offset = self.zone_offset.or_else(|| info.offset());
+        self.zone_name_timestamp = Some(info.zone_name_timestamp());
     }
 
     /// Sets the time zone ID.

--- a/ffi/capi/src/timezone.rs
+++ b/ffi/capi/src/timezone.rs
@@ -202,13 +202,13 @@ pub mod ffi {
         pub fn at_date_time_iso(&self, date: &IsoDate, time: &Time) -> Box<Self> {
             Box::new(Self {
                 zone_name_timestamp: Some(
-                    icu_time::zone::ZoneNameTimestamp::from_zoned_date_time_iso(
-                        icu_time::ZonedDateTime {
+                    self.id
+                        .with_offset(self.offset)
+                        .at_date_time_iso(icu_time::DateTime {
                             date: date.0,
                             time: time.0,
-                            zone: self.offset.unwrap_or(icu_time::zone::UtcOffset::zero()),
-                        },
-                    ),
+                        })
+                        .zone_name_timestamp(),
                 ),
                 ..*self
             })
@@ -296,6 +296,26 @@ pub mod ffi {
         #[allow(deprecated)]
         pub fn variant(&self) -> Option<TimeZoneVariant> {
             None
+        }
+    }
+}
+
+impl ffi::TimeZoneInfo {
+    pub(crate) fn as_rust_at_time<C: icu_calendar::Calendar>(
+        &self,
+        date: Option<icu_calendar::Date<C>>,
+        time: Option<icu_time::Time>,
+    ) -> icu_time::TimeZoneInfo<icu_time::zone::models::AtTime> {
+        let base = self.id.with_offset(self.offset);
+        if let Some(zone_name_timestamp) = self.zone_name_timestamp {
+            base.with_zone_name_timestamp(zone_name_timestamp)
+        } else if let Some(date) = date {
+            base.at_date_time_iso(icu_time::DateTime {
+                date: date.to_calendar(icu_calendar::Iso),
+                time: time.unwrap_or(icu_time::Time::noon()),
+            })
+        } else {
+            base.with_zone_name_timestamp(icu_time::zone::ZoneNameTimestamp::far_in_future())
         }
     }
 }

--- a/ffi/capi/src/timezone_formatter.rs
+++ b/ffi/capi/src/timezone_formatter.rs
@@ -467,31 +467,6 @@ pub mod ffi {
             )))
         }
         
-        fn format_raw(
-            &self,
-            mut input: icu_datetime::unchecked::DateTimeInputUnchecked,
-            zone: &TimeZoneInfo,
-            write: &mut diplomat_runtime::DiplomatWrite,
-        ) -> Result<(), DateTimeWriteError> {
-            input.set_time_zone_id(zone.id);
-            if let Some(offset) = zone.offset {
-                input.set_time_zone_utc_offset(offset);
-            }
-            if let Some(zone_name_timestamp) = zone.zone_name_timestamp {
-                input.set_time_zone_name_timestamp(zone_name_timestamp);
-            }
-            else {
-                input.set_time_zone_name_timestamp(icu_time::zone::ZoneNameTimestamp::far_in_future())
-            }
-            self
-                .0
-                .format_unchecked(input)
-                .try_write_to(write)
-                .ok()
-                .transpose()?;
-            Ok(())
-        }
-
         #[diplomat::rust_link(icu::datetime::FixedCalendarDateTimeFormatter::format, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::FormattedDateTime, Struct, hidden)]
         #[diplomat::rust_link(icu::datetime::FormattedDateTime::to_string, FnInStruct, hidden)]
@@ -500,8 +475,16 @@ pub mod ffi {
             zone: &TimeZoneInfo,
             write: &mut diplomat_runtime::DiplomatWrite,
         ) -> Result<(), DateTimeWriteError> {
-            let input = icu_datetime::unchecked::DateTimeInputUnchecked::default();
-            self.format_raw(input,  zone, write)
+            let mut input = icu_datetime::unchecked::DateTimeInputUnchecked::default();
+            input.set_time_zone_info_at_time_fields(zone.as_rust_at_time(None::<icu_calendar::Date<icu_calendar::AnyCalendar>>, None));
+
+            self
+                .0
+                .format_unchecked(input)
+                .try_write_to(write)
+                .ok()
+                .transpose()?;
+            Ok(())
         }
         
     }

--- a/ffi/capi/src/zoned_date_formatter.rs
+++ b/ffi/capi/src/zoned_date_formatter.rs
@@ -571,38 +571,6 @@ pub mod ffi {
             )
         }
         
-        fn format_raw(
-            &self,
-            mut input: icu_datetime::unchecked::DateTimeInputUnchecked,
-            iso_date_obj: impl FnOnce() -> icu_calendar::Date<icu_calendar::Iso>,
-            zone: &TimeZoneInfo,
-            write: &mut diplomat_runtime::DiplomatWrite,
-        ) -> Result<(), DateTimeWriteError> {
-            input.set_time_zone_id(zone.id);
-            if let Some(offset) = zone.offset {
-                input.set_time_zone_utc_offset(offset);
-            }
-            if let Some(zone_name_timestamp) = zone.zone_name_timestamp {
-                input.set_time_zone_name_timestamp(zone_name_timestamp);
-            }
-            else {
-                #[allow(deprecated)] // clean up in 3.0
-                input.set_time_zone_name_timestamp(zone.id.with_offset(zone.offset).with_zone_name_timestamp(
-                    icu_time::zone::ZoneNameTimestamp::from_date_time_iso(icu_time::DateTime {
-                        date: iso_date_obj(),
-                        time: icu_time::Time::noon(),
-                    })
-                ).zone_name_timestamp());
-            }
-            self
-                .0
-                .format_unchecked(input)
-                .try_write_to(write)
-                .ok()
-                .transpose()?;
-            Ok(())
-        }
-
         #[diplomat::rust_link(icu::datetime::DateTimeFormatter::format, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::FormattedDateTime, Struct, hidden)]
         #[diplomat::rust_link(icu::datetime::FormattedDateTime::to_string, FnInStruct, hidden)]
@@ -615,7 +583,15 @@ pub mod ffi {
             let mut input = icu_datetime::unchecked::DateTimeInputUnchecked::default();
             let date_in_calendar = iso_date.0.to_calendar(self.0.calendar());
             input.set_date_fields_unchecked(date_in_calendar); // calendar conversion on previous line
-            self.format_raw(input, || iso_date.0,  zone, write)
+            input.set_time_zone_info_at_time_fields(zone.as_rust_at_time(Some(iso_date.0), None));
+
+            self
+                .0
+                .format_unchecked(input)
+                .try_write_to(write)
+                .ok()
+                .transpose()?;
+            Ok(())
         }
         
         #[diplomat::rust_link(icu::datetime::DateTimeFormatter::format_same_calendar, FnInStruct)]
@@ -634,8 +610,13 @@ pub mod ffi {
             date_borrowed.check_any_calendar_kind(self.0.calendar().kind()).map_err(crate::unstable::errors::ffi::DateTimeMismatchedCalendarError::from)?;
             let mut input = icu_datetime::unchecked::DateTimeInputUnchecked::default();
             input.set_date_fields_unchecked(date_borrowed); // calendar check on previous lines
+            input.set_time_zone_info_at_time_fields(zone.as_rust_at_time(Some(date.0.clone()), None));
+
             let _ = self
-                .format_raw(input, || date.0.to_calendar(icu_calendar::Iso),  zone, write).ok();
+                .0
+                .format_unchecked(input)
+                .try_write_to(write);
+
             Ok(())
         }
     }
@@ -1165,38 +1146,6 @@ pub mod ffi {
             )
         }
         
-        fn format_raw(
-            &self,
-            mut input: icu_datetime::unchecked::DateTimeInputUnchecked,
-            iso_date_obj: impl FnOnce() -> icu_calendar::Date<icu_calendar::Iso>,
-            zone: &TimeZoneInfo,
-            write: &mut diplomat_runtime::DiplomatWrite,
-        ) -> Result<(), DateTimeWriteError> {
-            input.set_time_zone_id(zone.id);
-            if let Some(offset) = zone.offset {
-                input.set_time_zone_utc_offset(offset);
-            }
-            if let Some(zone_name_timestamp) = zone.zone_name_timestamp {
-                input.set_time_zone_name_timestamp(zone_name_timestamp);
-            }
-            else {
-                #[allow(deprecated)] // clean up in 3.0
-                input.set_time_zone_name_timestamp(zone.id.with_offset(zone.offset).with_zone_name_timestamp(
-                    icu_time::zone::ZoneNameTimestamp::from_date_time_iso(icu_time::DateTime {
-                        date: iso_date_obj(),
-                        time: icu_time::Time::noon(),
-                    })
-                ).zone_name_timestamp());
-            }
-            self
-                .0
-                .format_unchecked(input)
-                .try_write_to(write)
-                .ok()
-                .transpose()?;
-            Ok(())
-        }
-
         #[diplomat::rust_link(icu::datetime::FixedCalendarDateTimeFormatter::format, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::FormattedDateTime, Struct, hidden)]
         #[diplomat::rust_link(icu::datetime::FormattedDateTime::to_string, FnInStruct, hidden)]
@@ -1209,7 +1158,15 @@ pub mod ffi {
             let mut input = icu_datetime::unchecked::DateTimeInputUnchecked::default();
             let date_in_calendar = iso_date.0.to_calendar(Gregorian);
             input.set_date_fields_unchecked(date_in_calendar); // calendar conversion on previous line
-            self.format_raw(input, || iso_date.0,  zone, write)
+            input.set_time_zone_info_at_time_fields(zone.as_rust_at_time(Some(iso_date.0), None));
+
+            self
+                .0
+                .format_unchecked(input)
+                .try_write_to(write)
+                .ok()
+                .transpose()?;
+            Ok(())
         }
         
         #[diplomat::rust_link(icu::datetime::FixedCalendarDateTimeFormatter::format_same_calendar, FnInStruct)]
@@ -1228,8 +1185,13 @@ pub mod ffi {
             date_borrowed.check_any_calendar_kind(icu_calendar::AnyCalendarKind::Gregorian).map_err(crate::unstable::errors::ffi::DateTimeMismatchedCalendarError::from)?;
             let mut input = icu_datetime::unchecked::DateTimeInputUnchecked::default();
             input.set_date_fields_unchecked(date_borrowed); // calendar check on previous lines
+            input.set_time_zone_info_at_time_fields(zone.as_rust_at_time(Some(date.0.clone()), None));
+
             let _ = self
-                .format_raw(input, || date.0.to_calendar(icu_calendar::Iso),  zone, write).ok();
+                .0
+                .format_unchecked(input)
+                .try_write_to(write);
+
             Ok(())
         }
     }

--- a/ffi/capi/src/zoned_date_time_formatter.rs
+++ b/ffi/capi/src/zoned_date_time_formatter.rs
@@ -571,40 +571,6 @@ pub mod ffi {
             )
         }
         
-        fn format_raw(
-            &self,
-            mut input: icu_datetime::unchecked::DateTimeInputUnchecked,
-            iso_date_obj: impl FnOnce() -> icu_calendar::Date<icu_calendar::Iso>,
-            time: &Time,
-            zone: &TimeZoneInfo,
-            write: &mut diplomat_runtime::DiplomatWrite,
-        ) -> Result<(), DateTimeWriteError> {
-            input.set_time_fields(time.0);
-            input.set_time_zone_id(zone.id);
-            if let Some(offset) = zone.offset {
-                input.set_time_zone_utc_offset(offset);
-            }
-            if let Some(zone_name_timestamp) = zone.zone_name_timestamp {
-                input.set_time_zone_name_timestamp(zone_name_timestamp);
-            }
-            else {
-                #[allow(deprecated)] // clean up in 3.0
-                input.set_time_zone_name_timestamp(zone.id.with_offset(zone.offset).with_zone_name_timestamp(
-                    icu_time::zone::ZoneNameTimestamp::from_date_time_iso(icu_time::DateTime {
-                        date: iso_date_obj(),
-                        time: time.0,
-                    })
-                ).zone_name_timestamp());
-            }
-            self
-                .0
-                .format_unchecked(input)
-                .try_write_to(write)
-                .ok()
-                .transpose()?;
-            Ok(())
-        }
-
         #[diplomat::rust_link(icu::datetime::DateTimeFormatter::format, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::FormattedDateTime, Struct, hidden)]
         #[diplomat::rust_link(icu::datetime::FormattedDateTime::to_string, FnInStruct, hidden)]
@@ -618,7 +584,16 @@ pub mod ffi {
             let mut input = icu_datetime::unchecked::DateTimeInputUnchecked::default();
             let date_in_calendar = iso_date.0.to_calendar(self.0.calendar());
             input.set_date_fields_unchecked(date_in_calendar); // calendar conversion on previous line
-            self.format_raw(input, || iso_date.0, time, zone, write)
+            input.set_time_fields(time.0);
+            input.set_time_zone_info_at_time_fields(zone.as_rust_at_time(Some(iso_date.0), Some(time.0)));
+
+            self
+                .0
+                .format_unchecked(input)
+                .try_write_to(write)
+                .ok()
+                .transpose()?;
+            Ok(())
         }
         
         #[diplomat::rust_link(icu::datetime::DateTimeFormatter::format_same_calendar, FnInStruct)]
@@ -638,8 +613,14 @@ pub mod ffi {
             date_borrowed.check_any_calendar_kind(self.0.calendar().kind()).map_err(crate::unstable::errors::ffi::DateTimeMismatchedCalendarError::from)?;
             let mut input = icu_datetime::unchecked::DateTimeInputUnchecked::default();
             input.set_date_fields_unchecked(date_borrowed); // calendar check on previous lines
+            input.set_time_fields(time.0);
+            input.set_time_zone_info_at_time_fields(zone.as_rust_at_time(Some(date.0.clone()), Some(time.0)));
+
             let _ = self
-                .format_raw(input, || date.0.to_calendar(icu_calendar::Iso), time, zone, write).ok();
+                .0
+                .format_unchecked(input)
+                .try_write_to(write);
+
             Ok(())
         }
     }
@@ -1169,40 +1150,6 @@ pub mod ffi {
             )
         }
         
-        fn format_raw(
-            &self,
-            mut input: icu_datetime::unchecked::DateTimeInputUnchecked,
-            iso_date_obj: impl FnOnce() -> icu_calendar::Date<icu_calendar::Iso>,
-            time: &Time,
-            zone: &TimeZoneInfo,
-            write: &mut diplomat_runtime::DiplomatWrite,
-        ) -> Result<(), DateTimeWriteError> {
-            input.set_time_fields(time.0);
-            input.set_time_zone_id(zone.id);
-            if let Some(offset) = zone.offset {
-                input.set_time_zone_utc_offset(offset);
-            }
-            if let Some(zone_name_timestamp) = zone.zone_name_timestamp {
-                input.set_time_zone_name_timestamp(zone_name_timestamp);
-            }
-            else {
-                #[allow(deprecated)] // clean up in 3.0
-                input.set_time_zone_name_timestamp(zone.id.with_offset(zone.offset).with_zone_name_timestamp(
-                    icu_time::zone::ZoneNameTimestamp::from_date_time_iso(icu_time::DateTime {
-                        date: iso_date_obj(),
-                        time: time.0,
-                    })
-                ).zone_name_timestamp());
-            }
-            self
-                .0
-                .format_unchecked(input)
-                .try_write_to(write)
-                .ok()
-                .transpose()?;
-            Ok(())
-        }
-
         #[diplomat::rust_link(icu::datetime::FixedCalendarDateTimeFormatter::format, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::FormattedDateTime, Struct, hidden)]
         #[diplomat::rust_link(icu::datetime::FormattedDateTime::to_string, FnInStruct, hidden)]
@@ -1216,7 +1163,16 @@ pub mod ffi {
             let mut input = icu_datetime::unchecked::DateTimeInputUnchecked::default();
             let date_in_calendar = iso_date.0.to_calendar(Gregorian);
             input.set_date_fields_unchecked(date_in_calendar); // calendar conversion on previous line
-            self.format_raw(input, || iso_date.0, time, zone, write)
+            input.set_time_fields(time.0);
+            input.set_time_zone_info_at_time_fields(zone.as_rust_at_time(Some(iso_date.0), Some(time.0)));
+
+            self
+                .0
+                .format_unchecked(input)
+                .try_write_to(write)
+                .ok()
+                .transpose()?;
+            Ok(())
         }
         
         #[diplomat::rust_link(icu::datetime::FixedCalendarDateTimeFormatter::format_same_calendar, FnInStruct)]
@@ -1236,8 +1192,14 @@ pub mod ffi {
             date_borrowed.check_any_calendar_kind(icu_calendar::AnyCalendarKind::Gregorian).map_err(crate::unstable::errors::ffi::DateTimeMismatchedCalendarError::from)?;
             let mut input = icu_datetime::unchecked::DateTimeInputUnchecked::default();
             input.set_date_fields_unchecked(date_borrowed); // calendar check on previous lines
+            input.set_time_fields(time.0);
+            input.set_time_zone_info_at_time_fields(zone.as_rust_at_time(Some(date.0.clone()), Some(time.0)));
+
             let _ = self
-                .format_raw(input, || date.0.to_calendar(icu_calendar::Iso), time, zone, write).ok();
+                .0
+                .format_unchecked(input)
+                .try_write_to(write);
+
             Ok(())
         }
     }

--- a/ffi/capi/src/zoned_time_formatter.rs
+++ b/ffi/capi/src/zoned_time_formatter.rs
@@ -563,33 +563,6 @@ pub mod ffi {
             )))
         }
         
-        fn format_raw(
-            &self,
-            mut input: icu_datetime::unchecked::DateTimeInputUnchecked,
-            time: &Time,
-            zone: &TimeZoneInfo,
-            write: &mut diplomat_runtime::DiplomatWrite,
-        ) -> Result<(), DateTimeWriteError> {
-            input.set_time_fields(time.0);
-            input.set_time_zone_id(zone.id);
-            if let Some(offset) = zone.offset {
-                input.set_time_zone_utc_offset(offset);
-            }
-            if let Some(zone_name_timestamp) = zone.zone_name_timestamp {
-                input.set_time_zone_name_timestamp(zone_name_timestamp);
-            }
-            else {
-                input.set_time_zone_name_timestamp(icu_time::zone::ZoneNameTimestamp::far_in_future())
-            }
-            self
-                .0
-                .format_unchecked(input)
-                .try_write_to(write)
-                .ok()
-                .transpose()?;
-            Ok(())
-        }
-
         #[diplomat::rust_link(icu::datetime::FixedCalendarDateTimeFormatter::format, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::FormattedDateTime, Struct, hidden)]
         #[diplomat::rust_link(icu::datetime::FormattedDateTime::to_string, FnInStruct, hidden)]
@@ -599,8 +572,17 @@ pub mod ffi {
             zone: &TimeZoneInfo,
             write: &mut diplomat_runtime::DiplomatWrite,
         ) -> Result<(), DateTimeWriteError> {
-            let input = icu_datetime::unchecked::DateTimeInputUnchecked::default();
-            self.format_raw(input, time, zone, write)
+            let mut input = icu_datetime::unchecked::DateTimeInputUnchecked::default();
+            input.set_time_fields(time.0);
+            input.set_time_zone_info_at_time_fields(zone.as_rust_at_time(None::<icu_calendar::Date<icu_calendar::AnyCalendar>>, Some(time.0)));
+
+            self
+                .0
+                .format_unchecked(input)
+                .try_write_to(write)
+                .ok()
+                .transpose()?;
+            Ok(())
         }
         
     }

--- a/tools/make/codegen/templates/zoned_formatter.rs.jinja
+++ b/tools/make/codegen/templates/zoned_formatter.rs.jinja
@@ -177,62 +177,6 @@ pub mod ffi {
         }
         {% endfor %}
         {%- endfor %}
-        fn format_raw(
-            &self,
-            mut input: icu_datetime::unchecked::DateTimeInputUnchecked,
-            {%- if flavor.has_date() %}
-            iso_date_obj: impl FnOnce() -> icu_calendar::Date<icu_calendar::Iso>,
-            {%- endif %}
-            {%- if flavor.has_time() %}
-            time: &Time,
-            {%- endif %}
-            zone: &TimeZoneInfo,
-            write: &mut diplomat_runtime::DiplomatWrite,
-        ) -> Result<(), DateTimeWriteError> {
-            {%- if flavor.has_time() %}
-            input.set_time_fields(time.0);
-            {%- endif %}
-            input.set_time_zone_id(zone.id);
-            if let Some(offset) = zone.offset {
-                input.set_time_zone_utc_offset(offset);
-            }
-            if let Some(zone_name_timestamp) = zone.zone_name_timestamp {
-                input.set_time_zone_name_timestamp(zone_name_timestamp);
-            }
-            {%- if flavor.has_date() && flavor.has_time() %}
-            else {
-                #[allow(deprecated)] // clean up in 3.0
-                input.set_time_zone_name_timestamp(zone.id.with_offset(zone.offset).with_zone_name_timestamp(
-                    icu_time::zone::ZoneNameTimestamp::from_date_time_iso(icu_time::DateTime {
-                        date: iso_date_obj(),
-                        time: time.0,
-                    })
-                ).zone_name_timestamp());
-            }
-            {%- else if flavor.has_date() %}
-            else {
-                #[allow(deprecated)] // clean up in 3.0
-                input.set_time_zone_name_timestamp(zone.id.with_offset(zone.offset).with_zone_name_timestamp(
-                    icu_time::zone::ZoneNameTimestamp::from_date_time_iso(icu_time::DateTime {
-                        date: iso_date_obj(),
-                        time: icu_time::Time::noon(),
-                    })
-                ).zone_name_timestamp());
-            }
-            {%- else %}
-            else {
-                input.set_time_zone_name_timestamp(icu_time::zone::ZoneNameTimestamp::far_in_future())
-            }
-            {%- endif %}
-            self
-                .0
-                .format_unchecked(input)
-                .try_write_to(write)
-                .ok()
-                .transpose()?;
-            Ok(())
-        }
-
         #[diplomat::rust_link(icu::datetime::{{ formatter_kind.rust_type() }}::format, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::FormattedDateTime, Struct, hidden)]
         #[diplomat::rust_link(icu::datetime::FormattedDateTime::to_string, FnInStruct, hidden)]
@@ -247,7 +191,7 @@ pub mod ffi {
             zone: &TimeZoneInfo,
             write: &mut diplomat_runtime::DiplomatWrite,
         ) -> Result<(), DateTimeWriteError> {
-            {% if flavor.has_date() %}let mut input{% else %}let input{% endif %} = icu_datetime::unchecked::DateTimeInputUnchecked::default();
+            let mut input = icu_datetime::unchecked::DateTimeInputUnchecked::default();
             {%- if flavor.has_date() %}
             {%- if formatter_kind.is_fixed_calendar %}
             let date_in_calendar = iso_date.0.to_calendar(Gregorian);
@@ -256,11 +200,20 @@ pub mod ffi {
             {%- endif %}
             input.set_date_fields_unchecked(date_in_calendar); // calendar conversion on previous line
             {%- endif %}
-            {%- if flavor.has_date() %}
-            self.format_raw(input, || iso_date.0, {% if flavor.has_time() %}time,{% endif %} zone, write)
+            {%- if flavor.has_time() %}
+            input.set_time_fields(time.0);
+            input.set_time_zone_info_at_time_fields(zone.as_rust_at_time({% if flavor.has_date() %}Some(iso_date.0){% else %}None::<icu_calendar::Date<icu_calendar::AnyCalendar>>{% endif %}, Some(time.0)));
             {%- else %}
-            self.format_raw(input, {% if flavor.has_time() %}time,{% endif %} zone, write)
+            input.set_time_zone_info_at_time_fields(zone.as_rust_at_time({% if flavor.has_date() %}Some(iso_date.0){% else %}None::<icu_calendar::Date<icu_calendar::AnyCalendar>>{% endif %}, None));
             {%- endif %}
+
+            self
+                .0
+                .format_unchecked(input)
+                .try_write_to(write)
+                .ok()
+                .transpose()?;
+            Ok(())
         }
         {% if flavor.has_date() %}
         #[diplomat::rust_link(icu::datetime::{{ formatter_kind.rustlink() }}::format_same_calendar, {{ formatter_kind.rustlink_doctype_fn() }})]
@@ -290,8 +243,18 @@ pub mod ffi {
             {%- endif %}
             let mut input = icu_datetime::unchecked::DateTimeInputUnchecked::default();
             input.set_date_fields_unchecked(date_borrowed); // calendar check on previous lines
+            {%- if flavor.has_time() %}
+            input.set_time_fields(time.0);
+            input.set_time_zone_info_at_time_fields(zone.as_rust_at_time({% if flavor.has_date() %}Some(date.0.clone()){% else %}None::<icu_calendar::Date<icu_calendar::AnyCalendar>>{% endif %}, Some(time.0)));
+            {%- else %}
+            input.set_time_zone_info_at_time_fields(zone.as_rust_at_time({% if flavor.has_date() %}Some(date.0.clone()){% else %}None::<icu_calendar::Date<icu_calendar::AnyCalendar>>{% endif %}, None));
+            {%- endif %}
+
             let _ = self
-                .format_raw(input, || date.0.to_calendar(icu_calendar::Iso), {% if flavor.has_time() %}time,{% endif %} zone, write).ok();
+                .0
+                .format_unchecked(input)
+                .try_write_to(write);
+
             Ok(())
         }
         {%- endif %}


### PR DESCRIPTION
This encapsulates the `ZoneNameTimestamp` calculation/guessing in `ffi::TimeZoneInfo::as_rust_at_time` instead of having it in generated code across multiple formatters. It also uses `TimeZoneInfo::at_rd_time` instead of `TimeZoneInfo::at_date_time_iso`, as the RD is already calculated, and, especially if there is a calendar conversion, this saves doing multiple conversions and passing around `iso_date_obj: impl FnOnce() -> Date<Iso>`.

## Changelog: N/A

