### PR TITLE
Remove a potential source of UB from potential_utf

### DIFF
--- a/utils/potential_utf/src/ustr.rs
+++ b/utils/potential_utf/src/ustr.rs
@@ -76,8 +76,18 @@ impl PotentialUtf8 {
     #[inline]
     #[cfg(feature = "alloc")]
     pub fn from_boxed_bytes(other: Box<[u8]>) -> Box<Self> {
-        // Safety: PotentialUtf8 is transparent over [u8]
-        unsafe { core::mem::transmute::<Box<[u8]>, Box<Self>>(other) }
+        // Safety: PotentialUtf8 is transparent over [u8] therefore
+        // the cast between [u8] and Self is sound.
+        // Box::into_raw returns a well aligned pointer that is not
+        // null. The cast then changes the type, but the pointer
+        // is still well aligned, not null and created by the
+        // same global allocator, so it's safe to use Box::from_raw
+        // to create a new Box instance out of it.
+        //
+        // We cannot directly transmute the `Box` here as
+        // there is no gurantee about the layout of `Box` with
+        // unsized types.
+        unsafe { Box::from_raw(Box::into_raw(other) as *mut Self) }
     }
 
     /// Create a [`PotentialUtf8`] from a boxed `str`.


### PR DESCRIPTION
This commit removes a transmute from `PotentialUtf8::from_boxed_bytes` as this might rely on undefined behaviour.

It is only sound to transmute between two types like that if their layout is guranteed to be the same. For this particular case it's guranteed that `[u8]` and `PotentialUtf8` have the same layout via the `#[repr(transparent)]` attribute on `PotentialUtf8`. This gurantee doesn't seem to extend on `Box` as:

* `Box` itself is not marked as `#[repr(transparent)]` (or `#[repr(C)]`)
* The [memory layout](https://doc.rust-lang.org/std/boxed/index.html#memory-layout) section of the standard library documentation for `Box` only gurantees a certain layout for sized types:
> So long as T: Sized, a Box<T> is guaranteed to be represented as a single pointer and is also ABI-compatible with C pointers (i.e. the C type T*).
* This specific case involves unsized types, so that gurantee doesn't help us here.

Given that it seems safer to just perform a pointer cast there instead which only involves types with a known compatible layout.

Practically speaking I wouldn't expect that to ever become a problem, but it's better to use a way that's guranteed to work.


## Changelog

potential_utf: Use `Box::from_raw()` instead of `transmute` for converting unsized transparent boxes.
