### PR TITLE
fix(displaynames): honor Fallback option in multi Region/Script/Language/Variant `of()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 
+## Unreleased
+
+- Components
+    - `icu_experimental`
+        - **Breaking:** `displaynames`: `RegionDisplayNames::of`, `ScriptDisplayNames::of`, `LanguageDisplayNames::of`, and `VariantDisplayNames::of` now return `Option<Cow<'_, str>>` and honor `DisplayNamesOptions::fallback` (`Fallback::Code` returns the subtag as an owned string; `Fallback::None` returns `None`). Doctests, FFI (`icu_capi`), and example updated accordingly.
+
 ## icu 2.2.x
 
 Several crates have had patch releases in the 2.2 stream:

--- a/components/experimental/src/displaynames/displaynames.rs
+++ b/components/experimental/src/displaynames/displaynames.rs
@@ -38,7 +38,7 @@ define_preferences!(
 /// let display_name = RegionDisplayNames::try_new(locale, options)
 ///     .expect("Data should load successfully");
 ///
-/// assert_eq!(display_name.of(region!("AE")), Some("United Arab Emirates"));
+/// assert_eq!(display_name.of(region!("AE")).as_deref(), Some("United Arab Emirates"));
 /// ```
 #[derive(Default, Debug)]
 pub struct RegionDisplayNames {
@@ -79,14 +79,24 @@ impl RegionDisplayNames {
     }
 
     /// Returns the display name of a region.
-    pub fn of(&self, region: Region) -> Option<&str> {
+    ///
+    /// When no localized name exists, [`DisplayNamesOptions::fallback`](crate::DisplayNamesOptions::fallback)
+    /// controls whether this returns the region subtag as an owned string ([`Fallback::Code`]) or
+    /// [`None`] ([`Fallback::None`]).
+    pub fn of(&self, region: Region) -> Option<Cow<'_, str>> {
         let data = self.region_data.get();
-        match self.options.style {
+        let name = match self.options.style {
             Some(Style::Short) => data.short_names.get(&region.to_tinystr().to_unvalidated()),
             _ => None,
         }
-        .or_else(|| data.names.get(&region.to_tinystr().to_unvalidated()))
-        // TODO: Respect options.fallback
+        .or_else(|| data.names.get(&region.to_tinystr().to_unvalidated()));
+        match name {
+            Some(s) => Some(Cow::Borrowed(s)),
+            None => match self.options.fallback {
+                Fallback::Code => Some(Cow::Owned(region.as_str().into())),
+                Fallback::None => None,
+            },
+        }
     }
 }
 
@@ -105,7 +115,10 @@ impl RegionDisplayNames {
 /// let display_name = ScriptDisplayNames::try_new(locale, options)
 ///     .expect("Data should load successfully");
 ///
-/// assert_eq!(display_name.of(script!("Maya")), Some("Mayan hieroglyphs"));
+/// assert_eq!(
+///     display_name.of(script!("Maya")).as_deref(),
+///     Some("Mayan hieroglyphs")
+/// );
 /// ```
 #[derive(Default, Debug)]
 pub struct ScriptDisplayNames {
@@ -146,14 +159,22 @@ impl ScriptDisplayNames {
     }
 
     /// Returns the display name of a script.
-    pub fn of(&self, script: Script) -> Option<&str> {
+    ///
+    /// When no localized name exists, behavior follows [`DisplayNamesOptions::fallback`](crate::DisplayNamesOptions::fallback).
+    pub fn of(&self, script: Script) -> Option<Cow<'_, str>> {
         let data = self.script_data.get();
-        match self.options.style {
+        let name = match self.options.style {
             Some(Style::Short) => data.short_names.get(&script.to_tinystr().to_unvalidated()),
             _ => None,
         }
-        .or_else(|| data.names.get(&script.to_tinystr().to_unvalidated()))
-        // TODO: Respect options.fallback
+        .or_else(|| data.names.get(&script.to_tinystr().to_unvalidated()));
+        match name {
+            Some(s) => Some(Cow::Borrowed(s)),
+            None => match self.options.fallback {
+                Fallback::Code => Some(Cow::Owned(script.as_str().into())),
+                Fallback::None => None,
+            },
+        }
     }
 }
 
@@ -172,11 +193,13 @@ impl ScriptDisplayNames {
 /// let display_name = VariantDisplayNames::try_new(locale, options)
 ///     .expect("Data should load successfully");
 ///
-/// assert_eq!(display_name.of(variant!("POSIX")), Some("Computer"));
+/// assert_eq!(
+///     display_name.of(variant!("POSIX")).as_deref(),
+///     Some("Computer")
+/// );
 /// ```
 #[derive(Default, Debug)]
 pub struct VariantDisplayNames {
-    #[allow(dead_code)] //TODO: Add DisplayNamesOptions support for Variants.
     options: DisplayNamesOptions,
     variant_data: DataPayload<VariantDisplayNamesV1>,
 }
@@ -214,10 +237,18 @@ impl VariantDisplayNames {
     }
 
     /// Returns the display name of a variant.
-    pub fn of(&self, variant: Variant) -> Option<&str> {
+    ///
+    /// When no localized name exists, behavior follows [`DisplayNamesOptions::fallback`](crate::DisplayNamesOptions::fallback).
+    pub fn of(&self, variant: Variant) -> Option<Cow<'_, str>> {
         let data = self.variant_data.get();
-        data.names.get(&variant.to_tinystr().to_unvalidated())
-        // TODO: Respect options.fallback
+        let name = data.names.get(&variant.to_tinystr().to_unvalidated());
+        match name {
+            Some(s) => Some(Cow::Borrowed(s)),
+            None => match self.options.fallback {
+                Fallback::Code => Some(Cow::Owned(variant.as_str().into())),
+                Fallback::None => None,
+            },
+        }
     }
 }
 
@@ -236,7 +267,10 @@ impl VariantDisplayNames {
 /// let display_name = LanguageDisplayNames::try_new(locale, options)
 ///     .expect("Data should load successfully");
 ///
-/// assert_eq!(display_name.of(language!("de")), Some("German"));
+/// assert_eq!(
+///     display_name.of(language!("de")).as_deref(),
+///     Some("German")
+/// );
 /// ```
 #[derive(Default, Debug)]
 pub struct LanguageDisplayNames {
@@ -277,18 +311,25 @@ impl LanguageDisplayNames {
     }
 
     /// Returns the display name of a language.
-    pub fn of(&self, language: Language) -> Option<&str> {
+    ///
+    /// When no localized name exists, behavior follows [`DisplayNamesOptions::fallback`](crate::DisplayNamesOptions::fallback).
+    pub fn of(&self, language: Language) -> Option<Cow<'_, str>> {
         let data = self.language_data.get();
-        match self.options.style {
-            Some(Style::Short) => data
-                .short_names
-                .get(&language.to_tinystr().to_unvalidated()),
-            Some(Style::Long) => data.long_names.get(&language.to_tinystr().to_unvalidated()),
-            Some(Style::Menu) => data.menu_names.get(&language.to_tinystr().to_unvalidated()),
+        let key = language.to_tinystr().to_unvalidated();
+        let name = match self.options.style {
+            Some(Style::Short) => data.short_names.get(&key),
+            Some(Style::Long) => data.long_names.get(&key),
+            Some(Style::Menu) => data.menu_names.get(&key),
             _ => None,
         }
-        .or_else(|| data.names.get(&language.to_tinystr().to_unvalidated()))
-        // TODO: Respect options.fallback
+        .or_else(|| data.names.get(&key));
+        match name {
+            Some(s) => Some(Cow::Borrowed(s)),
+            None => match self.options.fallback {
+                Fallback::Code => Some(Cow::Owned(language.as_str().into())),
+                Fallback::None => None,
+            },
+        }
     }
 }
 

--- a/components/experimental/src/displaynames/mod.rs
+++ b/components/experimental/src/displaynames/mod.rs
@@ -31,8 +31,8 @@
 //!
 //! // Multi: Load a formatter that can display many regions.
 //! let multi = RegionDisplayNames::try_new(locale, DisplayNamesOptions::default()).unwrap();
-//! assert_writeable_eq!(multi.of(region!("US")).unwrap(), "United States");
-//! assert_writeable_eq!(multi.of(region!("GB")).unwrap(), "United Kingdom");
+//! assert_writeable_eq!(multi.of(region!("US")).expect("US"), "United States");
+//! assert_writeable_eq!(multi.of(region!("GB")).expect("GB"), "United Kingdom");
 //!
 //! // Single: Load only the region(s) we need.
 //! let us = RegionDisplayName::try_new(locale, region!("US")).unwrap();

--- a/components/experimental/src/displaynames/options.rs
+++ b/components/experimental/src/displaynames/options.rs
@@ -21,7 +21,7 @@
 ///     .expect("Data should load successfully");
 ///
 /// // Full name would be "Bosnia & Herzegovina"
-/// assert_eq!(display_name.of(region!("BA")), Some("Bosnia"));
+/// assert_eq!(display_name.of(region!("BA")).as_deref(), Some("Bosnia"));
 /// ```
 #[derive(Copy, Debug, Eq, PartialEq, Clone, Default)]
 #[non_exhaustive]

--- a/components/experimental/tests/displaynames/tests.rs
+++ b/components/experimental/tests/displaynames/tests.rs
@@ -2,8 +2,12 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use icu_experimental::displaynames::{multi::LocaleDisplayNamesFormatter, DisplayNamesOptions};
+use icu_experimental::displaynames::{
+    multi::{LocaleDisplayNamesFormatter, RegionDisplayNames},
+    DisplayNamesOptions, Fallback,
+};
 use icu_locale_core::locale;
+use icu_locale_core::subtags::region;
 use icu_locale_core::Locale;
 use std::borrow::Cow;
 
@@ -96,4 +100,27 @@ fn test_concatenate() {
             assert_eq!(result.capacity(), result.len());
         }
     }
+}
+
+#[test]
+fn region_display_fallback_code_uses_subtag() {
+    let display_name =
+        RegionDisplayNames::try_new(locale!("en").into(), DisplayNamesOptions::default())
+            .expect("Data should load successfully");
+    let r = region!("AA");
+    assert_eq!(
+        display_name.of(r).as_deref(),
+        Some("AA"),
+        "with Fallback::Code, missing data should return the region code"
+    );
+}
+
+#[test]
+fn region_display_fallback_none_returns_none() {
+    let mut options = DisplayNamesOptions::default();
+    options.fallback = Fallback::None;
+    let display_name = RegionDisplayNames::try_new(locale!("en").into(), options)
+        .expect("Data should load successfully");
+    let r = region!("AA");
+    assert!(display_name.of(r).is_none());
 }

--- a/examples/cargo/experimental/src/main.rs
+++ b/examples/cargo/experimental/src/main.rs
@@ -12,7 +12,7 @@ use icu::locale::{locale, subtags::region};
 fn main() {
     let names = RegionDisplayNames::try_new(locale!("fr").into(), Default::default())
         .expect("locale 'fr' should be present in compiled data");
-    let name = names.of(region!("DE")).unwrap();
-    assert_eq!(name, "Allemagne");
+    let name = names.of(region!("DE")).expect("DE display name");
+    assert_eq!(name.as_ref(), "Allemagne");
     println!("{name}");
 }

--- a/ffi/capi/src/displaynames.rs
+++ b/ffi/capi/src/displaynames.rs
@@ -210,11 +210,17 @@ pub mod ffi {
             region: &DiplomatStr,
             write: &mut DiplomatWrite,
         ) -> Result<(), LocaleParseError> {
-            let _infallible = self
+            match self
                 .0
                 .of(icu_locale_core::subtags::Region::try_from_utf8(region)?)
-                .unwrap_or("")
-                .write_to(write);
+            {
+                Some(name) => {
+                    let _infallible = name.write_to(write);
+                }
+                None => {
+                    let _infallible = "".write_to(write);
+                }
+            }
             Ok(())
         }
     }


### PR DESCRIPTION
## Summary

Split out from #7884 per maintainer request.

Breaking change in `icu_experimental` (`displaynames` is experimental): `RegionDisplayNames::of`, `ScriptDisplayNames::of`, `LanguageDisplayNames::of`, and `VariantDisplayNames::of` now return `Option<Cow<'_, str>>` and respect `DisplayNamesOptions::fallback`:

- `Fallback::Code` — return the subtag itself as an owned string when no localized name exists.
- `Fallback::None` — return `None`.

Doctests, the Rust example (`examples/cargo/experimental/src/main.rs`), and the FFI `RegionDisplayNames::of` shim in `icu_capi` are updated for the new return type.

## Test plan

- [x] `cargo test -p icu_experimental --features compiled_data --test displaynames_test` — 3 passed, including the two new tests:
  - `region_display_fallback_code_uses_subtag` — missing data under `Fallback::Code` returns the region code
  - `region_display_fallback_none_returns_none` — missing data under `Fallback::None` returns `None`
- [x] `cargo test -p icu_experimental --features compiled_data --doc displaynames` — 20 doctests pass
- [x] `cargo check -p icu_capi` — FFI shim compiles

## Context

Part of the split of #7884. That umbrella PR stays open and will be cross-linked as the pieces land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)