### PR TITLE
Add benchmarks for list component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1687,6 +1687,7 @@ dependencies = [
 name = "icu_list"
 version = "2.2.0"
 dependencies = [
+ "criterion",
  "databake",
  "icu",
  "icu_list_data",

--- a/components/list/Cargo.toml
+++ b/components/list/Cargo.toml
@@ -37,6 +37,8 @@ postcard = { workspace = true, features = ["use-std"] }
 rmp-serde = { workspace = true }
 serde_json = { workspace = true }
 
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+criterion = { workspace = true }
 
 [features]
 default = ["compiled_data"]
@@ -45,6 +47,11 @@ serde_human = ["serde", "regex-automata/dfa-build", "regex-automata/syntax", "al
 datagen = ["serde", "dep:databake", "regex-automata/dfa-build", "regex-automata/syntax", "zerovec/databake", "alloc", "serde_human", "icu_provider/export"]
 compiled_data = ["dep:icu_list_data", "dep:icu_locale", "icu_locale?/compiled_data", "icu_provider/baked"]
 alloc = ["zerovec/alloc", "icu_provider/alloc", "serde?/alloc"]
+
+[[bench]]
+name = "list"
+harness = false
+required-features = ["compiled_data"]
 
 [lints]
 workspace = true

--- a/components/list/benches/list.rs
+++ b/components/list/benches/list.rs
@@ -50,6 +50,10 @@ fn list_benches(c: &mut Criterion) {
     });
 
     // Benchmark formatting
+    fn generate_list(n: usize) -> Vec<String> {
+        (0..n).map(|i| format!("Item {}", i)).collect()
+    }
+
     let list_2 = generate_list(2);
     let list_5 = generate_list(5);
     let list_1000 = generate_list(1000);
@@ -57,21 +61,18 @@ fn list_benches(c: &mut Criterion) {
     let locale = locale!("en");
     let mut result = String::with_capacity(10000);
 
-    // And
     let formatter_and = ListFormatter::try_new_and(
         locale.clone().into(),
         ListFormatterOptions::default().with_length(ListLength::Wide),
     )
     .unwrap();
 
-    // Or
     let formatter_or = ListFormatter::try_new_or(
         locale.clone().into(),
         ListFormatterOptions::default().with_length(ListLength::Wide),
     )
     .unwrap();
 
-    // Unit
     let formatter_unit = ListFormatter::try_new_unit(
         locale.clone().into(),
         ListFormatterOptions::default().with_length(ListLength::Wide),
@@ -148,10 +149,6 @@ fn list_benches(c: &mut Criterion) {
     });
 
     group.finish();
-}
-
-fn generate_list(n: usize) -> Vec<String> {
-    (0..n).map(|i| format!("Item {}", i)).collect()
 }
 
 criterion_group!(benches, list_benches);

--- a/components/list/benches/list.rs
+++ b/components/list/benches/list.rs
@@ -21,7 +21,7 @@ fn list_benches(c: &mut Criterion) {
             for locale in black_box(&locales) {
                 let _ = ListFormatter::try_new_and(
                     locale.into(),
-                    ListFormatterOptions::default().with_length(ListLength::Wide),
+                    ListFormatterOptions::default().with_length(black_box(ListLength::Wide)),
                 );
             }
         })
@@ -32,7 +32,7 @@ fn list_benches(c: &mut Criterion) {
             for locale in black_box(&locales) {
                 let _ = ListFormatter::try_new_or(
                     locale.into(),
-                    ListFormatterOptions::default().with_length(ListLength::Short),
+                    ListFormatterOptions::default().with_length(black_box(ListLength::Short)),
                 );
             }
         })
@@ -43,7 +43,7 @@ fn list_benches(c: &mut Criterion) {
             for locale in black_box(&locales) {
                 let _ = ListFormatter::try_new_unit(
                     locale.into(),
-                    ListFormatterOptions::default().with_length(ListLength::Narrow),
+                    ListFormatterOptions::default().with_length(black_box(ListLength::Narrow)),
                 );
             }
         })

--- a/components/list/benches/list.rs
+++ b/components/list/benches/list.rs
@@ -54,48 +54,110 @@ fn list_benches(c: &mut Criterion) {
     let list_5 = generate_list(5);
     let list_1000 = generate_list(1000);
 
-    let locales = [
-        (locale!("en"), "en"),
-        (locale!("es"), "es"),
-        (locale!("ar"), "ar"),
-    ];
-
+    let locale = locale!("en");
     let mut result = String::with_capacity(10000);
 
-    for (locale, locale_str) in locales {
-        let formatter = ListFormatter::try_new_and(
-            locale.clone().into(),
-            ListFormatterOptions::default().with_length(ListLength::Wide),
-        )
-        .unwrap();
+    // And
+    let formatter_and = ListFormatter::try_new_and(
+        locale.clone().into(),
+        ListFormatterOptions::default().with_length(ListLength::Wide),
+    )
+    .unwrap();
 
-        group.bench_function(format!("format/and/wide/{locale_str}/2_items"), |b| {
-            b.iter(|| {
-                result.clear();
-                let _ = black_box(&formatter)
-                    .format(black_box(&list_2).iter())
-                    .write_to(&mut result);
-            })
-        });
+    group.bench_function("format/and/wide/2_items", |b| {
+        b.iter(|| {
+            result.clear();
+            let _ = black_box(&formatter_and)
+                .format(black_box(&list_2).iter())
+                .write_to(&mut result);
+        })
+    });
 
-        group.bench_function(format!("format/and/wide/{locale_str}/5_items"), |b| {
-            b.iter(|| {
-                result.clear();
-                let _ = black_box(&formatter)
-                    .format(black_box(&list_5).iter())
-                    .write_to(&mut result);
-            })
-        });
+    group.bench_function("format/and/wide/5_items", |b| {
+        b.iter(|| {
+            result.clear();
+            let _ = black_box(&formatter_and)
+                .format(black_box(&list_5).iter())
+                .write_to(&mut result);
+        })
+    });
 
-        group.bench_function(format!("format/and/wide/{locale_str}/1000_items"), |b| {
-            b.iter(|| {
-                result.clear();
-                let _ = black_box(&formatter)
-                    .format(black_box(&list_1000).iter())
-                    .write_to(&mut result);
-            })
-        });
-    }
+    group.bench_function("format/and/wide/1000_items", |b| {
+        b.iter(|| {
+            result.clear();
+            let _ = black_box(&formatter_and)
+                .format(black_box(&list_1000).iter())
+                .write_to(&mut result);
+        })
+    });
+
+    // Or
+    let formatter_or = ListFormatter::try_new_or(
+        locale.clone().into(),
+        ListFormatterOptions::default().with_length(ListLength::Wide),
+    )
+    .unwrap();
+
+    group.bench_function("format/or/wide/2_items", |b| {
+        b.iter(|| {
+            result.clear();
+            let _ = black_box(&formatter_or)
+                .format(black_box(&list_2).iter())
+                .write_to(&mut result);
+        })
+    });
+
+    group.bench_function("format/or/wide/5_items", |b| {
+        b.iter(|| {
+            result.clear();
+            let _ = black_box(&formatter_or)
+                .format(black_box(&list_5).iter())
+                .write_to(&mut result);
+        })
+    });
+
+    group.bench_function("format/or/wide/1000_items", |b| {
+        b.iter(|| {
+            result.clear();
+            let _ = black_box(&formatter_or)
+                .format(black_box(&list_1000).iter())
+                .write_to(&mut result);
+        })
+    });
+
+    // Unit
+    let formatter_unit = ListFormatter::try_new_unit(
+        locale.clone().into(),
+        ListFormatterOptions::default().with_length(ListLength::Wide),
+    )
+    .unwrap();
+
+    group.bench_function("format/unit/wide/2_items", |b| {
+        b.iter(|| {
+            result.clear();
+            let _ = black_box(&formatter_unit)
+                .format(black_box(&list_2).iter())
+                .write_to(&mut result);
+        })
+    });
+
+    group.bench_function("format/unit/wide/5_items", |b| {
+        b.iter(|| {
+            result.clear();
+            let _ = black_box(&formatter_unit)
+                .format(black_box(&list_5).iter())
+                .write_to(&mut result);
+        })
+    });
+
+    group.bench_function("format/unit/wide/1000_items", |b| {
+        b.iter(|| {
+            result.clear();
+            let _ = black_box(&formatter_unit)
+                .format(black_box(&list_1000).iter())
+                .write_to(&mut result);
+        })
+    });
 
     // Adversarial Spanish Benchmarks (Testing "or" pattern)
     let es_locale = locale!("es");

--- a/components/list/benches/list.rs
+++ b/components/list/benches/list.rs
@@ -97,6 +97,75 @@ fn list_benches(c: &mut Criterion) {
         });
     }
 
+    // Adversarial Spanish Benchmarks
+    let es_locale = locale!("es");
+
+    // Test 'and' (y -> e)
+    let formatter_and = ListFormatter::try_new_and(
+        es_locale.clone().into(),
+        ListFormatterOptions::default().with_length(ListLength::Wide),
+    )
+    .unwrap();
+
+    let list_higo = vec!["manzanas".to_string(), "higos".to_string()];
+    let list_hielo = vec!["leche".to_string(), "hielo".to_string()];
+
+    group.bench_function("format/and/wide/es/higo", |b| {
+        b.iter(|| {
+            result.clear();
+            let _ = black_box(&formatter_and)
+                .format(black_box(&list_higo).iter())
+                .write_to(&mut result);
+        })
+    });
+
+    group.bench_function("format/and/wide/es/hielo", |b| {
+        b.iter(|| {
+            result.clear();
+            let _ = black_box(&formatter_and)
+                .format(black_box(&list_hielo).iter())
+                .write_to(&mut result);
+        })
+    });
+
+    // Test 'or' (o -> u)
+    let formatter_or = ListFormatter::try_new_or(
+        es_locale.clone().into(),
+        ListFormatterOptions::default().with_length(ListLength::Wide),
+    )
+    .unwrap();
+
+    let list_8 = vec!["7".to_string(), "8".to_string()];
+    let list_11 = vec!["10".to_string(), "11".to_string()];
+    let list_110 = vec!["10".to_string(), "110".to_string()];
+
+    group.bench_function("format/or/wide/es/8", |b| {
+        b.iter(|| {
+            result.clear();
+            let _ = black_box(&formatter_or)
+                .format(black_box(&list_8).iter())
+                .write_to(&mut result);
+        })
+    });
+
+    group.bench_function("format/or/wide/es/11", |b| {
+        b.iter(|| {
+            result.clear();
+            let _ = black_box(&formatter_or)
+                .format(black_box(&list_11).iter())
+                .write_to(&mut result);
+        })
+    });
+
+    group.bench_function("format/or/wide/es/110", |b| {
+        b.iter(|| {
+            result.clear();
+            let _ = black_box(&formatter_or)
+                .format(black_box(&list_110).iter())
+                .write_to(&mut result);
+        })
+    });
+
     group.finish();
 }
 

--- a/components/list/benches/list.rs
+++ b/components/list/benches/list.rs
@@ -104,6 +104,17 @@ fn list_benches(c: &mut Criterion) {
         }
     }
 
+    for (size_str, list) in &lists {
+        group.bench_function(format!("format/baseline/{size_str}"), |b| {
+            b.iter(|| {
+                result.clear();
+                for item in black_box(list).iter() {
+                    result.push_str(item);
+                }
+            })
+        });
+    }
+
     // Adversarial Spanish Benchmarks (Testing "or" pattern)
     let formatter_or = ListFormatter::try_new_or(
         locale!("es").into(),

--- a/components/list/benches/list.rs
+++ b/components/list/benches/list.rs
@@ -1,0 +1,110 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use icu_list::{
+    options::{ListFormatterOptions, ListLength},
+    ListFormatter,
+};
+use icu_locale::locale;
+use writeable::Writeable;
+
+fn list_benches(c: &mut Criterion) {
+    let mut group = c.benchmark_group("list");
+
+    let locales = [locale!("en"), locale!("es"), locale!("th")];
+
+    // Benchmark construction
+    group.bench_function("construct/and/wide", |b| {
+        b.iter(|| {
+            for locale in black_box(&locales) {
+                let _ = ListFormatter::try_new_and(
+                    locale.into(),
+                    ListFormatterOptions::default().with_length(ListLength::Wide),
+                );
+            }
+        })
+    });
+
+    group.bench_function("construct/or/short", |b| {
+        b.iter(|| {
+            for locale in black_box(&locales) {
+                let _ = ListFormatter::try_new_or(
+                    locale.into(),
+                    ListFormatterOptions::default().with_length(ListLength::Short),
+                );
+            }
+        })
+    });
+
+    group.bench_function("construct/unit/narrow", |b| {
+        b.iter(|| {
+            for locale in black_box(&locales) {
+                let _ = ListFormatter::try_new_unit(
+                    locale.into(),
+                    ListFormatterOptions::default().with_length(ListLength::Narrow),
+                );
+            }
+        })
+    });
+
+    // Benchmark formatting
+    let list_2 = generate_list(2);
+    let list_3 = generate_list(3);
+    let list_5 = generate_list(5);
+    let list_1000 = generate_list(1000);
+
+    let formatter = ListFormatter::try_new_and(
+        locale!("en").into(),
+        ListFormatterOptions::default().with_length(ListLength::Wide),
+    )
+    .unwrap();
+
+    let mut result = String::with_capacity(10000);
+
+    group.bench_function("format/and/wide/2_items", |b| {
+        b.iter(|| {
+            result.clear();
+            let _ = black_box(&formatter)
+                .format(black_box(&list_2).iter())
+                .write_to(&mut result);
+        })
+    });
+
+    group.bench_function("format/and/wide/3_items", |b| {
+        b.iter(|| {
+            result.clear();
+            let _ = black_box(&formatter)
+                .format(black_box(&list_3).iter())
+                .write_to(&mut result);
+        })
+    });
+
+    group.bench_function("format/and/wide/5_items", |b| {
+        b.iter(|| {
+            result.clear();
+            let _ = black_box(&formatter)
+                .format(black_box(&list_5).iter())
+                .write_to(&mut result);
+        })
+    });
+
+    group.bench_function("format/and/wide/1000_items", |b| {
+        b.iter(|| {
+            result.clear();
+            let _ = black_box(&formatter)
+                .format(black_box(&list_1000).iter())
+                .write_to(&mut result);
+        })
+    });
+
+    group.finish();
+}
+
+fn generate_list(n: usize) -> Vec<String> {
+    (0..n).map(|i| format!("Item {}", i)).collect()
+}
+
+criterion_group!(benches, list_benches);
+criterion_main!(benches);

--- a/components/list/benches/list.rs
+++ b/components/list/benches/list.rs
@@ -97,71 +97,45 @@ fn list_benches(c: &mut Criterion) {
         });
     }
 
-    // Adversarial Spanish Benchmarks
+    // Adversarial Spanish Benchmarks (Testing "or" pattern)
     let es_locale = locale!("es");
 
-    // Test 'and' (y -> e)
-    let formatter_and = ListFormatter::try_new_and(
-        es_locale.clone().into(),
-        ListFormatterOptions::default().with_length(ListLength::Wide),
-    )
-    .unwrap();
-
-    let list_higo = vec!["manzanas".to_string(), "higos".to_string()];
-    let list_hielo = vec!["leche".to_string(), "hielo".to_string()];
-
-    group.bench_function("format/and/wide/es/higo", |b| {
-        b.iter(|| {
-            result.clear();
-            let _ = black_box(&formatter_and)
-                .format(black_box(&list_higo).iter())
-                .write_to(&mut result);
-        })
-    });
-
-    group.bench_function("format/and/wide/es/hielo", |b| {
-        b.iter(|| {
-            result.clear();
-            let _ = black_box(&formatter_and)
-                .format(black_box(&list_hielo).iter())
-                .write_to(&mut result);
-        })
-    });
-
-    // Test 'or' (o -> u)
     let formatter_or = ListFormatter::try_new_or(
         es_locale.clone().into(),
         ListFormatterOptions::default().with_length(ListLength::Wide),
     )
     .unwrap();
 
-    let list_8 = vec!["7".to_string(), "8".to_string()];
-    let list_11 = vec!["10".to_string(), "11".to_string()];
-    let list_110 = vec!["10".to_string(), "110".to_string()];
+    let list_match_word = vec!["casa".to_string(), "otro".to_string()];
+    let list_no_match_word = vec!["casa".to_string(), "perro".to_string()];
+    let list_long_number = vec![
+        "10".to_string(),
+        "11000000000000000000000000000000".to_string(),
+    ];
 
-    group.bench_function("format/or/wide/es/8", |b| {
+    group.bench_function("format/or/wide/es/match_word", |b| {
         b.iter(|| {
             result.clear();
             let _ = black_box(&formatter_or)
-                .format(black_box(&list_8).iter())
+                .format(black_box(&list_match_word).iter())
                 .write_to(&mut result);
         })
     });
 
-    group.bench_function("format/or/wide/es/11", |b| {
+    group.bench_function("format/or/wide/es/no_match_word", |b| {
         b.iter(|| {
             result.clear();
             let _ = black_box(&formatter_or)
-                .format(black_box(&list_11).iter())
+                .format(black_box(&list_no_match_word).iter())
                 .write_to(&mut result);
         })
     });
 
-    group.bench_function("format/or/wide/es/110", |b| {
+    group.bench_function("format/or/wide/es/long_number", |b| {
         b.iter(|| {
             result.clear();
             let _ = black_box(&formatter_or)
-                .format(black_box(&list_110).iter())
+                .format(black_box(&list_long_number).iter())
                 .write_to(&mut result);
         })
     });

--- a/components/list/benches/list.rs
+++ b/components/list/benches/list.rs
@@ -51,53 +51,51 @@ fn list_benches(c: &mut Criterion) {
 
     // Benchmark formatting
     let list_2 = generate_list(2);
-    let list_3 = generate_list(3);
     let list_5 = generate_list(5);
     let list_1000 = generate_list(1000);
 
-    let formatter = ListFormatter::try_new_and(
-        locale!("en").into(),
-        ListFormatterOptions::default().with_length(ListLength::Wide),
-    )
-    .unwrap();
+    let locales = [
+        (locale!("en"), "en"),
+        (locale!("es"), "es"),
+        (locale!("ar"), "ar"),
+    ];
 
     let mut result = String::with_capacity(10000);
 
-    group.bench_function("format/and/wide/2_items", |b| {
-        b.iter(|| {
-            result.clear();
-            let _ = black_box(&formatter)
-                .format(black_box(&list_2).iter())
-                .write_to(&mut result);
-        })
-    });
+    for (locale, locale_str) in locales {
+        let formatter = ListFormatter::try_new_and(
+            locale.clone().into(),
+            ListFormatterOptions::default().with_length(ListLength::Wide),
+        )
+        .unwrap();
 
-    group.bench_function("format/and/wide/3_items", |b| {
-        b.iter(|| {
-            result.clear();
-            let _ = black_box(&formatter)
-                .format(black_box(&list_3).iter())
-                .write_to(&mut result);
-        })
-    });
+        group.bench_function(format!("format/and/wide/{locale_str}/2_items"), |b| {
+            b.iter(|| {
+                result.clear();
+                let _ = black_box(&formatter)
+                    .format(black_box(&list_2).iter())
+                    .write_to(&mut result);
+            })
+        });
 
-    group.bench_function("format/and/wide/5_items", |b| {
-        b.iter(|| {
-            result.clear();
-            let _ = black_box(&formatter)
-                .format(black_box(&list_5).iter())
-                .write_to(&mut result);
-        })
-    });
+        group.bench_function(format!("format/and/wide/{locale_str}/5_items"), |b| {
+            b.iter(|| {
+                result.clear();
+                let _ = black_box(&formatter)
+                    .format(black_box(&list_5).iter())
+                    .write_to(&mut result);
+            })
+        });
 
-    group.bench_function("format/and/wide/1000_items", |b| {
-        b.iter(|| {
-            result.clear();
-            let _ = black_box(&formatter)
-                .format(black_box(&list_1000).iter())
-                .write_to(&mut result);
-        })
-    });
+        group.bench_function(format!("format/and/wide/{locale_str}/1000_items"), |b| {
+            b.iter(|| {
+                result.clear();
+                let _ = black_box(&formatter)
+                    .format(black_box(&list_1000).iter())
+                    .write_to(&mut result);
+            })
+        });
+    }
 
     group.finish();
 }

--- a/components/list/benches/list.rs
+++ b/components/list/benches/list.rs
@@ -104,10 +104,8 @@ fn list_benches(c: &mut Criterion) {
     }
 
     // Adversarial Spanish Benchmarks (Testing "or" pattern)
-    let es_locale = locale!("es");
-
     let formatter_or = ListFormatter::try_new_or(
-        es_locale.clone().into(),
+        locale!("es").into(),
         ListFormatterOptions::default().with_length(ListLength::Wide),
     )
     .unwrap();
@@ -116,6 +114,9 @@ fn list_benches(c: &mut Criterion) {
     let list_no_match_word = vec!["casa".to_string(), "perro".to_string()];
     let list_long_number = vec![
         "10".to_string(),
+        // The whole number needs to be processed by the DFA, as it
+        // needs to figure out if it starts with "11" (once), 110
+        // (ciento diez), or "1100" (mil cien).
         "11000000000000000000000000000000".to_string(),
     ];
 

--- a/components/list/benches/list.rs
+++ b/components/list/benches/list.rs
@@ -64,66 +64,12 @@ fn list_benches(c: &mut Criterion) {
     )
     .unwrap();
 
-    group.bench_function("format/and/wide/2_items", |b| {
-        b.iter(|| {
-            result.clear();
-            let _ = black_box(&formatter_and)
-                .format(black_box(&list_2).iter())
-                .write_to(&mut result);
-        })
-    });
-
-    group.bench_function("format/and/wide/5_items", |b| {
-        b.iter(|| {
-            result.clear();
-            let _ = black_box(&formatter_and)
-                .format(black_box(&list_5).iter())
-                .write_to(&mut result);
-        })
-    });
-
-    group.bench_function("format/and/wide/1000_items", |b| {
-        b.iter(|| {
-            result.clear();
-            let _ = black_box(&formatter_and)
-                .format(black_box(&list_1000).iter())
-                .write_to(&mut result);
-        })
-    });
-
     // Or
     let formatter_or = ListFormatter::try_new_or(
         locale.clone().into(),
         ListFormatterOptions::default().with_length(ListLength::Wide),
     )
     .unwrap();
-
-    group.bench_function("format/or/wide/2_items", |b| {
-        b.iter(|| {
-            result.clear();
-            let _ = black_box(&formatter_or)
-                .format(black_box(&list_2).iter())
-                .write_to(&mut result);
-        })
-    });
-
-    group.bench_function("format/or/wide/5_items", |b| {
-        b.iter(|| {
-            result.clear();
-            let _ = black_box(&formatter_or)
-                .format(black_box(&list_5).iter())
-                .write_to(&mut result);
-        })
-    });
-
-    group.bench_function("format/or/wide/1000_items", |b| {
-        b.iter(|| {
-            result.clear();
-            let _ = black_box(&formatter_or)
-                .format(black_box(&list_1000).iter())
-                .write_to(&mut result);
-        })
-    });
 
     // Unit
     let formatter_unit = ListFormatter::try_new_unit(
@@ -132,32 +78,30 @@ fn list_benches(c: &mut Criterion) {
     )
     .unwrap();
 
-    group.bench_function("format/unit/wide/2_items", |b| {
-        b.iter(|| {
-            result.clear();
-            let _ = black_box(&formatter_unit)
-                .format(black_box(&list_2).iter())
-                .write_to(&mut result);
-        })
-    });
+    let styles = [
+        ("and", &formatter_and),
+        ("or", &formatter_or),
+        ("unit", &formatter_unit),
+    ];
 
-    group.bench_function("format/unit/wide/5_items", |b| {
-        b.iter(|| {
-            result.clear();
-            let _ = black_box(&formatter_unit)
-                .format(black_box(&list_5).iter())
-                .write_to(&mut result);
-        })
-    });
+    let lists = [
+        ("2_items", &list_2),
+        ("5_items", &list_5),
+        ("1000_items", &list_1000),
+    ];
 
-    group.bench_function("format/unit/wide/1000_items", |b| {
-        b.iter(|| {
-            result.clear();
-            let _ = black_box(&formatter_unit)
-                .format(black_box(&list_1000).iter())
-                .write_to(&mut result);
-        })
-    });
+    for (style_str, formatter) in &styles {
+        for (size_str, list) in &lists {
+            group.bench_function(format!("format/{style_str}/wide/{size_str}"), |b| {
+                b.iter(|| {
+                    result.clear();
+                    let _ = black_box(formatter)
+                        .format(black_box(list).iter())
+                        .write_to(&mut result);
+                })
+            });
+        }
+    }
 
     // Adversarial Spanish Benchmarks (Testing "or" pattern)
     let es_locale = locale!("es");


### PR DESCRIPTION
See #1746 

Adds benchmarks for the list component, covering construction and formatting for different styles (And, Or, Unit). It also includes targeted adversarial benchmarks for Spanish to test complex conditional rules (e.g., "o" -> "u" before "o" sounds and numbers starting with 8 and 11).

## Changelog

N/A