### PR TITLE
Bump nightlies and LLVM

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -266,9 +266,8 @@ jobs:
       run: rustup show
 
     # Job-specific dependencies
-    # TODO: Remove on 2025-05-05, when clang-19 is in ubuntu-latest (https://github.com/actions/runner-images/issues/11895)
     - name: Install LLD and Clang
-      run: sudo apt-get install lld-19 clang-19
+      run: sudo apt-get install lld-21 clang-21
 
     # Actual job
     - name: Run `cargo make ci-job-test-c`
@@ -301,9 +300,8 @@ jobs:
       run: rustup show
 
     # Job-specific dependencies
-    # TODO: Remove on 2025-05-05, when clang-19 is in ubuntu-latest (https://github.com/actions/runner-images/issues/11895)
     - name: Install LLD
-      run: sudo apt-get install lld-19
+      run: sudo apt-get install lld-21
 
     # Actual job
     - name: Run `cargo make ci-job-test-js`

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -267,7 +267,7 @@ jobs:
 
     # Job-specific dependencies
     - name: Install LLD and Clang
-      run: sudo apt-get install lld-21 clang-21
+      run: sudo apt-get install lld-20 clang-20
 
     # Actual job
     - name: Run `cargo make ci-job-test-c`
@@ -301,7 +301,7 @@ jobs:
 
     # Job-specific dependencies
     - name: Install LLD
-      run: sudo apt-get install lld-21
+      run: sudo apt-get install lld-20
 
     # Actual job
     - name: Run `cargo make ci-job-test-js`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,7 +153,7 @@ Our wider testsuite is organized as `ci-job-foo` make tasks corresponding to eac
 <br/>
  
  - `ci-job-test-c`: Runs all C/C++ FFI tests; mostly important if you're changing the FFI interface.
-     + Requires `clang-19` and `lld-19` with the `gold` plugin (APT packages `llvm-19` and `lld-19`).
+     + Requires `clang-21` and `lld-21` with the `gold` plugin (APT packages `llvm-21` and `lld-21`).
  - `ci-job-test-js`: Runs all JS/WASM/Node FFI tests; mostly important if you're changing the FFI interface.
      + Requires Node.js version 16.18.0. This may not the one offered by the package manager; get it from the NodeJS website or `nvm`.
  - `ci-job-nostd`: Builds ICU4X for a `#[no_std]` target to verify that it's compatible.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,7 +153,7 @@ Our wider testsuite is organized as `ci-job-foo` make tasks corresponding to eac
 <br/>
  
  - `ci-job-test-c`: Runs all C/C++ FFI tests; mostly important if you're changing the FFI interface.
-     + Requires `clang-21` and `lld-21` with the `gold` plugin (APT packages `llvm-21` and `lld-21`).
+     + Requires `clang-20` and `lld-20` with the `gold` plugin (APT packages `llvm-20` and `lld-20`).
  - `ci-job-test-js`: Runs all JS/WASM/Node FFI tests; mostly important if you're changing the FFI interface.
      + Requires Node.js version 16.18.0. This may not the one offered by the package manager; get it from the NodeJS website or `nvm`.
  - `ci-job-nostd`: Builds ICU4X for a `#[no_std]` target to verify that it's compatible.

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -18,8 +18,8 @@ default_to_workspace = false
 # The toolchain that CI is being run in. Allows tests to change under beta/nightly.
 CI_TOOLCHAIN = { value = "pinned-stable", condition = { env_not_set = ["CI_TOOLCHAIN"]}}
 # The pinned nightly toolchain for jobs that require a nightly compiler.
-PINNED_CI_NIGHTLY = { value = "nightly-2025-09-27", condition = { env_not_set = ["PINNED_CI_NIGHTLY"] } }
-LLVM_COMPATIBLE_NIGHTLY = { value = "nightly-2025-02-17", condition = { env_not_set = ["LLVM_COMPATIBLE_NIGHTLY"] } }
+PINNED_CI_NIGHTLY = { value = "nightly-2026-01-01", condition = { env_not_set = ["PINNED_CI_NIGHTLY"] } }
+LLVM_COMPATIBLE_NIGHTLY = { value = "nightly-2026-01-01", condition = { env_not_set = ["LLVM_COMPATIBLE_NIGHTLY"] } }
 
 [tasks.quick]
 description = "Run quick version of all lints and builds (useful before pushing to GitHub)"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -18,8 +18,8 @@ default_to_workspace = false
 # The toolchain that CI is being run in. Allows tests to change under beta/nightly.
 CI_TOOLCHAIN = { value = "pinned-stable", condition = { env_not_set = ["CI_TOOLCHAIN"]}}
 # The pinned nightly toolchain for jobs that require a nightly compiler.
-PINNED_CI_NIGHTLY = { value = "nightly-2026-01-01", condition = { env_not_set = ["PINNED_CI_NIGHTLY"] } }
-LLVM_COMPATIBLE_NIGHTLY = { value = "nightly-2026-01-01", condition = { env_not_set = ["LLVM_COMPATIBLE_NIGHTLY"] } }
+PINNED_CI_NIGHTLY = { value = "nightly-2026-06-01", condition = { env_not_set = ["PINNED_CI_NIGHTLY"] } }
+LLVM_COMPATIBLE_NIGHTLY = { value = "nightly-2025-07-01", condition = { env_not_set = ["LLVM_COMPATIBLE_NIGHTLY"] } }
 
 [tasks.quick]
 description = "Run quick version of all lints and builds (useful before pushing to GitHub)"

--- a/examples/c-tiny/README.md
+++ b/examples/c-tiny/README.md
@@ -30,9 +30,9 @@ The maximally low-size build documented here involves using LTO with `-Clinker-p
 
 ```bash
 # Pick a toolchain where Rust and Clang use the same underlying LLVM version
-CLANG := clang-21
-LLD := lld-21
-LLVM_COMPATIBLE_NIGHTLY = "nightly-2026-01-01"
+CLANG := clang-20
+LLD := lld-20
+LLVM_COMPATIBLE_NIGHTLY = "nightly-2025-07-01"
 
 # Rust build
 # ============

--- a/examples/c-tiny/README.md
+++ b/examples/c-tiny/README.md
@@ -30,9 +30,9 @@ The maximally low-size build documented here involves using LTO with `-Clinker-p
 
 ```bash
 # Pick a toolchain where Rust and Clang use the same underlying LLVM version
-CLANG := clang-19
-LLD := lld-19
-LLVM_COMPATIBLE_NIGHTLY = "nightly-2025-02-17"
+CLANG := clang-21
+LLD := lld-21
+LLVM_COMPATIBLE_NIGHTLY = "nightly-2026-01-01"
 
 # Rust build
 # ============

--- a/examples/c-tiny/decimal/Makefile
+++ b/examples/c-tiny/decimal/Makefile
@@ -22,9 +22,9 @@ ALL_RUST_SRC = $(wildcard ../../../components/**/*.rs) $(wildcard ../../../provi
 $(ALL_HEADERS):
 
 GCC := gcc
-CLANG := clang-21
-LLD := lld-21
-LLVM_COMPATIBLE_NIGHTLY = "nightly-2026-01-01"
+CLANG := clang-20
+LLD := lld-20
+LLVM_COMPATIBLE_NIGHTLY = "nightly-2025-07-01"
 
 
 target/release/icu4x-datagen: $(ALL_RUST_SRC)

--- a/examples/c-tiny/decimal/Makefile
+++ b/examples/c-tiny/decimal/Makefile
@@ -22,9 +22,9 @@ ALL_RUST_SRC = $(wildcard ../../../components/**/*.rs) $(wildcard ../../../provi
 $(ALL_HEADERS):
 
 GCC := gcc
-CLANG := clang-19
-LLD := lld-19
-LLVM_COMPATIBLE_NIGHTLY = "nightly-2025-02-17"
+CLANG := clang-21
+LLD := lld-21
+LLVM_COMPATIBLE_NIGHTLY = "nightly-2026-01-01"
 
 
 target/release/icu4x-datagen: $(ALL_RUST_SRC)

--- a/examples/c-tiny/segmenter/Makefile
+++ b/examples/c-tiny/segmenter/Makefile
@@ -22,9 +22,9 @@ ALL_RUST_SRC = $(wildcard ../../../components/**/*.rs) $(wildcard ../../../provi
 $(ALL_HEADERS):
 
 GCC := gcc
-CLANG := clang-19
-LLD := lld-19
-LLVM_COMPATIBLE_NIGHTLY = "nightly-2025-02-17"
+CLANG := clang-21
+LLD := lld-21
+LLVM_COMPATIBLE_NIGHTLY = "nightly-2026-01-01"
 
 
 target-normal/release/libicu_capi.a:

--- a/examples/c-tiny/segmenter/Makefile
+++ b/examples/c-tiny/segmenter/Makefile
@@ -22,9 +22,9 @@ ALL_RUST_SRC = $(wildcard ../../../components/**/*.rs) $(wildcard ../../../provi
 $(ALL_HEADERS):
 
 GCC := gcc
-CLANG := clang-21
-LLD := lld-21
-LLVM_COMPATIBLE_NIGHTLY = "nightly-2026-01-01"
+CLANG := clang-20
+LLD := lld-20
+LLVM_COMPATIBLE_NIGHTLY = "nightly-2025-07-01"
 
 
 target-normal/release/libicu_capi.a:

--- a/examples/cargo/buffer/Makefile
+++ b/examples/cargo/buffer/Makefile
@@ -4,7 +4,7 @@
 
 export CARGO_TARGET_DIR ?= target
 
-PINNED_CI_NIGHTLY = "nightly-2025-09-27"
+PINNED_CI_NIGHTLY = "nightly-2026-01-01"
 
 ifeq ($(OS),Windows_NT)
 	BINARY_EXT = .exe

--- a/examples/cargo/buffer/Makefile
+++ b/examples/cargo/buffer/Makefile
@@ -4,7 +4,7 @@
 
 export CARGO_TARGET_DIR ?= target
 
-PINNED_CI_NIGHTLY = "nightly-2026-01-01"
+PINNED_CI_NIGHTLY = "nightly-2026-06-01"
 
 ifeq ($(OS),Windows_NT)
 	BINARY_EXT = .exe

--- a/examples/js-tiny/Makefile
+++ b/examples/js-tiny/Makefile
@@ -9,7 +9,7 @@ ICU_CAPI := $(shell cargo metadata --format-version 1 | jq '.packages[] | select
 HEADERS := ${ICU_CAPI}/bindings/js
 ALL_HEADERS := $(wildcard ${HEADERS}/*)
 
-LLVM_COMPATIBLE_NIGHTLY ?= "nightly-2025-02-17"
+LLVM_COMPATIBLE_NIGHTLY = "nightly-2026-01-01"
 
 $(ALL_HEADERS):
 
@@ -45,9 +45,9 @@ target/wasm32-unknown-unknown/release/icu_capi.wasm: FORCE
 	# -Z build-std-features=panic_immediate_abort: older version of -Cpanic=immediate-abort,
 	#   with the side-effect of disabling other optional std features that cause bloat. See:
 	#   <https://github.com/rust-lang/rust/issues/147257>
-	RUSTFLAGS="-Cpanic=abort -Copt-level=s -C link-arg=-zstack-size=${WASM_STACK_SIZE} -Clinker-plugin-lto -Ccodegen-units=1 -C linker=${BASEDIR}/ld.py -C linker-flavor=wasm-ld -Clto -Cembed-bitcode -Zwasm-c-abi=spec" \
+	RUSTFLAGS="-Zunstable-options -Cpanic=immediate-abort -Copt-level=s -C link-arg=-zstack-size=${WASM_STACK_SIZE} -Clinker-plugin-lto -Ccodegen-units=1 -C linker=${BASEDIR}/ld.py -C linker-flavor=wasm-ld -Clto -Cembed-bitcode -Zwasm-c-abi=spec" \
 	cargo +${LLVM_COMPATIBLE_NIGHTLY} rustc \
-		-Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort \
+		-Z build-std=std,panic_abort \
 		--target wasm32-unknown-unknown \
 		-p icu_capi \
 		--crate-type cdylib \

--- a/examples/js-tiny/Makefile
+++ b/examples/js-tiny/Makefile
@@ -9,7 +9,7 @@ ICU_CAPI := $(shell cargo metadata --format-version 1 | jq '.packages[] | select
 HEADERS := ${ICU_CAPI}/bindings/js
 ALL_HEADERS := $(wildcard ${HEADERS}/*)
 
-LLVM_COMPATIBLE_NIGHTLY = "nightly-2026-01-01"
+LLVM_COMPATIBLE_NIGHTLY = "nightly-2025-07-01"
 
 $(ALL_HEADERS):
 
@@ -45,9 +45,9 @@ target/wasm32-unknown-unknown/release/icu_capi.wasm: FORCE
 	# -Z build-std-features=panic_immediate_abort: older version of -Cpanic=immediate-abort,
 	#   with the side-effect of disabling other optional std features that cause bloat. See:
 	#   <https://github.com/rust-lang/rust/issues/147257>
-	RUSTFLAGS="-Zunstable-options -Cpanic=immediate-abort -Copt-level=s -C link-arg=-zstack-size=${WASM_STACK_SIZE} -Clinker-plugin-lto -Ccodegen-units=1 -C linker=${BASEDIR}/ld.py -C linker-flavor=wasm-ld -Clto -Cembed-bitcode -Zwasm-c-abi=spec" \
+	RUSTFLAGS="-Cpanic=abort -Copt-level=s -C link-arg=-zstack-size=${WASM_STACK_SIZE} -Clinker-plugin-lto -Ccodegen-units=1 -C linker=${BASEDIR}/ld.py -C linker-flavor=wasm-ld -Clto -Cembed-bitcode -Zwasm-c-abi=spec" \
 	cargo +${LLVM_COMPATIBLE_NIGHTLY} rustc \
-		-Z build-std=std,panic_abort \
+		-Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort \
 		--target wasm32-unknown-unknown \
 		-p icu_capi \
 		--crate-type cdylib \

--- a/examples/js-tiny/ld.py
+++ b/examples/js-tiny/ld.py
@@ -32,7 +32,7 @@ def main():
         else:
             new_argv += [arg]
             is_export = False
-    result = subprocess.run(["lld-19"] + new_argv, stdout=sys.stdout, stderr=sys.stderr)
+    result = subprocess.run(["lld-21"] + new_argv, stdout=sys.stdout, stderr=sys.stderr)
     return result.returncode
 
 if __name__ == "__main__":

--- a/examples/js-tiny/ld.py
+++ b/examples/js-tiny/ld.py
@@ -32,7 +32,7 @@ def main():
         else:
             new_argv += [arg]
             is_export = False
-    result = subprocess.run(["lld-21"] + new_argv, stdout=sys.stdout, stderr=sys.stderr)
+    result = subprocess.run(["lld-20"] + new_argv, stdout=sys.stdout, stderr=sys.stderr)
     return result.returncode
 
 if __name__ == "__main__":

--- a/ffi/capi/build.sh
+++ b/ffi/capi/build.sh
@@ -1,4 +1,4 @@
-NIGHTLY="${PINNED_CI_NIGHTLY:=nightly-2026-01-01}"
+NIGHTLY="${PINNED_CI_NIGHTLY:=nightly-2026-06-01}"
 
 case $TARGET in
     "riscv64-linux-android" | "riscv64gc-unknown-linux-gnu" | "wasm32-unknown-unknown") 

--- a/ffi/capi/build.sh
+++ b/ffi/capi/build.sh
@@ -1,4 +1,4 @@
-NIGHTLY="${PINNED_CI_NIGHTLY:=nightly-2025-09-27}"
+NIGHTLY="${PINNED_CI_NIGHTLY:=nightly-2026-01-01}"
 
 case $TARGET in
     "riscv64-linux-android" | "riscv64gc-unknown-linux-gnu" | "wasm32-unknown-unknown") 

--- a/ffi/dart/hook/build.dart
+++ b/ffi/dart/hook/build.dart
@@ -212,7 +212,7 @@ final class CheckoutMode extends BuildMode {
     final isNoStd = _isNoStdTarget(rustTarget);
 
     final nightly =
-        Platform.environment['PINNED_CI_NIGHTLY'] ?? 'nightly-2026-01-01';
+        Platform.environment['PINNED_CI_NIGHTLY'] ?? 'nightly-2026-06-01';
 
     if (buildStatic || isNoStd) {
       await runProcess('rustup', [

--- a/ffi/dart/hook/build.dart
+++ b/ffi/dart/hook/build.dart
@@ -212,7 +212,7 @@ final class CheckoutMode extends BuildMode {
     final isNoStd = _isNoStdTarget(rustTarget);
 
     final nightly =
-        Platform.environment['PINNED_CI_NIGHTLY'] ?? 'nightly-2025-09-27';
+        Platform.environment['PINNED_CI_NIGHTLY'] ?? 'nightly-2026-01-01';
 
     if (buildStatic || isNoStd) {
       await runProcess('rustup', [


### PR DESCRIPTION
This PR bumps the nightly to `nightly-2026-06-01`, the LLVM nightly to `nightly-2025-07-01` and LLVM to version 20.

Rust was on LLVM 20 until `nightly-2025-08-01`. 

The only thing blocking LLVM 21 is that the GH actions runner does not support it. `ubuntu-26` will.

https://github.com/unicode-org/icu4x/blob/main/documents/process/rust_versions.md:

* It MUST be available via apt on all currently-supported Ubuntu LTS
  * ✅ 24.04 https://launchpad.net/ubuntu/+source/llvm-toolchain-20
  * ✅ 22.04 available through https://apt.llvm.org/
* It MUST be available via apt on Debian `testing`
  * ✅ https://tracker.debian.org/pkg/llvm-toolchain-20
* It MUST be available via `brew`
  * ✅ https://formulae.brew.sh/formula/lld@21
* It MUST be available on Fedora via `yum`
  * ✅ https://packages.fedoraproject.org/pkgs/llvm/llvm/
  * There is no dedicated `llvm-20` package, but the `llvm` package has version 20
* It MUST be available on the GitHub Actions runners with ubuntu-latest
  * ✅ Can be installed through `apt`
* It SHOULD be available on the latest XCode
  * ✅ https://github.com/swiftlang/llvm-project/blob/swift/release/6.3/llvm/utils/gn/secondary/llvm/version.gni
* It SHOULD be available on ICU4X developer machines using nonstandard package management
  * ?
* It SHOULD be available on RHEL and latest Rocky Linux via yum
  * ?

## Changelog

N/A