### PR TITLE
Safety improvements for zoneinfo64

### DIFF
--- a/utils/zoneinfo64/src/deserialize.rs
+++ b/utils/zoneinfo64/src/deserialize.rs
@@ -238,6 +238,8 @@ fn rules<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Vec<(&'de str, Tz
                 {
                     return Err(A::Error::custom("Wrong length or align"));
                 }
+                // SAFETY: The pointer has been verified to be correctly aligned to [i32; 11] and the length matches size_of::<[i32; 11]>().
+                // Since any arbitrary byte pattern represents a valid [i32; 11] (i32 is plain-old-data), the cast is safe.
                 let value = unsafe { &*(value.as_ptr() as *const [i32; 11]) };
 
                 vec.push((


### PR DESCRIPTION
I've been using a Gemini Skill I wrote to help with unsafe reviews. It's not perfect and does not yet replace human review, however it does manage to catch some things.

I ran it on ICU4X utils and it came up with a bunch of minor safety comment improvements.

## Changelog: N/A

<!-- Please fill in according to documents/process/changelog.md -->
