### PR TITLE
Gate the shared (posix) module on the target OS

### DIFF
--- a/utils/host_info/src/backends/mod.rs
+++ b/utils/host_info/src/backends/mod.rs
@@ -32,6 +32,13 @@ use icu_locale_core::{
 
 use crate::error::HostInfoError;
 
+#[cfg(any(
+    target_os = "android",
+    target_os = "ios",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows"
+))]
 mod shared;
 
 #[cfg(target_os = "android")]

--- a/utils/host_info/src/backends/unavailable.rs
+++ b/utils/host_info/src/backends/unavailable.rs
@@ -2,10 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use crate::{
-    backends::{HostInfoBackend, RawHostInfoBackend},
-    error::HostInfoError,
-};
+use crate::backends::{HostInfoBackend, RawHostInfoBackend};
 
 pub struct UnavailableHostInfoBackend;
 


### PR DESCRIPTION
I'm not sure if this fixes CI. It was suggested in part by Gemini.

## Changelog: N/A