### PR TITLE
Support sparse enums in zerovec::make_ule

### DIFF
--- a/utils/zerovec/derive/src/make_ule.rs
+++ b/utils/zerovec/derive/src/make_ule.rs
@@ -6,7 +6,7 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 
 use crate::utils::{self, FieldInfo, ZeroVecAttrs};
-use std::collections::HashSet;
+
 use syn::spanned::Spanned;
 use syn::{parse_quote, Data, DataEnum, DataStruct, DeriveInput, Error, Expr, Fields, Ident, Lit};
 
@@ -96,14 +96,9 @@ fn make_ule_enum_impl(
             .to_compile_error();
     }
 
-    // the smallest discriminant seen
-    let mut min = None;
-    // the largest discriminant seen
-    let mut max = None;
-    // Discriminants that have not been found in series (we might find them later)
-    let mut not_found = HashSet::new();
+    let mut discriminants = std::collections::BTreeSet::new();
 
-    for (i, variant) in enu.variants.iter().enumerate() {
+    for variant in enu.variants.iter() {
         if !matches!(variant.fields, Fields::Unit) {
             // This can be supported in the future, see zerovec/design_doc.md
             return Error::new(
@@ -125,31 +120,7 @@ fn make_ule_enum_impl(
                         .to_compile_error();
                     }
                 };
-                match min {
-                    Some(x) if x < n => {}
-                    _ => {
-                        min = Some(n);
-                    }
-                }
-                match max {
-                    Some(x) if x >= n => {}
-                    _ => {
-                        let old_max = max.unwrap_or(0u8);
-                        for missing in (old_max + 1)..n {
-                            not_found.insert(missing);
-                        }
-                        max = Some(n);
-                    }
-                }
-
-                not_found.remove(&n);
-
-                // We require explicit discriminants so that it is clear that reordering
-                // fields would be a breaking change. Furthermore, using explicit discriminants helps ensure that
-                // platform-specific C ABI choices do not matter.
-                // We could potentially add in explicit discriminants on the user's behalf in the future, or support
-                // more complicated sets of explicit discriminant values.
-                if n as usize != i {}
+                discriminants.insert(n);
             } else {
                 return Error::new(
                     discr.span(),
@@ -166,15 +137,10 @@ fn make_ule_enum_impl(
         }
     }
 
-    let not_found = not_found.iter().collect::<Vec<_>>();
-    let min = min.unwrap();
-    let max = max.unwrap();
-
-    if not_found.len() > min as usize {
-        return Error::new(input.span(), format!("#[make_ule] must be applied to enums with discriminants \
-                                                  filling the range from a minimum to a maximum; could not find {not_found:?}"))
-            .to_compile_error();
-    }
+    let match_arms = discriminants
+        .iter()
+        .map(|d| quote::quote!(#d))
+        .collect::<Vec<_>>();
 
     let maybe_ord_derives = if attrs.skip_ord {
         quote!()
@@ -208,8 +174,9 @@ fn make_ule_enum_impl(
             #[inline]
             fn validate_bytes(bytes: &[u8]) -> Result<(), zerovec::ule::UleError> {
                 for byte in bytes {
-                    if *byte < #min || *byte > #max {
-                        return Err(zerovec::ule::UleError::parse::<Self>())
+                    match *byte {
+                        #( #match_arms )|* => {}
+                        _ => return Err(zerovec::ule::UleError::parse::<Self>())
                     }
                 }
                 Ok(())
@@ -236,7 +203,7 @@ fn make_ule_enum_impl(
             /// Attempt to construct the value from its corresponding integer,
             /// returning `None` if not possible
             pub(crate) fn new_from_u8(value: u8) -> Option<Self> {
-                if value <= #max {
+                if <#ule_name as zerovec::ule::ULE>::validate_bytes(&[value]).is_ok() {
                     Some(zerovec::ule::AsULE::from_unaligned(#ule_name(value)))
                 } else {
                     None

--- a/utils/zerovec/derive/tests/sparse_enum_test.rs
+++ b/utils/zerovec/derive/tests/sparse_enum_test.rs
@@ -1,0 +1,129 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+#![allow(dead_code)]
+
+use zerovec::ZeroVec;
+
+#[zerovec::make_ule(SparseEnumULE)]
+#[zerovec::skip_derive(ZeroMapKV)]
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
+enum SparseEnum {
+    One = 1,
+    Three = 3,
+}
+
+#[zerovec::make_ule(MissingZeroEnumULE)]
+#[zerovec::skip_derive(ZeroMapKV)]
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
+enum MissingZeroEnum {
+    One = 1,
+}
+
+#[zerovec::make_ule(NonZeroContiguousEnumULE)]
+#[zerovec::skip_derive(ZeroMapKV)]
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
+enum NonZeroContiguousEnum {
+    Two = 2,
+    Three = 3,
+}
+
+#[zerovec::make_ule(ComplexSparseEnumULE)]
+#[zerovec::skip_derive(ZeroMapKV)]
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
+enum ComplexSparseEnum {
+    A = 1,
+    B = 2,
+    C = 10,
+    D = 11,
+    E = 20,
+}
+
+#[test]
+fn make_ule_sparse_enum_parse_rejects_invalid_discriminant() {
+    let vec = ZeroVec::<SparseEnum>::parse_bytes(&[2]);
+    assert!(vec.is_err(), "Should reject byte 2");
+
+    let vec = ZeroVec::<SparseEnum>::parse_bytes(&[1]);
+    assert!(vec.is_ok(), "Should accept byte 1");
+
+    let vec = ZeroVec::<SparseEnum>::parse_bytes(&[3]);
+    assert!(vec.is_ok(), "Should accept byte 3");
+}
+
+#[test]
+fn make_ule_new_from_u8_rejects_invalid_discriminant() {
+    let value = MissingZeroEnum::new_from_u8(0);
+    assert!(value.is_none(), "Should reject 0");
+
+    let value = MissingZeroEnum::new_from_u8(1);
+    assert!(value.is_some(), "Should accept 1");
+}
+
+#[test]
+fn make_ule_non_zero_contiguous_enum() {
+    let vec = ZeroVec::<NonZeroContiguousEnum>::parse_bytes(&[1]);
+    assert!(vec.is_err(), "Should reject byte 1");
+
+    let vec = ZeroVec::<NonZeroContiguousEnum>::parse_bytes(&[2]);
+    assert!(vec.is_ok(), "Should accept byte 2");
+
+    let vec = ZeroVec::<NonZeroContiguousEnum>::parse_bytes(&[3]);
+    assert!(vec.is_ok(), "Should accept byte 3");
+
+    let vec = ZeroVec::<NonZeroContiguousEnum>::parse_bytes(&[4]);
+    assert!(vec.is_err(), "Should reject byte 4");
+
+    assert!(
+        NonZeroContiguousEnum::new_from_u8(1).is_none(),
+        "Should reject 1"
+    );
+    assert!(
+        NonZeroContiguousEnum::new_from_u8(2).is_some(),
+        "Should accept 2"
+    );
+    assert!(
+        NonZeroContiguousEnum::new_from_u8(3).is_some(),
+        "Should accept 3"
+    );
+    assert!(
+        NonZeroContiguousEnum::new_from_u8(4).is_none(),
+        "Should reject 4"
+    );
+}
+
+#[test]
+fn make_ule_complex_sparse_enum() {
+    let valid = &[1, 2, 10, 11, 20];
+    for &v in valid {
+        assert!(
+            ZeroVec::<ComplexSparseEnum>::parse_bytes(&[v]).is_ok(),
+            "Should accept byte {}",
+            v
+        );
+        assert!(
+            ComplexSparseEnum::new_from_u8(v).is_some(),
+            "Should accept {}",
+            v
+        );
+    }
+
+    let invalid = &[0, 3, 9, 12, 19, 21];
+    for &i in invalid {
+        assert!(
+            ZeroVec::<ComplexSparseEnum>::parse_bytes(&[i]).is_err(),
+            "Should reject byte {}",
+            i
+        );
+        assert!(
+            ComplexSparseEnum::new_from_u8(i).is_none(),
+            "Should reject {}",
+            i
+        );
+    }
+}


### PR DESCRIPTION
We currently ban sparse enums: enum discriminants cannot have "gaps" since zerovec validation uses fast range checking. But that's not actually necessary, we can easily compile more complex enums down to `match`es over ranges (which LLVM is pretty good at optimizing). It's not going to be _as_ fast, but zerovec validation is allowed to be that complex.

This also fixes a soundness issue found by @shnatsel (thanks!) where you could create sparse enums without zerovec realizing.

https://github.com/unicode-org/icu4x/security/advisories/GHSA-mx24-jf73-wh55

## Changelog

zerovec_derive: Support sparse enums in `zerovec::make_ule`.
