### PR TITLE
Genericize serde impl of GenericPackedPatterns

### DIFF
--- a/components/datetime/src/provider/packed_pattern.rs
+++ b/components/datetime/src/provider/packed_pattern.rs
@@ -577,10 +577,69 @@ impl<'data> GenericPackedPatterns<'data, PluralElementsPackedULE<ZeroSlice<Patte
 mod _serde {
     use super::*;
     use crate::provider::pattern::reference;
-    use serde::Deserialize;
+    use serde::{Deserialize, Deserializer};
     #[cfg(feature = "datagen")]
-    use serde::Serialize;
+    use serde::{Serialize, Serializer};
     use zerovec::{ule::VarULE, VarZeroSlice, VarZeroVec};
+
+    pub(crate) trait PackedElementDeserialize<'de>: Sized {
+        fn deserialize_element<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>;
+    }
+
+    #[cfg(feature = "datagen")]
+    pub(crate) trait PackedElementSerialize {
+        fn serialize_element<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer;
+    }
+
+    #[derive(serde::Deserialize)]
+    #[cfg_attr(feature = "datagen", derive(serde::Serialize))]
+    #[serde(transparent)]
+    pub(crate) struct PackedElementWrap<T>(
+        #[cfg_attr(
+            feature = "serde",
+            serde(
+                deserialize_with = "PackedElementDeserialize::deserialize_element",
+                bound(deserialize = "T: PackedElementDeserialize<'de>")
+            )
+        )]
+        #[cfg_attr(
+            feature = "datagen",
+            serde(
+                serialize_with = "PackedElementSerialize::serialize_element",
+                bound(serialize = "T: PackedElementSerialize")
+            )
+        )]
+        pub T,
+    );
+
+    impl<'de, T> PackedElementDeserialize<'de> for PluralElements<T>
+    where
+        T: Deserialize<'de>,
+    {
+        fn deserialize_element<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            icu_plurals::provider::deserialize_elements_flat_singleton(deserializer)
+        }
+    }
+
+    #[cfg(feature = "datagen")]
+    impl<T> PackedElementSerialize for PluralElements<T>
+    where
+        T: Serialize,
+    {
+        fn serialize_element<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            icu_plurals::provider::serialize_elements_flat_singleton(self, serializer)
+        }
+    }
 
     #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
     #[cfg_attr(feature = "datagen", derive(serde::Serialize))]
@@ -614,7 +673,18 @@ mod _serde {
             serde(default, skip_serializing_if = "Option::is_none")
         )]
         pub(super) variant_pattern_indices: Option<[u32; 6]>,
-        pub(super) elements: Vec<T>,
+        #[cfg_attr(
+            all(feature = "serde", not(feature = "datagen")),
+            serde(bound(deserialize = "T: PackedElementDeserialize<'de>"))
+        )]
+        #[cfg_attr(
+            all(feature = "serde", feature = "datagen"),
+            serde(bound(
+                serialize = "T: PackedElementSerialize",
+                deserialize = "T: PackedElementDeserialize<'de>"
+            ))
+        )]
+        pub(super) elements: Vec<PackedElementWrap<T>>,
     }
 
     impl<T> Default for GenericPackedPatternsHuman<T> {
@@ -629,14 +699,14 @@ mod _serde {
         }
     }
 
-    fn deserialize_helper<'de, 'data, U, T, D>(
+    pub(crate) fn deserialize_helper<'de, 'data, U, T, D>(
         deserializer: D,
         pack_fn: impl FnOnce(Vec<T>) -> VarZeroVec<'static, U>,
     ) -> Result<GenericPackedPatterns<'data, U>, D::Error>
     where
         U: VarULE + ?Sized,
-        T: Deserialize<'de>,
-        D: serde::Deserializer<'de>,
+        T: PackedElementDeserialize<'de>,
+        D: Deserializer<'de>,
         'de: 'data,
     {
         use serde::de::Error as _;
@@ -679,7 +749,7 @@ mod _serde {
                 }
             }
 
-            let elements = pack_fn(human.elements);
+            let elements = pack_fn(human.elements.into_iter().map(|w| w.0).collect());
             Ok(GenericPackedPatterns { header, elements })
         } else {
             let machine = <PackedPatternsMachine<'data, U>>::deserialize(deserializer)?;
@@ -691,15 +761,15 @@ mod _serde {
     }
 
     #[cfg(feature = "datagen")]
-    fn serialize_helper<'data, U, T, S>(
+    pub(crate) fn serialize_helper<'data, U, T, S>(
         packed: &GenericPackedPatterns<'data, U>,
         serializer: S,
         unpack_fn: impl FnOnce(&VarZeroSlice<U>) -> Vec<T>,
     ) -> Result<S::Ok, S::Error>
     where
         U: VarULE + Serialize + ?Sized,
-        T: Serialize,
-        S: serde::Serializer,
+        T: PackedElementSerialize,
+        S: Serializer,
     {
         if serializer.is_human_readable() {
             let unpacked = GenericUnpackedPatterns::from_packed(packed, unpack_fn);
@@ -718,7 +788,11 @@ mod _serde {
                 }
             }
 
-            human.elements = unpacked.elements;
+            human.elements = unpacked
+                .elements
+                .into_iter()
+                .map(PackedElementWrap)
+                .collect();
             human.serialize(serializer)
         } else {
             let machine = PackedPatternsMachine {
@@ -736,7 +810,7 @@ mod _serde {
     {
         fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where
-            D: serde::Deserializer<'de>,
+            D: Deserializer<'de>,
         {
             deserialize_helper::<_, PluralElements<reference::Pattern>, _>(
                 deserializer,
@@ -773,7 +847,7 @@ mod _serde {
     {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
-            S: serde::Serializer,
+            S: Serializer,
         {
             serialize_helper::<_, PluralElements<reference::Pattern>, _>(
                 self,

--- a/components/datetime/src/provider/packed_pattern.rs
+++ b/components/datetime/src/provider/packed_pattern.rs
@@ -278,7 +278,6 @@ impl<'a> GenericUnpackedPatterns<PluralElements<Pattern<'a>>> {
             elements.as_slice().into()
         })
     }
-
 }
 
 impl<T> GenericUnpackedPatterns<T> {
@@ -730,7 +729,7 @@ mod _serde {
         }
     }
 
-    impl<'de, 'data> serde::Deserialize<'de>
+    impl<'de, 'data> Deserialize<'de>
         for GenericPackedPatterns<'data, PluralElementsPackedULE<ZeroSlice<PatternItem>>>
     where
         'de: 'data,
@@ -739,16 +738,19 @@ mod _serde {
         where
             D: serde::Deserializer<'de>,
         {
-            deserialize_helper::<_, PluralElements<reference::Pattern>, _>(deserializer, |elements| {
-                let elements: Vec<PluralElements<Pattern<'static>>> = elements
-                    .into_iter()
-                    .map(|plural_elements| {
-                        plural_elements.map(|pattern| pattern.to_runtime_pattern())
-                    })
-                    .collect();
+            deserialize_helper::<_, PluralElements<reference::Pattern>, _>(
+                deserializer,
+                |elements| {
+                    let elements: Vec<PluralElements<Pattern<'static>>> = elements
+                        .into_iter()
+                        .map(|plural_elements| {
+                            plural_elements.map(|pattern| pattern.to_runtime_pattern())
+                        })
+                        .collect();
 
-                let packed_elements: Vec<PluralElements<(FourBitMetadata, &ZeroSlice<PatternItem>)>> =
-                    elements
+                    let packed_elements: Vec<
+                        PluralElements<(FourBitMetadata, &ZeroSlice<PatternItem>)>,
+                    > = elements
                         .iter()
                         .map(|plural_elements| {
                             plural_elements.as_ref().map(|pattern| {
@@ -773,20 +775,24 @@ mod _serde {
         where
             S: serde::Serializer,
         {
-            serialize_helper::<_, PluralElements<reference::Pattern>, _>(self, serializer, |elements| {
-                elements
-                    .iter()
-                    .map(|plural_elements| {
-                        plural_elements.decode().map(|(metadata, items)| {
-                            let pattern_borrowed = PatternBorrowed {
-                                metadata: PatternMetadata::from_u8(metadata.get()),
-                                items,
-                            };
-                            reference::Pattern::from(&pattern_borrowed.as_pattern())
+            serialize_helper::<_, PluralElements<reference::Pattern>, _>(
+                self,
+                serializer,
+                |elements| {
+                    elements
+                        .iter()
+                        .map(|plural_elements| {
+                            plural_elements.decode().map(|(metadata, items)| {
+                                let pattern_borrowed = PatternBorrowed {
+                                    metadata: PatternMetadata::from_u8(metadata.get()),
+                                    items,
+                                };
+                                reference::Pattern::from(&pattern_borrowed.as_pattern())
+                            })
                         })
-                    })
-                    .collect()
-            })
+                        .collect()
+                },
+            )
         }
     }
 }

--- a/components/datetime/src/provider/packed_pattern.rs
+++ b/components/datetime/src/provider/packed_pattern.rs
@@ -15,6 +15,8 @@ use icu_plurals::{
     PluralElements,
 };
 use icu_provider::prelude::*;
+#[cfg(feature = "datagen")]
+use zerovec::VarZeroSlice;
 use zerovec::{VarZeroVec, ZeroSlice};
 
 /// A field of [`PackedPatternsBuilder`].
@@ -277,8 +279,18 @@ impl<'a> GenericUnpackedPatterns<PluralElements<Pattern<'a>>> {
         })
     }
 
+}
+
+impl<T> GenericUnpackedPatterns<T> {
+    /// Reconstructs `GenericUnpackedPatterns` from a `GenericPackedPatterns`.
+    ///
+    /// `unpack_fn` is a closure used to unpack the elements from their packed representation
+    /// (`&VarZeroSlice<U>`) into their human-readable representation (`Vec<T>`).
     #[cfg(feature = "datagen")]
-    pub(super) fn from_packed(packed: &'a PackedPatterns<'_>) -> Self {
+    pub(super) fn from_packed<'a, 'data, U: zerovec::ule::VarULE + ?Sized>(
+        packed: &'a GenericPackedPatterns<'data, U>,
+        unpack_fn: impl FnOnce(&'a VarZeroSlice<U>) -> Vec<T>,
+    ) -> Self {
         let variant_indices = if (packed.header & constants::Q_BIT) != 0 {
             VariantIndices::OnePatternPerVariant
         } else {
@@ -291,19 +303,7 @@ impl<'a> GenericUnpackedPatterns<PluralElements<Pattern<'a>>> {
                 VariantPatternIndex::from_header_with_shift(packed.header, 18),
             ])
         };
-        let elements = packed
-            .elements
-            .iter()
-            .map(|plural_elements| {
-                plural_elements.decode().map(|(metadata, items)| {
-                    PatternBorrowed {
-                        metadata: PatternMetadata::from_u8(metadata.get()),
-                        items,
-                    }
-                    .as_pattern()
-                })
-            })
-            .collect();
+        let elements = unpack_fn(&packed.elements);
         Self {
             has_explicit_medium: (packed.header & constants::M_DIFFERS) != 0,
             has_explicit_short: (packed.header & constants::S_DIFFERS) != 0,
@@ -676,7 +676,20 @@ mod _serde {
             S: serde::Serializer,
         {
             if serializer.is_human_readable() {
-                let unpacked = GenericUnpackedPatterns::from_packed(self);
+                let unpacked = GenericUnpackedPatterns::from_packed(self, |elements| {
+                    elements
+                        .iter()
+                        .map(|plural_elements| {
+                            plural_elements.decode().map(|(metadata, items)| {
+                                let pattern_borrowed = PatternBorrowed {
+                                    metadata: PatternMetadata::from_u8(metadata.get()),
+                                    items,
+                                };
+                                pattern_borrowed.as_pattern()
+                            })
+                        })
+                        .collect()
+                });
                 let mut human = PackedPatternsHuman {
                     has_explicit_medium: unpacked.has_explicit_medium,
                     has_explicit_short: unpacked.has_explicit_short,

--- a/components/datetime/src/provider/packed_pattern.rs
+++ b/components/datetime/src/provider/packed_pattern.rs
@@ -578,20 +578,23 @@ impl<'data> GenericPackedPatterns<'data, PluralElementsPackedULE<ZeroSlice<Patte
 mod _serde {
     use super::*;
     use crate::provider::pattern::reference;
-    use zerovec::VarZeroSlice;
+    use serde::Deserialize;
+    #[cfg(feature = "datagen")]
+    use serde::Serialize;
+    use zerovec::{ule::VarULE, VarZeroSlice, VarZeroVec};
 
     #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
     #[cfg_attr(feature = "datagen", derive(serde::Serialize))]
-    struct PackedPatternsMachine<'data> {
+    struct PackedPatternsMachine<'data, U: VarULE + ?Sized> {
         pub header: u32,
         #[serde(borrow)]
-        pub elements: &'data VarZeroSlice<PluralElementsPackedULE<ZeroSlice<PatternItem>>>,
+        #[cfg_attr(feature = "serde", serde(bound(deserialize = "")))]
+        pub elements: &'data VarZeroSlice<U>,
     }
 
     #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
     #[cfg_attr(feature = "datagen", derive(serde::Serialize))]
-    #[derive(Default)]
-    struct PackedPatternsHuman {
+    struct GenericPackedPatternsHuman<T> {
         #[cfg_attr(
             feature = "serde",
             serde(default, skip_serializing_if = "core::ops::Not::not")
@@ -612,7 +615,119 @@ mod _serde {
             serde(default, skip_serializing_if = "Option::is_none")
         )]
         pub(super) variant_pattern_indices: Option<[u32; 6]>,
-        pub(super) elements: Vec<PluralElements<reference::Pattern>>,
+        pub(super) elements: Vec<T>,
+    }
+
+    impl<T> Default for GenericPackedPatternsHuman<T> {
+        fn default() -> Self {
+            Self {
+                has_explicit_medium: false,
+                has_explicit_short: false,
+                has_one_pattern_per_variant: false,
+                variant_pattern_indices: None,
+                elements: Vec::new(),
+            }
+        }
+    }
+
+    fn deserialize_helper<'de, 'data, U, T, D>(
+        deserializer: D,
+        pack_fn: impl FnOnce(Vec<T>) -> VarZeroVec<'static, U>,
+    ) -> Result<GenericPackedPatterns<'data, U>, D::Error>
+    where
+        U: VarULE + ?Sized,
+        T: Deserialize<'de>,
+        D: serde::Deserializer<'de>,
+        'de: 'data,
+    {
+        use serde::de::Error as _;
+        if deserializer.is_human_readable() {
+            let human = <GenericPackedPatternsHuman<T>>::deserialize(deserializer)?;
+            let variant_indices = match (
+                human.has_one_pattern_per_variant,
+                human.variant_pattern_indices,
+            ) {
+                (true, None) => VariantIndices::OnePatternPerVariant,
+                (false, Some(chunks)) => VariantIndices::IndicesPerVariant(
+                    VariantPatternIndex::try_from_chunks_u32(chunks)
+                        .ok_or_else(|| D::Error::custom("variant pattern index out of range"))?,
+                ),
+                _ => {
+                    return Err(D::Error::custom(
+                        "must have either one pattern per variant or indices",
+                    ))
+                }
+            };
+
+            let mut header = 0u32;
+            if human.has_explicit_medium {
+                header |= constants::M_DIFFERS;
+            }
+            if human.has_explicit_short {
+                header |= constants::S_DIFFERS;
+            }
+            match variant_indices {
+                VariantIndices::OnePatternPerVariant => {
+                    header |= constants::Q_BIT;
+                }
+                VariantIndices::IndicesPerVariant(chunks) => {
+                    let mut shift = 3;
+                    for chunk_u32 in VariantPatternIndex::to_chunks_u32(chunks).iter() {
+                        debug_assert!(*chunk_u32 <= constants::CHUNK_MASK);
+                        header |= *chunk_u32 << shift;
+                        shift += 3;
+                    }
+                }
+            }
+
+            let elements = pack_fn(human.elements);
+            Ok(GenericPackedPatterns { header, elements })
+        } else {
+            let machine = <PackedPatternsMachine<'data, U>>::deserialize(deserializer)?;
+            Ok(GenericPackedPatterns {
+                header: machine.header,
+                elements: machine.elements.as_varzerovec(),
+            })
+        }
+    }
+
+    #[cfg(feature = "datagen")]
+    fn serialize_helper<'data, U, T, S>(
+        packed: &GenericPackedPatterns<'data, U>,
+        serializer: S,
+        unpack_fn: impl FnOnce(&VarZeroSlice<U>) -> Vec<T>,
+    ) -> Result<S::Ok, S::Error>
+    where
+        U: VarULE + Serialize + ?Sized,
+        T: Serialize,
+        S: serde::Serializer,
+    {
+        if serializer.is_human_readable() {
+            let unpacked = GenericUnpackedPatterns::from_packed(packed, unpack_fn);
+            let mut human = GenericPackedPatternsHuman {
+                has_explicit_medium: unpacked.has_explicit_medium,
+                has_explicit_short: unpacked.has_explicit_short,
+                ..Default::default()
+            };
+            match unpacked.variant_indices {
+                VariantIndices::OnePatternPerVariant => {
+                    human.has_one_pattern_per_variant = true;
+                }
+                VariantIndices::IndicesPerVariant(chunks) => {
+                    let chunks = VariantPatternIndex::to_chunks_u32(chunks);
+                    human.variant_pattern_indices = Some(chunks);
+                }
+            }
+
+            human.elements = unpacked.elements;
+            human.serialize(serializer)
+        } else {
+            let machine = PackedPatternsMachine {
+                header: packed.header,
+                elements: &packed.elements,
+            };
+            machine.serialize(serializer)
+        }
     }
 
     impl<'de, 'data> serde::Deserialize<'de>
@@ -624,115 +739,54 @@ mod _serde {
         where
             D: serde::Deserializer<'de>,
         {
-            use serde::de::Error as _;
-            if deserializer.is_human_readable() {
-                let human = <PackedPatternsHuman>::deserialize(deserializer)?;
-                let variant_indices = match (
-                    human.has_one_pattern_per_variant,
-                    human.variant_pattern_indices,
-                ) {
-                    (true, None) => VariantIndices::OnePatternPerVariant,
-                    (false, Some(chunks)) => VariantIndices::IndicesPerVariant(
-                        VariantPatternIndex::try_from_chunks_u32(chunks).ok_or_else(|| {
-                            D::Error::custom("variant pattern index out of range")
-                        })?,
-                    ),
-                    _ => {
-                        return Err(D::Error::custom(
-                            "must have either one pattern per variant or indices",
-                        ))
-                    }
-                };
-                let elements = human
-                    .elements
+            deserialize_helper::<_, PluralElements<reference::Pattern>, _>(deserializer, |elements| {
+                let elements: Vec<PluralElements<Pattern<'static>>> = elements
                     .into_iter()
                     .map(|plural_elements| {
                         plural_elements.map(|pattern| pattern.to_runtime_pattern())
                     })
                     .collect();
-                let unpacked = GenericUnpackedPatterns {
-                    has_explicit_medium: human.has_explicit_medium,
-                    has_explicit_short: human.has_explicit_short,
-                    variant_indices,
-                    elements,
-                };
-                Ok(unpacked.build_generic(|elements| {
-                    let elements: Vec<PluralElements<(FourBitMetadata, &ZeroSlice<PatternItem>)>> =
-                        elements
-                            .iter()
-                            .map(|plural_elements| {
-                                plural_elements.as_ref().map(|pattern| {
-                                    (
-                                        pattern.metadata.to_four_bit_metadata(),
-                                        pattern.items.as_slice(),
-                                    )
-                                })
+
+                let packed_elements: Vec<PluralElements<(FourBitMetadata, &ZeroSlice<PatternItem>)>> =
+                    elements
+                        .iter()
+                        .map(|plural_elements| {
+                            plural_elements.as_ref().map(|pattern| {
+                                (
+                                    pattern.metadata.to_four_bit_metadata(),
+                                    pattern.items.as_slice(),
+                                )
                             })
-                            .collect();
-                    elements.as_slice().into()
-                }))
-            } else {
-                let machine = <PackedPatternsMachine>::deserialize(deserializer)?;
-                Ok(Self {
-                    header: machine.header,
-                    elements: machine.elements.as_varzerovec(),
-                })
-            }
+                        })
+                        .collect();
+                    packed_elements.as_slice().into()
+                },
+            )
         }
     }
 
     #[cfg(feature = "datagen")]
-    impl serde::Serialize
-        for GenericPackedPatterns<'_, PluralElementsPackedULE<ZeroSlice<PatternItem>>>
+    impl<'data> Serialize
+        for GenericPackedPatterns<'data, PluralElementsPackedULE<ZeroSlice<PatternItem>>>
     {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
             S: serde::Serializer,
         {
-            if serializer.is_human_readable() {
-                let unpacked = GenericUnpackedPatterns::from_packed(self, |elements| {
-                    elements
-                        .iter()
-                        .map(|plural_elements| {
-                            plural_elements.decode().map(|(metadata, items)| {
-                                let pattern_borrowed = PatternBorrowed {
-                                    metadata: PatternMetadata::from_u8(metadata.get()),
-                                    items,
-                                };
-                                pattern_borrowed.as_pattern()
-                            })
-                        })
-                        .collect()
-                });
-                let mut human = PackedPatternsHuman {
-                    has_explicit_medium: unpacked.has_explicit_medium,
-                    has_explicit_short: unpacked.has_explicit_short,
-                    ..Default::default()
-                };
-                match unpacked.variant_indices {
-                    VariantIndices::OnePatternPerVariant => {
-                        human.has_one_pattern_per_variant = true;
-                    }
-                    VariantIndices::IndicesPerVariant(chunks) => {
-                        let chunks = VariantPatternIndex::to_chunks_u32(chunks);
-                        human.variant_pattern_indices = Some(chunks);
-                    }
-                }
-                human.elements = unpacked
-                    .elements
-                    .into_iter()
+            serialize_helper::<_, PluralElements<reference::Pattern>, _>(self, serializer, |elements| {
+                elements
+                    .iter()
                     .map(|plural_elements| {
-                        plural_elements.map(|pattern| reference::Pattern::from(&pattern))
+                        plural_elements.decode().map(|(metadata, items)| {
+                            let pattern_borrowed = PatternBorrowed {
+                                metadata: PatternMetadata::from_u8(metadata.get()),
+                                items,
+                            };
+                            reference::Pattern::from(&pattern_borrowed.as_pattern())
+                        })
                     })
-                    .collect();
-                human.serialize(serializer)
-            } else {
-                let machine = PackedPatternsMachine {
-                    header: self.header,
-                    elements: &self.elements,
-                };
-                machine.serialize(serializer)
-            }
+                    .collect()
+            })
         }
     }
 }

--- a/components/datetime/src/provider/packed_pattern.rs
+++ b/components/datetime/src/provider/packed_pattern.rs
@@ -656,7 +656,21 @@ mod _serde {
                     variant_indices,
                     elements,
                 };
-                Ok(unpacked.build())
+                Ok(unpacked.build_generic(|elements| {
+                    let elements: Vec<PluralElements<(FourBitMetadata, &ZeroSlice<PatternItem>)>> =
+                        elements
+                            .iter()
+                            .map(|plural_elements| {
+                                plural_elements.as_ref().map(|pattern| {
+                                    (
+                                        pattern.metadata.to_four_bit_metadata(),
+                                        pattern.items.as_slice(),
+                                    )
+                                })
+                            })
+                            .collect();
+                    elements.as_slice().into()
+                }))
             } else {
                 let machine = <PackedPatternsMachine>::deserialize(deserializer)?;
                 Ok(Self {

--- a/components/datetime/src/provider/packed_pattern.rs
+++ b/components/datetime/src/provider/packed_pattern.rs
@@ -528,15 +528,27 @@ impl<'data> GenericPackedPatterns<'data, PluralElementsPackedULE<ZeroSlice<Patte
         }
     }
 
+    #[cfg(feature = "datagen")]
     fn get_as_plural_elements(
         &self,
         length: Length,
         variant: PackedSkeletonVariant,
     ) -> PluralElements<Pattern<'_>> {
-        PluralElements::new(self.get(length, variant).as_pattern())
+        let Some(plural_elements) = self.get_element(length, variant) else {
+            debug_assert!(false, "unreachable");
+            return PluralElements::new(Pattern::default());
+        };
+        plural_elements.decode().map(|(metadata, items)| {
+            PatternBorrowed {
+                metadata: PatternMetadata::from_u8(metadata.get()),
+                items,
+            }
+            .as_pattern()
+        })
     }
 
     /// Converts this packed data to a builder that can be mutated.
+    #[cfg(feature = "datagen")]
     pub fn to_builder(&self) -> PackedPatternsBuilder<'_> {
         use Length::*;
         use PackedSkeletonVariant::*;
@@ -600,7 +612,7 @@ mod _serde {
             serde(default, skip_serializing_if = "Option::is_none")
         )]
         pub(super) variant_pattern_indices: Option<[u32; 6]>,
-        pub(super) elements: Vec<reference::Pattern>,
+        pub(super) elements: Vec<PluralElements<reference::Pattern>>,
     }
 
     impl<'de, 'data> serde::Deserialize<'de>
@@ -633,8 +645,10 @@ mod _serde {
                 };
                 let elements = human
                     .elements
-                    .iter()
-                    .map(|pattern| PluralElements::new(pattern.to_runtime_pattern()))
+                    .into_iter()
+                    .map(|plural_elements| {
+                        plural_elements.map(|pattern| pattern.to_runtime_pattern())
+                    })
                     .collect();
                 let unpacked = GenericUnpackedPatterns {
                     has_explicit_medium: human.has_explicit_medium,
@@ -661,7 +675,6 @@ mod _serde {
         where
             S: serde::Serializer,
         {
-            use serde::ser::Error as _;
             if serializer.is_human_readable() {
                 let unpacked = GenericUnpackedPatterns::from_packed(self);
                 let mut human = PackedPatternsHuman {
@@ -678,13 +691,13 @@ mod _serde {
                         human.variant_pattern_indices = Some(chunks);
                     }
                 }
-                human.elements = Vec::with_capacity(unpacked.elements.len());
-                for pattern_elements in unpacked.elements.into_iter() {
-                    let pattern = pattern_elements
-                        .try_into_other()
-                        .ok_or_else(|| S::Error::custom("cannot yet serialize plural patterns"))?;
-                    human.elements.push(reference::Pattern::from(&pattern));
-                }
+                human.elements = unpacked
+                    .elements
+                    .into_iter()
+                    .map(|plural_elements| {
+                        plural_elements.map(|pattern| reference::Pattern::from(&pattern))
+                    })
+                    .collect();
                 human.serialize(serializer)
             } else {
                 let machine = PackedPatternsMachine {
@@ -853,7 +866,8 @@ mod tests {
         let lms1 = LengthPluralElements {
             long: PluralElements::new(patterns[3].clone()),
             medium: PluralElements::new(patterns[4].clone()),
-            short: PluralElements::new(patterns[5].clone()),
+            short: PluralElements::new(patterns[5].clone())
+                .with_one_value(Some(patterns[6].clone())),
         };
 
         let builder = PackedPatternsBuilder {
@@ -867,17 +881,18 @@ mod tests {
         assert_eq!(
             bincode_bytes.as_slice(),
             &[
-                26, 11, 0, 0, 72, 0, 0, 0, 0, 0, 0, 0, 5, 0, 16, 0, 26, 0, 30, 0, 46, 0, 0, 128,
+                26, 11, 0, 0, 85, 0, 0, 0, 0, 0, 0, 0, 5, 0, 16, 0, 26, 0, 30, 0, 46, 0, 0, 128,
                 32, 1, 0, 0, 47, 128, 64, 1, 0, 0, 47, 128, 16, 1, 2, 128, 114, 2, 0, 0, 58, 128,
                 128, 2, 0, 128, 80, 1, 0, 128, 80, 1, 0, 0, 32, 128, 32, 3, 0, 0, 32, 128, 64, 1,
-                0, 128, 64, 2, 0, 0, 46, 128, 32, 2, 0, 0, 46, 128, 16, 2
+                128, 15, 128, 64, 2, 0, 0, 46, 128, 32, 2, 0, 0, 46, 128, 16, 2, 1, 0, 17, 128,
+                113, 1, 0, 0, 32, 128, 96, 1
             ][..]
         );
         let bincode_recovered = bincode::deserialize::<PackedPatterns>(&bincode_bytes).unwrap();
         assert_eq!(builder, bincode_recovered.to_builder());
 
         let json_str = serde_json::to_string(&packed).unwrap();
-        assert_eq!(json_str, "{\"has_explicit_short\":true,\"variant_pattern_indices\":[3,4,5,0,0,0],\"elements\":[\"M/d/y\",\"HH:mm\",\"E\",\"E MMM d\",\"dd.MM.yy\"]}");
+        assert_eq!(json_str, "{\"has_explicit_short\":true,\"variant_pattern_indices\":[3,4,5,0,0,0],\"elements\":[\"M/d/y\",\"HH:mm\",\"E\",\"E MMM d\",{\"one\":\"h a\",\"other\":\"dd.MM.yy\"}]}");
         let json_recovered = serde_json::from_str::<PackedPatterns>(&json_str).unwrap();
         assert_eq!(builder, json_recovered.to_builder());
     }

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -994,7 +994,6 @@ impl<T> PluralElements<T> {
             _ => None,
         }
     }
-
     /// The value used when the [`PluralOperands`] are exactly 0.
     pub fn explicit_zero(&self) -> Option<&T> {
         self.0.explicit_zero.as_ref()
@@ -1156,44 +1155,7 @@ impl<T: PartialEq> PluralElements<T> {
 #[cfg(feature = "serde")]
 #[derive(serde::Deserialize)]
 #[serde(untagged)]
-enum PluralElementsHumanHelper<T> {
+pub(crate) enum PluralElementsHumanHelper<T> {
     Flat(T),
     Map(PluralElementsInner<T>),
-}
-
-#[cfg(feature = "serde")]
-impl<'de, T: serde::Deserialize<'de>> serde::Deserialize<'de> for PluralElements<T> {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        if deserializer.is_human_readable() {
-            let helper = PluralElementsHumanHelper::<T>::deserialize(deserializer)?;
-            match helper {
-                PluralElementsHumanHelper::Flat(other) => Ok(PluralElements::new(other)),
-                PluralElementsHumanHelper::Map(inner) => Ok(PluralElements(inner)),
-            }
-        } else {
-            let inner = PluralElementsInner::deserialize(deserializer)?;
-            Ok(PluralElements(inner))
-        }
-    }
-}
-
-#[cfg(feature = "datagen")]
-impl<T: serde::Serialize> serde::Serialize for PluralElements<T> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        if serializer.is_human_readable() {
-            if let Some(single) = self.as_single_other() {
-                single.serialize(serializer)
-            } else {
-                self.0.serialize(serializer)
-            }
-        } else {
-            self.0.serialize(serializer)
-        }
-    }
 }

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -978,6 +978,23 @@ impl<T> PluralElements<T> {
         }
     }
 
+    #[cfg(feature = "datagen")]
+    pub(crate) fn as_single_other(&self) -> Option<&T> {
+        match &self.0 {
+            PluralElementsInner {
+                zero: None,
+                one: None,
+                two: None,
+                few: None,
+                many: None,
+                other,
+                explicit_zero: None,
+                explicit_one: None,
+            } => Some(other),
+            _ => None,
+        }
+    }
+
     /// The value used when the [`PluralOperands`] are exactly 0.
     pub fn explicit_zero(&self) -> Option<&T> {
         self.0.explicit_zero.as_ref()
@@ -1133,5 +1150,50 @@ impl<T: PartialEq> PluralElements<T> {
             explicit_one,
             ..self.0
         })
+    }
+}
+
+#[cfg(feature = "serde")]
+#[derive(serde::Deserialize)]
+#[serde(untagged)]
+enum PluralElementsHumanHelper<T> {
+    Flat(T),
+    Map(PluralElementsInner<T>),
+}
+
+#[cfg(feature = "serde")]
+impl<'de, T: serde::Deserialize<'de>> serde::Deserialize<'de> for PluralElements<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        if deserializer.is_human_readable() {
+            let helper = PluralElementsHumanHelper::<T>::deserialize(deserializer)?;
+            match helper {
+                PluralElementsHumanHelper::Flat(other) => Ok(PluralElements::new(other)),
+                PluralElementsHumanHelper::Map(inner) => Ok(PluralElements(inner)),
+            }
+        } else {
+            let inner = PluralElementsInner::deserialize(deserializer)?;
+            Ok(PluralElements(inner))
+        }
+    }
+}
+
+#[cfg(feature = "datagen")]
+impl<T: serde::Serialize> serde::Serialize for PluralElements<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        if serializer.is_human_readable() {
+            if let Some(single) = self.as_single_other() {
+                single.serialize(serializer)
+            } else {
+                self.0.serialize(serializer)
+            }
+        } else {
+            self.0.serialize(serializer)
+        }
     }
 }

--- a/components/plurals/src/provider.rs
+++ b/components/plurals/src/provider.rs
@@ -928,7 +928,7 @@ impl<T> PluralElementsInner<(FourBitMetadata, T)> {
 }
 
 #[cfg(feature = "serde")]
-impl<'de, 'data, V> serde::Deserialize<'de> for &'data PluralElementsPackedULE<V>
+impl<'de, 'data, V> Deserialize<'de> for &'data PluralElementsPackedULE<V>
 where
     'de: 'data,
     V: VarULE + ?Sized,
@@ -949,10 +949,10 @@ where
 }
 
 #[cfg(feature = "serde")]
-impl<'de, V> serde::Deserialize<'de> for Box<PluralElementsPackedULE<V>>
+impl<'de, V> Deserialize<'de> for Box<PluralElementsPackedULE<V>>
 where
     V: VarULE + ?Sized,
-    Box<V>: serde::Deserialize<'de> + PartialEq + fmt::Debug,
+    Box<V>: Deserialize<'de> + PartialEq + fmt::Debug,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -972,9 +972,9 @@ where
 }
 
 #[cfg(feature = "datagen")]
-impl<V> serde::Serialize for PluralElementsPackedULE<V>
+impl<V> Serialize for PluralElementsPackedULE<V>
 where
-    V: PartialEq + serde::Serialize + VarULE + ?Sized,
+    V: PartialEq + Serialize + VarULE + ?Sized,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -1033,7 +1033,7 @@ where
     'de: 'data,
     D: serde::Deserializer<'de>,
     V: VarULE + ?Sized,
-    Box<PluralElementsPackedULE<V>>: serde::Deserialize<'de>,
+    Box<PluralElementsPackedULE<V>>: Deserialize<'de>,
 {
     use serde::Deserialize;
     if deserializer.is_human_readable() {
@@ -1079,6 +1079,55 @@ where
     /// Returns the value for the given [`PluralOperands`] and [`PluralRules`].
     pub fn get<'a>(&'a self, op: PluralOperands, rules: &PluralRules) -> &'a V {
         self.elements.get(op, rules).1
+    }
+}
+
+#[cfg(feature = "serde")]
+use crate::PluralElementsHumanHelper;
+#[cfg(feature = "serde")]
+use serde::Deserialize;
+#[cfg(feature = "datagen")]
+use serde::Serialize;
+
+/// Helper for serializing `PluralElements` with special case where singletons are serialized directly.
+#[cfg(feature = "datagen")]
+pub fn serialize_elements_flat_singleton<T, S>(
+    plural_elements: &PluralElements<T>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    T: Serialize,
+    S: serde::Serializer,
+{
+    if serializer.is_human_readable() {
+        if let Some(single) = plural_elements.as_single_other() {
+            single.serialize(serializer)
+        } else {
+            plural_elements.0.serialize(serializer)
+        }
+    } else {
+        plural_elements.0.serialize(serializer)
+    }
+}
+
+/// Helper for deserializing `PluralElements` with special case where singletons are serialized directly.
+#[cfg(feature = "serde")]
+pub fn deserialize_elements_flat_singleton<'de, T, D>(
+    deserializer: D,
+) -> Result<PluralElements<T>, D::Error>
+where
+    T: Deserialize<'de>,
+    D: serde::Deserializer<'de>,
+{
+    if deserializer.is_human_readable() {
+        let helper = PluralElementsHumanHelper::<T>::deserialize(deserializer)?;
+        match helper {
+            PluralElementsHumanHelper::Flat(other) => Ok(PluralElements::new(other)),
+            PluralElementsHumanHelper::Map(inner) => Ok(PluralElements(inner)),
+        }
+    } else {
+        let inner = PluralElementsInner::deserialize(deserializer)?;
+        Ok(PluralElements(inner))
     }
 }
 

--- a/components/plurals/tests/plurals.rs
+++ b/components/plurals/tests/plurals.rs
@@ -41,3 +41,43 @@ fn test_plural_category_all() {
     assert_eq!(categories[4], PluralCategory::Two);
     assert_eq!(categories[5], PluralCategory::Zero);
 }
+
+#[cfg(feature = "serde")]
+#[test]
+fn test_plural_elements_serde() {
+    use icu_plurals::PluralElements;
+
+    // 1. Single "other" value
+    let single = PluralElements::new("hello".to_string());
+
+    #[cfg(feature = "datagen")]
+    {
+        let single_json = serde_json::to_string(&single).unwrap();
+        // In human-readable format, it should serialize as a flat string.
+        assert_eq!(single_json, "\"hello\"");
+
+        // Deserialize back
+        let single_deser: PluralElements<String> = serde_json::from_str(&single_json).unwrap();
+        assert_eq!(single, single_deser);
+    }
+
+    // Deserialize from map format (it should also work)
+    let map_json = "{\"other\":\"hello\"}";
+    let map_deser: PluralElements<String> = serde_json::from_str(map_json).unwrap();
+    assert_eq!(single, map_deser);
+
+    // 2. Multiple values
+    let multi =
+        PluralElements::new("other_val".to_string()).with_one_value(Some("one_val".to_string()));
+
+    #[cfg(feature = "datagen")]
+    {
+        let multi_json = serde_json::to_string(&multi).unwrap();
+        // Should serialize as map
+        assert_eq!(multi_json, "{\"one\":\"one_val\",\"other\":\"other_val\"}");
+
+        // Deserialize back
+        let multi_deser: PluralElements<String> = serde_json::from_str(&multi_json).unwrap();
+        assert_eq!(multi, multi_deser);
+    }
+}

--- a/components/plurals/tests/plurals.rs
+++ b/components/plurals/tests/plurals.rs
@@ -45,6 +45,9 @@ fn test_plural_category_all() {
 #[cfg(feature = "serde")]
 #[test]
 fn test_plural_elements_serde() {
+    use icu_plurals::provider::{
+        deserialize_elements_flat_singleton, serialize_elements_flat_singleton,
+    };
     use icu_plurals::PluralElements;
 
     // 1. Single "other" value
@@ -52,18 +55,24 @@ fn test_plural_elements_serde() {
 
     #[cfg(feature = "datagen")]
     {
-        let single_json = serde_json::to_string(&single).unwrap();
+        let mut buf = Vec::new();
+        let mut serializer = serde_json::Serializer::new(&mut buf);
+        serialize_elements_flat_singleton(&single, &mut serializer).unwrap();
+        let single_json = String::from_utf8(buf).unwrap();
         // In human-readable format, it should serialize as a flat string.
         assert_eq!(single_json, "\"hello\"");
 
         // Deserialize back
-        let single_deser: PluralElements<String> = serde_json::from_str(&single_json).unwrap();
+        let mut deserializer = serde_json::Deserializer::from_str(&single_json);
+        let single_deser =
+            deserialize_elements_flat_singleton::<String, _>(&mut deserializer).unwrap();
         assert_eq!(single, single_deser);
     }
 
     // Deserialize from map format (it should also work)
     let map_json = "{\"other\":\"hello\"}";
-    let map_deser: PluralElements<String> = serde_json::from_str(map_json).unwrap();
+    let mut deserializer = serde_json::Deserializer::from_str(map_json);
+    let map_deser = deserialize_elements_flat_singleton::<String, _>(&mut deserializer).unwrap();
     assert_eq!(single, map_deser);
 
     // 2. Multiple values
@@ -72,12 +81,17 @@ fn test_plural_elements_serde() {
 
     #[cfg(feature = "datagen")]
     {
-        let multi_json = serde_json::to_string(&multi).unwrap();
+        let mut buf = Vec::new();
+        let mut serializer = serde_json::Serializer::new(&mut buf);
+        serialize_elements_flat_singleton(&multi, &mut serializer).unwrap();
+        let multi_json = String::from_utf8(buf).unwrap();
         // Should serialize as map
         assert_eq!(multi_json, "{\"one\":\"one_val\",\"other\":\"other_val\"}");
 
         // Deserialize back
-        let multi_deser: PluralElements<String> = serde_json::from_str(&multi_json).unwrap();
+        let mut deserializer = serde_json::Deserializer::from_str(&multi_json);
+        let multi_deser =
+            deserialize_elements_flat_singleton::<String, _>(&mut deserializer).unwrap();
         assert_eq!(multi, multi_deser);
     }
 }


### PR DESCRIPTION
This works by moving a bunch of the custom serde logic over into PluralElements, so that the generic code in packed patterns just has to call it.


Note that this code only partially supports plurals. Some of the changes here bring it closer to full support.


To be reviewed commit by commit.

I tried to do this in a way that minimizes the complexity of the diff. First by moving PluralElements-specific serialization logic onto PluralElements, then genericizing from_packed, then moving over to genericized helpers that take in closures for converting between the human types.

I could have introduced a trait but I didn't want there to be a public API. This means in the end we still will have concrete `impl Deserialize for GenericPackedPatterns<Foo>` impls, but those concrete impls will be small.


## Changelog: N/A

The trait impl on PluralElements is a new trait impl, but it's a new trait impl on provider types.

