### PR TITLE
Deprecate ICU-only properties

### DIFF
--- a/components/collections/src/iterator_utils.rs
+++ b/components/collections/src/iterator_utils.rs
@@ -149,10 +149,6 @@ mod tests {
         test_set::<Lowercase>("Lowercase");
         test_set::<Math>("Math");
         test_set::<NoncharacterCodePoint>("Noncharacter_Code_Point");
-        test_set::<NfcInert>("NFC_Inert");
-        test_set::<NfdInert>("NFD_Inert");
-        test_set::<NfkcInert>("NFKC_Inert");
-        test_set::<NfkdInert>("NFKD_Inert");
         test_set::<PatternSyntax>("Pattern_Syntax");
         test_set::<PatternWhiteSpace>("Pattern_White_Space");
         test_set::<PrependedConcatenationMark>("Prepended_Concatenation_Mark");
@@ -161,8 +157,6 @@ mod tests {
         test_set::<Radical>("Radical");
         test_set::<RegionalIndicator>("Regional_Indicator");
         test_set::<SoftDotted>("Soft_Dotted");
-        test_set::<SegmentStarter>("Segment_Starter");
-        test_set::<CaseSensitive>("Case_Sensitive");
         test_set::<SentenceTerminal>("Sentence_Terminal");
         test_set::<TerminalPunctuation>("Terminal_Punctuation");
         test_set::<UnifiedIdeograph>("Unified_Ideograph");

--- a/components/properties/src/lib.rs
+++ b/components/properties/src/lib.rs
@@ -107,3 +107,9 @@ mod harfbuzz;
 #[cfg(feature = "unstable")]
 #[cfg(feature = "alloc")]
 pub mod unicodeset_parse;
+
+#[cfg(not(feature = "unstable"))]
+#[cfg(feature = "alloc")]
+#[doc(hidden)]
+#[path = "unicodeset_parse/mod.rs"]
+pub mod unstable_unicodeset_parse;

--- a/components/properties/src/props.rs
+++ b/components/properties/src/props.rs
@@ -2126,10 +2126,12 @@ macro_rules! make_binary_property {
         #[non_exhaustive]
         pub struct $ident;
 
+        #[allow(deprecated)]
         impl crate::private::Sealed for $ident {}
 
+        #[allow(deprecated)]
         impl BinaryProperty for $ident {
-        type DataMarker = $data_marker;
+            type DataMarker = $data_marker;
             #[cfg(feature = "compiled_data")]
             const SINGLETON: &'static crate::provider::PropertyCodePointSet<'static> =
                 &crate::provider::Baked::$singleton;
@@ -3083,6 +3085,7 @@ make_binary_property! {
     data_marker: crate::provider::PropertyBinaryNfcInertV1;
     singleton: SINGLETON_PROPERTY_BINARY_NFC_INERT_V1;
     /// Characters that are inert under NFC, i.e., they do not interact with adjacent characters.
+    #[deprecated(since = "2.3.0", note = "not a UCD property")]
 }
 
 make_binary_property! {
@@ -3092,6 +3095,7 @@ make_binary_property! {
     data_marker: crate::provider::PropertyBinaryNfdInertV1;
     singleton: SINGLETON_PROPERTY_BINARY_NFD_INERT_V1;
     /// Characters that are inert under NFD, i.e., they do not interact with adjacent characters.
+    #[deprecated(since = "2.3.0", note = "not a UCD property")]
 }
 
 make_binary_property! {
@@ -3101,6 +3105,7 @@ make_binary_property! {
     data_marker: crate::provider::PropertyBinaryNfkcInertV1;
     singleton: SINGLETON_PROPERTY_BINARY_NFKC_INERT_V1;
     /// Characters that are inert under NFKC, i.e., they do not interact with adjacent characters.
+    #[deprecated(since = "2.3.0", note = "not a UCD property")]
 }
 
 make_binary_property! {
@@ -3110,6 +3115,7 @@ make_binary_property! {
     data_marker: crate::provider::PropertyBinaryNfkdInertV1;
     singleton: SINGLETON_PROPERTY_BINARY_NFKD_INERT_V1;
     /// Characters that are inert under NFKD, i.e., they do not interact with adjacent characters.
+    #[deprecated(since = "2.3.0", note = "not a UCD property")]
 }
 
 make_binary_property! {
@@ -3283,6 +3289,7 @@ make_binary_property! {
     singleton: SINGLETON_PROPERTY_BINARY_SEGMENT_STARTER_V1;
     /// Characters that are starters in terms of Unicode normalization and combining character
     /// sequences.
+    #[deprecated(since = "2.3.0", note = "not a UCD property")]
 }
 
 make_binary_property! {
@@ -3293,6 +3300,7 @@ make_binary_property! {
     singleton: SINGLETON_PROPERTY_BINARY_CASE_SENSITIVE_V1;
     /// Characters that are either the source of a case mapping or in the target of a case
     /// mapping.
+    #[deprecated(since = "2.3.0", note = "not a UCD property")]
 }
 
 make_binary_property! {

--- a/ffi/capi/bindings/cpp/icu4x/CodePointSetData.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/CodePointSetData.d.hpp
@@ -1053,84 +1053,120 @@ public:
    * Get the `Nfc_Inert` value for a given character, using compiled data
    *
    * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.2.0/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+   *
+   * \deprecated not a UCD property
    */
+  [[deprecated("not a UCD property")]]
   inline static bool nfc_inert_for_char(char32_t ch);
 
   /**
    * Create a set for the `Nfc_Inert` property, using compiled data.
    *
    * See the [Rust documentation for `NfcInert`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.NfcInert.html) for more information.
+   *
+   * \deprecated not a UCD property
    */
+  [[deprecated("not a UCD property")]]
   inline static std::unique_ptr<icu4x::CodePointSetData> create_nfc_inert();
 
   /**
    * Create a set for the `Nfc_Inert` property, using a particular data source.
    *
    * See the [Rust documentation for `NfcInert`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.NfcInert.html) for more information.
+   *
+   * \deprecated not a UCD property
    */
+  [[deprecated("not a UCD property")]]
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::CodePointSetData>, icu4x::DataError> create_nfc_inert_with_provider(const icu4x::DataProvider& provider);
 
   /**
    * Get the `Nfd_Inert` value for a given character, using compiled data
    *
    * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.2.0/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+   *
+   * \deprecated not a UCD property
    */
+  [[deprecated("not a UCD property")]]
   inline static bool nfd_inert_for_char(char32_t ch);
 
   /**
    * Create a set for the `Nfd_Inert` property, using compiled data.
    *
    * See the [Rust documentation for `NfdInert`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.NfdInert.html) for more information.
+   *
+   * \deprecated not a UCD property
    */
+  [[deprecated("not a UCD property")]]
   inline static std::unique_ptr<icu4x::CodePointSetData> create_nfd_inert();
 
   /**
    * Create a set for the `Nfd_Inert` property, using a particular data source.
    *
    * See the [Rust documentation for `NfdInert`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.NfdInert.html) for more information.
+   *
+   * \deprecated not a UCD property
    */
+  [[deprecated("not a UCD property")]]
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::CodePointSetData>, icu4x::DataError> create_nfd_inert_with_provider(const icu4x::DataProvider& provider);
 
   /**
    * Get the `Nfkc_Inert` value for a given character, using compiled data
    *
    * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.2.0/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+   *
+   * \deprecated not a UCD property
    */
+  [[deprecated("not a UCD property")]]
   inline static bool nfkc_inert_for_char(char32_t ch);
 
   /**
    * Create a set for the `Nfkc_Inert` property, using compiled data.
    *
    * See the [Rust documentation for `NfkcInert`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.NfkcInert.html) for more information.
+   *
+   * \deprecated not a UCD property
    */
+  [[deprecated("not a UCD property")]]
   inline static std::unique_ptr<icu4x::CodePointSetData> create_nfkc_inert();
 
   /**
    * Create a set for the `Nfkc_Inert` property, using a particular data source.
    *
    * See the [Rust documentation for `NfkcInert`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.NfkcInert.html) for more information.
+   *
+   * \deprecated not a UCD property
    */
+  [[deprecated("not a UCD property")]]
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::CodePointSetData>, icu4x::DataError> create_nfkc_inert_with_provider(const icu4x::DataProvider& provider);
 
   /**
    * Get the `Nfkd_Inert` value for a given character, using compiled data
    *
    * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.2.0/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+   *
+   * \deprecated not a UCD property
    */
+  [[deprecated("not a UCD property")]]
   inline static bool nfkd_inert_for_char(char32_t ch);
 
   /**
    * Create a set for the `Nfkd_Inert` property, using compiled data.
    *
    * See the [Rust documentation for `NfkdInert`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.NfkdInert.html) for more information.
+   *
+   * \deprecated not a UCD property
    */
+  [[deprecated("not a UCD property")]]
   inline static std::unique_ptr<icu4x::CodePointSetData> create_nfkd_inert();
 
   /**
    * Create a set for the `Nfkd_Inert` property, using a particular data source.
    *
    * See the [Rust documentation for `NfkdInert`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.NfkdInert.html) for more information.
+   *
+   * \deprecated not a UCD property
    */
+  [[deprecated("not a UCD property")]]
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::CodePointSetData>, icu4x::DataError> create_nfkd_inert_with_provider(const icu4x::DataProvider& provider);
 
   /**
@@ -1305,42 +1341,60 @@ public:
    * Get the `Segment_Starter` value for a given character, using compiled data
    *
    * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.2.0/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+   *
+   * \deprecated not a UCD property
    */
+  [[deprecated("not a UCD property")]]
   inline static bool segment_starter_for_char(char32_t ch);
 
   /**
    * Create a set for the `Segment_Starter` property, using compiled data.
    *
    * See the [Rust documentation for `SegmentStarter`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.SegmentStarter.html) for more information.
+   *
+   * \deprecated not a UCD property
    */
+  [[deprecated("not a UCD property")]]
   inline static std::unique_ptr<icu4x::CodePointSetData> create_segment_starter();
 
   /**
    * Create a set for the `Segment_Starter` property, using a particular data source.
    *
    * See the [Rust documentation for `SegmentStarter`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.SegmentStarter.html) for more information.
+   *
+   * \deprecated not a UCD property
    */
+  [[deprecated("not a UCD property")]]
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::CodePointSetData>, icu4x::DataError> create_segment_starter_with_provider(const icu4x::DataProvider& provider);
 
   /**
    * Get the `Case_Sensitive` value for a given character, using compiled data
    *
    * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.2.0/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+   *
+   * \deprecated not a UCD property
    */
+  [[deprecated("not a UCD property")]]
   inline static bool case_sensitive_for_char(char32_t ch);
 
   /**
    * Create a set for the `Case_Sensitive` property, using compiled data.
    *
    * See the [Rust documentation for `CaseSensitive`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.CaseSensitive.html) for more information.
+   *
+   * \deprecated not a UCD property
    */
+  [[deprecated("not a UCD property")]]
   inline static std::unique_ptr<icu4x::CodePointSetData> create_case_sensitive();
 
   /**
    * Create a set for the `Case_Sensitive` property, using a particular data source.
    *
    * See the [Rust documentation for `CaseSensitive`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.CaseSensitive.html) for more information.
+   *
+   * \deprecated not a UCD property
    */
+  [[deprecated("not a UCD property")]]
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::CodePointSetData>, icu4x::DataError> create_case_sensitive_with_provider(const icu4x::DataProvider& provider);
 
   /**

--- a/ffi/capi/src/properties_sets.rs
+++ b/ffi/capi/src/properties_sets.rs
@@ -9,6 +9,7 @@ pub mod ffi {
     #[cfg(any(feature = "compiled_data", feature = "buffer_provider"))]
     use icu_properties::props::GeneralCategory;
     #[cfg(any(feature = "compiled_data", feature = "buffer_provider"))]
+    #[allow(deprecated)]
     use icu_properties::props::{
         Alnum, Alphabetic, AsciiHexDigit, BidiControl, BidiMirrored, Blank, CaseIgnorable,
         CaseSensitive, Cased, ChangesWhenCasefolded, ChangesWhenCasemapped, ChangesWhenLowercased,

--- a/ffi/capi/src/properties_sets.rs
+++ b/ffi/capi/src/properties_sets.rs
@@ -1501,6 +1501,8 @@ pub mod ffi {
         /// Get the `Nfc_Inert` value for a given character, using compiled data
         #[diplomat::rust_link(icu::properties::props::BinaryProperty::for_char, FnInTrait)]
         #[cfg(feature = "compiled_data")]
+        #[allow(deprecated)]
+        #[deprecated(note = "not a UCD property")]
         pub fn nfc_inert_for_char(ch: DiplomatChar) -> bool {
             icu_properties::CodePointSetData::new::<NfcInert>().contains32(ch)
         }
@@ -1508,6 +1510,8 @@ pub mod ffi {
         #[diplomat::rust_link(icu::properties::props::NfcInert, Struct)]
         #[diplomat::attr(auto, named_constructor = "nfc_inert")]
         #[cfg(feature = "compiled_data")]
+        #[allow(deprecated)]
+        #[deprecated(note = "not a UCD property")]
         pub fn create_nfc_inert() -> Box<CodePointSetData> {
             Box::new(CodePointSetData(
                 icu_properties::CodePointSetData::new::<NfcInert>().static_to_owned(),
@@ -1518,6 +1522,8 @@ pub mod ffi {
         #[diplomat::rust_link(icu::properties::props::NfcInert, Struct)]
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "nfc_inert_with_provider")]
         #[cfg(feature = "buffer_provider")]
+        #[allow(deprecated)]
+        #[deprecated(note = "not a UCD property")]
         pub fn create_nfc_inert_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -1531,6 +1537,8 @@ pub mod ffi {
         /// Get the `Nfd_Inert` value for a given character, using compiled data
         #[diplomat::rust_link(icu::properties::props::BinaryProperty::for_char, FnInTrait)]
         #[cfg(feature = "compiled_data")]
+        #[allow(deprecated)]
+        #[deprecated(note = "not a UCD property")]
         pub fn nfd_inert_for_char(ch: DiplomatChar) -> bool {
             icu_properties::CodePointSetData::new::<NfdInert>().contains32(ch)
         }
@@ -1538,6 +1546,8 @@ pub mod ffi {
         #[diplomat::rust_link(icu::properties::props::NfdInert, Struct)]
         #[diplomat::attr(auto, named_constructor = "nfd_inert")]
         #[cfg(feature = "compiled_data")]
+        #[allow(deprecated)]
+        #[deprecated(note = "not a UCD property")]
         pub fn create_nfd_inert() -> Box<CodePointSetData> {
             Box::new(CodePointSetData(
                 icu_properties::CodePointSetData::new::<NfdInert>().static_to_owned(),
@@ -1548,6 +1558,8 @@ pub mod ffi {
         #[diplomat::rust_link(icu::properties::props::NfdInert, Struct)]
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "nfd_inert_with_provider")]
         #[cfg(feature = "buffer_provider")]
+        #[allow(deprecated)]
+        #[deprecated(note = "not a UCD property")]
         pub fn create_nfd_inert_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -1561,6 +1573,8 @@ pub mod ffi {
         /// Get the `Nfkc_Inert` value for a given character, using compiled data
         #[diplomat::rust_link(icu::properties::props::BinaryProperty::for_char, FnInTrait)]
         #[cfg(feature = "compiled_data")]
+        #[allow(deprecated)]
+        #[deprecated(note = "not a UCD property")]
         pub fn nfkc_inert_for_char(ch: DiplomatChar) -> bool {
             icu_properties::CodePointSetData::new::<NfkcInert>().contains32(ch)
         }
@@ -1568,6 +1582,8 @@ pub mod ffi {
         #[diplomat::rust_link(icu::properties::props::NfkcInert, Struct)]
         #[diplomat::attr(auto, named_constructor = "nfkc_inert")]
         #[cfg(feature = "compiled_data")]
+        #[allow(deprecated)]
+        #[deprecated(note = "not a UCD property")]
         pub fn create_nfkc_inert() -> Box<CodePointSetData> {
             Box::new(CodePointSetData(
                 icu_properties::CodePointSetData::new::<NfkcInert>().static_to_owned(),
@@ -1578,6 +1594,8 @@ pub mod ffi {
         #[diplomat::rust_link(icu::properties::props::NfkcInert, Struct)]
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "nfkc_inert_with_provider")]
         #[cfg(feature = "buffer_provider")]
+        #[allow(deprecated)]
+        #[deprecated(note = "not a UCD property")]
         pub fn create_nfkc_inert_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -1591,6 +1609,8 @@ pub mod ffi {
         /// Get the `Nfkd_Inert` value for a given character, using compiled data
         #[diplomat::rust_link(icu::properties::props::BinaryProperty::for_char, FnInTrait)]
         #[cfg(feature = "compiled_data")]
+        #[allow(deprecated)]
+        #[deprecated(note = "not a UCD property")]
         pub fn nfkd_inert_for_char(ch: DiplomatChar) -> bool {
             icu_properties::CodePointSetData::new::<NfkdInert>().contains32(ch)
         }
@@ -1598,6 +1618,8 @@ pub mod ffi {
         #[diplomat::rust_link(icu::properties::props::NfkdInert, Struct)]
         #[diplomat::attr(auto, named_constructor = "nfkd_inert")]
         #[cfg(feature = "compiled_data")]
+        #[allow(deprecated)]
+        #[deprecated(note = "not a UCD property")]
         pub fn create_nfkd_inert() -> Box<CodePointSetData> {
             Box::new(CodePointSetData(
                 icu_properties::CodePointSetData::new::<NfkdInert>().static_to_owned(),
@@ -1608,6 +1630,8 @@ pub mod ffi {
         #[diplomat::rust_link(icu::properties::props::NfkdInert, Struct)]
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "nfkd_inert_with_provider")]
         #[cfg(feature = "buffer_provider")]
+        #[allow(deprecated)]
+        #[deprecated(note = "not a UCD property")]
         pub fn create_nfkd_inert_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -1862,6 +1886,8 @@ pub mod ffi {
         /// Get the `Segment_Starter` value for a given character, using compiled data
         #[diplomat::rust_link(icu::properties::props::BinaryProperty::for_char, FnInTrait)]
         #[cfg(feature = "compiled_data")]
+        #[allow(deprecated)]
+        #[deprecated(note = "not a UCD property")]
         pub fn segment_starter_for_char(ch: DiplomatChar) -> bool {
             icu_properties::CodePointSetData::new::<SegmentStarter>().contains32(ch)
         }
@@ -1869,6 +1895,8 @@ pub mod ffi {
         #[diplomat::rust_link(icu::properties::props::SegmentStarter, Struct)]
         #[diplomat::attr(auto, named_constructor = "segment_starter")]
         #[cfg(feature = "compiled_data")]
+        #[allow(deprecated)]
+        #[deprecated(note = "not a UCD property")]
         pub fn create_segment_starter() -> Box<CodePointSetData> {
             Box::new(CodePointSetData(
                 icu_properties::CodePointSetData::new::<SegmentStarter>().static_to_owned(),
@@ -1879,6 +1907,8 @@ pub mod ffi {
         #[diplomat::rust_link(icu::properties::props::SegmentStarter, Struct)]
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "segment_starter_with_provider")]
         #[cfg(feature = "buffer_provider")]
+        #[allow(deprecated)]
+        #[deprecated(note = "not a UCD property")]
         pub fn create_segment_starter_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {
@@ -1892,6 +1922,8 @@ pub mod ffi {
         /// Get the `Case_Sensitive` value for a given character, using compiled data
         #[diplomat::rust_link(icu::properties::props::BinaryProperty::for_char, FnInTrait)]
         #[cfg(feature = "compiled_data")]
+        #[allow(deprecated)]
+        #[deprecated(note = "not a UCD property")]
         pub fn case_sensitive_for_char(ch: DiplomatChar) -> bool {
             icu_properties::CodePointSetData::new::<CaseSensitive>().contains32(ch)
         }
@@ -1899,6 +1931,8 @@ pub mod ffi {
         #[diplomat::rust_link(icu::properties::props::CaseSensitive, Struct)]
         #[diplomat::attr(auto, named_constructor = "case_sensitive")]
         #[cfg(feature = "compiled_data")]
+        #[allow(deprecated)]
+        #[deprecated(note = "not a UCD property")]
         pub fn create_case_sensitive() -> Box<CodePointSetData> {
             Box::new(CodePointSetData(
                 icu_properties::CodePointSetData::new::<CaseSensitive>().static_to_owned(),
@@ -1909,6 +1943,8 @@ pub mod ffi {
         #[diplomat::rust_link(icu::properties::props::CaseSensitive, Struct)]
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "case_sensitive_with_provider")]
         #[cfg(feature = "buffer_provider")]
+        #[allow(deprecated)]
+        #[deprecated(note = "not a UCD property")]
         pub fn create_case_sensitive_with_provider(
             provider: &DataProvider,
         ) -> Result<Box<CodePointSetData>, DataError> {

--- a/ffi/dart/lib/src/bindings/CodePointSetData.g.dart
+++ b/ffi/dart/lib/src/bindings/CodePointSetData.g.dart
@@ -1423,6 +1423,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// Get the `Nfc_Inert` value for a given character, using compiled data
   ///
   /// See the [Rust documentation for `for_char`](https://docs.rs/icu/2.2.0/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+  @core.Deprecated('not a UCD property')
   static bool nfcInertForChar(Rune ch) {
     final result = _icu4x_CodePointSetData_nfc_inert_for_char_mv1(ch);
     return result;
@@ -1431,6 +1432,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// Create a set for the `Nfc_Inert` property, using compiled data.
   ///
   /// See the [Rust documentation for `NfcInert`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.NfcInert.html) for more information.
+  @core.Deprecated('not a UCD property')
   factory CodePointSetData.nfcInert() {
     final result = _icu4x_CodePointSetData_create_nfc_inert_mv1();
     return CodePointSetData._fromFfi(result, []);
@@ -1441,6 +1443,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `NfcInert`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.NfcInert.html) for more information.
   ///
   /// Throws [DataError] on failure.
+  @core.Deprecated('not a UCD property')
   factory CodePointSetData.nfcInertWithProvider(DataProvider provider) {
     final result = _icu4x_CodePointSetData_create_nfc_inert_with_provider_mv1(provider._ffi);
     if (!result.isOk) {
@@ -1452,6 +1455,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// Get the `Nfd_Inert` value for a given character, using compiled data
   ///
   /// See the [Rust documentation for `for_char`](https://docs.rs/icu/2.2.0/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+  @core.Deprecated('not a UCD property')
   static bool nfdInertForChar(Rune ch) {
     final result = _icu4x_CodePointSetData_nfd_inert_for_char_mv1(ch);
     return result;
@@ -1460,6 +1464,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// Create a set for the `Nfd_Inert` property, using compiled data.
   ///
   /// See the [Rust documentation for `NfdInert`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.NfdInert.html) for more information.
+  @core.Deprecated('not a UCD property')
   factory CodePointSetData.nfdInert() {
     final result = _icu4x_CodePointSetData_create_nfd_inert_mv1();
     return CodePointSetData._fromFfi(result, []);
@@ -1470,6 +1475,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `NfdInert`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.NfdInert.html) for more information.
   ///
   /// Throws [DataError] on failure.
+  @core.Deprecated('not a UCD property')
   factory CodePointSetData.nfdInertWithProvider(DataProvider provider) {
     final result = _icu4x_CodePointSetData_create_nfd_inert_with_provider_mv1(provider._ffi);
     if (!result.isOk) {
@@ -1481,6 +1487,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// Get the `Nfkc_Inert` value for a given character, using compiled data
   ///
   /// See the [Rust documentation for `for_char`](https://docs.rs/icu/2.2.0/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+  @core.Deprecated('not a UCD property')
   static bool nfkcInertForChar(Rune ch) {
     final result = _icu4x_CodePointSetData_nfkc_inert_for_char_mv1(ch);
     return result;
@@ -1489,6 +1496,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// Create a set for the `Nfkc_Inert` property, using compiled data.
   ///
   /// See the [Rust documentation for `NfkcInert`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.NfkcInert.html) for more information.
+  @core.Deprecated('not a UCD property')
   factory CodePointSetData.nfkcInert() {
     final result = _icu4x_CodePointSetData_create_nfkc_inert_mv1();
     return CodePointSetData._fromFfi(result, []);
@@ -1499,6 +1507,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `NfkcInert`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.NfkcInert.html) for more information.
   ///
   /// Throws [DataError] on failure.
+  @core.Deprecated('not a UCD property')
   factory CodePointSetData.nfkcInertWithProvider(DataProvider provider) {
     final result = _icu4x_CodePointSetData_create_nfkc_inert_with_provider_mv1(provider._ffi);
     if (!result.isOk) {
@@ -1510,6 +1519,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// Get the `Nfkd_Inert` value for a given character, using compiled data
   ///
   /// See the [Rust documentation for `for_char`](https://docs.rs/icu/2.2.0/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+  @core.Deprecated('not a UCD property')
   static bool nfkdInertForChar(Rune ch) {
     final result = _icu4x_CodePointSetData_nfkd_inert_for_char_mv1(ch);
     return result;
@@ -1518,6 +1528,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// Create a set for the `Nfkd_Inert` property, using compiled data.
   ///
   /// See the [Rust documentation for `NfkdInert`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.NfkdInert.html) for more information.
+  @core.Deprecated('not a UCD property')
   factory CodePointSetData.nfkdInert() {
     final result = _icu4x_CodePointSetData_create_nfkd_inert_mv1();
     return CodePointSetData._fromFfi(result, []);
@@ -1528,6 +1539,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `NfkdInert`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.NfkdInert.html) for more information.
   ///
   /// Throws [DataError] on failure.
+  @core.Deprecated('not a UCD property')
   factory CodePointSetData.nfkdInertWithProvider(DataProvider provider) {
     final result = _icu4x_CodePointSetData_create_nfkd_inert_with_provider_mv1(provider._ffi);
     if (!result.isOk) {
@@ -1771,6 +1783,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// Get the `Segment_Starter` value for a given character, using compiled data
   ///
   /// See the [Rust documentation for `for_char`](https://docs.rs/icu/2.2.0/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+  @core.Deprecated('not a UCD property')
   static bool segmentStarterForChar(Rune ch) {
     final result = _icu4x_CodePointSetData_segment_starter_for_char_mv1(ch);
     return result;
@@ -1779,6 +1792,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// Create a set for the `Segment_Starter` property, using compiled data.
   ///
   /// See the [Rust documentation for `SegmentStarter`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.SegmentStarter.html) for more information.
+  @core.Deprecated('not a UCD property')
   factory CodePointSetData.segmentStarter() {
     final result = _icu4x_CodePointSetData_create_segment_starter_mv1();
     return CodePointSetData._fromFfi(result, []);
@@ -1789,6 +1803,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `SegmentStarter`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.SegmentStarter.html) for more information.
   ///
   /// Throws [DataError] on failure.
+  @core.Deprecated('not a UCD property')
   factory CodePointSetData.segmentStarterWithProvider(DataProvider provider) {
     final result = _icu4x_CodePointSetData_create_segment_starter_with_provider_mv1(provider._ffi);
     if (!result.isOk) {
@@ -1800,6 +1815,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// Get the `Case_Sensitive` value for a given character, using compiled data
   ///
   /// See the [Rust documentation for `for_char`](https://docs.rs/icu/2.2.0/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+  @core.Deprecated('not a UCD property')
   static bool caseSensitiveForChar(Rune ch) {
     final result = _icu4x_CodePointSetData_case_sensitive_for_char_mv1(ch);
     return result;
@@ -1808,6 +1824,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// Create a set for the `Case_Sensitive` property, using compiled data.
   ///
   /// See the [Rust documentation for `CaseSensitive`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.CaseSensitive.html) for more information.
+  @core.Deprecated('not a UCD property')
   factory CodePointSetData.caseSensitive() {
     final result = _icu4x_CodePointSetData_create_case_sensitive_mv1();
     return CodePointSetData._fromFfi(result, []);
@@ -1818,6 +1835,7 @@ final class CodePointSetData implements ffi.Finalizable {
   /// See the [Rust documentation for `CaseSensitive`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.CaseSensitive.html) for more information.
   ///
   /// Throws [DataError] on failure.
+  @core.Deprecated('not a UCD property')
   factory CodePointSetData.caseSensitiveWithProvider(DataProvider provider) {
     final result = _icu4x_CodePointSetData_create_case_sensitive_with_provider_mv1(provider._ffi);
     if (!result.isOk) {

--- a/ffi/npm/lib/CodePointSetData.d.ts
+++ b/ffi/npm/lib/CodePointSetData.d.ts
@@ -1035,6 +1035,8 @@ export class CodePointSetData {
      * Get the `Nfc_Inert` value for a given character, using compiled data
      *
      * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.2.0/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+     *
+     * @deprecated not a UCD property
      */
     static nfcInertForChar(ch: codepoint): boolean;
 
@@ -1042,6 +1044,8 @@ export class CodePointSetData {
      * Create a set for the `Nfc_Inert` property, using compiled data.
      *
      * See the [Rust documentation for `NfcInert`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.NfcInert.html) for more information.
+     *
+     * @deprecated not a UCD property
      */
     static createNfcInert(): CodePointSetData;
 
@@ -1049,6 +1053,8 @@ export class CodePointSetData {
      * Create a set for the `Nfc_Inert` property, using a particular data source.
      *
      * See the [Rust documentation for `NfcInert`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.NfcInert.html) for more information.
+     *
+     * @deprecated not a UCD property
      */
     static createNfcInertWithProvider(provider: DataProvider): CodePointSetData;
 
@@ -1056,6 +1062,8 @@ export class CodePointSetData {
      * Get the `Nfd_Inert` value for a given character, using compiled data
      *
      * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.2.0/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+     *
+     * @deprecated not a UCD property
      */
     static nfdInertForChar(ch: codepoint): boolean;
 
@@ -1063,6 +1071,8 @@ export class CodePointSetData {
      * Create a set for the `Nfd_Inert` property, using compiled data.
      *
      * See the [Rust documentation for `NfdInert`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.NfdInert.html) for more information.
+     *
+     * @deprecated not a UCD property
      */
     static createNfdInert(): CodePointSetData;
 
@@ -1070,6 +1080,8 @@ export class CodePointSetData {
      * Create a set for the `Nfd_Inert` property, using a particular data source.
      *
      * See the [Rust documentation for `NfdInert`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.NfdInert.html) for more information.
+     *
+     * @deprecated not a UCD property
      */
     static createNfdInertWithProvider(provider: DataProvider): CodePointSetData;
 
@@ -1077,6 +1089,8 @@ export class CodePointSetData {
      * Get the `Nfkc_Inert` value for a given character, using compiled data
      *
      * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.2.0/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+     *
+     * @deprecated not a UCD property
      */
     static nfkcInertForChar(ch: codepoint): boolean;
 
@@ -1084,6 +1098,8 @@ export class CodePointSetData {
      * Create a set for the `Nfkc_Inert` property, using compiled data.
      *
      * See the [Rust documentation for `NfkcInert`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.NfkcInert.html) for more information.
+     *
+     * @deprecated not a UCD property
      */
     static createNfkcInert(): CodePointSetData;
 
@@ -1091,6 +1107,8 @@ export class CodePointSetData {
      * Create a set for the `Nfkc_Inert` property, using a particular data source.
      *
      * See the [Rust documentation for `NfkcInert`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.NfkcInert.html) for more information.
+     *
+     * @deprecated not a UCD property
      */
     static createNfkcInertWithProvider(provider: DataProvider): CodePointSetData;
 
@@ -1098,6 +1116,8 @@ export class CodePointSetData {
      * Get the `Nfkd_Inert` value for a given character, using compiled data
      *
      * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.2.0/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+     *
+     * @deprecated not a UCD property
      */
     static nfkdInertForChar(ch: codepoint): boolean;
 
@@ -1105,6 +1125,8 @@ export class CodePointSetData {
      * Create a set for the `Nfkd_Inert` property, using compiled data.
      *
      * See the [Rust documentation for `NfkdInert`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.NfkdInert.html) for more information.
+     *
+     * @deprecated not a UCD property
      */
     static createNfkdInert(): CodePointSetData;
 
@@ -1112,6 +1134,8 @@ export class CodePointSetData {
      * Create a set for the `Nfkd_Inert` property, using a particular data source.
      *
      * See the [Rust documentation for `NfkdInert`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.NfkdInert.html) for more information.
+     *
+     * @deprecated not a UCD property
      */
     static createNfkdInertWithProvider(provider: DataProvider): CodePointSetData;
 
@@ -1287,6 +1311,8 @@ export class CodePointSetData {
      * Get the `Segment_Starter` value for a given character, using compiled data
      *
      * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.2.0/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+     *
+     * @deprecated not a UCD property
      */
     static segmentStarterForChar(ch: codepoint): boolean;
 
@@ -1294,6 +1320,8 @@ export class CodePointSetData {
      * Create a set for the `Segment_Starter` property, using compiled data.
      *
      * See the [Rust documentation for `SegmentStarter`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.SegmentStarter.html) for more information.
+     *
+     * @deprecated not a UCD property
      */
     static createSegmentStarter(): CodePointSetData;
 
@@ -1301,6 +1329,8 @@ export class CodePointSetData {
      * Create a set for the `Segment_Starter` property, using a particular data source.
      *
      * See the [Rust documentation for `SegmentStarter`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.SegmentStarter.html) for more information.
+     *
+     * @deprecated not a UCD property
      */
     static createSegmentStarterWithProvider(provider: DataProvider): CodePointSetData;
 
@@ -1308,6 +1338,8 @@ export class CodePointSetData {
      * Get the `Case_Sensitive` value for a given character, using compiled data
      *
      * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.2.0/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+     *
+     * @deprecated not a UCD property
      */
     static caseSensitiveForChar(ch: codepoint): boolean;
 
@@ -1315,6 +1347,8 @@ export class CodePointSetData {
      * Create a set for the `Case_Sensitive` property, using compiled data.
      *
      * See the [Rust documentation for `CaseSensitive`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.CaseSensitive.html) for more information.
+     *
+     * @deprecated not a UCD property
      */
     static createCaseSensitive(): CodePointSetData;
 
@@ -1322,6 +1356,8 @@ export class CodePointSetData {
      * Create a set for the `Case_Sensitive` property, using a particular data source.
      *
      * See the [Rust documentation for `CaseSensitive`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.CaseSensitive.html) for more information.
+     *
+     * @deprecated not a UCD property
      */
     static createCaseSensitiveWithProvider(provider: DataProvider): CodePointSetData;
 

--- a/ffi/npm/lib/CodePointSetData.mjs
+++ b/ffi/npm/lib/CodePointSetData.mjs
@@ -2971,6 +2971,8 @@ export class CodePointSetData {
      * Get the `Nfc_Inert` value for a given character, using compiled data
      *
      * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.2.0/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+     *
+     * @deprecated not a UCD property
      */
     static nfcInertForChar(ch) {
 
@@ -2989,6 +2991,8 @@ export class CodePointSetData {
      * Create a set for the `Nfc_Inert` property, using compiled data.
      *
      * See the [Rust documentation for `NfcInert`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.NfcInert.html) for more information.
+     *
+     * @deprecated not a UCD property
      */
     static createNfcInert() {
 
@@ -3007,6 +3011,8 @@ export class CodePointSetData {
      * Create a set for the `Nfc_Inert` property, using a particular data source.
      *
      * See the [Rust documentation for `NfcInert`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.NfcInert.html) for more information.
+     *
+     * @deprecated not a UCD property
      */
     static createNfcInertWithProvider(provider) {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
@@ -3032,6 +3038,8 @@ export class CodePointSetData {
      * Get the `Nfd_Inert` value for a given character, using compiled data
      *
      * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.2.0/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+     *
+     * @deprecated not a UCD property
      */
     static nfdInertForChar(ch) {
 
@@ -3050,6 +3058,8 @@ export class CodePointSetData {
      * Create a set for the `Nfd_Inert` property, using compiled data.
      *
      * See the [Rust documentation for `NfdInert`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.NfdInert.html) for more information.
+     *
+     * @deprecated not a UCD property
      */
     static createNfdInert() {
 
@@ -3068,6 +3078,8 @@ export class CodePointSetData {
      * Create a set for the `Nfd_Inert` property, using a particular data source.
      *
      * See the [Rust documentation for `NfdInert`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.NfdInert.html) for more information.
+     *
+     * @deprecated not a UCD property
      */
     static createNfdInertWithProvider(provider) {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
@@ -3093,6 +3105,8 @@ export class CodePointSetData {
      * Get the `Nfkc_Inert` value for a given character, using compiled data
      *
      * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.2.0/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+     *
+     * @deprecated not a UCD property
      */
     static nfkcInertForChar(ch) {
 
@@ -3111,6 +3125,8 @@ export class CodePointSetData {
      * Create a set for the `Nfkc_Inert` property, using compiled data.
      *
      * See the [Rust documentation for `NfkcInert`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.NfkcInert.html) for more information.
+     *
+     * @deprecated not a UCD property
      */
     static createNfkcInert() {
 
@@ -3129,6 +3145,8 @@ export class CodePointSetData {
      * Create a set for the `Nfkc_Inert` property, using a particular data source.
      *
      * See the [Rust documentation for `NfkcInert`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.NfkcInert.html) for more information.
+     *
+     * @deprecated not a UCD property
      */
     static createNfkcInertWithProvider(provider) {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
@@ -3154,6 +3172,8 @@ export class CodePointSetData {
      * Get the `Nfkd_Inert` value for a given character, using compiled data
      *
      * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.2.0/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+     *
+     * @deprecated not a UCD property
      */
     static nfkdInertForChar(ch) {
 
@@ -3172,6 +3192,8 @@ export class CodePointSetData {
      * Create a set for the `Nfkd_Inert` property, using compiled data.
      *
      * See the [Rust documentation for `NfkdInert`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.NfkdInert.html) for more information.
+     *
+     * @deprecated not a UCD property
      */
     static createNfkdInert() {
 
@@ -3190,6 +3212,8 @@ export class CodePointSetData {
      * Create a set for the `Nfkd_Inert` property, using a particular data source.
      *
      * See the [Rust documentation for `NfkdInert`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.NfkdInert.html) for more information.
+     *
+     * @deprecated not a UCD property
      */
     static createNfkdInertWithProvider(provider) {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
@@ -3703,6 +3727,8 @@ export class CodePointSetData {
      * Get the `Segment_Starter` value for a given character, using compiled data
      *
      * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.2.0/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+     *
+     * @deprecated not a UCD property
      */
     static segmentStarterForChar(ch) {
 
@@ -3721,6 +3747,8 @@ export class CodePointSetData {
      * Create a set for the `Segment_Starter` property, using compiled data.
      *
      * See the [Rust documentation for `SegmentStarter`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.SegmentStarter.html) for more information.
+     *
+     * @deprecated not a UCD property
      */
     static createSegmentStarter() {
 
@@ -3739,6 +3767,8 @@ export class CodePointSetData {
      * Create a set for the `Segment_Starter` property, using a particular data source.
      *
      * See the [Rust documentation for `SegmentStarter`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.SegmentStarter.html) for more information.
+     *
+     * @deprecated not a UCD property
      */
     static createSegmentStarterWithProvider(provider) {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
@@ -3764,6 +3794,8 @@ export class CodePointSetData {
      * Get the `Case_Sensitive` value for a given character, using compiled data
      *
      * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.2.0/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+     *
+     * @deprecated not a UCD property
      */
     static caseSensitiveForChar(ch) {
 
@@ -3782,6 +3814,8 @@ export class CodePointSetData {
      * Create a set for the `Case_Sensitive` property, using compiled data.
      *
      * See the [Rust documentation for `CaseSensitive`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.CaseSensitive.html) for more information.
+     *
+     * @deprecated not a UCD property
      */
     static createCaseSensitive() {
 
@@ -3800,6 +3834,8 @@ export class CodePointSetData {
      * Create a set for the `Case_Sensitive` property, using a particular data source.
      *
      * See the [Rust documentation for `CaseSensitive`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.CaseSensitive.html) for more information.
+     *
+     * @deprecated not a UCD property
      */
     static createCaseSensitiveWithProvider(provider) {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);

--- a/provider/source/src/properties/bin_cp_set.rs
+++ b/provider/source/src/properties/bin_cp_set.rs
@@ -5,7 +5,7 @@
 use crate::SourceDataProvider;
 use icu::collections::codepointinvlist::{CodePointInversionList, CodePointInversionListBuilder};
 use icu::properties::props::BinaryProperty;
-use icu::properties::{provider::*, CodePointMapData, CodePointSetData};
+use icu::properties::provider::*;
 use icu_provider::prelude::*;
 use std::collections::HashSet;
 
@@ -50,180 +50,65 @@ impl SourceDataProvider {
     ) -> Result<CodePointInversionList<'static>, DataError> {
         let mut builder = CodePointInversionListBuilder::new();
 
-        // UTS #18 Annex C Compatibility Properties
-        if name == "alnum" {
-            // \p{alpha}\p{digit} = \p{Alphabetic}\p{gc=Decimal_Number}
-            let gc = CodePointMapData::<icu::properties::props::GeneralCategory>::try_new_unstable(
-                &self,
-            )?;
+        self.validate_property_name(name, short_name)?;
 
-            builder.add_set(
-                &CodePointSetData::try_new_unstable::<icu::properties::props::Alphabetic>(self)?
-                    .to_code_point_inversion_list(),
-            );
-            builder.add_set(
-                &gc.as_borrowed()
-                    .get_set_for_value(icu::properties::props::GeneralCategory::DecimalNumber)
-                    .to_code_point_inversion_list(),
-            );
-        } else if name == "blank" {
-            // \p{gc=Space_Separator}\N{CHARACTER TABULATION}
-            let gc = CodePointMapData::<icu::properties::props::GeneralCategory>::try_new_unstable(
-                &self,
-            )?;
-
-            builder.add_set(
-                &gc.as_borrowed()
-                    .get_set_for_value(icu::properties::props::GeneralCategory::SpaceSeparator)
-                    .to_code_point_inversion_list(),
-            );
-            builder.add_char('\t');
-        } else if name == "graph" {
-            // [^\p{space}\p{gc=Control}\p{gc=Surrogate}\p{gc=Unassigned}] = [^\p{Whitespace}\p{gc=Control}\p{gc=Surrogate}\p{gc=Unassigned}]
-            let gc = CodePointMapData::<icu::properties::props::GeneralCategory>::try_new_unstable(
-                &self,
-            )?;
-
-            builder.add_set(
-                &CodePointSetData::try_new_unstable::<icu::properties::props::WhiteSpace>(self)?
-                    .to_code_point_inversion_list(),
-            );
-            builder.add_set(
-                &gc.as_borrowed()
-                    .get_set_for_value(icu::properties::props::GeneralCategory::Control)
-                    .to_code_point_inversion_list(),
-            );
-            builder.add_set(
-                &gc.as_borrowed()
-                    .get_set_for_value(icu::properties::props::GeneralCategory::Surrogate)
-                    .to_code_point_inversion_list(),
-            );
-            builder.add_set(
-                &gc.as_borrowed()
-                    .get_set_for_value(icu::properties::props::GeneralCategory::Unassigned)
-                    .to_code_point_inversion_list(),
-            );
-            builder.complement();
-        } else if name == "print" {
-            // \p{graph}\p{blank} -- \p{cntrl} = \p{graph}\p{blank} -- \p{gc=Control}
-            let gc = CodePointMapData::<icu::properties::props::GeneralCategory>::try_new_unstable(
-                &self,
-            )?;
-            builder.add_set(
-                &CodePointSetData::try_new_unstable::<icu::properties::props::Graph>(self)?
-                    .to_code_point_inversion_list(),
-            );
-            builder.add_set(
-                &CodePointSetData::try_new_unstable::<icu::properties::props::Blank>(self)?
-                    .to_code_point_inversion_list(),
-            );
-            builder.remove_set(
-                &gc.as_borrowed()
-                    .get_set_for_value(icu::properties::props::GeneralCategory::Control)
-                    .to_code_point_inversion_list(),
-            );
-        } else if name == "xdigit" {
-            // \p{gc=Decimal_Number}\p{Hex_Digit}
-            let gc = CodePointMapData::<icu::properties::props::GeneralCategory>::try_new_unstable(
-                &self,
-            )?;
-
-            builder.add_set(
-                &CodePointSetData::try_new_unstable::<icu::properties::props::HexDigit>(self)?
-                    .to_code_point_inversion_list(),
-            );
-            builder.add_set(
-                &gc.as_borrowed()
-                    .get_set_for_value(icu::properties::props::GeneralCategory::DecimalNumber)
-                    .to_code_point_inversion_list(),
-            );
-        } else if matches!(name, |"Case_Sensitive"| "NFC_Inert"
-            | "NFD_Inert"
-            | "NFKC_Inert"
-            | "NFKD_Inert"
-            | "Segment_Starter")
-        {
-            // Non-Unicode properties that we need to read from icuexportdata
-            let data = self
-                .icuexport()?
-                .read_and_parse_toml::<super::uprops_serde::binary::Main>(&format!(
-                    "uprops/{}/{}.toml",
-                    self.trie_type(),
-                    short_name
-                ))?
-                .binary_property
-                .first()
-                .ok_or_else(|| DataErrorKind::MarkerNotFound.into_error())?;
-
-            if name != data.long_name
-                || short_name != data.short_name.as_ref().unwrap_or(&data.long_name)
-            {
-                return Err(DataError::custom("Property name mismatch").with_display_context(name));
+        let file = match name {
+            "Alphabetic"
+            | "Case_Ignorable"
+            | "Cased"
+            | "Changes_When_Casefolded"
+            | "Changes_When_Casemapped"
+            | "Changes_When_Lowercased"
+            | "Changes_When_Titlecased"
+            | "Changes_When_Uppercased"
+            | "Default_Ignorable_Code_Point"
+            | "Grapheme_Base"
+            | "Grapheme_Extend"
+            | "Grapheme_Link"
+            | "ID_Continue"
+            | "ID_Start"
+            | "Lowercase"
+            | "Math"
+            | "Uppercase"
+            | "XID_Continue"
+            | "XID_Start" => "ucd/DerivedCoreProperties.txt",
+            "Changes_When_NFKC_Casefolded" | "Full_Composition_Exclusion" => {
+                "ucd/DerivedNormalizationProps.txt"
             }
-            for (start, end) in &data.ranges {
-                builder.add_range32(start..=end);
+            "Emoji_Component"
+            | "Emoji_Modifier_Base"
+            | "Emoji_Modifier"
+            | "Emoji_Presentation"
+            | "Emoji"
+            | "Extended_Pictographic" => "ucd/emoji/emoji-data.txt",
+            "Bidi_Mirrored" => "ucd/extracted/DerivedBinaryProperties.txt",
+            _ => "ucd/PropList.txt",
+        };
+
+        for line in self.unicode()?.read_to_string(file)?.lines() {
+            let line = line.split('#').next().unwrap().trim();
+            if line.is_empty() {
+                continue;
             }
-        } else {
-            self.validate_property_name(name, short_name)?;
 
-            let file = match name {
-                "Alphabetic"
-                | "Case_Ignorable"
-                | "Cased"
-                | "Changes_When_Casefolded"
-                | "Changes_When_Casemapped"
-                | "Changes_When_Lowercased"
-                | "Changes_When_Titlecased"
-                | "Changes_When_Uppercased"
-                | "Default_Ignorable_Code_Point"
-                | "Grapheme_Base"
-                | "Grapheme_Extend"
-                | "Grapheme_Link"
-                | "ID_Continue"
-                | "ID_Start"
-                | "Lowercase"
-                | "Math"
-                | "Uppercase"
-                | "XID_Continue"
-                | "XID_Start" => "ucd/DerivedCoreProperties.txt",
-                "Changes_When_NFKC_Casefolded" | "Full_Composition_Exclusion" => {
-                    "ucd/DerivedNormalizationProps.txt"
-                }
-                "Emoji_Component"
-                | "Emoji_Modifier_Base"
-                | "Emoji_Modifier"
-                | "Emoji_Presentation"
-                | "Emoji"
-                | "Extended_Pictographic" => "ucd/emoji/emoji-data.txt",
-                "Bidi_Mirrored" => "ucd/extracted/DerivedBinaryProperties.txt",
-                _ => "ucd/PropList.txt",
-            };
-
-            for line in self.unicode()?.read_to_string(file)?.lines() {
-                let line = line.split('#').next().unwrap().trim();
-                if line.is_empty() {
-                    continue;
-                }
-
-                let mut parts = line.split(';').map(str::trim);
-                let range = parts.next().unwrap();
-                if parts.next() != Some(name) {
-                    continue;
-                }
-
-                let (a, b) = range.split_once("..").unwrap_or((range, range));
-                let a = u32::from_str_radix(a, 16).unwrap();
-                let b = u32::from_str_radix(b, 16).unwrap();
-
-                builder.add_range32(a..=b);
+            let mut parts = line.split(';').map(str::trim);
+            let range = parts.next().unwrap();
+            if parts.next() != Some(name) {
+                continue;
             }
+
+            let (a, b) = range.split_once("..").unwrap_or((range, range));
+            let a = u32::from_str_radix(a, 16).unwrap();
+            let b = u32::from_str_radix(b, 16).unwrap();
+
+            builder.add_range32(a..=b);
         }
 
         Ok(builder.build())
     }
 }
 
-macro_rules! expand {
+macro_rules! impl_unicode_property {
     ($(($prop:ty, $marker:ident)),+) => {
         $(
             impl DataProvider<$marker> for SourceDataProvider {
@@ -253,12 +138,11 @@ macro_rules! expand {
     };
 }
 
-expand!(
+impl_unicode_property!(
     (
         icu::properties::props::AsciiHexDigit,
         PropertyBinaryAsciiHexDigitV1
     ),
-    (icu::properties::props::Alnum, PropertyBinaryAlnumV1),
     (
         icu::properties::props::Alphabetic,
         PropertyBinaryAlphabeticV1
@@ -271,7 +155,6 @@ expand!(
         icu::properties::props::BidiMirrored,
         PropertyBinaryBidiMirroredV1
     ),
-    (icu::properties::props::Blank, PropertyBinaryBlankV1),
     (icu::properties::props::Cased, PropertyBinaryCasedV1),
     (
         icu::properties::props::CaseIgnorable,
@@ -337,7 +220,6 @@ expand!(
         icu::properties::props::ExtendedPictographic,
         PropertyBinaryExtendedPictographicV1
     ),
-    (icu::properties::props::Graph, PropertyBinaryGraphV1),
     (
         icu::properties::props::GraphemeBase,
         PropertyBinaryGraphemeBaseV1
@@ -399,10 +281,6 @@ expand!(
         icu::properties::props::NoncharacterCodePoint,
         PropertyBinaryNoncharacterCodePointV1
     ),
-    (icu::properties::props::NfcInert, PropertyBinaryNfcInertV1),
-    (icu::properties::props::NfdInert, PropertyBinaryNfdInertV1),
-    (icu::properties::props::NfkcInert, PropertyBinaryNfkcInertV1),
-    (icu::properties::props::NfkdInert, PropertyBinaryNfkdInertV1),
     (
         icu::properties::props::PatternSyntax,
         PropertyBinaryPatternSyntaxV1
@@ -415,7 +293,6 @@ expand!(
         icu::properties::props::PrependedConcatenationMark,
         PropertyBinaryPrependedConcatenationMarkV1
     ),
-    (icu::properties::props::Print, PropertyBinaryPrintV1),
     (
         icu::properties::props::QuotationMark,
         PropertyBinaryQuotationMarkV1
@@ -428,14 +305,6 @@ expand!(
     (
         icu::properties::props::SoftDotted,
         PropertyBinarySoftDottedV1
-    ),
-    (
-        icu::properties::props::SegmentStarter,
-        PropertyBinarySegmentStarterV1
-    ),
-    (
-        icu::properties::props::CaseSensitive,
-        PropertyBinaryCaseSensitiveV1
     ),
     (
         icu::properties::props::SentenceTerminal,
@@ -458,12 +327,144 @@ expand!(
         icu::properties::props::WhiteSpace,
         PropertyBinaryWhiteSpaceV1
     ),
-    (icu::properties::props::Xdigit, PropertyBinaryXdigitV1),
     (
         icu::properties::props::XidContinue,
         PropertyBinaryXidContinueV1
     ),
     (icu::properties::props::XidStart, PropertyBinaryXidStartV1)
+);
+
+macro_rules! impl_icu4c_property {
+    ($(($prop:ty, $marker:ident)),+) => {
+        $(
+            #[allow(deprecated)]
+            impl DataProvider<$marker> for SourceDataProvider {
+                fn load(
+                    &self,
+                    req: DataRequest,
+                ) -> Result<DataResponse<$marker>, DataError> {
+                    self.check_req::<$marker>(req)?;
+
+                    let name = core::str::from_utf8(<$prop as BinaryProperty>::NAME).unwrap();
+                    let short_name = core::str::from_utf8(<$prop as BinaryProperty>::SHORT_NAME).unwrap();
+
+                    let mut builder = CodePointInversionListBuilder::new();
+                    let data = self
+                        .icuexport()?
+                        .read_and_parse_toml::<super::uprops_serde::binary::Main>(&format!(
+                            "uprops/{}/{}.toml",
+                            self.trie_type(),
+                            short_name
+                        ))?
+                        .binary_property
+                        .first()
+                        .ok_or_else(|| DataErrorKind::MarkerNotFound.into_error())?;
+
+                    if name != data.long_name
+                        || short_name != data.short_name.as_ref().unwrap_or(&data.long_name)
+                    {
+                        return Err(DataError::custom("Property name mismatch").with_display_context(name));
+                    }
+                    for (start, end) in &data.ranges {
+                        builder.add_range32(start..=end);
+                    }
+
+                    Ok(DataResponse {
+                        metadata: Default::default(),
+                        payload: DataPayload::from_owned(PropertyCodePointSet::InversionList(builder.build()))
+                    })
+                }
+            }
+
+            impl crate::IterableDataProviderCached<$marker> for SourceDataProvider {
+                fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+                    Ok(HashSet::from_iter([Default::default()]))
+                }
+            }
+        )+
+    };
+}
+
+impl_icu4c_property!(
+    (
+        icu::properties::props::SegmentStarter,
+        PropertyBinarySegmentStarterV1
+    ),
+    (
+        icu::properties::props::CaseSensitive,
+        PropertyBinaryCaseSensitiveV1
+    ),
+    (icu::properties::props::NfcInert, PropertyBinaryNfcInertV1),
+    (icu::properties::props::NfdInert, PropertyBinaryNfdInertV1),
+    (icu::properties::props::NfkcInert, PropertyBinaryNfkcInertV1),
+    (icu::properties::props::NfkdInert, PropertyBinaryNfkdInertV1)
+);
+
+macro_rules! impl_posix_property {
+    ($(($prop:ty, $marker:ident, $set_string:literal)),+) => {
+        $(
+            impl DataProvider<$marker> for SourceDataProvider {
+                fn load(
+                    &self,
+                    req: DataRequest,
+                ) -> Result<DataResponse<$marker>, DataError> {
+                    self.check_req::<$marker>(req)?;
+
+                    #[cfg(not(feature = "unstable"))]
+                    use icu::properties::unstable_unicodeset_parse::parse_unstable;
+                    #[cfg(feature = "unstable")]
+                    use icu::properties::unicodeset_parse::parse_unstable;
+
+                    let set = parse_unstable($set_string, self)
+                        .map_err(|e| e.fmt_with_source($set_string).to_string())
+                        .unwrap()
+                        .0
+                        .code_points()
+                        .clone();
+
+                    Ok(DataResponse {
+                        metadata: Default::default(),
+                        payload: DataPayload::from_owned(PropertyCodePointSet::InversionList(set))
+                    })
+                }
+            }
+
+            impl crate::IterableDataProviderCached<$marker> for SourceDataProvider {
+                fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+                    Ok(HashSet::from_iter([Default::default()]))
+                }
+            }
+        )+
+    };
+}
+
+// UTS #18 Annex C Compatibility Properties
+impl_posix_property!(
+    (
+        icu::properties::props::Alnum,
+        PropertyBinaryAlnumV1,
+        r#"[\p{Alphabetic}\p{gc=Decimal_Number}]"#
+    ),
+    (
+        icu::properties::props::Blank,
+        PropertyBinaryBlankV1,
+        r#"[\p{gc=Space_Separator} \u0009]"#
+    ),
+    (
+        icu::properties::props::Graph,
+        PropertyBinaryGraphV1,
+        r#"[^\p{White_Space}\p{gc=Control}\p{gc=Surrogate}\p{gc=Unassigned}]"#
+    ),
+    (
+        icu::properties::props::Print,
+        PropertyBinaryPrintV1,
+        r#"[[^\p{White_Space}\p{gc=Control}\p{gc=Surrogate}\p{gc=Unassigned}] \p{gc=Space_Separator}]"#
+    ),
+    (
+        icu::properties::props::Xdigit,
+        PropertyBinaryXdigitV1,
+        r#"[\p{gc=Decimal_Number}\p{Hex_Digit}]"#
+    )
 );
 
 #[test]


### PR DESCRIPTION
#7892

Also cleaned up datagen to have different code paths for Unicode properties, ICU properties (deprecated), and compatibility properties (probably should be deprecated as well)

## Changelog

`icu_properties`:
* Deprecate some non-Unicode properties