### PR TITLE
Fix some clippy warnings that only occur on specific features

### DIFF
--- a/components/locale_core/src/extensions/mod.rs
+++ b/components/locale_core/src/extensions/mod.rs
@@ -195,6 +195,7 @@ impl Extensions {
     }
 
     #[expect(clippy::type_complexity)]
+    #[cfg_attr(not(feature = "alloc"), expect(clippy::needless_borrow))]
     pub(crate) fn as_tuple(
         &self,
     ) -> (

--- a/components/segmenter/src/complex/mod.rs
+++ b/components/segmenter/src/complex/mod.rs
@@ -17,7 +17,7 @@ mod lstm;
 use lstm::*;
 
 #[derive(Debug, Clone)]
-#[expect(clippy::large_enum_variant)]
+#[cfg_attr(feature = "lstm", expect(clippy::large_enum_variant))]
 enum DictOrLstm {
     Dict(DataPayload<UCharDictionaryBreakDataV1>),
     #[cfg(feature = "lstm")]


### PR DESCRIPTION
These keep coming up when I'm in other crates that don't turn on all the features.

## Changelog: N/A

