### PR TITLE
Allow digits as extension singletons

### DIFF
--- a/components/locale_core/src/extensions/mod.rs
+++ b/components/locale_core/src/extensions/mod.rs
@@ -11,7 +11,7 @@
 //!  * [`Unicode Extensions`] - marked as `u`.
 //!  * [`Transform Extensions`] - marked as `t`.
 //!  * [`Private Use Extensions`] - marked as `x`.
-//!  * [`Other Extensions`] - marked as any `a-z` except of `u`, `t` and `x`.
+//!  * [`Other Extensions`] - marked as any `a-z` or `0-9` except `u`, `t`, and `x`.
 //!
 //! One can think of extensions as a bag of extra information on top of basic 4 [`subtags`].
 //!
@@ -102,7 +102,7 @@ impl ExtensionType {
             UNICODE_EXT_CHAR => Ok(Self::Unicode),
             TRANSFORM_EXT_CHAR => Ok(Self::Transform),
             PRIVATE_EXT_CHAR => Ok(Self::Private),
-            'a'..='z' => Ok(Self::Other(key)),
+            'a'..='z' | '0'..='9' => Ok(Self::Other(key)),
             _ => Err(ParseError::InvalidExtension),
         }
     }
@@ -396,5 +396,13 @@ fn test_writeable() {
             .unwrap()
             .extensions,
         "a-foo-t-foo-u-foo-w-foo-z-foo-x-foo",
+    );
+    assert_writeable_eq!(
+        "en-1-ext-value".parse::<Locale>().unwrap().extensions,
+        "1-ext-value",
+    );
+    assert_writeable_eq!(
+        "und-a-foo-1-bar".parse::<Locale>().unwrap().extensions,
+        "1-bar-a-foo",
     );
 }

--- a/components/locale_core/src/extensions/other/mod.rs
+++ b/components/locale_core/src/extensions/other/mod.rs
@@ -93,7 +93,7 @@ impl Other {
     ///
     /// # Panics
     ///
-    /// Panics if `ext` is not ASCII alphabetic.
+    /// Panics if `ext` is not ASCII alphanumeric.
     ///
     /// # Examples
     ///
@@ -114,7 +114,7 @@ impl Other {
 
     #[allow(dead_code)]
     pub(crate) fn from_short_slice_unchecked(ext: u8, keys: ShortBoxSlice<Subtag>) -> Self {
-        assert!(ext.is_ascii_alphabetic());
+        assert!(ext.is_ascii_alphanumeric());
         // Safety invariant upheld here: ext checked as ASCII above
         Self { ext, keys }
     }
@@ -156,7 +156,7 @@ impl Other {
     /// assert_eq!(other_ext.get_ext_str(), "a");
     /// ```
     pub fn get_ext_str(&self) -> &str {
-        debug_assert!(self.ext.is_ascii_alphabetic());
+        debug_assert!(self.ext.is_ascii_alphanumeric());
         // Safety: from safety invariant on self.ext (that it is ASCII)
         unsafe { core::str::from_utf8_unchecked(core::slice::from_ref(&self.ext)) }
     }
@@ -253,6 +253,9 @@ mod tests {
     fn test_other_extension_fromstr() {
         let oe: Other = "o-foo-bar".parse().expect("Failed to parse Other");
         assert_eq!(oe.to_string(), "o-foo-bar");
+
+        let oe: Other = "1-foo-bar".parse().expect("Failed to parse Other");
+        assert_eq!(oe.to_string(), "1-foo-bar");
 
         let oe: Result<Other, _> = "o".parse();
         assert!(oe.is_err());

--- a/components/locale_core/tests/fixtures/locale.json
+++ b/components/locale_core/tests/fixtures/locale.json
@@ -294,5 +294,38 @@
       "type": "Locale",
       "identifier": "en-a-bar-u-foo-w-bar-x-u-foo"
     }
+  },
+  {
+    "input": {
+      "type": "Locale",
+      "identifier": "en-1-ext-value"
+    },
+    "output": {
+      "type": "Locale",
+      "language": "en",
+      "extensions": {
+        "other": ["1-ext-value"]
+      }
+    }
+  },
+  {
+    "input": {
+      "type": "Locale",
+      "identifier": "en-w-bar-1-foo"
+    },
+    "output": {
+      "type": "Locale",
+      "identifier": "en-1-foo-w-bar"
+    }
+  },
+  {
+    "input": {
+      "type": "Locale",
+      "identifier": "en-w-bar-1-foo-u-baz"
+    },
+    "output": {
+      "type": "Locale",
+      "identifier": "en-1-foo-u-baz-w-bar"
+    }
   }
 ]

--- a/components/locale_core/tests/fixtures/mod.rs
+++ b/components/locale_core/tests/fixtures/mod.rs
@@ -5,6 +5,7 @@
 use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};
 
+use icu_locale_core::extensions::other;
 use icu_locale_core::extensions::private;
 use icu_locale_core::extensions::transform;
 use icu_locale_core::extensions::unicode;
@@ -40,7 +41,8 @@ pub struct LocaleExtensions {
     transform: Option<LocaleExtensionTransform>,
     #[serde(default)]
     private: Vec<String>,
-    _other: Option<String>,
+    #[serde(default)]
+    other: Vec<String>,
 }
 
 impl TryFrom<LocaleExtensions> for Extensions {
@@ -95,6 +97,15 @@ impl TryFrom<LocaleExtensions> for Extensions {
             .map(|v| private::Subtag::try_from_str(v).expect("Failed to add field."))
             .collect();
         ext.private = private::Private::from_vec_unchecked(v);
+        let mut other: Vec<other::Other> = input
+            .other
+            .iter()
+            .map(|v| {
+                other::Other::try_from_str(v).expect("Failed to parse Other extension")
+            })
+            .collect();
+        other.sort();
+        ext.other = other;
         Ok(ext)
     }
 }

--- a/components/locale_core/tests/fixtures/mod.rs
+++ b/components/locale_core/tests/fixtures/mod.rs
@@ -100,9 +100,7 @@ impl TryFrom<LocaleExtensions> for Extensions {
         let mut other: Vec<other::Other> = input
             .other
             .iter()
-            .map(|v| {
-                other::Other::try_from_str(v).expect("Failed to parse Other extension")
-            })
+            .map(|v| other::Other::try_from_str(v).expect("Failed to parse Other extension"))
             .collect();
         other.sort();
         ext.other = other;

--- a/components/locale_core/tests/locale.rs
+++ b/components/locale_core/tests/locale.rs
@@ -117,3 +117,18 @@ fn test_locale_strict_cmp() {
         }
     }
 }
+
+#[test]
+fn test_locale_total_cmp() {
+    let l_1_bar = "und-1-bar".parse::<Locale>().unwrap();
+    let l_a_foo = "und-a-foo".parse::<Locale>().unwrap();
+    let l_2_baz = "und-2-baz".parse::<Locale>().unwrap();
+
+    assert_eq!(l_1_bar.total_cmp(&l_a_foo), std::cmp::Ordering::Less);
+    assert_eq!(l_1_bar.total_cmp(&l_2_baz), std::cmp::Ordering::Less);
+    assert_eq!(l_2_baz.total_cmp(&l_a_foo), std::cmp::Ordering::Less);
+
+    let l_en_1 = "en-1-ext-value".parse::<Locale>().unwrap();
+    let l_en_a = "en-a-ext-value".parse::<Locale>().unwrap();
+    assert_eq!(l_en_1.total_cmp(&l_en_a), std::cmp::Ordering::Less);
+}


### PR DESCRIPTION
Fixes https://github.com/unicode-org/icu4x/issues/8018 using the steps I outlined in my comment there.

BCP47 allows digits as extension singletons ([RFC 5646 §2.1](https://www.rfc-editor.org/info/rfc5646/#section-2.1), production for `singleton`). We don't support that, and that doesn't appear to be intentional.

ICU4C seems to support this.

I don't know the history here, though.

## Changelog

icu_locale: Allow digits as extension singletons as allowed by BCP47, e.g. `-1-foobar`