### PR TITLE
Use grapheme segmentation for `LineBreakStrictness::Anywhere`

### DIFF
--- a/components/segmenter/src/complex/mod.rs
+++ b/components/segmenter/src/complex/mod.rs
@@ -59,7 +59,7 @@ pub(crate) struct ComplexPayloads {
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct ComplexPayloadsBorrowed<'data> {
-    grapheme: GraphemeClusterSegmenterBorrowed<'data>,
+    pub(crate) grapheme: GraphemeClusterSegmenterBorrowed<'data>,
     my: Option<DictOrLstmBorrowed<'data>>,
     km: Option<DictOrLstmBorrowed<'data>>,
     lo: Option<DictOrLstmBorrowed<'data>>,

--- a/components/segmenter/src/grapheme.rs
+++ b/components/segmenter/src/grapheme.rs
@@ -119,7 +119,7 @@ pub struct GraphemeClusterSegmenter {
 /// See [`GraphemeClusterSegmenter`] for examples.
 #[derive(Clone, Debug, Copy)]
 pub struct GraphemeClusterSegmenterBorrowed<'data> {
-    data: &'data RuleBreakData<'data>,
+    pub(crate) data: &'data RuleBreakData<'data>,
 }
 
 impl GraphemeClusterSegmenter {

--- a/components/segmenter/src/line.rs
+++ b/components/segmenter/src/line.rs
@@ -782,6 +782,25 @@ impl<Y: RuleBreakType> Iterator for LineBreakIterator<'_, '_, Y> {
     type Item = usize;
 
     fn next(&mut self) -> Option<Self::Item> {
+        if self.options.strictness == LineBreakStrictness::Anywhere {
+            let mut grapheme_iter: RuleBreakIterator<'_, '_, Y> = RuleBreakIterator {
+                iter: self.iter.clone(),
+                len: self.len,
+                current_pos_data: self.current_pos_data,
+                data: self.complex.grapheme.data,
+                result_cache: Default::default(),
+                complex: None,
+                boundary_property: 0,
+                locale_override: None,
+                handle_complex_language: empty_handle_complex_language,
+            };
+            let r = grapheme_iter.next();
+            self.iter = grapheme_iter.iter;
+            self.len = grapheme_iter.len;
+            self.current_pos_data = grapheme_iter.current_pos_data;
+            return r;
+        }
+
         match self.check_eof() {
             StringBoundaryPosType::Start => return Some(0),
             StringBoundaryPosType::End => return None,
@@ -813,17 +832,6 @@ impl<Y: RuleBreakType> Iterator for LineBreakIterator<'_, '_, Y> {
 
         'a: loop {
             debug_assert!(!self.is_eof());
-
-            // NOTE(egg): The special-casing of `LineBreakStrictness::Anywhere` allows us to pass
-            // a test, but eventually that option should just be simplified to call the extended
-            // grapheme cluster segmenter.
-            // TODO(egg): My reading of the CSS standard is that this
-            // should break around extended grapheme clusters, not at
-            // arbitrary code points, so this seems wrong.
-            if self.options.strictness == LineBreakStrictness::Anywhere {
-                self.advance_iter();
-                return Some(self.get_current_position().unwrap_or(self.len));
-            }
 
             let left_codepoint = self.get_current_codepoint()?;
             self.advance_iter();

--- a/components/segmenter/tests/css_line_break.rs
+++ b/components/segmenter/tests/css_line_break.rs
@@ -8,6 +8,7 @@ use icu_segmenter::options::LineBreakStrictness;
 use icu_segmenter::options::LineBreakWordOption;
 use icu_segmenter::LineSegmenter;
 
+#[track_caller]
 fn check_with_options(
     s: &str,
     mut expect_utf8: Vec<usize>,
@@ -30,6 +31,7 @@ fn check_with_options(
 
 static JA: LanguageIdentifier = langid!("ja");
 
+#[track_caller]
 fn strict(s: &str, ja_zh: bool, expect_utf8: Vec<usize>, expect_utf16: Vec<usize>) {
     let mut options = LineBreakOptions::default();
     options.strictness = Some(LineBreakStrictness::Strict);
@@ -38,6 +40,7 @@ fn strict(s: &str, ja_zh: bool, expect_utf8: Vec<usize>, expect_utf16: Vec<usize
     check_with_options(s, expect_utf8, expect_utf16, options);
 }
 
+#[track_caller]
 fn normal(s: &str, ja_zh: bool, expect_utf8: Vec<usize>, expect_utf16: Vec<usize>) {
     let mut options = LineBreakOptions::default();
     options.strictness = Some(LineBreakStrictness::Normal);
@@ -46,6 +49,7 @@ fn normal(s: &str, ja_zh: bool, expect_utf8: Vec<usize>, expect_utf16: Vec<usize
     check_with_options(s, expect_utf8, expect_utf16, options);
 }
 
+#[track_caller]
 fn loose(s: &str, ja_zh: bool, expect_utf8: Vec<usize>, expect_utf16: Vec<usize>) {
     let mut options = LineBreakOptions::default();
     options.strictness = Some(LineBreakStrictness::Loose);
@@ -54,6 +58,7 @@ fn loose(s: &str, ja_zh: bool, expect_utf8: Vec<usize>, expect_utf16: Vec<usize>
     check_with_options(s, expect_utf8, expect_utf16, options);
 }
 
+#[track_caller]
 fn anywhere(s: &str, ja_zh: bool, expect_utf8: Vec<usize>, expect_utf16: Vec<usize>) {
     let mut options = LineBreakOptions::default();
     options.strictness = Some(LineBreakStrictness::Anywhere);
@@ -200,15 +205,22 @@ fn linebreak_loose() {
 
 #[test]
 fn linebreak_anywhere() {
+    anywhere(
+        "الخيل والليل",
+        false,
+        vec![2, 4, 6, 8, 10, 11, 13, 15, 17, 19, 21, 23],
+        vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+    );
+
     // css/css-text/line-break/line-break-anywhere-001.html
     anywhere(
         "aa-a.a)a,a) a\u{00A0}aa\u{2060}a\u{200D}a･a",
         true,
         vec![
-            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15, 16, 17, 20, 21, 24, 25, 28, 29,
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15, 16, 17, 20, 24, 25, 28, 29,
         ],
         vec![
-            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 19, 20, 21, 22,
         ],
     );
 


### PR DESCRIPTION
#4771 #7932 

## Changelog

icu_segmenter:
* Use grapheme segmentation for `LineBreakStrictness:Anywhere`