### PR TITLE
Add APIs and tests for currency sign options to CurrencyFormatter

### DIFF
--- a/components/experimental/src/dimension/currency/format.rs
+++ b/components/experimental/src/dimension/currency/format.rs
@@ -9,7 +9,10 @@ mod tests {
     use tinystr::*;
     use writeable::assert_writeable_eq;
 
-    use crate::dimension::currency::{formatter::CurrencyFormatter, CurrencyCode};
+    use crate::dimension::currency::{
+        formatter::CurrencyFormatter, options::CurrencyFormatterOptions, options::CurrencySign,
+        CurrencyCode,
+    };
 
     #[test]
     pub fn test_en_us() {
@@ -65,5 +68,26 @@ mod tests {
             formatted_currency,
             "\u{61c}-\u{200f}١٢٬٣٤٥٫٦٧\u{a0}ج.م.\u{200f}"
         );
+    }
+
+    #[test]
+    #[should_panic] // TODO(#7786): implement currencySign option
+    pub fn test_en_us_accounting() {
+        let locale = locale!("en-US").into();
+        let currency_code = CurrencyCode(tinystr!(3, "USD"));
+
+        let options = CurrencyFormatterOptions::from(CurrencySign::Accounting);
+
+        let fmt = CurrencyFormatter::try_new(locale, options).unwrap();
+
+        // Positive case (should remain unchanged)
+        let positive_value = "12345.67".parse().unwrap();
+        let formatted_currency = fmt.format_fixed_decimal(&positive_value, &currency_code);
+        assert_writeable_eq!(formatted_currency, "$12,345.67");
+
+        // Negative case (accounting style → parentheses)
+        let negative_value = "-12345.67".parse().unwrap();
+        let formatted_currency = fmt.format_fixed_decimal(&negative_value, &currency_code);
+        assert_writeable_eq!(formatted_currency, "($12,345.67)");
     }
 }

--- a/components/experimental/src/dimension/currency/options.rs
+++ b/components/experimental/src/dimension/currency/options.rs
@@ -15,11 +15,27 @@ use serde::{Deserialize, Serialize};
 pub struct CurrencyFormatterOptions {
     /// The width of the currency format.
     pub width: Width,
+
+    /// The sign style for negative currency values.
+    /// Default is [`CurrencySign::Standard`].
+    pub currency_sign: CurrencySign,
 }
 
 impl From<Width> for CurrencyFormatterOptions {
     fn from(width: Width) -> Self {
-        Self { width }
+        Self {
+            width,
+            currency_sign: CurrencySign::default(),
+        }
+    }
+}
+
+impl From<CurrencySign> for CurrencyFormatterOptions {
+    fn from(currency_sign: CurrencySign) -> Self {
+        Self {
+            width: Width::default(),
+            currency_sign,
+        }
     }
 }
 
@@ -42,4 +58,34 @@ pub enum Width {
     /// For example, 1 USD formats as "$1.00" in most locales.
     #[cfg_attr(feature = "serde", serde(rename = "narrow"))]
     Narrow,
+}
+
+/// Controls how negative currency values are rendered.
+///
+/// This corresponds to ECMA-402 `Intl.NumberFormat`'s `currencySign` option.
+///
+/// - [`CurrencySign::Standard`] uses the locale's standard currency pattern for
+///   negative values, typically with a minus sign, for example `-$1,234.56`.
+/// - [`CurrencySign::Accounting`] uses the locale's accounting currency pattern
+///   for negative values, which in many locales is displayed with parentheses,
+///   for example `($1,234.56)`.
+///
+/// This option only affects currency formatting. Positive values are typically
+/// formatted the same for both variants unless the locale data specifies
+/// otherwise.
+///
+/// See also:
+/// - ECMA-402 `currencySign`
+/// - CLDR `currencyFormats.standard`
+/// - CLDR `currencyFormats.accounting`
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub enum CurrencySign {
+    /// Use the locale's standard currency pattern.
+    #[default]
+    Standard,
+
+    /// Use the locale's accounting currency pattern.
+    Accounting,
 }


### PR DESCRIPTION
## Summary

- Introduced `CurrencySign` enum to control formatting of negative currency values, supporting both standard and accounting styles.
- Updated `CurrencyFormatterOptions` to include a `currency_sign` field, defaulting to `Standard`.
- Added tests for accounting style formatting in `test_en_us_accounting` to implement the new behaviour in the next PR

## Changelog

icu_experimental/currency: Add options for accounting currency sign
- New enum: `CurrencySign`
- New field `CurrencyFormatterOptions::currency_sign`
- New impl: `impl From<CurrencySign> for CurrencyFormatterOptions`