### PR TITLE
Safety improvements for fixed_decimal

### DIFF
--- a/utils/fixed_decimal/src/decimal.rs
+++ b/utils/fixed_decimal/src/decimal.rs
@@ -119,6 +119,7 @@ pub struct UnsignedDecimal {
 impl UnsignedDecimal {
     /// The number 1.
     pub const ONE: Self = Self {
+        // SAFETY: The requested length (1) is less than or equal to the array capacity (8).
         digits: unsafe { SmallVec::from_const_with_len_unchecked([1; 8], 1) },
         magnitude: 0,
         upper_magnitude: 0,


### PR DESCRIPTION
I've been using a Gemini Skill I wrote to help with unsafe reviews. It's not perfect and does not yet replace human review, however it does manage to catch some things.

I ran it on ICU4X utils and it came up with a bunch of minor safety comment improvements.

## Changelog: N/A

<!-- Please fill in according to documents/process/changelog.md -->
