### PR TITLE
Address Askama 0.15 deprecation warnings in codegen templates

### DIFF
--- a/tools/make/codegen/templates/datetime_formatter.rs.jinja
+++ b/tools/make/codegen/templates/datetime_formatter.rs.jinja
@@ -34,7 +34,7 @@ pub mod ffi {
     use crate::unstable::provider::ffi::DataProvider;
 
     {%- for formatter_kind in flavor.formatter_kinds() %}
-    {%- let ffi_type %}
+    {%- decl ffi_type %}
     {%- if formatter_kind.is_gregorian %}
         {%- let ffi_type = format!("{}FormatterGregorian", {{ flavor.camel() }}) %}
     {%- else %}
@@ -59,8 +59,8 @@ pub mod ffi {
     impl {{ ffi_type }} {
         {%- for variant in variants %}
         {%- for ctor in ConstructorType::VALUES %}
-        {%- let named_constructor %}
-        {%- let named_constructor_full %}
+        {%- decl named_constructor %}
+        {%- decl named_constructor_full %}
         {%- if ctor.is_with_provider() %}
             {%- if variant.is_only_constructor() %}
                 {%- let named_constructor = "with_provider".to_string() %}

--- a/tools/make/codegen/templates/zoned_formatter.rs.jinja
+++ b/tools/make/codegen/templates/zoned_formatter.rs.jinja
@@ -37,9 +37,9 @@ pub mod ffi {
     use crate::unstable::provider::ffi::DataProvider;
 
     {%- for formatter_kind in flavor.formatter_kinds() %}
-    {%- let ffi_type %}
-    {%- let ffi_base_type %}
-    {%- let conversion_fn %}
+    {%- decl ffi_type %}
+    {%- decl ffi_base_type %}
+    {%- decl conversion_fn %}
     {%- if formatter_kind.is_gregorian %}
         {%- let ffi_type = format!("Zoned{}FormatterGregorian", flavor.camel()) %}
         {%- let ffi_base_type = format!("{}FormatterGregorian", flavor.camel()) %}


### PR DESCRIPTION
Replaced uninitialized `let` declarations with `decl` in `datetime_formatter.rs.jinja` and `zoned_formatter.rs.jinja`. The warning message from Askama 0.15 suggested using `create`, but that resulted in an "unknown node" error. Using `decl` worked and is consistent with Askama documentation for declaring uninitialized variables.

## Changelog

N/A