### PR TITLE
Use canonical property value names

### DIFF
--- a/components/properties/src/enum_values.rs
+++ b/components/properties/src/enum_values.rs
@@ -877,9 +877,9 @@ impl HangulSyllableType {
     /// `T`
     pub const TrailingJamo: Self = Self(3);
     /// `LV`
-    pub const LeadingVowelSyllable: Self = Self(4);
+    pub const LVSyllable: Self = Self(4);
     /// `LVT`
-    pub const LeadingVowelTrailingSyllable: Self = Self(5);
+    pub const LVTSyllable: Self = Self(5);
 }
 
 #[cfg(feature = "datagen")]
@@ -891,8 +891,8 @@ impl databake::Bake for HangulSyllableType {
             Self::LeadingJamo => databake::quote!(icu_properties::props::HangulSyllableType::LeadingJamo),
             Self::VowelJamo => databake::quote!(icu_properties::props::HangulSyllableType::VowelJamo),
             Self::TrailingJamo => databake::quote!(icu_properties::props::HangulSyllableType::TrailingJamo),
-            Self::LeadingVowelSyllable => databake::quote!(icu_properties::props::HangulSyllableType::LeadingVowelSyllable),
-            Self::LeadingVowelTrailingSyllable => databake::quote!(icu_properties::props::HangulSyllableType::LeadingVowelTrailingSyllable),
+            Self::LVSyllable => databake::quote!(icu_properties::props::HangulSyllableType::LVSyllable),
+            Self::LVTSyllable => databake::quote!(icu_properties::props::HangulSyllableType::LVTSyllable),
             Self(v) => databake::quote!(icu_properties::props::HangulSyllableType(#v)),
         }
     }
@@ -913,8 +913,8 @@ impl HangulSyllableType {
         Self::LeadingJamo,
         Self::VowelJamo,
         Self::TrailingJamo,
-        Self::LeadingVowelSyllable,
-        Self::LeadingVowelTrailingSyllable,
+        Self::LVSyllable,
+        Self::LVTSyllable,
     ];
 
     #[cfg(feature = "datagen")]
@@ -925,8 +925,8 @@ impl HangulSyllableType {
             ("L", Self::LeadingJamo),
             ("V", Self::VowelJamo),
             ("T", Self::TrailingJamo),
-            ("LV", Self::LeadingVowelSyllable),
-            ("LVT", Self::LeadingVowelTrailingSyllable),
+            ("LV", Self::LVSyllable),
+            ("LVT", Self::LVTSyllable),
         ].into_iter()
     }
 }
@@ -2203,7 +2203,7 @@ impl Script {
     /// `Deva`
     pub const Devanagari: Self = Self(10);
     /// `Ethi`
-    pub const Ethiopian: Self = Self(11);
+    pub const Ethiopic: Self = Self(11);
     /// `Geor`
     pub const Georgian: Self = Self(12);
     /// `Goth`
@@ -2616,7 +2616,7 @@ impl Script {
     /// `Nagm`
     pub const NagMundari: Self = Self(199);
     /// `Aran`
-    pub const Nastaliq: Self = Self(200);
+    pub const ArabicNastaliq: Self = Self(200);
     /// `Gara`
     pub const Garay: Self = Self(201);
     /// `Gukh`
@@ -2660,7 +2660,7 @@ impl databake::Bake for Script {
             Self::Cyrillic => databake::quote!(icu_properties::props::Script::Cyrillic),
             Self::Deseret => databake::quote!(icu_properties::props::Script::Deseret),
             Self::Devanagari => databake::quote!(icu_properties::props::Script::Devanagari),
-            Self::Ethiopian => databake::quote!(icu_properties::props::Script::Ethiopian),
+            Self::Ethiopic => databake::quote!(icu_properties::props::Script::Ethiopic),
             Self::Georgian => databake::quote!(icu_properties::props::Script::Georgian),
             Self::Gothic => databake::quote!(icu_properties::props::Script::Gothic),
             Self::Greek => databake::quote!(icu_properties::props::Script::Greek),
@@ -2849,7 +2849,7 @@ impl databake::Bake for Script {
             Self::Vithkuqi => databake::quote!(icu_properties::props::Script::Vithkuqi),
             Self::Kawi => databake::quote!(icu_properties::props::Script::Kawi),
             Self::NagMundari => databake::quote!(icu_properties::props::Script::NagMundari),
-            Self::Nastaliq => databake::quote!(icu_properties::props::Script::Nastaliq),
+            Self::ArabicNastaliq => databake::quote!(icu_properties::props::Script::ArabicNastaliq),
             Self::Garay => databake::quote!(icu_properties::props::Script::Garay),
             Self::GurungKhema => databake::quote!(icu_properties::props::Script::GurungKhema),
             Self::KiratRai => databake::quote!(icu_properties::props::Script::KiratRai),
@@ -2889,7 +2889,7 @@ impl Script {
         Self::Cyrillic,
         Self::Deseret,
         Self::Devanagari,
-        Self::Ethiopian,
+        Self::Ethiopic,
         Self::Georgian,
         Self::Gothic,
         Self::Greek,
@@ -3043,7 +3043,7 @@ impl Script {
         Self::Vithkuqi,
         Self::Kawi,
         Self::NagMundari,
-        Self::Nastaliq,
+        Self::ArabicNastaliq,
         Self::Garay,
         Self::GurungKhema,
         Self::KiratRai,
@@ -3072,7 +3072,7 @@ impl Script {
             ("Cyrl", Self::Cyrillic),
             ("Dsrt", Self::Deseret),
             ("Deva", Self::Devanagari),
-            ("Ethi", Self::Ethiopian),
+            ("Ethi", Self::Ethiopic),
             ("Geor", Self::Georgian),
             ("Goth", Self::Gothic),
             ("Grek", Self::Greek),
@@ -3261,7 +3261,7 @@ impl Script {
             ("Vith", Self::Vithkuqi),
             ("Kawi", Self::Kawi),
             ("Nagm", Self::NagMundari),
-            ("Aran", Self::Nastaliq),
+            ("Aran", Self::ArabicNastaliq),
             ("Gara", Self::Garay),
             ("Gukh", Self::GurungKhema),
             ("Krai", Self::KiratRai),

--- a/components/properties/src/props.rs
+++ b/components/properties/src/props.rs
@@ -621,6 +621,14 @@ impl Script {
     pub const fn from_icu4c_value(value: u16) -> Self {
         Self(value)
     }
+    /// Deprecated: non-canonical spelling
+    #[deprecated(since = "2.3.0", note = "use Script::Ethiopic instead")]
+    #[allow(non_upper_case_globals)]
+    pub const Ethiopian: Self = Self::Ethiopic;
+    /// Deprecated: non-canonical spelling
+    #[deprecated(since = "2.3.0", note = "use Script::ArabicNastaliq instead")]
+    #[allow(non_upper_case_globals)]
+    pub const Nastaliq: Self = Self::ArabicNastaliq;
 }
 
 impl Default for Script {
@@ -711,6 +719,14 @@ impl HangulSyllableType {
     pub const fn from_icu4c_value(value: u8) -> Self {
         Self(value)
     }
+    /// Deprecated: non-canonical spelling
+    #[deprecated(since = "2.3.0", note = "use HangulSyllableType::LVSyllable instead")]
+    #[allow(non_upper_case_globals)]
+    pub const LeadingVowelSyllable: Self = Self::LVSyllable;
+    /// Deprecated: non-canonical spelling
+    #[deprecated(since = "2.3.0", note = "use HangulSyllableType::LVTSyllable instead")]
+    #[allow(non_upper_case_globals)]
+    pub const LeadingVowelTrailingSyllable: Self = Self::LVTSyllable;
 }
 
 impl Default for HangulSyllableType {

--- a/ffi/capi/bindings/cpp/icu4x/HangulSyllableType.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/HangulSyllableType.d.hpp
@@ -55,11 +55,11 @@ public:
          */
         TrailingJamo = 3,
         /**
-         * See the [Rust documentation for `LeadingVowelSyllable`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.HangulSyllableType.html#associatedconstant.LeadingVowelSyllable) for more information.
+         * See the [Rust documentation for `LVSyllable`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.HangulSyllableType.html#associatedconstant.LVSyllable) for more information.
          */
         LeadingVowelSyllable = 4,
         /**
-         * See the [Rust documentation for `LeadingVowelTrailingSyllable`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.HangulSyllableType.html#associatedconstant.LeadingVowelTrailingSyllable) for more information.
+         * See the [Rust documentation for `LVTSyllable`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.HangulSyllableType.html#associatedconstant.LVTSyllable) for more information.
          */
         LeadingVowelTrailingSyllable = 5,
     };

--- a/ffi/capi/bindings/cpp/icu4x/Script.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/Script.d.hpp
@@ -291,7 +291,7 @@ public:
          */
         Devanagari = 10,
         /**
-         * See the [Rust documentation for `Ethiopian`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.Script.html#associatedconstant.Ethiopian) for more information.
+         * See the [Rust documentation for `Ethiopic`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.Script.html#associatedconstant.Ethiopic) for more information.
          */
         Ethiopian = 11,
         /**
@@ -1047,7 +1047,7 @@ public:
          */
         NagMundari = 199,
         /**
-         * See the [Rust documentation for `Nastaliq`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.Script.html#associatedconstant.Nastaliq) for more information.
+         * See the [Rust documentation for `ArabicNastaliq`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.Script.html#associatedconstant.ArabicNastaliq) for more information.
          */
         Nastaliq = 200,
         /**

--- a/ffi/capi/src/properties_enums.rs
+++ b/ffi/capi/src/properties_enums.rs
@@ -1190,12 +1190,12 @@ pub mod ffi {
         )]
         TrailingJamo = 3,
         #[diplomat::rust_link(
-            icu::properties::props::HangulSyllableType::LeadingVowelSyllable,
+            icu::properties::props::HangulSyllableType::LVSyllable,
             AssociatedConstantInStruct
         )]
         LeadingVowelSyllable = 4,
         #[diplomat::rust_link(
-            icu::properties::props::HangulSyllableType::LeadingVowelTrailingSyllable,
+            icu::properties::props::HangulSyllableType::LVTSyllable,
             AssociatedConstantInStruct
         )]
         LeadingVowelTrailingSyllable = 5,
@@ -2972,7 +2972,7 @@ pub mod ffi {
         )]
         Devanagari = 10,
         #[diplomat::rust_link(
-            icu::properties::props::Script::Ethiopian,
+            icu::properties::props::Script::Ethiopic,
             AssociatedConstantInStruct
         )]
         Ethiopian = 11,
@@ -3918,7 +3918,7 @@ pub mod ffi {
         )]
         NagMundari = 199,
         #[diplomat::rust_link(
-            icu::properties::props::Script::Nastaliq,
+            icu::properties::props::Script::ArabicNastaliq,
             AssociatedConstantInStruct
         )]
         Nastaliq = 200,

--- a/ffi/dart/lib/src/bindings/HangulSyllableType.g.dart
+++ b/ffi/dart/lib/src/bindings/HangulSyllableType.g.dart
@@ -13,9 +13,9 @@ enum HangulSyllableType {
   vowelJamo,
   /// See the [Rust documentation for `TrailingJamo`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.HangulSyllableType.html#associatedconstant.TrailingJamo) for more information.
   trailingJamo,
-  /// See the [Rust documentation for `LeadingVowelSyllable`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.HangulSyllableType.html#associatedconstant.LeadingVowelSyllable) for more information.
+  /// See the [Rust documentation for `LVSyllable`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.HangulSyllableType.html#associatedconstant.LVSyllable) for more information.
   leadingVowelSyllable,
-  /// See the [Rust documentation for `LeadingVowelTrailingSyllable`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.HangulSyllableType.html#associatedconstant.LeadingVowelTrailingSyllable) for more information.
+  /// See the [Rust documentation for `LVTSyllable`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.HangulSyllableType.html#associatedconstant.LVTSyllable) for more information.
   leadingVowelTrailingSyllable;
 
   /// See the [Rust documentation for `for_char`](https://docs.rs/icu/2.2.0/icu/properties/props/trait.EnumeratedProperty.html#tymethod.for_char) for more information.

--- a/ffi/dart/lib/src/bindings/Script.g.dart
+++ b/ffi/dart/lib/src/bindings/Script.g.dart
@@ -27,7 +27,7 @@ enum Script {
   deseret,
   /// See the [Rust documentation for `Devanagari`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.Script.html#associatedconstant.Devanagari) for more information.
   devanagari,
-  /// See the [Rust documentation for `Ethiopian`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.Script.html#associatedconstant.Ethiopian) for more information.
+  /// See the [Rust documentation for `Ethiopic`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.Script.html#associatedconstant.Ethiopic) for more information.
   ethiopian,
   /// See the [Rust documentation for `Georgian`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.Script.html#associatedconstant.Georgian) for more information.
   georgian,
@@ -405,7 +405,7 @@ enum Script {
   kawi,
   /// See the [Rust documentation for `NagMundari`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.Script.html#associatedconstant.NagMundari) for more information.
   nagMundari,
-  /// See the [Rust documentation for `Nastaliq`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.Script.html#associatedconstant.Nastaliq) for more information.
+  /// See the [Rust documentation for `ArabicNastaliq`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.Script.html#associatedconstant.ArabicNastaliq) for more information.
   nastaliq,
   /// See the [Rust documentation for `Garay`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.Script.html#associatedconstant.Garay) for more information.
   garay,

--- a/ffi/npm/lib/HangulSyllableType.d.ts
+++ b/ffi/npm/lib/HangulSyllableType.d.ts
@@ -33,11 +33,11 @@ export class HangulSyllableType {
      */
     static TrailingJamo : HangulSyllableType;
     /**
-     * See the [Rust documentation for `LeadingVowelSyllable`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.HangulSyllableType.html#associatedconstant.LeadingVowelSyllable) for more information.
+     * See the [Rust documentation for `LVSyllable`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.HangulSyllableType.html#associatedconstant.LVSyllable) for more information.
      */
     static LeadingVowelSyllable : HangulSyllableType;
     /**
-     * See the [Rust documentation for `LeadingVowelTrailingSyllable`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.HangulSyllableType.html#associatedconstant.LeadingVowelTrailingSyllable) for more information.
+     * See the [Rust documentation for `LVTSyllable`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.HangulSyllableType.html#associatedconstant.LVTSyllable) for more information.
      */
     static LeadingVowelTrailingSyllable : HangulSyllableType;
 

--- a/ffi/npm/lib/HangulSyllableType.mjs
+++ b/ffi/npm/lib/HangulSyllableType.mjs
@@ -87,11 +87,11 @@ export class HangulSyllableType {
      */
     static TrailingJamo = HangulSyllableType.#objectValues[3];
     /**
-     * See the [Rust documentation for `LeadingVowelSyllable`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.HangulSyllableType.html#associatedconstant.LeadingVowelSyllable) for more information.
+     * See the [Rust documentation for `LVSyllable`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.HangulSyllableType.html#associatedconstant.LVSyllable) for more information.
      */
     static LeadingVowelSyllable = HangulSyllableType.#objectValues[4];
     /**
-     * See the [Rust documentation for `LeadingVowelTrailingSyllable`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.HangulSyllableType.html#associatedconstant.LeadingVowelTrailingSyllable) for more information.
+     * See the [Rust documentation for `LVTSyllable`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.HangulSyllableType.html#associatedconstant.LVTSyllable) for more information.
      */
     static LeadingVowelTrailingSyllable = HangulSyllableType.#objectValues[5];
 

--- a/ffi/npm/lib/Script.d.ts
+++ b/ffi/npm/lib/Script.d.ts
@@ -61,7 +61,7 @@ export class Script {
      */
     static Devanagari : Script;
     /**
-     * See the [Rust documentation for `Ethiopian`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.Script.html#associatedconstant.Ethiopian) for more information.
+     * See the [Rust documentation for `Ethiopic`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.Script.html#associatedconstant.Ethiopic) for more information.
      */
     static Ethiopian : Script;
     /**
@@ -817,7 +817,7 @@ export class Script {
      */
     static NagMundari : Script;
     /**
-     * See the [Rust documentation for `Nastaliq`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.Script.html#associatedconstant.Nastaliq) for more information.
+     * See the [Rust documentation for `ArabicNastaliq`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.Script.html#associatedconstant.ArabicNastaliq) for more information.
      */
     static Nastaliq : Script;
     /**

--- a/ffi/npm/lib/Script.mjs
+++ b/ffi/npm/lib/Script.mjs
@@ -535,7 +535,7 @@ export class Script {
      */
     static Devanagari = Script.#objectValues[10];
     /**
-     * See the [Rust documentation for `Ethiopian`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.Script.html#associatedconstant.Ethiopian) for more information.
+     * See the [Rust documentation for `Ethiopic`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.Script.html#associatedconstant.Ethiopic) for more information.
      */
     static Ethiopian = Script.#objectValues[11];
     /**
@@ -1291,7 +1291,7 @@ export class Script {
      */
     static NagMundari = Script.#objectValues[199];
     /**
-     * See the [Rust documentation for `Nastaliq`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.Script.html#associatedconstant.Nastaliq) for more information.
+     * See the [Rust documentation for `ArabicNastaliq`](https://docs.rs/icu/2.2.0/icu/properties/props/struct.Script.html#associatedconstant.ArabicNastaliq) for more information.
      */
     static Nastaliq = Script.#objectValues[200];
     /**

--- a/tools/make/codegen/src/properties.rs
+++ b/tools/make/codegen/src/properties.rs
@@ -45,7 +45,7 @@ impl Prop {
         self.name == "Script"
             && [
                 // 200 (`Aran`) *should* be in here, but at some point we erroneously added it, so it
-                // looks like a Unicode value now.
+                // looks like a Unicode value now (https://github.com/unicode-org/icu4x/issues/4425).
                 64, 67, 68, 69, 70, 72, 73, 74, 77, 80, 81, 85, 93, 94, 95, 96, 97, 98, 100, 102,
                 105, 114, 119, 124, 128, 129, 132, 138, 139, 147, 148, 155, 172, 173, 174, 212,
             ]
@@ -57,8 +57,12 @@ impl Prop {
     }
 
     fn transform_long(&self, long_name: &str) -> String {
-        long_name
-            .replace('_', "")
+        long_name.replace('_', "")
+    }
+
+    fn transform_long_ffi(&self, long_name: &str) -> String {
+        self.transform_long(long_name)
+            // Unfortunately we're stuck with these non-canonical names on FFI
             .replace("Ethiopic", "Ethiopian")
             .replace("ArabicNastaliq", "Nastaliq")
             .replace("LVSyllable", "LeadingVowelSyllable")

--- a/tools/make/codegen/templates/properties_enums.rs.jinja
+++ b/tools/make/codegen/templates/properties_enums.rs.jinja
@@ -28,7 +28,7 @@ pub mod ffi {
         {%- if prop.default == discriminant %}
         #[diplomat::attr(auto, default)]
         {%- endif %}
-        {{prop.transform_long(long_name)}} = {{discriminant}},
+        {{prop.transform_long_ffi(long_name)}} = {{discriminant}},
         {%- endfor %}
     }
 
@@ -84,7 +84,7 @@ pub mod ffi {
         pub fn from_integer_value(other: {{ prop.int_type() }}) -> Option<Self> {
             Some(match other {
                 {%- for (discriminant, (_, long_name)) in prop.variants() %}
-                {{ discriminant }} => Self::{{prop.transform_long(long_name)}},
+                {{ discriminant }} => Self::{{prop.transform_long_ffi(long_name)}},
                 {%- endfor %}
                 _ => return None,
             })


### PR DESCRIPTION
`HangulSyllableType::LeadingVowelSyllable`, `HangulSyllableType::LeadingVowelTrailingSyllable`, `Script::Ethiopian`, and `Script::Nastaliq` use spellings that don't match Unicode/ICU4C. They were added in https://github.com/unicode-org/icu4x/pull/2416, https://github.com/unicode-org/icu4x/pull/4426, and https://github.com/unicode-org/icu4x/pull/4885.

Deprecate the values and replace by constants with the canonical spelling. Unfortunately we cannot do this on FFI.

## Changelog

icu_properties: Deprecate `HangulSyllableType::LeadingVowelSyllable`, `HangulSyllableType::LeadingVowelTrailingSyllable`, `Script::Ethiopian`, and `Script::Nastaliq` in favor of names matching their official Unicode names
 - New associated constants: `HangulSyllableType::LVSyllable`, `HangulSyllableType::LVTSyllable`, `Script::Ethiopic`, `Script::ArabicNastaliq`