### PR TITLE
fix Send/Sync impls on CartableOptionPointer, yoke 0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Several crates have had patch releases in the 2.2 stream:
         - Fix extended year calculations in Gregorian-like and Coptic-like calendars (unicode-org#7849)
 - Utils
     - (0.8.3) `yoke`
-        - Fix soundness of Send/Sync impls on CartableOptionPointer (unicode-org#XXXX)
+        - Fix soundness of Send/Sync impls on CartableOptionPointer (unicode-org#8029)
         - Update to 2024 edition where possible (unicode-org#7878)
 
 ## icu4x 2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Several crates have had patch releases in the 2.2 stream:
 - Components
     - (2.2.1) `icu_calendar`
         - Fix extended year calculations in Gregorian-like and Coptic-like calendars (unicode-org#7849)
+- Utils
+    - (0.8.3) `yoke`
+        - Fix soundness of Send/Sync impls on CartableOptionPointer (unicode-org#XXXX)
+        - Update to 2024 edition where possible (unicode-org#7878)
 
 ## icu4x 2.2
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4245,7 +4245,7 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "bincode",
  "postcard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,7 +201,7 @@ resb = { version = "0.2.0-dev", path = "utils/resb", default-features = false }
 tzif = { version = "0.5.0", path = "utils/tzif", default-features = false }
 tinystr = { version = "0.8.3", path = "utils/tinystr", default-features = false }
 writeable = { version = "0.6.1", path = "utils/writeable", default-features = false } # Current version: 0.6.2
-yoke = { version = "0.8.2", path = "utils/yoke", default-features = false }
+yoke = { version = "0.8.3", path = "utils/yoke", default-features = false }
 yoke-derive = { version = "0.8.2", path = "utils/yoke/derive", default-features = false }
 zerofrom = { version = "0.1.6", path = "utils/zerofrom", default-features = false } # Current version: 0.1.8
 zerofrom-derive = { version = "0.1.6", path = "utils/zerofrom/derive", default-features = false } # Current version: 0.1.7

--- a/utils/yoke/Cargo.toml
+++ b/utils/yoke/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "yoke"
 description = "Abstraction allowing borrowed data to be carried along with the backing data it borrows from"
-version = "0.8.2"
+version = "0.8.3"
 authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
 categories = ["data-structures", "memory-management", "caching", "no-std"]
 keywords = ["zero-copy", "serialization", "memory-efficiency", "self-referential"]

--- a/utils/yoke/src/cartable_ptr.rs
+++ b/utils/yoke/src/cartable_ptr.rs
@@ -370,10 +370,10 @@ unsafe impl<C> CloneableCart for CartableOptionPointer<C> where
 }
 
 // Safety: logically an Option<C>. Has same bounds as Option<C>
-unsafe impl<C> Send for CartableOptionPointer<C> where C: Sync + CartablePointerLike {}
+unsafe impl<C> Send for CartableOptionPointer<C> where C: Send + CartablePointerLike {}
 
 // Safety: logically an Option<C>. Has same bounds as Option<C>
-unsafe impl<C> Sync for CartableOptionPointer<C> where C: Send + CartablePointerLike {}
+unsafe impl<C> Sync for CartableOptionPointer<C> where C: Sync + CartablePointerLike {}
 
 #[cfg(test)]
 mod tests {
@@ -440,5 +440,34 @@ mod tests {
             assert_eq!(start, DROP_INVOCATIONS.with(Cell::get));
         }
         assert_eq!(start + 1, DROP_INVOCATIONS.with(Cell::get));
+    }
+
+    // Miri test for CartableOptionPointer Send/Sync soundness.
+    //
+    // Verifies that a CartableOptionPointer wrapping a Send + !Sync cart can be
+    // safely sent to another thread and dropped, which compiles under the corrected
+    // bounds but would fail under the old (backwards) bounds.
+    #[test]
+    fn test_send_drops_on_another_thread() {
+        use std::marker::PhantomData;
+
+        // ThreadDrop is Send but !Sync
+        struct ThreadDrop {
+            _not_sync: PhantomData<Cell<i32>>,
+        }
+
+        let yoke = Yoke::<usize, Box<ThreadDrop>>::attach_to_cart(
+            Box::new(ThreadDrop {
+                _not_sync: PhantomData,
+            }),
+            |_| 0,
+        )
+        .wrap_cart_in_option()
+        .convert_cart_into_option_pointer();
+
+        // This requires CartableOptionPointer to be Send.
+        // It is Send because Box<ThreadDrop> is Send.
+        // It would NOT be Send under the old bounds because Box<ThreadDrop> is !Sync.
+        std::thread::spawn(move || drop(yoke)).join().unwrap();
     }
 }


### PR DESCRIPTION
Discovered and reported by @shnatsel


These impls were backwards and unsound.

This is _technically_ a breaking change, however if you had code that relied upon this then it was basically guaranteed to be unsound.

## Changelog: N/A

(This contains its own changelog addition as this is an out of cycle yoke release)