### PR TITLE
Implement Currency Formatter API (New Design)

### DIFF
--- a/components/experimental/src/dimension/currency/generic_formatter.rs
+++ b/components/experimental/src/dimension/currency/generic_formatter.rs
@@ -1,0 +1,575 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use core::fmt::Display;
+use core::marker::PhantomData;
+use fixed_decimal::Decimal as FixedDecimal;
+use icu_decimal::{
+    DecimalFormatter, DecimalFormatterPreferences, options::DecimalFormatterOptions,
+    preferences::CompactDecimalFormatterPreferences,
+};
+use icu_locale_core::preferences::{define_preferences, prefs_convert};
+use icu_plurals::{PluralRules, PluralRulesPreferences};
+use icu_provider::prelude::*;
+use writeable::Writeable;
+
+use super::CurrencyCode;
+use super::options::{CurrencyFormatterOptions, Width};
+use crate::dimension::provider::currency::{
+    compact::ShortCurrencyCompactV1, essentials::CurrencyEssentialsV1,
+    extended::CurrencyExtendedDataV1, patterns::CurrencyPatternsDataV1,
+};
+
+extern crate alloc;
+
+define_preferences!(
+    /// The preferences for currency formatting.
+    [Copy]
+    CurrencyFormatterPreferences,
+    {
+        /// The user's preferred numbering system.
+        numbering_system: crate::dimension::preferences::NumberingSystem
+    }
+);
+
+prefs_convert!(CurrencyFormatterPreferences, DecimalFormatterPreferences, {
+    numbering_system
+});
+prefs_convert!(CurrencyFormatterPreferences, PluralRulesPreferences);
+
+define_preferences!(
+    /// The preferences for compact currency formatting.
+    [Copy]
+    CompactCurrencyFormatterPreferences,
+    {
+        /// The user's preferred numbering system.
+        numbering_system: crate::dimension::preferences::NumberingSystem
+    }
+);
+
+prefs_convert!(
+    CompactCurrencyFormatterPreferences,
+    DecimalFormatterPreferences,
+    { numbering_system }
+);
+prefs_convert!(
+    CompactCurrencyFormatterPreferences,
+    CompactDecimalFormatterPreferences
+);
+prefs_convert!(CompactCurrencyFormatterPreferences, PluralRulesPreferences);
+
+/// Trait for value representations in currency formatting.
+pub trait ValueRepresentation {
+    type InternalData;
+}
+
+/// Standard decimal value representation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Decimal;
+impl ValueRepresentation for Decimal {
+    type InternalData = DecimalCurrencyData;
+}
+
+/// Compact value representation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Compact;
+impl ValueRepresentation for Compact {
+    type InternalData = CompactCurrencyData;
+}
+
+/// Scientific value representation (stub for future implementation).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Scientific;
+impl ValueRepresentation for Scientific {
+    type InternalData = (); // Placeholder
+}
+
+#[derive(Debug)]
+pub enum DecimalCurrencyData {
+    Standard {
+        essential: DataPayload<CurrencyEssentialsV1>,
+        decimal_formatter: DecimalFormatter,
+        options: CurrencyFormatterOptions,
+    },
+    Long {
+        extended: DataPayload<CurrencyExtendedDataV1>,
+        patterns: DataPayload<CurrencyPatternsDataV1>,
+        decimal_formatter: DecimalFormatter,
+        plural_rules: PluralRules,
+    },
+}
+
+#[derive(Debug)]
+pub enum CompactCurrencyData {
+    Standard {
+        _short_currency_compact: DataPayload<ShortCurrencyCompactV1>,
+        essential: DataPayload<CurrencyEssentialsV1>,
+        decimal_formatter: DecimalFormatter,
+        compact_data: DataPayload<icu_decimal::provider::DecimalCompactShortV1>,
+        plural_rules: PluralRules,
+        options: CurrencyFormatterOptions,
+    },
+    Long {
+        extended: DataPayload<CurrencyExtendedDataV1>,
+        patterns: DataPayload<CurrencyPatternsDataV1>,
+        decimal_formatter: DecimalFormatter,
+        compact_data: DataPayload<icu_decimal::provider::DecimalCompactLongV1>,
+        plural_rules: PluralRules,
+    },
+}
+
+/// A generic currency formatter that can format monetary values using different representations.
+///
+/// This struct implements Option 1 exactly as designed in `design_docs/icu4x/number_formatter.md`.
+#[derive(Debug)]
+pub struct CurrencyFormatter<T: ValueRepresentation> {
+    data: T::InternalData,
+    _marker: PhantomData<T>,
+}
+
+impl CurrencyFormatter<Decimal> {
+    /// Creates a currency formatter for short formatting.
+    #[cfg(feature = "compiled_data")]
+    pub fn try_new_short(prefs: CurrencyFormatterPreferences) -> Result<Self, DataError> {
+        let locale = CurrencyEssentialsV1::make_locale(prefs.locale_preferences);
+        let decimal_formatter =
+            DecimalFormatter::try_new((&prefs).into(), DecimalFormatterOptions::default())?;
+        let essential = crate::provider::Baked
+            .load(DataRequest {
+                id: DataIdentifierBorrowed::for_locale(&locale),
+                ..Default::default()
+            })?
+            .payload;
+
+        let options = CurrencyFormatterOptions {
+            width: Width::Short,
+        };
+        Ok(Self {
+            data: DecimalCurrencyData::Standard {
+                essential,
+                decimal_formatter,
+                options,
+            },
+            _marker: PhantomData,
+        })
+    }
+
+    /// Creates a currency formatter for narrow formatting.
+    #[cfg(feature = "compiled_data")]
+    pub fn try_new_narrow(prefs: CurrencyFormatterPreferences) -> Result<Self, DataError> {
+        let locale = CurrencyEssentialsV1::make_locale(prefs.locale_preferences);
+        let decimal_formatter =
+            DecimalFormatter::try_new((&prefs).into(), DecimalFormatterOptions::default())?;
+        let essential = crate::provider::Baked
+            .load(DataRequest {
+                id: DataIdentifierBorrowed::for_locale(&locale),
+                ..Default::default()
+            })?
+            .payload;
+
+        let options = CurrencyFormatterOptions {
+            width: Width::Narrow,
+        };
+        Ok(Self {
+            data: DecimalCurrencyData::Standard {
+                essential,
+                decimal_formatter,
+                options,
+            },
+            _marker: PhantomData,
+        })
+    }
+
+    /// Creates a currency formatter for long formatting.
+    #[cfg(feature = "compiled_data")]
+    pub fn try_new_long(
+        prefs: CurrencyFormatterPreferences,
+        currency_code: &CurrencyCode,
+    ) -> Result<Self, DataError> {
+        let locale = CurrencyPatternsDataV1::make_locale(prefs.locale_preferences);
+        let decimal_formatter =
+            DecimalFormatter::try_new((&prefs).into(), DecimalFormatterOptions::default())?;
+
+        let marker_attributes = DataMarkerAttributes::try_from_str(currency_code.0.as_str())
+            .map_err(|_| {
+                DataErrorKind::IdentifierNotFound
+                    .into_error()
+                    .with_debug_context("failed to get data marker attribute from a `CurrencyCode`")
+            })?;
+
+        let extended = crate::provider::Baked
+            .load(DataRequest {
+                id: DataIdentifierBorrowed::for_marker_attributes_and_locale(
+                    marker_attributes,
+                    &locale,
+                ),
+                ..Default::default()
+            })?
+            .payload;
+
+        let patterns = crate::provider::Baked.load(Default::default())?.payload;
+
+        let plural_rules = PluralRules::try_new_cardinal((&prefs).into())?;
+
+        Ok(Self {
+            data: DecimalCurrencyData::Long {
+                extended,
+                patterns,
+                decimal_formatter,
+                plural_rules,
+            },
+            _marker: PhantomData,
+        })
+    }
+
+    /// Formats a [`FixedDecimal`] value for the given currency code.
+    pub fn format_fixed_decimal<'l>(
+        &'l self,
+        value: &'l FixedDecimal,
+        currency_code: &'l CurrencyCode,
+    ) -> impl Writeable + Display + 'l {
+        match &self.data {
+            DecimalCurrencyData::Standard {
+                essential,
+                decimal_formatter,
+                options,
+            } => {
+                let (currency_str, pattern, _pattern_selection) = essential
+                    .get()
+                    .name_and_pattern(options.width, currency_code);
+
+                decimal_formatter.format_sign(
+                    value.sign,
+                    pattern.interpolate((
+                        decimal_formatter
+                            .format_unsigned(icu_decimal::Cow::Borrowed(&value.absolute)),
+                        currency_str,
+                    )),
+                )
+            }
+            DecimalCurrencyData::Long {
+                extended,
+                patterns,
+                decimal_formatter,
+                plural_rules,
+            } => {
+                let operands = value.into();
+                let display_name = extended.get().display_names.get(operands, plural_rules);
+                let pattern = patterns.get().patterns.get(operands, plural_rules);
+
+                decimal_formatter.format_sign(
+                    value.sign,
+                    pattern.interpolate((
+                        decimal_formatter
+                            .format_unsigned(icu_decimal::Cow::Borrowed(&value.absolute)),
+                        display_name,
+                    )),
+                )
+            }
+        }
+    }
+}
+
+impl CurrencyFormatter<Compact> {
+    /// Creates a currency formatter for short compact formatting.
+    #[cfg(feature = "compiled_data")]
+    pub fn try_new_short(prefs: CompactCurrencyFormatterPreferences) -> Result<Self, DataError> {
+        let short_locale = ShortCurrencyCompactV1::make_locale(prefs.locale_preferences);
+        let _short_currency_compact = crate::provider::Baked
+            .load(DataRequest {
+                id: DataIdentifierBorrowed::for_locale(&short_locale),
+                ..Default::default()
+            })?
+            .payload;
+
+        let locale = CurrencyEssentialsV1::make_locale(prefs.locale_preferences);
+        let essential = crate::provider::Baked
+            .load(DataRequest {
+                id: DataIdentifierBorrowed::for_locale(&locale),
+                ..Default::default()
+            })?
+            .payload;
+
+        let decimal_formatter = DecimalFormatter::try_new((&prefs).into(), Default::default())?;
+
+        let compact_data = DataProvider::<icu_decimal::provider::DecimalCompactShortV1>::load(
+            &icu_decimal::provider::Baked,
+            DataRequest {
+                id: DataIdentifierBorrowed::for_locale(
+                    &icu_decimal::provider::DecimalCompactShortV1::make_locale(
+                        prefs.locale_preferences,
+                    ),
+                ),
+                ..Default::default()
+            },
+        )?
+        .payload
+        .cast();
+
+        let plural_rules = PluralRules::try_new_cardinal((&prefs).into())?;
+        let options = CurrencyFormatterOptions {
+            width: Width::Short,
+        };
+
+        Ok(Self {
+            data: CompactCurrencyData::Standard {
+                _short_currency_compact,
+                essential,
+                decimal_formatter,
+                compact_data,
+                plural_rules,
+                options,
+            },
+            _marker: PhantomData,
+        })
+    }
+
+    /// Creates a currency formatter for narrow compact formatting.
+    #[cfg(feature = "compiled_data")]
+    pub fn try_new_narrow(prefs: CompactCurrencyFormatterPreferences) -> Result<Self, DataError> {
+        let short_locale = ShortCurrencyCompactV1::make_locale(prefs.locale_preferences);
+        let _short_currency_compact = crate::provider::Baked
+            .load(DataRequest {
+                id: DataIdentifierBorrowed::for_locale(&short_locale),
+                ..Default::default()
+            })?
+            .payload;
+
+        let locale = CurrencyEssentialsV1::make_locale(prefs.locale_preferences);
+        let essential = crate::provider::Baked
+            .load(DataRequest {
+                id: DataIdentifierBorrowed::for_locale(&locale),
+                ..Default::default()
+            })?
+            .payload;
+
+        let decimal_formatter = DecimalFormatter::try_new((&prefs).into(), Default::default())?;
+
+        let compact_data = DataProvider::<icu_decimal::provider::DecimalCompactShortV1>::load(
+            &icu_decimal::provider::Baked,
+            DataRequest {
+                id: DataIdentifierBorrowed::for_locale(
+                    &icu_decimal::provider::DecimalCompactShortV1::make_locale(
+                        prefs.locale_preferences,
+                    ),
+                ),
+                ..Default::default()
+            },
+        )?
+        .payload
+        .cast();
+
+        let plural_rules = PluralRules::try_new_cardinal((&prefs).into())?;
+        let options = CurrencyFormatterOptions {
+            width: Width::Narrow,
+        };
+
+        Ok(Self {
+            data: CompactCurrencyData::Standard {
+                _short_currency_compact,
+                essential,
+                decimal_formatter,
+                compact_data,
+                plural_rules,
+                options,
+            },
+            _marker: PhantomData,
+        })
+    }
+
+    /// Creates a currency formatter for long compact formatting.
+    #[cfg(feature = "compiled_data")]
+    pub fn try_new_long(
+        prefs: CompactCurrencyFormatterPreferences,
+        currency_code: &CurrencyCode,
+    ) -> Result<Self, DataError> {
+        let decimal_formatter = DecimalFormatter::try_new((&prefs).into(), Default::default())?;
+
+        let compact_data = DataProvider::<icu_decimal::provider::DecimalCompactLongV1>::load(
+            &icu_decimal::provider::Baked,
+            DataRequest {
+                id: DataIdentifierBorrowed::for_locale(
+                    &icu_decimal::provider::DecimalCompactLongV1::make_locale(
+                        prefs.locale_preferences,
+                    ),
+                ),
+                ..Default::default()
+            },
+        )?
+        .payload
+        .cast();
+
+        let marker_attributes = DataMarkerAttributes::try_from_str(currency_code.0.as_str())
+            .map_err(|_| {
+                DataErrorKind::IdentifierNotFound
+                    .into_error()
+                    .with_debug_context("failed to get data marker attribute from a `CurrencyCode`")
+            })?;
+
+        let locale = &CurrencyPatternsDataV1::make_locale(prefs.locale_preferences);
+
+        let extended = crate::provider::Baked
+            .load(DataRequest {
+                id: DataIdentifierBorrowed::for_marker_attributes_and_locale(
+                    marker_attributes,
+                    locale,
+                ),
+                ..Default::default()
+            })?
+            .payload;
+
+        let patterns = crate::provider::Baked.load(Default::default())?.payload;
+
+        let plural_rules = PluralRules::try_new_cardinal((&prefs).into())?;
+
+        Ok(Self {
+            data: CompactCurrencyData::Long {
+                extended,
+                patterns,
+                decimal_formatter,
+                compact_data,
+                plural_rules,
+            },
+            _marker: PhantomData,
+        })
+    }
+
+    /// Formats a [`FixedDecimal`] value for the given currency code.
+    pub fn format_fixed_decimal<'l>(
+        &'l self,
+        value: &'l FixedDecimal,
+        currency_code: &'l CurrencyCode,
+    ) -> impl Writeable + Display + 'l {
+        match &self.data {
+            CompactCurrencyData::Standard {
+                _short_currency_compact,
+                essential,
+                decimal_formatter,
+                compact_data,
+                plural_rules,
+                options,
+            } => {
+                let (currency_placeholder, pattern, _pattern_selection) = essential
+                    .get()
+                    .name_and_pattern(options.width, currency_code);
+
+                let (compact_pattern, significand) = compact_data
+                    .get()
+                    .get_pattern_and_significand(&value.absolute, plural_rules);
+
+                decimal_formatter.format_sign(
+                    value.sign,
+                    pattern.interpolate((
+                        compact_pattern
+                            .unwrap_or(icu_pattern::SinglePlaceholderPattern::PASS_THROUGH)
+                            .interpolate([decimal_formatter
+                                .format_unsigned(icu_decimal::Cow::Owned(significand))]),
+                        currency_placeholder,
+                    )),
+                )
+            }
+            CompactCurrencyData::Long {
+                extended,
+                patterns,
+                decimal_formatter,
+                compact_data,
+                plural_rules,
+            } => {
+                let operands = value.into();
+                let display_name = extended.get().display_names.get(operands, plural_rules);
+                let pattern = patterns.get().patterns.get(operands, plural_rules);
+
+                let (compact_pattern, significand) = compact_data
+                    .get()
+                    .get_pattern_and_significand(&value.absolute, plural_rules);
+
+                decimal_formatter.format_sign(
+                    value.sign,
+                    pattern.interpolate((
+                        compact_pattern
+                            .unwrap_or(icu_pattern::SinglePlaceholderPattern::PASS_THROUGH)
+                            .interpolate([decimal_formatter
+                                .format_unsigned(icu_decimal::Cow::Owned(significand))]),
+                        display_name,
+                    )),
+                )
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "compiled_data")]
+mod tests {
+    use super::*;
+    use icu_locale::locale;
+    use tinystr::tinystr;
+    use writeable::assert_writeable_eq;
+
+    #[test]
+    fn test_decimal_short() {
+        let prefs = locale!("en-US").into();
+        let fmt = CurrencyFormatter::<Decimal>::try_new_short(prefs).unwrap();
+        let value = "12345.67".parse().unwrap();
+        let currency_code = CurrencyCode(tinystr!(3, "USD"));
+        assert_writeable_eq!(
+            fmt.format_fixed_decimal(&value, &currency_code),
+            "$12,345.67"
+        );
+    }
+
+    #[test]
+    fn test_decimal_narrow() {
+        let prefs = locale!("en-US").into();
+        let fmt = CurrencyFormatter::<Decimal>::try_new_narrow(prefs).unwrap();
+        let value = "12345.67".parse().unwrap();
+        let currency_code = CurrencyCode(tinystr!(3, "USD"));
+        assert_writeable_eq!(
+            fmt.format_fixed_decimal(&value, &currency_code),
+            "$12,345.67"
+        );
+    }
+
+    #[test]
+    fn test_decimal_long() {
+        let prefs = locale!("en-US").into();
+        let currency_code = CurrencyCode(tinystr!(3, "USD"));
+        let fmt = CurrencyFormatter::<Decimal>::try_new_long(prefs, &currency_code).unwrap();
+        let value = "12345.67".parse().unwrap();
+        assert_writeable_eq!(
+            fmt.format_fixed_decimal(&value, &currency_code),
+            "12,345.67 US dollars"
+        );
+    }
+
+    #[test]
+    fn test_compact_short() {
+        let prefs = locale!("en-US").into();
+        let fmt = CurrencyFormatter::<Compact>::try_new_short(prefs).unwrap();
+        let value = "12345.67".parse().unwrap();
+        let currency_code = CurrencyCode(tinystr!(3, "USD"));
+        assert_writeable_eq!(fmt.format_fixed_decimal(&value, &currency_code), "$12K");
+    }
+
+    #[test]
+    fn test_compact_narrow() {
+        let prefs = locale!("en-US").into();
+        let fmt = CurrencyFormatter::<Compact>::try_new_narrow(prefs).unwrap();
+        let value = "12345.67".parse().unwrap();
+        let currency_code = CurrencyCode(tinystr!(3, "USD"));
+        assert_writeable_eq!(fmt.format_fixed_decimal(&value, &currency_code), "$12K");
+    }
+
+    #[test]
+    fn test_compact_long() {
+        let prefs = locale!("en-US").into();
+        let currency_code = CurrencyCode(tinystr!(3, "USD"));
+        let fmt = CurrencyFormatter::<Compact>::try_new_long(prefs, &currency_code).unwrap();
+        let value = "12345.67".parse().unwrap();
+        assert_writeable_eq!(
+            fmt.format_fixed_decimal(&value, &currency_code),
+            "12 thousand US dollars"
+        );
+    }
+}

--- a/components/experimental/src/dimension/currency/generic_formatter.rs
+++ b/components/experimental/src/dimension/currency/generic_formatter.rs
@@ -6,16 +6,20 @@ use core::fmt::Display;
 use core::marker::PhantomData;
 use fixed_decimal::Decimal as FixedDecimal;
 use icu_decimal::{
-    DecimalFormatter, DecimalFormatterPreferences, options::DecimalFormatterOptions,
+    DecimalFormatter, DecimalFormatterPreferences,
     preferences::CompactDecimalFormatterPreferences,
 };
+#[cfg(feature = "compiled_data")]
+use icu_decimal::options::DecimalFormatterOptions;
 use icu_locale_core::preferences::{define_preferences, prefs_convert};
 use icu_plurals::{PluralRules, PluralRulesPreferences};
 use icu_provider::prelude::*;
 use writeable::Writeable;
 
 use super::CurrencyCode;
-use super::options::{CurrencyFormatterOptions, Width};
+use super::options::CurrencyFormatterOptions;
+#[cfg(feature = "compiled_data")]
+use super::options::Width;
 use crate::dimension::provider::currency::{
     compact::ShortCurrencyCompactV1, essentials::CurrencyEssentialsV1,
     extended::CurrencyExtendedDataV1, patterns::CurrencyPatternsDataV1,

--- a/components/experimental/src/dimension/currency/generic_formatter.rs
+++ b/components/experimental/src/dimension/currency/generic_formatter.rs
@@ -69,6 +69,7 @@ pub trait ValueRepresentation {
 
 /// Standard decimal value representation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct Decimal;
 impl ValueRepresentation for Decimal {
     type InternalData = DecimalCurrencyData;
@@ -76,6 +77,7 @@ impl ValueRepresentation for Decimal {
 
 /// Compact value representation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct Compact;
 impl ValueRepresentation for Compact {
     type InternalData = CompactCurrencyData;
@@ -83,12 +85,14 @@ impl ValueRepresentation for Compact {
 
 /// Scientific value representation (stub for future implementation).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct Scientific;
 impl ValueRepresentation for Scientific {
     type InternalData = (); // Placeholder
 }
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum DecimalCurrencyData {
     Standard {
         essential: DataPayload<CurrencyEssentialsV1>,
@@ -104,6 +108,7 @@ pub enum DecimalCurrencyData {
 }
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum CompactCurrencyData {
     Standard {
         _short_currency_compact: DataPayload<ShortCurrencyCompactV1>,

--- a/components/experimental/src/dimension/currency/generic_formatter.rs
+++ b/components/experimental/src/dimension/currency/generic_formatter.rs
@@ -5,12 +5,11 @@
 use core::fmt::Display;
 use core::marker::PhantomData;
 use fixed_decimal::Decimal as FixedDecimal;
-use icu_decimal::{
-    DecimalFormatter, DecimalFormatterPreferences,
-    preferences::CompactDecimalFormatterPreferences,
-};
 #[cfg(feature = "compiled_data")]
 use icu_decimal::options::DecimalFormatterOptions;
+use icu_decimal::{
+    DecimalFormatter, DecimalFormatterPreferences, preferences::CompactDecimalFormatterPreferences,
+};
 use icu_locale_core::preferences::{define_preferences, prefs_convert};
 use icu_plurals::{PluralRules, PluralRulesPreferences};
 use icu_provider::prelude::*;

--- a/components/experimental/src/dimension/currency/mod.rs
+++ b/components/experimental/src/dimension/currency/mod.rs
@@ -8,6 +8,7 @@ pub mod compact_format;
 pub mod compact_formatter;
 pub mod format;
 pub mod formatter;
+pub mod generic_formatter;
 pub mod long_compact_format;
 pub mod long_compact_formatter;
 pub mod long_format;


### PR DESCRIPTION
## Changelog

This PR implements the self-contained generic `CurrencyFormatter` API [(Option 1)](https://hackmd.io/UatazscbQ1Or4e0AkJWjIg#Option-1-Single-struct-with-generic-value-representation-Choosed-httpsgithubcomunicode-orgicu4xpull8045) as part of the experimental currency formatting architecture.

#### Core Architecture & Typestate
- **`ValueRepresentation` Trait**: Introduces a core trait to govern representation-specific internal data states.
- **Marker Structs**: Implements `Decimal`, `Compact`, and `Scientific` (placeholder) marker types to enforce compile-time typestates.
- **Unified Formatter**: Defines `CurrencyFormatter<T: ValueRepresentation>` which transparently adapts its internal storage based on the active typestate.

#### Data Models & Payloads
- **`DecimalCurrencyData`**: Added internal enum to handle both `Standard` (`CurrencyEssentialsV1`) and `Long` (`CurrencyExtendedDataV1` + `CurrencyPatternsDataV1`) data requirements.
- **`CompactCurrencyData`**: Added internal enum integrating currency data with `icu_decimal` compact payloads (`DecimalCompactShortV1` and `DecimalCompactLongV1`) and plural rules.

#### Preferences & Configuration
- **New Preference Types**: Defines `CurrencyFormatterPreferences` and `CompactCurrencyFormatterPreferences` supporting custom numbering systems.
- **Macro Integrations**: Implements `prefs_convert!` rules for zero-friction conversion into underlying `DecimalFormatterPreferences`, `CompactDecimalFormatterPreferences`, and `PluralRulesPreferences`.

#### Polymorphic Constructors
- **Standard Decimal**: Added `try_new_short`, `try_new_narrow`, and `try_new_long` implementations on `CurrencyFormatter<Decimal>`.
- **Compact Formats**: Added `try_new_short`, `try_new_narrow`, and `try_new_long` implementations on `CurrencyFormatter<Compact>`.
- **Marker Attributes**: Handles dynamic derivation of `DataMarkerAttributes` from `CurrencyCode` to properly resolve locale-specific long display names.

#### Formatting Execution
- **`format_fixed_decimal`**: Implements robust formatting logic returning `impl Writeable + Display`.
- **Pattern Interpolation**: Handles multi-placeholder pattern resolution, seamlessly combining currency symbols/names with formatted numbers and compact significands.
- **Sign & Plurality**: Correctly preserves value signs (`FixedDecimal::sign`) and evaluates `PluralRules` across all complex compact and long variants.

#### Testing & Verification
- Added a full suite of unit tests validating all 6 primary configurations (`Decimal`/`Compact` x `Short`/`Narrow`/`Long`).
- Verified expected textual outputs including exact symbol placement, rounding, compact suffixing, and pluralized long names (e.g., `$12,345.67`, `12,345.67 US dollars`, `$12K`, `12 thousand US dollars`).

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->


<!-- Please fill in according to documents/process/changelog.md -->
