### PR TITLE
In icu_time, limit use of the icu crate to doctests

### DIFF
--- a/components/time/src/zone/windows.rs
+++ b/components/time/src/zone/windows.rs
@@ -155,7 +155,7 @@ impl WindowsParserBorrowed<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use icu::locale::subtags::subtag;
+    use icu_locale_core::subtags::subtag;
 
     #[test]
     fn basic_windows_tz_lookup() {


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->
This is a really minor tweak, but one that’s useful to me as downstream maintainer of most of the packaged ICU4X crates in Fedora.

We don’t have the *entire* ICU4X stack packaged, so we don’t have a package for the top-level `icu` meta-crate. Even if we did, we would probably try to avoid circular test dependencies to make it easier to bootstrap everything. So while I do try to run as many tests as I reasonably can in each crate, I need to disable those that use the `icu` crate.

I’ve notice that in *almost all* cases, the `icu` meta-crate is used only in doctests, while tests that won’t appear in rustdoc output use the individual `icu_*` crates directly. This makes sense presentation-wise, and it is a really helpful convention for me, because it gives me the option to sidestep the `icu` test dependency by omitting doctests, and just building and running everything else.

This PR therefore “fixes” the sole use of the `icu` crate in `icu_time`’s lib-tests.

## Changelog: N/A

