### PR TITLE
Implement AsRef for Locale and LanguageIdentifier

### DIFF
--- a/components/locale_core/src/langid.rs
+++ b/components/locale_core/src/langid.rs
@@ -511,6 +511,12 @@ impl LanguageIdentifier {
     }
 }
 
+impl AsRef<LanguageIdentifier> for LanguageIdentifier {
+    fn as_ref(&self) -> &LanguageIdentifier {
+        self
+    }
+}
+
 impl core::fmt::Debug for LanguageIdentifier {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         core::fmt::Display::fmt(&self, f)

--- a/components/locale_core/src/locale.rs
+++ b/components/locale_core/src/locale.rs
@@ -475,6 +475,12 @@ impl Locale {
     }
 }
 
+impl AsRef<LanguageIdentifier> for Locale {
+    fn as_ref(&self) -> &LanguageIdentifier {
+        &self.id
+    }
+}
+
 /// ✨ *Enabled with the `alloc` Cargo feature.*
 #[cfg(feature = "alloc")]
 impl FromStr for Locale {


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->

This PR adds `AsRef<LanguageIdentifier>` implementations for the `Locale` and `LanguageIdentifier` types of `icu_locale_core`.

The usecase for this change are trait bounds such as in `fluent-langneg`:

```rust
pub fn foobar<
    'a,
    R: 'a + AsRef<LanguageIdentifier>,
>(
    requested: &[R],
);
```

In this example a pure `From<T> for LanguageIdentifier` impl is not sufficient and would necessitate cloning the value, even for just a read-only access.

This is essentially just adding back trait impls that were removed from when the crate was created from `icu_locid`.

## Changelog

icu_locale_core: Add `AsRef<LanguageIdentifier>` impls
  - New impls: `AsRef<LanguageIdentifier> for Locale`, `AsRef<LanguageIdentifier> for LanguageIdentifier`