### PR TITLE
Remove opaque_mut from segmenter APIs

### DIFF
--- a/ffi/capi/src/segmenter_line.rs
+++ b/ffi/capi/src/segmenter_line.rs
@@ -16,7 +16,7 @@ pub mod ffi {
     #[cfg(any(feature = "compiled_data", feature = "buffer_provider"))]
     use icu_segmenter::options::LineBreakOptions;
 
-    #[diplomat::opaque_mut] // TODO (#7704): This is unsound
+    #[diplomat::opaque]
     /// An ICU4X line-break segmenter, capable of finding breakpoints in strings.
     #[diplomat::rust_link(icu::segmenter::LineSegmenter, Struct)]
     #[diplomat::rust_link(icu::segmenter::LineSegmenterBorrowed, Struct, hidden)]

--- a/ffi/capi/src/segmenter_word.rs
+++ b/ffi/capi/src/segmenter_word.rs
@@ -24,7 +24,7 @@ pub mod ffi {
         Letter = 2,
     }
 
-    #[diplomat::opaque_mut] // TODO (#7704): This is unsound
+    #[diplomat::opaque]
     /// An ICU4X word-break segmenter, capable of finding word breakpoints in strings.
     #[diplomat::rust_link(icu::segmenter::WordSegmenter, Struct)]
     #[diplomat::rust_link(icu::segmenter::WordSegmenterBorrowed, Struct, hidden)]


### PR DESCRIPTION
Forgot that https://github.com/rust-diplomat/diplomat/pull/1065 had landed, should have done this in https://github.com/unicode-org/icu4x/pull/7715.

## Changelog: N/A

