### PR TITLE
Update docs on DataProvider support for forking providers

### DIFF
--- a/provider/adapters/src/fork/by_error.rs
+++ b/provider/adapters/src/fork/by_error.rs
@@ -13,8 +13,12 @@ use icu_provider::prelude::*;
 /// This is an abstract forking provider that must be provided with a type implementing the
 /// [`ForkByErrorPredicate`] trait.
 ///
-/// [`ForkByErrorProvider`] does not support forking between [`DataProvider`]s. However, it
-/// supports forking between [`BufferProvider`], and [`DynamicDataProvider`].
+/// This provider supports any data provider trait as long as it is implemented by both
+/// child providers.
+///
+/// Some traits like [`BufferProvider`] work on all markers. However, [`DataProvider<M>`]
+/// is specific to a single marker type `M`. For this reason, [`DataProvider<M>`] is only
+/// implemented if both child providers implement it for the same `M`.
 #[derive(Debug, PartialEq, Eq)]
 pub struct ForkByErrorProvider<P0, P1, F>(P0, P1, F);
 
@@ -163,8 +167,12 @@ where
 /// This is an abstract forking provider that must be provided with a type implementing the
 /// [`ForkByErrorPredicate`] trait.
 ///
-/// [`MultiForkByErrorProvider`] does not support forking between [`DataProvider`]s. However, it
-/// supports forking between [`BufferProvider`], and [`DynamicDataProvider`].
+/// This provider supports any data provider trait as long as it is implemented by all
+/// child providers.
+///
+/// Some traits like [`BufferProvider`] work on all markers. However, [`DataProvider<M>`]
+/// is specific to a single marker type `M`. For this reason, [`DataProvider<M>`] is only
+/// implemented if all child providers implement it for the same `M`.
 #[derive(Debug)]
 pub struct MultiForkByErrorProvider<P, F> {
     providers: Vec<P>,

--- a/provider/adapters/src/fork/mod.rs
+++ b/provider/adapters/src/fork/mod.rs
@@ -31,6 +31,8 @@
 //! - [`IdentiferNotFoundPredicate`]
 
 use alloc::vec::Vec;
+#[cfg(doc)]
+use icu_provider::prelude::*;
 
 mod by_error;
 

--- a/provider/adapters/src/fork/mod.rs
+++ b/provider/adapters/src/fork/mod.rs
@@ -48,8 +48,12 @@ use predicates::MarkerNotFoundPredicate;
 /// even if the request failed for other reasons (such as an unsupported language). Therefore,
 /// you should add child providers that support disjoint sets of markers.
 ///
-/// [`ForkByMarkerProvider`] does not support forking between [`DataProvider`]s. However, it
-/// supports forking between [`BufferProvider`], and [`DynamicDataProvider`].
+/// This provider supports any data provider trait as long as it is implemented by both
+/// child providers.
+///
+/// Some traits like [`BufferProvider`] work on all markers. However, [`DataProvider<M>`]
+/// is specific to a single marker type `M`. For this reason, [`DataProvider<M>`] is only
+/// implemented if both child providers implement it for the same `M`.
 ///
 /// # Examples
 ///
@@ -154,8 +158,12 @@ impl<P0, P1> ForkByMarkerProvider<P0, P1> {
 /// even if the request failed for other reasons (such as an unsupported language). Therefore,
 /// you should add child providers that support disjoint sets of markers.
 ///
-/// [`MultiForkByMarkerProvider`] does not support forking between [`DataProvider`]s. However, it
-/// supports forking between [`BufferProvider`], and [`DynamicDataProvider`].
+/// This provider supports any data provider trait as long as it is implemented by all
+/// child providers.
+///
+/// Some traits like [`BufferProvider`] work on all markers. However, [`DataProvider<M>`]
+/// is specific to a single marker type `M`. For this reason, [`DataProvider<M>`] is only
+/// implemented if all child providers implement it for the same `M`.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
The docs are not accurate. We implement `DataProvider<M>` since 0bec39c3b00.

## Changelog

N/A