### PR TITLE
Add zerofrom::transparent! macro

### DIFF
--- a/utils/zerofrom/src/lib.rs
+++ b/utils/zerofrom/src/lib.rs
@@ -40,4 +40,5 @@ pub use crate::zero_from::ZeroFrom;
 pub mod internal {
     pub use alloc::boxed::Box;
     pub use alloc::rc::Rc;
+    pub use crate::zf_transparent::cast_transparent_box;
 }

--- a/utils/zerofrom/src/lib.rs
+++ b/utils/zerofrom/src/lib.rs
@@ -38,7 +38,7 @@ pub use crate::zero_from::ZeroFrom;
 #[cfg(feature = "alloc")]
 #[doc(hidden)] // for macros
 pub mod internal {
+    pub use crate::zf_transparent::cast_transparent_box;
     pub use alloc::boxed::Box;
     pub use alloc::rc::Rc;
-    pub use crate::zf_transparent::cast_transparent_box;
 }

--- a/utils/zerofrom/src/lib.rs
+++ b/utils/zerofrom/src/lib.rs
@@ -28,8 +28,16 @@ extern crate alloc;
 
 mod macro_impls;
 mod zero_from;
+mod zf_transparent;
 
 #[cfg(feature = "derive")]
 pub use zerofrom_derive::ZeroFrom;
 
 pub use crate::zero_from::ZeroFrom;
+
+#[cfg(feature = "alloc")]
+#[doc(hidden)] // for macros
+pub mod internal {
+    pub use alloc::boxed::Box;
+    pub use alloc::rc::Rc;
+}

--- a/utils/zerofrom/src/lib.rs
+++ b/utils/zerofrom/src/lib.rs
@@ -39,6 +39,7 @@ pub use crate::zero_from::ZeroFrom;
 #[doc(hidden)] // for macros
 pub mod internal {
     pub use crate::zf_transparent::cast_transparent_box;
+    pub use crate::zf_transparent::cast_transparent_rc;
     pub use alloc::boxed::Box;
     pub use alloc::rc::Rc;
 }

--- a/utils/zerofrom/src/zf_transparent.rs
+++ b/utils/zerofrom/src/zf_transparent.rs
@@ -10,11 +10,13 @@ use alloc::boxed::Box;
 ///
 /// # Safety
 ///
-/// `Outer` is `repr(transparent)` and has one non-zero-sized field
-/// of type `Inner`.
+/// `Outer` is `repr(transparent)` and has one non-zero-sized field of type `Inner`.
+///
+/// Suggestion: explicitly setting the generic parameters to two types satisfying this invariant
+/// makes the fn safe to call.
 #[cfg(feature = "alloc")]
 #[inline(always)]
-pub unsafe fn cast_transparent_box<Outer, Inner>(inner: Box<Inner>) -> Box<Outer> {
+pub unsafe fn cast_transparent_box<Inner, Outer>(inner: Box<Inner>) -> Box<Outer> {
     // Safety:
     //
     // - Both boxes have the same allocator (the global allocator).
@@ -82,7 +84,7 @@ macro_rules! transparent {
 		$(
 			impl<'zf> $crate::ZeroFrom<'zf, $inner_zf> for &'zf $outer {
 				fn zero_from(inner: &'zf $inner) -> Self {
-					unsafe { core::mem::transmute(inner) }
+					unsafe { core::mem::transmute::<&$inner, &$outer>(inner) }
 				}
 			}
 		)?
@@ -90,21 +92,20 @@ macro_rules! transparent {
 			$(
 				$(#[$meta_ref])*
 				$vis_ref fn $fn_ref(inner: &$inner_ref) -> &Self {
-					unsafe { core::mem::transmute(inner) }
+					unsafe { core::mem::transmute::<&$inner, &$outer>(inner) }
 				}
 			)?
 			$(
 				$(#[$meta_slice])*
 				$vis_slice fn $fn_slice(inner: &[$inner_slice]) -> &[Self] {
-					unsafe { core::mem::transmute(inner) }
+					unsafe { core::mem::transmute::<&[$inner], &[$outer]>(inner) }
 				}
 			)?
 			$(
 				$(#[$meta_box])*
 				$vis_box fn $fn_box(inner: $crate::internal::Box<$inner_box>) -> $crate::internal::Box<Self> {
 					// Safety: $outer is repr(transparent) over $inner.
-					// TODO: Enforce that $inner is the same as $inner_box
-					unsafe { $crate::internal::cast_transparent_box(inner) }
+					unsafe { $crate::internal::cast_transparent_box::<$inner, $outer>(inner) }
 				}
 			)?
 			$(
@@ -116,3 +117,41 @@ macro_rules! transparent {
 		})?
 	};
 }
+
+/// Additional tests for failure modes.
+///
+/// ```compile_fail,E0053
+/// zerofrom::transparent! {
+///     #[repr(transparent)]
+///     pub struct Foo(String);
+///     // Wrong types in these positions!
+///     impl ZeroFrom<&Foo> for &String;
+/// };
+/// ```
+///
+/// ```compile_fail,E0308
+/// zerofrom::transparent! {
+///     #[repr(transparent)]
+///     pub struct Foo(String);
+///     impl {
+///         @ref
+///         // Wrong type in this position!
+///         pub fn from(&Foo) -> &Self;
+///     }
+/// };
+/// ```
+///
+/// ```compile_fail,E0308
+/// zerofrom::transparent! {
+///     #[repr(transparent)]
+///     pub struct Foo(String);
+///     impl {
+///         @slice
+///         // Wrong type in this position!
+///         pub fn from(&[Foo]) -> &[Self];
+///     }
+/// };
+/// ```
+///
+/// TODO: Rc
+mod _tests {}

--- a/utils/zerofrom/src/zf_transparent.rs
+++ b/utils/zerofrom/src/zf_transparent.rs
@@ -13,6 +13,7 @@ use alloc::boxed::Box;
 /// `Outer` is `repr(transparent)` and has one non-zero-sized field
 /// of type `Inner`.
 #[cfg(feature = "alloc")]
+#[inline(always)]
 pub unsafe fn cast_transparent_box<Outer, Inner>(inner: Box<Inner>) -> Box<Outer> {
     // Safety:
     //

--- a/utils/zerofrom/src/zf_transparent.rs
+++ b/utils/zerofrom/src/zf_transparent.rs
@@ -1,0 +1,95 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+/// Implements [`ZeroFrom`](crate::ZeroFrom) on a transparent type
+/// from a reference to the inner type.
+///
+/// Also supports creating concrete functions.
+///
+/// # Examples
+///
+/// ```
+/// use crate::zerofrom::ZeroFrom;
+///
+/// zerofrom::transparent!(
+///     #[repr(transparent)]
+///     pub struct StrWrap(str);
+///     impl ZeroFrom<&str> for &StrWrap;
+/// );
+///
+/// let s = "hello";
+/// let wrap = <&StrWrap>::zero_from(s);
+///
+/// assert_eq!(&wrap.0, "hello");
+/// ```
+#[macro_export]
+macro_rules! transparent {
+	(
+		#[repr(transparent)]
+		$(#[$meta:meta])*
+		$vis:vis struct $name:ident($type:ty);
+		$(
+			impl ZeroFrom<&$type_zf:ty> for &$name_zf:ident;
+		)?
+		$(impl {
+			$(
+				@ref
+				$(#[$meta_ref:meta])*
+				$vis_ref:vis fn $fn_ref:ident(&$type_ref:ty) -> &Self;
+			)?
+			$(
+				@slice
+				$(#[$meta_slice:meta])*
+				$vis_slice:vis fn $fn_slice:ident(&[$type_slice:ty]) -> &[Self];
+			)?
+			$(
+				@box
+				$(#[$meta_box:meta])*
+				$vis_box:vis fn $fn_box:ident(Box<$type_box:ty>) -> Box<Self>;
+			)?
+			$(
+				@rc
+				$(#[$meta_rc:meta])*
+				$vis_rc:vis fn $fn_rc:ident(Rc<$type_rc:ty>) -> Rc<Self>;
+			)?
+		})?
+	) => {
+		#[repr(transparent)]
+		$(#[$meta])*
+		$vis struct $name($type);
+		$(
+			impl<'zf> $crate::ZeroFrom<'zf, $type_zf> for &'zf $name {
+				fn zero_from(inner: &'zf $type) -> Self {
+					unsafe { core::mem::transmute(inner) }
+				}
+			}
+		)?
+		$(impl $name {
+			$(
+				$(#[$meta_ref])*
+				$vis_ref fn $fn_ref(inner: &$type_ref) -> &Self {
+					unsafe { core::mem::transmute(inner) }
+				}
+			)?
+			$(
+				$(#[$meta_slice])*
+				$vis_slice fn $fn_slice(inner: &[$type_slice]) -> &[Self] {
+					unsafe { core::mem::transmute(inner) }
+				}
+			)?
+			$(
+				$(#[$meta_box])*
+				$vis_box fn $fn_box(inner: $crate::internal::Box<$type_box>) -> $crate::internal::Box<Self> {
+					unsafe { core::mem::transmute(inner) }
+				}
+			)?
+			$(
+				$(#[$meta_rc])*
+				$vis_rc fn $fn_rc(inner: $crate::internal::Rc<$type_rc>) -> $crate::internal::Rc<Self> {
+					unsafe { core::mem::transmute(inner) }
+				}
+			)?
+		})?
+	};
+}

--- a/utils/zerofrom/src/zf_transparent.rs
+++ b/utils/zerofrom/src/zf_transparent.rs
@@ -2,6 +2,26 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+#[cfg(feature = "alloc")]
+use alloc::boxed::Box;
+
+/// Internal function: casts a box of `Inner` to a box of `Outer`, assuming
+/// `Outer` is transparent over `Inner`.
+///
+/// # Safety
+///
+/// `Outer` is `repr(transparent)` and has one non-zero-sized field
+/// of type `Inner`.
+#[cfg(feature = "alloc")]
+pub unsafe fn cast_transparent_box<Outer, Inner>(inner: Box<Inner>) -> Box<Outer> {
+    // Safety:
+    //
+    // - Both boxes have the same allocator (the global allocator).
+    // - Since `Outer` is transparent over `Inner`, they have the same layout.
+    // - `Box::into_raw` returns a properly aligned, non-null `*mut Inner`.
+    Box::from_raw(Box::into_raw(inner) as *mut Outer)
+}
+
 /// Implements [`ZeroFrom`](crate::ZeroFrom) on a transparent type
 /// from a reference to the inner type.
 ///
@@ -28,65 +48,67 @@ macro_rules! transparent {
 	(
 		#[repr(transparent)]
 		$(#[$meta:meta])*
-		$vis:vis struct $name:ident($type:ty);
+		$vis:vis struct $outer:ident($inner:ty);
 		$(
-			impl ZeroFrom<&$type_zf:ty> for &$name_zf:ident;
+			impl ZeroFrom<&$inner_zf:ty> for &$outer_zf:ident;
 		)?
 		$(impl {
 			$(
 				@ref
 				$(#[$meta_ref:meta])*
-				$vis_ref:vis fn $fn_ref:ident(&$type_ref:ty) -> &Self;
+				$vis_ref:vis fn $fn_ref:ident(&$inner_ref:ty) -> &Self;
 			)?
 			$(
 				@slice
 				$(#[$meta_slice:meta])*
-				$vis_slice:vis fn $fn_slice:ident(&[$type_slice:ty]) -> &[Self];
+				$vis_slice:vis fn $fn_slice:ident(&[$inner_slice:ty]) -> &[Self];
 			)?
 			$(
 				@box
 				$(#[$meta_box:meta])*
-				$vis_box:vis fn $fn_box:ident(Box<$type_box:ty>) -> Box<Self>;
+				$vis_box:vis fn $fn_box:ident(Box<$inner_box:ty>) -> Box<Self>;
 			)?
 			$(
 				@rc
 				$(#[$meta_rc:meta])*
-				$vis_rc:vis fn $fn_rc:ident(Rc<$type_rc:ty>) -> Rc<Self>;
+				$vis_rc:vis fn $fn_rc:ident(Rc<$inner_rc:ty>) -> Rc<Self>;
 			)?
 		})?
 	) => {
 		#[repr(transparent)]
 		$(#[$meta])*
-		$vis struct $name($type);
+		$vis struct $outer($inner);
 		$(
-			impl<'zf> $crate::ZeroFrom<'zf, $type_zf> for &'zf $name {
-				fn zero_from(inner: &'zf $type) -> Self {
+			impl<'zf> $crate::ZeroFrom<'zf, $inner_zf> for &'zf $outer {
+				fn zero_from(inner: &'zf $inner) -> Self {
 					unsafe { core::mem::transmute(inner) }
 				}
 			}
 		)?
-		$(impl $name {
+		$(impl $outer {
 			$(
 				$(#[$meta_ref])*
-				$vis_ref fn $fn_ref(inner: &$type_ref) -> &Self {
+				$vis_ref fn $fn_ref(inner: &$inner_ref) -> &Self {
 					unsafe { core::mem::transmute(inner) }
 				}
 			)?
 			$(
 				$(#[$meta_slice])*
-				$vis_slice fn $fn_slice(inner: &[$type_slice]) -> &[Self] {
+				$vis_slice fn $fn_slice(inner: &[$inner_slice]) -> &[Self] {
 					unsafe { core::mem::transmute(inner) }
 				}
 			)?
 			$(
 				$(#[$meta_box])*
-				$vis_box fn $fn_box(inner: $crate::internal::Box<$type_box>) -> $crate::internal::Box<Self> {
-					unsafe { core::mem::transmute(inner) }
+				$vis_box fn $fn_box(inner: $crate::internal::Box<$inner_box>) -> $crate::internal::Box<Self> {
+					// Safety: $outer is repr(transparent) over $inner.
+					// TODO: Enforce that $inner is the same as $inner_box
+					unsafe { $crate::internal::cast_transparent_box(inner) }
 				}
 			)?
 			$(
 				$(#[$meta_rc])*
-				$vis_rc fn $fn_rc(inner: $crate::internal::Rc<$type_rc>) -> $crate::internal::Rc<Self> {
+				$vis_rc fn $fn_rc(inner: $crate::internal::Rc<$inner_rc>) -> $crate::internal::Rc<Self> {
 					unsafe { core::mem::transmute(inner) }
 				}
 			)?

--- a/utils/zerofrom/src/zf_transparent.rs
+++ b/utils/zerofrom/src/zf_transparent.rs
@@ -3,17 +3,19 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 #[cfg(feature = "alloc")]
-use alloc::boxed::Box;
+use alloc::{boxed::Box, rc::Rc};
+
 
 /// Internal function: casts a box of `Inner` to a box of `Outer`, assuming
 /// `Outer` is transparent over `Inner`.
 ///
 /// # Safety
 ///
-/// `Outer` is `repr(transparent)` and has one non-zero-sized field of type `Inner`.
+/// `Outer` MUST be `repr(transparent)` and MUST have one non-zero-sized field,
+/// which MUST be of type `Inner`.
 ///
-/// Suggestion: explicitly setting the generic parameters to two types satisfying this invariant
-/// makes the fn safe to call.
+/// Suggestion: explicitly setting the generic parameters to two types satisfying
+/// this invariant makes the fn safe to call.
 #[cfg(feature = "alloc")]
 #[inline(always)]
 pub unsafe fn cast_transparent_box<Inner, Outer>(inner: Box<Inner>) -> Box<Outer> {
@@ -25,10 +27,32 @@ pub unsafe fn cast_transparent_box<Inner, Outer>(inner: Box<Inner>) -> Box<Outer
     Box::from_raw(Box::into_raw(inner) as *mut Outer)
 }
 
-/// Implements [`ZeroFrom`](crate::ZeroFrom) on a transparent type
-/// from a reference to the inner type.
+/// Internal function: casts a Rc of `Inner` to a Rc of `Outer`, assuming
+/// `Outer` is transparent over `Inner`.
 ///
-/// Also supports creating concrete functions.
+/// # Safety
+///
+/// `Outer` MUST be `repr(transparent)` and MUST have one non-zero-sized field,
+/// which MUST be of type `Inner`.
+///
+/// Suggestion: explicitly setting the generic parameters to two types satisfying
+/// this invariant makes the fn safe to call.
+#[cfg(feature = "alloc")]
+#[inline(always)]
+pub unsafe fn cast_transparent_rc<Inner, Outer>(inner: Rc<Inner>) -> Rc<Outer> {
+    // Safety:
+    //
+    // - Both boxes have the same allocator (the global allocator).
+    // - Since `Outer` is transparent over `Inner`, they have the same layout.
+    // - `Rc::into_raw` returns a properly aligned, non-null `*mut Inner`.
+    Rc::from_raw(Rc::into_raw(inner) as *mut Outer)
+}
+
+/// Implements functions that cast a reference of an inner type
+/// to a reference of an outer type that is `repr(transparent)`
+/// over the inner type.
+///
+/// These functions can be used to implement `ZeroFrom`.
 ///
 /// # Examples
 ///
@@ -38,8 +62,16 @@ pub unsafe fn cast_transparent_box<Inner, Outer>(inner: Box<Inner>) -> Box<Outer
 /// zerofrom::transparent!(
 ///     #[repr(transparent)]
 ///     pub struct StrWrap(str);
-///     impl ZeroFrom<&str> for &StrWrap;
+///     impl StrWrap {
+///         fn zero_from_transparent_ref(&str) -> &Self;
+///     }
 /// );
+///
+/// impl<'zf> ZeroFrom<'zf, str> for &'zf StrWrap {
+///     fn zero_from(other: &'zf str) -> &'zf StrWrap {
+///         StrWrap::zero_from_transparent_ref(other)
+///     }
+/// }
 ///
 /// let s = "hello";
 /// let wrap = <&StrWrap>::zero_from(s);
@@ -53,90 +85,66 @@ macro_rules! transparent {
 		$(#[$meta:meta])*
 		$vis:vis struct $outer:ident($inner:ty);
 		$(
-			impl ZeroFrom<&$inner_zf:ty> for &$outer_zf:ident;
-		)?
-		$(impl {
-			$(
-				@ref
-				$(#[$meta_ref:meta])*
-				$vis_ref:vis fn $fn_ref:ident(&$inner_ref:ty) -> &Self;
-			)?
-			$(
-				@slice
-				$(#[$meta_slice:meta])*
-				$vis_slice:vis fn $fn_slice:ident(&[$inner_slice:ty]) -> &[Self];
-			)?
-			$(
-				@box
-				$(#[$meta_box:meta])*
-				$vis_box:vis fn $fn_box:ident(Box<$inner_box:ty>) -> Box<Self>;
-			)?
-			$(
-				@rc
-				$(#[$meta_rc:meta])*
-				$vis_rc:vis fn $fn_rc:ident(Rc<$inner_rc:ty>) -> Rc<Self>;
-			)?
-		})?
+			$(#[$meta_impl:meta])*
+			impl $outer_impl:ident {
+				$(
+					fn zero_from_transparent_ref(&$inner_ref:ty) -> &Self;
+				)?
+				$(
+					fn zero_from_transparent_slice(&[$inner_slice:ty]) -> &[Self];
+				)?
+				$(
+					fn zero_from_transparent_box(Box<$inner_box:ty>) -> Box<Self>;
+				)?
+				$(
+					fn zero_from_transparent_rc(Rc<$inner_rc:ty>) -> Rc<Self>;
+				)?
+			}
+		)+
 	) => {
 		#[repr(transparent)]
 		$(#[$meta])*
 		$vis struct $outer($inner);
 		$(
-			impl<'zf> $crate::ZeroFrom<'zf, $inner_zf> for &'zf $outer {
-				fn zero_from(inner: &'zf $inner) -> Self {
-					unsafe { core::mem::transmute::<&$inner, &$outer>(inner) }
-				}
+			impl $outer {
+				$(
+					fn zero_from_transparent_ref(inner: &$inner_ref) -> &$outer_impl {
+						// Safety: $outer is repr(transparent) over $inner.
+						unsafe { core::mem::transmute::<&$inner, &$outer>(inner) }
+					}
+				)?
+				$(
+					fn zero_from_transparent_slice(inner: &[$inner_slice]) -> &[$outer_impl] {
+						// Safety: $outer is repr(transparent) over $inner.
+						unsafe { core::mem::transmute::<&[$inner], &[$outer]>(inner) }
+					}
+				)?
+				$(
+					fn zero_from_transparent_box(inner: $crate::internal::Box<$inner_box>) -> $crate::internal::Box<$outer_impl> {
+						// Safety: $outer is repr(transparent) over $inner.
+						unsafe { $crate::internal::cast_transparent_box::<$inner, $outer>(inner) }
+					}
+				)?
+				$(
+					fn zero_from_transparent_rc(inner: $crate::internal::Rc<$inner_rc>) -> $crate::internal::Rc<$outer_impl> {
+						// Safety: $outer is repr(transparent) over $inner.
+						unsafe { $crate::internal::cast_transparent_rc::<$inner, $outer>(inner) }
+					}
+				)?
 			}
-		)?
-		$(impl $outer {
-			$(
-				$(#[$meta_ref])*
-				$vis_ref fn $fn_ref(inner: &$inner_ref) -> &Self {
-					unsafe { core::mem::transmute::<&$inner, &$outer>(inner) }
-				}
-			)?
-			$(
-				$(#[$meta_slice])*
-				$vis_slice fn $fn_slice(inner: &[$inner_slice]) -> &[Self] {
-					unsafe { core::mem::transmute::<&[$inner], &[$outer]>(inner) }
-				}
-			)?
-			$(
-				$(#[$meta_box])*
-				$vis_box fn $fn_box(inner: $crate::internal::Box<$inner_box>) -> $crate::internal::Box<Self> {
-					// Safety: $outer is repr(transparent) over $inner.
-					unsafe { $crate::internal::cast_transparent_box::<$inner, $outer>(inner) }
-				}
-			)?
-			$(
-				$(#[$meta_rc])*
-				$vis_rc fn $fn_rc(inner: $crate::internal::Rc<$inner_rc>) -> $crate::internal::Rc<Self> {
-					unsafe { core::mem::transmute(inner) }
-				}
-			)?
-		})?
+		)+
 	};
 }
 
 /// Additional tests for failure modes.
 ///
-/// ```compile_fail,E0053
-/// zerofrom::transparent! {
-///     #[repr(transparent)]
-///     pub struct Foo(String);
-///     // Wrong types in these positions!
-///     impl ZeroFrom<&Foo> for &String;
-/// };
-/// ```
-///
 /// ```compile_fail,E0308
 /// zerofrom::transparent! {
 ///     #[repr(transparent)]
 ///     pub struct Foo(String);
-///     impl {
-///         @ref
-///         // Wrong type in this position!
-///         pub fn from(&Foo) -> &Self;
+///     impl Foo {
+///         // should be &String
+///         fn zero_from_transparent_ref(&Foo) -> &Self;
 ///     }
 /// };
 /// ```
@@ -145,10 +153,31 @@ macro_rules! transparent {
 /// zerofrom::transparent! {
 ///     #[repr(transparent)]
 ///     pub struct Foo(String);
-///     impl {
-///         @slice
-///         // Wrong type in this position!
-///         pub fn from(&[Foo]) -> &[Self];
+///     impl Foo {
+///         // should be &[String]
+///         fn zero_from_transparent_slice(&[Foo]) -> &[Self];
+///     }
+/// };
+/// ```
+///
+/// ```compile_fail,E0308
+/// zerofrom::transparent! {
+///     #[repr(transparent)]
+///     pub struct Foo(String);
+///     // should be Foo
+///     impl String {
+///         fn zero_from_transparent_slice(&[String]) -> &[Self];
+///     }
+/// };
+/// ```
+///
+/// ```compile_fail,E0277
+/// // Can't cast a slice of DSTs
+/// zerofrom::transparent! {
+///     #[repr(transparent)]
+///     pub struct DST(str);
+///     impl DST {
+///         fn zero_from_transparent_slice(&[str]) -> &[Self];
 ///     }
 /// };
 /// ```

--- a/utils/zerofrom/tests/test_transparent.rs
+++ b/utils/zerofrom/tests/test_transparent.rs
@@ -1,0 +1,29 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use zerofrom::transparent;
+
+transparent!(
+    #[repr(transparent)]
+    /// hello world
+    #[derive(Debug)]
+    pub(crate) struct Foo([u8; 3]);
+    impl ZeroFrom<&[u8; 3]> for &Foo;
+    impl {
+        @ref
+        /// Cast a transparent ref!
+        #[inline]
+        fn from_transparent_ref(&[u8; 3]) -> &Self;
+        @slice
+        /// Cast a transparent slice!
+        pub fn from_transparent_slice(&[[u8; 3]]) -> &[Self];
+        @box
+        /// Cast a transparent box!
+        #[cfg(feature = "alloc")]
+        fn from_transparent_box(Box<[u8; 3]>) -> Box<Self>;
+    }
+);
+
+#[test]
+fn test() {}

--- a/utils/zerofrom/tests/test_transparent.rs
+++ b/utils/zerofrom/tests/test_transparent.rs
@@ -9,19 +9,38 @@ transparent!(
     /// hello world
     #[derive(Debug)]
     pub(crate) struct Foo([u8; 3]);
-    impl ZeroFrom<&[u8; 3]> for &Foo;
-    impl {
-        @ref
-        /// Cast a transparent ref!
-        #[inline]
-        fn from_transparent_ref(&[u8; 3]) -> &Self;
-        @slice
-        /// Cast a transparent slice!
-        pub fn from_transparent_slice(&[[u8; 3]]) -> &[Self];
-        @box
-        /// Cast a transparent box!
-        #[cfg(feature = "alloc")]
-        fn from_transparent_box(Box<[u8; 3]>) -> Box<Self>;
+    impl Foo {
+        fn zero_from_transparent_ref(&[u8; 3]) -> &Self;
+        fn zero_from_transparent_slice(&[[u8; 3]]) -> &[Self];
+    }
+    #[cfg(feature = "alloc")]
+    impl Foo {
+        fn zero_from_transparent_box(Box<[u8; 3]>) -> Box<Self>;
+    }
+);
+
+// Check more permutations:
+
+transparent!(
+    #[repr(transparent)]
+    pub(crate) struct NoFns(str);
+    impl NoFns {
+    }
+);
+
+transparent!(
+    #[repr(transparent)]
+    pub(crate) struct Ref(str);
+    impl Ref {
+        fn zero_from_transparent_ref(&str) -> &Self;
+    }
+);
+
+transparent!(
+    #[repr(transparent)]
+    pub(crate) struct Slice(u32);
+    impl Slice {
+        fn zero_from_transparent_slice(&[u32]) -> &[Self];
     }
 );
 

--- a/utils/zerofrom/tests/test_transparent.rs
+++ b/utils/zerofrom/tests/test_transparent.rs
@@ -44,5 +44,14 @@ transparent!(
     }
 );
 
+// TODO: This should compile but it doesn't
+// transparent!(
+//     #[repr(transparent)]
+//     pub(crate) struct Box(str);
+//     impl Box {
+//         fn zero_from_transparent_box(Box<str>) -> Box<Self>;
+//     }
+// );
+
 #[test]
 fn test() {}


### PR DESCRIPTION
Latest attempt at #7607

Looking for feedback on the general approach, and then on the concrete implementation.

## Changelog

zerofrom: Adds macro to derive ZeroFrom and concrete functions for repr(transparent) conversions
- New macro: `zerofrom::transparent!`