### PR TITLE
Tuple layout fix for resb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2882,7 +2882,7 @@ dependencies = [
 
 [[package]]
 name = "resb"
-version = "0.1.2"
+version = "0.2.0-dev"
 dependencies = [
  "indexmap",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,7 +197,7 @@ fixed_decimal = { version = "0.7.2", path = "utils/fixed_decimal", default-featu
 ixdtf = { version = "0.6.5", path = "utils/ixdtf", default-features = false }
 litemap = { version = "0.8.0", path = "utils/litemap", default-features = false } # Current version: 0.8.2
 potential_utf = { version = "0.1.3", path = "utils/potential_utf", default-features = false } # Current version: 0.1.5
-resb = { version = "0.1.2", path = "utils/resb", default-features = false }
+resb = { version = "0.2.0-dev", path = "utils/resb", default-features = false }
 tzif = { version = "0.5.0", path = "utils/tzif", default-features = false }
 tinystr = { version = "0.8.3", path = "utils/tinystr", default-features = false }
 writeable = { version = "0.6.1", path = "utils/writeable", default-features = false } # Current version: 0.6.2

--- a/utils/resb/Cargo.toml
+++ b/utils/resb/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "resb"
 description = "Utilities for reading and writing ICU resource bundle files"
-version = "0.1.2"
+version = "0.2.0-dev"
 categories.workspace = true
 keywords = ["binary-format", "localization"]
 

--- a/utils/resb/src/binary/helpers.rs
+++ b/utils/resb/src/binary/helpers.rs
@@ -75,26 +75,44 @@ pub fn option_u32<'de, D: Deserializer<'de>>(
 }
 
 /// A layout-guaranteed pair of 32-bit signed integers.
+///
+/// # Safety Layout Invariants
+///
+/// We apply `#[repr(C)]` to guarantee that this struct has a stable and defined layout matching the C ABI:
+/// 1. The fields are laid out sequentially in declaration order.
+/// 2. Since `i32` has size 4 and alignment 4, there is no padding between the first and second fields.
+/// 3. The total size of the struct is exactly 8 bytes, and the alignment matches the alignment of `i32` (4 bytes).
+///
+/// This ensures that casting a correctly aligned 4-byte raw byte slice of size `8 * N` to `&[I32Pair]` is fully sound and stable.
 #[repr(C)]
+#[allow(
+    clippy::exhaustive_structs,
+    reason = "Stable struct representing a specific C layout"
+)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct I32Pair(pub i32, pub i32);
 
 /// TODO
 pub fn i32_tuple<'de, D: Deserializer<'de>>(deserializer: D) -> Result<&'de [I32Pair], D::Error> {
     let bytes = <&[u8]>::deserialize(deserializer)?;
-    // Safety: all byte representations are valid I32Pair
+    // SAFETY:
+    // 1. `cast_bytes_to_slice` verifies that the byte slice is aligned to 4 bytes (the alignment of `I32Pair`) and the length is a multiple of 8 bytes (the size of `I32Pair`).
+    // 2. `I32Pair` uses `#[repr(C)]` to guarantee a stable layout without padding.
+    // 3. All bit patterns are valid for `i32` (plain-old-data), so the cast is sound.
     unsafe { cast_bytes_to_slice(bytes) }
 }
 
 /// TODO
-#[expect(clippy::type_complexity)] // serde...
 pub fn option_i32_tuple<'de, D: Deserializer<'de>>(
     deserializer: D,
 ) -> Result<Option<&'de [I32Pair]>, D::Error> {
     let Some(bytes) = <Option<&[u8]>>::deserialize(deserializer)? else {
         return Ok(None);
     };
-    // Safety: all byte representations are valid I32Pair
+    // SAFETY:
+    // 1. `cast_bytes_to_slice` verifies that the byte slice is aligned to 4 bytes (the alignment of `I32Pair`) and the length is a multiple of 8 (the size of `I32Pair`).
+    // 2. `I32Pair` uses `#[repr(C)]` to guarantee a stable layout without padding.
+    // 3. All bit patterns are valid for `i32` (plain-old-data), so the cast is sound.
     unsafe { cast_bytes_to_slice(bytes) }.map(Some)
 }
 

--- a/utils/resb/src/binary/helpers.rs
+++ b/utils/resb/src/binary/helpers.rs
@@ -74,12 +74,15 @@ pub fn option_u32<'de, D: Deserializer<'de>>(
     unsafe { cast_bytes_to_slice(bytes) }.map(Some)
 }
 
+/// A layout-guaranteed pair of 32-bit signed integers.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct I32Pair(pub i32, pub i32);
+
 /// TODO
-pub fn i32_tuple<'de, D: Deserializer<'de>>(
-    deserializer: D,
-) -> Result<&'de [(i32, i32)], D::Error> {
+pub fn i32_tuple<'de, D: Deserializer<'de>>(deserializer: D) -> Result<&'de [I32Pair], D::Error> {
     let bytes = <&[u8]>::deserialize(deserializer)?;
-    // Safety: all byte representations are valid (i32, i32)
+    // Safety: all byte representations are valid I32Pair
     unsafe { cast_bytes_to_slice(bytes) }
 }
 
@@ -87,11 +90,11 @@ pub fn i32_tuple<'de, D: Deserializer<'de>>(
 #[expect(clippy::type_complexity)] // serde...
 pub fn option_i32_tuple<'de, D: Deserializer<'de>>(
     deserializer: D,
-) -> Result<Option<&'de [(i32, i32)]>, D::Error> {
+) -> Result<Option<&'de [I32Pair]>, D::Error> {
     let Some(bytes) = <Option<&[u8]>>::deserialize(deserializer)? else {
         return Ok(None);
     };
-    // Safety: all byte representations are valid (i32, i32)
+    // Safety: all byte representations are valid I32Pair
     unsafe { cast_bytes_to_slice(bytes) }.map(Some)
 }
 

--- a/utils/resb/src/binary/helpers.rs
+++ b/utils/resb/src/binary/helpers.rs
@@ -15,8 +15,7 @@ pub fn option_utf_16<'de, D: Deserializer<'de>>(
     let Some(bytes) = <Option<&[u8]>>::deserialize(deserializer)? else {
         return Ok(None);
     };
-    // Safety: all byte representations are valid u16s
-    unsafe { cast_bytes_to_slice(bytes) }
+    cast_bytes_to_u16_slice(bytes)
         .map(PotentialUtf16::from_slice)
         .map(Some)
 }
@@ -40,10 +39,7 @@ pub fn vec_utf_16<'de, D: Deserializer<'de>>(
         {
             let mut vec = Vec::with_capacity(seq.size_hint().unwrap_or_default());
             while let Some(bytes) = seq.next_element::<&[u8]>()? {
-                vec.push(PotentialUtf16::from_slice(
-                    // Safety: all byte representations are valid u16s
-                    unsafe { cast_bytes_to_slice(bytes) }?,
-                ));
+                vec.push(PotentialUtf16::from_slice(cast_bytes_to_u16_slice(bytes)?));
             }
             Ok(vec)
         }
@@ -59,8 +55,8 @@ pub fn option_i32<'de, D: Deserializer<'de>>(
     let Some(bytes) = <Option<&[u8]>>::deserialize(deserializer)? else {
         return Ok(None);
     };
-    // Safety: all byte representations are valid i32s
-    unsafe { cast_bytes_to_slice(bytes) }.map(Some)
+    let words = cast_bytes_to_u32_slice(bytes)?;
+    Ok(Some(cast_u32_to_i32_slice(words)))
 }
 
 /// TODO
@@ -70,8 +66,7 @@ pub fn option_u32<'de, D: Deserializer<'de>>(
     let Some(bytes) = <Option<&[u8]>>::deserialize(deserializer)? else {
         return Ok(None);
     };
-    // Safety: all byte representations are valid u32s
-    unsafe { cast_bytes_to_slice(bytes) }.map(Some)
+    cast_bytes_to_u32_slice(bytes).map(Some)
 }
 
 /// A layout-guaranteed pair of 32-bit signed integers.
@@ -95,11 +90,8 @@ pub struct I32Pair(pub i32, pub i32);
 /// TODO
 pub fn i32_tuple<'de, D: Deserializer<'de>>(deserializer: D) -> Result<&'de [I32Pair], D::Error> {
     let bytes = <&[u8]>::deserialize(deserializer)?;
-    // SAFETY:
-    // 1. `cast_bytes_to_slice` verifies that the byte slice is aligned to 4 bytes (the alignment of `I32Pair`) and the length is a multiple of 8 bytes (the size of `I32Pair`).
-    // 2. `I32Pair` uses `#[repr(C)]` to guarantee a stable layout without padding.
-    // 3. All bit patterns are valid for `i32` (plain-old-data), so the cast is sound.
-    unsafe { cast_bytes_to_slice(bytes) }
+    let words = cast_bytes_to_u32_slice(bytes)?;
+    cast_u32_to_i32_pair_slice(words)
 }
 
 /// TODO
@@ -109,34 +101,67 @@ pub fn option_i32_tuple<'de, D: Deserializer<'de>>(
     let Some(bytes) = <Option<&[u8]>>::deserialize(deserializer)? else {
         return Ok(None);
     };
-    // SAFETY:
-    // 1. `cast_bytes_to_slice` verifies that the byte slice is aligned to 4 bytes (the alignment of `I32Pair`) and the length is a multiple of 8 (the size of `I32Pair`).
-    // 2. `I32Pair` uses `#[repr(C)]` to guarantee a stable layout without padding.
-    // 3. All bit patterns are valid for `i32` (plain-old-data), so the cast is sound.
-    unsafe { cast_bytes_to_slice(bytes) }.map(Some)
+    let words = cast_bytes_to_u32_slice(bytes)?;
+    cast_u32_to_i32_pair_slice(words).map(Some)
 }
 
-/// Casts a slice of byte to a slice of T
+/// Casts a `&[u8]` slice to `&[u32]`.
 ///
 /// # Errors
 ///
-/// Errors if `T` is a Zero-Sized Type (ZST), or if the length or alignment of the byte slice is incorrect.
-///
-/// # Safety
-///
-/// Alignment and length are checked, however the caller has to guarantee that the byte representation is valid for type T.
-pub unsafe fn cast_bytes_to_slice<T, E: Error>(bytes: &[u8]) -> Result<&[T], E> {
-    if size_of::<T>() == 0
-        || bytes.as_ptr().align_offset(align_of::<T>()) != 0
-        || bytes.len() % size_of::<T>() != 0
-    {
+/// Errors if the slice is not 4-byte aligned, or if its length is not a multiple of 4.
+pub fn cast_bytes_to_u32_slice<E: Error>(bytes: &[u8]) -> Result<&[u32], E> {
+    if bytes.as_ptr().align_offset(align_of::<u32>()) != 0 || bytes.len() % size_of::<u32>() != 0 {
         return Err(E::custom("Wrong length or align"));
     }
-
-    // Safety: The check gurantees length and alignment
+    // SAFETY: The check above guarantees 4-byte alignment and size correctness,
+    // and all bit patterns are valid for u32.
     Ok(unsafe {
-        core::slice::from_raw_parts(bytes.as_ptr() as *const T, bytes.len() / size_of::<T>())
+        core::slice::from_raw_parts(bytes.as_ptr() as *const u32, bytes.len() / size_of::<u32>())
     })
+}
+
+/// Casts a `&[u8]` slice to `&[u16]`.
+///
+/// # Errors
+///
+/// Errors if the slice is not 2-byte aligned, or if its length is not a multiple of 2.
+pub fn cast_bytes_to_u16_slice<E: Error>(bytes: &[u8]) -> Result<&[u16], E> {
+    if bytes.as_ptr().align_offset(align_of::<u16>()) != 0 || bytes.len() % size_of::<u16>() != 0 {
+        return Err(E::custom("Wrong length or align"));
+    }
+    // SAFETY: The check above guarantees 2-byte alignment and size correctness,
+    // and all bit patterns are valid for u16.
+    Ok(unsafe {
+        core::slice::from_raw_parts(bytes.as_ptr() as *const u16, bytes.len() / size_of::<u16>())
+    })
+}
+
+/// Casts a `&[u32]` slice to `&[i32]`.
+///
+/// This cast is always safe because `u32` and `i32` have identical size and alignment,
+/// and all bit patterns are valid for both.
+pub fn cast_u32_to_i32_slice(words: &[u32]) -> &[i32] {
+    // SAFETY: u32 and i32 have identical size (4) and alignment (4),
+    // and all bit patterns are valid for both.
+    unsafe { core::slice::from_raw_parts(words.as_ptr() as *const i32, words.len()) }
+}
+
+/// Casts a `&[u32]` slice to `&[I32Pair]`.
+///
+/// # Errors
+///
+/// Errors if the length of `words` is not even.
+pub fn cast_u32_to_i32_pair_slice<E: Error>(words: &[u32]) -> Result<&[I32Pair], E> {
+    if words.len() % 2 != 0 {
+        return Err(E::custom("Wrong length"));
+    }
+    // SAFETY:
+    // 1. u32 and I32Pair have identical alignment (4 bytes), so alignment is guaranteed.
+    // 2. I32Pair is annotated with #[repr(C)] and has no padding.
+    // 3. Its fields are i32, which are plain-old-data (all bit patterns valid).
+    // 4. The size of I32Pair is exactly 8 bytes (two u32s), and the length check guarantees we do not read out of bounds.
+    Ok(unsafe { core::slice::from_raw_parts(words.as_ptr() as *const I32Pair, words.len() / 2) })
 }
 
 #[cfg(test)]
@@ -146,41 +171,48 @@ mod tests {
     type E = value::Error;
 
     #[test]
-    fn cast_aligned_correct_length() {
+    fn cast_bytes_to_u32_correct() {
         let data: [u32; 2] = [1, 2];
         let bytes: &[u8] =
             unsafe { core::slice::from_raw_parts(data.as_ptr() as *const u8, size_of_val(&data)) };
-        let result: Result<&[u32], E> = unsafe { cast_bytes_to_slice(bytes) };
+        let result: Result<&[u32], E> = cast_bytes_to_u32_slice(bytes);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), &[1u32, 2]);
     }
 
     #[test]
-    fn cast_wrong_length_only() {
-        // 4-byte aligned but 5 bytes long (not a multiple of 4)
+    fn cast_bytes_to_u32_wrong_length() {
         let data: [u32; 2] = [1, 2];
         let bytes: &[u8] = unsafe { core::slice::from_raw_parts(data.as_ptr() as *const u8, 5) };
-        let result: Result<&[u32], E> = unsafe { cast_bytes_to_slice(bytes) };
-        assert!(result.is_err(), "wrong length alone must be rejected");
+        let result: Result<&[u32], E> = cast_bytes_to_u32_slice(bytes);
+        assert!(result.is_err());
     }
 
     #[test]
-    fn cast_wrong_alignment_only() {
-        // Correctly sized (4 bytes) but misaligned by 1
+    fn cast_bytes_to_u32_wrong_alignment() {
         let data: [u8; 8] = [0; 8];
-        // Find a u32-aligned start, then offset by 1
         let aligned_start = data.as_ptr().align_offset(align_of::<u32>());
         let misaligned = &data[aligned_start + 1..aligned_start + 5];
-        assert_eq!(misaligned.len(), 4); // correct length for one u32
-        assert_ne!(misaligned.as_ptr().align_offset(align_of::<u32>()), 0);
-        let result: Result<&[u32], E> = unsafe { cast_bytes_to_slice(misaligned) };
-        assert!(result.is_err(), "wrong alignment alone must be rejected");
+        assert_eq!(misaligned.len(), 4);
+        let result: Result<&[u32], E> = cast_bytes_to_u32_slice(misaligned);
+        assert!(result.is_err());
     }
 
     #[test]
-    fn cast_zst() {
-        let bytes: &[u8] = &[];
-        let result: Result<&[()], E> = unsafe { cast_bytes_to_slice(bytes) };
-        assert!(result.is_err(), "ZSTs must be rejected");
+    fn cast_u32_to_i32_pair_correct() {
+        let words: [u32; 4] = [1, 2, 3, 4];
+        let result: Result<&[I32Pair], E> = cast_u32_to_i32_pair_slice(&words);
+        assert!(result.is_ok());
+        let slice = result.unwrap();
+        assert_eq!(slice.len(), 2);
+        assert_eq!(slice[0], I32Pair(1, 2));
+        assert_eq!(slice[1], I32Pair(3, 4));
+    }
+
+    #[test]
+    fn cast_u32_to_i32_pair_wrong_length() {
+        let words: [u32; 3] = [1, 2, 3];
+        let result: Result<&[I32Pair], E> = cast_u32_to_i32_pair_slice(&words);
+        assert!(result.is_err());
     }
 }

--- a/utils/zoneinfo64/src/deserialize.rs
+++ b/utils/zoneinfo64/src/deserialize.rs
@@ -256,41 +256,18 @@ fn rules<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Vec<(&'de str, Tz
 }
 
 fn regions<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Vec<Region>, D::Error> {
-    struct RegionsVisitor;
-
-    impl<'de> Visitor<'de> for RegionsVisitor {
-        type Value = Vec<Region>;
-
-        fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
-            write!(formatter, "a sequence of UTF-16 slices")
-        }
-
-        fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-        where
-            A: SeqAccess<'de>,
-        {
-            let mut vec = Vec::new();
-            while let Some(bytes) = seq.next_element::<&[u8]>()? {
-                let utf16 = PotentialUtf16::from_slice(
-                    // Safety: all byte representations are valid u16s
-                    unsafe { resb::binary::helpers::cast_bytes_to_slice::<_, A::Error>(bytes)? },
-                );
-
-                let mut utf16 = utf16.chars();
-
-                let Ok(region) = Region::try_from_raw([
-                    utf16.next().filter(char::is_ascii).unwrap_or_default() as u8,
-                    utf16.next().filter(char::is_ascii).unwrap_or_default() as u8,
-                    utf16.next().filter(char::is_ascii).unwrap_or_default() as u8,
-                ]) else {
-                    return Err(A::Error::custom("Invalid region code"));
-                };
-
-                vec.push(region);
-            }
-            Ok(vec)
-        }
+    let u16_slices = resb::binary::helpers::vec_utf_16(deserializer)?;
+    let mut vec = Vec::with_capacity(u16_slices.len());
+    for utf16 in u16_slices {
+        let mut chars = utf16.chars();
+        let Ok(region) = Region::try_from_raw([
+            chars.next().filter(char::is_ascii).unwrap_or_default() as u8,
+            chars.next().filter(char::is_ascii).unwrap_or_default() as u8,
+            chars.next().filter(char::is_ascii).unwrap_or_default() as u8,
+        ]) else {
+            return Err(D::Error::custom("Invalid region code"));
+        };
+        vec.push(region);
     }
-
-    deserializer.deserialize_seq(RegionsVisitor)
+    Ok(vec)
 }

--- a/utils/zoneinfo64/src/deserialize.rs
+++ b/utils/zoneinfo64/src/deserialize.rs
@@ -6,6 +6,7 @@ use crate::*;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::marker::PhantomData;
+use resb::binary::helpers::I32Pair;
 use resb::binary::BinaryDeserializerError;
 use serde::de::*;
 use serde::Deserialize;
@@ -180,7 +181,7 @@ impl<'de: 'a, 'a> Deserialize<'de> for TzZoneRaw<'a> {
 #[serde(rename_all = "camelCase")]
 pub struct TzZoneDataRaw<'a> {
     #[serde(borrow, deserialize_with = "resb::binary::helpers::i32_tuple")]
-    type_offsets: &'a [(i32, i32)],
+    type_offsets: &'a [I32Pair],
     #[serde(
         borrow,
         default,
@@ -192,13 +193,13 @@ pub struct TzZoneDataRaw<'a> {
         default,
         deserialize_with = "resb::binary::helpers::option_i32_tuple"
     )]
-    trans_pre32: Option<&'a [(i32, i32)]>,
+    trans_pre32: Option<&'a [I32Pair]>,
     #[serde(
         borrow,
         default,
         deserialize_with = "resb::binary::helpers::option_i32_tuple"
     )]
-    trans_post32: Option<&'a [(i32, i32)]>,
+    trans_post32: Option<&'a [I32Pair]>,
     type_map: Option<&'a [u8]>,
     #[serde(
         borrow,

--- a/utils/zoneinfo64/src/lib.rs
+++ b/utils/zoneinfo64/src/lib.rs
@@ -58,6 +58,7 @@ use alloc::vec::Vec;
 use calendrical_calculations::rata_die::RataDie;
 use core::fmt::Debug;
 use potential_utf::PotentialUtf16;
+use resb::binary::helpers::I32Pair;
 use resb::binary::BinaryDeserializerError;
 
 use icu_locale_core::subtags::Region;
@@ -115,18 +116,18 @@ enum TzZone<'a> {
 #[derive(Clone)]
 struct TzZoneData<'a> {
     /// Transitions before the epoch of `i32::MIN`
-    trans_pre32: &'a [(i32, i32)],
+    trans_pre32: &'a [I32Pair],
     /// Transitions with epoch values that can fit in an i32
     trans: &'a [i32],
     /// Transitions after the epoch of `i32::MAX`
-    trans_post32: &'a [(i32, i32)],
+    trans_post32: &'a [I32Pair],
     /// Map to offset from transitions. Treat [`trans_pre32`, trans, `trans_post32`]
     /// as a single array and use its corresponding index into this to get the index
     /// in `type_offsets`. The index in `type_offsets` is the *new* offset after the
     /// matching transition
     type_map: &'a [u8],
     /// Offsets. First entry is standard time, second entry is offset from standard time (if any)
-    type_offsets: &'a [(i32, i32)],
+    type_offsets: &'a [I32Pair],
     /// An index into the Rules table,
     /// its `standard_offset_seconds`, and its starting year.
     final_rule_offset_year: Option<(u32, i32, i32)>,
@@ -148,24 +149,24 @@ impl Debug for TzZoneData<'_> {
         }
 
         write!(f, "transitions/offsets: [")?;
-        let (std, rule) = self.type_offsets[0];
+        let I32Pair(std, rule) = self.type_offsets[0];
         write!(f, "{:?}, ", (std as f64 / 3600.0, rule as f64 / 3600.0))?;
         let mut i = 0;
-        for &(hi, lo) in self.trans_pre32 {
+        for &I32Pair(hi, lo) in self.trans_pre32 {
             dbg_timestamp(f, ((hi as u32 as u64) << 32 | (lo as u32 as u64)) as i64)?;
-            let (std, rule) = self.type_offsets[self.type_map[i] as usize];
+            let I32Pair(std, rule) = self.type_offsets[self.type_map[i] as usize];
             write!(f, "{:?}, ", (std as f64 / 3600.0, rule as f64 / 3600.0))?;
             i += 1;
         }
         for &t in self.trans {
             dbg_timestamp(f, t as i64)?;
-            let (std, rule) = self.type_offsets[self.type_map[i] as usize];
+            let I32Pair(std, rule) = self.type_offsets[self.type_map[i] as usize];
             write!(f, "{:?}, ", (std as f64 / 3600.0, rule as f64 / 3600.0))?;
             i += 1;
         }
-        for &(hi, lo) in self.trans_post32 {
+        for &I32Pair(hi, lo) in self.trans_post32 {
             dbg_timestamp(f, ((hi as u32 as u64) << 32 | (lo as u32 as u64)) as i64)?;
-            let (std, rule) = self.type_offsets[self.type_map[i] as usize];
+            let I32Pair(std, rule) = self.type_offsets[self.type_map[i] as usize];
             write!(f, "{:?}, ", (std as f64 / 3600.0, rule as f64 / 3600.0))?;
             i += 1;
         }
@@ -350,7 +351,7 @@ impl<'a> TzZoneData<'a> {
     fn prev_transition_offset_idx(&self, seconds_since_epoch: i64) -> isize {
         if seconds_since_epoch < i32::MIN as i64 {
             self.trans_pre32
-                .binary_search(&(
+                .binary_search(&I32Pair(
                     (seconds_since_epoch >> 32) as i32,
                     (seconds_since_epoch & 0xFFFFFFFF) as i32,
                 ))
@@ -370,7 +371,7 @@ impl<'a> TzZoneData<'a> {
                 + self.trans.len() as isize
                 + self
                     .trans_post32
-                    .binary_search(&(
+                    .binary_search(&I32Pair(
                         (seconds_since_epoch >> 32) as i32,
                         (seconds_since_epoch & 0xFFFFFFFF) as i32,
                     ))
@@ -394,7 +395,7 @@ impl<'a> TzZoneData<'a> {
         // before first transition don't use `type_map`, just the first entry in `type_offsets`
         if idx < 0 || self.type_map.is_empty() {
             #[expect(clippy::unwrap_used)] // type_offsets non-empty by invariant
-            let &(standard, rule_additional) = self.type_offsets.first().unwrap();
+            let &I32Pair(standard, rule_additional) = self.type_offsets.first().unwrap();
             return Transition {
                 since: i64::MIN,
                 offset: UtcOffset(standard + rule_additional),
@@ -410,16 +411,17 @@ impl<'a> TzZoneData<'a> {
 
         #[expect(clippy::indexing_slicing)]
         // type_map has length sum(trans*), and type_map values are validated to be valid indices in type_offsets
-        let (standard, rule_additional) = self.type_offsets[self.type_map[idx] as usize];
+        let I32Pair(standard, rule_additional) = self.type_offsets[self.type_map[idx] as usize];
 
         #[expect(clippy::indexing_slicing)] // by guards or invariant
         let since = if idx < self.trans_pre32.len() {
-            let (hi, lo) = self.trans_pre32[idx];
+            let I32Pair(hi, lo) = self.trans_pre32[idx];
             ((hi as u32 as u64) << 32 | (lo as u32 as u64)) as i64
         } else if idx - self.trans_pre32.len() < self.trans.len() {
             self.trans[idx - self.trans_pre32.len()] as i64
         } else {
-            let (hi, lo) = self.trans_post32[idx - self.trans_pre32.len() - self.trans.len()];
+            let I32Pair(hi, lo) =
+                self.trans_post32[idx - self.trans_pre32.len() - self.trans.len()];
             ((hi as u32 as u64) << 32 | (lo as u32 as u64)) as i64
         };
 


### PR DESCRIPTION
Fixes #8007 


## Changelog

resb: (breaking) APIs produce a typed `I32Pair` instead of `(i32, i32)` for maximum layout soundness
resb: (breaking) `cast_bytes_to_slice` replaced with type-specific cast functions
