### PR TITLE
Various safety fixes and defense-in-depth

### DIFF
--- a/components/list/src/patterns.rs
+++ b/components/list/src/patterns.rs
@@ -95,7 +95,8 @@ impl<'data> ListJoinerPattern<'data> {
                     && (allow_prefix || index_0 == 0)
                     && (allow_suffix || index_1 == pattern.len() - 3) =>
             {
-                if (index_0 > 0 && !cfg!(test)) || index_1 - 3 >= 256 {
+                let index1_minus_three = index_1.wrapping_sub(3);
+                if (index_0 > 0 && !cfg!(test)) || index_0 >= 256 || index1_minus_three >= 256 {
                     return Err(DataError::custom(
                         "Found valid pattern that cannot be stored in ListFormatterPatterns",
                     )
@@ -112,7 +113,7 @@ impl<'data> ListJoinerPattern<'data> {
                         .into_boxed_str(),
                     ),
                     index_0: index_0 as u8,
-                    index_1: (index_1 - 3) as u8,
+                    index_1: index1_minus_three as u8,
                 })
             }
             _ => Err(DataError::custom("Invalid list pattern").with_debug_context(pattern)),

--- a/provider/fs/src/fs_data_provider.rs
+++ b/provider/fs/src/fs_data_provider.rs
@@ -93,7 +93,12 @@ impl FsDataProvider {
                             })?,
                     );
                 } else {
-                    path.push(req.id.marker_attributes.as_str());
+                    let attr_path = req.id.marker_attributes.as_str();
+                    // Data marker attributes are already validated to be
+                    // alphanumeric + underscore/dash. This is defense-in-depth
+                    // against potential path traversal attacks.
+                    assert!(!attr_path.contains(['/', '\\']));
+                    path.push(attr_path);
                 }
             }
             let mut string_path = path.into_os_string();

--- a/utils/resb/src/binary.rs
+++ b/utils/resb/src/binary.rs
@@ -387,6 +387,7 @@ pub struct BinaryDeserializerError {
 
 impl BinaryDeserializerError {
     /// TODO
+    #[inline]
     pub const fn invalid_data(message: &'static str) -> Self {
         Self {
             kind: ErrorKind::InvalidData,
@@ -395,6 +396,7 @@ impl BinaryDeserializerError {
     }
 
     /// TODO
+    #[inline]
     pub const fn resource_type_mismatch(message: &'static str) -> Self {
         Self {
             kind: ErrorKind::ResourceTypeMismatch,
@@ -403,6 +405,7 @@ impl BinaryDeserializerError {
     }
 
     /// TODO
+    #[inline]
     pub const fn unsupported_format(message: &'static str) -> Self {
         Self {
             kind: ErrorKind::UnsupportedFormat,
@@ -411,6 +414,7 @@ impl BinaryDeserializerError {
     }
 
     /// TODO
+    #[inline]
     pub const fn unknown(message: &'static str) -> Self {
         Self {
             kind: ErrorKind::Unknown,

--- a/utils/resb/src/binary/deserializer.rs
+++ b/utils/resb/src/binary/deserializer.rs
@@ -71,6 +71,8 @@ impl<'de> ResourceTreeDeserializer<'de> {
     /// Creates a new deserializer from the header and index of the resource
     /// bundle.
     fn from_bytes(input: &'de [u32]) -> Result<Self, BinaryDeserializerError> {
+        // Safety: All valid u32 slices are also valid u8 slices since u32 is plain-old-data.
+        // We're using size_of_val to directly get the length of the underlying data.
         let input =
             unsafe { core::slice::from_raw_parts(input.as_ptr() as *const u8, size_of_val(input)) };
 
@@ -105,17 +107,23 @@ impl<'de> ResourceTreeDeserializer<'de> {
         let index = BinIndex::try_from(index)?;
 
         // Keys begin at the start of the body.
-        let keys = get_subslice(body, ..(index.keys_end as usize) * size_of::<u32>())?;
+        let keys_subslice_len = (index.keys_end as usize)
+            .checked_mul(size_of::<u32>())
+            .ok_or(BinaryDeserializerError::invalid_data("Too many keys"))?;
+        let keys = get_subslice(body, ..keys_subslice_len)?;
 
         let data_16_bit = if header.repr_info.format_version < FormatVersion::V2_0 {
             // The 16-bit data area was not introduced until format version 2.0.
             None
         } else if let Some(data_16_bit_end) = index.data_16_bit_end {
-            let data_16_bit = get_subslice(
-                body,
-                (index.keys_end as usize) * size_of::<u32>()
-                    ..(data_16_bit_end as usize) * size_of::<u32>(),
-            )?;
+            let start = (index.keys_end as usize)
+                .checked_mul(size_of::<u32>())
+                .ok_or(BinaryDeserializerError::invalid_data("Offset overflow"))?;
+            let end = (data_16_bit_end as usize)
+                .checked_mul(size_of::<u32>())
+                .ok_or(BinaryDeserializerError::invalid_data("Offset overflow"))?;
+
+            let data_16_bit = get_subslice(body, start..end)?;
             Some(data_16_bit)
         } else {
             return Err(BinaryDeserializerError::invalid_data(

--- a/utils/zerovec/src/hashmap/algorithms.rs
+++ b/utils/zerovec/src/hashmap/algorithms.rs
@@ -62,11 +62,12 @@ pub fn compute_index(f: (u32, u32), d: (u32, u32), m: u32) -> Option<usize> {
 /// # Arguments
 ///
 /// * `key_hashes` - [`ExactSizeIterator`] over the hashed key values
-#[expect(clippy::indexing_slicing, clippy::unwrap_used)]
+#[expect(clippy::indexing_slicing, clippy::unwrap_used, clippy::expect_used)]
 pub fn compute_displacements(
     key_hashes: impl ExactSizeIterator<Item = u64>,
 ) -> (Vec<(u32, u32)>, Vec<usize>) {
     let len = key_hashes.len();
+    let len_u32 = u32::try_from(len).expect("Hashmap too large for u32");
 
     // A vector to track the size of buckets for sorting.
     let mut bucket_sizes = vec![0; len];
@@ -122,8 +123,8 @@ pub fn compute_displacements(
         // start, end - 1 are always within bounds of `bucket_sizes`
         let buckets = &bucket_flatten[start..end];
 
-        'd0: for d0 in 0..len as u32 {
-            'd1: for d1 in 0..len as u32 {
+        'd0: for d0 in 0..len_u32 {
+            'd1: for d1 in 0..len_u32 {
                 if (d0, d1) == (0, 0) {
                     continue;
                 }
@@ -131,7 +132,7 @@ pub fn compute_displacements(
                 generation += 1;
 
                 for ((_, f0, f1), _) in buckets {
-                    let displacement_idx = compute_index((*f0, *f1), (d0, d1), len as u32).unwrap();
+                    let displacement_idx = compute_index((*f0, *f1), (d0, d1), len_u32).unwrap();
 
                     // displacement_idx is always within bounds
                     if occupied[displacement_idx] || assignments[displacement_idx] == generation {

--- a/utils/zerovec/src/hashmap/mod.rs
+++ b/utils/zerovec/src/hashmap/mod.rs
@@ -236,4 +236,24 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    #[should_panic(expected = "Hashmap too large for u32")]
+    #[cfg(target_pointer_width = "64")]
+    fn test_hashmap_too_large() {
+        struct HugeIter;
+        impl Iterator for HugeIter {
+            type Item = u64;
+            fn next(&mut self) -> Option<Self::Item> {
+                None
+            }
+        }
+        impl ExactSizeIterator for HugeIter {
+            fn len(&self) -> usize {
+                // Return something that is > u32::MAX on 64-bit systems
+                (u32::MAX as usize) + 1
+            }
+        }
+        let _ = compute_displacements(HugeIter);
+    }
 }

--- a/utils/zerovec/src/ule/option.rs
+++ b/utils/zerovec/src/ule/option.rs
@@ -197,6 +197,7 @@ unsafe impl<U: VarULE + ?Sized> VarULE for OptionVarULE<U> {
 
     #[inline]
     unsafe fn from_bytes_unchecked(bytes: &[u8]) -> &Self {
+        debug_assert!(!bytes.is_empty());
         let entire_struct_as_slice: *const [u8] =
             ::core::ptr::slice_from_raw_parts(bytes.as_ptr(), bytes.len() - 1);
         &*(entire_struct_as_slice as *const Self)
@@ -260,5 +261,19 @@ impl<U: VarULE + ?Sized + PartialOrd> PartialOrd for OptionVarULE<U> {
 impl<U: VarULE + ?Sized + Ord> Ord for OptionVarULE<U> {
     fn cmp(&self, other: &Self) -> Ordering {
         self.as_ref().cmp(&other.as_ref())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic]
+    fn test_option_varule_underflow() {
+        unsafe {
+            let _ = OptionVarULE::<str>::from_bytes_unchecked(&[]);
+        }
     }
 }

--- a/utils/zerovec/src/varzerovec/components.rs
+++ b/utils/zerovec/src/varzerovec/components.rs
@@ -279,11 +279,19 @@ impl<'a, T: VarULE + ?Sized, F: VarZeroVecFormat> VarZeroVecComponents<'a, T, F>
         };
         // The indices array is one element shorter since the first index is always 0,
         // so we use len_minus_one
+        //
+        // We do the math in u32 space so that we can be sure that VZVs constructed
+        // on 64 bit computers can still be used on 32 bit ones.
+        let indices_len = u32::try_from(F::Index::SIZE)
+            .ok()
+            .and_then(|x| x.checked_mul(len_minus_one))
+            .and_then(|x| usize::try_from(x).ok())
+            .ok_or(VarZeroVecFormatError::Metadata)?;
         let indices_bytes = slice
-            .get(..F::Index::SIZE * (len_minus_one as usize))
+            .get(..indices_len)
             .ok_or(VarZeroVecFormatError::Metadata)?;
         let things = slice
-            .get(F::Index::SIZE * (len_minus_one as usize)..)
+            .get(indices_len..)
             .ok_or(VarZeroVecFormatError::Metadata)?;
 
         let borrowed = VarZeroVecComponents {
@@ -322,6 +330,7 @@ impl<'a, T: VarULE + ?Sized, F: VarZeroVecFormat> VarZeroVecComponents<'a, T, F>
 
         let len = len_ule.get_unchecked(0).iule_to_usize();
         let len_u32 = len as u32;
+        debug_assert_eq!(len, len_u32 as usize);
 
         // Safety: This method requires the bytes to have passed through `parse_bytes()`
         // whereas we're calling something that asks for `parse_bytes_with_length()`.
@@ -351,8 +360,10 @@ impl<'a, T: VarULE + ?Sized, F: VarZeroVecFormat> VarZeroVecComponents<'a, T, F>
         };
         // The indices array is one element shorter since the first index is always 0,
         // so we use len_minus_one
-        let indices_bytes = slice.get_unchecked(..F::Index::SIZE * (len_minus_one as usize));
-        let things = slice.get_unchecked(F::Index::SIZE * (len_minus_one as usize)..);
+        let indices_len = F::Index::SIZE.wrapping_mul(len_minus_one as usize);
+        debug_assert!(F::Index::SIZE.checked_mul(len_minus_one as usize).is_some());
+        let indices_bytes = slice.get_unchecked(..indices_len);
+        let things = slice.get_unchecked(indices_len..);
 
         VarZeroVecComponents {
             len,
@@ -729,7 +740,14 @@ where
     // idx_offset = offset from the start of the buffer for the next index
     let mut idx_offset: usize = 0;
     // first_dat_offset = offset from the start of the buffer of the first data block
-    let first_dat_offset: usize = idx_offset + (elements.len() - 1) * F::Index::SIZE;
+    #[expect(
+        clippy::expect_used,
+        reason = "Function contract allows panicky behavior"
+    )]
+    let indices_size = F::Index::SIZE
+        .checked_mul(elements.len() - 1)
+        .expect(F::Index::TOO_LARGE_ERROR);
+    let first_dat_offset: usize = idx_offset + indices_size;
     // dat_offset = offset from the start of the buffer of the next data block
     let mut dat_offset: usize = first_dat_offset;
 
@@ -752,14 +770,24 @@ where
         }
 
         let dat_limit = dat_offset + element_len;
-        #[expect(clippy::indexing_slicing)] // Function contract allows panicky behavior
+        #[expect(
+            clippy::indexing_slicing,
+            reason = "Function contract allows panicky behavior"
+        )]
         let dat_slice = &mut output[dat_offset..dat_limit];
         element.encode_var_ule_write(dat_slice);
         debug_assert_eq!(T::validate_bytes(dat_slice), Ok(()));
         dat_offset = dat_limit;
     }
 
-    debug_assert_eq!(idx_offset, F::Index::SIZE * (elements.len() - 1));
+    #[expect(
+        clippy::expect_used,
+        reason = "Function contract allows panicky behavior"
+    )]
+    let indices_size = F::Index::SIZE
+        .checked_mul(elements.len() - 1)
+        .expect(F::Index::TOO_LARGE_ERROR);
+    debug_assert_eq!(idx_offset, indices_size);
     assert_eq!(dat_offset, output.len());
 }
 

--- a/utils/zerovec/src/varzerovec/owned.rs
+++ b/utils/zerovec/src/varzerovec/owned.rs
@@ -134,14 +134,23 @@ impl<T: VarULE + ?Sized, F: VarZeroVecFormat> VarZeroVecOwned<T, F> {
     /// `idx <= self.len()` and `self.as_encoded_bytes()` is well-formed.
     unsafe fn element_position_unchecked(&self, idx: usize) -> usize {
         let len = self.len();
+        if len == 0 {
+            return 0;
+        }
         let out = if idx == len {
-            self.entire_slice.len() - F::Len::SIZE - (F::Index::SIZE * (len - 1))
+            let indices_size = F::Index::SIZE
+                .checked_mul(len - 1)
+                .expect(F::Index::TOO_LARGE_ERROR);
+            self.entire_slice.len() - F::Len::SIZE - indices_size
         } else if let Some(idx) = self.index_data(idx) {
             idx.iule_to_usize()
         } else {
             0
         };
-        debug_assert!(out + F::Len::SIZE + (len - 1) * F::Index::SIZE <= self.entire_slice.len());
+        let indices_size = F::Index::SIZE
+            .checked_mul(len - 1)
+            .expect(F::Index::TOO_LARGE_ERROR);
+        debug_assert!(out + F::Len::SIZE + indices_size <= self.entire_slice.len());
         out
     }
 
@@ -173,7 +182,10 @@ impl<T: VarULE + ?Sized, F: VarZeroVecFormat> VarZeroVecOwned<T, F> {
     /// since there is no stored index for it.
     fn index_range(index: usize) -> Option<Range<usize>> {
         let index_minus_one = index.checked_sub(1)?;
-        let pos = F::Len::SIZE + F::Index::SIZE * index_minus_one;
+        let pos = F::Len::SIZE
+            + F::Index::SIZE
+                .checked_mul(index_minus_one)
+                .expect(F::Index::TOO_LARGE_ERROR);
         Some(pos..pos + F::Index::SIZE)
     }
 
@@ -215,8 +227,11 @@ impl<T: VarULE + ?Sized, F: VarZeroVecFormat> VarZeroVecOwned<T, F> {
             .checked_sub(1)
             .expect("shift_indices called with a 0 starting index");
         let len = self.len();
+        let indices_size = F::Index::SIZE
+            .checked_mul(len - 1)
+            .expect(F::Index::TOO_LARGE_ERROR);
         let indices = F::Index::iule_from_bytes_unchecked_mut(
-            &mut self.entire_slice[F::Len::SIZE..F::Len::SIZE + F::Index::SIZE * (len - 1)],
+            &mut self.entire_slice[F::Len::SIZE..F::Len::SIZE + indices_size],
         );
         for idx in &mut indices[normalized_idx..] {
             let mut new_idx = idx.iule_to_usize();
@@ -308,7 +323,10 @@ impl<T: VarULE + ?Sized, F: VarZeroVecFormat> VarZeroVecOwned<T, F> {
             // The start of the indices buffer
             let indices_start = slice_range.start.add(F::Len::SIZE);
             let old_slice_end = slice_range.start.add(slice_len);
-            let data_start = indices_start.add((len - 1) * F::Index::SIZE);
+            let indices_size = F::Index::SIZE
+                .checked_mul(len - 1)
+                .expect(F::Index::TOO_LARGE_ERROR);
+            let data_start = indices_start.add(indices_size);
             let prev_element_p =
                 data_start.add(prev_element.start)..data_start.add(prev_element.end);
 
@@ -318,7 +336,10 @@ impl<T: VarULE + ?Sized, F: VarZeroVecFormat> VarZeroVecOwned<T, F> {
             // When replacing: unused.
             // Will be None when the affected index is index 0, which is special
             let index_range = if let Some(index_minus_one) = index.checked_sub(1) {
-                let index_start = indices_start.add(F::Index::SIZE * index_minus_one);
+                let index_offset = F::Index::SIZE
+                    .checked_mul(index_minus_one)
+                    .expect(F::Index::TOO_LARGE_ERROR);
+                let index_start = indices_start.add(index_offset);
                 Some(index_start..index_start.add(F::Index::SIZE))
             } else {
                 None
@@ -400,9 +421,10 @@ impl<T: VarULE + ?Sized, F: VarZeroVecFormat> VarZeroVecOwned<T, F> {
         debug_assert!(self.verify_integrity());
 
         // Return a mut slice to the new element data.
-        let element_pos = F::Len::SIZE
-            + (self.len() - 1) * F::Index::SIZE
-            + self.element_position_unchecked(index);
+        let indices_size = F::Index::SIZE
+            .checked_mul(self.len() - 1)
+            .expect(F::Index::TOO_LARGE_ERROR);
+        let element_pos = F::Len::SIZE + indices_size + self.element_position_unchecked(index);
         &mut self.entire_slice[element_pos..element_pos + new_size]
     }
 
@@ -429,10 +451,13 @@ impl<T: VarULE + ?Sized, F: VarZeroVecFormat> VarZeroVecOwned<T, F> {
             // An empty vec must have an empty slice: there is only a single valid byte representation.
             panic!("VarZeroVecOwned integrity: Found empty VarZeroVecOwned with a nonempty slice");
         }
-        if self.entire_slice.len() < F::Len::SIZE + (len - 1) * F::Index::SIZE {
+        let indices_size = F::Index::SIZE
+            .checked_mul(len - 1)
+            .expect(F::Index::TOO_LARGE_ERROR);
+        if self.entire_slice.len() < F::Len::SIZE + indices_size {
             panic!("VarZeroVecOwned integrity: Not enough room for the indices");
         }
-        let data_len = self.entire_slice.len() - F::Len::SIZE - (len - 1) * F::Index::SIZE;
+        let data_len = self.entire_slice.len() - F::Len::SIZE - indices_size;
         if data_len > F::Index::MAX_VALUE as usize {
             panic!("VarZeroVecOwned integrity: Data segment is too long");
         }
@@ -440,7 +465,7 @@ impl<T: VarULE + ?Sized, F: VarZeroVecFormat> VarZeroVecOwned<T, F> {
         // Test index validity.
         let indices = unsafe {
             F::Index::slice_from_bytes_unchecked(
-                &self.entire_slice[F::Len::SIZE..F::Len::SIZE + (len - 1) * F::Index::SIZE],
+                &self.entire_slice[F::Len::SIZE..F::Len::SIZE + indices_size],
             )
         };
         for idx in indices {

--- a/utils/zerovec/src/varzerovec/vec.rs
+++ b/utils/zerovec/src/varzerovec/vec.rs
@@ -517,3 +517,24 @@ fn weird_empty_representation_equality() {
         VarZeroVec::<str>::parse_bytes(&[]).unwrap()
     );
 }
+
+#[test]
+fn test_overflow_parse_bytes_with_length() {
+    use super::components::{Index32, VarZeroVecComponents};
+    // Tests that you can't try to construct a VZV that is too big to store its length
+    // as a u32.
+
+    // We want to distinguish between "failed because of slice bounds" and "failed because of u32 overflow".
+    // On 64-bit, 4 * 0x4000_0000 = 4GB.
+    // If we had the u32 check, it would return Metadata error regardless of slice size.
+    // If we didn't, it would only return Metadata error if slice size < 4GB.
+
+    // We don't use a fully valid VZV here because we just want to ensure the first few lines of code
+    // return the metadata error without panicking. Actually allocating and instantiating
+    // a 4GB VZV candidate is very slow.
+
+    let mut bytes = vec![0u8; 4];
+    bytes.copy_from_slice(&0x4000_0001u32.to_le_bytes());
+    let result = VarZeroVecComponents::<str, Index32>::parse_bytes(&bytes);
+    assert!(matches!(result, Err(VarZeroVecFormatError::Metadata)));
+}


### PR DESCRIPTION
This fixes a bunch of issues found by @sayrer by running Claude on ICU4X to look for vulnerabilities (reported in https://github.com/unicode-org/icu4x/security/advisories/GHSA-c8m9-943c-5xmw).



Most of the fixes here are defense in depth: the code was already safe, but we can add assertions/etc to make it safer. In other cases the issues found were potential correctness issues, not safety issues.

The only real safety issue found was the multiplication overflows in VarZeroVec validation code: in theory, a 64 bit platform might validate a VZV that is invalid on a 32 bit platform. These have been fixed. They aren't severe enough to warrant a patch release / advisory: the only time this can cause a security issue is if you are trusting VZV data blobs constructed on a 64 bit platform on a 32 bit platform, which only happens with baked data, and 4GB-size VZVs aren't really a thing there.



Thanks, @sayrer !



The first commit was agent assisted but in the end mostly rewritten by me.

Changes not included in changelog:

icu_list: Prevent correctness errors from out-of-range indices in list patterns.

## Changelog

zerovec: Fix minor soundness issue around unchecked multiplication, add defense in depth against other overflow situations.

resb: Add defense-in-depth around checked multiplication.

icu_provider_fs: Add defense-in-depth against path traversal.