### PR TITLE
Updated the docs for Locale and LanguageIdentifier.

### DIFF
--- a/components/locale_core/src/langid.rs
+++ b/components/locale_core/src/langid.rs
@@ -105,6 +105,10 @@ impl LanguageIdentifier {
     ///
     /// ✨ *Enabled with the `alloc` Cargo feature.*
     ///
+    /// Note: Support for the legacy `_` separator has been dropped since 2.0.0.
+    /// Users of ICU4X need to convert the `_` to `-` before calling the
+    /// function.
+    ///
     /// # Examples
     ///
     /// ```
@@ -180,7 +184,7 @@ impl LanguageIdentifier {
 
     /// Normalize the language identifier (operating on UTF-8 formatted byte slices)
     ///
-    /// This operation will normalize casing and the separator.
+    /// This operation will normalize casing.
     ///
     /// ✨ *Enabled with the `alloc` Cargo feature.*
     ///
@@ -202,7 +206,7 @@ impl LanguageIdentifier {
 
     /// Normalize the language identifier (operating on strings)
     ///
-    /// This operation will normalize casing and the separator.
+    /// This operation will normalize casing.
     ///
     /// ✨ *Enabled with the `alloc` Cargo feature.*
     ///

--- a/components/locale_core/src/locale.rs
+++ b/components/locale_core/src/locale.rs
@@ -139,6 +139,10 @@ impl Locale {
     ///
     /// ✨ *Enabled with the `alloc` Cargo feature.*
     ///
+    /// Note: Support for the legacy `_` separator has been dropped since 2.0.0.
+    /// Users of ICU4X need to convert the `_` to `-` before calling the
+    /// function.
+    ///
     /// # Examples
     ///
     /// ```
@@ -162,7 +166,7 @@ impl Locale {
 
     /// Normalize the locale (operating on UTF-8 formatted byte slices)
     ///
-    /// This operation will normalize casing and the separator.
+    /// This operation will normalize casing.
     ///
     /// ✨ *Enabled with the `alloc` Cargo feature.*
     ///
@@ -184,7 +188,7 @@ impl Locale {
 
     /// Normalize the locale (operating on strings)
     ///
-    /// This operation will normalize casing and the separator.
+    /// This operation will normalize casing.
     ///
     /// ✨ *Enabled with the `alloc` Cargo feature.*
     ///


### PR DESCRIPTION
Removal of the mention of the separator for the normalisation functions. Added sentence to inform users that support for the legacy `_` separator was dropped from version 2.0.0.

## Changelog (N/A)

simple docs fix
