### PR TITLE
Fix off-by-one Unihan range boundary in identical-level sort key

### DIFF
--- a/components/collator/src/comparison.rs
+++ b/components/collator/src/comparison.rs
@@ -2520,7 +2520,7 @@ where
     let mut prev = 0i32;
 
     for c in iter {
-        if !(0x4e00..=0xa000).contains(&prev) {
+        if !(0x4e00..0xa000).contains(&prev) {
             prev = (prev & !0x7f) - SLOPE_REACH_NEG_1;
         } else {
             // Unihan U+4e00..U+9fa5:  double-bytes down from the upper end


### PR DESCRIPTION
ICU4C said `prev<0x4e00 || prev>=0xa000`, but the BOCSU port used an inclusive range, so U+A000 went into the wrong branch.

## Changelog

icu_collator: Fix generation of identical level sort keys containing the codepoint U+A000.
