### PR TITLE
ScriptExtensions FFI should use the `Script` enum

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -367,13 +367,14 @@ jobs:
         rm dylib
 
     - name: Run `cargo make ci-job-test-dart` in fetch mode
+      if: false # needs release
       run: |
         git clean -xf ffi examples
         yq -i ".hooks.user_defines.icu4x.buildMode = \"fetch\"" ffi/dart/pubspec.yaml
         yq -i ".hooks.user_defines.icu4x.buildMode = \"fetch\"" examples/dart/pubspec.yaml
         cargo make ci-job-test-dart
  
-   # ci-job-test-kotlin
+  # ci-job-test-kotlin
   test-kotlin:
     strategy:
       fail-fast: false

--- a/ffi/capi/bindings/cpp/icu4x/ScriptWithExtensionsBorrowed.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/ScriptWithExtensionsBorrowed.d.hpp
@@ -36,7 +36,6 @@ public:
 
   /**
    * Get the Script property value for a code point
-   * Get the Script property value for a code point
    *
    * See the [Rust documentation for `get_script_val`](https://docs.rs/icu/2.2.0/icu/properties/script/struct.ScriptWithExtensionsBorrowed.html#method.get_script_val) for more information.
    */

--- a/ffi/capi/src/script.rs
+++ b/ffi/capi/src/script.rs
@@ -7,6 +7,7 @@
 pub mod ffi {
     use alloc::boxed::Box;
 
+    use crate::unstable::properties_enums::ffi::Script;
     use crate::unstable::properties_iter::ffi::CodePointRangeIterator;
     use crate::unstable::properties_sets::ffi::CodePointSetData;
     #[cfg(feature = "buffer_provider")]
@@ -75,8 +76,27 @@ pub mod ffi {
             FnInStruct,
             hidden
         )]
-        pub fn get_script_val(&self, ch: DiplomatChar) -> u16 {
-            self.0.as_borrowed().get_script_val32(ch).to_icu4c_value()
+        #[diplomat::attr(any(dart, kotlin), disable)]
+        #[diplomat::attr(*, rename = "get_script_val")]
+        #[diplomat::abi_rename = "icu4x_ScriptWithExtensions_get_script_val_mv1"]
+        pub fn get_script_val_raw(&self, ch: DiplomatChar) -> u16 {
+            self.get_script_val(ch).to_integer_value()
+        }
+
+        /// Get the Script property value for a code point
+        #[diplomat::rust_link(
+            icu::properties::script::ScriptWithExtensionsBorrowed::get_script_val,
+            FnInStruct
+        )]
+        #[diplomat::rust_link(
+            icu::properties::script::ScriptWithExtensionsBorrowed::get_script_val32,
+            FnInStruct,
+            hidden
+        )]
+        #[diplomat::attr(not(any(dart, kotlin)), disable)]
+        #[diplomat::abi_rename = "icu4x_ScriptWithExtensions_get_script_val_mv2"]
+        pub fn get_script_val(&self, ch: DiplomatChar) -> Script {
+            Script::from(self.0.as_borrowed().get_script_val32(ch))
         }
 
         /// Check if the `Script_Extensions` property of the given code point covers the given script
@@ -89,10 +109,30 @@ pub mod ffi {
             FnInStruct,
             hidden
         )]
-        pub fn has_script(&self, ch: DiplomatChar, script: u16) -> bool {
-            self.0
-                .as_borrowed()
-                .has_script32(ch, icu_properties::props::Script::from_icu4c_value(script))
+        #[diplomat::attr(any(dart, kotlin), disable)]
+        #[diplomat::attr(*, rename = "has_script")]
+        #[diplomat::abi_rename = "icu4x_ScriptWithExtensions_has_script_mv1"]
+        pub fn has_script_raw(&self, ch: DiplomatChar, script: u16) -> bool {
+            self.has_script(
+                ch,
+                Script::from_integer_value(script).unwrap_or(Script::Unknown),
+            )
+        }
+
+        /// Check if the `Script_Extensions` property of the given code point covers the given script
+        #[diplomat::rust_link(
+            icu::properties::script::ScriptWithExtensionsBorrowed::has_script,
+            FnInStruct
+        )]
+        #[diplomat::rust_link(
+            icu::properties::script::ScriptWithExtensionsBorrowed::has_script32,
+            FnInStruct,
+            hidden
+        )]
+        #[diplomat::attr(not(any(dart, kotlin)), disable)]
+        #[diplomat::abi_rename = "icu4x_ScriptWithExtensions_has_script_mv2"]
+        pub fn has_script(&self, ch: DiplomatChar, script: Script) -> bool {
+            self.0.as_borrowed().has_script32(ch, script.into())
         }
 
         /// Borrow this object for a slightly faster variant with more operations
@@ -110,14 +150,33 @@ pub mod ffi {
             icu::properties::script::ScriptWithExtensionsBorrowed::get_script_extensions_ranges,
             FnInStruct
         )]
-        pub fn iter_ranges_for_script<'a>(
+        #[diplomat::attr(any(dart, kotlin), disable)]
+        #[diplomat::attr(*, rename = "iter_ranges_for_script")]
+        #[diplomat::abi_rename = "icu4x_ScriptWithExtensions_iter_ranges_for_script_mv1"]
+        pub fn iter_ranges_for_script_raw<'a>(
             &'a self,
             script: u16,
         ) -> Box<CodePointRangeIterator<'a>> {
+            self.iter_ranges_for_script(
+                Script::from_integer_value(script).unwrap_or(Script::Unknown),
+            )
+        }
+
+        /// Get a list of ranges of code points that contain this script in their `Script_Extensions` values
+        #[diplomat::rust_link(
+            icu::properties::script::ScriptWithExtensionsBorrowed::get_script_extensions_ranges,
+            FnInStruct
+        )]
+        #[diplomat::attr(not(any(dart, kotlin)), disable)]
+        #[diplomat::abi_rename = "icu4x_ScriptWithExtensions_iter_ranges_for_script_mv2"]
+        pub fn iter_ranges_for_script<'a>(
+            &'a self,
+            script: Script,
+        ) -> Box<CodePointRangeIterator<'a>> {
             Box::new(CodePointRangeIterator(Box::new(
-                self.0.as_borrowed().get_script_extensions_ranges(
-                    icu_properties::props::Script::from_icu4c_value(script),
-                ),
+                self.0
+                    .as_borrowed()
+                    .get_script_extensions_ranges(script.into()),
             )))
         }
     }
@@ -128,14 +187,31 @@ pub mod ffi {
             icu::properties::script::ScriptWithExtensionsBorrowed::get_script_val,
             FnInStruct
         )]
-        /// Get the Script property value for a code point
         #[diplomat::rust_link(
             icu::properties::script::ScriptWithExtensionsBorrowed::get_script_val32,
             FnInStruct,
             hidden
         )]
-        pub fn get_script_val(&self, ch: DiplomatChar) -> u16 {
-            self.0.get_script_val32(ch).to_icu4c_value()
+        #[diplomat::attr(any(dart, kotlin), disable)]
+        #[diplomat::attr(*, rename = "get_script_val")]
+        #[diplomat::abi_rename = "icu4x_ScriptWithExtensionsBorrowed_get_script_val_mv1"]
+        pub fn get_script_val_raw(&self, ch: DiplomatChar) -> u16 {
+            self.get_script_val(ch).to_integer_value()
+        }
+        /// Get the Script property value for a code point
+        #[diplomat::rust_link(
+            icu::properties::script::ScriptWithExtensionsBorrowed::get_script_val,
+            FnInStruct
+        )]
+        #[diplomat::rust_link(
+            icu::properties::script::ScriptWithExtensionsBorrowed::get_script_val32,
+            FnInStruct,
+            hidden
+        )]
+        #[diplomat::attr(not(any(dart, kotlin)), disable)]
+        #[diplomat::abi_rename = "icu4x_ScriptWithExtensionsBorrowed_get_script_val_mv2"]
+        pub fn get_script_val(&self, ch: DiplomatChar) -> Script {
+            Script::from(self.0.get_script_val32(ch))
         }
         /// Get the Script property value for a code point
         #[diplomat::rust_link(
@@ -160,9 +236,29 @@ pub mod ffi {
             FnInStruct,
             hidden
         )]
-        pub fn has_script(&self, ch: DiplomatChar, script: u16) -> bool {
-            self.0
-                .has_script32(ch, icu_properties::props::Script::from_icu4c_value(script))
+        #[diplomat::attr(any(dart, kotlin), disable)]
+        #[diplomat::attr(*, rename = "has_script")]
+        #[diplomat::abi_rename = "icu4x_ScriptWithExtensionsBorrowed_has_script_mv1"]
+        pub fn has_script_raw(&self, ch: DiplomatChar, script: u16) -> bool {
+            self.has_script(
+                ch,
+                Script::from_integer_value(script).unwrap_or(Script::Unknown),
+            )
+        }
+        /// Check if the `Script_Extensions` property of the given code point covers the given script
+        #[diplomat::rust_link(
+            icu::properties::script::ScriptWithExtensionsBorrowed::has_script,
+            FnInStruct
+        )]
+        #[diplomat::rust_link(
+            icu::properties::script::ScriptWithExtensionsBorrowed::has_script32,
+            FnInStruct,
+            hidden
+        )]
+        #[diplomat::attr(not(any(dart, kotlin)), disable)]
+        #[diplomat::abi_rename = "icu4x_ScriptWithExtensionsBorrowed_has_script_mv2"]
+        pub fn has_script(&self, ch: DiplomatChar, script: Script) -> bool {
+            self.0.has_script32(ch, script.into())
         }
 
         /// Build the `CodePointSetData` corresponding to a codepoints matching a particular script
@@ -171,11 +267,25 @@ pub mod ffi {
             icu::properties::script::ScriptWithExtensionsBorrowed::get_script_extensions_set,
             FnInStruct
         )]
-        pub fn get_script_extensions_set(&self, script: u16) -> Box<CodePointSetData> {
-            let list = self
-                .0
-                .get_script_extensions_set(icu_properties::props::Script::from_icu4c_value(script))
-                .into_owned();
+        #[diplomat::attr(any(dart, kotlin), disable)]
+        #[diplomat::attr(*, rename = "get_script_extensions_set")]
+        #[diplomat::abi_rename = "icu4x_ScriptWithExtensionsBorrowed_get_script_extensions_set_mv1"]
+        pub fn get_script_extensions_set_raw(&self, script: u16) -> Box<CodePointSetData> {
+            self.get_script_extensions_set(
+                Script::from_integer_value(script).unwrap_or(Script::Unknown),
+            )
+        }
+
+        /// Build the `CodePointSetData` corresponding to a codepoints matching a particular script
+        /// in their `Script_Extensions`
+        #[diplomat::rust_link(
+            icu::properties::script::ScriptWithExtensionsBorrowed::get_script_extensions_set,
+            FnInStruct
+        )]
+        #[diplomat::attr(not(any(dart, kotlin)), disable)]
+        #[diplomat::abi_rename = "icu4x_ScriptWithExtensionsBorrowed_get_script_extensions_set_mv2"]
+        pub fn get_script_extensions_set(&self, script: Script) -> Box<CodePointSetData> {
+            let list = self.0.get_script_extensions_set(script.into()).into_owned();
             let set = icu_properties::CodePointSetData::from_code_point_inversion_list(list);
             Box::new(CodePointSetData(set))
         }
@@ -183,9 +293,18 @@ pub mod ffi {
     impl<'a> ScriptExtensionsSet<'a> {
         /// Check if the `Script_Extensions` property of the given code point covers the given script
         #[diplomat::rust_link(icu::properties::script::ScriptExtensionsSet::contains, FnInStruct)]
-        pub fn contains(&self, script: u16) -> bool {
-            self.0
-                .contains(&icu_properties::props::Script::from_icu4c_value(script))
+        #[diplomat::attr(any(dart, kotlin), disable)]
+        #[diplomat::attr(*, rename = "contains")]
+        #[diplomat::abi_rename = "icu4x_ScriptExtensionsSet_contains_mv1"]
+        pub fn contains_raw(&self, script: u16) -> bool {
+            self.contains(Script::from_integer_value(script).unwrap_or(Script::Unknown))
+        }
+        /// Check if the `Script_Extensions` property of the given code point covers the given script
+        #[diplomat::rust_link(icu::properties::script::ScriptExtensionsSet::contains, FnInStruct)]
+        #[diplomat::attr(not(any(dart, kotlin)), disable)]
+        #[diplomat::abi_rename = "icu4x_ScriptExtensionsSet_contains_mv2"]
+        pub fn contains(&self, script: Script) -> bool {
+            self.0.contains(&script.into())
         }
 
         /// Get the number of scripts contained in here
@@ -197,8 +316,19 @@ pub mod ffi {
 
         /// Get script at index
         #[diplomat::rust_link(icu::properties::script::ScriptExtensionsSet::iter, FnInStruct)]
-        pub fn script_at(&self, index: usize) -> Option<u16> {
-            self.0.array_get(index).map(|x| x.to_icu4c_value())
+        #[diplomat::attr(any(dart, kotlin), disable)]
+        #[diplomat::attr(*, rename = "script_at")]
+        #[diplomat::abi_rename = "icu4x_ScriptExtensionsSet_script_at_mv1"]
+        pub fn script_at_raw(&self, index: usize) -> Option<u16> {
+            self.script_at(index).map(|s| s.to_integer_value())
+        }
+
+        /// Get script at index
+        #[diplomat::rust_link(icu::properties::script::ScriptExtensionsSet::iter, FnInStruct)]
+        #[diplomat::attr(not(any(dart, kotlin)), disable)]
+        #[diplomat::abi_rename = "icu4x_ScriptExtensionsSet_script_at_mv2"]
+        pub fn script_at(&self, index: usize) -> Option<Script> {
+            self.0.array_get(index).map(Into::into)
         }
     }
 }

--- a/ffi/dart/lib/src/bindings/ScriptExtensionsSet.g.dart
+++ b/ffi/dart/lib/src/bindings/ScriptExtensionsSet.g.dart
@@ -31,8 +31,8 @@ final class ScriptExtensionsSet implements ffi.Finalizable {
   /// Check if the `Script_Extensions` property of the given code point covers the given script
   ///
   /// See the [Rust documentation for `contains`](https://docs.rs/icu/2.2.0/icu/properties/script/struct.ScriptExtensionsSet.html#method.contains) for more information.
-  bool contains(int script) {
-    final result = _icu4x_ScriptExtensionsSet_contains_mv1(_ffi, script);
+  bool contains(Script script) {
+    final result = _icu4x_ScriptExtensionsSet_contains_mv2(_ffi, script._ffi);
     return result;
   }
 
@@ -47,12 +47,12 @@ final class ScriptExtensionsSet implements ffi.Finalizable {
   /// Get script at index
   ///
   /// See the [Rust documentation for `iter`](https://docs.rs/icu/2.2.0/icu/properties/script/struct.ScriptExtensionsSet.html#method.iter) for more information.
-  int? scriptAt(int index) {
-    final result = _icu4x_ScriptExtensionsSet_script_at_mv1(_ffi, index);
+  Script? scriptAt(int index) {
+    final result = _icu4x_ScriptExtensionsSet_script_at_mv2(_ffi, index);
     if (!result.isOk) {
       return null;
     }
-    return result.union.ok;
+    return Script.values.firstWhere((v) => v._ffi == result.union.ok);
   }
 
 }
@@ -62,19 +62,19 @@ final class ScriptExtensionsSet implements ffi.Finalizable {
 // ignore: non_constant_identifier_names
 external void _icu4x_ScriptExtensionsSet_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_ScriptExtensionsSet_contains_mv1')
-@ffi.Native<ffi.Bool Function(ffi.Pointer<ffi.Opaque>, ffi.Uint16)>(isLeaf: true, symbol: 'icu4x_ScriptExtensionsSet_contains_mv1')
+@_DiplomatFfiUse('icu4x_ScriptExtensionsSet_contains_mv2')
+@ffi.Native<ffi.Bool Function(ffi.Pointer<ffi.Opaque>, ffi.Int32)>(isLeaf: true, symbol: 'icu4x_ScriptExtensionsSet_contains_mv2')
 // ignore: non_constant_identifier_names
-external bool _icu4x_ScriptExtensionsSet_contains_mv1(ffi.Pointer<ffi.Opaque> self, int script);
+external bool _icu4x_ScriptExtensionsSet_contains_mv2(ffi.Pointer<ffi.Opaque> self, int script);
 
 @_DiplomatFfiUse('icu4x_ScriptExtensionsSet_count_mv1')
 @ffi.Native<ffi.Size Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ScriptExtensionsSet_count_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_ScriptExtensionsSet_count_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_ScriptExtensionsSet_script_at_mv1')
-@ffi.Native<_ResultUint16Void Function(ffi.Pointer<ffi.Opaque>, ffi.Size)>(isLeaf: true, symbol: 'icu4x_ScriptExtensionsSet_script_at_mv1')
+@_DiplomatFfiUse('icu4x_ScriptExtensionsSet_script_at_mv2')
+@ffi.Native<_ResultInt32Void Function(ffi.Pointer<ffi.Opaque>, ffi.Size)>(isLeaf: true, symbol: 'icu4x_ScriptExtensionsSet_script_at_mv2')
 // ignore: non_constant_identifier_names
-external _ResultUint16Void _icu4x_ScriptExtensionsSet_script_at_mv1(ffi.Pointer<ffi.Opaque> self, int index);
+external _ResultInt32Void _icu4x_ScriptExtensionsSet_script_at_mv2(ffi.Pointer<ffi.Opaque> self, int index);
 
 // dart format on

--- a/ffi/dart/lib/src/bindings/ScriptWithExtensions.g.dart
+++ b/ffi/dart/lib/src/bindings/ScriptWithExtensions.g.dart
@@ -50,16 +50,16 @@ final class ScriptWithExtensions implements ffi.Finalizable {
   /// Get the Script property value for a code point
   ///
   /// See the [Rust documentation for `get_script_val`](https://docs.rs/icu/2.2.0/icu/properties/script/struct.ScriptWithExtensionsBorrowed.html#method.get_script_val) for more information.
-  int getScriptVal(Rune ch) {
-    final result = _icu4x_ScriptWithExtensions_get_script_val_mv1(_ffi, ch);
-    return result;
+  Script getScriptVal(Rune ch) {
+    final result = _icu4x_ScriptWithExtensions_get_script_val_mv2(_ffi, ch);
+    return Script.values.firstWhere((v) => v._ffi == result);
   }
 
   /// Check if the `Script_Extensions` property of the given code point covers the given script
   ///
   /// See the [Rust documentation for `has_script`](https://docs.rs/icu/2.2.0/icu/properties/script/struct.ScriptWithExtensionsBorrowed.html#method.has_script) for more information.
-  bool hasScript(Rune ch, int script) {
-    final result = _icu4x_ScriptWithExtensions_has_script_mv1(_ffi, ch, script);
+  bool hasScript(Rune ch, Script script) {
+    final result = _icu4x_ScriptWithExtensions_has_script_mv2(_ffi, ch, script._ffi);
     return result;
   }
 
@@ -76,10 +76,10 @@ final class ScriptWithExtensions implements ffi.Finalizable {
   /// Get a list of ranges of code points that contain this script in their `Script_Extensions` values
   ///
   /// See the [Rust documentation for `get_script_extensions_ranges`](https://docs.rs/icu/2.2.0/icu/properties/script/struct.ScriptWithExtensionsBorrowed.html#method.get_script_extensions_ranges) for more information.
-  CodePointRangeIterator iterRangesForScript(int script) {
+  CodePointRangeIterator iterRangesForScript(Script script) {
     // This lifetime edge depends on lifetimes: 'a
     final aEdges = [this];
-    final result = _icu4x_ScriptWithExtensions_iter_ranges_for_script_mv1(_ffi, script);
+    final result = _icu4x_ScriptWithExtensions_iter_ranges_for_script_mv2(_ffi, script._ffi);
     return CodePointRangeIterator._fromFfi(result, [], aEdges);
   }
 
@@ -100,24 +100,24 @@ external ffi.Pointer<ffi.Opaque> _icu4x_ScriptWithExtensions_create_mv1();
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ScriptWithExtensions_create_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_ScriptWithExtensions_get_script_val_mv1')
-@ffi.Native<ffi.Uint16 Function(ffi.Pointer<ffi.Opaque>, ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_ScriptWithExtensions_get_script_val_mv1')
+@_DiplomatFfiUse('icu4x_ScriptWithExtensions_get_script_val_mv2')
+@ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>, ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_ScriptWithExtensions_get_script_val_mv2')
 // ignore: non_constant_identifier_names
-external int _icu4x_ScriptWithExtensions_get_script_val_mv1(ffi.Pointer<ffi.Opaque> self, Rune ch);
+external int _icu4x_ScriptWithExtensions_get_script_val_mv2(ffi.Pointer<ffi.Opaque> self, Rune ch);
 
-@_DiplomatFfiUse('icu4x_ScriptWithExtensions_has_script_mv1')
-@ffi.Native<ffi.Bool Function(ffi.Pointer<ffi.Opaque>, ffi.Uint32, ffi.Uint16)>(isLeaf: true, symbol: 'icu4x_ScriptWithExtensions_has_script_mv1')
+@_DiplomatFfiUse('icu4x_ScriptWithExtensions_has_script_mv2')
+@ffi.Native<ffi.Bool Function(ffi.Pointer<ffi.Opaque>, ffi.Uint32, ffi.Int32)>(isLeaf: true, symbol: 'icu4x_ScriptWithExtensions_has_script_mv2')
 // ignore: non_constant_identifier_names
-external bool _icu4x_ScriptWithExtensions_has_script_mv1(ffi.Pointer<ffi.Opaque> self, Rune ch, int script);
+external bool _icu4x_ScriptWithExtensions_has_script_mv2(ffi.Pointer<ffi.Opaque> self, Rune ch, int script);
 
 @_DiplomatFfiUse('icu4x_ScriptWithExtensions_as_borrowed_mv1')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ScriptWithExtensions_as_borrowed_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_ScriptWithExtensions_as_borrowed_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_ScriptWithExtensions_iter_ranges_for_script_mv1')
-@ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Uint16)>(isLeaf: true, symbol: 'icu4x_ScriptWithExtensions_iter_ranges_for_script_mv1')
+@_DiplomatFfiUse('icu4x_ScriptWithExtensions_iter_ranges_for_script_mv2')
+@ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Int32)>(isLeaf: true, symbol: 'icu4x_ScriptWithExtensions_iter_ranges_for_script_mv2')
 // ignore: non_constant_identifier_names
-external ffi.Pointer<ffi.Opaque> _icu4x_ScriptWithExtensions_iter_ranges_for_script_mv1(ffi.Pointer<ffi.Opaque> self, int script);
+external ffi.Pointer<ffi.Opaque> _icu4x_ScriptWithExtensions_iter_ranges_for_script_mv2(ffi.Pointer<ffi.Opaque> self, int script);
 
 // dart format on

--- a/ffi/dart/lib/src/bindings/ScriptWithExtensionsBorrowed.g.dart
+++ b/ffi/dart/lib/src/bindings/ScriptWithExtensionsBorrowed.g.dart
@@ -29,12 +29,11 @@ final class ScriptWithExtensionsBorrowed implements ffi.Finalizable {
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_ScriptWithExtensionsBorrowed_destroy_mv1));
 
   /// Get the Script property value for a code point
-  /// Get the Script property value for a code point
   ///
   /// See the [Rust documentation for `get_script_val`](https://docs.rs/icu/2.2.0/icu/properties/script/struct.ScriptWithExtensionsBorrowed.html#method.get_script_val) for more information.
-  int getScriptVal(Rune ch) {
-    final result = _icu4x_ScriptWithExtensionsBorrowed_get_script_val_mv1(_ffi, ch);
-    return result;
+  Script getScriptVal(Rune ch) {
+    final result = _icu4x_ScriptWithExtensionsBorrowed_get_script_val_mv2(_ffi, ch);
+    return Script.values.firstWhere((v) => v._ffi == result);
   }
 
   /// Get the Script property value for a code point
@@ -50,8 +49,8 @@ final class ScriptWithExtensionsBorrowed implements ffi.Finalizable {
   /// Check if the `Script_Extensions` property of the given code point covers the given script
   ///
   /// See the [Rust documentation for `has_script`](https://docs.rs/icu/2.2.0/icu/properties/script/struct.ScriptWithExtensionsBorrowed.html#method.has_script) for more information.
-  bool hasScript(Rune ch, int script) {
-    final result = _icu4x_ScriptWithExtensionsBorrowed_has_script_mv1(_ffi, ch, script);
+  bool hasScript(Rune ch, Script script) {
+    final result = _icu4x_ScriptWithExtensionsBorrowed_has_script_mv2(_ffi, ch, script._ffi);
     return result;
   }
 
@@ -59,8 +58,8 @@ final class ScriptWithExtensionsBorrowed implements ffi.Finalizable {
   /// in their `Script_Extensions`
   ///
   /// See the [Rust documentation for `get_script_extensions_set`](https://docs.rs/icu/2.2.0/icu/properties/script/struct.ScriptWithExtensionsBorrowed.html#method.get_script_extensions_set) for more information.
-  CodePointSetData getScriptExtensionsSet(int script) {
-    final result = _icu4x_ScriptWithExtensionsBorrowed_get_script_extensions_set_mv1(_ffi, script);
+  CodePointSetData getScriptExtensionsSet(Script script) {
+    final result = _icu4x_ScriptWithExtensionsBorrowed_get_script_extensions_set_mv2(_ffi, script._ffi);
     return CodePointSetData._fromFfi(result, []);
   }
 
@@ -71,24 +70,24 @@ final class ScriptWithExtensionsBorrowed implements ffi.Finalizable {
 // ignore: non_constant_identifier_names
 external void _icu4x_ScriptWithExtensionsBorrowed_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_ScriptWithExtensionsBorrowed_get_script_val_mv1')
-@ffi.Native<ffi.Uint16 Function(ffi.Pointer<ffi.Opaque>, ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_ScriptWithExtensionsBorrowed_get_script_val_mv1')
+@_DiplomatFfiUse('icu4x_ScriptWithExtensionsBorrowed_get_script_val_mv2')
+@ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>, ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_ScriptWithExtensionsBorrowed_get_script_val_mv2')
 // ignore: non_constant_identifier_names
-external int _icu4x_ScriptWithExtensionsBorrowed_get_script_val_mv1(ffi.Pointer<ffi.Opaque> self, Rune ch);
+external int _icu4x_ScriptWithExtensionsBorrowed_get_script_val_mv2(ffi.Pointer<ffi.Opaque> self, Rune ch);
 
 @_DiplomatFfiUse('icu4x_ScriptWithExtensionsBorrowed_get_script_extensions_val_mv1')
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_ScriptWithExtensionsBorrowed_get_script_extensions_val_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_ScriptWithExtensionsBorrowed_get_script_extensions_val_mv1(ffi.Pointer<ffi.Opaque> self, Rune ch);
 
-@_DiplomatFfiUse('icu4x_ScriptWithExtensionsBorrowed_has_script_mv1')
-@ffi.Native<ffi.Bool Function(ffi.Pointer<ffi.Opaque>, ffi.Uint32, ffi.Uint16)>(isLeaf: true, symbol: 'icu4x_ScriptWithExtensionsBorrowed_has_script_mv1')
+@_DiplomatFfiUse('icu4x_ScriptWithExtensionsBorrowed_has_script_mv2')
+@ffi.Native<ffi.Bool Function(ffi.Pointer<ffi.Opaque>, ffi.Uint32, ffi.Int32)>(isLeaf: true, symbol: 'icu4x_ScriptWithExtensionsBorrowed_has_script_mv2')
 // ignore: non_constant_identifier_names
-external bool _icu4x_ScriptWithExtensionsBorrowed_has_script_mv1(ffi.Pointer<ffi.Opaque> self, Rune ch, int script);
+external bool _icu4x_ScriptWithExtensionsBorrowed_has_script_mv2(ffi.Pointer<ffi.Opaque> self, Rune ch, int script);
 
-@_DiplomatFfiUse('icu4x_ScriptWithExtensionsBorrowed_get_script_extensions_set_mv1')
-@ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Uint16)>(isLeaf: true, symbol: 'icu4x_ScriptWithExtensionsBorrowed_get_script_extensions_set_mv1')
+@_DiplomatFfiUse('icu4x_ScriptWithExtensionsBorrowed_get_script_extensions_set_mv2')
+@ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Int32)>(isLeaf: true, symbol: 'icu4x_ScriptWithExtensionsBorrowed_get_script_extensions_set_mv2')
 // ignore: non_constant_identifier_names
-external ffi.Pointer<ffi.Opaque> _icu4x_ScriptWithExtensionsBorrowed_get_script_extensions_set_mv1(ffi.Pointer<ffi.Opaque> self, int script);
+external ffi.Pointer<ffi.Opaque> _icu4x_ScriptWithExtensionsBorrowed_get_script_extensions_set_mv2(ffi.Pointer<ffi.Opaque> self, int script);
 
 // dart format on

--- a/ffi/dart/lib/src/bindings/lib.g.dart
+++ b/ffi/dart/lib/src/bindings/lib.g.dart
@@ -630,33 +630,6 @@ final class _ResultTimeZoneAndCanonicalFfiVoid extends ffi.Struct {
   }
 }
 
-final class _ResultUint16VoidUnion extends ffi.Union {
-  @ffi.Uint16()
-  external int ok;
-
-}
-
-final class _ResultUint16Void extends ffi.Struct {
-  external _ResultUint16VoidUnion union;
-
-  @ffi.Bool()
-  external bool isOk;
-
-  // ignore: unused_element
-  factory _ResultUint16Void.ok(int val) {
-    final struct = ffi.Struct.create<_ResultUint16Void>();
-    struct.isOk = true;
-    struct.union.ok = val;
-    return struct;
-  }
-  // ignore: unused_element
-  factory _ResultUint16Void.err() {
-    final struct = ffi.Struct.create<_ResultUint16Void>();
-    struct.isOk = false;
-    return struct;
-  }
-}
-
 final class _ResultUint32VoidUnion extends ffi.Union {
   @ffi.Uint32()
   external Rune ok;

--- a/ffi/dart/test/icu_test.dart
+++ b/ffi/dart/test/icu_test.dart
@@ -354,4 +354,11 @@ void main() {
       'Mi., 15.01.2025, 14:32:12 Mitteleuropäische Zeit',
     );
   });
+
+  test('ScriptExtension', () {
+    expect(
+      ScriptWithExtensions().hasScript('A'.runes.first, Script.latin),
+      true,
+    );
+  });
 }

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/ScriptExtensionsSet.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/ScriptExtensionsSet.kt
@@ -7,9 +7,9 @@ import com.sun.jna.Structure
 
 internal interface ScriptExtensionsSetLib: Library {
     fun icu4x_ScriptExtensionsSet_destroy_mv1(handle: Pointer)
-    fun icu4x_ScriptExtensionsSet_contains_mv1(handle: Pointer, script: FFIUint16): Byte
+    fun icu4x_ScriptExtensionsSet_contains_mv2(handle: Pointer, script: Int): Byte
     fun icu4x_ScriptExtensionsSet_count_mv1(handle: Pointer): FFISizet
-    fun icu4x_ScriptExtensionsSet_script_at_mv1(handle: Pointer, index: FFISizet): OptionFFIUint16
+    fun icu4x_ScriptExtensionsSet_script_at_mv2(handle: Pointer, index: FFISizet): OptionInt
 }
 /** An object that represents the `Script_Extensions` property for a single character
 *
@@ -48,9 +48,9 @@ class ScriptExtensionsSet internal constructor (
     *
     *See the [Rust documentation for `contains`](https://docs.rs/icu/2.2.0/icu/properties/script/struct.ScriptExtensionsSet.html#method.contains) for more information.
     */
-    fun contains(script: UShort): Boolean {
+    fun contains(script: Script): Boolean {
         
-        val returnVal = lib.icu4x_ScriptExtensionsSet_contains_mv1(handle, FFIUint16(script));
+        val returnVal = lib.icu4x_ScriptExtensionsSet_contains_mv2(handle, script.toNative());
         return (returnVal > 0)
     }
     
@@ -68,10 +68,12 @@ class ScriptExtensionsSet internal constructor (
     *
     *See the [Rust documentation for `iter`](https://docs.rs/icu/2.2.0/icu/properties/script/struct.ScriptExtensionsSet.html#method.iter) for more information.
     */
-    fun scriptAt(index: ULong): UShort? {
+    fun scriptAt(index: ULong): Script? {
         
-        val returnVal = lib.icu4x_ScriptExtensionsSet_script_at_mv1(handle, FFISizet(index));
-        return returnVal.option()?.toUShort()
+        val returnVal = lib.icu4x_ScriptExtensionsSet_script_at_mv2(handle, FFISizet(index));
+        
+        val intermediateOption = returnVal.option() ?: return null
+        return Script.fromNative(intermediateOption)
     }
 
 }

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/ScriptWithExtensions.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/ScriptWithExtensions.kt
@@ -9,10 +9,10 @@ internal interface ScriptWithExtensionsLib: Library {
     fun icu4x_ScriptWithExtensions_destroy_mv1(handle: Pointer)
     fun icu4x_ScriptWithExtensions_create_mv1(): Pointer
     fun icu4x_ScriptWithExtensions_create_with_provider_mv1(provider: Pointer): ResultPointerInt
-    fun icu4x_ScriptWithExtensions_get_script_val_mv1(handle: Pointer, ch: Int): FFIUint16
-    fun icu4x_ScriptWithExtensions_has_script_mv1(handle: Pointer, ch: Int, script: FFIUint16): Byte
+    fun icu4x_ScriptWithExtensions_get_script_val_mv2(handle: Pointer, ch: Int): Int
+    fun icu4x_ScriptWithExtensions_has_script_mv2(handle: Pointer, ch: Int, script: Int): Byte
     fun icu4x_ScriptWithExtensions_as_borrowed_mv1(handle: Pointer): Pointer
-    fun icu4x_ScriptWithExtensions_iter_ranges_for_script_mv1(handle: Pointer, script: FFIUint16): Pointer
+    fun icu4x_ScriptWithExtensions_iter_ranges_for_script_mv2(handle: Pointer, script: Int): Pointer
 }
 /** An ICU4X `ScriptWithExtensions` map object, capable of holding a map of codepoints to scriptextensions values
 *
@@ -83,19 +83,19 @@ class ScriptWithExtensions internal constructor (
     *
     *See the [Rust documentation for `get_script_val`](https://docs.rs/icu/2.2.0/icu/properties/script/struct.ScriptWithExtensionsBorrowed.html#method.get_script_val) for more information.
     */
-    fun getScriptVal(ch: Int): UShort {
+    fun getScriptVal(ch: Int): Script {
         
-        val returnVal = lib.icu4x_ScriptWithExtensions_get_script_val_mv1(handle, ch);
-        return (returnVal.toUShort())
+        val returnVal = lib.icu4x_ScriptWithExtensions_get_script_val_mv2(handle, ch);
+        return (Script.fromNative(returnVal))
     }
     
     /** Check if the `Script_Extensions` property of the given code point covers the given script
     *
     *See the [Rust documentation for `has_script`](https://docs.rs/icu/2.2.0/icu/properties/script/struct.ScriptWithExtensionsBorrowed.html#method.has_script) for more information.
     */
-    fun hasScript(ch: Int, script: UShort): Boolean {
+    fun hasScript(ch: Int, script: Script): Boolean {
         
-        val returnVal = lib.icu4x_ScriptWithExtensions_has_script_mv1(handle, ch, FFIUint16(script));
+        val returnVal = lib.icu4x_ScriptWithExtensions_has_script_mv2(handle, ch, script.toNative());
         return (returnVal > 0)
     }
     
@@ -118,11 +118,11 @@ class ScriptWithExtensions internal constructor (
     *
     *See the [Rust documentation for `get_script_extensions_ranges`](https://docs.rs/icu/2.2.0/icu/properties/script/struct.ScriptWithExtensionsBorrowed.html#method.get_script_extensions_ranges) for more information.
     */
-    fun iterRangesForScript(script: UShort): CodePointRangeIterator {
+    fun iterRangesForScript(script: Script): CodePointRangeIterator {
         // This lifetime edge depends on lifetimes: 'a
         val aEdges: MutableList<Any> = mutableListOf(this);
         
-        val returnVal = lib.icu4x_ScriptWithExtensions_iter_ranges_for_script_mv1(handle, FFIUint16(script));
+        val returnVal = lib.icu4x_ScriptWithExtensions_iter_ranges_for_script_mv2(handle, script.toNative());
         val selfEdges: List<Any> = listOf()
         val handle = returnVal 
         val returnOpaque = CodePointRangeIterator(handle, selfEdges, aEdges, true)

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/ScriptWithExtensionsBorrowed.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/ScriptWithExtensionsBorrowed.kt
@@ -7,10 +7,10 @@ import com.sun.jna.Structure
 
 internal interface ScriptWithExtensionsBorrowedLib: Library {
     fun icu4x_ScriptWithExtensionsBorrowed_destroy_mv1(handle: Pointer)
-    fun icu4x_ScriptWithExtensionsBorrowed_get_script_val_mv1(handle: Pointer, ch: Int): FFIUint16
+    fun icu4x_ScriptWithExtensionsBorrowed_get_script_val_mv2(handle: Pointer, ch: Int): Int
     fun icu4x_ScriptWithExtensionsBorrowed_get_script_extensions_val_mv1(handle: Pointer, ch: Int): Pointer
-    fun icu4x_ScriptWithExtensionsBorrowed_has_script_mv1(handle: Pointer, ch: Int, script: FFIUint16): Byte
-    fun icu4x_ScriptWithExtensionsBorrowed_get_script_extensions_set_mv1(handle: Pointer, script: FFIUint16): Pointer
+    fun icu4x_ScriptWithExtensionsBorrowed_has_script_mv2(handle: Pointer, ch: Int, script: Int): Byte
+    fun icu4x_ScriptWithExtensionsBorrowed_get_script_extensions_set_mv2(handle: Pointer, script: Int): Pointer
 }
 /** A slightly faster `ScriptWithExtensions` object
 *
@@ -46,14 +46,13 @@ class ScriptWithExtensionsBorrowed internal constructor (
     }
     
     /** Get the Script property value for a code point
-    *Get the Script property value for a code point
     *
     *See the [Rust documentation for `get_script_val`](https://docs.rs/icu/2.2.0/icu/properties/script/struct.ScriptWithExtensionsBorrowed.html#method.get_script_val) for more information.
     */
-    fun getScriptVal(ch: Int): UShort {
+    fun getScriptVal(ch: Int): Script {
         
-        val returnVal = lib.icu4x_ScriptWithExtensionsBorrowed_get_script_val_mv1(handle, ch);
-        return (returnVal.toUShort())
+        val returnVal = lib.icu4x_ScriptWithExtensionsBorrowed_get_script_val_mv2(handle, ch);
+        return (Script.fromNative(returnVal))
     }
     
     /** Get the Script property value for a code point
@@ -75,9 +74,9 @@ class ScriptWithExtensionsBorrowed internal constructor (
     *
     *See the [Rust documentation for `has_script`](https://docs.rs/icu/2.2.0/icu/properties/script/struct.ScriptWithExtensionsBorrowed.html#method.has_script) for more information.
     */
-    fun hasScript(ch: Int, script: UShort): Boolean {
+    fun hasScript(ch: Int, script: Script): Boolean {
         
-        val returnVal = lib.icu4x_ScriptWithExtensionsBorrowed_has_script_mv1(handle, ch, FFIUint16(script));
+        val returnVal = lib.icu4x_ScriptWithExtensionsBorrowed_has_script_mv2(handle, ch, script.toNative());
         return (returnVal > 0)
     }
     
@@ -86,9 +85,9 @@ class ScriptWithExtensionsBorrowed internal constructor (
     *
     *See the [Rust documentation for `get_script_extensions_set`](https://docs.rs/icu/2.2.0/icu/properties/script/struct.ScriptWithExtensionsBorrowed.html#method.get_script_extensions_set) for more information.
     */
-    fun getScriptExtensionsSet(script: UShort): CodePointSetData {
+    fun getScriptExtensionsSet(script: Script): CodePointSetData {
         
-        val returnVal = lib.icu4x_ScriptWithExtensionsBorrowed_get_script_extensions_set_mv1(handle, FFIUint16(script));
+        val returnVal = lib.icu4x_ScriptWithExtensionsBorrowed_get_script_extensions_set_mv2(handle, script.toNative());
         val selfEdges: List<Any> = listOf()
         val handle = returnVal 
         val returnOpaque = CodePointSetData(handle, selfEdges, true)

--- a/ffi/npm/lib/ScriptWithExtensionsBorrowed.d.ts
+++ b/ffi/npm/lib/ScriptWithExtensionsBorrowed.d.ts
@@ -19,7 +19,6 @@ export class ScriptWithExtensionsBorrowed {
 
     /**
      * Get the Script property value for a code point
-     * Get the Script property value for a code point
      *
      * See the [Rust documentation for `get_script_val`](https://docs.rs/icu/2.2.0/icu/properties/script/struct.ScriptWithExtensionsBorrowed.html#method.get_script_val) for more information.
      */

--- a/ffi/npm/lib/ScriptWithExtensionsBorrowed.mjs
+++ b/ffi/npm/lib/ScriptWithExtensionsBorrowed.mjs
@@ -46,7 +46,6 @@ export class ScriptWithExtensionsBorrowed {
 
     /**
      * Get the Script property value for a code point
-     * Get the Script property value for a code point
      *
      * See the [Rust documentation for `get_script_val`](https://docs.rs/icu/2.2.0/icu/properties/script/struct.ScriptWithExtensionsBorrowed.html#method.get_script_val) for more information.
      */


### PR DESCRIPTION
We currently use raw `u16`s, even though we have a `Script` type.

I'm not sure whether this is breaking for JS, and whether we care about the breakage for C++ and C, so I've only done this for Dart and Kotlin.

## Changelog

`icu_capi`:
* Dart, Kotlin: use the `Script` type on `ScriptExtension` APIs