### PR TITLE
Warn on unknown alt variants in display names

### DIFF
--- a/provider/source/src/displaynames/language.rs
+++ b/provider/source/src/displaynames/language.rs
@@ -95,6 +95,8 @@ impl From<&cldr_serde::displaynames::language::Resource> for LanguageDisplayName
                 }
             } else if let Ok(lang) = key.parse::<Language>() {
                 names.insert(lang.to_tinystr(), value.as_ref());
+            } else if key.contains(ALT_SUBSTRING) {
+                log::warn!("Unknown alt variant for language: {}", key);
             }
         }
         Self {

--- a/provider/source/src/displaynames/language.rs
+++ b/provider/source/src/displaynames/language.rs
@@ -96,10 +96,11 @@ impl From<&cldr_serde::displaynames::language::Resource> for LanguageDisplayName
                 }
             } else if let Ok(lang) = key.parse::<Language>() {
                 names.insert(lang.to_tinystr(), value.as_ref());
-            } else if key.ends_with(ALT_VARIANT_SUBSTRING) || key.ends_with(ALT_SECONDARY_SUBSTRING) {
-                // TODO: Handle this with datagen alt flags. See issue #8012. I think sffc started implementing it for alt ascii in PR #7902
+            } else if key.ends_with(ALT_VARIANT_SUBSTRING) || key.ends_with(ALT_SECONDARY_SUBSTRING)
+            {
+                // TODO(#8012)
             } else if key.ends_with(ALT_OFFICIAL_SUBSTRING) {
-                // TODO: Support alt=official for display names. See issue #8012
+                // TODO(#8012)
             } else if key.contains(ALT_SUBSTRING) {
                 log::warn!("Unknown alt variant for language: {}", key);
             }

--- a/provider/source/src/displaynames/language.rs
+++ b/provider/source/src/displaynames/language.rs
@@ -96,11 +96,11 @@ impl From<&cldr_serde::displaynames::language::Resource> for LanguageDisplayName
                 }
             } else if let Ok(lang) = key.parse::<Language>() {
                 names.insert(lang.to_tinystr(), value.as_ref());
-            } else if key.ends_with(ALT_VARIANT_SUBSTRING) || key.ends_with(ALT_SECONDARY_SUBSTRING)
+            } else if key.ends_with(ALT_VARIANT_SUBSTRING)
+                || key.ends_with(ALT_SECONDARY_SUBSTRING)
+                || key.ends_with(ALT_OFFICIAL_SUBSTRING)
             {
-                // TODO(#8012)
-            } else if key.ends_with(ALT_OFFICIAL_SUBSTRING) {
-                // TODO(#8012)
+                // TODO(#8012): Handle preference-specific alt variants.
             } else if key.contains(ALT_SUBSTRING) {
                 log::warn!("Unknown alt variant for language: {}", key);
             }

--- a/provider/source/src/displaynames/language.rs
+++ b/provider/source/src/displaynames/language.rs
@@ -4,8 +4,9 @@
 
 use crate::cldr_serde;
 use crate::displaynames::{
-    ALT_LONG_SUBSTRING, ALT_MENU_SUBSTRING, ALT_SHORT_SUBSTRING, ALT_SUBSTRING,
-    MENU_CORE_SUBSTRING, MENU_EXTENSION_SUBSTRING,
+    ALT_LONG_SUBSTRING, ALT_MENU_SUBSTRING, ALT_OFFICIAL_SUBSTRING, ALT_SECONDARY_SUBSTRING,
+    ALT_SHORT_SUBSTRING, ALT_SUBSTRING, ALT_VARIANT_SUBSTRING, MENU_CORE_SUBSTRING,
+    MENU_EXTENSION_SUBSTRING,
 };
 use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
@@ -95,6 +96,10 @@ impl From<&cldr_serde::displaynames::language::Resource> for LanguageDisplayName
                 }
             } else if let Ok(lang) = key.parse::<Language>() {
                 names.insert(lang.to_tinystr(), value.as_ref());
+            } else if key.ends_with(ALT_VARIANT_SUBSTRING) || key.ends_with(ALT_SECONDARY_SUBSTRING) {
+                // TODO: Handle this with datagen alt flags. See issue #8012. I think sffc started implementing it for alt ascii in PR #7902
+            } else if key.ends_with(ALT_OFFICIAL_SUBSTRING) {
+                // TODO: Support alt=official for display names. See issue #8012
             } else if key.contains(ALT_SUBSTRING) {
                 log::warn!("Unknown alt variant for language: {}", key);
             }

--- a/provider/source/src/displaynames/mod.rs
+++ b/provider/source/src/displaynames/mod.rs
@@ -10,6 +10,11 @@ pub(crate) mod variant;
 pub(crate) const ALT_SUBSTRING: &str = "-alt-";
 pub(crate) const ALT_SHORT_SUBSTRING: &str = "-alt-short";
 pub(crate) const ALT_LONG_SUBSTRING: &str = "-alt-long";
+pub(crate) const ALT_VARIANT_SUBSTRING: &str = "-alt-variant";
+pub(crate) const ALT_STANDALONE_SUBSTRING: &str = "-alt-stand-alone";
+pub(crate) const ALT_OFFICIAL_SUBSTRING: &str = "-alt-official";
+pub(crate) const ALT_SECONDARY_SUBSTRING: &str = "-alt-secondary";
+pub(crate) const ALT_BIOT_SUBSTRING: &str = "-alt-biot";
 /// Alternate name for territory code `IO` (British Indian Ocean Territory) mapping to "Chagos Archipelago".
 pub(crate) const ALT_CHAGOS_SUBSTRING: &str = "-alt-chagos";
 pub(crate) const MENU_SUBSTRING: &str = "-menu-";

--- a/provider/source/src/displaynames/mod.rs
+++ b/provider/source/src/displaynames/mod.rs
@@ -10,6 +10,8 @@ pub(crate) mod variant;
 pub(crate) const ALT_SUBSTRING: &str = "-alt-";
 pub(crate) const ALT_SHORT_SUBSTRING: &str = "-alt-short";
 pub(crate) const ALT_LONG_SUBSTRING: &str = "-alt-long";
+/// Alternate name for territory code `IO` (British Indian Ocean Territory) mapping to "Chagos Archipelago".
+pub(crate) const ALT_CHAGOS_SUBSTRING: &str = "-alt-chagos";
 pub(crate) const MENU_SUBSTRING: &str = "-menu-";
 pub(crate) const MENU_CORE_SUBSTRING: &str = "-menu-core";
 pub(crate) const MENU_EXTENSION_SUBSTRING: &str = "-menu-extension";

--- a/provider/source/src/displaynames/mod.rs
+++ b/provider/source/src/displaynames/mod.rs
@@ -13,7 +13,9 @@ pub(crate) const ALT_LONG_SUBSTRING: &str = "-alt-long";
 pub(crate) const ALT_VARIANT_SUBSTRING: &str = "-alt-variant";
 pub(crate) const ALT_STANDALONE_SUBSTRING: &str = "-alt-stand-alone";
 pub(crate) const ALT_OFFICIAL_SUBSTRING: &str = "-alt-official";
+/// Secondary name variant, used in languages and scripts.
 pub(crate) const ALT_SECONDARY_SUBSTRING: &str = "-alt-secondary";
+/// Abbreviation for territory code `IO` (British Indian Ocean Territory).
 pub(crate) const ALT_BIOT_SUBSTRING: &str = "-alt-biot";
 /// Alternate name for territory code `IO` (British Indian Ocean Territory) mapping to "Chagos Archipelago".
 pub(crate) const ALT_CHAGOS_SUBSTRING: &str = "-alt-chagos";

--- a/provider/source/src/displaynames/region.rs
+++ b/provider/source/src/displaynames/region.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::cldr_serde;
-use crate::displaynames::{ALT_SHORT_SUBSTRING, ALT_SUBSTRING};
+use crate::displaynames::{ALT_CHAGOS_SUBSTRING, ALT_SHORT_SUBSTRING, ALT_SUBSTRING};
 use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use core::convert::TryFrom;
@@ -59,6 +59,12 @@ impl TryFrom<&cldr_serde::displaynames::region::Resource> for RegionDisplayNames
                 short_names.insert(Region::try_from_str(region)?.to_tinystr(), value.as_str());
             } else if !region.contains(ALT_SUBSTRING) {
                 names.insert(Region::try_from_str(region)?.to_tinystr(), value.as_str());
+            } else if region.ends_with("-alt-variant") {
+                // TODO: Handle this with datagen alt flags. See issue #1225. I think sffc started implementing it for alt ascii in PR #7902
+            } else if region.ends_with(ALT_CHAGOS_SUBSTRING) {
+                // Ignore alt-chagos as requested
+            } else {
+                log::warn!("Unknown alt variant for region: {}", region);
             }
         }
         Ok(Self {

--- a/provider/source/src/displaynames/region.rs
+++ b/provider/source/src/displaynames/region.rs
@@ -66,7 +66,7 @@ impl TryFrom<&cldr_serde::displaynames::region::Resource> for RegionDisplayNames
                 || region.ends_with(ALT_CHAGOS_SUBSTRING)
                 || region.ends_with(ALT_BIOT_SUBSTRING)
             {
-                // TODO(#8012)
+                // TODO(#8012): Handle this with datagen alt flags.
             } else {
                 log::warn!("Unknown alt variant for region: {}", region);
             }

--- a/provider/source/src/displaynames/region.rs
+++ b/provider/source/src/displaynames/region.rs
@@ -66,7 +66,7 @@ impl TryFrom<&cldr_serde::displaynames::region::Resource> for RegionDisplayNames
                 || region.ends_with(ALT_CHAGOS_SUBSTRING)
                 || region.ends_with(ALT_BIOT_SUBSTRING)
             {
-                // TODO: Handle this with datagen alt flags. See issue #8012. I think sffc started implementing it for alt ascii in PR #7902
+                // TODO(#8012)
             } else {
                 log::warn!("Unknown alt variant for region: {}", region);
             }

--- a/provider/source/src/displaynames/region.rs
+++ b/provider/source/src/displaynames/region.rs
@@ -3,7 +3,10 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::cldr_serde;
-use crate::displaynames::{ALT_CHAGOS_SUBSTRING, ALT_SHORT_SUBSTRING, ALT_SUBSTRING};
+use crate::displaynames::{
+    ALT_BIOT_SUBSTRING, ALT_CHAGOS_SUBSTRING, ALT_SHORT_SUBSTRING, ALT_SUBSTRING,
+    ALT_VARIANT_SUBSTRING,
+};
 use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use core::convert::TryFrom;
@@ -59,10 +62,11 @@ impl TryFrom<&cldr_serde::displaynames::region::Resource> for RegionDisplayNames
                 short_names.insert(Region::try_from_str(region)?.to_tinystr(), value.as_str());
             } else if !region.contains(ALT_SUBSTRING) {
                 names.insert(Region::try_from_str(region)?.to_tinystr(), value.as_str());
-            } else if region.ends_with("-alt-variant") {
-                // TODO: Handle this with datagen alt flags. See issue #1225. I think sffc started implementing it for alt ascii in PR #7902
-            } else if region.ends_with(ALT_CHAGOS_SUBSTRING) {
-                // Ignore alt-chagos as requested
+            } else if region.ends_with(ALT_VARIANT_SUBSTRING)
+                || region.ends_with(ALT_CHAGOS_SUBSTRING)
+                || region.ends_with(ALT_BIOT_SUBSTRING)
+            {
+                // TODO: Handle this with datagen alt flags. See issue #8012. I think sffc started implementing it for alt ascii in PR #7902
             } else {
                 log::warn!("Unknown alt variant for region: {}", region);
             }

--- a/provider/source/src/displaynames/script.rs
+++ b/provider/source/src/displaynames/script.rs
@@ -63,6 +63,8 @@ impl TryFrom<&cldr_serde::displaynames::script::Resource> for ScriptDisplayNames
                     Script::try_from_str(entry.0)?.to_tinystr(),
                     entry.1.as_str(),
                 );
+            } else {
+                log::warn!("Unknown alt variant for script: {}", entry.0);
             }
         }
         Ok(Self {

--- a/provider/source/src/displaynames/script.rs
+++ b/provider/source/src/displaynames/script.rs
@@ -3,7 +3,10 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::cldr_serde;
-use crate::displaynames::{ALT_SHORT_SUBSTRING, ALT_SUBSTRING};
+use crate::displaynames::{
+    ALT_SECONDARY_SUBSTRING, ALT_SHORT_SUBSTRING, ALT_STANDALONE_SUBSTRING, ALT_SUBSTRING,
+    ALT_VARIANT_SUBSTRING,
+};
 use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use core::convert::TryFrom;
@@ -63,6 +66,10 @@ impl TryFrom<&cldr_serde::displaynames::script::Resource> for ScriptDisplayNames
                     Script::try_from_str(entry.0)?.to_tinystr(),
                     entry.1.as_str(),
                 );
+            } else if entry.0.ends_with(ALT_VARIANT_SUBSTRING) || entry.0.ends_with(ALT_SECONDARY_SUBSTRING) {
+                // TODO: Handle this with datagen alt flags. See issue #8012. I think sffc started implementing it for alt ascii in PR #7902
+            } else if entry.0.ends_with(ALT_STANDALONE_SUBSTRING) {
+                // TODO: Support standalone display names. See issue #8011
             } else {
                 log::warn!("Unknown alt variant for script: {}", entry.0);
             }

--- a/provider/source/src/displaynames/script.rs
+++ b/provider/source/src/displaynames/script.rs
@@ -66,10 +66,12 @@ impl TryFrom<&cldr_serde::displaynames::script::Resource> for ScriptDisplayNames
                     Script::try_from_str(entry.0)?.to_tinystr(),
                     entry.1.as_str(),
                 );
-            } else if entry.0.ends_with(ALT_VARIANT_SUBSTRING) || entry.0.ends_with(ALT_SECONDARY_SUBSTRING) {
-                // TODO: Handle this with datagen alt flags. See issue #8012. I think sffc started implementing it for alt ascii in PR #7902
+            } else if entry.0.ends_with(ALT_VARIANT_SUBSTRING)
+                || entry.0.ends_with(ALT_SECONDARY_SUBSTRING)
+            {
+                // TODO(#8012)
             } else if entry.0.ends_with(ALT_STANDALONE_SUBSTRING) {
-                // TODO: Support standalone display names. See issue #8011
+                // TODO(#8011)
             } else {
                 log::warn!("Unknown alt variant for script: {}", entry.0);
             }

--- a/provider/source/src/displaynames/script.rs
+++ b/provider/source/src/displaynames/script.rs
@@ -69,9 +69,9 @@ impl TryFrom<&cldr_serde::displaynames::script::Resource> for ScriptDisplayNames
             } else if entry.0.ends_with(ALT_VARIANT_SUBSTRING)
                 || entry.0.ends_with(ALT_SECONDARY_SUBSTRING)
             {
-                // TODO(#8012)
+                // TODO(#8012): Handle this with datagen alt flags.
             } else if entry.0.ends_with(ALT_STANDALONE_SUBSTRING) {
-                // TODO(#8011)
+                // TODO(#8011): Support standalone display names.
             } else {
                 log::warn!("Unknown alt variant for script: {}", entry.0);
             }

--- a/provider/source/src/displaynames/variant.rs
+++ b/provider/source/src/displaynames/variant.rs
@@ -62,7 +62,7 @@ impl TryFrom<&cldr_serde::displaynames::variant::Resource> for VariantDisplayNam
                     entry.1.as_str(),
                 );
             } else if entry.0.ends_with(ALT_SECONDARY_SUBSTRING) {
-                // TODO(#8012)
+                // TODO(#8012): Handle this with datagen alt flags.
             } else {
                 log::warn!("Unknown alt variant for variant: {}", entry.0);
             }

--- a/provider/source/src/displaynames/variant.rs
+++ b/provider/source/src/displaynames/variant.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::cldr_serde;
-use crate::displaynames::{ALT_SHORT_SUBSTRING, ALT_SUBSTRING};
+use crate::displaynames::{ALT_SECONDARY_SUBSTRING, ALT_SHORT_SUBSTRING, ALT_SUBSTRING};
 use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use core::convert::TryFrom;
@@ -61,6 +61,8 @@ impl TryFrom<&cldr_serde::displaynames::variant::Resource> for VariantDisplayNam
                     Variant::try_from_str(entry.0)?.to_tinystr(),
                     entry.1.as_str(),
                 );
+            } else if entry.0.ends_with(ALT_SECONDARY_SUBSTRING) {
+                // TODO(#8012)
             } else {
                 log::warn!("Unknown alt variant for variant: {}", entry.0);
             }

--- a/provider/source/src/displaynames/variant.rs
+++ b/provider/source/src/displaynames/variant.rs
@@ -61,6 +61,8 @@ impl TryFrom<&cldr_serde::displaynames::variant::Resource> for VariantDisplayNam
                     Variant::try_from_str(entry.0)?.to_tinystr(),
                     entry.1.as_str(),
                 );
+            } else {
+                log::warn!("Unknown alt variant for variant: {}", entry.0);
             }
         }
         Ok(Self {


### PR DESCRIPTION
This PR adds warnings to the datagen for display names when unknown `alt` variants are encountered in the CLDR source data. It also explicitly ignores `-alt-variant` and `-alt-chagos` for regions to avoid noisy warnings for these known cases.

🤖 This pull request was created by an AI agent working with @sffc.

## Changelog
icu_provider_source: Warn on unknown alt variants in display names
  * Added warnings for unknown `alt` variants in `language.rs`, `script.rs`, and `variant.rs`.
  * Ignored `-alt-variant` and `-alt-chagos` in `region.rs`.
