### PR TITLE
Graduate Date::try_from_fields and date arithmetic APIs

### DIFF
--- a/components/calendar/src/any_calendar.rs
+++ b/components/calendar/src/any_calendar.rs
@@ -21,8 +21,6 @@ macro_rules! make_any_calendar {
         $(#[$any_date_meta:meta])*
         $any_date_ident:ident,
 
-        #[$unstable_cfg:meta],
-
         $(
             $(#[$variant_meta:meta])*
             $variant:ident($ty:ty),
@@ -82,7 +80,6 @@ macro_rules! make_any_calendar {
                 })
             }
 
-            #[$unstable_cfg]
             fn from_fields(
                 &self,
                 fields: $crate::types::DateFields,
@@ -223,7 +220,6 @@ macro_rules! make_any_calendar {
                 }
             }
 
-            #[$unstable_cfg]
             fn add(
                 &self,
                 date: &Self::DateInner,
@@ -243,7 +239,6 @@ macro_rules! make_any_calendar {
                 Ok(date)
             }
 
-            #[$unstable_cfg]
             fn until(
                 &self,
                 date1: &Self::DateInner,
@@ -391,7 +386,6 @@ make_any_calendar!(
 
     #[non_exhaustive]
     AnyDateInner,
-    #[cfg(feature = "unstable")],
 
     Buddhist(Buddhist),
     Chinese(ChineseTraditional),

--- a/components/calendar/src/cal/abstract_gregorian.rs
+++ b/components/calendar/src/cal/abstract_gregorian.rs
@@ -96,7 +96,6 @@ impl<Y: GregorianYears> Calendar for AbstractGregorian<Y> {
             .map(ArithmeticDate::cast)
     }
 
-    #[cfg(feature = "unstable")]
     fn from_fields(
         &self,
         fields: types::DateFields,
@@ -142,7 +141,6 @@ impl<Y: GregorianYears> Calendar for AbstractGregorian<Y> {
         AbstractGregorian::<IsoEra>::days_in_provided_month(date.year(), date.month())
     }
 
-    #[cfg(feature = "unstable")]
     fn add(
         &self,
         date: &Self::DateInner,
@@ -152,7 +150,6 @@ impl<Y: GregorianYears> Calendar for AbstractGregorian<Y> {
         date.added(duration, &AbstractGregorian(IsoEra), options)
     }
 
-    #[cfg(feature = "unstable")]
     fn until(
         &self,
         date1: &Self::DateInner,
@@ -231,7 +228,6 @@ macro_rules! impl_with_abstract_gregorian {
                     .map($inner_date_ty)
             }
 
-            #[cfg(feature = "unstable")]
             fn from_fields(
                 &self,
                 fields: crate::types::DateFields,
@@ -289,7 +285,6 @@ macro_rules! impl_with_abstract_gregorian {
                 crate::cal::abstract_gregorian::AbstractGregorian($eras_expr).days_in_month(&date.0)
             }
 
-            #[cfg(feature = "unstable")]
             fn add(
                 &self,
                 date: &Self::DateInner,
@@ -302,7 +297,6 @@ macro_rules! impl_with_abstract_gregorian {
                     .map($inner_date_ty)
             }
 
-            #[cfg(feature = "unstable")]
             fn until(
                 &self,
                 date1: &Self::DateInner,

--- a/components/calendar/src/cal/coptic.rs
+++ b/components/calendar/src/cal/coptic.rs
@@ -140,7 +140,6 @@ impl Calendar for Coptic {
         ArithmeticDate::from_input_year_month_code_day(year, month, day, self).map(CopticDateInner)
     }
 
-    #[cfg(feature = "unstable")]
     fn from_fields(
         &self,
         fields: types::DateFields,
@@ -182,7 +181,6 @@ impl Calendar for Coptic {
         Self::days_in_provided_month(date.0.year(), date.0.month())
     }
 
-    #[cfg(feature = "unstable")]
     fn add(
         &self,
         date: &Self::DateInner,
@@ -192,7 +190,6 @@ impl Calendar for Coptic {
         date.0.added(duration, self, options).map(CopticDateInner)
     }
 
-    #[cfg(feature = "unstable")]
     fn until(
         &self,
         date1: &Self::DateInner,

--- a/components/calendar/src/cal/east_asian_traditional.rs
+++ b/components/calendar/src/cal/east_asian_traditional.rs
@@ -707,7 +707,6 @@ impl<R: Rules> Calendar for EastAsianTraditional<R> {
         ArithmeticDate::from_input_year_month_code_day(year, month, day, self).map(ChineseDateInner)
     }
 
-    #[cfg(feature = "unstable")]
     fn from_fields(
         &self,
         fields: types::DateFields,
@@ -749,7 +748,6 @@ impl<R: Rules> Calendar for EastAsianTraditional<R> {
         Self::days_in_provided_month(date.0.year(), date.0.month())
     }
 
-    #[cfg(feature = "unstable")]
     fn add(
         &self,
         date: &Self::DateInner,
@@ -759,7 +757,6 @@ impl<R: Rules> Calendar for EastAsianTraditional<R> {
         date.0.added(duration, self, options).map(ChineseDateInner)
     }
 
-    #[cfg(feature = "unstable")]
     fn until(
         &self,
         date1: &Self::DateInner,

--- a/components/calendar/src/cal/ethiopian.rs
+++ b/components/calendar/src/cal/ethiopian.rs
@@ -157,7 +157,6 @@ impl Calendar for Ethiopian {
             .map(EthiopianDateInner)
     }
 
-    #[cfg(feature = "unstable")]
     fn from_fields(
         &self,
         fields: DateFields,
@@ -193,7 +192,6 @@ impl Calendar for Ethiopian {
         Coptic.days_in_month(&date.0)
     }
 
-    #[cfg(feature = "unstable")]
     fn add(
         &self,
         date: &Self::DateInner,
@@ -205,7 +203,6 @@ impl Calendar for Ethiopian {
             .map(EthiopianDateInner)
     }
 
-    #[cfg(feature = "unstable")]
     fn until(
         &self,
         date1: &Self::DateInner,

--- a/components/calendar/src/cal/hebrew.rs
+++ b/components/calendar/src/cal/hebrew.rs
@@ -266,7 +266,6 @@ impl Calendar for Hebrew {
         ArithmeticDate::from_input_year_month_code_day(year, month, day, self).map(HebrewDateInner)
     }
 
-    #[cfg(feature = "unstable")]
     fn from_fields(
         &self,
         fields: DateFields,
@@ -312,7 +311,6 @@ impl Calendar for Hebrew {
         Self::days_in_provided_month(date.0.year(), date.0.month())
     }
 
-    #[cfg(feature = "unstable")]
     fn add(
         &self,
         date: &Self::DateInner,
@@ -322,7 +320,6 @@ impl Calendar for Hebrew {
         date.0.added(duration, self, options).map(HebrewDateInner)
     }
 
-    #[cfg(feature = "unstable")]
     fn until(
         &self,
         date1: &Self::DateInner,

--- a/components/calendar/src/cal/hijri.rs
+++ b/components/calendar/src/cal/hijri.rs
@@ -927,7 +927,6 @@ impl<R: Rules> Calendar for Hijri<R> {
         ArithmeticDate::from_input_year_month_code_day(year, month, day, self).map(HijriDateInner)
     }
 
-    #[cfg(feature = "unstable")]
     fn from_fields(
         &self,
         fields: DateFields,
@@ -965,7 +964,6 @@ impl<R: Rules> Calendar for Hijri<R> {
         Self::days_in_provided_month(date.0.year(), date.0.month())
     }
 
-    #[cfg(feature = "unstable")]
     fn add(
         &self,
         date: &Self::DateInner,
@@ -975,7 +973,6 @@ impl<R: Rules> Calendar for Hijri<R> {
         date.0.added(duration, self, options).map(HijriDateInner)
     }
 
-    #[cfg(feature = "unstable")]
     fn until(
         &self,
         date1: &Self::DateInner,

--- a/components/calendar/src/cal/indian.rs
+++ b/components/calendar/src/cal/indian.rs
@@ -141,7 +141,6 @@ impl Calendar for Indian {
         ArithmeticDate::from_input_year_month_code_day(year, month, day, self).map(IndianDateInner)
     }
 
-    #[cfg(feature = "unstable")]
     fn from_fields(
         &self,
         fields: DateFields,
@@ -217,7 +216,6 @@ impl Calendar for Indian {
         Self::days_in_provided_month(date.0.year(), date.0.month())
     }
 
-    #[cfg(feature = "unstable")]
     fn add(
         &self,
         date: &Self::DateInner,
@@ -227,7 +225,6 @@ impl Calendar for Indian {
         date.0.added(duration, self, options).map(IndianDateInner)
     }
 
-    #[cfg(feature = "unstable")]
     fn until(
         &self,
         date1: &Self::DateInner,

--- a/components/calendar/src/cal/julian.rs
+++ b/components/calendar/src/cal/julian.rs
@@ -149,7 +149,6 @@ impl Calendar for Julian {
         ArithmeticDate::from_input_year_month_code_day(year, month, day, self).map(JulianDateInner)
     }
 
-    #[cfg(feature = "unstable")]
     fn from_fields(
         &self,
         fields: DateFields,
@@ -187,7 +186,6 @@ impl Calendar for Julian {
         Self::days_in_provided_month(date.0.year(), date.0.month())
     }
 
-    #[cfg(feature = "unstable")]
     fn add(
         &self,
         date: &Self::DateInner,
@@ -197,7 +195,6 @@ impl Calendar for Julian {
         date.0.added(duration, self, options).map(JulianDateInner)
     }
 
-    #[cfg(feature = "unstable")]
     fn until(
         &self,
         date1: &Self::DateInner,

--- a/components/calendar/src/cal/persian.rs
+++ b/components/calendar/src/cal/persian.rs
@@ -120,7 +120,6 @@ impl Calendar for Persian {
         ArithmeticDate::from_input_year_month_code_day(year, month, day, self).map(PersianDateInner)
     }
 
-    #[cfg(feature = "unstable")]
     fn from_fields(
         &self,
         fields: DateFields,
@@ -162,7 +161,6 @@ impl Calendar for Persian {
         Self::days_in_provided_month(date.0.year(), date.0.month())
     }
 
-    #[cfg(feature = "unstable")]
     fn add(
         &self,
         date: &Self::DateInner,
@@ -172,7 +170,6 @@ impl Calendar for Persian {
         date.0.added(duration, self, options).map(PersianDateInner)
     }
 
-    #[cfg(feature = "unstable")]
     fn until(
         &self,
         date1: &Self::DateInner,

--- a/components/calendar/src/calendar.rs
+++ b/components/calendar/src/calendar.rs
@@ -103,17 +103,7 @@ pub trait Calendar: crate::cal::scaffold::UnstableSealed {
     ) -> Result<Self::DateInner, DateNewError>;
 
     /// Construct a date from a bag of date fields.
-    ///
-    /// <div class="stab unstable">
-    /// 🚧 This code is considered unstable; it may change at any time, in breaking or non-breaking ways,
-    /// including in SemVer minor releases. Do not use this type unless you are prepared for things to occasionally break.
-    ///
-    /// Graduation tracking issue: [issue #7161](https://github.com/unicode-org/icu4x/issues/7161).
-    /// </div>
-    ///
-    /// ✨ *Enabled with the `unstable` Cargo feature.*
     #[expect(clippy::wrong_self_convention)]
-    #[cfg(feature = "unstable")]
     fn from_fields(
         &self,
         fields: types::DateFields,
@@ -177,16 +167,6 @@ pub trait Calendar: crate::cal::scaffold::UnstableSealed {
     fn day_of_year(&self, date: &Self::DateInner) -> types::DayOfYear;
 
     /// Add `duration` to `date`
-    ///
-    /// <div class="stab unstable">
-    /// 🚧 This code is considered unstable; it may change at any time, in breaking or non-breaking ways,
-    /// including in SemVer minor releases. Do not use this type unless you are prepared for things to occasionally break.
-    ///
-    /// Graduation tracking issue: [issue #3964](https://github.com/unicode-org/icu4x/issues/3964).
-    /// </div>
-    ///
-    /// ✨ *Enabled with the `unstable` Cargo feature.*
-    #[cfg(feature = "unstable")]
     fn add(
         &self,
         date: &Self::DateInner,
@@ -197,16 +177,6 @@ pub trait Calendar: crate::cal::scaffold::UnstableSealed {
     /// Calculate `date2 - date` as a duration.
     ///
     /// This requires the associated calendars to have passed [`Self::check_date_compatibility`].
-    ///
-    /// <div class="stab unstable">
-    /// 🚧 This code is considered unstable; it may change at any time, in breaking or non-breaking ways,
-    /// including in SemVer minor releases. Do not use this type unless you are prepared for things to occasionally break.
-    ///
-    /// Graduation tracking issue: [issue #3964](https://github.com/unicode-org/icu4x/issues/3964).
-    /// </div>
-    ///
-    /// ✨ *Enabled with the `unstable` Cargo feature.*
-    #[cfg(feature = "unstable")]
     fn until(
         &self,
         date1: &Self::DateInner,

--- a/components/calendar/src/date.rs
+++ b/components/calendar/src/date.rs
@@ -222,16 +222,6 @@ impl<A: AsCalendar> Date<A> {
     /// ```
     ///
     /// See [`DateFromFieldsError`] for examples of error conditions.
-    ///
-    /// <div class="stab unstable">
-    /// 🚧 This code is considered unstable; it may change at any time, in breaking or non-breaking ways,
-    /// including in SemVer minor releases. Do not use this type unless you are prepared for things to occasionally break.
-    ///
-    /// Graduation tracking issue: [issue #7161](https://github.com/unicode-org/icu4x/issues/7161).
-    /// </div>
-    ///
-    /// ✨ *Enabled with the `unstable` Cargo feature.*
-    #[cfg(feature = "unstable")]
     #[inline]
     pub fn try_from_fields(
         fields: types::DateFields,
@@ -375,16 +365,6 @@ impl<A: AsCalendar> Date<A> {
     ///
     /// This API will not construct dates outside of the fundamental range described on the [`Date`] type,
     /// instead returning [`DateAddError::Overflow`].
-    ///
-    /// <div class="stab unstable">
-    /// 🚧 This code is considered unstable; it may change at any time, in breaking or non-breaking ways,
-    /// including in SemVer minor releases. Do not use this type unless you are prepared for things to occasionally break.
-    ///
-    /// Graduation tracking issue: [issue #3964](https://github.com/unicode-org/icu4x/issues/3964).
-    /// </div>
-    ///
-    /// ✨ *Enabled with the `unstable` Cargo feature.*
-    #[cfg(feature = "unstable")]
     #[inline]
     pub fn try_add_with_options(
         &mut self,
@@ -403,16 +383,6 @@ impl<A: AsCalendar> Date<A> {
     ///
     /// This API will not construct dates outside of the fundamental range described on the [`Date`] type,
     /// instead returning [`DateAddError::Overflow`].
-    ///
-    /// <div class="stab unstable">
-    /// 🚧 This code is considered unstable; it may change at any time, in breaking or non-breaking ways,
-    /// including in SemVer minor releases. Do not use this type unless you are prepared for things to occasionally break.
-    ///
-    /// Graduation tracking issue: [issue #3964](https://github.com/unicode-org/icu4x/issues/3964).
-    /// </div>
-    ///
-    /// ✨ *Enabled with the `unstable` Cargo feature.*
-    #[cfg(feature = "unstable")]
     #[inline]
     pub fn try_added_with_options(
         mut self,
@@ -473,16 +443,6 @@ impl<A: AsCalendar> Date<A> {
     ///
     /// [`Infallible`]: core::convert::Infallible
     /// [pattern matching]: https://doc.rust-lang.org/book/ch19-03-pattern-syntax.html
-    ///
-    /// <div class="stab unstable">
-    /// 🚧 This code is considered unstable; it may change at any time, in breaking or non-breaking ways,
-    /// including in SemVer minor releases. Do not use this type unless you are prepared for things to occasionally break.
-    ///
-    /// Graduation tracking issue: [issue #3964](https://github.com/unicode-org/icu4x/issues/3964).
-    /// </div>
-    ///
-    /// ✨ *Enabled with the `unstable` Cargo feature.*
-    #[cfg(feature = "unstable")]
     #[inline]
     pub fn try_until_with_options<B: AsCalendar<Calendar = A::Calendar>>(
         &self,

--- a/components/calendar/src/duration.rs
+++ b/components/calendar/src/duration.rs
@@ -101,17 +101,6 @@ use crate::error::DateDurationParseError;
 /// assert_eq!(mutated_date_iso.month().ordinal, 11);
 /// assert_eq!(mutated_date_iso.day_of_month().0, 27);
 /// ```
-///
-/// Currently unstable for ICU4X 1.0
-///
-/// <div class="stab unstable">
-/// 🚧 This code is considered unstable; it may change at any time, in breaking or non-breaking ways,
-/// including in SemVer minor releases. Do not use this type unless you are prepared for things to occasionally break.
-///
-/// Graduation tracking issue: [issue #3964](https://github.com/unicode-org/icu4x/issues/3964).
-/// </div>
-///
-/// ✨ *Enabled with the `unstable` Cargo feature.*
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Default)]
 #[allow(clippy::exhaustive_structs)] // spec-defined in Temporal
 pub struct DateDuration {

--- a/components/calendar/src/error.rs
+++ b/components/calendar/src/error.rs
@@ -143,488 +143,450 @@ pub enum LunisolarDateError {
 
 impl core::error::Error for LunisolarDateError {}
 
-#[cfg(feature = "unstable")]
-pub use unstable::{DateAddError, DateFromFieldsError, MismatchedCalendarError};
-#[cfg(not(feature = "unstable"))]
-pub(crate) use unstable::{DateAddError, DateFromFieldsError, MismatchedCalendarError};
-
-mod unstable {
-    pub use super::*;
-
-    /// Error type for date creation via [`Date::try_from_fields`].
-    ///
-    /// [`Date::try_from_fields`]: crate::Date::try_from_fields
-    ///
-    /// <div class="stab unstable">
-    /// 🚧 This code is considered unstable; it may change at any time, in breaking or non-breaking ways,
-    /// including in SemVer minor releases. Do not use this type unless you are prepared for things to occasionally break.
-    ///
-    /// Graduation tracking issue: [issue #7161](https://github.com/unicode-org/icu4x/issues/7161).
-    /// </div>
-    ///
-    /// ✨ *Enabled with the `unstable` Cargo feature.*
-    #[derive(Debug, Copy, Clone, PartialEq, Display)]
-    #[non_exhaustive]
-    pub enum DateFromFieldsError {
-        /// The day is invalid for the given month.
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use icu::calendar::error::DateFromFieldsError;
-        /// use icu::calendar::error::RangeError;
-        /// use icu::calendar::types::DateFields;
-        /// use icu::calendar::Date;
-        /// use icu::calendar::Iso;
-        ///
-        /// let mut fields = DateFields::default();
-        /// fields.extended_year = Some(2000);
-        /// fields.ordinal_month = Some(11);
-        /// fields.day = Some(31);
-        ///
-        /// let err = Date::try_from_fields(fields, Default::default(), Iso)
-        ///     .expect_err("no day 31 in November");
-        ///
-        /// assert!(matches!(
-        ///     err,
-        ///     DateFromFieldsError::InvalidDay { max: 30 }
-        /// ));
-        /// ```
-        #[displaydoc("Invalid day for month, max is {max}")]
-        InvalidDay {
-            /// The maximum allowed value (the minimum is 1).
-            max: u8,
-        },
-        /// The ordinal month is is invalid for the given year.
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use icu::calendar::error::DateFromFieldsError;
-        /// use icu::calendar::error::RangeError;
-        /// use icu::calendar::types::DateFields;
-        /// use icu::calendar::Date;
-        /// use icu::calendar::Iso;
-        ///
-        /// let mut fields = DateFields::default();
-        /// fields.extended_year = Some(2000);
-        /// fields.ordinal_month = Some(13);
-        /// fields.day = Some(1);
-        ///
-        /// let err = Date::try_from_fields(fields, Default::default(), Iso)
-        ///     .expect_err("no month 13 in the ISO calendar");
-        ///
-        /// assert!(matches!(
-        ///     err,
-        ///     DateFromFieldsError::InvalidOrdinalMonth { max: 12 }
-        /// ));
-        /// ```
-        #[displaydoc("Invalid ordinal month for year, max is {max}")]
-        InvalidOrdinalMonth {
-            /// The maximum allowed value (the minimum is 1).
-            max: u8,
-        },
-        /// The month code syntax is invalid.
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use icu::calendar::error::DateFromFieldsError;
-        /// use icu::calendar::types::DateFields;
-        /// use icu::calendar::Date;
-        /// use icu::calendar::Iso;
-        ///
-        /// let mut fields = DateFields::default();
-        /// fields.extended_year = Some(2000);
-        /// fields.month_code = Some(b"sep");
-        /// fields.day = Some(1);
-        ///
-        /// let err = Date::try_from_fields(fields, Default::default(), Iso)
-        ///     .expect_err("month code is invalid");
-        ///
-        /// assert_eq!(err, DateFromFieldsError::MonthCodeInvalidSyntax);
-        /// ```
-        #[displaydoc("Invalid month code syntax")]
-        MonthCodeInvalidSyntax,
-        /// The specified month does not exist in this calendar.
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use icu::calendar::cal::Hebrew;
-        /// use icu::calendar::error::DateFromFieldsError;
-        /// use icu::calendar::types::{DateFields, Month};
-        /// use icu::calendar::Date;
-        ///
-        /// let mut fields = DateFields::default();
-        /// fields.extended_year = Some(5783);
-        /// fields.month = Some(Month::new(13));
-        /// fields.day = Some(1);
-        ///
-        /// let err = Date::try_from_fields(fields, Default::default(), Hebrew)
-        ///     .expect_err("no month M13 in Hebrew");
-        /// assert_eq!(err, DateFromFieldsError::MonthNotInCalendar);
-        /// ```
-        #[displaydoc("The specified month does not exist in this calendar")]
-        MonthNotInCalendar,
-        /// The specified month exists in this calendar, but not in the specified year.
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use icu::calendar::cal::Hebrew;
-        /// use icu::calendar::error::DateFromFieldsError;
-        /// use icu::calendar::types::{DateFields, Month};
-        /// use icu::calendar::Date;
-        ///
-        /// let mut fields = DateFields::default();
-        /// fields.extended_year = Some(5783);
-        /// fields.month = Some(Month::leap(5));
-        /// fields.day = Some(1);
-        ///
-        /// let err = Date::try_from_fields(fields, Default::default(), Hebrew)
-        ///     .expect_err("no month M05L in Hebrew year 5783");
-        /// assert_eq!(err, DateFromFieldsError::MonthNotInYear);
-        /// ```
-        #[displaydoc("The specified month exists in this calendar, but not for this year")]
-        MonthNotInYear,
-        /// The era code is invalid for the calendar.
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use icu::calendar::cal::Hebrew;
-        /// use icu::calendar::error::DateFromFieldsError;
-        /// use icu::calendar::types::DateFields;
-        /// use icu::calendar::Date;
-        ///
-        /// let mut fields = DateFields::default();
-        /// fields.era = Some(b"ce"); // valid in Gregorian, but not Hebrew
-        /// fields.era_year = Some(1);
-        /// fields.ordinal_month = Some(1);
-        /// fields.day = Some(1);
-        ///
-        /// let err = Date::try_from_fields(fields, Default::default(), Hebrew::new())
-        ///     .expect_err("era is unknown for Hebrew");
-        ///
-        /// assert_eq!(err, DateFromFieldsError::InvalidEra);
-        /// ```
-        #[displaydoc("Unknown era or invalid syntax")]
-        InvalidEra,
-        /// The year was specified in multiple inconsistent ways.
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use icu::calendar::cal::Japanese;
-        /// use icu::calendar::error::DateFromFieldsError;
-        /// use icu::calendar::types::DateFields;
-        /// use icu::calendar::Date;
-        ///
-        /// let mut fields = DateFields::default();
-        /// fields.era = Some(b"reiwa");
-        /// fields.era_year = Some(6);
-        /// fields.ordinal_month = Some(1);
-        /// fields.day = Some(1);
-        ///
-        /// Date::try_from_fields(fields, Default::default(), Japanese::new())
-        ///     .expect("a well-defined Japanese date");
-        ///
-        /// fields.extended_year = Some(1900);
-        ///
-        /// let err =
-        ///     Date::try_from_fields(fields, Default::default(), Japanese::new())
-        ///         .expect_err("year 1900 is not the same as 6 Reiwa");
-        ///
-        /// assert_eq!(err, DateFromFieldsError::InconsistentYear);
-        /// ```
-        #[displaydoc("Inconsistent year")]
-        InconsistentYear,
-        /// The month was specified in multiple inconsistent ways.
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use icu::calendar::cal::Hebrew;
-        /// use icu::calendar::error::DateFromFieldsError;
-        /// use icu::calendar::types::{DateFields, Month};
-        /// use icu::calendar::Date;
-        /// use tinystr::tinystr;
-        ///
-        /// let mut fields = DateFields::default();
-        /// fields.extended_year = Some(5783);
-        /// fields.month = Some(Month::new(6));
-        /// fields.ordinal_month = Some(6);
-        /// fields.day = Some(1);
-        ///
-        /// Date::try_from_fields(fields, Default::default(), Hebrew)
-        ///     .expect("a well-defined Hebrew date in a common year");
-        ///
-        /// fields.extended_year = Some(5784);
-        ///
-        /// let err = Date::try_from_fields(fields, Default::default(), Hebrew)
-        ///     .expect_err("month M06 is not the 6th month in leap year 5784");
-        ///
-        /// assert_eq!(err, DateFromFieldsError::InconsistentMonth);
-        /// ```
-        #[displaydoc("Inconsistent month")]
-        InconsistentMonth,
-        /// Too many fields were specified to form a well-defined date.
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use icu::calendar::error::DateFromFieldsError;
-        /// use icu::calendar::types::{DateFields, Month};
-        /// use icu::calendar::Date;
-        /// use icu::calendar::Iso;
-        ///
-        /// let mut fields = DateFields::default();
-        /// fields.extended_year = Some(2000);
-        /// fields.month = Some(Month::new(1));
-        /// fields.month_code = Some(b"M01");
-        /// fields.day = Some(1);
-        ///
-        /// let err = Date::try_from_fields(fields, Default::default(), Iso)
-        ///     .expect_err("cannot specify both month and month_code");
-        ///
-        /// assert_eq!(err, DateFromFieldsError::TooManyFields);
-        /// ```
-        #[displaydoc("Too many fields")]
-        TooManyFields,
-        /// Not enough fields were specified to form a well-defined date.
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use icu::calendar::cal::Hebrew;
-        /// use icu::calendar::error::DateFromFieldsError;
-        /// use icu::calendar::types::DateFields;
-        /// use icu::calendar::Date;
-        /// use tinystr::tinystr;
-        ///
-        /// let mut fields = DateFields::default();
-        ///
-        /// fields.ordinal_month = Some(3);
-        ///
-        /// let err = Date::try_from_fields(fields, Default::default(), Hebrew)
-        ///     .expect_err("need more than just an ordinal month");
-        /// assert_eq!(err, DateFromFieldsError::NotEnoughFields);
-        ///
-        /// fields.era_year = Some(5783);
-        ///
-        /// let err = Date::try_from_fields(fields, Default::default(), Hebrew)
-        ///     .expect_err("need more than an ordinal month and an era year");
-        /// assert_eq!(err, DateFromFieldsError::NotEnoughFields);
-        ///
-        /// fields.extended_year = Some(5783);
-        ///
-        /// let err = Date::try_from_fields(fields, Default::default(), Hebrew)
-        ///     .expect_err("era year still needs an era");
-        /// assert_eq!(err, DateFromFieldsError::NotEnoughFields);
-        ///
-        /// fields.era = Some(b"am");
-        ///
-        /// let date = Date::try_from_fields(fields, Default::default(), Hebrew)
-        ///     .expect_err("still missing the day");
-        /// assert_eq!(err, DateFromFieldsError::NotEnoughFields);
-        ///
-        /// fields.day = Some(1);
-        /// let date = Date::try_from_fields(fields, Default::default(), Hebrew)
-        ///     .expect("we have enough fields!");
-        /// ```
-        #[displaydoc("Not enough fields")]
-        NotEnoughFields,
-        /// The date is out of range (see docs on [`Date`](crate::Date)
-        /// for more information about `Date`'s fundamental range invariant).
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use icu::calendar::error::DateFromFieldsError;
-        /// use icu::calendar::error::RangeError;
-        /// use icu::calendar::types::DateFields;
-        /// use icu::calendar::Date;
-        /// use icu::calendar::Iso;
-        ///
-        /// let mut fields = DateFields::default();
-        /// fields.extended_year = Some(12345678);
-        /// fields.ordinal_month = Some(12);
-        /// fields.day = Some(31);
-        ///
-        /// let err = Date::try_from_fields(fields, Default::default(), Iso)
-        ///     .expect_err("date out of range");
-        ///
-        /// assert!(matches!(
-        ///     err,
-        ///     DateFromFieldsError::Overflow
-        /// ));
-        #[displaydoc("Result out of range")]
-        Overflow,
-    }
-
-    impl core::error::Error for DateFromFieldsError {}
-
-    /// Error type for date addition via [`Date::try_add_with_options`].
-    ///
-    /// [`Date::try_add_with_options`]: crate::Date::try_add_with_options
-    ///
-    /// <div class="stab unstable">
-    /// 🚧 This code is considered unstable; it may change at any time, in breaking or non-breaking ways,
-    /// including in SemVer minor releases. Do not use this type unless you are prepared for things to occasionally break.
-    ///
-    /// Graduation tracking issue: [issue #7161](https://github.com/unicode-org/icu4x/issues/7161).
-    /// </div>
-    ///
-    /// ✨ *Enabled with the `unstable` Cargo feature.*
-    #[derive(Debug, Copy, Clone, PartialEq, Display)]
-    #[non_exhaustive]
-    pub enum DateAddError {
-        /// The day is invalid for the given month.
-        ///
-        /// This is only possible with [`Overflow::Reject`](crate::options::Overflow::Reject).
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use icu::calendar::Date;
-        /// use icu::calendar::error::DateAddError;
-        /// use icu::calendar::options::{DateAddOptions, Overflow};
-        /// use icu::calendar::types::DateDuration;
-        ///
-        /// // There is a day 31 in October but not in November.
-        /// let d = Date::try_new_iso(2025, 10, 31).unwrap();
-        /// let duration = DateDuration::for_months(1);
-        ///
-        /// let mut options = DateAddOptions::default();
-        /// options.overflow = Some(Overflow::Reject);
-        ///
-        /// let err = d
-        ///     .try_added_with_options(duration, options)
-        ///     .expect_err("no day 31 in November");
-        ///
-        /// assert!(matches!(err, DateAddError::InvalidDay { max: 30 }));
-        /// ```
-        #[displaydoc("Invalid day for month, max is {max}")]
-        InvalidDay {
-            /// The maximum allowed value (the minimum is 1).
-            max: u8,
-        },
-        /// The specified month exists in this calendar, but not in the specified year.
-        ///
-        /// This is only possible with [`Overflow::Reject`](crate::options::Overflow::Reject).
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use icu::calendar::cal::Hebrew;
-        /// use icu::calendar::types::{DateDuration, Month};
-        /// use icu::calendar::Date;
-        /// use icu::calendar::error::DateAddError;
-        /// use icu::calendar::options::{DateAddOptions, Overflow};
-        ///
-        /// // Hebrew year 5784 is a leap year, 5785 is not.
-        /// // Adar I (the leap month) is month 5 in a leap year.
-        /// let d = Date::try_new_hebrew_v2(5784, Month::leap(5), 1).unwrap();
-        /// let duration = DateDuration::for_years(1);
-        ///
-        /// let mut options = DateAddOptions::default();
-        /// options.overflow = Some(Overflow::Reject);
-        ///
-        /// let err = d
-        ///     .try_added_with_options(duration, options)
-        ///     .expect_err("5785 is not a leap year");
-        ///
-        /// assert_eq!(err, DateAddError::MonthNotInYear);
-        /// ```
-        #[displaydoc("The specified month exists in this calendar, but not for this year")]
-        MonthNotInYear,
-        /// The date is out of range (see docs on [`Date`](crate::Date)
-        /// for more information about `Date`'s fundamental range invariant).
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use icu::calendar::Date;
-        /// use icu::calendar::error::DateAddError;
-        /// use icu::calendar::types::DateDuration;
-        ///
-        /// let d = Date::try_new_iso(2025, 1, 1).unwrap();
-        /// let duration = DateDuration::for_years(1_000_000);
-        ///
-        /// let err = d
-        ///     .try_added_with_options(duration, Default::default())
-        ///     .expect_err("date overflow");
-        ///
-        /// assert_eq!(err, DateAddError::Overflow);
-        /// ```
-        #[displaydoc("Result out of range")]
-        Overflow,
-    }
-
-    impl core::error::Error for DateAddError {}
-
-    /// Error returned when interacting two [`Date`](crate::Date)s with non-singleton calendars.
+/// Error type for date creation via [`Date::try_from_fields`].
+///
+/// [`Date::try_from_fields`]: crate::Date::try_from_fields
+#[derive(Debug, Copy, Clone, PartialEq, Display)]
+#[non_exhaustive]
+pub enum DateFromFieldsError {
+    /// The day is invalid for the given month.
     ///
     /// # Examples
     ///
     /// ```
-    /// use icu::calendar::error::MismatchedCalendarError;
+    /// use icu::calendar::error::DateFromFieldsError;
+    /// use icu::calendar::error::RangeError;
+    /// use icu::calendar::types::DateFields;
     /// use icu::calendar::Date;
-    /// use icu::calendar::options::DateDifferenceOptions;
-    /// use icu::calendar::options::DateDurationUnit;
+    /// use icu::calendar::Iso;
     ///
-    /// let d1 = Date::try_new_gregorian(2000, 1, 1).unwrap().to_any();
-    /// let d2 = Date::try_new_persian(1562, 1, 1).unwrap().to_any();
+    /// let mut fields = DateFields::default();
+    /// fields.extended_year = Some(2000);
+    /// fields.ordinal_month = Some(11);
+    /// fields.day = Some(31);
     ///
-    /// assert_eq!(
-    ///     d1.try_until_with_options(&d2, Default::default())
-    ///         .unwrap_err(),
-    ///     MismatchedCalendarError,
-    /// );
+    /// let err = Date::try_from_fields(fields, Default::default(), Iso)
+    ///     .expect_err("no day 31 in November");
     ///
-    /// // To compare the dates, convert them to the same calendar.
-    /// // Note that the result may differ based on the calendar used,
-    /// // e.g if comparing in months and days.
-    ///
-    /// let mut options = DateDifferenceOptions::default();
-    /// options.largest_unit = Some(DateDurationUnit::Months);
-    ///
-    /// let diff1 = d1.to_calendar(d2.calendar().clone())
-    ///     .try_until_with_options(&d2, options)
-    ///     .unwrap();
-    /// let diff2 = d1
-    ///     .try_until_with_options(&d2.to_calendar(d1.calendar().clone()),
-    ///                             options)
-    ///     .unwrap();
-    ///
-    /// assert_ne!(diff1, diff2);
+    /// assert!(matches!(
+    ///     err,
+    ///     DateFromFieldsError::InvalidDay { max: 30 }
+    /// ));
     /// ```
+    #[displaydoc("Invalid day for month, max is {max}")]
+    InvalidDay {
+        /// The maximum allowed value (the minimum is 1).
+        max: u8,
+    },
+    /// The ordinal month is is invalid for the given year.
     ///
-    /// N
-    #[derive(Clone, Copy, PartialEq, Debug, Display)]
-    #[displaydoc("Attempted to interact two `Date`s with different calendars")]
-    #[allow(
-        clippy::exhaustive_structs,
-        reason = "This is the only possible error with multi-calendar operations"
-    )]
-    pub struct MismatchedCalendarError;
-
-    impl core::error::Error for MismatchedCalendarError {}
+    /// # Examples
+    ///
+    /// ```
+    /// use icu::calendar::error::DateFromFieldsError;
+    /// use icu::calendar::error::RangeError;
+    /// use icu::calendar::types::DateFields;
+    /// use icu::calendar::Date;
+    /// use icu::calendar::Iso;
+    ///
+    /// let mut fields = DateFields::default();
+    /// fields.extended_year = Some(2000);
+    /// fields.ordinal_month = Some(13);
+    /// fields.day = Some(1);
+    ///
+    /// let err = Date::try_from_fields(fields, Default::default(), Iso)
+    ///     .expect_err("no month 13 in the ISO calendar");
+    ///
+    /// assert!(matches!(
+    ///     err,
+    ///     DateFromFieldsError::InvalidOrdinalMonth { max: 12 }
+    /// ));
+    /// ```
+    #[displaydoc("Invalid ordinal month for year, max is {max}")]
+    InvalidOrdinalMonth {
+        /// The maximum allowed value (the minimum is 1).
+        max: u8,
+    },
+    /// The month code syntax is invalid.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu::calendar::error::DateFromFieldsError;
+    /// use icu::calendar::types::DateFields;
+    /// use icu::calendar::Date;
+    /// use icu::calendar::Iso;
+    ///
+    /// let mut fields = DateFields::default();
+    /// fields.extended_year = Some(2000);
+    /// fields.month_code = Some(b"sep");
+    /// fields.day = Some(1);
+    ///
+    /// let err = Date::try_from_fields(fields, Default::default(), Iso)
+    ///     .expect_err("month code is invalid");
+    ///
+    /// assert_eq!(err, DateFromFieldsError::MonthCodeInvalidSyntax);
+    /// ```
+    #[displaydoc("Invalid month code syntax")]
+    MonthCodeInvalidSyntax,
+    /// The specified month does not exist in this calendar.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu::calendar::cal::Hebrew;
+    /// use icu::calendar::error::DateFromFieldsError;
+    /// use icu::calendar::types::{DateFields, Month};
+    /// use icu::calendar::Date;
+    ///
+    /// let mut fields = DateFields::default();
+    /// fields.extended_year = Some(5783);
+    /// fields.month = Some(Month::new(13));
+    /// fields.day = Some(1);
+    ///
+    /// let err = Date::try_from_fields(fields, Default::default(), Hebrew)
+    ///     .expect_err("no month M13 in Hebrew");
+    /// assert_eq!(err, DateFromFieldsError::MonthNotInCalendar);
+    /// ```
+    #[displaydoc("The specified month does not exist in this calendar")]
+    MonthNotInCalendar,
+    /// The specified month exists in this calendar, but not in the specified year.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu::calendar::cal::Hebrew;
+    /// use icu::calendar::error::DateFromFieldsError;
+    /// use icu::calendar::types::{DateFields, Month};
+    /// use icu::calendar::Date;
+    ///
+    /// let mut fields = DateFields::default();
+    /// fields.extended_year = Some(5783);
+    /// fields.month = Some(Month::leap(5));
+    /// fields.day = Some(1);
+    ///
+    /// let err = Date::try_from_fields(fields, Default::default(), Hebrew)
+    ///     .expect_err("no month M05L in Hebrew year 5783");
+    /// assert_eq!(err, DateFromFieldsError::MonthNotInYear);
+    /// ```
+    #[displaydoc("The specified month exists in this calendar, but not for this year")]
+    MonthNotInYear,
+    /// The era code is invalid for the calendar.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu::calendar::cal::Hebrew;
+    /// use icu::calendar::error::DateFromFieldsError;
+    /// use icu::calendar::types::DateFields;
+    /// use icu::calendar::Date;
+    ///
+    /// let mut fields = DateFields::default();
+    /// fields.era = Some(b"ce"); // valid in Gregorian, but not Hebrew
+    /// fields.era_year = Some(1);
+    /// fields.ordinal_month = Some(1);
+    /// fields.day = Some(1);
+    ///
+    /// let err = Date::try_from_fields(fields, Default::default(), Hebrew::new())
+    ///     .expect_err("era is unknown for Hebrew");
+    ///
+    /// assert_eq!(err, DateFromFieldsError::InvalidEra);
+    /// ```
+    #[displaydoc("Unknown era or invalid syntax")]
+    InvalidEra,
+    /// The year was specified in multiple inconsistent ways.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu::calendar::cal::Japanese;
+    /// use icu::calendar::error::DateFromFieldsError;
+    /// use icu::calendar::types::DateFields;
+    /// use icu::calendar::Date;
+    ///
+    /// let mut fields = DateFields::default();
+    /// fields.era = Some(b"reiwa");
+    /// fields.era_year = Some(6);
+    /// fields.ordinal_month = Some(1);
+    /// fields.day = Some(1);
+    ///
+    /// Date::try_from_fields(fields, Default::default(), Japanese::new())
+    ///     .expect("a well-defined Japanese date");
+    ///
+    /// fields.extended_year = Some(1900);
+    ///
+    /// let err =
+    ///     Date::try_from_fields(fields, Default::default(), Japanese::new())
+    ///         .expect_err("year 1900 is not the same as 6 Reiwa");
+    ///
+    /// assert_eq!(err, DateFromFieldsError::InconsistentYear);
+    /// ```
+    #[displaydoc("Inconsistent year")]
+    InconsistentYear,
+    /// The month was specified in multiple inconsistent ways.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu::calendar::cal::Hebrew;
+    /// use icu::calendar::error::DateFromFieldsError;
+    /// use icu::calendar::types::{DateFields, Month};
+    /// use icu::calendar::Date;
+    /// use tinystr::tinystr;
+    ///
+    /// let mut fields = DateFields::default();
+    /// fields.extended_year = Some(5783);
+    /// fields.month = Some(Month::new(6));
+    /// fields.ordinal_month = Some(6);
+    /// fields.day = Some(1);
+    ///
+    /// Date::try_from_fields(fields, Default::default(), Hebrew)
+    ///     .expect("a well-defined Hebrew date in a common year");
+    ///
+    /// fields.extended_year = Some(5784);
+    ///
+    /// let err = Date::try_from_fields(fields, Default::default(), Hebrew)
+    ///     .expect_err("month M06 is not the 6th month in leap year 5784");
+    ///
+    /// assert_eq!(err, DateFromFieldsError::InconsistentMonth);
+    /// ```
+    #[displaydoc("Inconsistent month")]
+    InconsistentMonth,
+    /// Too many fields were specified to form a well-defined date.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu::calendar::error::DateFromFieldsError;
+    /// use icu::calendar::types::{DateFields, Month};
+    /// use icu::calendar::Date;
+    /// use icu::calendar::Iso;
+    ///
+    /// let mut fields = DateFields::default();
+    /// fields.extended_year = Some(2000);
+    /// fields.month = Some(Month::new(1));
+    /// fields.month_code = Some(b"M01");
+    /// fields.day = Some(1);
+    ///
+    /// let err = Date::try_from_fields(fields, Default::default(), Iso)
+    ///     .expect_err("cannot specify both month and month_code");
+    ///
+    /// assert_eq!(err, DateFromFieldsError::TooManyFields);
+    /// ```
+    #[displaydoc("Too many fields")]
+    TooManyFields,
+    /// Not enough fields were specified to form a well-defined date.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu::calendar::cal::Hebrew;
+    /// use icu::calendar::error::DateFromFieldsError;
+    /// use icu::calendar::types::DateFields;
+    /// use icu::calendar::Date;
+    /// use tinystr::tinystr;
+    ///
+    /// let mut fields = DateFields::default();
+    ///
+    /// fields.ordinal_month = Some(3);
+    ///
+    /// let err = Date::try_from_fields(fields, Default::default(), Hebrew)
+    ///     .expect_err("need more than just an ordinal month");
+    /// assert_eq!(err, DateFromFieldsError::NotEnoughFields);
+    ///
+    /// fields.era_year = Some(5783);
+    ///
+    /// let err = Date::try_from_fields(fields, Default::default(), Hebrew)
+    ///     .expect_err("need more than an ordinal month and an era year");
+    /// assert_eq!(err, DateFromFieldsError::NotEnoughFields);
+    ///
+    /// fields.extended_year = Some(5783);
+    ///
+    /// let err = Date::try_from_fields(fields, Default::default(), Hebrew)
+    ///     .expect_err("era year still needs an era");
+    /// assert_eq!(err, DateFromFieldsError::NotEnoughFields);
+    ///
+    /// fields.era = Some(b"am");
+    ///
+    /// let date = Date::try_from_fields(fields, Default::default(), Hebrew)
+    ///     .expect_err("still missing the day");
+    /// assert_eq!(err, DateFromFieldsError::NotEnoughFields);
+    ///
+    /// fields.day = Some(1);
+    /// let date = Date::try_from_fields(fields, Default::default(), Hebrew)
+    ///     .expect("we have enough fields!");
+    /// ```
+    #[displaydoc("Not enough fields")]
+    NotEnoughFields,
+    /// The date is out of range (see docs on [`Date`](crate::Date)
+    /// for more information about `Date`'s fundamental range invariant).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu::calendar::error::DateFromFieldsError;
+    /// use icu::calendar::error::RangeError;
+    /// use icu::calendar::types::DateFields;
+    /// use icu::calendar::Date;
+    /// use icu::calendar::Iso;
+    ///
+    /// let mut fields = DateFields::default();
+    /// fields.extended_year = Some(12345678);
+    /// fields.ordinal_month = Some(12);
+    /// fields.day = Some(31);
+    ///
+    /// let err = Date::try_from_fields(fields, Default::default(), Iso)
+    ///     .expect_err("date out of range");
+    ///
+    /// assert!(matches!(
+    ///     err,
+    ///     DateFromFieldsError::Overflow
+    /// ));
+    #[displaydoc("Result out of range")]
+    Overflow,
 }
+
+impl core::error::Error for DateFromFieldsError {}
+
+/// Error type for date addition via [`Date::try_add_with_options`].
+///
+/// [`Date::try_add_with_options`]: crate::Date::try_add_with_options
+#[derive(Debug, Copy, Clone, PartialEq, Display)]
+#[non_exhaustive]
+pub enum DateAddError {
+    /// The day is invalid for the given month.
+    ///
+    /// This is only possible with [`Overflow::Reject`](crate::options::Overflow::Reject).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu::calendar::Date;
+    /// use icu::calendar::error::DateAddError;
+    /// use icu::calendar::options::{DateAddOptions, Overflow};
+    /// use icu::calendar::types::DateDuration;
+    ///
+    /// // There is a day 31 in October but not in November.
+    /// let d = Date::try_new_iso(2025, 10, 31).unwrap();
+    /// let duration = DateDuration::for_months(1);
+    ///
+    /// let mut options = DateAddOptions::default();
+    /// options.overflow = Some(Overflow::Reject);
+    ///
+    /// let err = d
+    ///     .try_added_with_options(duration, options)
+    ///     .expect_err("no day 31 in November");
+    ///
+    /// assert!(matches!(err, DateAddError::InvalidDay { max: 30 }));
+    /// ```
+    #[displaydoc("Invalid day for month, max is {max}")]
+    InvalidDay {
+        /// The maximum allowed value (the minimum is 1).
+        max: u8,
+    },
+    /// The specified month exists in this calendar, but not in the specified year.
+    ///
+    /// This is only possible with [`Overflow::Reject`](crate::options::Overflow::Reject).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu::calendar::cal::Hebrew;
+    /// use icu::calendar::types::{DateDuration, Month};
+    /// use icu::calendar::Date;
+    /// use icu::calendar::error::DateAddError;
+    /// use icu::calendar::options::{DateAddOptions, Overflow};
+    ///
+    /// // Hebrew year 5784 is a leap year, 5785 is not.
+    /// // Adar I (the leap month) is month 5 in a leap year.
+    /// let d = Date::try_new_hebrew_v2(5784, Month::leap(5), 1).unwrap();
+    /// let duration = DateDuration::for_years(1);
+    ///
+    /// let mut options = DateAddOptions::default();
+    /// options.overflow = Some(Overflow::Reject);
+    ///
+    /// let err = d
+    ///     .try_added_with_options(duration, options)
+    ///     .expect_err("5785 is not a leap year");
+    ///
+    /// assert_eq!(err, DateAddError::MonthNotInYear);
+    /// ```
+    #[displaydoc("The specified month exists in this calendar, but not for this year")]
+    MonthNotInYear,
+    /// The date is out of range (see docs on [`Date`](crate::Date)
+    /// for more information about `Date`'s fundamental range invariant).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu::calendar::Date;
+    /// use icu::calendar::error::DateAddError;
+    /// use icu::calendar::types::DateDuration;
+    ///
+    /// let d = Date::try_new_iso(2025, 1, 1).unwrap();
+    /// let duration = DateDuration::for_years(1_000_000);
+    ///
+    /// let err = d
+    ///     .try_added_with_options(duration, Default::default())
+    ///     .expect_err("date overflow");
+    ///
+    /// assert_eq!(err, DateAddError::Overflow);
+    /// ```
+    #[displaydoc("Result out of range")]
+    Overflow,
+}
+
+impl core::error::Error for DateAddError {}
+
+/// Error returned when interacting two [`Date`](crate::Date)s with non-singleton calendars.
+///
+/// # Examples
+///
+/// ```
+/// use icu::calendar::error::MismatchedCalendarError;
+/// use icu::calendar::Date;
+/// use icu::calendar::options::DateDifferenceOptions;
+/// use icu::calendar::options::DateDurationUnit;
+///
+/// let d1 = Date::try_new_gregorian(2000, 1, 1).unwrap().to_any();
+/// let d2 = Date::try_new_persian(1562, 1, 1).unwrap().to_any();
+///
+/// assert_eq!(
+///     d1.try_until_with_options(&d2, Default::default())
+///         .unwrap_err(),
+///     MismatchedCalendarError,
+/// );
+///
+/// // To compare the dates, convert them to the same calendar.
+/// // Note that the result may differ based on the calendar used,
+/// // e.g if comparing in months and days.
+///
+/// let mut options = DateDifferenceOptions::default();
+/// options.largest_unit = Some(DateDurationUnit::Months);
+///
+/// let diff1 = d1.to_calendar(d2.calendar().clone())
+///     .try_until_with_options(&d2, options)
+///     .unwrap();
+/// let diff2 = d1
+///     .try_until_with_options(&d2.to_calendar(d1.calendar().clone()),
+///                             options)
+///     .unwrap();
+///
+/// assert_ne!(diff1, diff2);
+/// ```
+#[derive(Clone, Copy, PartialEq, Debug, Display)]
+#[displaydoc("Attempted to interact two `Date`s with different calendars")]
+#[allow(
+    clippy::exhaustive_structs,
+    reason = "This is the only possible error with multi-calendar operations"
+)]
+pub struct MismatchedCalendarError;
+
+impl core::error::Error for MismatchedCalendarError {}
 
 /// Error type for date creation via [`Date::try_new`].
 ///
 /// [`Date::try_new`]: crate::Date::try_new
-///
-/// <div class="stab unstable">
-/// 🚧 This code is considered unstable; it may change at any time, in breaking or non-breaking ways,
-/// including in SemVer minor releases. Do not use this type unless you are prepared for things to occasionally break.
-///
-/// Graduation tracking issue: [issue #7512](https://github.com/unicode-org/icu4x/issues/7512).
-/// </div>
-///
-/// ✨ *Enabled with the `unstable` Cargo feature.*
 #[derive(Debug, Copy, Clone, PartialEq, Display)]
 #[non_exhaustive]
 pub enum DateNewError {
@@ -708,6 +670,100 @@ impl From<MonthError> for DateFromFieldsError {
     }
 }
 
+/// Errors that can occur when parsing an ISO 8601 date-only duration string.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum DateDurationParseError {
+    /// The input does not follow the expected ISO 8601 date only duration structure.
+    ///
+    /// This error occurs when the duration string is incomplete,
+    /// or contains unexpected characters.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use icu::calendar::error::DateDurationParseError;
+    /// use icu::calendar::types::DateDuration;
+    ///
+    /// assert_eq!(DateDuration::try_from_str("P"),  Err(DateDurationParseError::InvalidStructure));
+    /// assert_eq!(DateDuration::try_from_str("P1"), Err(DateDurationParseError::InvalidStructure));
+    /// ```
+    InvalidStructure,
+
+    /// The duration contains a time component, which is not supported.
+    ///
+    /// Only date based units (`Y`, `M`, `W`, `D`) are supported. Any duration
+    /// containing a `T` time separator is rejected.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use icu::calendar::error::DateDurationParseError;
+    /// use icu::calendar::types::DateDuration;
+    ///
+    /// assert_eq!(DateDuration::try_from_str("PT5M"), Err(DateDurationParseError::TimeNotSupported));
+    /// assert_eq!(DateDuration::try_from_str("P1DT"), Err(DateDurationParseError::TimeNotSupported));
+    /// ```
+    TimeNotSupported,
+
+    /// A duration unit appeared without a number before it.
+    ///
+    /// For example, the string contains `Y`, `M`, `W`, or `D` without a
+    /// numeric value directly in front of it.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use icu::calendar::error::DateDurationParseError;
+    /// use icu::calendar::types::DateDuration;
+    ///
+    /// assert_eq!(DateDuration::try_from_str("PY"), Err(DateDurationParseError::MissingValue));
+    /// assert_eq!(DateDuration::try_from_str("PX1D"), Err(DateDurationParseError::MissingValue));
+    /// ```
+    MissingValue,
+
+    /// A duration unit was specified more than once.
+    ///
+    /// Each unit (`Y`, `M`, `W`, `D`) may appear at most once only.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use icu::calendar::error::DateDurationParseError;
+    /// use icu::calendar::types::DateDuration;
+    ///
+    /// assert_eq!(DateDuration::try_from_str("P1Y2Y"), Err(DateDurationParseError::DuplicateUnit));
+    /// assert_eq!(DateDuration::try_from_str("P1D1D"), Err(DateDurationParseError::DuplicateUnit));
+    /// ```
+    DuplicateUnit,
+
+    /// A numeric value exceeded or was more than the supported range.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use icu::calendar::error::DateDurationParseError;
+    /// use icu::calendar::types::DateDuration;
+    ///
+    /// assert_eq!(DateDuration::try_from_str("P4294967296Y"), Err(DateDurationParseError::NumberOverflow));
+    /// ```
+    NumberOverflow,
+
+    /// A duration starts with a `+` sign, which is not allowed.
+    ///
+    /// Only negative durations using a leading `-` are supported.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use icu::calendar::error::DateDurationParseError;
+    /// use icu::calendar::types::DateDuration;
+    ///
+    /// assert_eq!(DateDuration::try_from_str("+P1D"), Err(DateDurationParseError::PlusNotAllowed));
+    /// ```
+    PlusNotAllowed,
+}
+
 mod inner {
     /// Internal narrow error type for calculating the ECMA reference year
     ///
@@ -733,113 +789,12 @@ mod inner {
         /// something like UseIfConstrain(y, m, d).
         UseRegularIfConstrain,
     }
-
-    /// Errors that can occur when parsing an ISO 8601 date-only duration string.
-    ///
-    /// <div class="stab unstable">
-    /// 🚧 This code is considered unstable; it may change at any time, in breaking or non-breaking ways,
-    /// including in SemVer minor releases. Do not use this type unless you are prepared for things to occasionally break.
-    ///
-    /// Graduation tracking issue: [issue #3964](https://github.com/unicode-org/icu4x/issues/3964).
-    /// </div>
-    #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-    #[non_exhaustive]
-    pub enum DateDurationParseError {
-        /// The input does not follow the expected ISO 8601 date only duration structure.
-        ///
-        /// This error occurs when the duration string is incomplete,
-        /// or contains unexpected characters.
-        ///
-        /// # Examples
-        ///
-        /// ```rust
-        /// use icu::calendar::error::DateDurationParseError;
-        /// use icu::calendar::types::DateDuration;
-        ///
-        /// assert_eq!(DateDuration::try_from_str("P"),  Err(DateDurationParseError::InvalidStructure));
-        /// assert_eq!(DateDuration::try_from_str("P1"), Err(DateDurationParseError::InvalidStructure));
-        /// ```
-        InvalidStructure,
-
-        /// The duration contains a time component, which is not supported.
-        ///
-        /// Only date based units (`Y`, `M`, `W`, `D`) are supported. Any duration
-        /// containing a `T` time separator is rejected.
-        ///
-        /// # Examples
-        ///
-        /// ```rust
-        /// use icu::calendar::error::DateDurationParseError;
-        /// use icu::calendar::types::DateDuration;
-        ///
-        /// assert_eq!(DateDuration::try_from_str("PT5M"), Err(DateDurationParseError::TimeNotSupported));
-        /// assert_eq!(DateDuration::try_from_str("P1DT"), Err(DateDurationParseError::TimeNotSupported));
-        /// ```
-        TimeNotSupported,
-
-        /// A duration unit appeared without a number before it.
-        ///
-        /// For example, the string contains `Y`, `M`, `W`, or `D` without a
-        /// numeric value directly in front of it.
-        ///
-        /// # Examples
-        ///
-        /// ```rust
-        /// use icu::calendar::error::DateDurationParseError;
-        /// use icu::calendar::types::DateDuration;
-        ///
-        /// assert_eq!(DateDuration::try_from_str("PY"), Err(DateDurationParseError::MissingValue));
-        /// assert_eq!(DateDuration::try_from_str("PX1D"), Err(DateDurationParseError::MissingValue));
-        /// ```
-        MissingValue,
-
-        /// A duration unit was specified more than once.
-        ///
-        /// Each unit (`Y`, `M`, `W`, `D`) may appear at most once only.
-        ///
-        /// # Examples
-        ///
-        /// ```rust
-        /// use icu::calendar::error::DateDurationParseError;
-        /// use icu::calendar::types::DateDuration;
-        ///
-        /// assert_eq!(DateDuration::try_from_str("P1Y2Y"), Err(DateDurationParseError::DuplicateUnit));
-        /// assert_eq!(DateDuration::try_from_str("P1D1D"), Err(DateDurationParseError::DuplicateUnit));
-        /// ```
-        DuplicateUnit,
-
-        /// A numeric value exceeded or was more than the supported range.
-        ///
-        /// # Examples
-        ///
-        /// ```rust
-        /// use icu::calendar::error::DateDurationParseError;
-        /// use icu::calendar::types::DateDuration;
-        ///
-        /// assert_eq!(DateDuration::try_from_str("P4294967296Y"), Err(DateDurationParseError::NumberOverflow));
-        /// ```
-        NumberOverflow,
-
-        /// A duration starts with a `+` sign, which is not allowed.
-        ///
-        /// Only negative durations using a leading `-` are supported.
-        ///
-        /// # Examples
-        ///
-        /// ```rust
-        /// use icu::calendar::error::DateDurationParseError;
-        /// use icu::calendar::types::DateDuration;
-        ///
-        /// assert_eq!(DateDuration::try_from_str("+P1D"), Err(DateDurationParseError::PlusNotAllowed));
-        /// ```
-        PlusNotAllowed,
-    }
 }
 
 #[cfg(feature = "unstable")]
-pub use inner::{DateDurationParseError, EcmaReferenceYearError};
+pub use inner::EcmaReferenceYearError;
 #[cfg(not(feature = "unstable"))]
-pub(crate) use inner::{DateDurationParseError, EcmaReferenceYearError};
+pub(crate) use inner::EcmaReferenceYearError;
 
 impl From<EcmaReferenceYearError> for DateFromFieldsError {
     #[inline]

--- a/components/calendar/src/options.rs
+++ b/components/calendar/src/options.rs
@@ -4,436 +4,370 @@
 
 //! Options used by types in this crate
 
-#[cfg(feature = "unstable")]
-pub use unstable::{
-    DateAddOptions, DateDifferenceOptions, DateDurationUnit, DateFromFieldsOptions,
-    MissingFieldsStrategy, Overflow,
-};
-#[cfg(not(feature = "unstable"))]
-pub(crate) use unstable::{
-    DateAddOptions, DateDifferenceOptions, DateDurationUnit, DateFromFieldsOptions,
-    MissingFieldsStrategy, Overflow,
-};
-
-mod unstable {
-    /// Options bag for [`Date::try_from_fields`](crate::Date::try_from_fields).
+/// Options bag for [`Date::try_from_fields`](crate::Date::try_from_fields).
+#[derive(Copy, Clone, Debug, PartialEq, Default)]
+#[non_exhaustive]
+pub struct DateFromFieldsOptions {
+    /// How to behave with out-of-bounds fields.
     ///
-    /// <div class="stab unstable">
-    /// 🚧 This code is considered unstable; it may change at any time, in breaking or non-breaking ways,
-    /// including in SemVer minor releases. Do not use this type unless you are prepared for things to occasionally break.
+    /// Defaults to [`Overflow::Reject`].
     ///
-    /// Graduation tracking issue: [issue #7161](https://github.com/unicode-org/icu4x/issues/7161).
-    /// </div>
+    /// # Examples
     ///
-    /// ✨ *Enabled with the `unstable` Cargo feature.*
-    #[derive(Copy, Clone, Debug, PartialEq, Default)]
-    #[non_exhaustive]
-    pub struct DateFromFieldsOptions {
-        /// How to behave with out-of-bounds fields.
-        ///
-        /// Defaults to [`Overflow::Reject`].
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use icu::calendar::options::DateFromFieldsOptions;
-        /// use icu::calendar::options::Overflow;
-        /// use icu::calendar::types::DateFields;
-        /// use icu::calendar::Date;
-        /// use icu::calendar::Iso;
-        ///
-        /// // There is no day 31 in September.
-        /// let mut fields = DateFields::default();
-        /// fields.extended_year = Some(2025);
-        /// fields.ordinal_month = Some(9);
-        /// fields.day = Some(31);
-        ///
-        /// let options_default = DateFromFieldsOptions::default();
-        /// assert!(Date::try_from_fields(fields, options_default, Iso).is_err());
-        ///
-        /// let mut options_reject = options_default;
-        /// options_reject.overflow = Some(Overflow::Reject);
-        /// assert!(Date::try_from_fields(fields, options_reject, Iso).is_err());
-        ///
-        /// let mut options_constrain = options_default;
-        /// options_constrain.overflow = Some(Overflow::Constrain);
-        /// assert_eq!(
-        ///     Date::try_from_fields(fields, options_constrain, Iso).unwrap(),
-        ///     Date::try_new_iso(2025, 9, 30).unwrap()
-        /// );
-        /// ```
-        pub overflow: Option<Overflow>,
-        /// How to behave when the fields that are present do not fully constitute a Date.
-        ///
-        /// This option can be used to fill in a missing year given a month and a day according to
-        /// the ECMAScript Temporal specification.
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use icu::calendar::options::DateFromFieldsOptions;
-        /// use icu::calendar::options::MissingFieldsStrategy;
-        /// use icu::calendar::types::{DateFields, Month};
-        /// use icu::calendar::Date;
-        /// use icu::calendar::Iso;
-        ///
-        /// // These options are missing a year.
-        /// let mut fields = DateFields::default();
-        /// fields.month = Some(Month::new(2));
-        /// fields.day = Some(1);
-        ///
-        /// let options_default = DateFromFieldsOptions::default();
-        /// assert!(Date::try_from_fields(fields, options_default, Iso).is_err());
-        ///
-        /// let mut options_reject = options_default;
-        /// options_reject.missing_fields_strategy =
-        ///     Some(MissingFieldsStrategy::Reject);
-        /// assert!(Date::try_from_fields(fields, options_reject, Iso).is_err());
-        ///
-        /// let mut options_ecma = options_default;
-        /// options_ecma.missing_fields_strategy = Some(MissingFieldsStrategy::Ecma);
-        /// assert_eq!(
-        ///     Date::try_from_fields(fields, options_ecma, Iso).unwrap(),
-        ///     Date::try_new_iso(1972, 2, 1).unwrap()
-        /// );
-        /// ```
-        pub missing_fields_strategy: Option<MissingFieldsStrategy>,
-    }
-
-    /// Options for adding a duration to a date.
+    /// ```
+    /// use icu::calendar::options::DateFromFieldsOptions;
+    /// use icu::calendar::options::Overflow;
+    /// use icu::calendar::types::DateFields;
+    /// use icu::calendar::Date;
+    /// use icu::calendar::Iso;
     ///
-    /// <div class="stab unstable">
-    /// 🚧 This code is considered unstable; it may change at any time, in breaking or non-breaking ways,
-    /// including in SemVer minor releases. Do not use this type unless you are prepared for things to occasionally break.
+    /// // There is no day 31 in September.
+    /// let mut fields = DateFields::default();
+    /// fields.extended_year = Some(2025);
+    /// fields.ordinal_month = Some(9);
+    /// fields.day = Some(31);
     ///
-    /// Graduation tracking issue: [issue #3964](https://github.com/unicode-org/icu4x/issues/3964).
-    /// </div>
+    /// let options_default = DateFromFieldsOptions::default();
+    /// assert!(Date::try_from_fields(fields, options_default, Iso).is_err());
     ///
-    /// ✨ *Enabled with the `unstable` Cargo feature.*
-    #[derive(Copy, Clone, PartialEq, Debug, Default)]
-    #[non_exhaustive]
-    pub struct DateAddOptions {
-        /// How to behave with out-of-bounds fields during arithmetic.
-        ///
-        /// Defaults to [`Overflow::Constrain`].
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use icu::calendar::options::DateAddOptions;
-        /// use icu::calendar::options::Overflow;
-        /// use icu::calendar::types::DateDuration;
-        /// use icu::calendar::Date;
-        ///
-        /// // There is a day 31 in October but not in November.
-        /// let d1 = Date::try_new_iso(2025, 10, 31).unwrap();
-        /// let duration = DateDuration::for_months(1);
-        ///
-        /// let options_default = DateAddOptions::default();
-        /// assert_eq!(
-        ///     d1.try_added_with_options(duration, options_default)
-        ///         .unwrap(),
-        ///     Date::try_new_iso(2025, 11, 30).unwrap()
-        /// );
-        ///
-        /// let mut options_reject = options_default;
-        /// options_reject.overflow = Some(Overflow::Reject);
-        /// assert!(d1.try_added_with_options(duration, options_reject).is_err());
-        ///
-        /// let mut options_constrain = options_default;
-        /// options_constrain.overflow = Some(Overflow::Constrain);
-        /// assert_eq!(
-        ///     d1.try_added_with_options(duration, options_constrain)
-        ///         .unwrap(),
-        ///     Date::try_new_iso(2025, 11, 30).unwrap()
-        /// );
-        /// ```
-        pub overflow: Option<Overflow>,
-    }
-
-    /// Options for taking the difference between two dates.
+    /// let mut options_reject = options_default;
+    /// options_reject.overflow = Some(Overflow::Reject);
+    /// assert!(Date::try_from_fields(fields, options_reject, Iso).is_err());
     ///
-    /// <div class="stab unstable">
-    /// 🚧 This code is considered unstable; it may change at any time, in breaking or non-breaking ways,
-    /// including in SemVer minor releases. Do not use this type unless you are prepared for things to occasionally break.
+    /// let mut options_constrain = options_default;
+    /// options_constrain.overflow = Some(Overflow::Constrain);
+    /// assert_eq!(
+    ///     Date::try_from_fields(fields, options_constrain, Iso).unwrap(),
+    ///     Date::try_new_iso(2025, 9, 30).unwrap()
+    /// );
+    /// ```
+    pub overflow: Option<Overflow>,
+    /// How to behave when the fields that are present do not fully constitute a Date.
     ///
-    /// Graduation tracking issue: [issue #3964](https://github.com/unicode-org/icu4x/issues/3964).
-    /// </div>
+    /// This option can be used to fill in a missing year given a month and a day according to
+    /// the ECMAScript Temporal specification.
     ///
-    /// ✨ *Enabled with the `unstable` Cargo feature.*
-    #[derive(Copy, Clone, PartialEq, Debug, Default)]
-    #[non_exhaustive]
-    pub struct DateDifferenceOptions {
-        /// Which date field to allow as the largest in a duration when taking the difference.
-        ///
-        /// This defaults to [`DateDurationUnit::Days`].
-        ///
-        /// When choosing [`Months`] or [`Years`], the resulting [`DateDuration`] might not be
-        /// associative or commutative in subsequent arithmetic operations, and it might require
-        /// [`Overflow::Constrain`] in addition.
-        ///
-        /// The resultant duration will not have any `weeks` value unless [`DateDurationUnit::Weeks`]
-        /// is explicitly specified as `largest_unit`.
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use icu::calendar::options::DateDifferenceOptions;
-        /// use icu::calendar::types::DateDuration;
-        /// use icu::calendar::options::DateDurationUnit;
-        /// use icu::calendar::Date;
-        ///
-        /// let d1 = Date::try_new_iso(2025, 3, 31).unwrap();
-        /// let d2 = Date::try_new_iso(2026, 5, 15).unwrap();
-        ///
-        /// let options_default = DateDifferenceOptions::default();
-        /// assert_eq!(
-        ///     d1.try_until_with_options(&d2, options_default).unwrap(),
-        ///     DateDuration::for_days(410)
-        /// );
-        ///
-        /// let mut options_days = options_default;
-        /// options_days.largest_unit = Some(DateDurationUnit::Days);
-        /// assert_eq!(
-        ///     d1.try_until_with_options(&d2, options_days).unwrap(),
-        ///     DateDuration::for_days(410)
-        /// );
-        ///
-        /// let mut options_weeks = options_default;
-        /// options_weeks.largest_unit = Some(DateDurationUnit::Weeks);
-        /// assert_eq!(
-        ///     d1.try_until_with_options(&d2, options_weeks).unwrap(),
-        ///     DateDuration {
-        ///         // This is the only time there is a `weeks` value.
-        ///         weeks: 58,
-        ///         days: 4,
-        ///         ..Default::default()
-        ///     }
-        /// );
-        ///
-        /// let mut options_months = options_default;
-        /// options_months.largest_unit = Some(DateDurationUnit::Months);
-        /// assert_eq!(
-        ///     d1.try_until_with_options(&d2, options_months).unwrap(),
-        ///     DateDuration {
-        ///         months: 13,
-        ///         days: 15,
-        ///         ..Default::default()
-        ///     }
-        /// );
-        ///
-        /// let mut options_years = options_default;
-        /// options_years.largest_unit = Some(DateDurationUnit::Years);
-        /// assert_eq!(
-        ///     d1.try_until_with_options(&d2, options_years).unwrap(),
-        ///     DateDuration {
-        ///         years: 1,
-        ///         months: 1,
-        ///         days: 15,
-        ///         ..Default::default()
-        ///     }
-        /// );
-        /// ```
-        ///
-        /// [`Months`]: crate::options::DateDurationUnit::Months
-        /// [`Years`]: crate::options::DateDurationUnit::Years
-        /// [`DateDuration`]: crate::types::DateDuration
-        pub largest_unit: Option<DateDurationUnit>,
-    }
-
-    /// Whether to constrain or reject out-of-bounds values when constructing a Date.
+    /// # Examples
     ///
-    /// The behavior conforms to the ECMAScript Temporal specification.
+    /// ```
+    /// use icu::calendar::options::DateFromFieldsOptions;
+    /// use icu::calendar::options::MissingFieldsStrategy;
+    /// use icu::calendar::types::{DateFields, Month};
+    /// use icu::calendar::Date;
+    /// use icu::calendar::Iso;
     ///
-    /// <div class="stab unstable">
-    /// 🚧 This code is considered unstable; it may change at any time, in breaking or non-breaking ways,
-    /// including in SemVer minor releases. Do not use this type unless you are prepared for things to occasionally break.
+    /// // These options are missing a year.
+    /// let mut fields = DateFields::default();
+    /// fields.month = Some(Month::new(2));
+    /// fields.day = Some(1);
     ///
-    /// Graduation tracking issue: [issue #7161](https://github.com/unicode-org/icu4x/issues/7161).
-    /// </div>
+    /// let options_default = DateFromFieldsOptions::default();
+    /// assert!(Date::try_from_fields(fields, options_default, Iso).is_err());
     ///
-    /// ✨ *Enabled with the `unstable` Cargo feature.*
-    #[derive(Copy, Clone, Debug, PartialEq, Default)]
-    #[non_exhaustive]
-    pub enum Overflow {
-        /// Constrain out-of-bounds fields to the nearest in-bounds value.
-        ///
-        /// Only the out-of-bounds field is constrained. If the other fields are not themselves
-        /// out of bounds, they are not changed.
-        ///
-        /// This is the [default option](
-        /// https://tc39.es/proposal-temporal/#sec-temporal-gettemporaloverflowoption),
-        /// following the ECMAScript Temporal specification. See also the [docs on MDN](
-        /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDate#invalid_date_clamping).
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use icu::calendar::cal::Hebrew;
-        /// use icu::calendar::options::DateFromFieldsOptions;
-        /// use icu::calendar::options::Overflow;
-        /// use icu::calendar::types::{DateFields, Month};
-        /// use icu::calendar::Date;
-        /// use icu::calendar::DateError;
-        ///
-        /// let mut options = DateFromFieldsOptions::default();
-        /// options.overflow = Some(Overflow::Constrain);
-        ///
-        /// // 5784, a leap year, contains M05L, but the day is too big.
-        /// let mut fields = DateFields::default();
-        /// fields.extended_year = Some(5784);
-        /// fields.month = Some(Month::leap(5));
-        /// fields.day = Some(50);
-        ///
-        /// let date = Date::try_from_fields(fields, options, Hebrew).unwrap();
-        ///
-        /// // Constrained to the 30th day of M05L of year 5784
-        /// assert_eq!(date.year().extended_year(), 5784);
-        /// assert_eq!(date.month().standard_code.0, "M05L");
-        /// assert_eq!(date.day_of_month().0, 30);
-        ///
-        /// // 5785, a common year, does not contain M05L.
-        /// fields.extended_year = Some(5785);
-        ///
-        /// let date = Date::try_from_fields(fields, options, Hebrew).unwrap();
-        ///
-        /// // Constrained to the 29th day of M06 of year 5785
-        /// assert_eq!(date.year().extended_year(), 5785);
-        /// assert_eq!(date.month().standard_code.0, "M06");
-        /// assert_eq!(date.day_of_month().0, 29);
-        /// ```
-        Constrain,
-        /// Return an error if any fields are out of bounds.
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use icu::calendar::cal::Hebrew;
-        /// use icu::calendar::error::DateFromFieldsError;
-        /// use icu::calendar::options::DateFromFieldsOptions;
-        /// use icu::calendar::options::Overflow;
-        /// use icu::calendar::types::{DateFields, Month};
-        /// use icu::calendar::Date;
-        /// use tinystr::tinystr;
-        ///
-        /// let mut options = DateFromFieldsOptions::default();
-        /// options.overflow = Some(Overflow::Reject);
-        ///
-        /// // 5784, a leap year, contains M05L, but the day is too big.
-        /// let mut fields = DateFields::default();
-        /// fields.extended_year = Some(5784);
-        /// fields.month = Some(Month::leap(5));
-        /// fields.day = Some(50);
-        ///
-        /// let err = Date::try_from_fields(fields, options, Hebrew)
-        ///     .expect_err("Day is out of bounds");
-        /// assert!(matches!(err, DateFromFieldsError::InvalidDay { .. }));
-        ///
-        /// // Set the day to one that exists
-        /// fields.day = Some(1);
-        /// Date::try_from_fields(fields, options, Hebrew)
-        ///     .expect("A valid Hebrew date");
-        ///
-        /// // 5785, a common year, does not contain M05L.
-        /// fields.extended_year = Some(5785);
-        ///
-        /// let err = Date::try_from_fields(fields, options, Hebrew)
-        ///     .expect_err("Month is out of bounds");
-        /// assert!(matches!(err, DateFromFieldsError::MonthNotInYear));
-        /// ```
-        #[default]
-        Reject,
-    }
-
-    /// How to infer missing fields when the fields that are present do not fully constitute a Date.
+    /// let mut options_reject = options_default;
+    /// options_reject.missing_fields_strategy =
+    ///     Some(MissingFieldsStrategy::Reject);
+    /// assert!(Date::try_from_fields(fields, options_reject, Iso).is_err());
     ///
-    /// In order for the fields to fully constitute a Date, they must identify a year, a month,
-    /// and a day. The fields `era`, `era_year`, and `extended_year` identify the year:
-    ///
-    /// | Era? | Era Year? | Extended Year? | Outcome |
-    /// |------|-----------|----------------|---------|
-    /// | -    | -         | -              | Error |
-    /// | Some | -         | -              | Error |
-    /// | -    | Some      | -              | Error |
-    /// | -    | -         | Some           | OK |
-    /// | Some | Some      | -              | OK |
-    /// | Some | -         | Some           | Error (era requires era year) |
-    /// | -    | Some      | Some           | Error (era year requires era) |
-    /// | Some | Some      | Some           | OK (but error if inconsistent) |
-    ///
-    /// The fields `month_code` and `ordinal_month` identify the month:
-    ///
-    /// | Month( Code)? | Ordinal Month? | Outcome |
-    /// |-------------|----------------|---------|
-    /// | -           | -              | Error |
-    /// | Some        | -              | OK |
-    /// | -           | Some           | OK |
-    /// | Some        | Some           | OK (but error if inconsistent) |
-    ///
-    /// The field `day` identifies the day.
-    ///
-    /// If the fields identify a year, a month, and a day, then there are no missing fields, so
-    /// the strategy chosen here has no effect (fields that are out-of-bounds or inconsistent
-    /// are handled by other errors).
-    ///
-    /// <div class="stab unstable">
-    /// 🚧 This code is considered unstable; it may change at any time, in breaking or non-breaking ways,
-    /// including in SemVer minor releases. Do not use this type unless you are prepared for things to occasionally break.
-    ///
-    /// Graduation tracking issue: [issue #7161](https://github.com/unicode-org/icu4x/issues/7161).
-    /// </div>
-    ///
-    /// ✨ *Enabled with the `unstable` Cargo feature.*
-    #[derive(Copy, Clone, Debug, PartialEq, Default)]
-    #[non_exhaustive]
-    pub enum MissingFieldsStrategy {
-        /// If the fields that are present do not fully constitute a Date,
-        /// return [`DateFromFieldsError::NotEnoughFields`].
-        ///
-        /// [`DateFromFieldsError::NotEnoughFields`]: crate::error::DateFromFieldsError::NotEnoughFields
-        #[default]
-        Reject,
-        /// If the fields that are present do not fully constitute a Date,
-        /// follow the ECMAScript specification when possible.
-        ///
-        /// ⚠️ This option causes a year or day to be implicitly added to the Date!
-        ///
-        /// This strategy makes the following changes:
-        ///
-        /// 1. If the fields identify a year and a month, but not a day, then set `day` to 1.
-        /// 2. If month and day are set but nothing else, then set the year to a
-        ///    _reference year_: some year in the calendar that contains the specified month
-        ///    and day, according to the ECMAScript specification.
-        ///
-        /// Note that the reference year is _not_ added if an ordinal month is present, since
-        /// the identity of an ordinal month changes from year to year.
-        Ecma,
-    }
-
-    /// A "duration unit" used to specify the minimum or maximum duration of time to
-    /// care about.
-    ///
-    /// <div class="stab unstable">
-    /// 🚧 This code is considered unstable; it may change at any time, in breaking or non-breaking ways,
-    /// including in SemVer minor releases. Do not use this type unless you are prepared for things to occasionally break.
-    ///
-    /// Graduation tracking issue: [issue #3964](https://github.com/unicode-org/icu4x/issues/3964).
-    /// </div>
-    ///
-    /// ✨ *Enabled with the `unstable` Cargo feature.*
-    #[derive(Copy, Clone, Eq, PartialEq, Debug)]
-    #[allow(clippy::exhaustive_enums)] // this type should be stable
-    pub enum DateDurationUnit {
-        /// Duration in years
-        Years,
-        /// Duration in months
-        Months,
-        /// Duration in weeks
-        Weeks,
-        /// Duration in days
-        Days,
-    }
+    /// let mut options_ecma = options_default;
+    /// options_ecma.missing_fields_strategy = Some(MissingFieldsStrategy::Ecma);
+    /// assert_eq!(
+    ///     Date::try_from_fields(fields, options_ecma, Iso).unwrap(),
+    ///     Date::try_new_iso(1972, 2, 1).unwrap()
+    /// );
+    /// ```
+    pub missing_fields_strategy: Option<MissingFieldsStrategy>,
 }
+
+/// Options for adding a duration to a date.
+#[derive(Copy, Clone, PartialEq, Debug, Default)]
+#[non_exhaustive]
+pub struct DateAddOptions {
+    /// How to behave with out-of-bounds fields during arithmetic.
+    ///
+    /// Defaults to [`Overflow::Constrain`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu::calendar::options::DateAddOptions;
+    /// use icu::calendar::options::Overflow;
+    /// use icu::calendar::types::DateDuration;
+    /// use icu::calendar::Date;
+    ///
+    /// // There is a day 31 in October but not in November.
+    /// let d1 = Date::try_new_iso(2025, 10, 31).unwrap();
+    /// let duration = DateDuration::for_months(1);
+    ///
+    /// let options_default = DateAddOptions::default();
+    /// assert_eq!(
+    ///     d1.try_added_with_options(duration, options_default)
+    ///         .unwrap(),
+    ///     Date::try_new_iso(2025, 11, 30).unwrap()
+    /// );
+    ///
+    /// let mut options_reject = options_default;
+    /// options_reject.overflow = Some(Overflow::Reject);
+    /// assert!(d1.try_added_with_options(duration, options_reject).is_err());
+    ///
+    /// let mut options_constrain = options_default;
+    /// options_constrain.overflow = Some(Overflow::Constrain);
+    /// assert_eq!(
+    ///     d1.try_added_with_options(duration, options_constrain)
+    ///         .unwrap(),
+    ///     Date::try_new_iso(2025, 11, 30).unwrap()
+    /// );
+    /// ```
+    pub overflow: Option<Overflow>,
+}
+
+/// Options for taking the difference between two dates.
+#[derive(Copy, Clone, PartialEq, Debug, Default)]
+#[non_exhaustive]
+pub struct DateDifferenceOptions {
+    /// Which date field to allow as the largest in a duration when taking the difference.
+    ///
+    /// This defaults to [`DateDurationUnit::Days`].
+    ///
+    /// When choosing [`Months`] or [`Years`], the resulting [`DateDuration`] might not be
+    /// associative or commutative in subsequent arithmetic operations, and it might require
+    /// [`Overflow::Constrain`] in addition.
+    ///
+    /// The resultant duration will not have any `weeks` value unless [`DateDurationUnit::Weeks`]
+    /// is explicitly specified as `largest_unit`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu::calendar::options::DateDifferenceOptions;
+    /// use icu::calendar::types::DateDuration;
+    /// use icu::calendar::options::DateDurationUnit;
+    /// use icu::calendar::Date;
+    ///
+    /// let d1 = Date::try_new_iso(2025, 3, 31).unwrap();
+    /// let d2 = Date::try_new_iso(2026, 5, 15).unwrap();
+    ///
+    /// let options_default = DateDifferenceOptions::default();
+    /// assert_eq!(
+    ///     d1.try_until_with_options(&d2, options_default).unwrap(),
+    ///     DateDuration::for_days(410)
+    /// );
+    ///
+    /// let mut options_days = options_default;
+    /// options_days.largest_unit = Some(DateDurationUnit::Days);
+    /// assert_eq!(
+    ///     d1.try_until_with_options(&d2, options_days).unwrap(),
+    ///     DateDuration::for_days(410)
+    /// );
+    ///
+    /// let mut options_weeks = options_default;
+    /// options_weeks.largest_unit = Some(DateDurationUnit::Weeks);
+    /// assert_eq!(
+    ///     d1.try_until_with_options(&d2, options_weeks).unwrap(),
+    ///     DateDuration {
+    ///         // This is the only time there is a `weeks` value.
+    ///         weeks: 58,
+    ///         days: 4,
+    ///         ..Default::default()
+    ///     }
+    /// );
+    ///
+    /// let mut options_months = options_default;
+    /// options_months.largest_unit = Some(DateDurationUnit::Months);
+    /// assert_eq!(
+    ///     d1.try_until_with_options(&d2, options_months).unwrap(),
+    ///     DateDuration {
+    ///         months: 13,
+    ///         days: 15,
+    ///         ..Default::default()
+    ///     }
+    /// );
+    ///
+    /// let mut options_years = options_default;
+    /// options_years.largest_unit = Some(DateDurationUnit::Years);
+    /// assert_eq!(
+    ///     d1.try_until_with_options(&d2, options_years).unwrap(),
+    ///     DateDuration {
+    ///         years: 1,
+    ///         months: 1,
+    ///         days: 15,
+    ///         ..Default::default()
+    ///     }
+    /// );
+    /// ```
+    ///
+    /// [`Months`]: crate::options::DateDurationUnit::Months
+    /// [`Years`]: crate::options::DateDurationUnit::Years
+    /// [`DateDuration`]: crate::types::DateDuration
+    pub largest_unit: Option<DateDurationUnit>,
+}
+
+/// Whether to constrain or reject out-of-bounds values when constructing a Date.
+///
+/// The behavior conforms to the ECMAScript Temporal specification.
+#[derive(Copy, Clone, Debug, PartialEq, Default)]
+#[non_exhaustive]
+pub enum Overflow {
+    /// Constrain out-of-bounds fields to the nearest in-bounds value.
+    ///
+    /// Only the out-of-bounds field is constrained. If the other fields are not themselves
+    /// out of bounds, they are not changed.
+    ///
+    /// This is the [default option](
+    /// https://tc39.es/proposal-temporal/#sec-temporal-gettemporaloverflowoption),
+    /// following the ECMAScript Temporal specification. See also the [docs on MDN](
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDate#invalid_date_clamping).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu::calendar::cal::Hebrew;
+    /// use icu::calendar::options::DateFromFieldsOptions;
+    /// use icu::calendar::options::Overflow;
+    /// use icu::calendar::types::{DateFields, Month};
+    /// use icu::calendar::Date;
+    /// use icu::calendar::DateError;
+    ///
+    /// let mut options = DateFromFieldsOptions::default();
+    /// options.overflow = Some(Overflow::Constrain);
+    ///
+    /// // 5784, a leap year, contains M05L, but the day is too big.
+    /// let mut fields = DateFields::default();
+    /// fields.extended_year = Some(5784);
+    /// fields.month = Some(Month::leap(5));
+    /// fields.day = Some(50);
+    ///
+    /// let date = Date::try_from_fields(fields, options, Hebrew).unwrap();
+    ///
+    /// // Constrained to the 30th day of M05L of year 5784
+    /// assert_eq!(date.year().extended_year(), 5784);
+    /// assert_eq!(date.month().standard_code.0, "M05L");
+    /// assert_eq!(date.day_of_month().0, 30);
+    ///
+    /// // 5785, a common year, does not contain M05L.
+    /// fields.extended_year = Some(5785);
+    ///
+    /// let date = Date::try_from_fields(fields, options, Hebrew).unwrap();
+    ///
+    /// // Constrained to the 29th day of M06 of year 5785
+    /// assert_eq!(date.year().extended_year(), 5785);
+    /// assert_eq!(date.month().standard_code.0, "M06");
+    /// assert_eq!(date.day_of_month().0, 29);
+    /// ```
+    Constrain,
+    /// Return an error if any fields are out of bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu::calendar::cal::Hebrew;
+    /// use icu::calendar::error::DateFromFieldsError;
+    /// use icu::calendar::options::DateFromFieldsOptions;
+    /// use icu::calendar::options::Overflow;
+    /// use icu::calendar::types::{DateFields, Month};
+    /// use icu::calendar::Date;
+    /// use tinystr::tinystr;
+    ///
+    /// let mut options = DateFromFieldsOptions::default();
+    /// options.overflow = Some(Overflow::Reject);
+    ///
+    /// // 5784, a leap year, contains M05L, but the day is too big.
+    /// let mut fields = DateFields::default();
+    /// fields.extended_year = Some(5784);
+    /// fields.month = Some(Month::leap(5));
+    /// fields.day = Some(50);
+    ///
+    /// let err = Date::try_from_fields(fields, options, Hebrew)
+    ///     .expect_err("Day is out of bounds");
+    /// assert!(matches!(err, DateFromFieldsError::InvalidDay { .. }));
+    ///
+    /// // Set the day to one that exists
+    /// fields.day = Some(1);
+    /// Date::try_from_fields(fields, options, Hebrew)
+    ///     .expect("A valid Hebrew date");
+    ///
+    /// // 5785, a common year, does not contain M05L.
+    /// fields.extended_year = Some(5785);
+    ///
+    /// let err = Date::try_from_fields(fields, options, Hebrew)
+    ///     .expect_err("Month is out of bounds");
+    /// assert!(matches!(err, DateFromFieldsError::MonthNotInYear));
+    /// ```
+    #[default]
+    Reject,
+}
+
+/// How to infer missing fields when the fields that are present do not fully constitute a Date.
+///
+/// In order for the fields to fully constitute a Date, they must identify a year, a month,
+/// and a day. The fields `era`, `era_year`, and `extended_year` identify the year:
+///
+/// | Era? | Era Year? | Extended Year? | Outcome |
+/// |------|-----------|----------------|---------|
+/// | -    | -         | -              | Error |
+/// | Some | -         | -              | Error |
+/// | -    | Some      | -              | Error |
+/// | -    | -         | Some           | OK |
+/// | Some | Some      | -              | OK |
+/// | Some | -         | Some           | Error (era requires era year) |
+/// | -    | Some      | Some           | Error (era year requires era) |
+/// | Some | Some      | Some           | OK (but error if inconsistent) |
+///
+/// The fields `month_code` and `ordinal_month` identify the month:
+///
+/// | Month( Code)? | Ordinal Month? | Outcome |
+/// |-------------|----------------|---------|
+/// | -           | -              | Error |
+/// | Some        | -              | OK |
+/// | -           | Some           | OK |
+/// | Some        | Some           | OK (but error if inconsistent) |
+///
+/// The field `day` identifies the day.
+///
+/// If the fields identify a year, a month, and a day, then there are no missing fields, so
+/// the strategy chosen here has no effect (fields that are out-of-bounds or inconsistent
+/// are handled by other errors).
+#[derive(Copy, Clone, Debug, PartialEq, Default)]
+#[non_exhaustive]
+pub enum MissingFieldsStrategy {
+    /// If the fields that are present do not fully constitute a Date,
+    /// return [`DateFromFieldsError::NotEnoughFields`].
+    ///
+    /// [`DateFromFieldsError::NotEnoughFields`]: crate::error::DateFromFieldsError::NotEnoughFields
+    #[default]
+    Reject,
+    /// If the fields that are present do not fully constitute a Date,
+    /// follow the ECMAScript specification when possible.
+    ///
+    /// ⚠️ This option causes a year or day to be implicitly added to the Date!
+    ///
+    /// This strategy makes the following changes:
+    ///
+    /// 1. If the fields identify a year and a month, but not a day, then set `day` to 1.
+    /// 2. If month and day are set but nothing else, then set the year to a
+    ///    _reference year_: some year in the calendar that contains the specified month
+    ///    and day, according to the ECMAScript specification.
+    ///
+    /// Note that the reference year is _not_ added if an ordinal month is present, since
+    /// the identity of an ordinal month changes from year to year.
+    Ecma,
+}
+
+/// A "duration unit" used to specify the minimum or maximum duration of time to
+/// care about.
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[allow(clippy::exhaustive_enums)] // this type should be stable
+pub enum DateDurationUnit {
+    /// Duration in years
+    Years,
+    /// Duration in months
+    Months,
+    /// Duration in weeks
+    Weeks,
+    /// Duration in days
+    Days,
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{

--- a/components/calendar/src/types.rs
+++ b/components/calendar/src/types.rs
@@ -11,211 +11,194 @@ use tinystr::TinyAsciiStr;
 use zerovec::ule::AsULE;
 
 // Export the duration types from here
-#[cfg(feature = "unstable")]
 pub use crate::duration::DateDuration;
 use crate::{calendar_arithmetic::ArithmeticDate, error::MonthCodeParseError};
-
-#[cfg(feature = "unstable")]
-pub use unstable::DateFields;
-#[cfg(not(feature = "unstable"))]
-pub(crate) use unstable::DateFields;
 
 #[cfg(doc)]
 use crate::Date;
 
-mod unstable {
-    /// A bag of various ways of expressing the year, month, and/or day.
+/// A bag of various ways of expressing the year, month, and/or day.
+///
+/// Pass this into [`Date::try_from_fields`](crate::Date::try_from_fields).
+#[derive(Copy, Clone, PartialEq, Default)]
+#[non_exhaustive]
+pub struct DateFields<'a> {
+    /// The era code as a UTF-8 string.
     ///
-    /// Pass this into [`Date::try_from_fields`](crate::Date::try_from_fields).
+    /// The acceptable codes are defined by CLDR and documented on each calendar.
     ///
-    /// <div class="stab unstable">
-    /// 🚧 This code is considered unstable; it may change at any time, in breaking or non-breaking ways,
-    /// including in SemVer minor releases. Do not use this type unless you are prepared for things to occasionally break.
+    /// If set, [`Self::era_year`] must also be set.
     ///
-    /// Graduation tracking issue: [issue #7161](https://github.com/unicode-org/icu4x/issues/7161).
-    /// </div>
+    /// # Examples
     ///
-    /// ✨ *Enabled with the `unstable` Cargo feature.*
-    #[derive(Copy, Clone, PartialEq, Default)]
-    #[non_exhaustive]
-    pub struct DateFields<'a> {
-        /// The era code as a UTF-8 string.
-        ///
-        /// The acceptable codes are defined by CLDR and documented on each calendar.
-        ///
-        /// If set, [`Self::era_year`] must also be set.
-        ///
-        /// # Examples
-        ///
-        /// To set the era field, use a byte string:
-        ///
-        /// ```
-        /// use icu::calendar::types::DateFields;
-        ///
-        /// let mut fields = DateFields::default();
-        ///
-        /// // As a byte string literal:
-        /// fields.era = Some(b"reiwa");
-        ///
-        /// // Using str::as_bytes:
-        /// fields.era = Some("reiwa".as_bytes());
-        /// ```
-        ///
-        /// For a full example, see [`Self::extended_year`].
-        pub era: Option<&'a [u8]>,
-        /// The numeric year in [`Self::era`].
-        ///
-        /// If set, [`Self::era`] must also be set.
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use icu::calendar::types::DateFields;
-        ///
-        /// let mut fields = DateFields::default();
-        /// fields.era = Some(b"ce");
-        /// fields.era_year = Some(2025);
-        /// ```
-        ///
-        /// For a full example, see [`Self::extended_year`].
-        pub era_year: Option<i32>,
-        /// See [`YearInfo::extended_year()`](crate::types::YearInfo::extended_year).
-        ///
-        /// If both this and [`Self::era`]/[`Self::era_year`] are set, they must
-        /// refer to the same year.
-        ///
-        /// # Examples
-        ///
-        /// Either `extended_year` or `era` + `era_year` can be used in `DateFields`:
-        ///
-        /// ```
-        /// use icu::calendar::cal::Japanese;
-        /// use icu::calendar::types::DateFields;
-        /// use icu::calendar::Date;
-        ///
-        /// let mut fields1 = DateFields::default();
-        /// fields1.era = Some(b"reiwa");
-        /// fields1.era_year = Some(7);
-        /// fields1.ordinal_month = Some(1);
-        /// fields1.day = Some(1);
-        ///
-        /// let date1 =
-        ///     Date::try_from_fields(fields1, Default::default(), Japanese::new())
-        ///         .expect("a well-defined Japanese date from era year");
-        ///
-        /// let mut fields2 = DateFields::default();
-        /// fields2.extended_year = Some(2025);
-        /// fields2.ordinal_month = Some(1);
-        /// fields2.day = Some(1);
-        ///
-        /// let date2 =
-        ///     Date::try_from_fields(fields2, Default::default(), Japanese::new())
-        ///         .expect("a well-defined Japanese date from extended year");
-        ///
-        /// assert_eq!(date1, date2);
-        ///
-        /// let year_info = date1.year().era().unwrap();
-        /// assert_eq!(year_info.year, 7);
-        /// assert_eq!(year_info.era.as_str(), "reiwa");
-        /// assert_eq!(year_info.extended_year, 2025);
-        /// ```
-        pub extended_year: Option<i32>,
-        /// The month representing a valid month in this calendar year.
-        ///
-        /// Only one of [`Self::month`] and [`Self::month_code`] may be set.
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use icu::calendar::types::{DateFields, Month};
-        ///
-        /// let mut fields = DateFields::default();
-        /// fields.month = Some(Month::new(1));
-        /// ```
-        ///
-        /// For a full example, see [`Self::ordinal_month`].
-        pub month: Option<crate::types::Month>,
-        /// The month code representing a valid month in this calendar year,
-        /// as a UTF-8 string.
-        ///
-        /// See [`MonthCode`](crate::types::MonthCode) for information on the syntax.
-        ///
-        /// Only one of [`Self::month`] and [`Self::month_code`] may be set.
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use icu::calendar::types::DateFields;
-        ///
-        /// let mut fields = DateFields::default();
-        /// fields.month_code = Some(b"M01");
-        /// ```
-        ///
-        /// For a full example, see [`Self::ordinal_month`].
-        pub month_code: Option<&'a [u8]>,
-        /// See [`MonthInfo::ordinal`](crate::types::MonthInfo::ordinal).
-        ///
-        /// If both this and [`Self::month`]/[`Self::month_code`] are set, they must refer to
-        /// the same month.
-        ///
-        /// Note: using [`Self::month`]/[`Self::month_code`] is recommended, because the ordinal
-        /// month numbers can vary from year to year, as illustrated in the following example.
-        ///
-        /// # Examples
-        ///
-        /// Either `month`/`month_code`, or `ordinal_month` can be used in [`DateFields`], but they
-        /// might not resolve to the same month number:
-        ///
-        /// ```
-        /// use icu::calendar::cal::ChineseTraditional;
-        /// use icu::calendar::types::{DateFields, Month};
-        /// use icu::calendar::Date;
-        ///
-        /// // The 2023 Year of the Rabbit had a leap month after the 2nd month.
-        /// let mut fields1 = DateFields::default();
-        /// fields1.extended_year = Some(2023);
-        /// fields1.month = Some(Month::leap(2));
-        /// fields1.day = Some(1);
-        ///
-        /// let date1 = Date::try_from_fields(
-        ///     fields1,
-        ///     Default::default(),
-        ///     ChineseTraditional::new(),
-        /// )
-        /// .expect("a well-defined Chinese date from month code");
-        ///
-        /// let mut fields2 = DateFields::default();
-        /// fields2.extended_year = Some(2023);
-        /// fields2.ordinal_month = Some(3);
-        /// fields2.day = Some(1);
-        ///
-        /// let date2 = Date::try_from_fields(
-        ///     fields2,
-        ///     Default::default(),
-        ///     ChineseTraditional::new(),
-        /// )
-        /// .expect("a well-defined Chinese date from ordinal month");
-        ///
-        /// assert_eq!(date1, date2);
-        ///
-        /// let month_info = date1.month();
-        /// assert_eq!(month_info.ordinal, 3);
-        /// assert_eq!(month_info.number(), 2);
-        /// assert_eq!(month_info.is_leap(), true);
-        /// ```
-        pub ordinal_month: Option<u8>,
-        /// See [`DayOfMonth`](crate::types::DayOfMonth).
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use icu::calendar::types::DateFields;
-        ///
-        /// let mut fields = DateFields::default();
-        /// fields.day = Some(1);
-        /// ```
-        pub day: Option<u8>,
-    }
+    /// To set the era field, use a byte string:
+    ///
+    /// ```
+    /// use icu::calendar::types::DateFields;
+    ///
+    /// let mut fields = DateFields::default();
+    ///
+    /// // As a byte string literal:
+    /// fields.era = Some(b"reiwa");
+    ///
+    /// // Using str::as_bytes:
+    /// fields.era = Some("reiwa".as_bytes());
+    /// ```
+    ///
+    /// For a full example, see [`Self::extended_year`].
+    pub era: Option<&'a [u8]>,
+    /// The numeric year in [`Self::era`].
+    ///
+    /// If set, [`Self::era`] must also be set.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu::calendar::types::DateFields;
+    ///
+    /// let mut fields = DateFields::default();
+    /// fields.era = Some(b"ce");
+    /// fields.era_year = Some(2025);
+    /// ```
+    ///
+    /// For a full example, see [`Self::extended_year`].
+    pub era_year: Option<i32>,
+    /// See [`YearInfo::extended_year()`](crate::types::YearInfo::extended_year).
+    ///
+    /// If both this and [`Self::era`]/[`Self::era_year`] are set, they must
+    /// refer to the same year.
+    ///
+    /// # Examples
+    ///
+    /// Either `extended_year` or `era` + `era_year` can be used in `DateFields`:
+    ///
+    /// ```
+    /// use icu::calendar::cal::Japanese;
+    /// use icu::calendar::types::DateFields;
+    /// use icu::calendar::Date;
+    ///
+    /// let mut fields1 = DateFields::default();
+    /// fields1.era = Some(b"reiwa");
+    /// fields1.era_year = Some(7);
+    /// fields1.ordinal_month = Some(1);
+    /// fields1.day = Some(1);
+    ///
+    /// let date1 =
+    ///     Date::try_from_fields(fields1, Default::default(), Japanese::new())
+    ///         .expect("a well-defined Japanese date from era year");
+    ///
+    /// let mut fields2 = DateFields::default();
+    /// fields2.extended_year = Some(2025);
+    /// fields2.ordinal_month = Some(1);
+    /// fields2.day = Some(1);
+    ///
+    /// let date2 =
+    ///     Date::try_from_fields(fields2, Default::default(), Japanese::new())
+    ///         .expect("a well-defined Japanese date from extended year");
+    ///
+    /// assert_eq!(date1, date2);
+    ///
+    /// let year_info = date1.year().era().unwrap();
+    /// assert_eq!(year_info.year, 7);
+    /// assert_eq!(year_info.era.as_str(), "reiwa");
+    /// assert_eq!(year_info.extended_year, 2025);
+    /// ```
+    pub extended_year: Option<i32>,
+    /// The month representing a valid month in this calendar year.
+    ///
+    /// Only one of [`Self::month`] and [`Self::month_code`] may be set.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu::calendar::types::{DateFields, Month};
+    ///
+    /// let mut fields = DateFields::default();
+    /// fields.month = Some(Month::new(1));
+    /// ```
+    ///
+    /// For a full example, see [`Self::ordinal_month`].
+    pub month: Option<Month>,
+    /// The month code representing a valid month in this calendar year,
+    /// as a UTF-8 string.
+    ///
+    /// See [`MonthCode`] for information on the syntax.
+    ///
+    /// Only one of [`Self::month`] and [`Self::month_code`] may be set.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu::calendar::types::DateFields;
+    ///
+    /// let mut fields = DateFields::default();
+    /// fields.month_code = Some(b"M01");
+    /// ```
+    ///
+    /// For a full example, see [`Self::ordinal_month`].
+    pub month_code: Option<&'a [u8]>,
+    /// See [`MonthInfo::ordinal`].
+    ///
+    /// If both this and [`Self::month`]/[`Self::month_code`] are set, they must refer to
+    /// the same month.
+    ///
+    /// Note: using [`Self::month`]/[`Self::month_code`] is recommended, because the ordinal
+    /// month numbers can vary from year to year, as illustrated in the following example.
+    ///
+    /// # Examples
+    ///
+    /// Either `month`/`month_code`, or `ordinal_month` can be used in [`DateFields`], but they
+    /// might not resolve to the same month number:
+    ///
+    /// ```
+    /// use icu::calendar::cal::ChineseTraditional;
+    /// use icu::calendar::types::{DateFields, Month};
+    /// use icu::calendar::Date;
+    ///
+    /// // The 2023 Year of the Rabbit had a leap month after the 2nd month.
+    /// let mut fields1 = DateFields::default();
+    /// fields1.extended_year = Some(2023);
+    /// fields1.month = Some(Month::leap(2));
+    /// fields1.day = Some(1);
+    ///
+    /// let date1 = Date::try_from_fields(
+    ///     fields1,
+    ///     Default::default(),
+    ///     ChineseTraditional::new(),
+    /// )
+    /// .expect("a well-defined Chinese date from month code");
+    ///
+    /// let mut fields2 = DateFields::default();
+    /// fields2.extended_year = Some(2023);
+    /// fields2.ordinal_month = Some(3);
+    /// fields2.day = Some(1);
+    ///
+    /// let date2 = Date::try_from_fields(
+    ///     fields2,
+    ///     Default::default(),
+    ///     ChineseTraditional::new(),
+    /// )
+    /// .expect("a well-defined Chinese date from ordinal month");
+    ///
+    /// assert_eq!(date1, date2);
+    ///
+    /// let month_info = date1.month();
+    /// assert_eq!(month_info.ordinal, 3);
+    /// assert_eq!(month_info.number(), 2);
+    /// assert_eq!(month_info.is_leap(), true);
+    /// ```
+    pub ordinal_month: Option<u8>,
+    /// See [`DayOfMonth`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu::calendar::types::DateFields;
+    ///
+    /// let mut fields = DateFields::default();
+    /// fields.day = Some(1);
+    /// ```
+    pub day: Option<u8>,
 }
 
 // Custom impl to stringify era and month_code where possible.

--- a/ffi/capi/bindings/cpp/icu4x/Date.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/Date.d.hpp
@@ -58,8 +58,6 @@ public:
   /**
    * Creates a new {@link Date} from the given fields, which are interpreted in the given calendar system.
    *
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_from_fields`](https://docs.rs/icu/2.1.1/icu/calendar/struct.Date.html#method.try_from_fields) for more information.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::Date>, icu4x::CalendarDateFromFieldsError> from_fields_in_calendar(icu4x::DateFields fields, icu4x::DateFromFieldsOptions options, const icu4x::Calendar& calendar);
@@ -256,16 +254,12 @@ public:
   /**
    * Returns a new {@link Date} with the given duration added to it.
    *
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_added_with_options`](https://docs.rs/icu/2.1.1/icu/calendar/struct.Date.html#method.try_added_with_options) for more information.
    */
   inline icu4x::diplomat::result<std::unique_ptr<icu4x::Date>, icu4x::CalendarDateAddError> try_add_with_options(icu4x::DateDuration duration, icu4x::DateAddOptions options) const;
 
   /**
    * Calculating the duration between `other - self`
-   *
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    *
    * See the [Rust documentation for `try_until_with_options`](https://docs.rs/icu/2.1.1/icu/calendar/struct.Date.html#method.try_until_with_options) for more information.
    */

--- a/ffi/capi/bindings/cpp/icu4x/DateDuration.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/DateDuration.d.hpp
@@ -46,16 +46,12 @@ struct DateDuration {
   /**
    * Creates a new {@link DateDuration} from an ISO 8601 string.
    *
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_from_str`](https://docs.rs/icu/2.1.1/icu/calendar/types/struct.DateDuration.html#method.try_from_str) for more information.
    */
   inline static icu4x::diplomat::result<icu4x::DateDuration, icu4x::DateDurationParseError> from_string(std::string_view v);
 
   /**
    * Returns a new {@link DateDuration} representing a number of years.
-   *
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    *
    * See the [Rust documentation for `for_years`](https://docs.rs/icu/2.1.1/icu/calendar/types/struct.DateDuration.html#method.for_years) for more information.
    */
@@ -64,8 +60,6 @@ struct DateDuration {
   /**
    * Returns a new {@link DateDuration} representing a number of months.
    *
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `for_months`](https://docs.rs/icu/2.1.1/icu/calendar/types/struct.DateDuration.html#method.for_months) for more information.
    */
   inline static icu4x::DateDuration for_months(int32_t months);
@@ -73,16 +67,12 @@ struct DateDuration {
   /**
    * Returns a new {@link DateDuration} representing a number of weeks.
    *
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `for_weeks`](https://docs.rs/icu/2.1.1/icu/calendar/types/struct.DateDuration.html#method.for_weeks) for more information.
    */
   inline static icu4x::DateDuration for_weeks(int32_t weeks);
 
   /**
    * Returns a new {@link DateDuration} representing a number of days.
-   *
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    *
    * See the [Rust documentation for `for_days`](https://docs.rs/icu/2.1.1/icu/calendar/types/struct.DateDuration.html#method.for_days) for more information.
    */

--- a/ffi/capi/bindings/cpp/icu4x/DateFields.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/DateFields.d.hpp
@@ -30,8 +30,6 @@ namespace capi {
 
 namespace icu4x {
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `DateFields`](https://docs.rs/icu/2.1.1/icu/calendar/types/struct.DateFields.html) for more information.
  */
 struct DateFields {

--- a/ffi/capi/bindings/cpp/icu4x/DateFromFieldsOptions.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/DateFromFieldsOptions.d.hpp
@@ -33,8 +33,6 @@ namespace capi {
 
 namespace icu4x {
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `DateFromFieldsOptions`](https://docs.rs/icu/2.1.1/icu/calendar/options/struct.DateFromFieldsOptions.html) for more information.
  */
 struct DateFromFieldsOptions {

--- a/ffi/capi/bindings/cpp/icu4x/DateMissingFieldsStrategy.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/DateMissingFieldsStrategy.d.hpp
@@ -25,8 +25,6 @@ namespace capi {
 
 namespace icu4x {
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `MissingFieldsStrategy`](https://docs.rs/icu/2.1.1/icu/calendar/options/enum.MissingFieldsStrategy.html) for more information.
  */
 class DateMissingFieldsStrategy {

--- a/ffi/capi/bindings/cpp/icu4x/DateOverflow.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/DateOverflow.d.hpp
@@ -25,8 +25,6 @@ namespace capi {
 
 namespace icu4x {
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `Overflow`](https://docs.rs/icu/2.1.1/icu/calendar/options/enum.Overflow.html) for more information.
  */
 class DateOverflow {

--- a/ffi/capi/bindings/cpp/icu4x/IsoDate.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/IsoDate.d.hpp
@@ -174,16 +174,12 @@ public:
   /**
    * Returns a new {@link IsoDate} with the given duration added to it.
    *
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_added_with_options`](https://docs.rs/icu/2.1.1/icu/calendar/struct.Date.html#method.try_added_with_options) for more information.
    */
   inline icu4x::diplomat::result<std::unique_ptr<icu4x::IsoDate>, icu4x::CalendarDateAddError> try_add_with_options(icu4x::DateDuration duration, icu4x::DateAddOptions options) const;
 
   /**
    * Calculating the duration between `other - self`
-   *
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    *
    * See the [Rust documentation for `try_until_with_options`](https://docs.rs/icu/2.1.1/icu/calendar/struct.Date.html#method.try_until_with_options) for more information.
    */

--- a/ffi/capi/src/date.rs
+++ b/ffi/capi/src/date.rs
@@ -9,12 +9,10 @@ use ffi::IsoWeekOfYear;
 pub mod ffi {
     use alloc::boxed::Box;
     use core::fmt::Write;
-    #[cfg(feature = "unstable")]
     use diplomat_runtime::DiplomatOption;
     use icu_calendar::Iso;
 
     use crate::unstable::calendar::ffi::Calendar;
-    #[cfg(feature = "unstable")]
     use crate::unstable::errors::ffi::{
         CalendarDateAddError, CalendarDateFromFieldsError, CalendarMismatchedCalendarError,
         DateDurationParseError,
@@ -36,7 +34,6 @@ pub mod ffi {
 
     #[diplomat::enum_convert(icu_calendar::options::DateDurationUnit, needs_wildcard)]
     #[diplomat::rust_link(icu::calendar::options::DateDurationUnit, Enum)]
-    #[cfg(feature = "unstable")]
     #[non_exhaustive]
     pub enum DateDurationUnit {
         Years,
@@ -46,7 +43,6 @@ pub mod ffi {
     }
 
     #[diplomat::rust_link(icu::calendar::types::DateDuration, Struct)]
-    #[cfg(feature = "unstable")]
     pub struct DateDuration {
         pub is_negative: bool,
         pub years: u32,
@@ -55,11 +51,8 @@ pub mod ffi {
         pub days: u64,
     }
 
-    #[cfg(feature = "unstable")]
     impl DateDuration {
         /// Creates a new [`DateDuration`] from an ISO 8601 string.
-        ///
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::rust_link(icu::calendar::types::DateDuration::try_from_str, FnInStruct)]
         #[diplomat::rust_link(
             icu::calendar::types::DateDuration::try_from_utf8,
@@ -73,8 +66,6 @@ pub mod ffi {
         }
 
         /// Returns a new [`DateDuration`] representing a number of years.
-        ///
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::rust_link(icu::calendar::types::DateDuration::for_years, FnInStruct)]
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor)]
         pub fn for_years(years: i32) -> DateDuration {
@@ -82,8 +73,6 @@ pub mod ffi {
         }
 
         /// Returns a new [`DateDuration`] representing a number of months.
-        ///
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::rust_link(icu::calendar::types::DateDuration::for_months, FnInStruct)]
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor)]
         pub fn for_months(months: i32) -> DateDuration {
@@ -91,8 +80,6 @@ pub mod ffi {
         }
 
         /// Returns a new [`DateDuration`] representing a number of weeks.
-        ///
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::rust_link(icu::calendar::types::DateDuration::for_weeks, FnInStruct)]
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor)]
         pub fn for_weeks(weeks: i32) -> DateDuration {
@@ -100,8 +87,6 @@ pub mod ffi {
         }
 
         /// Returns a new [`DateDuration`] representing a number of days.
-        ///
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::rust_link(icu::calendar::types::DateDuration::for_days, FnInStruct)]
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor)]
         pub fn for_days(days: i64) -> DateDuration {
@@ -110,13 +95,11 @@ pub mod ffi {
     }
 
     #[diplomat::rust_link(icu::calendar::options::DateAddOptions, Struct)]
-    #[cfg(feature = "unstable")]
     pub struct DateAddOptions {
         pub overflow: DiplomatOption<DateOverflow>,
     }
 
     #[diplomat::rust_link(icu::calendar::options::DateDifferenceOptions, Struct)]
-    #[cfg(feature = "unstable")]
     pub struct DateDifferenceOptions {
         pub largest_unit: DiplomatOption<DateDurationUnit>,
     }
@@ -278,11 +261,8 @@ pub mod ffi {
         }
 
         /// Returns a new [`IsoDate`] with the given duration added to it.
-        ///
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::rust_link(icu::calendar::Date::try_added_with_options, FnInStruct)]
         #[diplomat::rust_link(icu::calendar::Date::try_add_with_options, FnInStruct, hidden)]
-        #[cfg(feature = "unstable")]
         pub fn try_add_with_options(
             &self,
             duration: DateDuration,
@@ -295,10 +275,7 @@ pub mod ffi {
         }
 
         /// Calculating the duration between `other - self`
-        ///
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::rust_link(icu::calendar::Date::try_until_with_options, FnInStruct)]
-        #[cfg(feature = "unstable")]
         pub fn until_with_options(
             &self,
             other: &IsoDate,
@@ -309,17 +286,13 @@ pub mod ffi {
         }
     }
 
-    /// 🚧 This API is unstable and may experience breaking changes outside major releases.
     #[diplomat::rust_link(icu::calendar::options::DateFromFieldsOptions, Struct)]
-    #[cfg(feature = "unstable")]
     pub struct DateFromFieldsOptions {
         pub overflow: DiplomatOption<DateOverflow>,
         pub missing_fields_strategy: DiplomatOption<DateMissingFieldsStrategy>,
     }
 
-    /// 🚧 This API is unstable and may experience breaking changes outside major releases.
     #[diplomat::rust_link(icu::calendar::types::DateFields, Struct)]
-    #[cfg(feature = "unstable")]
     pub struct DateFields<'a> {
         pub era: DiplomatOption<&'a DiplomatStr>,
         pub era_year: DiplomatOption<i32>,
@@ -329,21 +302,17 @@ pub mod ffi {
         pub day: DiplomatOption<u8>,
     }
 
-    /// 🚧 This API is unstable and may experience breaking changes outside major releases.
     #[diplomat::enum_convert(icu_calendar::options::Overflow, needs_wildcard)]
     #[diplomat::rust_link(icu::calendar::options::Overflow, Enum)]
     #[non_exhaustive]
-    #[cfg(feature = "unstable")]
     pub enum DateOverflow {
         Constrain,
         Reject,
     }
 
-    /// 🚧 This API is unstable and may experience breaking changes outside major releases.
     #[diplomat::enum_convert(icu_calendar::options::MissingFieldsStrategy, needs_wildcard)]
     #[diplomat::rust_link(icu::calendar::options::MissingFieldsStrategy, Enum)]
     #[non_exhaustive]
-    #[cfg(feature = "unstable")]
     pub enum DateMissingFieldsStrategy {
         Reject,
         Ecma,
@@ -374,11 +343,8 @@ pub mod ffi {
         }
 
         /// Creates a new [`Date`] from the given fields, which are interpreted in the given calendar system.
-        ///
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::rust_link(icu::calendar::Date::try_from_fields, FnInStruct)]
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor)]
-        #[cfg(feature = "unstable")]
         pub fn from_fields_in_calendar(
             fields: DateFields,
             options: DateFromFieldsOptions,
@@ -638,10 +604,7 @@ pub mod ffi {
         }
 
         /// Returns a new [`Date`] with the given duration added to it.
-        ///
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::rust_link(icu::calendar::Date::try_added_with_options, FnInStruct)]
-        #[cfg(feature = "unstable")]
         pub fn try_add_with_options(
             &self,
             duration: DateDuration,
@@ -659,10 +622,7 @@ pub mod ffi {
         }
 
         /// Calculating the duration between `other - self`
-        ///
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::rust_link(icu::calendar::Date::try_until_with_options, FnInStruct)]
-        #[cfg(feature = "unstable")]
         pub fn try_until_with_options(
             &self,
             other: &Date,
@@ -697,7 +657,6 @@ impl From<icu_calendar::types::IsoWeekOfYear> for IsoWeekOfYear {
     }
 }
 
-#[cfg(feature = "unstable")]
 impl From<ffi::DateFromFieldsOptions> for icu_calendar::options::DateFromFieldsOptions {
     fn from(other: ffi::DateFromFieldsOptions) -> Self {
         let mut options = Self::default();
@@ -709,7 +668,6 @@ impl From<ffi::DateFromFieldsOptions> for icu_calendar::options::DateFromFieldsO
     }
 }
 
-#[cfg(feature = "unstable")]
 impl<'a> From<ffi::DateFields<'a>> for icu_calendar::types::DateFields<'a> {
     fn from(other: ffi::DateFields<'a>) -> Self {
         let mut fields = Self::default();
@@ -724,7 +682,6 @@ impl<'a> From<ffi::DateFields<'a>> for icu_calendar::types::DateFields<'a> {
     }
 }
 
-#[cfg(feature = "unstable")]
 impl From<icu_calendar::types::DateDuration> for ffi::DateDuration {
     fn from(other: icu_calendar::types::DateDuration) -> Self {
         Self {
@@ -737,7 +694,6 @@ impl From<icu_calendar::types::DateDuration> for ffi::DateDuration {
     }
 }
 
-#[cfg(feature = "unstable")]
 impl From<ffi::DateDuration> for icu_calendar::types::DateDuration {
     fn from(other: ffi::DateDuration) -> Self {
         Self {
@@ -750,7 +706,6 @@ impl From<ffi::DateDuration> for icu_calendar::types::DateDuration {
     }
 }
 
-#[cfg(feature = "unstable")]
 impl From<ffi::DateAddOptions> for icu_calendar::options::DateAddOptions {
     fn from(other: ffi::DateAddOptions) -> Self {
         let mut options = Self::default();
@@ -759,7 +714,6 @@ impl From<ffi::DateAddOptions> for icu_calendar::options::DateAddOptions {
     }
 }
 
-#[cfg(feature = "unstable")]
 impl From<ffi::DateDifferenceOptions> for icu_calendar::options::DateDifferenceOptions {
     fn from(other: ffi::DateDifferenceOptions) -> Self {
         let mut options = Self::default();

--- a/ffi/capi/src/errors.rs
+++ b/ffi/capi/src/errors.rs
@@ -81,7 +81,7 @@ pub mod ffi {
     #[derive(Debug, PartialEq, Eq)]
     #[repr(C)]
     #[diplomat::rust_link(icu::calendar::error::DateFromFieldsError, Enum, compact)]
-    #[cfg(all(feature = "unstable", feature = "calendar"))]
+    #[cfg(feature = "calendar")]
     #[non_exhaustive]
     #[diplomat::attr(auto, error)]
     pub enum CalendarDateFromFieldsError {
@@ -102,7 +102,7 @@ pub mod ffi {
     #[derive(Debug, PartialEq, Eq)]
     #[repr(C)]
     #[diplomat::rust_link(icu::calendar::error::DateAddError, Enum, compact)]
-    #[cfg(all(feature = "unstable", feature = "calendar"))]
+    #[cfg(feature = "calendar")]
     #[non_exhaustive]
     #[diplomat::attr(auto, error)]
     pub enum CalendarDateAddError {
@@ -115,7 +115,7 @@ pub mod ffi {
     #[derive(Debug, PartialEq, Eq)]
     #[repr(C)]
     #[diplomat::rust_link(icu::calendar::error::MismatchedCalendarError, Struct, compact)]
-    #[cfg(all(feature = "unstable", feature = "calendar"))]
+    #[cfg(feature = "calendar")]
     #[non_exhaustive]
     #[diplomat::attr(auto, error)]
     pub struct CalendarMismatchedCalendarError;
@@ -123,7 +123,7 @@ pub mod ffi {
     #[derive(Debug, PartialEq, Eq)]
     #[repr(C)]
     #[diplomat::rust_link(icu::calendar::error::DateDurationParseError, Enum, compact)]
-    #[cfg(all(feature = "unstable", feature = "calendar"))]
+    #[cfg(feature = "calendar")]
     #[non_exhaustive]
     #[diplomat::attr(auto, error)]
     pub enum DateDurationParseError {
@@ -260,7 +260,6 @@ impl From<icu_calendar::DateError> for CalendarError {
 }
 
 #[cfg(feature = "calendar")]
-#[cfg(all(feature = "unstable", feature = "calendar"))]
 impl From<icu_calendar::error::DateFromFieldsError> for CalendarDateFromFieldsError {
     fn from(e: icu_calendar::error::DateFromFieldsError) -> Self {
         match e {
@@ -301,7 +300,6 @@ impl From<icu_calendar::error::DateNewError> for CalendarError {
 }
 
 #[cfg(feature = "calendar")]
-#[cfg(all(feature = "unstable", feature = "calendar"))]
 impl From<icu_calendar::error::DateAddError> for CalendarDateAddError {
     fn from(e: icu_calendar::error::DateAddError) -> Self {
         match e {
@@ -314,7 +312,6 @@ impl From<icu_calendar::error::DateAddError> for CalendarDateAddError {
 }
 
 #[cfg(feature = "calendar")]
-#[cfg(all(feature = "unstable", feature = "calendar"))]
 impl From<icu_calendar::error::DateDurationParseError> for DateDurationParseError {
     fn from(e: icu_calendar::error::DateDurationParseError) -> Self {
         match e {

--- a/ffi/dart/lib/src/bindings/Date.g.dart
+++ b/ffi/dart/lib/src/bindings/Date.g.dart
@@ -42,8 +42,6 @@ final class Date implements ffi.Finalizable {
 
   /// Creates a new [Date] from the given fields, which are interpreted in the given calendar system.
   ///
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_from_fields`](https://docs.rs/icu/2.1.1/icu/calendar/struct.Date.html#method.try_from_fields) for more information.
   ///
   /// Throws [CalendarDateFromFieldsError] on failure.
@@ -282,8 +280,6 @@ final class Date implements ffi.Finalizable {
 
   /// Returns a new [Date] with the given duration added to it.
   ///
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_added_with_options`](https://docs.rs/icu/2.1.1/icu/calendar/struct.Date.html#method.try_added_with_options) for more information.
   ///
   /// Throws [CalendarDateAddError] on failure.
@@ -297,8 +293,6 @@ final class Date implements ffi.Finalizable {
   }
 
   /// Calculating the duration between `other - self`
-  ///
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
   ///
   /// See the [Rust documentation for `try_until_with_options`](https://docs.rs/icu/2.1.1/icu/calendar/struct.Date.html#method.try_until_with_options) for more information.
   ///

--- a/ffi/dart/lib/src/bindings/DateDuration.g.dart
+++ b/ffi/dart/lib/src/bindings/DateDuration.g.dart
@@ -58,8 +58,6 @@ final class DateDuration {
 
   /// Creates a new [DateDuration] from an ISO 8601 string.
   ///
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_from_str`](https://docs.rs/icu/2.1.1/icu/calendar/types/struct.DateDuration.html#method.try_from_str) for more information.
   ///
   /// Throws [DateDurationParseError] on failure.
@@ -74,8 +72,6 @@ final class DateDuration {
 
   /// Returns a new [DateDuration] representing a number of years.
   ///
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `for_years`](https://docs.rs/icu/2.1.1/icu/calendar/types/struct.DateDuration.html#method.for_years) for more information.
   factory DateDuration.forYears(int years) {
     final result = _icu4x_DateDuration_for_years_mv1(years);
@@ -83,8 +79,6 @@ final class DateDuration {
   }
 
   /// Returns a new [DateDuration] representing a number of months.
-  ///
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
   ///
   /// See the [Rust documentation for `for_months`](https://docs.rs/icu/2.1.1/icu/calendar/types/struct.DateDuration.html#method.for_months) for more information.
   factory DateDuration.forMonths(int months) {
@@ -94,8 +88,6 @@ final class DateDuration {
 
   /// Returns a new [DateDuration] representing a number of weeks.
   ///
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `for_weeks`](https://docs.rs/icu/2.1.1/icu/calendar/types/struct.DateDuration.html#method.for_weeks) for more information.
   factory DateDuration.forWeeks(int weeks) {
     final result = _icu4x_DateDuration_for_weeks_mv1(weeks);
@@ -103,8 +95,6 @@ final class DateDuration {
   }
 
   /// Returns a new [DateDuration] representing a number of days.
-  ///
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
   ///
   /// See the [Rust documentation for `for_days`](https://docs.rs/icu/2.1.1/icu/calendar/types/struct.DateDuration.html#method.for_days) for more information.
   factory DateDuration.forDays(int days) {

--- a/ffi/dart/lib/src/bindings/DateFields.g.dart
+++ b/ffi/dart/lib/src/bindings/DateFields.g.dart
@@ -12,8 +12,6 @@ final class _DateFieldsFfi extends ffi.Struct {
   external _ResultUint8Void day;
 }
 
-/// 🚧 This API is unstable and may experience breaking changes outside major releases.
-///
 /// See the [Rust documentation for `DateFields`](https://docs.rs/icu/2.1.1/icu/calendar/types/struct.DateFields.html) for more information.
 final class DateFields {
   // ignore: public_member_api_docs

--- a/ffi/dart/lib/src/bindings/DateFromFieldsOptions.g.dart
+++ b/ffi/dart/lib/src/bindings/DateFromFieldsOptions.g.dart
@@ -8,8 +8,6 @@ final class _DateFromFieldsOptionsFfi extends ffi.Struct {
   external _ResultInt32Void missingFieldsStrategy;
 }
 
-/// 🚧 This API is unstable and may experience breaking changes outside major releases.
-///
 /// See the [Rust documentation for `DateFromFieldsOptions`](https://docs.rs/icu/2.1.1/icu/calendar/options/struct.DateFromFieldsOptions.html) for more information.
 final class DateFromFieldsOptions {
   // ignore: public_member_api_docs

--- a/ffi/dart/lib/src/bindings/DateMissingFieldsStrategy.g.dart
+++ b/ffi/dart/lib/src/bindings/DateMissingFieldsStrategy.g.dart
@@ -3,8 +3,6 @@
 
 part of 'lib.g.dart';
 
-/// 🚧 This API is unstable and may experience breaking changes outside major releases.
-///
 /// See the [Rust documentation for `MissingFieldsStrategy`](https://docs.rs/icu/2.1.1/icu/calendar/options/enum.MissingFieldsStrategy.html) for more information.
 enum DateMissingFieldsStrategy {
   // ignore: public_member_api_docs

--- a/ffi/dart/lib/src/bindings/DateOverflow.g.dart
+++ b/ffi/dart/lib/src/bindings/DateOverflow.g.dart
@@ -3,8 +3,6 @@
 
 part of 'lib.g.dart';
 
-/// 🚧 This API is unstable and may experience breaking changes outside major releases.
-///
 /// See the [Rust documentation for `Overflow`](https://docs.rs/icu/2.1.1/icu/calendar/options/enum.Overflow.html) for more information.
 enum DateOverflow {
   // ignore: public_member_api_docs

--- a/ffi/dart/lib/src/bindings/IsoDate.g.dart
+++ b/ffi/dart/lib/src/bindings/IsoDate.g.dart
@@ -181,8 +181,6 @@ final class IsoDate implements ffi.Finalizable {
 
   /// Returns a new [IsoDate] with the given duration added to it.
   ///
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_added_with_options`](https://docs.rs/icu/2.1.1/icu/calendar/struct.Date.html#method.try_added_with_options) for more information.
   ///
   /// Throws [CalendarDateAddError] on failure.
@@ -196,8 +194,6 @@ final class IsoDate implements ffi.Finalizable {
   }
 
   /// Calculating the duration between `other - self`
-  ///
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
   ///
   /// See the [Rust documentation for `try_until_with_options`](https://docs.rs/icu/2.1.1/icu/calendar/struct.Date.html#method.try_until_with_options) for more information.
   DateDuration untilWithOptions(IsoDate other, DateDifferenceOptions options) {

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/Date.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/Date.kt
@@ -88,8 +88,6 @@ class Date internal constructor (
         
         /** Creates a new [Date] from the given fields, which are interpreted in the given calendar system.
         *
-        *🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
         *See the [Rust documentation for `try_from_fields`](https://docs.rs/icu/2.1.1/icu/calendar/struct.Date.html#method.try_from_fields) for more information.
         */
         fun fromFieldsInCalendar(fields: DateFields, options: DateFromFieldsOptions, calendar: Calendar): Result<Date> {
@@ -410,8 +408,6 @@ class Date internal constructor (
     
     /** Returns a new [Date] with the given duration added to it.
     *
-    *🚧 This API is unstable and may experience breaking changes outside major releases.
-    *
     *See the [Rust documentation for `try_added_with_options`](https://docs.rs/icu/2.1.1/icu/calendar/struct.Date.html#method.try_added_with_options) for more information.
     */
     fun tryAddWithOptions(duration: DateDuration, options: DateAddOptions): Result<Date> {
@@ -429,8 +425,6 @@ class Date internal constructor (
     }
     
     /** Calculating the duration between `other - self`
-    *
-    *🚧 This API is unstable and may experience breaking changes outside major releases.
     *
     *See the [Rust documentation for `try_until_with_options`](https://docs.rs/icu/2.1.1/icu/calendar/struct.Date.html#method.try_until_with_options) for more information.
     */

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateDuration.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateDuration.kt
@@ -96,8 +96,6 @@ class DateDuration (var isNegative: Boolean, var years: UInt, var months: UInt, 
         
         /** Creates a new [DateDuration] from an ISO 8601 string.
         *
-        *🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
         *See the [Rust documentation for `try_from_str`](https://docs.rs/icu/2.1.1/icu/calendar/types/struct.DateDuration.html#method.try_from_str) for more information.
         */
         fun fromString(v: String): Result<DateDuration> {
@@ -120,8 +118,6 @@ class DateDuration (var isNegative: Boolean, var years: UInt, var months: UInt, 
         
         /** Returns a new [DateDuration] representing a number of years.
         *
-        *🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
         *See the [Rust documentation for `for_years`](https://docs.rs/icu/2.1.1/icu/calendar/types/struct.DateDuration.html#method.for_years) for more information.
         */
         fun forYears(years: Int): DateDuration {
@@ -133,8 +129,6 @@ class DateDuration (var isNegative: Boolean, var years: UInt, var months: UInt, 
         @JvmStatic
         
         /** Returns a new [DateDuration] representing a number of months.
-        *
-        *🚧 This API is unstable and may experience breaking changes outside major releases.
         *
         *See the [Rust documentation for `for_months`](https://docs.rs/icu/2.1.1/icu/calendar/types/struct.DateDuration.html#method.for_months) for more information.
         */
@@ -148,8 +142,6 @@ class DateDuration (var isNegative: Boolean, var years: UInt, var months: UInt, 
         
         /** Returns a new [DateDuration] representing a number of weeks.
         *
-        *🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
         *See the [Rust documentation for `for_weeks`](https://docs.rs/icu/2.1.1/icu/calendar/types/struct.DateDuration.html#method.for_weeks) for more information.
         */
         fun forWeeks(weeks: Int): DateDuration {
@@ -161,8 +153,6 @@ class DateDuration (var isNegative: Boolean, var years: UInt, var months: UInt, 
         @JvmStatic
         
         /** Returns a new [DateDuration] representing a number of days.
-        *
-        *🚧 This API is unstable and may experience breaking changes outside major releases.
         *
         *See the [Rust documentation for `for_days`](https://docs.rs/icu/2.1.1/icu/calendar/types/struct.DateDuration.html#method.for_days) for more information.
         */

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateFields.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateFields.kt
@@ -70,9 +70,7 @@ internal class OptionDateFieldsNative constructor(): Structure(), Structure.ByVa
 
 }
 
-/** 🚧 This API is unstable and may experience breaking changes outside major releases.
-*
-*See the [Rust documentation for `DateFields`](https://docs.rs/icu/2.1.1/icu/calendar/types/struct.DateFields.html) for more information.
+/** See the [Rust documentation for `DateFields`](https://docs.rs/icu/2.1.1/icu/calendar/types/struct.DateFields.html) for more information.
 */
 class DateFields (var era: String?, var eraYear: Int?, var extendedYear: Int?, var monthCode: String?, var ordinalMonth: UByte?, var day: UByte?) {
     companion object {

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateFromFieldsOptions.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateFromFieldsOptions.kt
@@ -62,9 +62,7 @@ internal class OptionDateFromFieldsOptionsNative constructor(): Structure(), Str
 
 }
 
-/** 🚧 This API is unstable and may experience breaking changes outside major releases.
-*
-*See the [Rust documentation for `DateFromFieldsOptions`](https://docs.rs/icu/2.1.1/icu/calendar/options/struct.DateFromFieldsOptions.html) for more information.
+/** See the [Rust documentation for `DateFromFieldsOptions`](https://docs.rs/icu/2.1.1/icu/calendar/options/struct.DateFromFieldsOptions.html) for more information.
 */
 class DateFromFieldsOptions (var overflow: DateOverflow?, var missingFieldsStrategy: DateMissingFieldsStrategy?) {
     companion object {

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateMissingFieldsStrategy.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateMissingFieldsStrategy.kt
@@ -8,9 +8,7 @@ import com.sun.jna.Structure
 
 internal interface DateMissingFieldsStrategyLib: Library {
 }
-/** 🚧 This API is unstable and may experience breaking changes outside major releases.
-*
-*See the [Rust documentation for `MissingFieldsStrategy`](https://docs.rs/icu/2.1.1/icu/calendar/options/enum.MissingFieldsStrategy.html) for more information.
+/** See the [Rust documentation for `MissingFieldsStrategy`](https://docs.rs/icu/2.1.1/icu/calendar/options/enum.MissingFieldsStrategy.html) for more information.
 */
 enum class DateMissingFieldsStrategy {
     Reject,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateOverflow.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateOverflow.kt
@@ -8,9 +8,7 @@ import com.sun.jna.Structure
 
 internal interface DateOverflowLib: Library {
 }
-/** 🚧 This API is unstable and may experience breaking changes outside major releases.
-*
-*See the [Rust documentation for `Overflow`](https://docs.rs/icu/2.1.1/icu/calendar/options/enum.Overflow.html) for more information.
+/** See the [Rust documentation for `Overflow`](https://docs.rs/icu/2.1.1/icu/calendar/options/enum.Overflow.html) for more information.
 */
 enum class DateOverflow {
     Constrain,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/IsoDate.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/IsoDate.kt
@@ -270,8 +270,6 @@ class IsoDate internal constructor (
     
     /** Returns a new [IsoDate] with the given duration added to it.
     *
-    *🚧 This API is unstable and may experience breaking changes outside major releases.
-    *
     *See the [Rust documentation for `try_added_with_options`](https://docs.rs/icu/2.1.1/icu/calendar/struct.Date.html#method.try_added_with_options) for more information.
     */
     fun tryAddWithOptions(duration: DateDuration, options: DateAddOptions): Result<IsoDate> {
@@ -289,8 +287,6 @@ class IsoDate internal constructor (
     }
     
     /** Calculating the duration between `other - self`
-    *
-    *🚧 This API is unstable and may experience breaking changes outside major releases.
     *
     *See the [Rust documentation for `try_until_with_options`](https://docs.rs/icu/2.1.1/icu/calendar/struct.Date.html#method.try_until_with_options) for more information.
     */

--- a/ffi/npm/lib/Date.d.ts
+++ b/ffi/npm/lib/Date.d.ts
@@ -44,8 +44,6 @@ export class Date {
     /**
      * Creates a new {@link Date} from the given fields, which are interpreted in the given calendar system.
      *
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_from_fields`](https://docs.rs/icu/2.1.1/icu/calendar/struct.Date.html#method.try_from_fields) for more information.
      */
     static fromFieldsInCalendar(fields: DateFields_obj, options: DateFromFieldsOptions_obj, calendar: Calendar): Date;
@@ -237,16 +235,12 @@ export class Date {
     /**
      * Returns a new {@link Date} with the given duration added to it.
      *
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_added_with_options`](https://docs.rs/icu/2.1.1/icu/calendar/struct.Date.html#method.try_added_with_options) for more information.
      */
     tryAddWithOptions(duration: DateDuration_obj, options: DateAddOptions_obj): Date;
 
     /**
      * Calculating the duration between `other - self`
-     *
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
      * See the [Rust documentation for `try_until_with_options`](https://docs.rs/icu/2.1.1/icu/calendar/struct.Date.html#method.try_until_with_options) for more information.
      */

--- a/ffi/npm/lib/Date.mjs
+++ b/ffi/npm/lib/Date.mjs
@@ -82,8 +82,6 @@ export class Date {
     /**
      * Creates a new {@link Date} from the given fields, which are interpreted in the given calendar system.
      *
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_from_fields`](https://docs.rs/icu/2.1.1/icu/calendar/struct.Date.html#method.try_from_fields) for more information.
      */
     static fromFieldsInCalendar(fields, options, calendar) {
@@ -575,8 +573,6 @@ export class Date {
     /**
      * Returns a new {@link Date} with the given duration added to it.
      *
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_added_with_options`](https://docs.rs/icu/2.1.1/icu/calendar/struct.Date.html#method.try_added_with_options) for more information.
      */
     tryAddWithOptions(duration, options) {
@@ -605,8 +601,6 @@ export class Date {
 
     /**
      * Calculating the duration between `other - self`
-     *
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
      * See the [Rust documentation for `try_until_with_options`](https://docs.rs/icu/2.1.1/icu/calendar/struct.Date.html#method.try_until_with_options) for more information.
      */

--- a/ffi/npm/lib/DateDuration.d.ts
+++ b/ffi/npm/lib/DateDuration.d.ts
@@ -39,16 +39,12 @@ export class DateDuration {
     /**
      * Creates a new {@link DateDuration} from an ISO 8601 string.
      *
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_from_str`](https://docs.rs/icu/2.1.1/icu/calendar/types/struct.DateDuration.html#method.try_from_str) for more information.
      */
     static fromString(v: string): DateDuration;
 
     /**
      * Returns a new {@link DateDuration} representing a number of years.
-     *
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
      * See the [Rust documentation for `for_years`](https://docs.rs/icu/2.1.1/icu/calendar/types/struct.DateDuration.html#method.for_years) for more information.
      */
@@ -57,8 +53,6 @@ export class DateDuration {
     /**
      * Returns a new {@link DateDuration} representing a number of months.
      *
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `for_months`](https://docs.rs/icu/2.1.1/icu/calendar/types/struct.DateDuration.html#method.for_months) for more information.
      */
     static forMonths(months: number): DateDuration;
@@ -66,16 +60,12 @@ export class DateDuration {
     /**
      * Returns a new {@link DateDuration} representing a number of weeks.
      *
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `for_weeks`](https://docs.rs/icu/2.1.1/icu/calendar/types/struct.DateDuration.html#method.for_weeks) for more information.
      */
     static forWeeks(weeks: number): DateDuration;
 
     /**
      * Returns a new {@link DateDuration} representing a number of days.
-     *
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
      * See the [Rust documentation for `for_days`](https://docs.rs/icu/2.1.1/icu/calendar/types/struct.DateDuration.html#method.for_days) for more information.
      */

--- a/ffi/npm/lib/DateDuration.mjs
+++ b/ffi/npm/lib/DateDuration.mjs
@@ -162,8 +162,6 @@ export class DateDuration {
     /**
      * Creates a new {@link DateDuration} from an ISO 8601 string.
      *
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_from_str`](https://docs.rs/icu/2.1.1/icu/calendar/types/struct.DateDuration.html#method.try_from_str) for more information.
      */
     static fromString(v) {
@@ -194,8 +192,6 @@ export class DateDuration {
     /**
      * Returns a new {@link DateDuration} representing a number of years.
      *
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `for_years`](https://docs.rs/icu/2.1.1/icu/calendar/types/struct.DateDuration.html#method.for_years) for more information.
      */
     static forYears(years) {
@@ -216,8 +212,6 @@ export class DateDuration {
 
     /**
      * Returns a new {@link DateDuration} representing a number of months.
-     *
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
      * See the [Rust documentation for `for_months`](https://docs.rs/icu/2.1.1/icu/calendar/types/struct.DateDuration.html#method.for_months) for more information.
      */
@@ -240,8 +234,6 @@ export class DateDuration {
     /**
      * Returns a new {@link DateDuration} representing a number of weeks.
      *
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `for_weeks`](https://docs.rs/icu/2.1.1/icu/calendar/types/struct.DateDuration.html#method.for_weeks) for more information.
      */
     static forWeeks(weeks) {
@@ -262,8 +254,6 @@ export class DateDuration {
 
     /**
      * Returns a new {@link DateDuration} representing a number of days.
-     *
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
      * See the [Rust documentation for `for_days`](https://docs.rs/icu/2.1.1/icu/calendar/types/struct.DateDuration.html#method.for_days) for more information.
      */

--- a/ffi/npm/lib/DateFields.d.ts
+++ b/ffi/npm/lib/DateFields.d.ts
@@ -13,8 +13,6 @@ export type DateFields_obj = {
 
 
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `DateFields`](https://docs.rs/icu/2.1.1/icu/calendar/types/struct.DateFields.html) for more information.
  */
 export class DateFields {

--- a/ffi/npm/lib/DateFields.mjs
+++ b/ffi/npm/lib/DateFields.mjs
@@ -5,8 +5,6 @@ import * as diplomatRuntime from "./diplomat-runtime.mjs";
 
 
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `DateFields`](https://docs.rs/icu/2.1.1/icu/calendar/types/struct.DateFields.html) for more information.
  */
 export class DateFields {

--- a/ffi/npm/lib/DateFromFieldsOptions.d.ts
+++ b/ffi/npm/lib/DateFromFieldsOptions.d.ts
@@ -11,8 +11,6 @@ export type DateFromFieldsOptions_obj = {
 
 
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `DateFromFieldsOptions`](https://docs.rs/icu/2.1.1/icu/calendar/options/struct.DateFromFieldsOptions.html) for more information.
  */
 export class DateFromFieldsOptions {

--- a/ffi/npm/lib/DateFromFieldsOptions.mjs
+++ b/ffi/npm/lib/DateFromFieldsOptions.mjs
@@ -7,8 +7,6 @@ import * as diplomatRuntime from "./diplomat-runtime.mjs";
 
 
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `DateFromFieldsOptions`](https://docs.rs/icu/2.1.1/icu/calendar/options/struct.DateFromFieldsOptions.html) for more information.
  */
 export class DateFromFieldsOptions {

--- a/ffi/npm/lib/DateMissingFieldsStrategy.d.ts
+++ b/ffi/npm/lib/DateMissingFieldsStrategy.d.ts
@@ -4,8 +4,6 @@ import type { pointer, codepoint } from "./diplomat-runtime.d.ts";
 
 
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `MissingFieldsStrategy`](https://docs.rs/icu/2.1.1/icu/calendar/options/enum.MissingFieldsStrategy.html) for more information.
  */
 export class DateMissingFieldsStrategy {

--- a/ffi/npm/lib/DateMissingFieldsStrategy.mjs
+++ b/ffi/npm/lib/DateMissingFieldsStrategy.mjs
@@ -5,8 +5,6 @@ import * as diplomatRuntime from "./diplomat-runtime.mjs";
 
 
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `MissingFieldsStrategy`](https://docs.rs/icu/2.1.1/icu/calendar/options/enum.MissingFieldsStrategy.html) for more information.
  */
 export class DateMissingFieldsStrategy {

--- a/ffi/npm/lib/DateOverflow.d.ts
+++ b/ffi/npm/lib/DateOverflow.d.ts
@@ -4,8 +4,6 @@ import type { pointer, codepoint } from "./diplomat-runtime.d.ts";
 
 
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `Overflow`](https://docs.rs/icu/2.1.1/icu/calendar/options/enum.Overflow.html) for more information.
  */
 export class DateOverflow {

--- a/ffi/npm/lib/DateOverflow.mjs
+++ b/ffi/npm/lib/DateOverflow.mjs
@@ -5,8 +5,6 @@ import * as diplomatRuntime from "./diplomat-runtime.mjs";
 
 
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `Overflow`](https://docs.rs/icu/2.1.1/icu/calendar/options/enum.Overflow.html) for more information.
  */
 export class DateOverflow {

--- a/ffi/npm/lib/IsoDate.d.ts
+++ b/ffi/npm/lib/IsoDate.d.ts
@@ -148,16 +148,12 @@ export class IsoDate {
     /**
      * Returns a new {@link IsoDate} with the given duration added to it.
      *
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_added_with_options`](https://docs.rs/icu/2.1.1/icu/calendar/struct.Date.html#method.try_added_with_options) for more information.
      */
     tryAddWithOptions(duration: DateDuration_obj, options: DateAddOptions_obj): IsoDate;
 
     /**
      * Calculating the duration between `other - self`
-     *
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
      * See the [Rust documentation for `try_until_with_options`](https://docs.rs/icu/2.1.1/icu/calendar/struct.Date.html#method.try_until_with_options) for more information.
      */

--- a/ffi/npm/lib/IsoDate.mjs
+++ b/ffi/npm/lib/IsoDate.mjs
@@ -388,8 +388,6 @@ export class IsoDate {
     /**
      * Returns a new {@link IsoDate} with the given duration added to it.
      *
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_added_with_options`](https://docs.rs/icu/2.1.1/icu/calendar/struct.Date.html#method.try_added_with_options) for more information.
      */
     tryAddWithOptions(duration, options) {
@@ -418,8 +416,6 @@ export class IsoDate {
 
     /**
      * Calculating the duration between `other - self`
-     *
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
      * See the [Rust documentation for `try_until_with_options`](https://docs.rs/icu/2.1.1/icu/calendar/struct.Date.html#method.try_until_with_options) for more information.
      */


### PR DESCRIPTION
Fixes #3964, fixes #7161, fixes #7422

## Changelog

icu_calendar: New Date::try_from_fields API for fully general date construction from various choices of year and month values
   - New methods: `Date::try_from_fields()`
   - New types: `DateFields`, `DateFromFieldsOptions`, `Overflow`, `MissingFieldsStrategy`, `DateFromFieldsError`
   - New associated method: `Calendar::from_fields()`


icu_calendar: New Date arithmetic APIs for adding and subtracting dates
  - New methods: `Date::try_add_with_options`, `Date::try_added_with_options`, `Date::try_until_with_options`
  - New types: `DateDuration`  `DateAddOptions`, `DateDifferenceOptions`, `DateDurationUnit`, , `DateDurationParseError`, `DateAddError`, `MismatchedCalendarError`
  - New associated items: `Calendar::add`, `Calendar::until`, `Calendar::DateCompatibilityError`