### PR TITLE
feat: Add currency display options to CurrencyFormatter (#7785)

### DIFF
--- a/components/experimental/src/dimension/currency/format.rs
+++ b/components/experimental/src/dimension/currency/format.rs
@@ -5,11 +5,13 @@
 // TODO: add more tests for this module to cover more locales & currencies.
 #[cfg(test)]
 mod tests {
+    use crate::dimension::currency::{
+        formatter::CurrencyFormatter, options::CurrencyDisplay, options::CurrencyFormatterOptions,
+        CurrencyCode,
+    };
     use icu_locale_core::locale;
     use tinystr::*;
     use writeable::assert_writeable_eq;
-
-    use crate::dimension::currency::{formatter::CurrencyFormatter, CurrencyCode};
 
     #[test]
     pub fn test_en_us() {
@@ -65,5 +67,83 @@ mod tests {
             formatted_currency,
             "\u{61c}-\u{200f}١٢٬٣٤٥٫٦٧\u{a0}ج.م.\u{200f}"
         );
+    }
+
+    #[test]
+    #[should_panic] // TODO(#7785): implement currencyDisplay
+    pub fn test_currency_display_code_en_us() {
+        let locale = locale!("en-US").into();
+        let currency_code = CurrencyCode(tinystr!(3, "USD"));
+        let fmt = CurrencyFormatter::try_new(
+            locale,
+            CurrencyFormatterOptions {
+                currency_display: CurrencyDisplay::Code,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let value = "12345.67".parse().unwrap();
+        let formatted_currency = fmt.format_fixed_decimal(&value, &currency_code);
+
+        assert_writeable_eq!(formatted_currency, "USD 12,345.67");
+    }
+
+    #[test]
+    pub fn test_currency_display_symbol_en_us() {
+        let locale = locale!("en-US").into();
+        let currency_code = CurrencyCode(tinystr!(3, "USD"));
+        let fmt = CurrencyFormatter::try_new(
+            locale,
+            CurrencyFormatterOptions {
+                currency_display: CurrencyDisplay::Symbol,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let value = "12345.67".parse().unwrap();
+        let formatted_currency = fmt.format_fixed_decimal(&value, &currency_code);
+
+        assert_writeable_eq!(formatted_currency, "$12,345.67");
+    }
+
+    #[test]
+    pub fn test_currency_display_narrow_symbol_en_us() {
+        let locale = locale!("en-US").into();
+        let currency_code = CurrencyCode(tinystr!(3, "USD"));
+        let fmt = CurrencyFormatter::try_new(
+            locale,
+            CurrencyFormatterOptions {
+                currency_display: CurrencyDisplay::NarrowSymbol,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let value = "12345.67".parse().unwrap();
+        let formatted_currency = fmt.format_fixed_decimal(&value, &currency_code);
+
+        assert_writeable_eq!(formatted_currency, "$12,345.67");
+    }
+
+    #[test]
+    #[should_panic] // TODO(#7785): implement currencyDisplay
+    pub fn test_currency_display_name_en_us() {
+        let locale = locale!("en-US").into();
+        let currency_code = CurrencyCode(tinystr!(3, "USD"));
+        let fmt = CurrencyFormatter::try_new(
+            locale,
+            CurrencyFormatterOptions {
+                currency_display: CurrencyDisplay::Name,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let value = "12345.67".parse().unwrap();
+        let formatted_currency = fmt.format_fixed_decimal(&value, &currency_code);
+
+        assert_writeable_eq!(formatted_currency, "12,345.67 US dollars");
     }
 }

--- a/components/experimental/src/dimension/currency/options.rs
+++ b/components/experimental/src/dimension/currency/options.rs
@@ -15,12 +15,46 @@ use serde::{Deserialize, Serialize};
 pub struct CurrencyFormatterOptions {
     /// The width of the currency format.
     pub width: Width,
+
+    /// The display style for currencies.
+    /// Default is [`CurrencyDisplay::Symbol`].
+    pub currency_display: CurrencyDisplay,
 }
 
 impl From<Width> for CurrencyFormatterOptions {
     fn from(width: Width) -> Self {
-        Self { width }
+        Self {
+            width,
+            currency_display: CurrencyDisplay::default(),
+        }
     }
+}
+
+impl From<CurrencyDisplay> for CurrencyFormatterOptions {
+    fn from(currency_display: CurrencyDisplay) -> Self {
+        Self {
+            width: Width::default(),
+            currency_display,
+        }
+    }
+}
+
+#[derive(Default, Debug, Eq, PartialEq, Clone, Copy, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub enum CurrencyDisplay {
+    /// Display with the default currency symbol.
+    #[default]
+    Symbol,
+
+    /// Display with the narrow currency symbol.
+    NarrowSymbol,
+
+    /// Display with the ISO currency code.
+    Code,
+
+    /// Display with the localized currency name.
+    Name,
 }
 
 #[derive(Default, Debug, Eq, PartialEq, Clone, Copy, Hash)]


### PR DESCRIPTION
Enhance the CurrencyFormatterOptions struct to include a `currency_display` field, allowing for different display styles (Symbol, NarrowSymbol, Code, Name). 

Implement tests for each display style in the format module and adding todo to implement these test cases.

## Changelog

icu_experimental/currency: Add options for selecting currency format style
- New enum: `CurrencyDisplay`
- New field `CurrencyFormatterOptions::currency_display`
- New impl: `impl From<CurrencyDisplay> for CurrencyFormatterOptions`