### PR TITLE
Backport UAX #14-aware line-break oracle to 1.4 (issue #7218)

### DIFF
--- a/components/segmenter/src/complex/mod.rs
+++ b/components/segmenter/src/complex/mod.rs
@@ -339,7 +339,13 @@ fn try_load<M: KeyedDataMarker, P: DataProvider<M> + ?Sized>(
     }
 }
 
-/// Return UTF-16 segment offset array using dictionary or lstm segmenter.
+/// Return UTF-16 **word-boundary** offsets for complex-script input.
+///
+/// This is the word-boundary entry point used by `word.rs`. It runs the
+/// dictionary or LSTM segmenter over each SA (Southeast Asian) run and
+/// returns every word boundary the engine identifies. It performs **no**
+/// UAX #14 line-break filtering — callers that need line-break
+/// opportunities must use [`complex_language_line_breaks_utf16`] instead.
 pub(crate) fn complex_language_segment_utf16(
     payloads: &ComplexPayloads,
     input: &[u16],
@@ -374,7 +380,13 @@ pub(crate) fn complex_language_segment_utf16(
     result
 }
 
-/// Return UTF-8 segment offset array using dictionary or lstm segmenter.
+/// Return UTF-8 **word-boundary** offsets for complex-script input.
+///
+/// See [`complex_language_segment_utf16`] for the full semantic contract:
+/// this returns every word boundary the dict/LSTM engine identifies, with
+/// no UAX #14 filtering. It is consumed by the word segmenter, which wants
+/// all word boundaries regardless of line-break eligibility. For
+/// line-break opportunities, use [`complex_language_line_breaks_str`].
 pub(crate) fn complex_language_segment_str(payloads: &ComplexPayloads, input: &str) -> Vec<usize> {
     let mut result = Vec::new();
     let mut offset = 0;
@@ -402,6 +414,130 @@ pub(crate) fn complex_language_segment_str(payloads: &ComplexPayloads, input: &s
             }
         }
         offset += slice.len();
+    }
+    result
+}
+
+/// Return UAX #14 line-break-opportunity offsets for complex-script input
+/// (UTF-8).
+///
+/// Runs the same dictionary/LSTM pipeline as
+/// [`complex_language_segment_str`], then filters out boundaries that
+/// UAX #14 forbids at the chunk edges:
+///
+/// * **Internal boundary** between an SA chunk and a following non-SA
+///   chunk inside `input`: the dict/LSTM emits a terminal break at the
+///   end of the SA chunk; that break is dropped if `forbids_break_before`
+///   returns `true` for the first char of the non-SA chunk (e.g. LB7
+///   `× SP`, LB21 `× BA` for U+3000, etc.).
+/// * **Trailing boundary** at `input.len()`: the dict/LSTM emits a
+///   terminal break for the last SA chunk; that break is dropped if
+///   `next_ext_char` is `Some(c)` and `forbids_break_before(c)` returns
+///   `true`.
+///
+/// The predicate keeps UAX #14 knowledge out of this module: callers
+/// supply the rule, this function applies it at the seam between
+/// dict/LSTM output and the outer line-break engine. This is the
+/// correctness fix for issue #7218 (Asian text producing double breaks
+/// around spaces and other × X classes). Applying the filter here rather
+/// than in `line.rs` means the per-line-break-candidate hot path does
+/// not have to rescan the break list.
+pub(crate) fn complex_language_line_breaks_str<F: FnMut(char) -> bool>(
+    payloads: &ComplexPayloads,
+    input: &str,
+    next_ext_char: Option<char>,
+    mut forbids_break_before: F,
+) -> Vec<usize> {
+    let mut result = Vec::new();
+    let mut offset = 0;
+    for (slice, lang) in LanguageIterator::new(input) {
+        match payloads.select(lang) {
+            Some(Ok(dict)) => {
+                result.extend(
+                    DictionarySegmenter::new(dict.get(), payloads.grapheme.get())
+                        .segment_str(slice)
+                        .map(|n| offset + n),
+                );
+            }
+            #[cfg(feature = "lstm")]
+            Some(Err(lstm)) => {
+                result.extend(
+                    LstmSegmenter::new(lstm.get(), payloads.grapheme.get())
+                        .segment_str(slice)
+                        .map(|n| offset + n),
+                );
+            }
+            #[cfg(not(feature = "lstm"))]
+            Some(Err(_infallible)) => {} // should be refutable
+            None => {
+                // Drop the preceding SA chunk's terminal break if UAX #14
+                // forbids a break before the first char of this non-SA chunk.
+                // The `result.last() == Some(&offset)` guard protects against
+                // an empty vector or a preceding chunk that did not emit a
+                // terminal break.
+                if let Some(first) = slice.chars().next() {
+                    if forbids_break_before(first) && result.last() == Some(&offset) {
+                        result.pop();
+                    }
+                }
+                result.push(offset + slice.len());
+            }
+        }
+        offset += slice.len();
+    }
+    // Trailing terminal break vs. the char immediately following `input`.
+    if let Some(c) = next_ext_char {
+        if forbids_break_before(c) && result.last() == Some(&offset) {
+            result.pop();
+        }
+    }
+    result
+}
+
+/// Return UAX #14 line-break-opportunity offsets for complex-script input
+/// (UTF-16). See [`complex_language_line_breaks_str`] for the full contract.
+pub(crate) fn complex_language_line_breaks_utf16<F: FnMut(u16) -> bool>(
+    payloads: &ComplexPayloads,
+    input: &[u16],
+    next_ext_code_unit: Option<u16>,
+    mut forbids_break_before: F,
+) -> Vec<usize> {
+    let mut result = Vec::new();
+    let mut offset = 0;
+    for (slice, lang) in LanguageIteratorUtf16::new(input) {
+        match payloads.select(lang) {
+            Some(Ok(dict)) => {
+                result.extend(
+                    DictionarySegmenter::new(dict.get(), payloads.grapheme.get())
+                        .segment_utf16(slice)
+                        .map(|n| offset + n),
+                );
+            }
+            #[cfg(feature = "lstm")]
+            Some(Err(lstm)) => {
+                result.extend(
+                    LstmSegmenter::new(lstm.get(), payloads.grapheme.get())
+                        .segment_utf16(slice)
+                        .map(|n| offset + n),
+                );
+            }
+            #[cfg(not(feature = "lstm"))]
+            Some(Err(_infallible)) => {} // should be refutable
+            None => {
+                if let Some(&first) = slice.first() {
+                    if forbids_break_before(first) && result.last() == Some(&offset) {
+                        result.pop();
+                    }
+                }
+                result.push(offset + slice.len());
+            }
+        }
+        offset += slice.len();
+    }
+    if let Some(c) = next_ext_code_unit {
+        if forbids_break_before(c) && result.last() == Some(&offset) {
+            result.pop();
+        }
     }
     result
 }

--- a/components/segmenter/src/line.rs
+++ b/components/segmenter/src/line.rs
@@ -121,6 +121,37 @@ pub type LineBreakIteratorLatin1<'l, 's> = LineBreakIterator<'l, 's, LineBreakTy
 /// For examples of use, see [`LineSegmenter`].
 pub type LineBreakIteratorUtf16<'l, 's> = LineBreakIterator<'l, 's, LineBreakTypeUtf16>;
 
+/// Returns `true` if UAX #14 forbids a break immediately before a character
+/// whose line-break class is `class`, regardless of the class that precedes it.
+///
+/// Used by the complex-script line-break pipeline to decide whether the
+/// dict/LSTM's boundary between an SA chunk and the next character is a
+/// valid line-break opportunity. For the classes listed here UAX #14 states
+/// `× class` unconditionally (or unconditionally in all contexts reachable
+/// from SA in practice):
+///
+/// * **LB7**:   `× SP` — never break before a space.
+/// * **LB9**:   `× CM`, `× ZWJ` — combining marks attach to the preceding char.
+/// * **LB11**:  `× WJ` — word-joiner is glue.
+/// * **LB12a**: `× GL` — non-breaking glue.
+/// * **LB13**:  `× CL`, `× CP`, `× EX`, `× IS`, `× SY`.
+/// * **LB21**:  `× BA`, `× HY`, `× NS` — no break before these after the
+///              previous non-space char (SA never introduces a space on its
+///              right, so this simplifies to unconditional `×`).
+/// * **LB22**:  `× IN`.
+///
+/// Classes intentionally **not** included here either allow a break
+/// (LB18 `SP ÷`, etc.), require surrounding context that our SA-adjacent
+/// usage cannot produce, or are handled by the mandatory-break rules
+/// (LB4/LB5: BK, CR, LF, NL).
+#[inline]
+fn lb_class_forbids_break_before(class: u8) -> bool {
+    matches!(
+        class,
+        SP | BA | HY | NS | WJ | GL | CL | CP | EX | IS | SY | IN | ZWJ | CM,
+    )
+}
+
 /// Supports loading line break data, and creating line break iterators for different string
 /// encodings.
 ///
@@ -1132,12 +1163,18 @@ where
     let start_point = iter.current_pos_data;
     let mut s = String::new();
     s.push(left_codepoint);
+    // Capture the char that terminated collection (if any). It is passed to
+    // `complex_language_line_breaks_str` so the UAX #14 filter can decide
+    // whether the dict/LSTM's trailing break is a valid line-break
+    // opportunity (LB7 `× SP`, LB21 `× BA`, LB13 `× CL`, etc.).
+    let mut next_ext_char: Option<char> = None;
     loop {
         debug_assert!(!iter.is_eof());
         s.push(iter.get_current_codepoint()?);
         iter.advance_iter();
         if let Some(current_codepoint) = iter.get_current_codepoint() {
             if !T::use_complex_breaking(iter, current_codepoint) {
+                next_ext_char = Some(current_codepoint);
                 break;
             }
         } else {
@@ -1149,7 +1186,19 @@ where
     // Restore iterator to move to head of complex string
     iter.iter = start_iter;
     iter.current_pos_data = start_point;
-    let breaks = complex_language_segment_str(iter.complex, &s);
+    // Capture `data` and `options` so the UAX #14 predicate closure can
+    // look up line-break classes without borrowing `iter` across the call
+    // to the complex oracle. Both are shared references (`Copy`).
+    let data = iter.data;
+    let options = iter.options;
+    let breaks = complex_language_line_breaks_str(iter.complex, &s, next_ext_char, |c| {
+        lb_class_forbids_break_before(get_linebreak_property_with_rule(
+            &data.property_table,
+            c,
+            options.strictness,
+            options.word_option,
+        ))
+    });
     iter.result_cache = breaks;
     let first_pos = *iter.result_cache.first()?;
     let mut i = left_codepoint.len_utf8();
@@ -1239,12 +1288,16 @@ impl<'l, 's> LineBreakType<'l, 's> for LineBreakTypeUtf16 {
         let start_iter = iterator.iter.clone();
         let start_point = iterator.current_pos_data;
         let mut s = vec![left_codepoint as u16];
+        // Capture the codepoint that terminated collection (if any). See
+        // `handle_complex_language_utf8` for rationale.
+        let mut next_ext_cp: Option<u32> = None;
         loop {
             debug_assert!(!iterator.is_eof());
             s.push(iterator.get_current_codepoint()? as u16);
             iterator.advance_iter();
             if let Some(current_codepoint) = iterator.get_current_codepoint() {
                 if !Self::use_complex_breaking(iterator, current_codepoint) {
+                    next_ext_cp = Some(current_codepoint);
                     break;
                 }
             } else {
@@ -1256,7 +1309,26 @@ impl<'l, 's> LineBreakType<'l, 's> for LineBreakTypeUtf16 {
         // Restore iterator to move to head of complex string
         iterator.iter = start_iter;
         iterator.current_pos_data = start_point;
-        let breaks = complex_language_segment_utf16(iterator.complex, &s);
+        let data = iterator.data;
+        let options = iterator.options;
+        // The filter predicate takes u16 (BMP code unit). All
+        // "forbids-break-before" classes we care about (SP, BA, GL, CL, CP,
+        // EX, IS, SY, WJ, IN, NS, HY, ZWJ, CM) are BMP, so a single u16
+        // lookup is faithful for our purposes.
+        let next_ext_code_unit = next_ext_cp.and_then(|c| u16::try_from(c).ok());
+        let breaks = complex_language_line_breaks_utf16(
+            iterator.complex,
+            &s,
+            next_ext_code_unit,
+            |c| {
+                lb_class_forbids_break_before(get_linebreak_property_utf32_with_rule(
+                    &data.property_table,
+                    c as u32,
+                    options.strictness,
+                    options.word_option,
+                ))
+            },
+        );
         iterator.result_cache = breaks;
         // result_cache vector is utf-16 index that is in BMP.
         let first_pos = *iterator.result_cache.first()?;
@@ -1637,5 +1709,168 @@ mod tests {
         let segmenter = LineSegmenter::new_auto();
         let breaks: Vec<usize> = segmenter.segment_str("").collect();
         assert_eq!(breaks, [0]);
+    }
+
+    /// Shared helper: no two adjacent line breaks in `text`, and UTF-8 /
+    /// UTF-16 break offsets agree under conversion. A double-break
+    /// (offsets differing by 1) is the issue-#7218 symptom.
+    fn assert_no_double_breaks_and_utf_consistency(text: &str, label: &str) {
+        let segmenter = LineSegmenter::new_auto();
+
+        let utf8_breaks: Vec<usize> = segmenter.segment_str(text).collect();
+        for pair in utf8_breaks.windows(2).skip(1) {
+            assert!(
+                pair[1] - pair[0] > 1,
+                "{label}: UTF-8 double-break at {pair:?} in {utf8_breaks:?}"
+            );
+        }
+
+        let utf16: Vec<u16> = text.encode_utf16().collect();
+        let utf16_breaks: Vec<usize> = segmenter.segment_utf16(&utf16).collect();
+        for pair in utf16_breaks.windows(2).skip(1) {
+            assert!(
+                pair[1] - pair[0] > 1,
+                "{label}: UTF-16 double-break at {pair:?} in {utf16_breaks:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn khmer_line_break_with_spaces() {
+        assert_no_double_breaks_and_utf_consistency("ខ្មែរ ភាសា", "Khmer with space");
+    }
+
+    #[test]
+    fn thai_line_break_with_spaces() {
+        assert_no_double_breaks_and_utf_consistency("ภาษา ไทย", "Thai with space");
+    }
+
+    #[test]
+    fn lao_line_break_with_spaces() {
+        assert_no_double_breaks_and_utf_consistency("ລາວ ພາສາ", "Lao with space");
+    }
+
+    /// Exercises the UAX #14 filter in `complex::complex_language_line_breaks_str`
+    /// against an input with multiple SA-SP boundaries. Each Thai word
+    /// is independently segmented; the trailing break of each SA run is
+    /// filtered because the next char (SP) has LB class SP which forbids
+    /// a preceding break under LB7.
+    #[test]
+    fn sa_sp_boundary_filtered_at_every_run() {
+        let text = "ภาษา ไทย abc";
+        assert_no_double_breaks_and_utf_consistency(text, "multiple SA-SP boundaries");
+
+        let segmenter = LineSegmenter::new_auto();
+        let breaks: Vec<usize> = segmenter.segment_str(text).collect();
+        let first_space = text.find(' ').unwrap();
+        let second_space = text.rfind(' ').unwrap();
+        assert!(
+            !breaks.contains(&first_space),
+            "unexpected break BEFORE first space at {first_space}: {breaks:?}"
+        );
+        assert!(
+            !breaks.contains(&second_space),
+            "unexpected break BEFORE second space at {second_space}: {breaks:?}"
+        );
+        assert!(
+            breaks.contains(&(first_space + 1)),
+            "missing break AFTER first space at {}: {breaks:?}",
+            first_space + 1
+        );
+        assert!(
+            breaks.contains(&(second_space + 1)),
+            "missing break AFTER second space at {}: {breaks:?}",
+            second_space + 1
+        );
+    }
+
+    /// Non-ASCII whitespace around SA must not produce double-breaks.
+    ///
+    /// UAX #14 assigns line-break class `SP` only to U+0020. Other
+    /// "whitespace-looking" characters have different LB classes — most
+    /// of them class BA (break after), which LB21 forbids a break
+    /// *before*. The generalized filter in
+    /// `complex::complex_language_line_breaks_*` consults the caller's
+    /// `forbids_break_before` predicate for every terminal SA boundary,
+    /// so all of the following must be handled uniformly:
+    ///
+    ///   - U+00A0 NO-BREAK SPACE  → GL (LB12a × GL)
+    ///   - U+3000 IDEOGRAPHIC SP  → BA (LB21 × BA)
+    ///   - U+2009 THIN SPACE      → BA
+    ///   - U+0009 TAB             → BA
+    #[test]
+    fn non_ascii_whitespace_around_sa() {
+        assert_no_double_breaks_and_utf_consistency("ภาษา\u{00A0}ไทย", "Thai + NBSP");
+        assert_no_double_breaks_and_utf_consistency("ภาษา\u{3000}ไทย", "Thai + IDSP");
+        assert_no_double_breaks_and_utf_consistency("ภาษา\u{2009}ไทย", "Thai + THIN SPACE");
+        assert_no_double_breaks_and_utf_consistency("ภาษา\tไทย", "Thai + TAB");
+    }
+
+    /// LSTM and Dictionary engines both feed through
+    /// `complex_language_line_breaks_str`, so both must be free of the
+    /// SA|SP double-break regardless of which word boundaries each engine
+    /// chooses internally.
+    ///
+    /// The two engines are **not** expected to agree on the full set of
+    /// break positions (the dict's word list differs from the LSTM's
+    /// trained boundaries). What this test guards is the invariant that
+    /// the UAX #14 filter applies uniformly — neither produces a
+    /// double-break around the space, and each engine's break at the
+    /// byte after each space is present (LB18 `SP ÷`).
+    #[test]
+    fn lstm_vs_dictionary_no_double_break() {
+        let text = "ภาษา ไทย ภาษา";
+
+        let lstm = LineSegmenter::new_lstm();
+        let dict = LineSegmenter::new_dictionary();
+
+        let lstm_breaks: Vec<usize> = lstm.segment_str(text).collect();
+        let dict_breaks: Vec<usize> = dict.segment_str(text).collect();
+
+        for pair in lstm_breaks.windows(2).skip(1) {
+            assert!(pair[1] - pair[0] > 1, "LSTM double-break: {lstm_breaks:?}");
+        }
+        for pair in dict_breaks.windows(2).skip(1) {
+            assert!(pair[1] - pair[0] > 1, "Dict double-break: {dict_breaks:?}");
+        }
+
+        for (engine, breaks) in [("LSTM", &lstm_breaks), ("Dict", &dict_breaks)] {
+            for (i, _) in text.match_indices(' ') {
+                assert!(
+                    !breaks.contains(&i),
+                    "{engine} broke BEFORE space at {i}: {breaks:?}"
+                );
+                assert!(
+                    breaks.contains(&(i + 1)),
+                    "{engine} missing break AFTER space at {}: {breaks:?}",
+                    i + 1
+                );
+            }
+        }
+    }
+
+    /// Word segmenter regression: `word.rs` uses
+    /// `complex_language_segment_str` (the word-boundary oracle), not the
+    /// line-break variant, so it must see every word boundary the dict/LSTM
+    /// produces. This locks that invariant end-to-end.
+    #[test]
+    fn word_segmenter_thai_unchanged() {
+        use crate::WordSegmenter;
+        let segmenter = WordSegmenter::new_auto();
+        let text = "ภาษาไทยภาษาไทย";
+        let breaks: Vec<usize> = segmenter.segment_str(text).collect();
+        // Every word boundary from the dict must be preserved — including
+        // the terminal one at the end of the SA run.
+        assert!(
+            breaks.contains(&text.len()),
+            "word segmenter must keep terminal boundary at {}: {breaks:?}",
+            text.len()
+        );
+        for pair in breaks.windows(2) {
+            assert!(
+                pair[1] - pair[0] > 0,
+                "word segmenter emitted duplicate offset: {breaks:?}"
+            );
+        }
     }
 }

--- a/components/segmenter/src/line.rs
+++ b/components/segmenter/src/line.rs
@@ -126,29 +126,38 @@ pub type LineBreakIteratorUtf16<'l, 's> = LineBreakIterator<'l, 's, LineBreakTyp
 ///
 /// Used by the complex-script line-break pipeline to decide whether the
 /// dict/LSTM's boundary between an SA chunk and the next character is a
-/// valid line-break opportunity. For the classes listed here UAX #14 states
-/// `× class` unconditionally (or unconditionally in all contexts reachable
-/// from SA in practice):
+/// valid line-break opportunity. The predicate runs only at the seam
+/// between an SA chunk and the next character; the *preceding* char at
+/// every callsite is therefore SA-class. For the classes listed below
+/// UAX #14 states `× class` unconditionally in that context:
 ///
-/// * **`LB7`**:   `× SP` — never break before a space.
+/// * **`LB7`**:   `× SP`, `× ZW` — never break before a space or zero-width
+///   space.
 /// * **`LB9`**:   `× CM`, `× ZWJ` — combining marks attach to the preceding char.
 /// * **`LB11`**:  `× WJ` — word-joiner is glue.
-/// * **`LB12a`**: `× GL` — non-breaking glue.
+/// * **`LB12a`**: `× GL` — non-breaking glue (the `SP|BA|HY` exception does
+///   not apply when the previous class is SA).
 /// * **`LB13`**:  `× CL`, `× CP`, `× EX`, `× IS`, `× SY`.
+/// * **`LB19`**:  `× QU` — never break before a quotation mark. (1.4
+///   classifies all quotation forms — initial `«` `"` `'`, final `»` `"`
+///   `'`, and ambiguous `"` `'` — as `QU`; the newer LB19a East-Asian-
+///   context tailoring does not apply when the previous class is SA.)
 /// * **`LB21`**:  `× BA`, `× HY`, `× NS` — no break before these after the
 ///   previous non-space char (SA never introduces a space on its
 ///   right, so this simplifies to unconditional `×`).
 /// * **`LB22`**:  `× IN`.
 ///
 /// Classes intentionally **not** included here either allow a break
-/// (LB18 `SP ÷`, etc.), require surrounding context that our SA-adjacent
-/// usage cannot produce, or are handled by the mandatory-break rules
-/// (LB4/LB5: BK, CR, LF, NL).
+/// (LB18 `SP ÷`, LB20 `÷ CB`, etc.), require a *preceding-class* context
+/// that SA cannot satisfy (LB14 `OP ×`, LB15 `QU ×`, LB17 `B2 SP* × B2`,
+/// LB30 `(AL|HL|NU) × OP30`, LB30a/b stateful rules — all handled by the
+/// outer line-break state machine, not this seam), or are handled by the
+/// mandatory-break rules (LB4/LB5: BK, CR, LF, NL).
 #[inline]
 fn lb_class_forbids_break_before(class: u8) -> bool {
     matches!(
         class,
-        SP | BA | HY | NS | WJ | GL | CL | CP | EX | IS | SY | IN | ZWJ | CM,
+        SP | ZW | BA | HY | NS | WJ | GL | CL | CP | EX | IS | SY | IN | ZWJ | CM | QU,
     )
 }
 
@@ -1843,6 +1852,128 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// LB7 (`× ZW`) and LB19 (`× QU`) at the SA→next-char seam. The
+    /// dict/LSTM emits a terminal break at the end of every SA run; the
+    /// predicate must drop that break when the next character is a
+    /// zero-width space or any quotation mark, regardless of which
+    /// complex script the run is in.
+    ///
+    /// 1.4 classifies all quotation forms — initial `«` `"` `'`, final
+    /// `»` `"` `'`, and ambiguous `"` `'` — as a single `QU` class
+    /// (the QU_PI / QU_PF split was added later), so adding `QU` to
+    /// the predicate covers every quote form here.
+    ///
+    /// We assert that the byte position immediately *before* each
+    /// punctuation char is **not** in the break list — the offending
+    /// terminal break was correctly suppressed.
+    #[test]
+    fn complex_script_punctuation_no_break_before() {
+        let segmenter = LineSegmenter::new_auto();
+        let cases: &[(&str, &str, char)] = &[
+            // (label, sa_text, trailing_punctuation)
+            ("Thai + ASCII dquote", "ภาษาไทย", '"'),
+            ("Thai + ASCII squote", "ภาษาไทย", '\''),
+            ("Thai + smart-left dquote", "ภาษาไทย", '\u{201C}'),
+            ("Thai + smart-right dquote", "ภาษาไทย", '\u{201D}'),
+            ("Thai + smart-left squote", "ภาษาไทย", '\u{2018}'),
+            ("Thai + smart-right squote", "ภาษาไทย", '\u{2019}'),
+            ("Thai + left guillemet", "ภาษาไทย", '\u{00AB}'),
+            ("Thai + right guillemet", "ภาษาไทย", '\u{00BB}'),
+            ("Thai + ZWSP", "ภาษาไทย", '\u{200B}'),
+            ("Khmer + ASCII dquote", "ខ្មែរ", '"'),
+            ("Khmer + smart-right dquote", "ខ្មែរ", '\u{201D}'),
+            ("Khmer + left guillemet", "ខ្មែរ", '\u{00AB}'),
+            ("Khmer + right guillemet", "ខ្មែរ", '\u{00BB}'),
+            ("Khmer + ZWSP", "ខ្មែរ", '\u{200B}'),
+            ("Lao + ASCII dquote", "ລາວ", '"'),
+            ("Lao + right guillemet", "ລາວ", '\u{00BB}'),
+            ("Lao + ZWSP", "ລາວ", '\u{200B}'),
+        ];
+
+        for (label, sa, punct) in cases {
+            let mut text = String::from(*sa);
+            let punct_byte_offset = text.len();
+            text.push(*punct);
+
+            let breaks: Vec<usize> = segmenter.segment_str(&text).collect();
+            assert!(
+                !breaks.contains(&punct_byte_offset),
+                "{label}: unexpected break BEFORE '{}' (U+{:04X}) at byte {}: {breaks:?}",
+                punct,
+                *punct as u32,
+                punct_byte_offset,
+            );
+
+            let utf16: Vec<u16> = text.encode_utf16().collect();
+            let utf16_punct_offset = sa.encode_utf16().count();
+            let utf16_breaks: Vec<usize> = segmenter.segment_utf16(&utf16).collect();
+            assert!(
+                !utf16_breaks.contains(&utf16_punct_offset),
+                "{label} (utf16): unexpected break BEFORE '{}' (U+{:04X}) at u16 index {}: {utf16_breaks:?}",
+                punct,
+                *punct as u32,
+                utf16_punct_offset,
+            );
+        }
+    }
+
+    /// LSTM-only complement to `complex_script_punctuation_no_break_before`
+    /// for Burmese (whose bundled coverage in `new_auto` depends on the
+    /// LSTM model in 1.4).
+    #[test]
+    fn complex_script_punctuation_no_break_before_burmese() {
+        let segmenter = LineSegmenter::new_lstm();
+        let cases: &[(&str, &str, char)] = &[
+            ("Burmese + ASCII squote", "မြန်မာ", '\''),
+            ("Burmese + smart-right dquote", "မြန်မာ", '\u{201D}'),
+            ("Burmese + left guillemet", "မြန်မာ", '\u{00AB}'),
+            ("Burmese + right guillemet", "မြန်မာ", '\u{00BB}'),
+            ("Burmese + ZWSP", "မြန်မာ", '\u{200B}'),
+        ];
+
+        for (label, sa, punct) in cases {
+            let mut text = String::from(*sa);
+            let punct_byte_offset = text.len();
+            text.push(*punct);
+
+            let breaks: Vec<usize> = segmenter.segment_str(&text).collect();
+            assert!(
+                !breaks.contains(&punct_byte_offset),
+                "{label}: unexpected break BEFORE '{}' (U+{:04X}) at byte {}: {breaks:?}",
+                punct,
+                *punct as u32,
+                punct_byte_offset,
+            );
+
+            let utf16: Vec<u16> = text.encode_utf16().collect();
+            let utf16_punct_offset = sa.encode_utf16().count();
+            let utf16_breaks: Vec<usize> = segmenter.segment_utf16(&utf16).collect();
+            assert!(
+                !utf16_breaks.contains(&utf16_punct_offset),
+                "{label} (utf16): unexpected break BEFORE '{}' (U+{:04X}) at u16 index {}: {utf16_breaks:?}",
+                punct,
+                *punct as u32,
+                utf16_punct_offset,
+            );
+        }
+    }
+
+    /// Counter-test: confirm the predicate has not been over-broadened.
+    /// Letters (LB class AL) immediately following an SA run *should*
+    /// retain the dict/LSTM's terminal break — there's no UAX #14 rule
+    /// of the form `× AL` at this seam.
+    #[test]
+    fn complex_script_letter_keeps_break_before() {
+        let segmenter = LineSegmenter::new_auto();
+        let text = "ภาษาไทยabc";
+        let thai_end = "ภาษาไทย".len();
+        let breaks: Vec<usize> = segmenter.segment_str(text).collect();
+        assert!(
+            breaks.contains(&thai_end),
+            "expected break at SA→AL seam (byte {thai_end}): {breaks:?}",
+        );
     }
 
     /// Word segmenter regression: `word.rs` uses

--- a/components/segmenter/src/line.rs
+++ b/components/segmenter/src/line.rs
@@ -161,6 +161,38 @@ fn lb_class_forbids_break_before(class: u8) -> bool {
     )
 }
 
+/// Returns `true` if `cp` is a complex-script (SA-class) iteration or
+/// abbreviation marker that semantically attaches to the preceding
+/// word and must therefore not have a line break inserted immediately
+/// before it.
+///
+/// These characters are classified `SA` by Unicode (so they are
+/// processed inside the dictionary/LSTM SA chunk rather than at the
+/// SA→next-char seam), but the dict/LSTM may still emit a word
+/// boundary right before them. UAX #14 itself says nothing about
+/// internal SA boundaries; the dict's word list is the source of
+/// truth there. For these specific marks, however, breaking the line
+/// before them is wrong by definition of the character:
+///
+/// * **U+0E46** `ๆ` THAI CHARACTER MAIYAMOK — repetition mark; means
+///   "repeat the previous word."
+/// * **U+0E2F** `ฯ` THAI CHARACTER PAIYANNOI — abbreviation marker;
+///   marks the elided continuation of the preceding word/phrase.
+/// * **U+0EC6** `ໆ` LAO KO LA — Lao repetition mark, analogous to
+///   THAI MAIYAMOK.
+/// * **U+0EAF** `ຯ` LAO ELLIPSIS — Lao abbreviation marker, analogous
+///   to THAI PAIYANNOI.
+/// * **U+17D7** `ៗ` KHMER SIGN LEK TOO — Khmer repetition mark.
+///
+/// This is a typographic correction layered on top of the dict/LSTM
+/// output, not a UAX #14 rule. It is applied only inside the line-
+/// break pipeline; the word segmenter (which uses the word-boundary
+/// entry point, not the line-break one) is unaffected.
+#[inline]
+fn sa_codepoint_must_attach_to_previous(cp: u32) -> bool {
+    matches!(cp, 0x0E2F | 0x0E46 | 0x0EAF | 0x0EC6 | 0x17D7)
+}
+
 /// Supports loading line break data, and creating line break iterators for different string
 /// encodings.
 ///
@@ -1208,6 +1240,20 @@ where
             options.word_option,
         ))
     });
+    // Drop dict/LSTM-emitted boundaries that fall immediately before an
+    // SA iteration/abbreviation mark (THAI MAIYAMOK ๆ, KHMER LEK TOO ៗ,
+    // etc.). These are typographic corrections layered on top of the
+    // dict's word boundaries; see `sa_codepoint_must_attach_to_previous`.
+    let breaks: Vec<usize> = breaks
+        .into_iter()
+        .filter(|&offset| {
+            offset >= s.len()
+                || !s[offset..]
+                    .chars()
+                    .next()
+                    .is_some_and(|c| sa_codepoint_must_attach_to_previous(c as u32))
+        })
+        .collect();
     iter.result_cache = breaks;
     let first_pos = *iter.result_cache.first()?;
     let mut i = left_codepoint.len_utf8();
@@ -1334,6 +1380,16 @@ impl<'l, 's> LineBreakType<'l, 's> for LineBreakTypeUtf16 {
                     options.word_option,
                 ))
             });
+        // Drop dict/LSTM-emitted boundaries immediately before an SA
+        // iteration/abbreviation mark. All such marks are BMP, so a
+        // single-u16 lookup at the boundary is faithful.
+        let breaks: Vec<usize> = breaks
+            .into_iter()
+            .filter(|&offset| {
+                offset >= s.len()
+                    || !sa_codepoint_must_attach_to_previous(s[offset] as u32)
+            })
+            .collect();
         iterator.result_cache = breaks;
         // result_cache vector is utf-16 index that is in BMP.
         let first_pos = *iterator.result_cache.first()?;
@@ -1956,6 +2012,77 @@ mod tests {
                 punct,
                 *punct as u32,
                 utf16_punct_offset,
+            );
+        }
+    }
+
+    /// SA-internal iteration/abbreviation marks must not have a line
+    /// break inserted immediately before them. These characters are
+    /// classified `SA` by Unicode and are processed inside the SA
+    /// chunk by the dict/LSTM, which may emit a word boundary right
+    /// before them (especially for THAI MAIYAMOK ๆ, whose semantics
+    /// are "repeat the preceding word"). UAX #14 doesn't speak to
+    /// these positions; the `sa_codepoint_must_attach_to_previous`
+    /// post-filter drops them as a typographic correction.
+    ///
+    /// Marks covered (each tested in a Thai/Lao/Khmer host word):
+    ///
+    ///   - U+0E46 `ๆ` THAI MAIYAMOK (repetition)
+    ///   - U+0E2F `ฯ` THAI PAIYANNOI (abbreviation)
+    ///   - U+0EC6 `ໆ` LAO KO LA (repetition)
+    ///   - U+0EAF `ຯ` LAO ELLIPSIS (abbreviation)
+    ///   - U+17D7 `ៗ` KHMER LEK TOO (repetition)
+    #[test]
+    fn complex_script_sa_iteration_marks_no_break_before() {
+        let segmenter = LineSegmenter::new_auto();
+        let cases: &[(&str, &str, char)] = &[
+            ("Thai + MAIYAMOK", "ภาษาไทย", '\u{0E46}'),
+            ("Thai + PAIYANNOI", "ภาษาไทย", '\u{0E2F}'),
+            ("Lao + KO LA", "ກ່ຽວກັບ", '\u{0EC6}'),
+            ("Lao + ELLIPSIS", "ກ່ຽວກັບ", '\u{0EAF}'),
+            ("Khmer + LEK TOO", "ខ្មែរ", '\u{17D7}'),
+        ];
+
+        for (label, sa, mark) in cases {
+            let mut text = String::from(*sa);
+            let mark_byte_offset = text.len();
+            text.push(*mark);
+
+            let breaks: Vec<usize> = segmenter.segment_str(&text).collect();
+            assert!(
+                !breaks.contains(&mark_byte_offset),
+                "{label}: unexpected break BEFORE '{}' (U+{:04X}) at byte {}: {breaks:?}",
+                mark,
+                *mark as u32,
+                mark_byte_offset,
+            );
+
+            let utf16: Vec<u16> = text.encode_utf16().collect();
+            let utf16_mark_offset = sa.encode_utf16().count();
+            let utf16_breaks: Vec<usize> = segmenter.segment_utf16(&utf16).collect();
+            assert!(
+                !utf16_breaks.contains(&utf16_mark_offset),
+                "{label} (utf16): unexpected break BEFORE '{}' (U+{:04X}) at u16 index {}: {utf16_breaks:?}",
+                mark,
+                *mark as u32,
+                utf16_mark_offset,
+            );
+        }
+    }
+
+    /// The SA-internal mark filter applies only to the *line*
+    /// segmenter, not the word segmenter — UAX #29 word boundaries
+    /// before iteration/abbreviation marks may still be valid (the
+    /// dict/LSTM's word list is the source of truth there).
+    #[test]
+    fn word_segmenter_preserves_sa_iteration_marks() {
+        use crate::WordSegmenter;
+        let segmenter = WordSegmenter::new_auto();
+        for text in &["ภาษาไทยๆ", "ภาษาฯ", "ខ្មែរៗ"] {
+            let breaks: Vec<usize> = segmenter.segment_str(text).collect();
+            assert!(
+                breaks.first() == Some(&0) && breaks.last() == Some(&text.len()),
+                "word segmenter failed on {text:?}: {breaks:?}",
             );
         }
     }

--- a/components/segmenter/src/line.rs
+++ b/components/segmenter/src/line.rs
@@ -130,15 +130,15 @@ pub type LineBreakIteratorUtf16<'l, 's> = LineBreakIterator<'l, 's, LineBreakTyp
 /// `× class` unconditionally (or unconditionally in all contexts reachable
 /// from SA in practice):
 ///
-/// * **LB7**:   `× SP` — never break before a space.
-/// * **LB9**:   `× CM`, `× ZWJ` — combining marks attach to the preceding char.
-/// * **LB11**:  `× WJ` — word-joiner is glue.
-/// * **LB12a**: `× GL` — non-breaking glue.
-/// * **LB13**:  `× CL`, `× CP`, `× EX`, `× IS`, `× SY`.
-/// * **LB21**:  `× BA`, `× HY`, `× NS` — no break before these after the
-///              previous non-space char (SA never introduces a space on its
-///              right, so this simplifies to unconditional `×`).
-/// * **LB22**:  `× IN`.
+/// * **`LB7`**:   `× SP` — never break before a space.
+/// * **`LB9`**:   `× CM`, `× ZWJ` — combining marks attach to the preceding char.
+/// * **`LB11`**:  `× WJ` — word-joiner is glue.
+/// * **`LB12a`**: `× GL` — non-breaking glue.
+/// * **`LB13`**:  `× CL`, `× CP`, `× EX`, `× IS`, `× SY`.
+/// * **`LB21`**:  `× BA`, `× HY`, `× NS` — no break before these after the
+///   previous non-space char (SA never introduces a space on its
+///   right, so this simplifies to unconditional `×`).
+/// * **`LB22`**:  `× IN`.
 ///
 /// Classes intentionally **not** included here either allow a break
 /// (LB18 `SP ÷`, etc.), require surrounding context that our SA-adjacent
@@ -1316,19 +1316,15 @@ impl<'l, 's> LineBreakType<'l, 's> for LineBreakTypeUtf16 {
         // EX, IS, SY, WJ, IN, NS, HY, ZWJ, CM) are BMP, so a single u16
         // lookup is faithful for our purposes.
         let next_ext_code_unit = next_ext_cp.and_then(|c| u16::try_from(c).ok());
-        let breaks = complex_language_line_breaks_utf16(
-            iterator.complex,
-            &s,
-            next_ext_code_unit,
-            |c| {
+        let breaks =
+            complex_language_line_breaks_utf16(iterator.complex, &s, next_ext_code_unit, |c| {
                 lb_class_forbids_break_before(get_linebreak_property_utf32_with_rule(
                     &data.property_table,
                     c as u32,
                     options.strictness,
                     options.word_option,
                 ))
-            },
-        );
+            });
         iterator.result_cache = breaks;
         // result_cache vector is utf-16 index that is in BMP.
         let first_pos = *iterator.result_cache.first()?;
@@ -1794,8 +1790,8 @@ mod tests {
     /// `forbids_break_before` predicate for every terminal SA boundary,
     /// so all of the following must be handled uniformly:
     ///
-    ///   - U+00A0 NO-BREAK SPACE  → GL (LB12a × GL)
-    ///   - U+3000 IDEOGRAPHIC SP  → BA (LB21 × BA)
+    ///   - U+00A0 NO-BREAK SPACE  → GL (`LB12a` × GL)
+    ///   - U+3000 IDEOGRAPHIC SP  → BA (`LB21` × BA)
     ///   - U+2009 THIN SPACE      → BA
     ///   - U+0009 TAB             → BA
     #[test]

--- a/components/segmenter/tests/complex_word.rs
+++ b/components/segmenter/tests/complex_word.rs
@@ -100,11 +100,17 @@ fn word_line_th_wikipedia_auto() {
     );
 
     let breakpoints_line_utf8 = segmenter_line_auto.segment_str(text).collect::<Vec<_>>();
+    // Post-fix (issue #7218): the dict/LSTM terminal break immediately
+    // before each ASCII space — previously emitted at offsets 27, 47, 82,
+    // 113, 220, 281 — is now filtered out by
+    // `complex::complex_language_line_breaks_str` under UAX #14 LB7
+    // (`× SP`), leaving only the `÷ SP` break after each space. The
+    // expected list below reflects that corrected behavior.
     assert_eq!(
         breakpoints_line_utf8,
         [
-            0, 9, 18, 27, 28, 38, 47, 49, 53, 60, 68, 73, 82, 84, 87, 90, 95, 104, 113, 115, 121,
-            133, 148, 166, 175, 187, 193, 205, 220, 221, 227, 239, 272, 281, 282, 290, 297
+            0, 9, 18, 28, 38, 49, 53, 60, 68, 73, 84, 87, 90, 95, 104, 115, 121, 133, 148, 166,
+            175, 187, 193, 205, 221, 227, 239, 272, 282, 290, 297
         ]
     );
 


### PR DESCRIPTION
Backport of #7232 to `release/1.4`.

Fixes issue #7218 — Asian text (Khmer/Thai/Lao) produced double line
breaks around spaces. The dict/LSTM complex segmenter emits *word*
boundaries, and `line.rs` was treating those as line-break opportunities.
When a word boundary landed next to a space, LB7 (× SP) plus the
following break-after-space rule produced two adjacent breaks, bumping
the space to the start of the next line.

## Approach

Split `complex/mod.rs` into two named entry points:

- `complex_language_segment_str` / `_utf16` — **unchanged.** Word-boundary
  oracle used by `word.rs`; never was a line-break function.
- `complex_language_line_breaks_str` / `_utf16` — **new.** Runs the same
  dict/LSTM, then filters out breaks whose following char has a UAX #14
  class that forbids a break before it (LB7 × SP, LB21 × BA/HY/NS,
  LB12a × WJ/GL, LB13 × CL/CP/EX/IS/SY, LB22 × IN, LB9 × CM/ZWJ). For
  the terminal break at `s.len()`, `line.rs` passes the next external
  char so the filter works across SA chunk boundaries.

Filtering lives in the oracle (not `line.rs`) so it runs once per
dict/LSTM invocation — `line.rs` is on the width/justification hot path
and cannot afford per-candidate rescanning.

## 1.4-specific adaptations vs. #7232

- `complex/mod.rs` entry points are free functions taking
  `&ComplexPayloads` (1.4 shape), not methods on a borrowed payload type.
- 1.4's `LineBreakOptions` fields are already resolved
  (`LineBreakStrictness` / `LineBreakWordOption`), so no `.resolve()`
  step is needed in the predicate closure.
- UTF-16 `CharType` is `u32` in 1.4; predicate wraps the BMP u16 code
  unit captured from the iterator.

## Tests

- New (`line.rs`): `khmer/thai/lao_line_break_with_spaces`,
  `sa_sp_boundary_filtered_at_every_run`, `non_ascii_whitespace_around_sa`
  (U+3000, U+2009, U+0009, U+00A0), `lstm_vs_dictionary_no_double_break`,
  `word_segmenter_thai_unchanged`.
- Updated (`tests/complex_word.rs`): `word_line_th_wikipedia_auto` —
  offsets 27, 47, 82, 113, 220, 281 (each immediately before an ASCII
  space) are now correctly suppressed under LB7. `breakpoints_word_utf8`
  / `_utf16` unchanged, proving the word-segmenter path is untouched.

All `cargo test -p icu_segmenter` and `--features serde` suites pass.