### PR TITLE
Remove `YearInfo: PartialEq` bound

### DIFF
--- a/components/calendar/src/cal/east_asian_traditional.rs
+++ b/components/calendar/src/cal/east_asian_traditional.rs
@@ -841,7 +841,7 @@ impl<A: AsCalendar<Calendar = ChineseTraditional>> Date<A> {
 }
 
 /// Information about a [`EastAsianTraditional`] year.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug)]
 // TODO(#3933): potentially make this smaller
 pub struct EastAsianTraditionalYear {
     /// Contains:
@@ -982,7 +982,8 @@ impl EastAsianTraditionalYear {
 /// including in SemVer minor releases. While the serde representation of data structs is guaranteed
 /// to be stable, their Rust representation might not be. Use with caution.
 /// </div>
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Copy, Clone)]
+#[cfg_attr(test, derive(PartialEq))]
 struct PackedEastAsianTraditionalYearData(u8, u8, u8);
 
 impl PackedEastAsianTraditionalYearData {

--- a/components/calendar/src/cal/hebrew.rs
+++ b/components/calendar/src/cal/hebrew.rs
@@ -64,7 +64,7 @@ impl Hebrew {
     }
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug)]
 pub(crate) struct HebrewYear {
     keviyah: Keviyah,
     value: i32,

--- a/components/calendar/src/cal/hijri.rs
+++ b/components/calendar/src/cal/hijri.rs
@@ -481,7 +481,7 @@ impl Hijri<TabularAlgorithm> {
 ///
 /// Graduation tracking issue: [issue #6962](https://github.com/unicode-org/icu4x/issues/6962).
 /// </div>
-#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, Hash)]
 pub struct HijriYear {
     packed: PackedHijriYearData,
     extended_year: i32,
@@ -589,7 +589,8 @@ impl HijriYear {
 ///
 /// Graduation tracking issue: [issue #6962](https://github.com/unicode-org/icu4x/issues/6962).
 /// </div>
-#[derive(Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Debug)]
+#[derive(Copy, Clone, Hash, Debug)]
+#[cfg_attr(test, derive(PartialEq))]
 struct PackedHijriYearData(u16);
 
 impl PackedHijriYearData {

--- a/components/calendar/src/calendar_arithmetic.rs
+++ b/components/calendar/src/calendar_arithmetic.rs
@@ -187,7 +187,7 @@ impl PackWithMD for i32 {
 pub(crate) trait DateFieldsResolver: Calendar {
     /// This stores the year as either an i32, or a type containing more
     /// useful computational information.
-    type YearInfo: Copy + Debug + PartialEq + ToExtendedYear + PackWithMD;
+    type YearInfo: Copy + Debug + ToExtendedYear + PackWithMD;
 
     fn days_in_provided_month(year: Self::YearInfo, month: u8) -> u8;
 
@@ -420,7 +420,7 @@ impl<C: DateFieldsResolver> ArithmeticDate<C> {
                             _ => return Err(DateFromFieldsError::NotEnoughFields),
                         };
                         let ref_year = calendar.reference_year_from_month_day(m, d);
-                        if ref_year == Err(EcmaReferenceYearError::UseRegularIfConstrain)
+                        if ref_year.err() == Some(EcmaReferenceYearError::UseRegularIfConstrain)
                             && options.overflow == Some(Overflow::Constrain)
                         {
                             let new_valid_month = Month::new(m.number());
@@ -653,7 +653,7 @@ impl<C: DateFieldsResolver> ArithmeticDate<C> {
         // (note: integer steps omitted)
         // 1. Else if _day_ ≠ _target_.[[Day]], then
         //   1. If _sign_ × (_day_ - _target_.[[Day]]) > 0, return *true*.
-        if year != target.year() {
+        if year.to_extended_year() != target.year().to_extended_year() {
             if sign
                 * (i64::from(year.to_extended_year()) - i64::from(target.year().to_extended_year()))
                 > 0
@@ -697,7 +697,7 @@ impl<C: DateFieldsResolver> ArithmeticDate<C> {
         //   1. If _sign_ × (_month_ - _target_.[[Month]]) > 0, return *true*.
         // 1. Else if _day_ ≠ _target_.[[Day]], then
         //   1. If _sign_ × (_day_ - _target_.[[Day]]) > 0, return *true*.
-        if year != target.year() {
+        if year.to_extended_year() != target.year().to_extended_year() {
             if sign
                 * (i64::from(year.to_extended_year()) - i64::from(target.year().to_extended_year()))
                 > 0


### PR DESCRIPTION
There's code that compares whole `YearInfo`s when it should be comparing extended years.