### PR TITLE
Make segmenter tests readable

### DIFF
--- a/components/segmenter/tests/complex_word.rs
+++ b/components/segmenter/tests/complex_word.rs
@@ -3,8 +3,56 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use icu_segmenter::{options::WordBreakInvariantOptions, WordSegmenter};
+use icu_segmenter::{LineSegmenterBorrowed, WordSegmenterBorrowed};
+use itertools::Itertools;
 
 // Additional word segmenter tests with complex string.
+
+#[track_caller]
+fn test_word(segmenter: WordSegmenterBorrowed, s: &str, expected: &[&str]) {
+    let segments = segmenter
+        .segment_str(s)
+        .tuple_windows()
+        .map(|(a, b)| &s[a..b])
+        .collect::<Vec<_>>();
+    assert_eq!(segments, expected);
+
+    let utf16: Vec<u16> = s.encode_utf16().collect();
+    let expected = expected
+        .iter()
+        .copied()
+        .map(|s| s.encode_utf16().collect::<Vec<_>>())
+        .collect::<Vec<_>>();
+    let iter = segmenter
+        .segment_utf16(&utf16)
+        .tuple_windows()
+        .map(|(a, b)| &utf16[a..b])
+        .collect::<Vec<_>>();
+    assert_eq!(iter, expected);
+}
+
+#[track_caller]
+fn test_line(segmenter: LineSegmenterBorrowed, s: &str, expected: &[&str]) {
+    let segments = segmenter
+        .segment_str(s)
+        .tuple_windows()
+        .map(|(a, b)| &s[a..b])
+        .collect::<Vec<_>>();
+    assert_eq!(segments, expected);
+
+    let utf16: Vec<u16> = s.encode_utf16().collect();
+    let expected = expected
+        .iter()
+        .copied()
+        .map(|s| s.encode_utf16().collect::<Vec<_>>())
+        .collect::<Vec<_>>();
+    let iter = segmenter
+        .segment_utf16(&utf16)
+        .tuple_windows()
+        .map(|(a, b)| &utf16[a..b])
+        .collect::<Vec<_>>();
+    assert_eq!(iter, expected);
+}
 
 #[test]
 fn word_break_th() {
@@ -14,29 +62,15 @@ fn word_break_th() {
     ] {
         // http://wpt.live/css/css-text/word-break/word-break-normal-th-000.html
         let s = "ภาษาไทยภาษาไทย";
-        let utf16: Vec<u16> = s.encode_utf16().collect();
-        let iter = segmenter.segment_utf16(&utf16);
-        assert_eq!(
-            iter.collect::<Vec<usize>>(),
-            vec![0, 4, 7, 11, 14],
-            "word segmenter with Thai"
-        );
-        let iter = segmenter.segment_str(s);
-        assert_eq!(
-            iter.collect::<Vec<usize>>(),
-            vec![0, 12, 21, 33, 42],
-            "word segmenter with Thai"
-        );
+        let expected = ["ภาษา", "ไทย", "ภาษา", "ไทย"];
+
+        test_word(segmenter, s, &expected);
 
         // Combine non-Thai and Thai.
         let s = "aภาษาไทยภาษาไทยb";
-        let utf16: Vec<u16> = s.encode_utf16().collect();
-        let iter = segmenter.segment_utf16(&utf16);
-        assert_eq!(
-            iter.collect::<Vec<usize>>(),
-            vec![0, 1, 5, 8, 12, 15, 16],
-            "word segmenter with Thai and ascii"
-        );
+        let expected = ["a", "ภาษา", "ไทย", "ภาษา", "ไทย", "b"];
+
+        test_word(segmenter, s, &expected);
     }
 }
 
@@ -45,13 +79,8 @@ fn word_break_my() {
     let segmenter = WordSegmenter::new_auto(WordBreakInvariantOptions::default());
 
     let s = "မြန်မာစာမြန်မာစာမြန်မာစာ";
-    let utf16: Vec<u16> = s.encode_utf16().collect();
-    let iter = segmenter.segment_utf16(&utf16);
-    assert_eq!(
-        iter.collect::<Vec<usize>>(),
-        vec![0, 8, 16, 22, 24],
-        "word segmenter with Burmese"
-    );
+    let expected = ["မြန်မာစာ", "မြန်မာစာ", "မြန်မာ", "စာ"];
+    test_word(segmenter, s, &expected);
 }
 
 #[test]
@@ -61,12 +90,8 @@ fn word_break_hiragana() {
         WordSegmenter::new_dictionary(WordBreakInvariantOptions::default()),
     ] {
         let s = "うなぎうなじ";
-        let iter = segmenter.segment_str(s);
-        assert_eq!(
-            iter.collect::<Vec<usize>>(),
-            vec![0, 9, 18],
-            "word segmenter with Hiragana"
-        );
+        let expected = ["うなぎ", "うなじ"];
+        test_word(segmenter, s, &expected);
     }
 }
 
@@ -77,12 +102,8 @@ fn word_break_mixed_han() {
         WordSegmenter::new_dictionary(WordBreakInvariantOptions::default()),
     ] {
         let s = "Welcome龟山岛龟山岛Welcome";
-        let iter = segmenter.segment_str(s);
-        assert_eq!(
-            iter.collect::<Vec<usize>>(),
-            vec![0, 7, 16, 25, 32],
-            "word segmenter with Chinese and letter"
-        );
+        let expected = ["Welcome", "龟山岛", "龟山岛", "Welcome"];
+        test_word(segmenter, s, &expected);
     }
 }
 
@@ -91,53 +112,107 @@ fn word_line_th_wikipedia_auto() {
     use icu_segmenter::LineSegmenter;
 
     let text = "แพนด้าแดง (อังกฤษ: Red panda, Shining cat; จีน: 小熊貓; พินอิน: Xiǎo xióngmāo) สัตว์เลี้ยงลูกด้วยนมชนิดหนึ่ง มีชื่อวิทยาศาสตร์ว่า Ailurus fulgens";
-    assert_eq!(text.len(), 297);
-    let utf16: Vec<u16> = text.encode_utf16().collect();
-    assert_eq!(utf16.len(), 142);
 
     let segmenter_word_auto = WordSegmenter::new_auto(Default::default());
     let segmenter_line_auto = LineSegmenter::new_auto(Default::default());
 
-    let breakpoints_word_utf8 = segmenter_word_auto.segment_str(text).collect::<Vec<_>>();
-    assert_eq!(
-        breakpoints_word_utf8,
-        [
-            0, 9, 18, 27, 28, 29, 38, 47, 48, 49, 52, 53, 58, 59, 60, 67, 68, 71, 72, 73, 82, 83,
-            84, 90, 93, 94, 95, 104, 113, 114, 115, 120, 121, 131, 132, 133, 148, 166, 175, 187,
-            193, 205, 220, 221, 227, 239, 272, 281, 282, 289, 290, 297
-        ]
+    test_word(
+        segmenter_word_auto,
+        text,
+        &[
+            "แพน",
+            "ด้า",
+            "แดง",
+            " ",
+            "(",
+            "อัง",
+            "กฤษ",
+            ":",
+            " ",
+            "Red",
+            " ",
+            "panda",
+            ",",
+            " ",
+            "Shining",
+            " ",
+            "cat",
+            ";",
+            " ",
+            "จีน",
+            ":",
+            " ",
+            "小熊",
+            "貓",
+            ";",
+            " ",
+            "พิน",
+            "อิน",
+            ":",
+            " ",
+            "Xiǎo",
+            " ",
+            "xióngmāo",
+            ")",
+            " ",
+            "สัตว์",
+            "เลี้ยง",
+            "ลูก",
+            "ด้วย",
+            "นม",
+            "ชนิด",
+            "หนึ่ง",
+            " ",
+            "มี",
+            "ชื่อ",
+            "วิทยาศาสตร์",
+            "ว่า",
+            " ",
+            "Ailurus",
+            " ",
+            "fulgens",
+        ],
     );
-
-    let breakpoints_line_utf8 = segmenter_line_auto.segment_str(text).collect::<Vec<_>>();
-    assert_eq!(
-        breakpoints_line_utf8,
-        [
-            0, 9, 18, 27, 28, 38, 47, 49, 53, 60, 68, 73, 82, 84, 87, 90, 95, 104, 113, 115, 121,
-            133, 148, 166, 175, 187, 193, 205, 220, 221, 227, 239, 272, 281, 282, 290, 297
-        ]
-    );
-
-    let breakpoints_word_utf16 = segmenter_word_auto
-        .segment_utf16(&utf16)
-        .collect::<Vec<_>>();
-    assert_eq!(
-        breakpoints_word_utf16,
-        [
-            0, 3, 6, 9, 10, 11, 14, 17, 18, 19, 22, 23, 28, 29, 30, 37, 38, 41, 42, 43, 46, 47, 48,
-            50, 51, 52, 53, 56, 59, 60, 61, 65, 66, 74, 75, 76, 81, 87, 90, 94, 96, 100, 105, 106,
-            108, 112, 123, 126, 127, 134, 135, 142
-        ]
-    );
-
-    let breakpoints_word_utf16 = segmenter_word_auto
-        .segment_utf16(&utf16)
-        .collect::<Vec<_>>();
-    assert_eq!(
-        breakpoints_word_utf16,
-        [
-            0, 3, 6, 9, 10, 11, 14, 17, 18, 19, 22, 23, 28, 29, 30, 37, 38, 41, 42, 43, 46, 47, 48,
-            50, 51, 52, 53, 56, 59, 60, 61, 65, 66, 74, 75, 76, 81, 87, 90, 94, 96, 100, 105, 106,
-            108, 112, 123, 126, 127, 134, 135, 142
-        ]
+    test_line(
+        segmenter_line_auto,
+        text,
+        &[
+            "แพน",
+            "ด้า",
+            "แดง",
+            " ",
+            "(อัง",
+            "กฤษ",
+            ": ",
+            "Red ",
+            "panda, ",
+            "Shining ",
+            "cat; ",
+            "จีน",
+            ": ",
+            "小",
+            "熊",
+            "貓; ",
+            "พิน",
+            "อิน",
+            ": ",
+            "Xiǎo ",
+            "xióngmāo) ",
+            "สัตว์",
+            "เลี้ยง",
+            "ลูก",
+            "ด้วย",
+            "นม",
+            "ชนิด",
+            "หนึ่ง",
+            " ",
+            "มี",
+            "ชื่อ",
+            "วิทยาศาสตร์",
+            "ว่า",
+            " ",
+            "Ailurus ",
+            "fulgens",
+        ],
     );
 }

--- a/components/segmenter/tests/css_line_break.rs
+++ b/components/segmenter/tests/css_line_break.rs
@@ -7,200 +7,200 @@ use icu_segmenter::options::LineBreakOptions;
 use icu_segmenter::options::LineBreakStrictness;
 use icu_segmenter::options::LineBreakWordOption;
 use icu_segmenter::LineSegmenter;
+use itertools::Itertools;
 
 #[track_caller]
-fn check_with_options(
-    s: &str,
-    mut expect_utf8: Vec<usize>,
-    mut expect_utf16: Vec<usize>,
-    options: LineBreakOptions,
-) {
+fn check_with_options(s: &str, expected: &[&str], options: LineBreakOptions) {
     let segmenter = LineSegmenter::new_dictionary(options);
 
-    let iter = segmenter.segment_str(s);
-    let result: Vec<usize> = iter.collect();
-    expect_utf8.insert(0, 0);
-    assert_eq!(expect_utf8, result, "{s}");
+    let segments = segmenter
+        .segment_str(s)
+        .tuple_windows()
+        .map(|(a, b)| &s[a..b])
+        .collect::<Vec<_>>();
+    assert_eq!(segments, expected, "{s}");
 
-    let s_utf16: Vec<u16> = s.encode_utf16().collect();
-    let iter = segmenter.segment_utf16(&s_utf16);
-    let result: Vec<usize> = iter.collect();
-    expect_utf16.insert(0, 0);
-    assert_eq!(expect_utf16, result, "{s}");
+    let utf16: Vec<u16> = s.encode_utf16().collect();
+    let expected = expected
+        .iter()
+        .copied()
+        .map(|s| s.encode_utf16().collect::<Vec<_>>())
+        .collect::<Vec<_>>();
+    let iter = segmenter
+        .segment_utf16(&utf16)
+        .tuple_windows()
+        .map(|(a, b)| &utf16[a..b])
+        .collect::<Vec<_>>();
+    assert_eq!(iter, expected, "{s}");
 }
 
 static JA: LanguageIdentifier = langid!("ja");
 
 #[track_caller]
-fn strict(s: &str, ja_zh: bool, expect_utf8: Vec<usize>, expect_utf16: Vec<usize>) {
+fn strict(s: &str, ja_zh: bool, expected: &[&str]) {
     let mut options = LineBreakOptions::default();
     options.strictness = Some(LineBreakStrictness::Strict);
     options.word_option = Some(LineBreakWordOption::Normal);
     options.content_locale = ja_zh.then_some(&JA);
-    check_with_options(s, expect_utf8, expect_utf16, options);
+    check_with_options(s, expected, options);
 }
 
 #[track_caller]
-fn normal(s: &str, ja_zh: bool, expect_utf8: Vec<usize>, expect_utf16: Vec<usize>) {
+fn normal(s: &str, ja_zh: bool, expected: &[&str]) {
     let mut options = LineBreakOptions::default();
     options.strictness = Some(LineBreakStrictness::Normal);
     options.word_option = Some(LineBreakWordOption::Normal);
     options.content_locale = ja_zh.then_some(&JA);
-    check_with_options(s, expect_utf8, expect_utf16, options);
+    check_with_options(s, expected, options);
 }
 
 #[track_caller]
-fn loose(s: &str, ja_zh: bool, expect_utf8: Vec<usize>, expect_utf16: Vec<usize>) {
+fn loose(s: &str, ja_zh: bool, expected: &[&str]) {
     let mut options = LineBreakOptions::default();
     options.strictness = Some(LineBreakStrictness::Loose);
     options.word_option = Some(LineBreakWordOption::Normal);
     options.content_locale = ja_zh.then_some(&JA);
-    check_with_options(s, expect_utf8, expect_utf16, options);
+    check_with_options(s, expected, options);
 }
 
 #[track_caller]
-fn anywhere(s: &str, ja_zh: bool, expect_utf8: Vec<usize>, expect_utf16: Vec<usize>) {
+fn anywhere(s: &str, ja_zh: bool, expected: &[&str]) {
     let mut options = LineBreakOptions::default();
     options.strictness = Some(LineBreakStrictness::Anywhere);
     options.word_option = Some(LineBreakWordOption::Normal);
     options.content_locale = ja_zh.then_some(&JA);
-    check_with_options(s, expect_utf8, expect_utf16, options);
+    check_with_options(s, expected, options);
 }
 
 #[test]
 fn linebreak_strict() {
     // from css/css-text/line-break/line-break-*-011.xht
-    strict("サ\u{3041}サ", false, vec![6, 9], vec![2, 3]);
+    strict("サぁサ", false, &["サぁ", "サ"]);
 
     // from css/css-text/line-break/line-break-*-012.xht
-    strict("サ\u{30FC}サ", false, vec![6, 9], vec![2, 3]);
+    strict("サーサ", false, &["サー", "サ"]);
 
     // from css/css-text/line-break/line-break-*-013.xht
-    strict("サ\u{301C}サ", false, vec![6, 9], vec![2, 3]);
+    strict("サ〜サ", false, &["サ〜", "サ"]);
 
     // from css/css-text/line-break/line-break-*-014.xht
-    strict("サ\u{3005}サ", false, vec![6, 9], vec![2, 3]);
+    strict("サ々サ", false, &["サ々", "サ"]);
 
     // from css/css-text/line-break/line-break-*-015a.xht
     // XXX ID x IN in UAX14. But why?
-    strict("サ\u{2025}\u{2025}サ", false, vec![9, 12], vec![3, 4]);
+    strict("サ‥‥サ", false, &["サ‥‥", "サ"]);
 
     // from css/css-text/line-break/line-break-*-016a.xht
-    strict("サ\u{30FB}サ", false, vec![6, 9], vec![2, 3]);
+    strict("サ・サ", false, &["サ・", "サ"]);
 
     // from css/css-text/line-break/line-break-*-017a.xht
-    strict("サ\u{00B0}サ", false, vec![5, 8], vec![2, 3]);
+    strict("サ°サ", false, &["サ°", "サ"]);
 
     // from css/css-text/line-break/line-break-*-018.xht
-    //strict("サ\u{20AC}サ", false, vec![9], vec![3]);
+    // strict("サ€サ", false, vec![9], vec![3]);
 
     // from css/css-text/i18n/ja/css-text-line-break-ja-pr-strict.html
     // TODO: Why ID ÷ ID × PR × ID ÷ ID ?
-    //strict("文文\u{00b1}字字", true, vec![3, 11, 14], vec![1, 4, 5]);
-    //strict("文文\u{20AC}字字", true, vec![3, 11, 14], vec![1, 4, 5]);
-    //strict("文文\u{FF04}字字", true, vec![3, 11, 14], vec![1, 4, 5]);
+    // strict("文文±字字", true, &["文", "文±字", "字"]);
+    // strict("文文€字字", true, &["文", "文€字", "字"]);
+    // strict("文文＄字字", true, &["文", "文＄字", "字"]);
 }
 
 #[test]
 fn linebreak_normal() {
     // from css/css-text/line-break/line-break-*-011.xht
-    normal("サ\u{3041}サ", false, vec![3, 6, 9], vec![1, 2, 3]);
+    normal("サぁサ", false, &["サ", "ぁ", "サ"]);
 
     // from css/css-text/line-break/line-break-*-012.xht
-    normal("サ\u{30FC}サ", false, vec![3, 6, 9], vec![1, 2, 3]);
+    normal("サーサ", false, &["サ", "ー", "サ"]);
 
     // from css/css-text/line-break/line-break-*-013.xht
-    normal("サ\u{301C}サ", true, vec![3, 6, 9], vec![1, 2, 3]);
+    normal("サ〜サ", true, &["サ", "〜", "サ"]);
 
     // from css/css-text/line-break/line-break-*-014.xht
-    normal("サ\u{3005}サ", true, vec![6, 9], vec![2, 3]);
+    normal("サ々サ", true, &["サ々", "サ"]);
 
     // from css/css-text/line-break/line-break-*-015.xht
-    normal("サ\u{2025}\u{2025}サ", true, vec![9, 12], vec![3, 4]);
+    normal("サ‥‥サ", true, &["サ‥‥", "サ"]);
 
     // from css/css-text/line-break/line-break-*-016a.xht
-    normal("サ\u{30FB}サ", true, vec![6, 9], vec![2, 3]);
+    normal("サ・サ", true, &["サ・", "サ"]);
 
     // from css/css-text/line-break/line-break-*-017a.xht
-    normal("サ\u{00B0}サ", true, vec![5, 8], vec![2, 3]);
+    normal("サ°サ", true, &["サ°", "サ"]);
 
     // from css/css-text/line-break/line-break-*-018.xht
-    normal("サ\u{20AC}サ", true, vec![3, 9], vec![1, 3]);
+    normal("サ€サ", true, &["サ", "€サ"]);
 
     // from css/css-text/i18n/unknown-lang/css-text-line-break-pr-normal.html
     // TODO: Why ID ÷ ID × PR × ID ÷ ID ?
-    //normal("文文\u{00b1}字字", false, vec![3, 11, 14], vec![1, 4, 5]);
-    //normal("文文\u{20AC}字字", false, vec![3, 11, 14], vec![1, 4, 5]);
-    //normal("文文\u{2116}字字", false, vec![3, 11, 14], vec![1, 4, 5]);
+    // normal("文文±字字", false, &["文", "文±字", "字"]);
+    // normal("文文€字字", false, &["文", "文€字", "字"]);
+    // normal("文文№字字", false, &["文", "文№字", "字"]);
 }
 
 #[test]
 fn linebreak_loose() {
     // from css/css-text/line-break/line-break-*-011.xht
-    loose("サ\u{3041}サ", true, vec![3, 6, 9], vec![1, 2, 3]);
+    loose("サぁサ", true, &["サ", "ぁ", "サ"]);
 
     // from css/css-text/line-break/line-break-*-012.xht
-    loose("サ\u{30FC}サ", true, vec![3, 6, 9], vec![1, 2, 3]);
+    loose("サーサ", true, &["サ", "ー", "サ"]);
 
     // from css/css-text/line-break/line-break-loose-013.xht
-    loose("サ\u{301C}サ", true, vec![3, 6, 9], vec![1, 2, 3]);
+    loose("サ〜サ", true, &["サ", "〜", "サ"]);
 
     // from css/css-text/line-break/line-break-*-014.xht
-    loose("サ\u{3005}サ", true, vec![3, 6, 9], vec![1, 2, 3]);
+    loose("サ々サ", true, &["サ", "々", "サ"]);
 
     // from css/css-text/line-break/line-break-*-015.xht
-    loose(
-        "サ\u{2025}\u{2025}サ",
-        true,
-        vec![3, 6, 9, 12],
-        vec![1, 2, 3, 4],
-    );
+    loose("サ‥‥サ", true, &["サ", "‥", "‥", "サ"]);
 
     // from css/css-text/line-break/line-break-*-016a.xht
-    loose("サ\u{30FB}サ", true, vec![3, 6, 9], vec![1, 2, 3]);
+    loose("サ・サ", true, &["サ", "・", "サ"]);
 
     // from css/css-text/line-break/line-break-*-017a.xht
-    loose("サ\u{00B0}サ", true, vec![3, 5, 8], vec![1, 2, 3]);
+    loose("サ°サ", true, &["サ", "°", "サ"]);
 
     // from css/css-text/line-break/line-break-*-018.xht
-    loose("文\u{20AC}文", true, vec![3, 6, 9], vec![1, 2, 3]);
-    loose("文\u{2116}文", true, vec![3, 6, 9], vec![1, 2, 3]);
-    loose("文\u{ff04}文", true, vec![3, 6, 9], vec![1, 2, 3]);
-    loose("文\u{ffe1}文", true, vec![3, 6, 9], vec![1, 2, 3]);
-    loose("文\u{ffe5}文", true, vec![3, 6, 9], vec![1, 2, 3]);
+    loose("文€文", true, &["文", "€", "文"]);
+    loose("文№文", true, &["文", "№", "文"]);
+    loose("文＄文", true, &["文", "＄", "文"]);
+    loose("文￡文", true, &["文", "￡", "文"]);
+    loose("文￥文", true, &["文", "￥", "文"]);
 
     // from css/css-text/i18n/ja/css-text-line-break-ja-pr-loose.html
-    loose("文\u{00b1}文", true, vec![3, 5, 8], vec![1, 2, 3]);
-    loose("文\u{20ac}文", true, vec![3, 6, 9], vec![1, 2, 3]);
-    loose("文\u{ff04}文", true, vec![3, 6, 9], vec![1, 2, 3]);
+    loose("文±文", true, &["文", "±", "文"]);
+    loose("文€文", true, &["文", "€", "文"]);
+    loose("文＄文", true, &["文", "＄", "文"]);
 
     // from css/css-text/i18n/unknown-lang/css-text-line-break-in-loose.html
-    loose("文\u{2024}文", false, vec![3, 6, 9], vec![1, 2, 3]);
-    loose("文\u{2025}文", false, vec![3, 6, 9], vec![1, 2, 3]);
-    loose("文\u{2026}文", false, vec![3, 6, 9], vec![1, 2, 3]);
-    loose("文\u{22ef}文", false, vec![3, 6, 9], vec![1, 2, 3]);
-    loose("文\u{fe19}文", false, vec![3, 6, 9], vec![1, 2, 3]);
+    loose("文․文", false, &["文", "․", "文"]);
+    loose("文‥文", false, &["文", "‥", "文"]);
+    loose("文…文", false, &["文", "…", "文"]);
+    loose("文⋯文", false, &["文", "⋯", "文"]);
+    loose("文︙文", false, &["文", "︙", "文"]);
 
     // from css/css-text/i18n/unknown-lang/css-text-line-break-pr-loose.html
-    //loose("文\u{00b1}文", false, vec![8], vec![3]);
-    //loose("文\u{20ac}文", false, vec![9], vec![3]);
-    //loose("文\u{2116}文", false, vec![9], vec![3]);
-    //loose("文\u{ff04}文", false, vec![9], vec![3]);
+    // loose("文±文", false, &["文±文"]);
+    // loose("文€文", false, &["文€文"]);
+    // loose("文№文", false, &["文№文"]);
+    // loose("文＄文", false, &["文＄文"]);
 
     // from css/css-text/i18n/zh/css-text-line-break-zh-in-loose.xht
-    loose("文\u{2024}文", true, vec![3, 6, 9], vec![1, 2, 3]);
-    loose("文\u{2025}文", true, vec![3, 6, 9], vec![1, 2, 3]);
-    loose("文\u{2026}文", true, vec![3, 6, 9], vec![1, 2, 3]);
-    loose("文\u{22ef}文", true, vec![3, 6, 9], vec![1, 2, 3]);
-    loose("文\u{fe19}文", true, vec![3, 6, 9], vec![1, 2, 3]);
+    loose("文․文", true, &["文", "․", "文"]);
+    loose("文‥文", true, &["文", "‥", "文"]);
+    loose("文…文", true, &["文", "…", "文"]);
+    loose("文⋯文", true, &["文", "⋯", "文"]);
+    loose("文︙文", true, &["文", "︙", "文"]);
 
     // css/css-text/line-break/line-break-loose-hyphens-001.html
-    loose("文\u{2010}文", true, vec![3, 6, 9], vec![1, 2, 3]);
-    loose("文\u{2013}文", true, vec![3, 6, 9], vec![1, 2, 3]);
+    loose("文‐文", true, &["文", "‐", "文"]);
+    loose("文–文", true, &["文", "–", "文"]);
 
     // css/css-text/line-break/line-break-loose-hyphens-003.html
-    loose("aa\u{2010}", false, vec![5], vec![3]);
-    loose("aa\u{2013}", false, vec![5], vec![3]);
+    loose("aa‐", false, &["aa‐"]);
+    loose("aa–", false, &["aa–"]);
 }
 
 #[test]
@@ -208,19 +208,16 @@ fn linebreak_anywhere() {
     anywhere(
         "الخيل والليل",
         false,
-        vec![2, 4, 6, 8, 10, 11, 13, 15, 17, 19, 21, 23],
-        vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+        &["ا", "ل", "خ", "ي", "ل", " ", "و", "ا", "ل", "ل", "ي", "ل"],
     );
 
     // css/css-text/line-break/line-break-anywhere-001.html
     anywhere(
-        "aa-a.a)a,a) a\u{00A0}aa\u{2060}a\u{200D}a･a",
+        "aa-a.a)a,a) a aa\u{2060}aa･a",
         true,
-        vec![
-            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15, 16, 17, 20, 24, 25, 28, 29,
-        ],
-        vec![
-            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 19, 20, 21, 22,
+        &[
+            "a", "a", "-", "a", ".", "a", ")", "a", ",", "a", ")", " ", "a", " ", "a", "a",
+            "\u{2060}", "a", "a", "･", "a",
         ],
     );
 
@@ -228,103 +225,71 @@ fn linebreak_anywhere() {
     anywhere(
         "no hyphenation",
         false,
-        vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
-        vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
+        &[
+            "n", "o", " ", "h", "y", "p", "h", "e", "n", "a", "t", "i", "o", "n",
+        ],
     );
 
     // css/css-text/line-break/line-break-anywhere-003.html
-    anywhere("latin", false, vec![1, 2, 3, 4, 5], vec![1, 2, 3, 4, 5]);
+    anywhere("latin", false, &["l", "a", "t", "i", "n"]);
 
     // css/css-text/line-break/line-break-anywhere-004.html
-    anywhere(
-        "XX XXX",
-        false,
-        vec![1, 2, 3, 4, 5, 6],
-        vec![1, 2, 3, 4, 5, 6],
-    );
+    anywhere("XX XXX", false, &["X", "X", " ", "X", "X", "X"]);
 
     // css/css-text/line-break/line-break-anywhere-005.html
-    anywhere("X X", false, vec![1, 2, 3], vec![1, 2, 3]);
+    anywhere("X X", false, &["X", " ", "X"]);
 
     // css/css-text/line-break/line-break-anywhere-006.html
     anywhere(
-        "XXXX\u{00A0}XXXX",
+        "XXXX XXXX",
         false,
-        vec![1, 2, 3, 4, 6, 7, 8, 9, 10],
-        vec![1, 2, 3, 4, 5, 6, 7, 8, 9],
+        &["X", "X", "X", "X", " ", "X", "X", "X", "X"],
     );
 
     // css/css-text/line-break/line-break-anywhere-007.html
-    anywhere(
-        "X XX...",
-        true,
-        vec![1, 2, 3, 4, 5, 6, 7],
-        vec![1, 2, 3, 4, 5, 6, 7],
-    );
+    anywhere("X XX...", true, &["X", " ", "X", "X", ".", ".", "."]);
 
     // css/css-text/line-break/line-break-anywhere-008.html
-    anywhere(
-        "X XX...",
-        true,
-        vec![1, 2, 3, 4, 5, 6, 7],
-        vec![1, 2, 3, 4, 5, 6, 7],
-    );
+    anywhere("X XX...", true, &["X", " ", "X", "X", ".", ".", "."]);
 
     // css/css-text/line-break/line-break-anywhere-009.html
-    anywhere("X\u{00A0}X", true, vec![1, 3, 4], vec![1, 2, 3]);
+    anywhere("X X", true, &["X", " ", "X"]);
 
     // css/css-text/line-break/line-break-anywhere-010.html
     anywhere(
-        "XXXX\u{00A0}XXXX",
+        "XXXX XXXX",
         true,
-        vec![1, 2, 3, 4, 6, 7, 8, 9, 10],
-        vec![1, 2, 3, 4, 5, 6, 7, 8, 9],
+        &["X", "X", "X", "X", " ", "X", "X", "X", "X"],
     );
 
     // css/css-text/line-break/line-break-anywhere-011.html
-    anywhere("XX///", true, vec![1, 2, 3, 4, 5], vec![1, 2, 3, 4, 5]);
+    anywhere("XX///", true, &["X", "X", "/", "/", "/"]);
 
     // css/css-text/line-break/line-break-anywhere-012.html
-    anywhere(
-        "X XX\\\\\\",
-        true,
-        vec![1, 2, 3, 4, 5, 6, 7],
-        vec![1, 2, 3, 4, 5, 6, 7],
-    );
+    anywhere(r#"X XX\\\"#, true, &["X", " ", "X", "X", "\\", "\\", "\\"]);
 
     // css/css-text/line-break/line-break-anywhere-013.html
-    anywhere("XXX/X", true, vec![1, 2, 3, 4, 5], vec![1, 2, 3, 4, 5]);
+    anywhere("XXX/X", true, &["X", "X", "X", "/", "X"]);
 
     // css/css-text/line-break/line-break-anywhere-014.html
-    anywhere("XXX\\X", false, vec![1, 2, 3, 4, 5], vec![1, 2, 3, 4, 5]);
+    anywhere(r#"XXX\X"#, false, &["X", "X", "X", "\\", "X"]);
 
     // css/css-text/line-break/line-break-anywhere-015.html
-    anywhere("XXX\\X", false, vec![1, 2, 3, 4, 5], vec![1, 2, 3, 4, 5]);
+    anywhere(r#"XXX\X"#, false, &["X", "X", "X", "\\", "X"]);
 
     // css/css-text/line-break/line-break-anywhere-016.html
-    anywhere("XXX/X", false, vec![1, 2, 3, 4, 5], vec![1, 2, 3, 4, 5]);
+    anywhere("XXX/X", false, &["X", "X", "X", "/", "X"]);
 
     // css/css-text/line-break/line-break-anywhere-017.html
-    anywhere(
-        "XXXX X",
-        false,
-        vec![1, 2, 3, 4, 5, 6],
-        vec![1, 2, 3, 4, 5, 6],
-    );
+    anywhere("XXXX X", false, &["X", "X", "X", "X", " ", "X"]);
 
     // line-break-anywhere-overrides-uax-behavior-001.htm
-    anywhere(
-        "XX\u{2060}XX",
-        false,
-        vec![1, 2, 5, 6, 7],
-        vec![1, 2, 3, 4, 5],
-    );
+    anywhere("XX\u{2060}XX", false, &["X", "X", "\u{2060}", "X", "X"]);
 
     // line-break-anywhere-overrides-uax-behavior-004.htm
     anywhere(
         "..\u{200B}...X",
         false,
-        vec![1, 2, 5, 6, 7, 8, 9],
-        vec![1, 2, 3, 4, 5, 6, 7],
+        &[".", ".", "\u{200B}", ".", ".", ".", "X"],
     );
 }

--- a/components/segmenter/tests/css_word_break.rs
+++ b/components/segmenter/tests/css_word_break.rs
@@ -6,178 +6,164 @@ use icu_segmenter::options::LineBreakOptions;
 use icu_segmenter::options::LineBreakStrictness;
 use icu_segmenter::options::LineBreakWordOption;
 use icu_segmenter::LineSegmenter;
+use itertools::Itertools;
 
-fn check_with_options(
-    s: &str,
-    mut expect_utf8: Vec<usize>,
-    mut expect_utf16: Vec<usize>,
-    options: LineBreakOptions,
-) {
+#[track_caller]
+fn check_with_options(s: &str, expected: &[&str], options: LineBreakOptions) {
     let segmenter = LineSegmenter::new_dictionary(options);
 
-    let iter = segmenter.segment_str(s);
-    let result: Vec<usize> = iter.collect();
-    expect_utf8.insert(0, 0);
-    assert_eq!(expect_utf8, result, "{s}");
+    let segments = segmenter
+        .segment_str(s)
+        .tuple_windows()
+        .map(|(a, b)| &s[a..b])
+        .collect::<Vec<_>>();
+    assert_eq!(segments, expected, "{s}");
 
-    let s_utf16: Vec<u16> = s.encode_utf16().collect();
-    let iter = segmenter.segment_utf16(&s_utf16);
-    let result: Vec<usize> = iter.collect();
-    expect_utf16.insert(0, 0);
-    assert_eq!(expect_utf16, result, "{s}");
+    let utf16: Vec<u16> = s.encode_utf16().collect();
+    let expected = expected
+        .iter()
+        .copied()
+        .map(|s| s.encode_utf16().collect::<Vec<_>>())
+        .collect::<Vec<_>>();
+    let iter = segmenter
+        .segment_utf16(&utf16)
+        .tuple_windows()
+        .map(|(a, b)| &utf16[a..b])
+        .collect::<Vec<_>>();
+    assert_eq!(iter, expected, "{s}");
 }
 
-fn break_all(s: &str, expect_utf8: Vec<usize>, expect_utf16: Vec<usize>) {
+#[track_caller]
+fn break_all(s: &str, expected: &[&str]) {
     let mut options = LineBreakOptions::default();
     options.strictness = Some(LineBreakStrictness::Strict);
     options.word_option = Some(LineBreakWordOption::BreakAll);
     options.content_locale = None;
-    check_with_options(s, expect_utf8, expect_utf16, options);
+    check_with_options(s, expected, options);
 }
 
-fn keep_all(s: &str, expect_utf8: Vec<usize>, expect_utf16: Vec<usize>) {
+#[track_caller]
+fn keep_all(s: &str, expected: &[&str]) {
     let mut options = LineBreakOptions::default();
     options.strictness = Some(LineBreakStrictness::Strict);
     options.word_option = Some(LineBreakWordOption::KeepAll);
     options.content_locale = None;
-    check_with_options(s, expect_utf8, expect_utf16, options);
+    check_with_options(s, expected, options);
 }
 
-fn normal(s: &str, expect_utf8: Vec<usize>, expect_utf16: Vec<usize>) {
+#[track_caller]
+fn normal(s: &str, expected: &[&str]) {
     let mut options = LineBreakOptions::default();
     options.strictness = Some(LineBreakStrictness::Strict);
     options.word_option = Some(LineBreakWordOption::Normal);
     options.content_locale = None;
-    check_with_options(s, expect_utf8, expect_utf16, options);
+    check_with_options(s, expected, options);
 }
 
 #[test]
 fn wordbreak_breakall() {
     // from css/css-text/word-break/word-break-break-all-000.html
-    let s = "\u{65e5}\u{672c}\u{8a9e}";
-    break_all(s, vec![3, 6, 9], vec![1, 2, 3]);
+    break_all("日本語", &["日", "本", "語"]);
 
     // from css/css-text/word-break/word-break-break-all-001.html
-    let s = "latin";
-    break_all(s, vec![1, 2, 3, 4, 5], vec![1, 2, 3, 4, 5]);
+    break_all("latin", &["l", "a", "t", "i", "n"]);
 
     // from css/css-text/word-break/word-break-break-all-002.html
-    let s = "\u{d55c}\u{ae00}\u{c77e}";
-    break_all(s, vec![3, 6, 9], vec![1, 2, 3]);
+    break_all("한글읾", &["한", "글", "읾"]);
 
     // from css/css-text/word-break/word-break-break-all-003.html
-    let s = "ภาษาไทยภาษาไทย";
     break_all(
-        s,
-        vec![3, 6, 9, 12, 15, 18, 21, 24, 27, 30, 33, 36, 39, 42],
-        vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
+        "ภาษาไทยภาษาไทย",
+        &[
+            "ภ", "า", "ษ", "า", "ไ", "ท", "ย", "ภ", "า", "ษ", "า", "ไ", "ท", "ย",
+        ],
     );
 
     // from css/css-text/word-break/word-break-break-all-004.html
-    let s = "التدويل نشاط التدويل";
     break_all(
-        s,
-        vec![
-            2, 4, 6, 8, 10, 12, 15, 17, 19, 21, 24, 26, 28, 30, 32, 34, 36, 38,
-        ],
-        vec![
-            1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 13, 14, 15, 16, 17, 18, 19, 20,
+        "التدويل نشاط التدويل",
+        &[
+            "ا", "ل", "ت", "د", "و", "ي", "ل ", "ن", "ش", "ا", "ط ", "ا", "ل", "ت", "د", "و", "ي",
+            "ل",
         ],
     );
 
     // from css/css-text/word-break/word-break-break-all-008.html
-    let s = "हिन्दी हिन्दी हिन्दी";
     break_all(
-        s,
-        vec![6, 12, 19, 25, 31, 38, 44, 50, 56],
-        vec![2, 4, 7, 9, 11, 14, 16, 18, 20],
+        "हिन्दी हिन्दी हिन्दी",
+        &["हि", "न्", "दी ", "हि", "न्", "दी ", "हि", "न्", "दी"],
     );
 
     // from css/css-text/word-break/word-break-break-all-014.html
-    let s = "\u{1f496}\u{1f494}";
-    break_all(s, vec![4, 8], vec![2, 4]);
+    break_all("💖💔", &["💖", "💔"]);
 
     // from css/css-text/word-break/word-break-break-all-018.html
-    //let s = "XXXX\u{00a0}X";
-    //break_all(s, vec![1, 2, 3, 5, 6], vec![1, 2, 3, 5, 6]);
+    // break_all("XXXX X", &["X", "X", "X", "X\u{a0}", "X"]);
 
     // from css/css-text/word-break/word-break-break-all-022.html
-    //let s = "XX\u{00a0}X";
-    //break_all(s, vec![1, 2, 4, 5], vec![1, 2, 3, 4]);
+    // break_all("XX X", &["X", "X", " ", "X"]);
 
     // from css/css-text/word-break/word-break-break-all-023.html
-    let s = "XX XX\u{005C}\u{005C}\u{005C}";
-    break_all(s, vec![1, 3, 4, 5, 6, 7, 8], vec![1, 3, 4, 5, 6, 7, 8]);
+    break_all(r#"XX XX\\\"#, &["X", "X ", "X", "X", "\\", "\\", "\\"]);
 
     // from css/css-text/word-break/word-break-break-all-026.html
-    let s = "XX XXX///";
-    break_all(s, vec![1, 3, 4, 5, 9], vec![1, 3, 4, 5, 9]);
+    break_all("XX XXX///", &["X", "X ", "X", "X", "X///"]);
 
     // css/css-text/word-break/word-break-break-all-inline-008.html
-    let s = "X.";
-    break_all(s, vec![2], vec![2]);
+    break_all("X.", &["X."]);
 
     // ID and CJ
-    let s = "フォ";
-    break_all(s, vec![3, 6], vec![1, 2]);
+    break_all("フォ", &["フ", "ォ"]);
 }
 
 #[test]
 fn wordbreak_keepall() {
     // from css/css-text/word-break/word-break-keep-all-000.html
-    let s = "latin";
-    keep_all(s, vec![5], vec![5]);
+    keep_all("latin", &["latin"]);
 
     // from css/css-text/word-break/word-break-keep-all-001.html
-    let s = "\u{65e5}\u{672c}\u{8a9e}";
-    keep_all(s, vec![9], vec![3]);
+    keep_all("日本語", &["日本語"]);
 
     // from css/css-text/word-break/word-break-keep-all-002.html
-    let s = "한글이";
-    keep_all(s, vec![9], vec![3]);
+    keep_all("한글이", &["한글이"]);
 
     // from css/css-text/word-break/word-break-keep-all-005.html
-    let s = "字\u{3000}字";
-    keep_all(s, vec![6, 9], vec![2, 3]);
+    keep_all("字　字", &["字　", "字"]);
 
     // from css/css-text/word-break/word-break-keep-all-006.html
-    let s = "字\u{3001}字";
-    keep_all(s, vec![6, 9], vec![2, 3]);
+    keep_all("字、字", &["字、", "字"]);
 
     // from css/css-text/word-boundary/word-boundary-107.html
-    let s = "しょう。";
-    keep_all(s, vec![12], vec![4]);
+    keep_all("しょう。", &["しょう。"]);
 
     // failed test. JL, JV and JT
-    let s = "\u{110B}\u{1162}\u{1100}\u{1175}\u{1111}\u{1161}\u{11AB}\u{1103}\u{1161}";
-    keep_all(s, vec![27], vec![9]);
+    keep_all("애기판다", &["애기판다"]);
 }
 
 #[test]
 #[cfg(feature = "lstm")]
 fn wordbreak_keepall_lstm() {
     // from css/css-text/word-break/word-break-keep-all-003.html
-    let s = "และและ";
-    keep_all(s, vec![9, 18], vec![3, 6]);
+    keep_all("และและ", &["และ", "และ"]);
 }
 
 #[test]
 fn wordbreak_normal() {
     // from css/css-text/word-break/word-break-normal-th-000.html
-    let s = "ภาษาไทยภาษาไทย";
-    normal(s, vec![12, 21, 33, 42], vec![4, 7, 11, 14]);
+    normal("ภาษาไทยภาษาไทย", &["ภาษา", "ไทย", "ภาษา", "ไทย"]);
 }
 
 #[test]
 fn wordbreak_normal_km() {
     // from css/css-text/word-break/word-break-normal-km-000.html
-    let _s = "ភាសាខ្មែរភាសាខ្មែរភាសាខ្មែរ";
-    normal(_s, vec![27, 54, 81], vec![9, 18, 27]);
+    normal("ភាសាខ្មែរភាសាខ្មែរភាសាខ្មែរ", &["ភាសាខ្មែរ", "ភាសាខ្មែរ", "ភាសាខ្មែរ"]);
 }
 
 #[test]
 fn wordbreak_normal_lo() {
     // from css/css-text/word-break/word-break-normal-lo-000.html
-    let _s = "ພາສາລາວພາສາລາວພາສາລາວ";
-    normal(_s, vec![12, 21, 33, 42, 54, 63], vec![4, 7, 11, 14, 18, 21]);
+    normal(
+        "ພາສາລາວພາສາລາວພາສາລາວ",
+        &["ພາສາ", "ລາວ", "ພາສາ", "ລາວ", "ພາສາ", "ລາວ"],
+    );
 }

--- a/components/segmenter/tests/locale.rs
+++ b/components/segmenter/tests/locale.rs
@@ -23,11 +23,7 @@ fn word_break_with_locale() {
         .tuple_windows()
         .map(|(a, b)| &s[a..b])
         .collect::<Vec<_>>();
-    assert_eq!(
-        segments,
-        &["hello:world"],
-        "word segmenter with Swedish"
-    );
+    assert_eq!(segments, &["hello:world"], "word segmenter with Swedish");
 
     let mut options_en = WordBreakOptions::default();
     let langid = langid!("en");

--- a/components/segmenter/tests/locale.rs
+++ b/components/segmenter/tests/locale.rs
@@ -5,6 +5,7 @@
 use icu_locale_core::langid;
 use icu_segmenter::options::{SentenceBreakOptions, WordBreakOptions};
 use icu_segmenter::{SentenceSegmenter, WordSegmenter};
+use itertools::Itertools;
 
 // Additional segmenter tests with locale.
 
@@ -16,11 +17,15 @@ fn word_break_with_locale() {
     let langid = langid!("sv");
     options_sv.content_locale = Some(&langid);
     let segmenter = WordSegmenter::try_new_auto(options_sv).expect("Loading should succeed!");
-    let segmenter = segmenter.as_borrowed();
-    let iter = segmenter.segment_str(s);
+    let segments = segmenter
+        .as_borrowed()
+        .segment_str(s)
+        .tuple_windows()
+        .map(|(a, b)| &s[a..b])
+        .collect::<Vec<_>>();
     assert_eq!(
-        iter.collect::<Vec<usize>>(),
-        vec![0, 11],
+        segments,
+        &["hello:world"],
         "word segmenter with Swedish"
     );
 
@@ -28,11 +33,15 @@ fn word_break_with_locale() {
     let langid = langid!("en");
     options_en.content_locale = Some(&langid);
     let segmenter = WordSegmenter::try_new_auto(options_en).expect("Loading should succeed!");
-    let segmenter = segmenter.as_borrowed();
-    let iter = segmenter.segment_str(s);
+    let segments = segmenter
+        .as_borrowed()
+        .segment_str(s)
+        .tuple_windows()
+        .map(|(a, b)| &s[a..b])
+        .collect::<Vec<_>>();
     assert_eq!(
-        iter.collect::<Vec<usize>>(),
-        vec![0, 5, 6, 11],
+        segments,
+        &["hello", ":", "world"],
         "word segmenter with English"
     );
 }
@@ -45,11 +54,15 @@ fn sentence_break_with_locale() {
     let langid = langid!("el");
     options_el.content_locale = Some(&langid);
     let segmenter = SentenceSegmenter::try_new(options_el).expect("Loading should succeed!");
-    let segmenter = segmenter.as_borrowed();
-    let iter = segmenter.segment_str(s);
+    let segments = segmenter
+        .as_borrowed()
+        .segment_str(s)
+        .tuple_windows()
+        .map(|(a, b)| &s[a..b])
+        .collect::<Vec<_>>();
     assert_eq!(
-        iter.collect::<Vec<usize>>(),
-        vec![0, 7, 12],
+        segments,
+        &["hello; ", "world"],
         "sentence segmenter with Greek"
     );
 
@@ -57,11 +70,15 @@ fn sentence_break_with_locale() {
     let langid = langid!("en");
     options_en.content_locale = Some(&langid);
     let segmenter = SentenceSegmenter::try_new(options_en).expect("Loading should succeed!");
-    let segmenter = segmenter.as_borrowed();
-    let iter = segmenter.segment_str(s);
+    let segments = segmenter
+        .as_borrowed()
+        .segment_str(s)
+        .tuple_windows()
+        .map(|(a, b)| &s[a..b])
+        .collect::<Vec<_>>();
     assert_eq!(
-        iter.collect::<Vec<usize>>(),
-        vec![0, 12],
+        segments,
+        &["hello; world"],
         "sentence segmenter with English"
     );
 }


### PR DESCRIPTION
I don't want to stare at lists of indices when debugging the new implementation.

## Changelog

N/A