### PR TITLE
Let CI platforms fail independently

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -50,7 +50,6 @@ jobs:
     strategy:
       matrix: 
         behavior: [check, features-1, features-2, features-3, features-4]
-      fail-fast: true
     # Set CARGO_HTTP_MULTIPLEXING=false to work around crates.io curl bug:
     # <https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/timeout.20investigation>
     env:
@@ -86,6 +85,7 @@ jobs:
   # ci-job-test
   test:
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
@@ -188,6 +188,7 @@ jobs:
   # ci-job-testdata
   testdata:
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
@@ -312,6 +313,7 @@ jobs:
   # ci-job-test-dart
   test-dart:
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Currently the failing jobs for Windows, which has been quite flaky, are cancelling the Ubuntu and Mac jobs. Don't do that.

## Changelog: N/A

