### PR TITLE
Ignore `RUSTDOCFLAGS` in `diplomat-coverage`

### DIFF
--- a/tools/make/diplomat-coverage/src/main.rs
+++ b/tools/make/diplomat-coverage/src/main.rs
@@ -116,6 +116,7 @@ fn collect_public_types(krate: &str) -> impl Iterator<Item = (Vec<String>, ast::
                     "--output-format",
                     "json",
                 ])
+                .env_remove("RUSTDOCFLAGS")
                 .output()
                 .expect("failed to execute rustdoc");
             if !output.status.success() {


### PR DESCRIPTION
`diplomat-coverage` fails if it's run in the same cargo-make invocation as `ci-job-doc`, because the latter sets `-D warnings` and cargo-make jobs are not hermetic.

## Changelog: N/A

