### PR TITLE
fix(personnames): cap derived initials at two (#3077)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 
+## Unreleased
+
+- Components
+    - `icu_experimental`
+        - `personnames`: `derive_missing_initials` now caps derived initials at two for multi-part given names; the `initial_sequence_pattern` is a two-slot pattern, so further initials would overflow the intended display width (unicode-org#3077)
+
 ## icu 2.2.x
 
 Several crates have had patch releases in the 2.2 stream:

--- a/components/experimental/src/personnames/specifications/derive_missing_initials.rs
+++ b/components/experimental/src/personnames/specifications/derive_missing_initials.rs
@@ -34,7 +34,10 @@ pub fn derive_missing_initials(
                 modifier: requested_field.modifier.with_length(FieldLength::Auto),
             })
             .split(' ')
-            .filter_map(|s| s.trim().chars().next());
+            .filter_map(|s| s.trim().chars().next())
+            // Cap at two initials: `initial_sequence_pattern` is a two-slot pattern, and
+            // interpolating further initials would append beyond the intended display width.
+            .take(2);
 
         let mut interpolated_initials =
             initials.map(|initial| initial_pattern.interpolate((initial,)));
@@ -129,8 +132,7 @@ mod tests {
         let result =
             super::derive_missing_initials(&person_name, requested_field, "{0}.", "{0} {1}");
 
-        // TODO(#3077): broken, this should be equal
-        assert_ne!(result, "M. J.");
+        assert_eq!(result, "M. J.");
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

Split out from #7884 per maintainer request.

- `personnames::specifications::derive_missing_initials` now caps derived initials at two for multi-part given names.
- Rationale: `initial_sequence_pattern` is a two-slot pattern, so interpolating further initials would append beyond the intended display width.
- The existing multi-initial test (previously gated with a \`TODO(#3077)\` and `assert_ne!`) now holds as `assert_eq!(result, \"M. J.\")`.

## Test plan

- [x] `cargo test -p icu_experimental --lib personnames::specifications::derive_missing_initials` — 3 passed (`test_multi_3_initial_should_still_only_be_2`, `test_multi_initial`, `test_single_initial`).

## Related issues

- unicode-org#3077 — `personnames` derived initials overflow

## Context

Part of the split of #7884. That umbrella PR stays open and will be cross-linked as the pieces land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)