### PR TITLE
Remove circular meta crate dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2028,7 +2028,6 @@ dependencies = [
  "chrono-tz",
  "databake",
  "displaydoc",
- "icu",
  "icu_calendar",
  "icu_datetime",
  "icu_locale_core",

--- a/components/time/Cargo.toml
+++ b/components/time/Cargo.toml
@@ -43,7 +43,6 @@ chrono-tz = { workspace = true, optional = true }
 icu_time_data = { workspace = true, optional = true }
 
 [dev-dependencies]
-icu = { path = "../../components/icu", default-features = false }
 icu_datetime = { path = "../../components/datetime", features = ["compiled_data"] }
 icu_provider_blob = { path = "../../provider/blob" }
 tinystr = { workspace = true }

--- a/components/time/src/ixdtf.rs
+++ b/components/time/src/ixdtf.rs
@@ -56,6 +56,7 @@ pub enum ParseError {
     ///
     /// # Example
     /// ```
+    #[doc = crate::setup_metacrate!(time, calendar)]
     /// use icu::calendar::Iso;
     /// use icu::time::{ZonedDateTime, ParseError, zone::IanaParser};
     ///
@@ -420,6 +421,7 @@ impl<A: AsCalendar> ZonedDateTime<A, TimeZoneInfo<models::AtTime>> {
     /// Basic usage:
     ///
     /// ```
+    #[doc = crate::setup_metacrate!(time, calendar)]
     /// use icu::calendar::cal::Hebrew;
     /// use icu::locale::subtags::subtag;
     /// use icu::time::{
@@ -464,6 +466,7 @@ impl<A: AsCalendar> ZonedDateTime<A, TimeZoneInfo<models::AtTime>> {
     /// `DateTime` string.
     ///
     /// ```
+    #[doc = crate::setup_metacrate!(time, calendar)]
     /// use icu::calendar::Iso;
     /// use icu::time::{zone::UtcOffset, TimeZoneInfo, ZonedDateTime};
     ///
@@ -484,6 +487,7 @@ impl<A: AsCalendar> ZonedDateTime<A, TimeZoneInfo<models::AtTime>> {
     /// Below is an example of a time zone being provided by a time zone annotation.
     ///
     /// ```
+    #[doc = crate::setup_metacrate!(time, calendar)]
     /// use icu::calendar::Iso;
     /// use icu::locale::subtags::subtag;
     /// use icu::time::{
@@ -525,6 +529,7 @@ impl<A: AsCalendar> ZonedDateTime<A, TimeZoneInfo<models::AtTime>> {
     /// These annotations must always be consistent as they should be either the same value or are inconsistent.
     ///
     /// ```
+    #[doc = crate::setup_metacrate!(time, calendar)]
     /// use icu::calendar::Iso;
     /// use icu::time::{
     ///     zone::UtcOffset, ParseError, TimeZone, TimeZoneInfo, ZonedDateTime,
@@ -702,6 +707,7 @@ impl ZonedTime<TimeZoneInfo<models::AtTime>> {
     /// Basic usage:
     ///
     /// ```
+    #[doc = crate::setup_metacrate!(time, calendar)]
     /// use icu::calendar::cal::Hebrew;
     /// use icu::locale::subtags::subtag;
     /// use icu::time::{
@@ -738,6 +744,7 @@ impl ZonedTime<TimeZoneInfo<models::AtTime>> {
     /// `DateTime` string.
     ///
     /// ```
+    #[doc = crate::setup_metacrate!(time, calendar)]
     /// use icu::calendar::Iso;
     /// use icu::time::{zone::UtcOffset, TimeZoneInfo, ZonedTime};
     ///
@@ -757,6 +764,7 @@ impl ZonedTime<TimeZoneInfo<models::AtTime>> {
     /// Below is an example of a time zone being provided by a time zone annotation.
     ///
     /// ```
+    #[doc = crate::setup_metacrate!(time, calendar)]
     /// use icu::calendar::Iso;
     /// use icu::locale::subtags::subtag;
     /// use icu::time::{
@@ -796,6 +804,7 @@ impl ZonedTime<TimeZoneInfo<models::AtTime>> {
     /// These annotations must always be consistent as they should be either the same value or are inconsistent.
     ///
     /// ```
+    #[doc = crate::setup_metacrate!(time, calendar)]
     /// use icu::calendar::Iso;
     /// use icu::time::{
     ///     zone::UtcOffset, ParseError, TimeZone, TimeZoneInfo, ZonedTime,
@@ -863,6 +872,7 @@ impl<A: AsCalendar> DateTime<A> {
     /// # Examples
     ///
     /// ```
+    #[doc = crate::setup_metacrate!(time, calendar)]
     /// use icu::calendar::cal::Hebrew;
     /// use icu::time::DateTime;
     ///
@@ -909,6 +919,7 @@ impl Time {
     /// # Examples
     ///
     /// ```
+    #[doc = crate::setup_metacrate!(time)]
     /// use icu::time::Time;
     ///
     /// let time = Time::try_from_str("16:01:17.045").unwrap();

--- a/components/time/src/lib.rs
+++ b/components/time/src/lib.rs
@@ -46,3 +46,17 @@ mod chrono;
 mod jiff;
 #[cfg(feature = "time_0_3")]
 mod time_crate;
+
+macro_rules! setup_metacrate {
+    ($($component:ident),+) => {
+        concat!(
+            "# mod icu {",
+            "pub extern crate icu_locale_core as locale;",
+            $(
+                "pub extern crate icu_", stringify!($component), " as ", stringify!($component), ";",
+            )+
+            "}",
+        )
+    }
+}
+use setup_metacrate;

--- a/components/time/src/types.rs
+++ b/components/time/src/types.rs
@@ -373,6 +373,7 @@ impl ZonedDateTime<Iso, UtcOffset> {
     /// # Examples
     ///
     /// ```
+    #[doc = crate::setup_metacrate!(time, calendar)]
     /// use icu::calendar::cal::Iso;
     /// use icu::time::zone::UtcOffset;
     /// use icu::time::ZonedDateTime;
@@ -395,6 +396,7 @@ impl ZonedDateTime<Iso, UtcOffset> {
     /// Negative timestamps are supported:
     ///
     /// ```
+    #[doc = crate::setup_metacrate!(time, calendar)]
     /// use icu::calendar::cal::Iso;
     /// use icu::time::zone::UtcOffset;
     /// use icu::time::ZonedDateTime;
@@ -418,6 +420,7 @@ impl ZonedDateTime<Iso, UtcOffset> {
     /// saturates to the maximum or minimum representable date in the ISO calendar
     ///
     /// ```
+    #[doc = crate::setup_metacrate!(time, calendar)]
     /// use icu::calendar::cal::Iso;
     /// use icu::time::zone::UtcOffset;
     /// use icu::time::ZonedDateTime;
@@ -480,6 +483,7 @@ impl ZonedDateTime<Iso, UtcOffset> {
 ///
 /// ```
 /// # #[cfg(feature = "ixdtf")] {
+#[doc = crate::setup_metacrate!(time)]
 /// use icu::time::zone::iana::IanaParser;
 /// use icu::time::ZonedTime;
 ///

--- a/components/time/src/zone/iana.rs
+++ b/components/time/src/zone/iana.rs
@@ -35,6 +35,7 @@ use crate::{
 /// # Examples
 ///
 /// ```
+#[doc = crate::setup_metacrate!(time)]
 /// use icu::locale::subtags::subtag;
 /// use icu::time::zone::IanaParser;
 /// use icu::time::TimeZone;
@@ -177,8 +178,9 @@ impl<'a> IanaParserBorrowed<'a> {
     /// # Examples
     ///
     /// ```
-    /// use icu_time::zone::iana::IanaParser;
-    /// use icu_time::TimeZone;
+    #[doc = crate::setup_metacrate!(time)]
+    /// use icu::time::zone::iana::IanaParser;
+    /// use icu::time::TimeZone;
     ///
     /// let parser = IanaParser::new();
     ///
@@ -221,6 +223,7 @@ impl<'a> IanaParserBorrowed<'a> {
     /// # Examples
     ///
     /// ```
+    #[doc = crate::setup_metacrate!(time)]
     /// use icu::locale::subtags::subtag;
     /// use icu::time::zone::IanaParser;
     /// use icu::time::zone::TimeZone;
@@ -421,8 +424,9 @@ impl<'a> IanaParserExtendedBorrowed<'a> {
     /// # Examples
     ///
     /// ```
-    /// use icu_time::zone::iana::IanaParserExtended;
-    /// use icu_time::TimeZone;
+    #[doc = crate::setup_metacrate!(time)]
+    /// use icu::time::zone::iana::IanaParserExtended;
+    /// use icu::time::TimeZone;
     ///
     /// let parser = IanaParserExtended::new();
     ///
@@ -498,6 +502,7 @@ impl<'a> IanaParserExtendedBorrowed<'a> {
     /// # Examples
     ///
     /// ```
+    #[doc = crate::setup_metacrate!(time)]
     /// use icu::locale::subtags::subtag;
     /// use icu::time::zone::iana::IanaParserExtended;
     /// use icu::time::zone::TimeZone;
@@ -535,6 +540,7 @@ impl<'a> IanaParserExtendedBorrowed<'a> {
     /// # Examples
     ///
     /// ```
+    #[doc = crate::setup_metacrate!(time)]
     /// use icu::time::zone::iana::IanaParserExtended;
     /// use icu::time::zone::TimeZone;
     /// use std::collections::BTreeMap;

--- a/components/time/src/zone/mod.rs
+++ b/components/time/src/zone/mod.rs
@@ -156,6 +156,7 @@ pub mod models {
 /// See the docs on [`zone`](crate::zone) for more information.
 ///
 /// ```
+#[doc = crate::setup_metacrate!(time)]
 /// use icu::locale::subtags::subtag;
 /// use icu::time::zone::{IanaParser, TimeZone};
 ///
@@ -261,6 +262,7 @@ impl<'a> zerovec::maps::ZeroMapKV<'a> for TimeZone {
 /// # Examples
 ///
 /// ```
+#[doc = crate::setup_metacrate!(time, calendar)]
 /// use icu::calendar::Date;
 /// use icu::locale::subtags::subtag;
 /// use icu::time::zone::TimeZoneVariant;
@@ -492,6 +494,7 @@ impl TimeZoneInfo<models::AtTime> {
     ///
     /// # Example
     /// ```
+    #[doc = crate::setup_metacrate!(time, calendar)]
     /// use icu::calendar::Date;
     /// use icu::time::zone::TimeZoneVariant;
     /// use icu::time::zone::VariantOffsetsCalculator;

--- a/components/time/src/zone/offset.rs
+++ b/components/time/src/zone/offset.rs
@@ -57,6 +57,7 @@ impl UtcOffset {
     /// # Examples
     ///
     /// ```
+    #[doc = crate::setup_metacrate!(time)]
     /// use icu::time::zone::UtcOffset;
     ///
     /// let offset0: UtcOffset = UtcOffset::try_from_str("Z").unwrap();
@@ -331,6 +332,7 @@ impl VariantOffsetsCalculatorBorrowed<'_> {
     /// # Examples
     ///
     /// ```
+    #[doc = crate::setup_metacrate!(time, calendar)]
     /// use icu::calendar::Date;
     /// use icu::locale::subtags::subtag;
     /// use icu::time::zone::UtcOffset;

--- a/components/time/src/zone/windows.rs
+++ b/components/time/src/zone/windows.rs
@@ -116,6 +116,7 @@ impl WindowsParserBorrowed<'_> {
     /// then the territory will default to the M.49 World Code, `001`.
     ///
     /// ```rust
+    #[doc = crate::setup_metacrate!(time)]
     /// use icu::locale::subtags::{region, subtag};
     /// use icu::time::{zone::WindowsParser, TimeZone};
     ///

--- a/components/time/src/zone/zone_name_timestamp.rs
+++ b/components/time/src/zone/zone_name_timestamp.rs
@@ -30,6 +30,7 @@ use crate::{zone::UtcOffset, DateTime, ZonedDateTime};
 /// Alaska Time multiple times between 2010 and 2025.
 ///
 /// ```
+#[doc = crate::setup_metacrate!(time, calendar, datetime)]
 /// use icu::calendar::Iso;
 /// use icu::datetime::fieldsets::zone::GenericLong;
 /// use icu::datetime::NoCalendarFormatter;
@@ -102,6 +103,7 @@ impl ZoneNameTimestamp {
     /// [`ZonedDateTime`] does _not_ necessarily roundtrip:
     ///
     /// ```
+    #[doc = crate::setup_metacrate!(time, calendar)]
     /// use icu::calendar::Date;
     /// use icu::time::zone::ZoneNameTimestamp;
     /// use icu::time::{ZonedDateTime, Time, zone::UtcOffset};


### PR DESCRIPTION
It's very annoying how all our tests depend on *everything*, which leads to long build times during local iteration.

This is a proof-of-concept of how we could remove this dependency.