### PR TITLE
experimental/currency: Polish documentation, extraction logic, and error reporting across extended data, display names, and compact patterns

### DIFF
--- a/components/experimental/src/dimension/provider/currency/compact.rs
+++ b/components/experimental/src/dimension/provider/currency/compact.rs
@@ -12,12 +12,12 @@ use icu_provider::prelude::*;
 use icu_decimal::provider::CompactPatterns;
 
 icu_provider::data_marker!(
-    /// `ShortCurrencyCompactV1`
+    /// Compact currency formatting patterns (short).
     ShortCurrencyCompactV1,
     ShortCurrencyCompact<'static>
 );
 
-/// Currency Compact  data struct.
+/// Compact currency data struct containing standard and alpha-next-to-number patterns.
 #[derive(Debug, Clone, PartialEq, yoke::Yokeable, zerofrom::ZeroFrom)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]

--- a/components/experimental/src/dimension/provider/currency/displayname.rs
+++ b/components/experimental/src/dimension/provider/currency/displayname.rs
@@ -20,14 +20,14 @@ use icu_provider::prelude::*;
 pub use crate::provider::Baked;
 
 icu_provider::data_marker!(
-    /// `CurrencyDisplaynameV1`
+    /// Currency display name data.
     CurrencyDisplaynameV1,
     CurrencyDisplayname<'static>,
     #[cfg(feature = "datagen")]
     attributes_domain = "currency",
 );
 
-/// Currency Extended  data struct.
+/// Currency display name data struct.
 #[derive(Debug, Clone, Default, PartialEq, yoke::Yokeable, zerofrom::ZeroFrom)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]

--- a/components/experimental/src/dimension/provider/currency/extended.rs
+++ b/components/experimental/src/dimension/provider/currency/extended.rs
@@ -27,7 +27,7 @@ icu_provider::data_marker!(
     attributes_domain = "currency",
 );
 
-/// Currency Extended  data struct.
+/// Currency extended data struct.
 #[derive(Debug, Clone, PartialEq, yoke::Yokeable, zerofrom::ZeroFrom)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize))]
@@ -38,9 +38,10 @@ pub struct CurrencyExtendedData<'data> {
     ///     - "US Dollars" when count is `zero`,
     ///     - "US Dollar" when count is `one`,
     ///     ... etc.
-    /// # NOTE
-    ///    Regards to the [Unicode Report TR35](https://unicode.org/reports/tr35/tr35-numbers.html#Currencies),
-    ///    If no matching for specific count, the `other` count will be used.
+    ///
+    /// # Note
+    /// According to [Unicode TR35](https://unicode.org/reports/tr35/tr35-numbers.html#Currencies),
+    /// if no match is found for a specific count, the `other` variant is used as a fallback.
     #[cfg_attr(feature = "serde", serde(borrow))]
     pub display_names: PluralElementsPackedCow<'data, str>,
 }

--- a/provider/source/src/currency/compact.rs
+++ b/provider/source/src/currency/compact.rs
@@ -60,7 +60,7 @@ impl DataProvider<ShortCurrencyCompactV1> for SourceDataProvider {
             u8,
             (u8, PluralElements<Box<DoublePlaceholderPattern>>),
         > = BTreeMap::new();
-        let mut alpha_next_to_patterns: BTreeMap<
+        let mut alpha_next_to_number_patterns: BTreeMap<
             u8,
             (u8, PluralElements<Box<DoublePlaceholderPattern>>),
         > = BTreeMap::new();
@@ -68,7 +68,7 @@ impl DataProvider<ShortCurrencyCompactV1> for SourceDataProvider {
         for (target, source) in [
             (&mut standard_patterns, &compact_patterns.standard),
             (
-                &mut alpha_next_to_patterns,
+                &mut alpha_next_to_number_patterns,
                 &compact_patterns.alpha_next_to_number,
             ),
         ] {
@@ -105,7 +105,7 @@ impl DataProvider<ShortCurrencyCompactV1> for SourceDataProvider {
                         })
                         .dedup(),
                 )
-                .map_err(|e| DataError::custom("pattern").with_display_context(&e))?;
+                .map_err(|e| DataError::custom("Could not parse compact currency pattern").with_display_context(&e))?;
 
                 if log10_type < number_of_0s.unwrap_or_default() {
                     return Err(DataError::custom("pattern").with_display_context(&format!(
@@ -146,10 +146,14 @@ impl DataProvider<ShortCurrencyCompactV1> for SourceDataProvider {
         Ok(DataResponse {
             metadata: Default::default(),
             payload: DataPayload::from_owned(ShortCurrencyCompact {
-                standard: CompactPatterns::new(standard_patterns, None)
-                    .map_err(|e| DataError::custom("pattern").with_display_context(&e))?,
-                alpha_next_to_number: CompactPatterns::new(alpha_next_to_patterns, None)
-                    .map_err(|e| DataError::custom("pattern").with_display_context(&e))?,
+                standard: CompactPatterns::new(standard_patterns, None).map_err(|e| {
+                    DataError::custom("Invalid standard compact patterns").with_display_context(&e)
+                })?,
+                alpha_next_to_number: CompactPatterns::new(alpha_next_to_number_patterns, None)
+                    .map_err(|e| {
+                        DataError::custom("Invalid alpha-next-to-number compact patterns")
+                            .with_display_context(&e)
+                    })?,
             }),
         })
     }

--- a/provider/source/src/currency/displayname.rs
+++ b/provider/source/src/currency/displayname.rs
@@ -27,23 +27,17 @@ impl DataProvider<CurrencyDisplaynameV1> for SourceDataProvider {
             .ok_or_else(|| {
                 DataErrorKind::IdentifierNotFound
                     .into_error()
-                    .with_debug_context("No data for currency")
+                    .with_debug_context("No currency associated with the auxiliary key")
             })?;
 
         Ok(DataResponse {
             metadata: Default::default(),
             payload: DataPayload::from_owned(CurrencyDisplayname {
-                display_name: Cow::Owned(
-                    currency
-                        .display_name
-                        .as_deref()
-                        .ok_or_else(|| {
-                            DataErrorKind::IdentifierNotFound
-                                .into_error()
-                                .with_debug_context("No display name found for the currency")
-                        })?
-                        .to_string(),
-                ),
+                display_name: Cow::Owned(currency.display_name.clone().ok_or_else(|| {
+                    DataErrorKind::IdentifierNotFound
+                        .into_error()
+                        .with_debug_context("No display name found for the currency")
+                })?),
             }),
         })
     }
@@ -61,13 +55,13 @@ impl crate::IterableDataProviderCached<CurrencyDisplaynameV1> for SourceDataProv
                 .read_and_parse(&locale, "currencies.json")?;
 
             let currencies = &currencies_resource.main.value.numbers.currencies;
-            for (currency, patterns) in currencies {
-                // If the currency doesn't have a display name, we can not create `CurrencyDisplayname` for it.
+            for (iso, currency_data) in currencies {
+                // If the currency doesn't have a display name, we cannot create `CurrencyDisplayname` for it.
                 // Therefore, we skip it.
-                if patterns.display_name.is_none() {
+                if currency_data.display_name.is_none() {
                     continue;
                 }
-                if let Ok(attributes) = DataMarkerAttributes::try_from_string(currency.clone()) {
+                if let Ok(attributes) = DataMarkerAttributes::try_from_string(iso.clone()) {
                     result.insert(DataIdentifierCow::from_owned(attributes, locale));
                 }
             }

--- a/provider/source/src/currency/extended.rs
+++ b/provider/source/src/currency/extended.rs
@@ -24,7 +24,9 @@ impl DataProvider<CurrencyExtendedDataV1> for SourceDataProvider {
             .numbers
             .currencies
             .get(req.id.marker_attributes.as_str())
-            .ok_or(DataError::custom("No currency associated with the aux key"))?;
+            .ok_or(DataError::custom(
+                "No currency associated with the auxiliary key",
+            ))?;
 
         Ok(DataResponse {
             metadata: Default::default(),
@@ -61,13 +63,12 @@ impl crate::IterableDataProviderCached<CurrencyExtendedDataV1> for SourceDataPro
 
             let currencies = &currencies_resource.main.value.numbers.currencies;
             for (currency, displaynames) in currencies {
-                // By TR 35 (https://unicode.org/reports/tr35/tr35-numbers.html#Currencies)
-                //      If the displayname is not found for the associated `Count`, fall back to the `Count::Other` displayname.
-                //      And the `other` displayname must be present.
-                //      Therefore, we filter out any currencies that do not have an `other` displayname.
-                //      NOTE:
-                //          In case of `other` displayname does not exist, File a Jira ticket to CLDR:
-                //          https://unicode-org.atlassian.net/browse/CLDR
+                // According to TR 35 (https://unicode.org/reports/tr35/tr35-numbers.html#Currencies),
+                // if the display name is not found for an associated `Count`, it falls back to `Count::Other`.
+                // Therefore, we filter out any currencies that lack an `other` display name.
+                //
+                // Note: If an `other` display name does not exist upstream, file an issue with CLDR at:
+                // https://unicode-org.atlassian.net/browse/CLDR
                 if displaynames.other.is_none() {
                     continue;
                 }


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->

## Changelog

icu_experimental/currency: Polishes documentation, extraction logic, and error reporting across experimental currency components:
- **`CurrencyExtendedDataV1`**: Improves grammar in struct doc comments and standardizes runtime error context to use precise "auxiliary key" terminology.
- **`CurrencyDisplaynameV1`**: Corrects copy-paste artifacts in definitions and optimizes payload construction in `load` by eliminating redundant string conversions.
- **`ShortCurrencyCompactV1`**: Renames internal map to `alpha_next_to_number_patterns` for perfect field alignment and replaces vague `"pattern"` runtime error strings with detailed, actionable messages.
