### PR TITLE
Add doctests for experimental unit converter

### DIFF
--- a/components/experimental/src/units/converter.rs
+++ b/components/experimental/src/units/converter.rs
@@ -23,10 +23,10 @@ use crate::units::convertible::Convertible;
 /// let factory = ConverterFactory::new();
 /// let meter = MeasureUnit::try_from_str("meter").unwrap();
 /// let foot = MeasureUnit::try_from_str("foot").unwrap();
-/// let converter = factory.converter::<f64>(&meter, &foot).unwrap();
 ///
 /// // 10 meters is approximately 32.8084 feet.
 /// // We use approximate comparison due to floating-point precision.
+/// let converter = factory.converter::<f64>(&meter, &foot).unwrap();
 /// assert!((converter.convert(&10.0) - 32.8084).abs() < 1e-4);
 /// ```
 #[derive(Debug, Clone)]
@@ -49,9 +49,9 @@ where
     /// let factory = ConverterFactory::new();
     /// let celsius = MeasureUnit::try_from_str("celsius").unwrap();
     /// let fahrenheit = MeasureUnit::try_from_str("fahrenheit").unwrap();
-    /// let converter = factory.converter::<f64>(&celsius, &fahrenheit).unwrap();
     ///
     /// // 0°C is exactly 32°F.
+    /// let converter = factory.converter::<f64>(&celsius, &fahrenheit).unwrap();
     /// assert!((converter.convert(&0.0) - 32.0).abs() < 1e-9);
     /// // 100°C is exactly 212°F.
     /// assert!((converter.convert(&100.0) - 212.0).abs() < 1e-9);

--- a/components/experimental/src/units/converter.rs
+++ b/components/experimental/src/units/converter.rs
@@ -29,6 +29,28 @@ use crate::units::convertible::Convertible;
 /// let converter = factory.converter::<f64>(&meter, &foot).unwrap();
 /// assert!((converter.convert(&10.0) - 32.8084).abs() < 1e-4);
 /// ```
+///
+/// High-precision conversion using `Ratio<BigInt>`:
+///
+/// ```
+/// use icu_experimental::units::converter_factory::ConverterFactory;
+/// use icu_experimental::measure::measureunit::MeasureUnit;
+/// use num_bigint::BigInt;
+/// use num_rational::Ratio;
+///
+/// let factory = ConverterFactory::new();
+/// let meter = MeasureUnit::try_from_str("meter").unwrap();
+/// let foot = MeasureUnit::try_from_str("foot").unwrap();
+///
+/// // 1 foot is exactly 0.3048 meters.
+/// // 1 meter is 10000 / 3048 feet = 1250 / 381 feet.
+/// let converter = factory.converter::<Ratio<BigInt>>(&meter, &foot).unwrap();
+///
+/// // 1 meter should be exactly 1250/381 feet.
+/// let one = Ratio::from(BigInt::from(1));
+/// let expected = Ratio::new(BigInt::from(1250), BigInt::from(381));
+/// assert_eq!(converter.convert(&one), expected);
+/// ```
 #[derive(Debug, Clone)]
 pub struct UnitsConverter<N>(pub(crate) UnitsConverterInner<N>)
 where
@@ -40,22 +62,8 @@ where
 {
     /// Converts the given value from the input unit to the output unit.
     ///
-    /// # Examples
     ///
-    /// ```
-    /// use icu_experimental::units::converter_factory::ConverterFactory;
-    /// use icu_experimental::measure::measureunit::MeasureUnit;
-    ///
-    /// let factory = ConverterFactory::new();
-    /// let celsius = MeasureUnit::try_from_str("celsius").unwrap();
-    /// let fahrenheit = MeasureUnit::try_from_str("fahrenheit").unwrap();
-    ///
-    /// // 0°C is exactly 32°F.
-    /// let converter = factory.converter::<f64>(&celsius, &fahrenheit).unwrap();
-    /// assert!((converter.convert(&0.0) - 32.0).abs() < 1e-9);
-    /// // 100°C is exactly 212°F.
-    /// assert!((converter.convert(&100.0) - 212.0).abs() < 1e-9);
-    /// ```
+    /// See [`UnitsConverter`] for examples.
     pub fn convert(&self, value: &N) -> N {
         self.0.convert(value)
     }

--- a/components/experimental/src/units/converter.rs
+++ b/components/experimental/src/units/converter.rs
@@ -13,6 +13,22 @@ use crate::units::convertible::Convertible;
 /// NOTE:
 ///     This converter does not support conversions between mixed units,
 ///     for example, from "meter" to "foot-and-inch".
+///
+/// # Examples
+///
+/// ```
+/// use icu_experimental::units::converter_factory::ConverterFactory;
+/// use icu_experimental::measure::measureunit::MeasureUnit;
+///
+/// let factory = ConverterFactory::new();
+/// let meter = MeasureUnit::try_from_str("meter").unwrap();
+/// let foot = MeasureUnit::try_from_str("foot").unwrap();
+/// let converter = factory.converter::<f64>(&meter, &foot).unwrap();
+///
+/// // 10 meters is approximately 32.8084 feet.
+/// // We use approximate comparison due to floating-point precision.
+/// assert!((converter.convert(&10.0) - 32.8084).abs() < 1e-4);
+/// ```
 #[derive(Debug, Clone)]
 pub struct UnitsConverter<N>(pub(crate) UnitsConverterInner<N>)
 where
@@ -23,6 +39,23 @@ where
     N: Convertible,
 {
     /// Converts the given value from the input unit to the output unit.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu_experimental::units::converter_factory::ConverterFactory;
+    /// use icu_experimental::measure::measureunit::MeasureUnit;
+    ///
+    /// let factory = ConverterFactory::new();
+    /// let celsius = MeasureUnit::try_from_str("celsius").unwrap();
+    /// let fahrenheit = MeasureUnit::try_from_str("fahrenheit").unwrap();
+    /// let converter = factory.converter::<f64>(&celsius, &fahrenheit).unwrap();
+    ///
+    /// // 0°C is exactly 32°F.
+    /// assert!((converter.convert(&0.0) - 32.0).abs() < 1e-9);
+    /// // 100°C is exactly 212°F.
+    /// assert!((converter.convert(&100.0) - 212.0).abs() < 1e-9);
+    /// ```
     pub fn convert(&self, value: &N) -> N {
         self.0.convert(value)
     }

--- a/components/experimental/src/units/converter_factory.rs
+++ b/components/experimental/src/units/converter_factory.rs
@@ -26,28 +26,18 @@ use super::convertible::Convertible;
 ///
 /// # Examples
 ///
-/// Demonstrating how to use a single factory to create different types of converters:
-///
 /// ```
 /// use icu_experimental::units::converter_factory::ConverterFactory;
 /// use icu_experimental::measure::measureunit::MeasureUnit;
 ///
 /// let factory = ConverterFactory::new();
 ///
-/// let meter = MeasureUnit::try_from_str("meter").unwrap();
 /// let foot = MeasureUnit::try_from_str("foot").unwrap();
+/// let meter = MeasureUnit::try_from_str("meter").unwrap();
 ///
-/// // 10 meters is approximately 32.8084 feet.
-/// // We use approximate comparison due to floating-point precision.
-/// let meters_to_feet = factory.converter::<f64>(&meter, &foot).unwrap();
-/// assert!((meters_to_feet.convert(&10.0) - 32.8084).abs() < 1e-4);
-///
-/// let celsius = MeasureUnit::try_from_str("celsius").unwrap();
-/// let fahrenheit = MeasureUnit::try_from_str("fahrenheit").unwrap();
-///
-/// // 0°C is exactly 32°F.
-/// let celsius_to_fahrenheit = factory.converter::<f64>(&celsius, &fahrenheit).unwrap();
-/// assert!((celsius_to_fahrenheit.convert(&0.0) - 32.0).abs() < 1e-9);
+/// // 1 foot is exactly 0.3048 meters.
+/// let foot_to_meter = factory.converter::<f64>(&foot, &meter).unwrap();
+/// assert!((foot_to_meter.convert(&1.0) - 0.3048).abs() < 1e-9);
 /// ```
 #[derive(Debug)]
 pub struct ConverterFactory {

--- a/components/experimental/src/units/converter_factory.rs
+++ b/components/experimental/src/units/converter_factory.rs
@@ -23,6 +23,34 @@ use zerovec::ZeroSlice;
 
 use super::convertible::Convertible;
 /// `ConverterFactory` is responsible for creating converters.
+///
+/// # Examples
+///
+/// Demonstrating how to use a single factory to create different types of converters:
+///
+/// ```
+/// use icu_experimental::units::converter_factory::ConverterFactory;
+/// use icu_experimental::measure::measureunit::MeasureUnit;
+///
+/// let factory = ConverterFactory::new();
+///
+/// // 1. Create a proportional converter (meters to feet)
+/// let meter = MeasureUnit::try_from_str("meter").unwrap();
+/// let foot = MeasureUnit::try_from_str("foot").unwrap();
+/// let meters_to_feet = factory.converter::<f64>(&meter, &foot).unwrap();
+///
+/// // 10 meters is approximately 32.8084 feet.
+/// // We use approximate comparison due to floating-point precision.
+/// assert!((meters_to_feet.convert(&10.0) - 32.8084).abs() < 1e-4);
+///
+/// // 2. Create an offset converter (Celsius to Fahrenheit) from the same factory
+/// let celsius = MeasureUnit::try_from_str("celsius").unwrap();
+/// let fahrenheit = MeasureUnit::try_from_str("fahrenheit").unwrap();
+/// let celsius_to_fahrenheit = factory.converter::<f64>(&celsius, &fahrenheit).unwrap();
+///
+/// // 0°C is exactly 32°F.
+/// assert!((celsius_to_fahrenheit.convert(&0.0) - 32.0).abs() < 1e-9);
+/// ```
 #[derive(Debug)]
 pub struct ConverterFactory {
     /// Contains the necessary data for the conversion factory.
@@ -283,6 +311,21 @@ impl ConverterFactory {
     /// NOTE:
     ///    This converter does not support conversions between mixed units,
     ///    such as, from "meter" to "foot-and-inch".
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu_experimental::units::converter_factory::ConverterFactory;
+    /// use icu_experimental::measure::measureunit::MeasureUnit;
+    ///
+    /// let factory = ConverterFactory::new();
+    /// let meter = MeasureUnit::try_from_str("meter").unwrap();
+    /// let foot = MeasureUnit::try_from_str("foot").unwrap();
+    /// let converter = factory.converter::<f64>(&meter, &foot).unwrap();
+    ///
+    /// // 2 meters is approximately 6.56168 feet.
+    /// assert!((converter.convert(&2.0) - 6.56168).abs() < 1e-5);
+    /// ```
     pub fn converter<T: Convertible>(
         &self,
         input_unit: &MeasureUnit,

--- a/components/experimental/src/units/converter_factory.rs
+++ b/components/experimental/src/units/converter_factory.rs
@@ -26,14 +26,21 @@ use super::convertible::Convertible;
 ///
 /// # Examples
 ///
+/// Demonstrating how to use a single factory to create different converters:
+///
 /// ```
 /// use icu_experimental::units::converter_factory::ConverterFactory;
 /// use icu_experimental::measure::measureunit::MeasureUnit;
 ///
 /// let factory = ConverterFactory::new();
 ///
-/// let foot = MeasureUnit::try_from_str("foot").unwrap();
 /// let meter = MeasureUnit::try_from_str("meter").unwrap();
+/// let foot = MeasureUnit::try_from_str("foot").unwrap();
+///
+/// // 10 meters is approximately 32.8084 feet.
+/// // We use approximate comparison due to floating-point precision.
+/// let meter_to_foot = factory.converter::<f64>(&meter, &foot).unwrap();
+/// assert!((meter_to_foot.convert(&10.0) - 32.8084).abs() < 1e-4);
 ///
 /// // 1 foot is exactly 0.3048 meters.
 /// let foot_to_meter = factory.converter::<f64>(&foot, &meter).unwrap();

--- a/components/experimental/src/units/converter_factory.rs
+++ b/components/experimental/src/units/converter_factory.rs
@@ -34,21 +34,19 @@ use super::convertible::Convertible;
 ///
 /// let factory = ConverterFactory::new();
 ///
-/// // 1. Create a proportional converter (meters to feet)
 /// let meter = MeasureUnit::try_from_str("meter").unwrap();
 /// let foot = MeasureUnit::try_from_str("foot").unwrap();
-/// let meters_to_feet = factory.converter::<f64>(&meter, &foot).unwrap();
 ///
 /// // 10 meters is approximately 32.8084 feet.
 /// // We use approximate comparison due to floating-point precision.
+/// let meters_to_feet = factory.converter::<f64>(&meter, &foot).unwrap();
 /// assert!((meters_to_feet.convert(&10.0) - 32.8084).abs() < 1e-4);
 ///
-/// // 2. Create an offset converter (Celsius to Fahrenheit) from the same factory
 /// let celsius = MeasureUnit::try_from_str("celsius").unwrap();
 /// let fahrenheit = MeasureUnit::try_from_str("fahrenheit").unwrap();
-/// let celsius_to_fahrenheit = factory.converter::<f64>(&celsius, &fahrenheit).unwrap();
 ///
 /// // 0°C is exactly 32°F.
+/// let celsius_to_fahrenheit = factory.converter::<f64>(&celsius, &fahrenheit).unwrap();
 /// assert!((celsius_to_fahrenheit.convert(&0.0) - 32.0).abs() < 1e-9);
 /// ```
 #[derive(Debug)]
@@ -312,20 +310,7 @@ impl ConverterFactory {
     ///    This converter does not support conversions between mixed units,
     ///    such as, from "meter" to "foot-and-inch".
     ///
-    /// # Examples
-    ///
-    /// ```
-    /// use icu_experimental::units::converter_factory::ConverterFactory;
-    /// use icu_experimental::measure::measureunit::MeasureUnit;
-    ///
-    /// let factory = ConverterFactory::new();
-    /// let meter = MeasureUnit::try_from_str("meter").unwrap();
-    /// let foot = MeasureUnit::try_from_str("foot").unwrap();
-    /// let converter = factory.converter::<f64>(&meter, &foot).unwrap();
-    ///
-    /// // 2 meters is approximately 6.56168 feet.
-    /// assert!((converter.convert(&2.0) - 6.56168).abs() < 1e-5);
-    /// ```
+    /// See [`ConverterFactory`] for examples.
     pub fn converter<T: Convertible>(
         &self,
         input_unit: &MeasureUnit,

--- a/components/experimental/src/units/mod.rs
+++ b/components/experimental/src/units/mod.rs
@@ -2,6 +2,117 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+//! 🚧 \[Unstable\] The experimental unit conversion module of the `ICU4X` project.
+//!
+//! <div class="stab unstable">
+//! 🚧 This code is considered unstable; it may change at any time, in breaking or non-breaking ways,
+//! including in SemVer minor releases. Use with caution.
+//! </div>
+//!
+//! This module provides APIs for converting values between different units of measurement.
+//! It supports proportional, offset, and reciprocal conversions, as well as compound units.
+//!
+//! The main entry point is [`converter_factory::ConverterFactory`], which loads the necessary conversion data
+//! and creates [`converter::UnitsConverter`] instances.
+//!
+//! # Examples
+//!
+//! ## Proportional Conversion (f64)
+//!
+//! Converting meters to feet:
+//!
+//! ```
+//! use icu_experimental::units::converter_factory::ConverterFactory;
+//! use icu_experimental::measure::measureunit::MeasureUnit;
+//!
+//! let factory = ConverterFactory::new();
+//! let meter = MeasureUnit::try_from_str("meter").unwrap();
+//! let foot = MeasureUnit::try_from_str("foot").unwrap();
+//! let converter = factory.converter::<f64>(&meter, &foot).unwrap();
+//!
+//! // 2 meters is approximately 6.56168 feet.
+//! assert!((converter.convert(&2.0) - 6.56168).abs() < 1e-5);
+//! ```
+//!
+//! ## Proportional Conversion (Ratio)
+//!
+//! Using [`num_rational::Ratio`] for high-precision conversions:
+//!
+//! ```
+//! use icu_experimental::units::converter_factory::ConverterFactory;
+//! use icu_experimental::measure::measureunit::MeasureUnit;
+//! use num_rational::Ratio;
+//! use num_bigint::BigInt;
+//! use num_traits::ToPrimitive;
+//!
+//! let factory = ConverterFactory::new();
+//! let meter = MeasureUnit::try_from_str("meter").unwrap();
+//! let foot = MeasureUnit::try_from_str("foot").unwrap();
+//! let converter = factory.converter::<Ratio<BigInt>>(&meter, &foot).unwrap();
+//!
+//! let meters = Ratio::new(BigInt::from(2), BigInt::from(1));
+//! let feet = converter.convert(&meters);
+//!
+//! // 2 meters is approximately 6.56168 feet.
+//! // We convert the resulting Ratio to f64 for easy approximate comparison.
+//! let feet_f64 = feet.numer().to_f64().unwrap() / feet.denom().to_f64().unwrap();
+//! assert!((feet_f64 - 6.56168).abs() < 1e-5);
+//! ```
+//!
+//! ## Offset Conversion
+//!
+//! Converting Celsius to Fahrenheit (requires offset handling):
+//!
+//! ```
+//! use icu_experimental::units::converter_factory::ConverterFactory;
+//! use icu_experimental::measure::measureunit::MeasureUnit;
+//!
+//! let factory = ConverterFactory::new();
+//! let celsius = MeasureUnit::try_from_str("celsius").unwrap();
+//! let fahrenheit = MeasureUnit::try_from_str("fahrenheit").unwrap();
+//! let converter = factory.converter::<f64>(&celsius, &fahrenheit).unwrap();
+//!
+//! // 0°C is exactly 32°F.
+//! assert!((converter.convert(&0.0) - 32.0).abs() < 1e-9);
+//! // 100°C is exactly 212°F.
+//! assert!((converter.convert(&100.0) - 212.0).abs() < 1e-9);
+//! ```
+//!
+//! ## Reciprocal Conversion
+//!
+//! Converting mile-per-gallon to liter-per-100-kilometer (reciprocal relationship):
+//!
+//! ```
+//! use icu_experimental::units::converter_factory::ConverterFactory;
+//! use icu_experimental::measure::measureunit::MeasureUnit;
+//!
+//! let factory = ConverterFactory::new();
+//! let mpg = MeasureUnit::try_from_str("mile-per-gallon").unwrap();
+//! let lp100km = MeasureUnit::try_from_str("liter-per-100-kilometer").unwrap();
+//! let converter = factory.converter::<f64>(&mpg, &lp100km).unwrap();
+//!
+//! // 30 mpg is approximately 7.840486 L/100km.
+//! // Formula: 235.2145833 / mpg = lp100km
+//! assert!((converter.convert(&30.0) - 7.840486).abs() < 1e-5);
+//! ```
+//!
+//! ## Incompatible Units
+//!
+//! Attempting to convert incompatible units returns `None`:
+//!
+//! ```
+//! use icu_experimental::units::converter_factory::ConverterFactory;
+//! use icu_experimental::measure::measureunit::MeasureUnit;
+//!
+//! let factory = ConverterFactory::new();
+//! let meter = MeasureUnit::try_from_str("meter").unwrap();
+//! let second = MeasureUnit::try_from_str("second").unwrap();
+//!
+//! // Cannot convert meters to seconds, should return None.
+//! let converter = factory.converter::<f64>(&meter, &second);
+//! assert!(converter.is_none());
+//! ```
+
 #![allow(missing_docs)] // todo
 
 use displaydoc::Display;


### PR DESCRIPTION
This PR adds doctests showing the status quo for the unit converter in the `icu_experimental` crate.

🤖 This pull request was created by an AI agent working with @sffc.

## Changelog

N/A (docs only)