### PR TITLE
fix(provider_source): merge currency PatternSelection across `;` subpatterns (#6064)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 
+## Unreleased
+
+- Data
+    - `icu_provider_source`: `currency_pattern_selection` now considers the optional CLDR negative subpattern alongside the positive one; when the two arms disagree, a single `PatternSelection` is chosen so negative amounts render consistently (unicode-org#6064)
+    - `icu_provider_source`: short compact currency datagen parses the optional negative subpattern with the same rules as positive and only logs when they mismatch or fail to parse, instead of warning whenever a negative subpattern is present (unicode-org#6064)
+
 ## icu 2.2.x
 
 Several crates have had patch releases in the 2.2 stream:

--- a/provider/source/src/currency/compact.rs
+++ b/provider/source/src/currency/compact.rs
@@ -3,6 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::cldr_serde;
+use crate::cldr_serde::numbers::NumberPattern;
 use crate::cldr_serde::numbers::NumberPatternItem;
 use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
@@ -20,6 +21,54 @@ use icu_pattern::PatternItemCow;
 use icu_provider::prelude::*;
 use icu_provider::DataProvider;
 use itertools::Itertools;
+
+fn parse_short_compact_currency_subpattern(
+    items: &[NumberPatternItem],
+) -> Result<Box<DoublePlaceholderPattern>, DataError> {
+    DoublePlaceholderPattern::try_from_items(
+        items
+            .iter()
+            .map(|i| match i {
+                NumberPatternItem::MandatoryDigit => {
+                    PatternItemCow::Placeholder(DoublePlaceholderKey::Place0)
+                }
+                NumberPatternItem::Currency => {
+                    PatternItemCow::Placeholder(DoublePlaceholderKey::Place1)
+                }
+                i => PatternItemCow::Literal(Cow::Borrowed(i.as_str())),
+            })
+            .dedup(),
+    )
+    .map_err(|e| DataError::custom("pattern").with_display_context(&e))
+}
+
+fn warn_if_compact_currency_negative_differs(
+    locale: &DataLocale,
+    number_pattern: &NumberPattern,
+    parsed_positive: &DoublePlaceholderPattern,
+) {
+    let Some(negative) = number_pattern.negative.as_deref() else {
+        return;
+    };
+    match parse_short_compact_currency_subpattern(negative) {
+        Ok(parsed_negative) => {
+            if parsed_negative.as_ref() != parsed_positive {
+                log::warn!(
+                    "Compact currency negative subpattern differs from positive (unicode-org#6064); negative is ignored for locale={} pattern={}",
+                    locale,
+                    number_pattern
+                );
+            }
+        }
+        Err(_) => {
+            log::warn!(
+                "Compact currency pattern has a negative subpattern that could not be parsed with the same rules as positive (unicode-org#6064): locale={} pattern={}",
+                locale,
+                number_pattern
+            );
+        }
+    }
+}
 
 impl DataProvider<ShortCurrencyCompactV1> for SourceDataProvider {
     fn load(&self, req: DataRequest) -> Result<DataResponse<ShortCurrencyCompactV1>, DataError> {
@@ -73,51 +122,35 @@ impl DataProvider<ShortCurrencyCompactV1> for SourceDataProvider {
             ),
         ] {
             for (&log10_type, pattern) in source {
-                let pattern = pattern.as_ref().try_map(|pattern| {
-
-                if pattern.negative.is_some() {
-                    log::warn!(
-                        "Unexpected negative pattern for {}: {}",
+                let pattern = pattern.as_ref().try_map(|number_pattern: &NumberPattern| {
+                    let parsed =
+                        parse_short_compact_currency_subpattern(&number_pattern.positive)?;
+                    warn_if_compact_currency_negative_differs(
                         req.id.locale,
-                        pattern
+                        number_pattern,
+                        &parsed,
                     );
-                }
 
-                let number_of_0s = Some(
-                    pattern.positive
-                        .iter()
-                        .filter(|&i| *i == NumberPatternItem::MandatoryDigit)
-                        .count() as u8,
-                )
-                .filter(|&n| n != 0);
+                    let number_of_0s = Some(
+                        number_pattern
+                            .positive
+                            .iter()
+                            .filter(|&i| *i == NumberPatternItem::MandatoryDigit)
+                            .count() as u8,
+                    )
+                    .filter(|&n| n != 0);
 
-                let parsed = DoublePlaceholderPattern::try_from_items(
-                    pattern.positive
-                        .iter()
-                        .map(|i| match i {
-                            NumberPatternItem::MandatoryDigit => {
-                                PatternItemCow::Placeholder(DoublePlaceholderKey::Place0)
-                            }
-                            NumberPatternItem::Currency => {
-                                PatternItemCow::Placeholder(DoublePlaceholderKey::Place1)
-                            }
-                            i => PatternItemCow::Literal(Cow::Borrowed(i.as_str())),
-                        })
-                        .dedup(),
-                )
-                .map_err(|e| DataError::custom("pattern").with_display_context(&e))?;
+                    if log10_type < number_of_0s.unwrap_or_default() {
+                        return Err(DataError::custom("pattern").with_display_context(&format!(
+                            "Too many 0s in type 10^{}, ({}, implying nonpositive exponent c={}), pattern = {:?}",
+                            log10_type,
+                            number_of_0s.unwrap_or_default(),
+                            log10_type as i8 - number_of_0s.unwrap_or_default() as i8 + 1,
+                            number_pattern
+                        )));
+                    }
 
-                if log10_type < number_of_0s.unwrap_or_default() {
-                    return Err(DataError::custom("pattern").with_display_context(&format!(
-                        "Too many 0s in type 10^{}, ({}, implying nonpositive exponent c={}), pattern = {:?}",
-                        log10_type,
-                        number_of_0s.unwrap_or_default(),
-                        log10_type as i8 - number_of_0s.unwrap_or_default() as i8 + 1,
-                        pattern
-                    )));
-                }
-
-                Ok((number_of_0s, parsed))
+                    Ok((number_of_0s, parsed))
                 })?;
 
                 let other_number_of_0s = pattern.other().0.ok_or_else(|| {

--- a/provider/source/src/currency/essentials.rs
+++ b/provider/source/src/currency/essentials.rs
@@ -31,6 +31,24 @@ use icu_provider::DataProvider;
 use icu::experimental::dimension::provider::currency::essentials::*;
 use icu_provider::prelude::*;
 
+/// When positive and negative CLDR subpatterns disagree on whether the symbol is
+/// “alpha next to number”, keep a single selection for the locale until data carries both.
+#[inline]
+fn merge_currency_pattern_selections(
+    positive: PatternSelection,
+    negative: PatternSelection,
+) -> PatternSelection {
+    if negative == positive {
+        positive
+    } else if positive == PatternSelection::StandardAlphaNextToNumber
+        || negative == PatternSelection::StandardAlphaNextToNumber
+    {
+        PatternSelection::StandardAlphaNextToNumber
+    } else {
+        PatternSelection::Standard
+    }
+}
+
 /// Returns the pattern selection for a currency.
 /// For example:
 ///    if the pattern is ¤#,##0.00 and the symbol is EGP,
@@ -47,53 +65,61 @@ fn currency_pattern_selection(
         return Err(DataError::custom("Place holder value must not be empty"));
     }
 
-    // TODO(#6064): Handle the negative sub pattern.
-    let pattern = &pattern.positive;
-
-    let currency_sign_index = pattern
-        .iter()
-        .position(|i| matches!(i, NumberPatternItem::Currency))
-        .unwrap();
-    let first_num_index = pattern
-        .iter()
-        .position(|i| {
-            matches!(
-                i,
-                NumberPatternItem::MandatoryDigit | NumberPatternItem::OptionalDigit
-            )
-        })
-        .unwrap();
-    let last_num_index = pattern
-        .iter()
-        .rposition(|i| {
-            matches!(
-                i,
-                NumberPatternItem::MandatoryDigit | NumberPatternItem::OptionalDigit
-            )
-        })
-        .unwrap();
-
     let letters_set = CodePointMapData::<GeneralCategory>::try_new_unstable(provider)?
         .as_borrowed()
         .get_set_for_value_group(GeneralCategoryGroup::Letter);
 
-    let char_closer_to_number = if currency_sign_index < first_num_index {
-        placeholder_value.chars().next_back().unwrap()
-    } else if currency_sign_index > last_num_index {
-        placeholder_value.chars().next().unwrap()
-    } else {
-        return Err(DataError::custom(
-            "Currency sign must not be in the middle of the pattern",
-        ));
+    let classify_subpattern = |items: &[NumberPatternItem]| -> Result<PatternSelection, DataError> {
+        let currency_sign_index = items
+            .iter()
+            .position(|i| matches!(i, NumberPatternItem::Currency))
+            .unwrap();
+        let first_num_index = items
+            .iter()
+            .position(|i| {
+                matches!(
+                    i,
+                    NumberPatternItem::MandatoryDigit | NumberPatternItem::OptionalDigit
+                )
+            })
+            .unwrap();
+        let last_num_index = items
+            .iter()
+            .rposition(|i| {
+                matches!(
+                    i,
+                    NumberPatternItem::MandatoryDigit | NumberPatternItem::OptionalDigit
+                )
+            })
+            .unwrap();
+
+        let char_closer_to_number = if currency_sign_index < first_num_index {
+            placeholder_value.chars().next_back().unwrap()
+        } else if currency_sign_index > last_num_index {
+            placeholder_value.chars().next().unwrap()
+        } else {
+            return Err(DataError::custom(
+                "Currency sign must not be in the middle of the pattern",
+            ));
+        };
+
+        Ok(
+            if letters_set.as_borrowed().contains(char_closer_to_number) {
+                PatternSelection::StandardAlphaNextToNumber
+            } else {
+                PatternSelection::Standard
+            },
+        )
     };
 
-    Ok(
-        if letters_set.as_borrowed().contains(char_closer_to_number) {
-            PatternSelection::StandardAlphaNextToNumber
-        } else {
-            PatternSelection::Standard
-        },
-    )
+    let positive_selection = classify_subpattern(&pattern.positive)?;
+    Ok(match pattern.negative.as_deref() {
+        None => positive_selection,
+        Some(negative) => {
+            let negative_selection = classify_subpattern(negative)?;
+            merge_currency_pattern_selections(positive_selection, negative_selection)
+        }
+    })
 }
 
 impl DataProvider<CurrencyEssentialsV1> for SourceDataProvider {
@@ -411,4 +437,46 @@ fn test_basic() {
     );
     assert_eq!(ar_eg_usd_short, "US$");
     assert_eq!(ar_eg_usd_narrow, "US$");
+}
+
+#[cfg(test)]
+mod merge_currency_pattern_selections_tests {
+    use super::merge_currency_pattern_selections;
+    use icu::experimental::dimension::provider::currency::essentials::PatternSelection;
+
+    #[test]
+    fn merge_identical() {
+        assert_eq!(
+            merge_currency_pattern_selections(
+                PatternSelection::Standard,
+                PatternSelection::Standard
+            ),
+            PatternSelection::Standard
+        );
+        assert_eq!(
+            merge_currency_pattern_selections(
+                PatternSelection::StandardAlphaNextToNumber,
+                PatternSelection::StandardAlphaNextToNumber
+            ),
+            PatternSelection::StandardAlphaNextToNumber
+        );
+    }
+
+    #[test]
+    fn merge_union_prefers_alpha_when_either_arm_is_alpha() {
+        assert_eq!(
+            merge_currency_pattern_selections(
+                PatternSelection::Standard,
+                PatternSelection::StandardAlphaNextToNumber
+            ),
+            PatternSelection::StandardAlphaNextToNumber
+        );
+        assert_eq!(
+            merge_currency_pattern_selections(
+                PatternSelection::StandardAlphaNextToNumber,
+                PatternSelection::Standard
+            ),
+            PatternSelection::StandardAlphaNextToNumber
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Split out from #7884 per maintainer request.

- `currency_pattern_selection` now classifies both the positive and optional negative CLDR subpatterns and merges them via a small helper:
  - identical arms pass through,
  - when the two arms disagree, `StandardAlphaNextToNumber` wins so negative amounts render consistently until per-polarity selections exist in data.
- Unit tests cover the merge heuristic (identical + union-prefers-alpha cases).
- Short compact currency datagen parses the optional negative subpattern with the **same rules as positive** and only logs on mismatch or parse failure, instead of warning whenever a negative subpattern is present.

## Test plan

- [x] `cargo test -p icu_provider_source --features unstable --lib currency::` — 8 passed (including the two new `merge_currency_pattern_selections_tests`).

## Related issues

- unicode-org#6064 — currency negative subpatterns / pattern selection / compact warnings

## Context

Part of the split of #7884. That umbrella PR stays open and will be cross-linked as the pieces land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)