### PR TITLE
Make CCC a transparent newtype, deprecate `icu4c_value` conversions

### DIFF
--- a/components/collator/src/elements.rs
+++ b/components/collator/src/elements.rs
@@ -146,7 +146,7 @@ fn decomposition_starts_with_non_starter(trie_value: u32) -> bool {
 /// See components/normalizer/trie-value-format.md
 fn ccc_from_trie_value(trie_value: u32) -> CanonicalCombiningClass {
     if trie_value_has_ccc(trie_value) {
-        CanonicalCombiningClass::from_icu4c_value(trie_value as u8)
+        CanonicalCombiningClass(trie_value as u8)
     } else {
         CanonicalCombiningClass::NotReordered
     }
@@ -727,7 +727,7 @@ impl CharacterAndClassAndTrieValue {
     pub fn new_with_non_zero_ccc(c: char, ccc: CanonicalCombiningClass) -> Self {
         CharacterAndClassAndTrieValue {
             c_and_c: CharacterAndClass::new(c, ccc),
-            trie_val: 0xD800 | u32::from(ccc.to_icu4c_value()),
+            trie_val: 0xD800 | u32::from(ccc.0),
         }
     }
     pub fn new_with_non_special_decomposition_trie_val(c: char, trie_val: u32) -> Self {
@@ -747,7 +747,7 @@ impl CharacterAndClassAndTrieValue {
             }
         } else {
             CharacterAndClassAndTrieValue {
-                c_and_c: CharacterAndClass::new(c, CanonicalCombiningClass::from_icu4c_value(0xFF)),
+                c_and_c: CharacterAndClass::new(c, CanonicalCombiningClass(0xFF)),
                 trie_val,
             }
         }
@@ -763,7 +763,7 @@ impl CharacterAndClassAndTrieValue {
 
     fn ccc(&self) -> CanonicalCombiningClass {
         let ret = self.c_and_c.ccc();
-        debug_assert_ne!(ret, CanonicalCombiningClass::from_icu4c_value(0xFF));
+        debug_assert_ne!(ret, CanonicalCombiningClass(0xFF));
         ret
     }
 }
@@ -798,7 +798,7 @@ impl CharacterAndClass {
     pub fn new(c: char, ccc: CanonicalCombiningClass) -> Self {
         // Safety invariant upheld here: the first half is a valid char
         // and the second half does not affect the low 24 bits
-        CharacterAndClass(u32::from(c) | (u32::from(ccc.to_icu4c_value()) << 24))
+        CharacterAndClass(u32::from(c) | (u32::from(ccc.0) << 24))
     }
     pub fn new_with_placeholder(c: char) -> Self {
         // Safety invariant upheld here: the first half is a valid char
@@ -815,7 +815,7 @@ impl CharacterAndClass {
     pub fn ccc(&self) -> CanonicalCombiningClass {
         // Safety invariant upheld here: The argument is outside of the low 24 bits,
         // and \0 is a valid character
-        CanonicalCombiningClass::from_icu4c_value((self.0 >> 24) as u8)
+        CanonicalCombiningClass((self.0 >> 24) as u8)
     }
     pub fn character_and_ccc(&self) -> (char, CanonicalCombiningClass) {
         (self.character(), self.ccc())
@@ -827,8 +827,7 @@ impl CharacterAndClass {
         let scalar = self.0 & 0xFF_FFFF;
         // Safety invariant upheld here: The first half doesn't affect the lower 24 bits,
         // and the second half was taken from the old `self` which had these invariants upheld already.
-        self.0 =
-            ((ccc_from_trie_value(trie.get32_u32(scalar)).to_icu4c_value() as u32) << 24) | scalar;
+        self.0 = ((ccc_from_trie_value(trie.get32_u32(scalar)).0 as u32) << 24) | scalar;
     }
 }
 

--- a/components/normalizer/src/lib.rs
+++ b/components/normalizer/src/lib.rs
@@ -83,20 +83,6 @@ type Trie<'trie> = CodePointTrie<'trie, u32>;
 #[cfg(icu4x_unstable_fast_trie_only)]
 type Trie<'trie> = FastCodePointTrie<'trie, u32>;
 
-// We don't depend on icu_properties to minimize deps, but we want to be able
-// to ensure we're using the right CCC values
-macro_rules! ccc {
-    ($name:ident, $num:expr) => {
-        const {
-            #[cfg(feature = "icu_properties")]
-            if icu_properties::props::CanonicalCombiningClass::$name.to_icu4c_value() != $num {
-                panic!("icu_normalizer has incorrect ccc values")
-            }
-            CanonicalCombiningClass::from_icu4c_value($num)
-        }
-    };
-}
-
 #[cfg(feature = "harfbuzz_traits")]
 mod harfbuzz;
 pub mod properties;
@@ -174,20 +160,16 @@ fn likely(b: bool) -> bool {
 // It should not be exposed to users.
 #[cfg(not(feature = "icu_properties"))]
 #[derive(Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
-struct CanonicalCombiningClass(pub(crate) u8);
+struct CanonicalCombiningClass(u8);
 
 #[cfg(not(feature = "icu_properties"))]
+#[allow(non_upper_case_globals)]
 impl CanonicalCombiningClass {
-    const fn from_icu4c_value(v: u8) -> Self {
-        Self(v)
-    }
-    const fn to_icu4c_value(self) -> u8 {
-        self.0
-    }
+    // See https://www.unicode.org/reports/tr44/#Canonical_Combining_Class_Values
+    const NotReordered: Self = Self(0);
+    const Above: Self = Self(230);
+    const KanaVoicing: Self = Self(8);
 }
-
-const CCC_NOT_REORDERED: CanonicalCombiningClass = ccc!(NotReordered, 0);
-const CCC_ABOVE: CanonicalCombiningClass = ccc!(Above, 230);
 
 /// Treatment of the ignorable marker (0xFFFFFFFF) in data.
 #[derive(Debug, PartialEq, Eq)]
@@ -259,9 +241,9 @@ fn decomposition_starts_with_non_starter(trie_value: u32) -> bool {
 /// See trie-value-format.md
 fn ccc_from_trie_value(trie_value: u32) -> CanonicalCombiningClass {
     if trie_value_has_ccc(trie_value) {
-        CanonicalCombiningClass::from_icu4c_value(trie_value as u8)
+        CanonicalCombiningClass(trie_value as u8)
     } else {
-        CCC_NOT_REORDERED
+        CanonicalCombiningClass::NotReordered
     }
 }
 
@@ -502,7 +484,7 @@ struct CharacterAndClass(u32);
 
 impl CharacterAndClass {
     pub fn new(c: char, ccc: CanonicalCombiningClass) -> Self {
-        CharacterAndClass(u32::from(c) | (u32::from(ccc.to_icu4c_value()) << 24))
+        CharacterAndClass(u32::from(c) | (u32::from(ccc.0) << 24))
     }
     pub fn new_with_placeholder(c: char) -> Self {
         CharacterAndClass(u32::from(c) | ((0xFF) << 24))
@@ -522,7 +504,7 @@ impl CharacterAndClass {
     }
     /// This method must exist for Pernosco to apply its special rendering.
     pub fn ccc(&self) -> CanonicalCombiningClass {
-        CanonicalCombiningClass::from_icu4c_value((self.0 >> 24) as u8)
+        CanonicalCombiningClass((self.0 >> 24) as u8)
     }
 
     pub fn character_and_ccc(&self) -> (char, CanonicalCombiningClass) {
@@ -533,8 +515,7 @@ impl CharacterAndClass {
             return;
         }
         let scalar = self.0 & 0xFFFFFF;
-        self.0 =
-            ((ccc_from_trie_value(trie.get32_u32(scalar)).to_icu4c_value() as u32) << 24) | scalar;
+        self.0 = ((ccc_from_trie_value(trie.get32_u32(scalar)).0 as u32) << 24) | scalar;
     }
 }
 
@@ -943,47 +924,55 @@ where
                 let mapped = match ch_and_trie_val.character {
                     '\u{0340}' => {
                         // COMBINING GRAVE TONE MARK
-                        CharacterAndClass::new('\u{0300}', CCC_ABOVE)
+                        CharacterAndClass::new('\u{0300}', CanonicalCombiningClass::Above)
                     }
                     '\u{0341}' => {
                         // COMBINING ACUTE TONE MARK
-                        CharacterAndClass::new('\u{0301}', CCC_ABOVE)
+                        CharacterAndClass::new('\u{0301}', CanonicalCombiningClass::Above)
                     }
                     '\u{0343}' => {
                         // COMBINING GREEK KORONIS
-                        CharacterAndClass::new('\u{0313}', CCC_ABOVE)
+                        CharacterAndClass::new('\u{0313}', CanonicalCombiningClass::Above)
                     }
                     '\u{0344}' => {
                         // COMBINING GREEK DIALYTIKA TONOS
-                        self.buffer
-                            .push(CharacterAndClass::new('\u{0308}', CCC_ABOVE));
-                        CharacterAndClass::new('\u{0301}', CCC_ABOVE)
+                        self.buffer.push(CharacterAndClass::new(
+                            '\u{0308}',
+                            CanonicalCombiningClass::Above,
+                        ));
+                        CharacterAndClass::new('\u{0301}', CanonicalCombiningClass::Above)
                     }
                     '\u{0F73}' => {
                         // TIBETAN VOWEL SIGN II
-                        self.buffer
-                            .push(CharacterAndClass::new('\u{0F71}', ccc!(CCC129, 129)));
-                        CharacterAndClass::new('\u{0F72}', ccc!(CCC130, 130))
+                        self.buffer.push(CharacterAndClass::new(
+                            '\u{0F71}',
+                            CanonicalCombiningClass(129),
+                        ));
+                        CharacterAndClass::new('\u{0F72}', CanonicalCombiningClass(130))
                     }
                     '\u{0F75}' => {
                         // TIBETAN VOWEL SIGN UU
-                        self.buffer
-                            .push(CharacterAndClass::new('\u{0F71}', ccc!(CCC129, 129)));
-                        CharacterAndClass::new('\u{0F74}', ccc!(CCC132, 132))
+                        self.buffer.push(CharacterAndClass::new(
+                            '\u{0F71}',
+                            CanonicalCombiningClass(129),
+                        ));
+                        CharacterAndClass::new('\u{0F74}', CanonicalCombiningClass(132))
                     }
                     '\u{0F81}' => {
                         // TIBETAN VOWEL SIGN REVERSED II
-                        self.buffer
-                            .push(CharacterAndClass::new('\u{0F71}', ccc!(CCC129, 129)));
-                        CharacterAndClass::new('\u{0F80}', ccc!(CCC130, 130))
+                        self.buffer.push(CharacterAndClass::new(
+                            '\u{0F71}',
+                            CanonicalCombiningClass(129),
+                        ));
+                        CharacterAndClass::new('\u{0F80}', CanonicalCombiningClass(130))
                     }
                     '\u{FF9E}' => {
                         // HALFWIDTH KATAKANA VOICED SOUND MARK
-                        CharacterAndClass::new('\u{3099}', ccc!(KanaVoicing, 8))
+                        CharacterAndClass::new('\u{3099}', CanonicalCombiningClass::KanaVoicing)
                     }
                     '\u{FF9F}' => {
                         // HALFWIDTH KATAKANA VOICED SOUND MARK
-                        CharacterAndClass::new('\u{309A}', ccc!(KanaVoicing, 8))
+                        CharacterAndClass::new('\u{309A}', CanonicalCombiningClass::KanaVoicing)
                     }
                     _ => {
                         // GIGO case
@@ -1105,7 +1094,7 @@ where
                         self.decomposition.buffer.clear();
                         self.decomposition.buffer_pos = 0;
                     }
-                    if ccc == CCC_NOT_REORDERED {
+                    if ccc == CanonicalCombiningClass::NotReordered {
                         // Previous decomposition contains a starter. This must
                         // now become the `unprocessed_starter` for it to have
                         // a chance to compose with the upcoming characters.
@@ -1197,7 +1186,7 @@ where
                         .drain(0..self.decomposition.buffer_pos);
                 }
                 self.decomposition.buffer_pos = 0;
-                if most_recent_skipped_ccc == CCC_NOT_REORDERED {
+                if most_recent_skipped_ccc == CanonicalCombiningClass::NotReordered {
                     // We failed to compose a starter. Discontiguous match not allowed.
                     // We leave the starter in `buffer` for `next()` to find.
                     return Some(starter);
@@ -1209,7 +1198,7 @@ where
                     .get(i)
                     .map(|c| c.character_and_ccc())
                 {
-                    if ccc == CCC_NOT_REORDERED {
+                    if ccc == CanonicalCombiningClass::NotReordered {
                         // Discontiguous match not allowed.
                         return Some(starter);
                     }
@@ -1348,7 +1337,7 @@ macro_rules! composing_normalize_to {
                             continue;
                         }
                         let mut most_recent_skipped_ccc = ccc;
-                        if most_recent_skipped_ccc == CCC_NOT_REORDERED {
+                        if most_recent_skipped_ccc == CanonicalCombiningClass::NotReordered {
                             // We failed to compose a starter. Discontiguous match not allowed.
                             // Write the current `starter` we've been composing, make the unmatched
                             // starter in the buffer the new `starter` (we know it's been decomposed)
@@ -1373,7 +1362,7 @@ macro_rules! composing_normalize_to {
                             .get(i)
                             .map(|c| c.character_and_ccc())
                         {
-                            if ccc == CCC_NOT_REORDERED {
+                            if ccc == CanonicalCombiningClass::NotReordered {
                                 // Discontiguous match not allowed.
                                 $sink.write_char(starter)?;
                                 for cc in $composition.decomposition.buffer.drain(..i) {

--- a/components/normalizer/src/properties.rs
+++ b/components/normalizer/src/properties.rs
@@ -564,35 +564,45 @@ impl CanonicalCombiningClassMapBorrowed<'static> {
 }
 
 impl CanonicalCombiningClassMapBorrowed<'_> {
+    #[inline(always)]
+    fn get_internal(&self, c: char) -> CanonicalCombiningClass {
+        let trie_value = self.decompositions.trie.get(c);
+        if trie_value_has_ccc(trie_value) {
+            CanonicalCombiningClass(trie_value as u8)
+        } else {
+            CanonicalCombiningClass::NotReordered
+        }
+    }
+
+    #[inline(always)]
+    fn get32_internal(&self, c: u32) -> CanonicalCombiningClass {
+        let trie_value = self.decompositions.trie.get32(c);
+        if trie_value_has_ccc(trie_value) {
+            CanonicalCombiningClass(trie_value as u8)
+        } else {
+            CanonicalCombiningClass::NotReordered
+        }
+    }
+
     /// Look up the canonical combining class for a scalar value.
     ///
-    /// The return value is a u8 representing the canonical combining class,
+    /// The return value is a `u8` representing the canonical combining class,
     /// you may enable the `"icu_properties"` feature if you would like to use a typed
     /// `CanonicalCombiningClass`.
     #[inline(always)]
     pub fn get_u8(&self, c: char) -> u8 {
-        let trie_value = self.decompositions.trie.get(c);
-        if trie_value_has_ccc(trie_value) {
-            trie_value as u8
-        } else {
-            ccc!(NotReordered, 0).to_icu4c_value()
-        }
+        self.get_internal(c).0
     }
 
     /// Look up the canonical combining class for a scalar value
     /// represented as `u32`. If the argument is outside the scalar
-    /// value range, `Not_Reordered` is returned.
+    /// value range, `0` is returned.
     ///
-    /// The return value is a u8 representing the canonical combining class,
+    /// The return value is a `u8` representing the canonical combining class,
     /// you may enable the `"icu_properties"` feature if you would like to use a typed
     /// `CanonicalCombiningClass`.
     pub fn get32_u8(&self, c: u32) -> u8 {
-        let trie_value = self.decompositions.trie.get32(c);
-        if trie_value_has_ccc(trie_value) {
-            trie_value as u8
-        } else {
-            ccc!(NotReordered, 0).to_icu4c_value()
-        }
+        self.get32_internal(c).0
     }
 
     /// Look up the canonical combining class for a scalar value
@@ -601,7 +611,7 @@ impl CanonicalCombiningClassMapBorrowed<'_> {
     #[inline(always)]
     #[cfg(feature = "icu_properties")]
     pub fn get(&self, c: char) -> CanonicalCombiningClass {
-        CanonicalCombiningClass::from_icu4c_value(self.get_u8(c))
+        self.get_internal(c)
     }
 
     /// Look up the canonical combining class for a scalar value
@@ -611,7 +621,7 @@ impl CanonicalCombiningClassMapBorrowed<'_> {
     /// ✨ *Enabled with the `icu_properties` Cargo feature.*
     #[cfg(feature = "icu_properties")]
     pub fn get32(&self, c: u32) -> CanonicalCombiningClass {
-        CanonicalCombiningClass::from_icu4c_value(self.get32_u8(c))
+        self.get32_internal(c)
     }
 }
 

--- a/components/properties/src/props.rs
+++ b/components/properties/src/props.rs
@@ -75,7 +75,7 @@ macro_rules! create_const_array {
                     $(
                         Self::$i => databake::quote!(icu_properties::props::$enum_ty::$i),
                     )*
-                    Self(v) => databake::quote!(icu_properties::props::$enum_ty::from_icu4c_value(#v)),
+                    Self(v) => databake::quote!(icu_properties::props::$enum_ty(#v)),
                 }
             }
         }
@@ -178,10 +178,12 @@ pub struct BidiClass(pub(crate) u8);
 
 impl BidiClass {
     /// Returns an ICU4C `UBidiClass` value.
+    #[deprecated]
     pub const fn to_icu4c_value(self) -> u8 {
         self.0
     }
     /// Constructor from an ICU4C `UBidiClass` value.
+    #[deprecated]
     pub const fn from_icu4c_value(value: u8) -> Self {
         Self(value)
     }
@@ -278,10 +280,12 @@ pub struct NumericType(pub(crate) u8);
 
 impl NumericType {
     /// Returns an ICU4C `UNumericType` value.
+    #[deprecated]
     pub const fn to_icu4c_value(self) -> u8 {
         self.0
     }
     /// Constructor from an ICU4C `UNumericType` value.
+    #[deprecated]
     pub const fn from_icu4c_value(value: u8) -> Self {
         Self(value)
     }
@@ -829,10 +833,12 @@ pub struct Script(pub(crate) u16);
 
 impl Script {
     /// Returns an ICU4C `UScriptCode` value.
+    #[deprecated]
     pub const fn to_icu4c_value(self) -> u16 {
         self.0
     }
     /// Constructor from an ICU4C `UScriptCode` value.
+    #[deprecated]
     pub const fn from_icu4c_value(value: u16) -> Self {
         Self(value)
     }
@@ -1091,10 +1097,12 @@ pub struct HangulSyllableType(pub(crate) u8);
 
 impl HangulSyllableType {
     /// Returns an ICU4C `UHangulSyllableType` value.
+    #[deprecated]
     pub const fn to_icu4c_value(self) -> u8 {
         self.0
     }
     /// Constructor from an ICU4C `UHangulSyllableType` value.
+    #[deprecated]
     pub const fn from_icu4c_value(value: u8) -> Self {
         Self(value)
     }
@@ -1158,10 +1166,12 @@ pub struct EastAsianWidth(pub(crate) u8);
 
 impl EastAsianWidth {
     /// Returns an ICU4C `UEastAsianWidth` value.
+    #[deprecated]
     pub const fn to_icu4c_value(self) -> u8 {
         self.0
     }
     /// Constructor from an ICU4C `UEastAsianWidth` value.
+    #[deprecated]
     pub const fn from_icu4c_value(value: u8) -> Self {
         Self(value)
     }
@@ -1223,10 +1233,12 @@ pub struct LineBreak(pub(crate) u8);
 
 impl LineBreak {
     /// Returns an ICU4C `ULineBreak` value.
+    #[deprecated]
     pub const fn to_icu4c_value(self) -> u8 {
         self.0
     }
     /// Constructor from an ICU4C `ULineBreak` value.
+    #[deprecated]
     pub const fn from_icu4c_value(value: u8) -> Self {
         Self(value)
     }
@@ -1334,10 +1346,12 @@ pub struct GraphemeClusterBreak(pub(crate) u8);
 
 impl GraphemeClusterBreak {
     /// Returns an ICU4C `UGraphemeClusterBreak` value.
+    #[deprecated]
     pub const fn to_icu4c_value(self) -> u8 {
         self.0
     }
     /// Constructor from an ICU4C `UGraphemeClusterBreak` value.
+    #[deprecated]
     pub const fn from_icu4c_value(value: u8) -> Self {
         Self(value)
     }
@@ -1414,10 +1428,12 @@ pub struct WordBreak(pub(crate) u8);
 
 impl WordBreak {
     /// Returns an ICU4C `UWordBreak` value.
+    #[deprecated]
     pub const fn to_icu4c_value(self) -> u8 {
         self.0
     }
     /// Constructor from an ICU4C `UWordBreak` value.
+    #[deprecated]
     pub const fn from_icu4c_value(value: u8) -> Self {
         Self(value)
     }
@@ -1499,10 +1515,12 @@ pub struct SentenceBreak(pub(crate) u8);
 
 impl SentenceBreak {
     /// Returns an ICU4C `USentenceBreak` value.
+    #[deprecated]
     pub const fn to_icu4c_value(self) -> u8 {
         self.0
     }
     /// Constructor from an ICU4C `USentenceBreak` value.
+    #[deprecated]
     pub const fn from_icu4c_value(value: u8) -> Self {
         Self(value)
     }
@@ -1576,10 +1594,12 @@ pub struct CanonicalCombiningClass(pub u8);
 
 impl CanonicalCombiningClass {
     /// Returns an ICU4C `UCanonicalCombiningClass` value.
+    #[deprecated]
     pub const fn to_icu4c_value(self) -> u8 {
         self.0
     }
     /// Constructor from an ICU4C `UCanonicalCombiningClass` value.
+    #[deprecated]
     pub const fn from_icu4c_value(value: u8) -> Self {
         Self(value)
     }
@@ -1697,10 +1717,12 @@ pub struct IndicConjunctBreak(pub(crate) u8);
 
 impl IndicConjunctBreak {
     /// Returns an ICU4C `UIndicConjunctBreak` value.
+    #[deprecated]
     pub const fn to_icu4c_value(self) -> u8 {
         self.0
     }
     /// Constructor from an ICU4C `UIndicConjunctBreak` value.
+    #[deprecated]
     pub const fn from_icu4c_value(value: u8) -> Self {
         Self(value)
     }
@@ -1755,10 +1777,12 @@ pub struct IndicSyllabicCategory(pub(crate) u8);
 
 impl IndicSyllabicCategory {
     /// Returns an ICU4C `UIndicSyllabicCategory` value.
+    #[deprecated]
     pub const fn to_icu4c_value(self) -> u8 {
         self.0
     }
     /// Constructor from an ICU4C `UIndicSyllabicCategory` value.
+    #[deprecated]
     pub const fn from_icu4c_value(value: u8) -> Self {
         Self(value)
     }
@@ -1845,10 +1869,12 @@ pub struct JoiningGroup(pub(crate) u8);
 
 impl JoiningGroup {
     /// Returns an ICU4C `UJoiningType` value.
+    #[deprecated]
     pub const fn to_icu4c_value(self) -> u8 {
         self.0
     }
     /// Constructor from an ICU4C `UJoiningType` value.
+    #[deprecated]
     pub const fn from_icu4c_value(value: u8) -> Self {
         Self(value)
     }
@@ -2006,10 +2032,12 @@ pub struct JoiningType(pub(crate) u8);
 
 impl JoiningType {
     /// Returns an ICU4C `UJoiningType` value.
+    #[deprecated]
     pub const fn to_icu4c_value(self) -> u8 {
         self.0
     }
     /// Constructor from an ICU4C `UJoiningType` value.
+    #[deprecated]
     pub const fn from_icu4c_value(value: u8) -> Self {
         Self(value)
     }
@@ -2075,10 +2103,12 @@ pub struct VerticalOrientation(pub(crate) u8);
 
 impl VerticalOrientation {
     /// Returns an ICU4C `UVerticalOrientation` value.
+    #[deprecated]
     pub const fn to_icu4c_value(self) -> u8 {
         self.0
     }
     /// Constructor from an ICU4C `UVerticalOrientation` value.
+    #[deprecated]
     pub const fn from_icu4c_value(value: u8) -> Self {
         Self(value)
     }

--- a/components/properties/src/props.rs
+++ b/components/properties/src/props.rs
@@ -1546,10 +1546,7 @@ make_enumerated_property! {
 /// See UAX #15:
 /// <https://www.unicode.org/reports/tr15/>.
 ///
-/// See `icu::normalizer::properties::CanonicalCombiningClassMap` for the API
-/// to look up the `Canonical_Combining_Class` property by scalar value.
-///
-/// **Note:** See `icu::normalizer::CanonicalCombiningClassMap` for the preferred API
+/// **Note:** See `icu::normalizer::properties::CanonicalCombiningClassMap` for the preferred API
 /// to look up the `Canonical_Combining_Class` property by scalar value.
 ///
 /// # Example
@@ -1575,7 +1572,7 @@ make_enumerated_property! {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::exhaustive_structs)] // newtype
 #[repr(transparent)]
-pub struct CanonicalCombiningClass(pub(crate) u8);
+pub struct CanonicalCombiningClass(pub u8);
 
 impl CanonicalCombiningClass {
     /// Returns an ICU4C `UCanonicalCombiningClass` value.

--- a/components/properties/src/props.rs
+++ b/components/properties/src/props.rs
@@ -178,12 +178,18 @@ pub struct BidiClass(pub(crate) u8);
 
 impl BidiClass {
     /// Returns an ICU4C `UBidiClass` value.
-    #[deprecated]
+    #[deprecated(
+        since = "2.3.0",
+        note = "please comment on https://github.com/unicode-org/icu4x/issues/6067 if you need this"
+    )]
     pub const fn to_icu4c_value(self) -> u8 {
         self.0
     }
     /// Constructor from an ICU4C `UBidiClass` value.
-    #[deprecated]
+    #[deprecated(
+        since = "2.3.0",
+        note = "please comment on https://github.com/unicode-org/icu4x/issues/6067 if you need this"
+    )]
     pub const fn from_icu4c_value(value: u8) -> Self {
         Self(value)
     }
@@ -280,12 +286,18 @@ pub struct NumericType(pub(crate) u8);
 
 impl NumericType {
     /// Returns an ICU4C `UNumericType` value.
-    #[deprecated]
+    #[deprecated(
+        since = "2.3.0",
+        note = "please comment on https://github.com/unicode-org/icu4x/issues/6067 if you need this"
+    )]
     pub const fn to_icu4c_value(self) -> u8 {
         self.0
     }
     /// Constructor from an ICU4C `UNumericType` value.
-    #[deprecated]
+    #[deprecated(
+        since = "2.3.0",
+        note = "please comment on https://github.com/unicode-org/icu4x/issues/6067 if you need this"
+    )]
     pub const fn from_icu4c_value(value: u8) -> Self {
         Self(value)
     }
@@ -833,12 +845,18 @@ pub struct Script(pub(crate) u16);
 
 impl Script {
     /// Returns an ICU4C `UScriptCode` value.
-    #[deprecated]
+    #[deprecated(
+        since = "2.3.0",
+        note = "please comment on https://github.com/unicode-org/icu4x/issues/6067 if you need this"
+    )]
     pub const fn to_icu4c_value(self) -> u16 {
         self.0
     }
     /// Constructor from an ICU4C `UScriptCode` value.
-    #[deprecated]
+    #[deprecated(
+        since = "2.3.0",
+        note = "please comment on https://github.com/unicode-org/icu4x/issues/6067 if you need this"
+    )]
     pub const fn from_icu4c_value(value: u16) -> Self {
         Self(value)
     }
@@ -1034,7 +1052,10 @@ impl Script {
     // Doesn't actually exist!
     #[doc(hidden)]
     #[allow(non_upper_case_globals)]
-    #[deprecated]
+    #[deprecated(
+        since = "2.3.0",
+        note = "please comment on https://github.com/unicode-org/icu4x/issues/6067 if you need this"
+    )]
     // Some high value that ICU4C will not use anytime soon
     pub const Chisoi: Script = Self(60_000);
 }
@@ -1097,12 +1118,18 @@ pub struct HangulSyllableType(pub(crate) u8);
 
 impl HangulSyllableType {
     /// Returns an ICU4C `UHangulSyllableType` value.
-    #[deprecated]
+    #[deprecated(
+        since = "2.3.0",
+        note = "please comment on https://github.com/unicode-org/icu4x/issues/6067 if you need this"
+    )]
     pub const fn to_icu4c_value(self) -> u8 {
         self.0
     }
     /// Constructor from an ICU4C `UHangulSyllableType` value.
-    #[deprecated]
+    #[deprecated(
+        since = "2.3.0",
+        note = "please comment on https://github.com/unicode-org/icu4x/issues/6067 if you need this"
+    )]
     pub const fn from_icu4c_value(value: u8) -> Self {
         Self(value)
     }
@@ -1166,12 +1193,18 @@ pub struct EastAsianWidth(pub(crate) u8);
 
 impl EastAsianWidth {
     /// Returns an ICU4C `UEastAsianWidth` value.
-    #[deprecated]
+    #[deprecated(
+        since = "2.3.0",
+        note = "please comment on https://github.com/unicode-org/icu4x/issues/6067 if you need this"
+    )]
     pub const fn to_icu4c_value(self) -> u8 {
         self.0
     }
     /// Constructor from an ICU4C `UEastAsianWidth` value.
-    #[deprecated]
+    #[deprecated(
+        since = "2.3.0",
+        note = "please comment on https://github.com/unicode-org/icu4x/issues/6067 if you need this"
+    )]
     pub const fn from_icu4c_value(value: u8) -> Self {
         Self(value)
     }
@@ -1233,12 +1266,18 @@ pub struct LineBreak(pub(crate) u8);
 
 impl LineBreak {
     /// Returns an ICU4C `ULineBreak` value.
-    #[deprecated]
+    #[deprecated(
+        since = "2.3.0",
+        note = "please comment on https://github.com/unicode-org/icu4x/issues/6067 if you need this"
+    )]
     pub const fn to_icu4c_value(self) -> u8 {
         self.0
     }
     /// Constructor from an ICU4C `ULineBreak` value.
-    #[deprecated]
+    #[deprecated(
+        since = "2.3.0",
+        note = "please comment on https://github.com/unicode-org/icu4x/issues/6067 if you need this"
+    )]
     pub const fn from_icu4c_value(value: u8) -> Self {
         Self(value)
     }
@@ -1346,12 +1385,18 @@ pub struct GraphemeClusterBreak(pub(crate) u8);
 
 impl GraphemeClusterBreak {
     /// Returns an ICU4C `UGraphemeClusterBreak` value.
-    #[deprecated]
+    #[deprecated(
+        since = "2.3.0",
+        note = "please comment on https://github.com/unicode-org/icu4x/issues/6067 if you need this"
+    )]
     pub const fn to_icu4c_value(self) -> u8 {
         self.0
     }
     /// Constructor from an ICU4C `UGraphemeClusterBreak` value.
-    #[deprecated]
+    #[deprecated(
+        since = "2.3.0",
+        note = "please comment on https://github.com/unicode-org/icu4x/issues/6067 if you need this"
+    )]
     pub const fn from_icu4c_value(value: u8) -> Self {
         Self(value)
     }
@@ -1428,12 +1473,18 @@ pub struct WordBreak(pub(crate) u8);
 
 impl WordBreak {
     /// Returns an ICU4C `UWordBreak` value.
-    #[deprecated]
+    #[deprecated(
+        since = "2.3.0",
+        note = "please comment on https://github.com/unicode-org/icu4x/issues/6067 if you need this"
+    )]
     pub const fn to_icu4c_value(self) -> u8 {
         self.0
     }
     /// Constructor from an ICU4C `UWordBreak` value.
-    #[deprecated]
+    #[deprecated(
+        since = "2.3.0",
+        note = "please comment on https://github.com/unicode-org/icu4x/issues/6067 if you need this"
+    )]
     pub const fn from_icu4c_value(value: u8) -> Self {
         Self(value)
     }
@@ -1515,12 +1566,18 @@ pub struct SentenceBreak(pub(crate) u8);
 
 impl SentenceBreak {
     /// Returns an ICU4C `USentenceBreak` value.
-    #[deprecated]
+    #[deprecated(
+        since = "2.3.0",
+        note = "please comment on https://github.com/unicode-org/icu4x/issues/6067 if you need this"
+    )]
     pub const fn to_icu4c_value(self) -> u8 {
         self.0
     }
     /// Constructor from an ICU4C `USentenceBreak` value.
-    #[deprecated]
+    #[deprecated(
+        since = "2.3.0",
+        note = "please comment on https://github.com/unicode-org/icu4x/issues/6067 if you need this"
+    )]
     pub const fn from_icu4c_value(value: u8) -> Self {
         Self(value)
     }
@@ -1594,12 +1651,18 @@ pub struct CanonicalCombiningClass(pub u8);
 
 impl CanonicalCombiningClass {
     /// Returns an ICU4C `UCanonicalCombiningClass` value.
-    #[deprecated]
+    #[deprecated(
+        since = "2.3.0",
+        note = "please comment on https://github.com/unicode-org/icu4x/issues/6067 if you need this"
+    )]
     pub const fn to_icu4c_value(self) -> u8 {
         self.0
     }
     /// Constructor from an ICU4C `UCanonicalCombiningClass` value.
-    #[deprecated]
+    #[deprecated(
+        since = "2.3.0",
+        note = "please comment on https://github.com/unicode-org/icu4x/issues/6067 if you need this"
+    )]
     pub const fn from_icu4c_value(value: u8) -> Self {
         Self(value)
     }
@@ -1717,12 +1780,18 @@ pub struct IndicConjunctBreak(pub(crate) u8);
 
 impl IndicConjunctBreak {
     /// Returns an ICU4C `UIndicConjunctBreak` value.
-    #[deprecated]
+    #[deprecated(
+        since = "2.3.0",
+        note = "please comment on https://github.com/unicode-org/icu4x/issues/6067 if you need this"
+    )]
     pub const fn to_icu4c_value(self) -> u8 {
         self.0
     }
     /// Constructor from an ICU4C `UIndicConjunctBreak` value.
-    #[deprecated]
+    #[deprecated(
+        since = "2.3.0",
+        note = "please comment on https://github.com/unicode-org/icu4x/issues/6067 if you need this"
+    )]
     pub const fn from_icu4c_value(value: u8) -> Self {
         Self(value)
     }
@@ -1777,12 +1846,18 @@ pub struct IndicSyllabicCategory(pub(crate) u8);
 
 impl IndicSyllabicCategory {
     /// Returns an ICU4C `UIndicSyllabicCategory` value.
-    #[deprecated]
+    #[deprecated(
+        since = "2.3.0",
+        note = "please comment on https://github.com/unicode-org/icu4x/issues/6067 if you need this"
+    )]
     pub const fn to_icu4c_value(self) -> u8 {
         self.0
     }
     /// Constructor from an ICU4C `UIndicSyllabicCategory` value.
-    #[deprecated]
+    #[deprecated(
+        since = "2.3.0",
+        note = "please comment on https://github.com/unicode-org/icu4x/issues/6067 if you need this"
+    )]
     pub const fn from_icu4c_value(value: u8) -> Self {
         Self(value)
     }
@@ -1869,12 +1944,18 @@ pub struct JoiningGroup(pub(crate) u8);
 
 impl JoiningGroup {
     /// Returns an ICU4C `UJoiningType` value.
-    #[deprecated]
+    #[deprecated(
+        since = "2.3.0",
+        note = "please comment on https://github.com/unicode-org/icu4x/issues/6067 if you need this"
+    )]
     pub const fn to_icu4c_value(self) -> u8 {
         self.0
     }
     /// Constructor from an ICU4C `UJoiningType` value.
-    #[deprecated]
+    #[deprecated(
+        since = "2.3.0",
+        note = "please comment on https://github.com/unicode-org/icu4x/issues/6067 if you need this"
+    )]
     pub const fn from_icu4c_value(value: u8) -> Self {
         Self(value)
     }
@@ -2032,12 +2113,18 @@ pub struct JoiningType(pub(crate) u8);
 
 impl JoiningType {
     /// Returns an ICU4C `UJoiningType` value.
-    #[deprecated]
+    #[deprecated(
+        since = "2.3.0",
+        note = "please comment on https://github.com/unicode-org/icu4x/issues/6067 if you need this"
+    )]
     pub const fn to_icu4c_value(self) -> u8 {
         self.0
     }
     /// Constructor from an ICU4C `UJoiningType` value.
-    #[deprecated]
+    #[deprecated(
+        since = "2.3.0",
+        note = "please comment on https://github.com/unicode-org/icu4x/issues/6067 if you need this"
+    )]
     pub const fn from_icu4c_value(value: u8) -> Self {
         Self(value)
     }
@@ -2103,12 +2190,18 @@ pub struct VerticalOrientation(pub(crate) u8);
 
 impl VerticalOrientation {
     /// Returns an ICU4C `UVerticalOrientation` value.
-    #[deprecated]
+    #[deprecated(
+        since = "2.3.0",
+        note = "please comment on https://github.com/unicode-org/icu4x/issues/6067 if you need this"
+    )]
     pub const fn to_icu4c_value(self) -> u8 {
         self.0
     }
     /// Constructor from an ICU4C `UVerticalOrientation` value.
-    #[deprecated]
+    #[deprecated(
+        since = "2.3.0",
+        note = "please comment on https://github.com/unicode-org/icu4x/issues/6067 if you need this"
+    )]
     pub const fn from_icu4c_value(value: u8) -> Self {
         Self(value)
     }

--- a/components/properties/src/script.rs
+++ b/components/properties/src/script.rs
@@ -726,4 +726,10 @@ mod tests {
             ]
         );
     }
+
+    #[test]
+    fn test_high_discriminant() {
+        let swe = ScriptWithExtensions::new();
+        assert!(!swe.has_script32(0x0640, Script(0xAFFE)));
+    }
 }

--- a/components/properties/src/script.rs
+++ b/components/properties/src/script.rs
@@ -51,7 +51,7 @@ impl ScriptWithExt {
     pub const Unknown: ScriptWithExt = Self::single(Script::Unknown);
 
     pub const fn single(script: Script) -> Self {
-        Self(script.to_icu4c_value() & SCRIPT_X_SCRIPT_VAL)
+        Self(script.0 & SCRIPT_X_SCRIPT_VAL)
     }
 
     pub const fn new(script: Script, extensions: u16) -> Self {

--- a/components/properties/src/unicodeset_parse/parse.rs
+++ b/components/properties/src/unicodeset_parse/parse.rs
@@ -1546,11 +1546,7 @@ where
             .as_borrowed()
             .get_loose(name)
             // TODO: make the property parser do this
-            .or_else(|| {
-                name.parse()
-                    .ok()
-                    .map(CanonicalCombiningClass::from_icu4c_value)
-            })
+            .or_else(|| name.parse().ok().map(CanonicalCombiningClass))
             .ok_or(PEK::UnknownProperty)?;
         // TODO(#3550): This could be cached; does not depend on name.
         let property_map =

--- a/ffi/capi/src/properties_enums.rs
+++ b/ffi/capi/src/properties_enums.rs
@@ -4520,125 +4520,74 @@ pub mod ffi {
     }
 }
 
-#[cfg(test)]
 #[rustfmt::skip]
-mod test {
-    use super::ffi::*;
+#[test]
+fn test_all_cases_covered() {
+    use ffi::*;
     use icu_properties::props;
-
-    #[test]
-    fn test_all_cases_covered() {
-        for prop in props::BidiClass::ALL_VALUES {
-            let ffi_prop = BidiClass::from_integer_value(prop.to_icu4c_value())
-                .expect("Found BidiClass value not supported in ffi");
-            assert_eq!(prop.to_icu4c_value(), ffi_prop.to_integer_value());
-            assert_eq!(*prop, props::BidiClass::from(ffi_prop));
-        }
-        
-        for prop in props::NumericType::ALL_VALUES {
-            let ffi_prop = NumericType::from_integer_value(prop.to_icu4c_value())
-                .expect("Found NumericType value not supported in ffi");
-            assert_eq!(prop.to_icu4c_value(), ffi_prop.to_integer_value());
-            assert_eq!(*prop, props::NumericType::from(ffi_prop));
-        }
-        
-        for prop in props::Script::ALL_VALUES {
-            let ffi_prop = Script::from_integer_value(prop.to_icu4c_value())
-                .expect("Found Script value not supported in ffi");
-            assert_eq!(prop.to_icu4c_value(), ffi_prop.to_integer_value());
-            assert_eq!(*prop, props::Script::from(ffi_prop));
-        }
-        
-        for prop in props::HangulSyllableType::ALL_VALUES {
-            let ffi_prop = HangulSyllableType::from_integer_value(prop.to_icu4c_value())
-                .expect("Found HangulSyllableType value not supported in ffi");
-            assert_eq!(prop.to_icu4c_value(), ffi_prop.to_integer_value());
-            assert_eq!(*prop, props::HangulSyllableType::from(ffi_prop));
-        }
-        
-        for prop in props::EastAsianWidth::ALL_VALUES {
-            let ffi_prop = EastAsianWidth::from_integer_value(prop.to_icu4c_value())
-                .expect("Found EastAsianWidth value not supported in ffi");
-            assert_eq!(prop.to_icu4c_value(), ffi_prop.to_integer_value());
-            assert_eq!(*prop, props::EastAsianWidth::from(ffi_prop));
-        }
-        
-        for prop in props::LineBreak::ALL_VALUES {
-            let ffi_prop = LineBreak::from_integer_value(prop.to_icu4c_value())
-                .expect("Found LineBreak value not supported in ffi");
-            assert_eq!(prop.to_icu4c_value(), ffi_prop.to_integer_value());
-            assert_eq!(*prop, props::LineBreak::from(ffi_prop));
-        }
-        
-        for prop in props::GraphemeClusterBreak::ALL_VALUES {
-            let ffi_prop = GraphemeClusterBreak::from_integer_value(prop.to_icu4c_value())
-                .expect("Found GraphemeClusterBreak value not supported in ffi");
-            assert_eq!(prop.to_icu4c_value(), ffi_prop.to_integer_value());
-            assert_eq!(*prop, props::GraphemeClusterBreak::from(ffi_prop));
-        }
-        
-        for prop in props::WordBreak::ALL_VALUES {
-            let ffi_prop = WordBreak::from_integer_value(prop.to_icu4c_value())
-                .expect("Found WordBreak value not supported in ffi");
-            assert_eq!(prop.to_icu4c_value(), ffi_prop.to_integer_value());
-            assert_eq!(*prop, props::WordBreak::from(ffi_prop));
-        }
-        
-        for prop in props::SentenceBreak::ALL_VALUES {
-            let ffi_prop = SentenceBreak::from_integer_value(prop.to_icu4c_value())
-                .expect("Found SentenceBreak value not supported in ffi");
-            assert_eq!(prop.to_icu4c_value(), ffi_prop.to_integer_value());
-            assert_eq!(*prop, props::SentenceBreak::from(ffi_prop));
-        }
-        
-        for prop in props::CanonicalCombiningClass::ALL_VALUES {
-            let ffi_prop = CanonicalCombiningClass::from_integer_value(prop.to_icu4c_value())
-                .expect("Found CanonicalCombiningClass value not supported in ffi");
-            assert_eq!(prop.to_icu4c_value(), ffi_prop.to_integer_value());
-            assert_eq!(*prop, props::CanonicalCombiningClass::from(ffi_prop));
-        }
-        
-        for prop in props::IndicSyllabicCategory::ALL_VALUES {
-            let ffi_prop = IndicSyllabicCategory::from_integer_value(prop.to_icu4c_value())
-                .expect("Found IndicSyllabicCategory value not supported in ffi");
-            assert_eq!(prop.to_icu4c_value(), ffi_prop.to_integer_value());
-            assert_eq!(*prop, props::IndicSyllabicCategory::from(ffi_prop));
-        }
-        
-        for prop in props::IndicConjunctBreak::ALL_VALUES {
-            let ffi_prop = IndicConjunctBreak::from_integer_value(prop.to_icu4c_value())
-                .expect("Found IndicConjunctBreak value not supported in ffi");
-            assert_eq!(prop.to_icu4c_value(), ffi_prop.to_integer_value());
-            assert_eq!(*prop, props::IndicConjunctBreak::from(ffi_prop));
-        }
-        
-        for prop in props::JoiningGroup::ALL_VALUES {
-            let ffi_prop = JoiningGroup::from_integer_value(prop.to_icu4c_value())
-                .expect("Found JoiningGroup value not supported in ffi");
-            assert_eq!(prop.to_icu4c_value(), ffi_prop.to_integer_value());
-            assert_eq!(*prop, props::JoiningGroup::from(ffi_prop));
-        }
-        
-        for prop in props::JoiningType::ALL_VALUES {
-            let ffi_prop = JoiningType::from_integer_value(prop.to_icu4c_value())
-                .expect("Found JoiningType value not supported in ffi");
-            assert_eq!(prop.to_icu4c_value(), ffi_prop.to_integer_value());
-            assert_eq!(*prop, props::JoiningType::from(ffi_prop));
-        }
-        
-        for prop in props::GeneralCategory::ALL_VALUES {
-            let ffi_prop = GeneralCategory::from_integer_value(*prop as u8)
-                .expect("Found GeneralCategory value not supported in ffi");
-            assert_eq!(*prop as u8, ffi_prop.to_integer_value());
-            assert_eq!(*prop, props::GeneralCategory::from(ffi_prop));
-        }
-        
-        for prop in props::VerticalOrientation::ALL_VALUES {
-            let ffi_prop = VerticalOrientation::from_integer_value(prop.to_icu4c_value())
-                .expect("Found VerticalOrientation value not supported in ffi");
-            assert_eq!(prop.to_icu4c_value(), ffi_prop.to_integer_value());
-            assert_eq!(*prop, props::VerticalOrientation::from(ffi_prop));
-        }
-        
+    
+    for &prop in props::BidiClass::ALL_VALUES {
+        let ffi_prop = BidiClass::from(prop);
+        assert_eq!(prop, props::BidiClass::from(ffi_prop));
+    }
+    for &prop in props::NumericType::ALL_VALUES {
+        let ffi_prop = NumericType::from(prop);
+        assert_eq!(prop, props::NumericType::from(ffi_prop));
+    }
+    for &prop in props::Script::ALL_VALUES {
+        let ffi_prop = Script::from(prop);
+        assert_eq!(prop, props::Script::from(ffi_prop));
+    }
+    for &prop in props::HangulSyllableType::ALL_VALUES {
+        let ffi_prop = HangulSyllableType::from(prop);
+        assert_eq!(prop, props::HangulSyllableType::from(ffi_prop));
+    }
+    for &prop in props::EastAsianWidth::ALL_VALUES {
+        let ffi_prop = EastAsianWidth::from(prop);
+        assert_eq!(prop, props::EastAsianWidth::from(ffi_prop));
+    }
+    for &prop in props::LineBreak::ALL_VALUES {
+        let ffi_prop = LineBreak::from(prop);
+        assert_eq!(prop, props::LineBreak::from(ffi_prop));
+    }
+    for &prop in props::GraphemeClusterBreak::ALL_VALUES {
+        let ffi_prop = GraphemeClusterBreak::from(prop);
+        assert_eq!(prop, props::GraphemeClusterBreak::from(ffi_prop));
+    }
+    for &prop in props::WordBreak::ALL_VALUES {
+        let ffi_prop = WordBreak::from(prop);
+        assert_eq!(prop, props::WordBreak::from(ffi_prop));
+    }
+    for &prop in props::SentenceBreak::ALL_VALUES {
+        let ffi_prop = SentenceBreak::from(prop);
+        assert_eq!(prop, props::SentenceBreak::from(ffi_prop));
+    }
+    for &prop in props::CanonicalCombiningClass::ALL_VALUES {
+        let ffi_prop = CanonicalCombiningClass::from(prop);
+        assert_eq!(prop, props::CanonicalCombiningClass::from(ffi_prop));
+    }
+    for &prop in props::IndicSyllabicCategory::ALL_VALUES {
+        let ffi_prop = IndicSyllabicCategory::from(prop);
+        assert_eq!(prop, props::IndicSyllabicCategory::from(ffi_prop));
+    }
+    for &prop in props::IndicConjunctBreak::ALL_VALUES {
+        let ffi_prop = IndicConjunctBreak::from(prop);
+        assert_eq!(prop, props::IndicConjunctBreak::from(ffi_prop));
+    }
+    for &prop in props::JoiningGroup::ALL_VALUES {
+        let ffi_prop = JoiningGroup::from(prop);
+        assert_eq!(prop, props::JoiningGroup::from(ffi_prop));
+    }
+    for &prop in props::JoiningType::ALL_VALUES {
+        let ffi_prop = JoiningType::from(prop);
+        assert_eq!(prop, props::JoiningType::from(ffi_prop));
+    }
+    for &prop in props::GeneralCategory::ALL_VALUES {
+        let ffi_prop = GeneralCategory::from(prop);
+        assert_eq!(prop, props::GeneralCategory::from(ffi_prop));
+    }
+    for &prop in props::VerticalOrientation::ALL_VALUES {
+        let ffi_prop = VerticalOrientation::from(prop);
+        assert_eq!(prop, props::VerticalOrientation::from(ffi_prop));
     }
 }

--- a/provider/source/src/properties/script.rs
+++ b/provider/source/src/properties/script.rs
@@ -304,10 +304,6 @@ mod tests {
         assert!(swe.has_script32(0xFDF2, Script::Arabic)); // main Script value
         assert!(!swe.has_script32(0xFDF2, Script::Syriac));
         assert!(swe.has_script32(0xFDF2, Script::Thaana));
-
-        // The ICU4J comment for this test says:
-        // An unguarded implementation might go into an infinite loop.
-        assert!(!swe.has_script32(0x0640, Script::from_icu4c_value(0xAFFE)));
     }
 
     #[test]

--- a/tools/make/codegen/templates/properties_enums.rs.jinja
+++ b/tools/make/codegen/templates/properties_enums.rs.jinja
@@ -119,27 +119,15 @@ pub mod ffi {
     }
 }
 
-#[cfg(test)]
 #[rustfmt::skip]
-mod test {
-    use super::ffi::*;
+#[test]
+fn test_all_cases_covered() {
+    use ffi::*;
     use icu_properties::props;
-
-    #[test]
-    fn test_all_cases_covered() {
-        {%- for prop in props %}
-        for prop in props::{{prop.name}}::ALL_VALUES {
-            {%- if prop.is_open %}
-            let ffi_prop = {{prop.name}}::from_integer_value(prop.to_icu4c_value())
-                .expect("Found {{prop.name}} value not supported in ffi");
-            assert_eq!(prop.to_icu4c_value(), ffi_prop.to_integer_value());
-            {%- else %}
-            let ffi_prop = {{prop.name}}::from_integer_value(*prop as u8)
-                .expect("Found {{prop.name}} value not supported in ffi");
-            assert_eq!(*prop as u8, ffi_prop.to_integer_value());
-            {%- endif %}
-            assert_eq!(*prop, props::{{prop.name}}::from(ffi_prop));
-        }
-        {% endfor %}
+    {% for prop in props %}
+    for &prop in props::{{prop.name}}::ALL_VALUES {
+        let ffi_prop = {{prop.name}}::from(prop);
+        assert_eq!(prop, props::{{prop.name}}::from(ffi_prop));
     }
+    {%- endfor %}
 }


### PR DESCRIPTION
`CanonicalCombiningClass` is unique in the sense that the numeric values are define by Unicode, not by ICU4C. Currently they are only accessible through `to_icu4c_value`/`from_icu4c_value`, which are pretty much the only use cases of these methods (there are some internal ones that are easy to replace as well).

Instead, we should make the field public and allow clients to treat CCC as an integer.

## Changelog

`icu_properties`:
* Deprecate `to_icu4c_value`/`from_icu4c_value` on enumerated properties
* Expose `CanonicalCombiningClass`' integer field