### PR TITLE
Safety improvements for tinystr

### DIFF
--- a/utils/tinystr/src/int_ops.rs
+++ b/utils/tinystr/src/int_ops.rs
@@ -129,6 +129,10 @@ impl Aligned4 {
     pub const fn to_ascii_lowercase(&self) -> [AsciiByte; 4] {
         let word = self.0;
         let result = word | (((word + 0x3f3f_3f3f) & !(word + 0x2525_2525) & 0x8080_8080) >> 2);
+        // SAFETY: The bitwise arithmetic identifies uppercase ASCII bytes ('A'..='Z') in the word,
+        // shifts that match to produce 0x20 for those bytes, and ORs them to map to lowercase ('a'..='z').
+        // All other bytes are ORed with 0 and remain unchanged.
+        // Since all input bytes are valid ASCII (0..=127), this mapping preserves the ASCII range (0..=127) on all bytes.
         unsafe { AsciiByte::to_ascii_byte_array(&result.to_ne_bytes()) }
     }
 
@@ -136,12 +140,21 @@ impl Aligned4 {
         let word = self.0.to_le();
         let mask = ((word + 0x3f3f_3f1f) & !(word + 0x2525_2505) & 0x8080_8080) >> 2;
         let result = (word | mask) & !(0x20 & mask);
+        // SAFETY: The bitwise arithmetic identifies lowercase ASCII bytes ('a'..='z') at byte 0,
+        // and uppercase ASCII bytes ('A'..='Z') at bytes 1..=3.
+        // It then clears the 0x20 bit on byte 0 (if lowercase) and sets the 0x20 bit on bytes 1..=3 (if uppercase),
+        // leaving non-alphabetic bytes completely unchanged.
+        // Since all input bytes are valid ASCII (0..=127), this mapping preserves the ASCII range (0..=127) on all bytes.
         unsafe { AsciiByte::to_ascii_byte_array(&u32::from_le(result).to_ne_bytes()) }
     }
 
     pub const fn to_ascii_uppercase(&self) -> [AsciiByte; 4] {
         let word = self.0;
         let result = word & !(((word + 0x1f1f_1f1f) & !(word + 0x0505_0505) & 0x8080_8080) >> 2);
+        // SAFETY: The bitwise arithmetic identifies lowercase ASCII bytes ('a'..='z') in the word,
+        // shifts that match to produce 0x20 for those bytes, and ANDs with !0x20 to clear it, mapping to uppercase ('A'..='Z').
+        // All other bytes are ANDed with !0 and remain unchanged.
+        // Since all input bytes are valid ASCII (0..=127), this mapping preserves the ASCII range (0..=127) on all bytes.
         unsafe { AsciiByte::to_ascii_byte_array(&result.to_ne_bytes()) }
     }
 }
@@ -260,6 +273,10 @@ impl Aligned8 {
                 & !(word + 0x2525_2525_2525_2525)
                 & 0x8080_8080_8080_8080)
                 >> 2);
+        // SAFETY: The bitwise arithmetic identifies uppercase ASCII bytes ('A'..='Z') in the word,
+        // shifts that match to produce 0x20 for those bytes, and ORs them to map to lowercase ('a'..='z').
+        // All other bytes are ORed with 0 and remain unchanged.
+        // Since all input bytes are valid ASCII (0..=127), this mapping preserves the ASCII range (0..=127) on all bytes.
         unsafe { AsciiByte::to_ascii_byte_array(&result.to_ne_bytes()) }
     }
 
@@ -270,6 +287,11 @@ impl Aligned8 {
             & 0x8080_8080_8080_8080)
             >> 2;
         let result = (word | mask) & !(0x20 & mask);
+        // SAFETY: The bitwise arithmetic identifies lowercase ASCII bytes ('a'..='z') at byte 0,
+        // and uppercase ASCII bytes ('A'..='Z') at bytes 1..=7.
+        // It then clears the 0x20 bit on byte 0 (if lowercase) and sets the 0x20 bit on bytes 1..=7 (if uppercase),
+        // leaving non-alphabetic bytes completely unchanged.
+        // Since all input bytes are valid ASCII (0..=127), this mapping preserves the ASCII range (0..=127) on all bytes.
         unsafe { AsciiByte::to_ascii_byte_array(&u64::from_le(result).to_ne_bytes()) }
     }
 
@@ -280,6 +302,10 @@ impl Aligned8 {
                 & !(word + 0x0505_0505_0505_0505)
                 & 0x8080_8080_8080_8080)
                 >> 2);
+        // SAFETY: The bitwise arithmetic identifies lowercase ASCII bytes ('a'..='z') in the word,
+        // shifts that match to produce 0x20 for those bytes, and ANDs with !0x20 to clear it, mapping to uppercase ('A'..='Z').
+        // All other bytes are ANDed with !0 and remain unchanged.
+        // Since all input bytes are valid ASCII (0..=127), this mapping preserves the ASCII range (0..=127) on all bytes.
         unsafe { AsciiByte::to_ascii_byte_array(&result.to_ne_bytes()) }
     }
 }

--- a/utils/tinystr/src/int_ops.rs
+++ b/utils/tinystr/src/int_ops.rs
@@ -273,8 +273,8 @@ impl Aligned8 {
                 & !(word + 0x2525_2525_2525_2525)
                 & 0x8080_8080_8080_8080)
                 >> 2);
-        // SAFETY: The existing word is ASCII, and it is bitwise-ORed with a subset of 0x80_80_80_...,
-        // which keeps the word in the ASCII range (all bytes <= 127).
+        // SAFETY: The existing word is ASCII, and it is bitwise-ORed with a subset of 0x20_20_20_...
+        // (0x80_... >> 2), which keeps the word in the ASCII range (all bytes <= 127).
         unsafe { AsciiByte::to_ascii_byte_array(&result.to_ne_bytes()) }
     }
 
@@ -285,8 +285,8 @@ impl Aligned8 {
             & 0x8080_8080_8080_8080)
             >> 2;
         let result = (word | mask) & !(0x20 & mask);
-        // SAFETY: The existing word is ASCII, and it is bitwise-ORed with a subset of 0x80_80_80_...,
-        // which keeps the word in the ASCII range (all bytes <= 127).
+        // SAFETY: The existing word is ASCII, and it is bitwise-ORed with a subset of 0x20_20_20_...
+        // (0x80_... >> 2), which keeps the word in the ASCII range (all bytes <= 127).
         unsafe { AsciiByte::to_ascii_byte_array(&u64::from_le(result).to_ne_bytes()) }
     }
 
@@ -297,8 +297,8 @@ impl Aligned8 {
                 & !(word + 0x0505_0505_0505_0505)
                 & 0x8080_8080_8080_8080)
                 >> 2);
-        // SAFETY: The existing word is ASCII, and it is bitwise-ORed with a subset of 0x80_80_80_...,
-        // which keeps the word in the ASCII range (all bytes <= 127).
+        // SAFETY: The existing word is ASCII, and it is bitwise-ORed with a subset of 0x20_20_20_...
+        // (0x80_... >> 2), which keeps the word in the ASCII range (all bytes <= 127).
         unsafe { AsciiByte::to_ascii_byte_array(&result.to_ne_bytes()) }
     }
 }

--- a/utils/tinystr/src/int_ops.rs
+++ b/utils/tinystr/src/int_ops.rs
@@ -273,10 +273,8 @@ impl Aligned8 {
                 & !(word + 0x2525_2525_2525_2525)
                 & 0x8080_8080_8080_8080)
                 >> 2);
-        // SAFETY: The bitwise arithmetic identifies uppercase ASCII bytes ('A'..='Z') in the word,
-        // shifts that match to produce 0x20 for those bytes, and ORs them to map to lowercase ('a'..='z').
-        // All other bytes are ORed with 0 and remain unchanged.
-        // Since all input bytes are valid ASCII (0..=127), this mapping preserves the ASCII range (0..=127) on all bytes.
+        /// SAFETY: The existing word is ASCII, and it is bitwise-ORed with a subset of 0x80_80_80_...,
+        /// which keeps the word in the ASCII range (all bytes <= 127).
         unsafe { AsciiByte::to_ascii_byte_array(&result.to_ne_bytes()) }
     }
 
@@ -287,11 +285,8 @@ impl Aligned8 {
             & 0x8080_8080_8080_8080)
             >> 2;
         let result = (word | mask) & !(0x20 & mask);
-        // SAFETY: The bitwise arithmetic identifies lowercase ASCII bytes ('a'..='z') at byte 0,
-        // and uppercase ASCII bytes ('A'..='Z') at bytes 1..=7.
-        // It then clears the 0x20 bit on byte 0 (if lowercase) and sets the 0x20 bit on bytes 1..=7 (if uppercase),
-        // leaving non-alphabetic bytes completely unchanged.
-        // Since all input bytes are valid ASCII (0..=127), this mapping preserves the ASCII range (0..=127) on all bytes.
+        /// SAFETY: The existing word is ASCII, and it is bitwise-ORed with a subset of 0x80_80_80_...,
+        /// which keeps the word in the ASCII range (all bytes <= 127).
         unsafe { AsciiByte::to_ascii_byte_array(&u64::from_le(result).to_ne_bytes()) }
     }
 
@@ -302,10 +297,8 @@ impl Aligned8 {
                 & !(word + 0x0505_0505_0505_0505)
                 & 0x8080_8080_8080_8080)
                 >> 2);
-        // SAFETY: The bitwise arithmetic identifies lowercase ASCII bytes ('a'..='z') in the word,
-        // shifts that match to produce 0x20 for those bytes, and ANDs with !0x20 to clear it, mapping to uppercase ('A'..='Z').
-        // All other bytes are ANDed with !0 and remain unchanged.
-        // Since all input bytes are valid ASCII (0..=127), this mapping preserves the ASCII range (0..=127) on all bytes.
+        /// SAFETY: The existing word is ASCII, and it is bitwise-ORed with a subset of 0x80_80_80_...,
+        /// which keeps the word in the ASCII range (all bytes <= 127).
         unsafe { AsciiByte::to_ascii_byte_array(&result.to_ne_bytes()) }
     }
 }

--- a/utils/tinystr/src/int_ops.rs
+++ b/utils/tinystr/src/int_ops.rs
@@ -273,8 +273,8 @@ impl Aligned8 {
                 & !(word + 0x2525_2525_2525_2525)
                 & 0x8080_8080_8080_8080)
                 >> 2);
-        /// SAFETY: The existing word is ASCII, and it is bitwise-ORed with a subset of 0x80_80_80_...,
-        /// which keeps the word in the ASCII range (all bytes <= 127).
+        // SAFETY: The existing word is ASCII, and it is bitwise-ORed with a subset of 0x80_80_80_...,
+        // which keeps the word in the ASCII range (all bytes <= 127).
         unsafe { AsciiByte::to_ascii_byte_array(&result.to_ne_bytes()) }
     }
 
@@ -285,8 +285,8 @@ impl Aligned8 {
             & 0x8080_8080_8080_8080)
             >> 2;
         let result = (word | mask) & !(0x20 & mask);
-        /// SAFETY: The existing word is ASCII, and it is bitwise-ORed with a subset of 0x80_80_80_...,
-        /// which keeps the word in the ASCII range (all bytes <= 127).
+        // SAFETY: The existing word is ASCII, and it is bitwise-ORed with a subset of 0x80_80_80_...,
+        // which keeps the word in the ASCII range (all bytes <= 127).
         unsafe { AsciiByte::to_ascii_byte_array(&u64::from_le(result).to_ne_bytes()) }
     }
 
@@ -297,8 +297,8 @@ impl Aligned8 {
                 & !(word + 0x0505_0505_0505_0505)
                 & 0x8080_8080_8080_8080)
                 >> 2);
-        /// SAFETY: The existing word is ASCII, and it is bitwise-ORed with a subset of 0x80_80_80_...,
-        /// which keeps the word in the ASCII range (all bytes <= 127).
+        // SAFETY: The existing word is ASCII, and it is bitwise-ORed with a subset of 0x80_80_80_...,
+        // which keeps the word in the ASCII range (all bytes <= 127).
         unsafe { AsciiByte::to_ascii_byte_array(&result.to_ne_bytes()) }
     }
 }

--- a/utils/tinystr/src/int_ops.rs
+++ b/utils/tinystr/src/int_ops.rs
@@ -128,11 +128,11 @@ impl Aligned4 {
 
     pub const fn to_ascii_lowercase(&self) -> [AsciiByte; 4] {
         let word = self.0;
-        let result = word | (((word + 0x3f3f_3f3f) & !(word + 0x2525_2525) & 0x8080_8080) >> 2);
-        // SAFETY: The bitwise arithmetic identifies uppercase ASCII bytes ('A'..='Z') in the word,
-        // shifts that match to produce 0x20 for those bytes, and ORs them to map to lowercase ('a'..='z').
-        // All other bytes are ORed with 0 and remain unchanged.
-        // Since all input bytes are valid ASCII (0..=127), this mapping preserves the ASCII range (0..=127) on all bytes.
+        let mask = ((word + 0x3f3f_3f3f) & !(word + 0x2525_2525) & 0x8080_8080) >> 2;
+        let result = word | mask;
+        // SAFETY: The existing word is ASCII, and it is bitwise-ORed with `mask`,
+        // a subset of 0x20_20_20_... (0x80_... >> 2), which keeps the word
+        // in the ASCII range (all bytes <= 127).
         unsafe { AsciiByte::to_ascii_byte_array(&result.to_ne_bytes()) }
     }
 
@@ -140,21 +140,19 @@ impl Aligned4 {
         let word = self.0.to_le();
         let mask = ((word + 0x3f3f_3f1f) & !(word + 0x2525_2505) & 0x8080_8080) >> 2;
         let result = (word | mask) & !(0x20 & mask);
-        // SAFETY: The bitwise arithmetic identifies lowercase ASCII bytes ('a'..='z') at byte 0,
-        // and uppercase ASCII bytes ('A'..='Z') at bytes 1..=3.
-        // It then clears the 0x20 bit on byte 0 (if lowercase) and sets the 0x20 bit on bytes 1..=3 (if uppercase),
-        // leaving non-alphabetic bytes completely unchanged.
-        // Since all input bytes are valid ASCII (0..=127), this mapping preserves the ASCII range (0..=127) on all bytes.
+        // SAFETY: The existing word is ASCII, and it is bitwise-ORed with `mask`, a subset of 0x20_20_20_...
+        // (0x80_... >> 2), which keeps the word in the ASCII range (all bytes <= 127). It is then ANDed
+        // which cannot introduce new bits.
         unsafe { AsciiByte::to_ascii_byte_array(&u32::from_le(result).to_ne_bytes()) }
     }
 
     pub const fn to_ascii_uppercase(&self) -> [AsciiByte; 4] {
         let word = self.0;
-        let result = word & !(((word + 0x1f1f_1f1f) & !(word + 0x0505_0505) & 0x8080_8080) >> 2);
-        // SAFETY: The bitwise arithmetic identifies lowercase ASCII bytes ('a'..='z') in the word,
-        // shifts that match to produce 0x20 for those bytes, and ANDs with !0x20 to clear it, mapping to uppercase ('A'..='Z').
-        // All other bytes are ANDed with !0 and remain unchanged.
-        // Since all input bytes are valid ASCII (0..=127), this mapping preserves the ASCII range (0..=127) on all bytes.
+        let mask = !(((word + 0x1f1f_1f1f) & !(word + 0x0505_0505) & 0x8080_8080) >> 2);
+        let result = word & mask;
+        // SAFETY: The existing word is ASCII, and it is bitwise-ANDed with `mask`,
+        // which is a subset of 0x20_20_20_... (0x80_... >> 2), which keeps the word
+        // in the ASCII range (all bytes <= 127).
         unsafe { AsciiByte::to_ascii_byte_array(&result.to_ne_bytes()) }
     }
 }
@@ -268,13 +266,14 @@ impl Aligned8 {
 
     pub const fn to_ascii_lowercase(&self) -> [AsciiByte; 8] {
         let word = self.0;
-        let result = word
-            | (((word + 0x3f3f_3f3f_3f3f_3f3f)
-                & !(word + 0x2525_2525_2525_2525)
-                & 0x8080_8080_8080_8080)
-                >> 2);
-        // SAFETY: The existing word is ASCII, and it is bitwise-ORed with a subset of 0x20_20_20_...
-        // (0x80_... >> 2), which keeps the word in the ASCII range (all bytes <= 127).
+        let mask = ((word + 0x3f3f_3f3f_3f3f_3f3f)
+            & !(word + 0x2525_2525_2525_2525)
+            & 0x8080_8080_8080_8080)
+            >> 2;
+        let result = word | mask;
+        // SAFETY: The existing word is ASCII, and it is bitwise-ORed with `mask`,
+        // a subset of 0x20_20_20_... (0x80_... >> 2), which keeps the word
+        // in the ASCII range (all bytes <= 127).
         unsafe { AsciiByte::to_ascii_byte_array(&result.to_ne_bytes()) }
     }
 
@@ -285,20 +284,22 @@ impl Aligned8 {
             & 0x8080_8080_8080_8080)
             >> 2;
         let result = (word | mask) & !(0x20 & mask);
-        // SAFETY: The existing word is ASCII, and it is bitwise-ORed with a subset of 0x20_20_20_...
-        // (0x80_... >> 2), which keeps the word in the ASCII range (all bytes <= 127).
+        // SAFETY: The existing word is ASCII, and it is bitwise-ORed with `mask`, a subset of 0x20_20_20_...
+        // (0x80_... >> 2), which keeps the word in the ASCII range (all bytes <= 127). It is then ANDed
+        // which cannot introduce new bits.
         unsafe { AsciiByte::to_ascii_byte_array(&u64::from_le(result).to_ne_bytes()) }
     }
 
     pub const fn to_ascii_uppercase(&self) -> [AsciiByte; 8] {
         let word = self.0;
-        let result = word
-            & !(((word + 0x1f1f_1f1f_1f1f_1f1f)
-                & !(word + 0x0505_0505_0505_0505)
-                & 0x8080_8080_8080_8080)
-                >> 2);
-        // SAFETY: The existing word is ASCII, and it is bitwise-ORed with a subset of 0x20_20_20_...
-        // (0x80_... >> 2), which keeps the word in the ASCII range (all bytes <= 127).
+        let mask = !(((word + 0x1f1f_1f1f_1f1f_1f1f)
+            & !(word + 0x0505_0505_0505_0505)
+            & 0x8080_8080_8080_8080)
+            >> 2);
+        let result = word & mask;
+        // SAFETY: The existing word is ASCII, and it is bitwise-ANDed with `mask`,
+        // which is a subset of 0x20_20_20_... (0x80_... >> 2), which keeps the word
+        // in the ASCII range (all bytes <= 127).
         unsafe { AsciiByte::to_ascii_byte_array(&result.to_ne_bytes()) }
     }
 }

--- a/utils/tinystr/src/int_ops.rs
+++ b/utils/tinystr/src/int_ops.rs
@@ -151,8 +151,7 @@ impl Aligned4 {
         let mask = !(((word + 0x1f1f_1f1f) & !(word + 0x0505_0505) & 0x8080_8080) >> 2);
         let result = word & mask;
         // SAFETY: The existing word is ASCII, and it is bitwise-ANDed with `mask`,
-        // which is a subset of 0x20_20_20_... (0x80_... >> 2), which keeps the word
-        // in the ASCII range (all bytes <= 127).
+        // which cannot introduce new bits, so it stays ASCII.
         unsafe { AsciiByte::to_ascii_byte_array(&result.to_ne_bytes()) }
     }
 }
@@ -298,8 +297,7 @@ impl Aligned8 {
             >> 2);
         let result = word & mask;
         // SAFETY: The existing word is ASCII, and it is bitwise-ANDed with `mask`,
-        // which is a subset of 0x20_20_20_... (0x80_... >> 2), which keeps the word
-        // in the ASCII range (all bytes <= 127).
+        // which cannot introduce new bits, so it stays ASCII.
         unsafe { AsciiByte::to_ascii_byte_array(&result.to_ne_bytes()) }
     }
 }


### PR DESCRIPTION
I've been using a Gemini Skill I wrote to help with unsafe reviews. It's not perfect and does not yet replace human review, however it does manage to catch some things.

I ran it on ICU4X utils and it came up with a bunch of minor safety comment improvements.

## Changelog: N/A

<!-- Please fill in according to documents/process/changelog.md -->
