### PR TITLE
currency: Move experimental currency formatting to legacy

### DIFF
--- a/components/experimental/src/dimension/currency/legacy/compact_format.rs
+++ b/components/experimental/src/dimension/currency/legacy/compact_format.rs
@@ -2,60 +2,78 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-// TODO: add more tests for this module to cover more locales & currencies.
+// TODO: Legacy code. Should be removed after implementing the new implementation of https://hackmd.io/@younies/number_formatter_4x
+
 #[cfg(test)]
 mod tests {
     use icu_locale_core::locale;
     use tinystr::*;
     use writeable::assert_writeable_eq;
 
-    use crate::dimension::currency::{CurrencyCode, formatter::CurrencyFormatter};
+    use crate::dimension::currency::{CurrencyCode, legacy::compact_formatter::CompactCurrencyFormatter};
 
     #[test]
     pub fn test_en_us() {
         let locale = locale!("en-US").into();
         let currency_code = CurrencyCode(tinystr!(3, "USD"));
-        let fmt = CurrencyFormatter::try_new(locale, Default::default()).unwrap();
+        let fmt = CompactCurrencyFormatter::try_new(locale, Default::default()).unwrap();
 
         // Positive case
         let positive_value = "12345.67".parse().unwrap();
         let formatted_currency = fmt.format_fixed_decimal(&positive_value, &currency_code);
-        assert_writeable_eq!(formatted_currency, "$12,345.67");
+        assert_writeable_eq!(formatted_currency, "$12K");
 
         // Negative case
         let negative_value = "-12345.67".parse().unwrap();
         let formatted_currency = fmt.format_fixed_decimal(&negative_value, &currency_code);
-        assert_writeable_eq!(formatted_currency, "-$12,345.67");
+        assert_writeable_eq!(formatted_currency, "-$12K");
     }
 
     #[test]
     pub fn test_fr_fr() {
         let locale = locale!("fr-FR").into();
         let currency_code = CurrencyCode(tinystr!(3, "EUR"));
-        let fmt = CurrencyFormatter::try_new(locale, Default::default()).unwrap();
+        let fmt = CompactCurrencyFormatter::try_new(locale, Default::default()).unwrap();
 
         // Positive case
         let positive_value = "12345.67".parse().unwrap();
         let formatted_currency = fmt.format_fixed_decimal(&positive_value, &currency_code);
-        assert_writeable_eq!(formatted_currency, "12\u{202f}345,67\u{a0}€");
+        assert_writeable_eq!(formatted_currency, "12\u{a0}k\u{a0}€");
 
         // Negative case
         let negative_value = "-12345.67".parse().unwrap();
         let formatted_currency = fmt.format_fixed_decimal(&negative_value, &currency_code);
-        assert_writeable_eq!(formatted_currency, "-12\u{202f}345,67\u{a0}€");
+        assert_writeable_eq!(formatted_currency, "-12\u{a0}k\u{a0}€");
+    }
+
+    #[test]
+    pub fn test_zh_cn() {
+        let locale = locale!("zh-CN").into();
+        let currency_code = CurrencyCode(tinystr!(3, "CNY"));
+        let fmt = CompactCurrencyFormatter::try_new(locale, Default::default()).unwrap();
+
+        // Positive case
+        let positive_value = "12345.67".parse().unwrap();
+        let formatted_currency = fmt.format_fixed_decimal(&positive_value, &currency_code);
+        assert_writeable_eq!(formatted_currency, "¥1.2万");
+
+        // Negative case
+        let negative_value = "-12345.67".parse().unwrap();
+        let formatted_currency = fmt.format_fixed_decimal(&negative_value, &currency_code);
+        assert_writeable_eq!(formatted_currency, "-¥1.2万");
     }
 
     #[test]
     pub fn test_ar_eg() {
         let locale = locale!("ar-EG").into();
         let currency_code = CurrencyCode(tinystr!(3, "EGP"));
-        let fmt = CurrencyFormatter::try_new(locale, Default::default()).unwrap();
+        let fmt = CompactCurrencyFormatter::try_new(locale, Default::default()).unwrap();
 
         // Positive case
         let positive_value = "12345.67".parse().unwrap();
         let formatted_currency = fmt.format_fixed_decimal(&positive_value, &currency_code);
         // TODO(#6064)
-        assert_writeable_eq!(formatted_currency, "\u{200f}١٢٬٣٤٥٫٦٧\u{a0}ج.م.\u{200f}");
+        assert_writeable_eq!(formatted_currency, "\u{200f}١٢\u{a0}ألف\u{a0}ج.م.\u{200f}"); //  "ج.م.١٢ألف"
 
         // Negative case
         let negative_value = "-12345.67".parse().unwrap();
@@ -63,7 +81,7 @@ mod tests {
         // TODO(#6064)
         assert_writeable_eq!(
             formatted_currency,
-            "\u{61c}-\u{200f}١٢٬٣٤٥٫٦٧\u{a0}ج.م.\u{200f}"
+            "\u{61c}-\u{200f}١٢\u{a0}ألف\u{a0}ج.م.\u{200f}"
         );
     }
 }

--- a/components/experimental/src/dimension/currency/legacy/compact_format.rs
+++ b/components/experimental/src/dimension/currency/legacy/compact_format.rs
@@ -10,7 +10,9 @@ mod tests {
     use tinystr::*;
     use writeable::assert_writeable_eq;
 
-    use crate::dimension::currency::{CurrencyCode, legacy::compact_formatter::CompactCurrencyFormatter};
+    use crate::dimension::currency::{
+        CurrencyCode, legacy::compact_formatter::CompactCurrencyFormatter,
+    };
 
     #[test]
     pub fn test_en_us() {

--- a/components/experimental/src/dimension/currency/legacy/compact_formatter.rs
+++ b/components/experimental/src/dimension/currency/legacy/compact_formatter.rs
@@ -2,6 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+// TODO: Legacy code. Should be removed after implementing the new implementation of https://hackmd.io/@younies/number_formatter_4x
+
 use core::fmt::Display;
 
 use crate::dimension::provider::{
@@ -15,7 +17,8 @@ use icu_plurals::{PluralRules, PluralRulesPreferences};
 use icu_provider::prelude::*;
 use writeable::Writeable;
 
-use super::{CurrencyCode, options::CurrencyFormatterOptions};
+use crate::dimension::currency::CurrencyCode;
+use super::options::CurrencyFormatterOptions;
 use icu_pattern::DoublePlaceholderPattern;
 
 extern crate alloc;
@@ -208,7 +211,7 @@ impl CompactCurrencyFormatter {
     ///
     /// # Examples
     /// ```
-    /// use icu::experimental::dimension::currency::compact_formatter::CompactCurrencyFormatter;
+    /// use icu::experimental::dimension::currency::legacy::compact_formatter::CompactCurrencyFormatter;
     /// use icu::experimental::dimension::currency::CurrencyCode;
     /// use icu::locale::locale;
     /// use tinystr::*;

--- a/components/experimental/src/dimension/currency/legacy/compact_formatter.rs
+++ b/components/experimental/src/dimension/currency/legacy/compact_formatter.rs
@@ -17,8 +17,8 @@ use icu_plurals::{PluralRules, PluralRulesPreferences};
 use icu_provider::prelude::*;
 use writeable::Writeable;
 
-use crate::dimension::currency::CurrencyCode;
 use super::options::CurrencyFormatterOptions;
+use crate::dimension::currency::CurrencyCode;
 use icu_pattern::DoublePlaceholderPattern;
 
 extern crate alloc;

--- a/components/experimental/src/dimension/currency/legacy/format.rs
+++ b/components/experimental/src/dimension/currency/legacy/format.rs
@@ -2,76 +2,62 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+// TODO: Legacy code. Should be removed after implementing the new implementation of https://hackmd.io/@younies/number_formatter_4x
+
+// TODO: add more tests for this module to cover more locales & currencies.
 #[cfg(test)]
 mod tests {
     use icu_locale_core::locale;
     use tinystr::*;
     use writeable::assert_writeable_eq;
 
-    use crate::dimension::currency::{CurrencyCode, compact_formatter::CompactCurrencyFormatter};
+    use crate::dimension::currency::{CurrencyCode, legacy::formatter::CurrencyFormatter};
 
     #[test]
     pub fn test_en_us() {
         let locale = locale!("en-US").into();
         let currency_code = CurrencyCode(tinystr!(3, "USD"));
-        let fmt = CompactCurrencyFormatter::try_new(locale, Default::default()).unwrap();
+        let fmt = CurrencyFormatter::try_new(locale, Default::default()).unwrap();
 
         // Positive case
         let positive_value = "12345.67".parse().unwrap();
         let formatted_currency = fmt.format_fixed_decimal(&positive_value, &currency_code);
-        assert_writeable_eq!(formatted_currency, "$12K");
+        assert_writeable_eq!(formatted_currency, "$12,345.67");
 
         // Negative case
         let negative_value = "-12345.67".parse().unwrap();
         let formatted_currency = fmt.format_fixed_decimal(&negative_value, &currency_code);
-        assert_writeable_eq!(formatted_currency, "-$12K");
+        assert_writeable_eq!(formatted_currency, "-$12,345.67");
     }
 
     #[test]
     pub fn test_fr_fr() {
         let locale = locale!("fr-FR").into();
         let currency_code = CurrencyCode(tinystr!(3, "EUR"));
-        let fmt = CompactCurrencyFormatter::try_new(locale, Default::default()).unwrap();
+        let fmt = CurrencyFormatter::try_new(locale, Default::default()).unwrap();
 
         // Positive case
         let positive_value = "12345.67".parse().unwrap();
         let formatted_currency = fmt.format_fixed_decimal(&positive_value, &currency_code);
-        assert_writeable_eq!(formatted_currency, "12\u{a0}k\u{a0}€");
+        assert_writeable_eq!(formatted_currency, "12\u{202f}345,67\u{a0}€");
 
         // Negative case
         let negative_value = "-12345.67".parse().unwrap();
         let formatted_currency = fmt.format_fixed_decimal(&negative_value, &currency_code);
-        assert_writeable_eq!(formatted_currency, "-12\u{a0}k\u{a0}€");
-    }
-
-    #[test]
-    pub fn test_zh_cn() {
-        let locale = locale!("zh-CN").into();
-        let currency_code = CurrencyCode(tinystr!(3, "CNY"));
-        let fmt = CompactCurrencyFormatter::try_new(locale, Default::default()).unwrap();
-
-        // Positive case
-        let positive_value = "12345.67".parse().unwrap();
-        let formatted_currency = fmt.format_fixed_decimal(&positive_value, &currency_code);
-        assert_writeable_eq!(formatted_currency, "¥1.2万");
-
-        // Negative case
-        let negative_value = "-12345.67".parse().unwrap();
-        let formatted_currency = fmt.format_fixed_decimal(&negative_value, &currency_code);
-        assert_writeable_eq!(formatted_currency, "-¥1.2万");
+        assert_writeable_eq!(formatted_currency, "-12\u{202f}345,67\u{a0}€");
     }
 
     #[test]
     pub fn test_ar_eg() {
         let locale = locale!("ar-EG").into();
         let currency_code = CurrencyCode(tinystr!(3, "EGP"));
-        let fmt = CompactCurrencyFormatter::try_new(locale, Default::default()).unwrap();
+        let fmt = CurrencyFormatter::try_new(locale, Default::default()).unwrap();
 
         // Positive case
         let positive_value = "12345.67".parse().unwrap();
         let formatted_currency = fmt.format_fixed_decimal(&positive_value, &currency_code);
         // TODO(#6064)
-        assert_writeable_eq!(formatted_currency, "\u{200f}١٢\u{a0}ألف\u{a0}ج.م.\u{200f}"); //  "ج.م.١٢ألف"
+        assert_writeable_eq!(formatted_currency, "\u{200f}١٢٬٣٤٥٫٦٧\u{a0}ج.م.\u{200f}");
 
         // Negative case
         let negative_value = "-12345.67".parse().unwrap();
@@ -79,7 +65,7 @@ mod tests {
         // TODO(#6064)
         assert_writeable_eq!(
             formatted_currency,
-            "\u{61c}-\u{200f}١٢\u{a0}ألف\u{a0}ج.م.\u{200f}"
+            "\u{61c}-\u{200f}١٢٬٣٤٥٫٦٧\u{a0}ج.م.\u{200f}"
         );
     }
 }

--- a/components/experimental/src/dimension/currency/legacy/formatter.rs
+++ b/components/experimental/src/dimension/currency/legacy/formatter.rs
@@ -15,9 +15,9 @@ use icu_plurals::PluralRulesPreferences;
 use icu_provider::prelude::*;
 use writeable::Writeable;
 
-use crate::dimension::provider::currency::essentials::CurrencyEssentialsV1;
-use crate::dimension::currency::CurrencyCode;
 use super::options::CurrencyFormatterOptions;
+use crate::dimension::currency::CurrencyCode;
+use crate::dimension::provider::currency::essentials::CurrencyEssentialsV1;
 use icu_pattern::DoublePlaceholderPattern;
 
 extern crate alloc;

--- a/components/experimental/src/dimension/currency/legacy/formatter.rs
+++ b/components/experimental/src/dimension/currency/legacy/formatter.rs
@@ -2,6 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+// TODO: Legacy code. Should be removed after implementing the new implementation of https://hackmd.io/@younies/number_formatter_4x
+
 use core::fmt::Display;
 
 use fixed_decimal::Decimal;
@@ -13,8 +15,8 @@ use icu_plurals::PluralRulesPreferences;
 use icu_provider::prelude::*;
 use writeable::Writeable;
 
-use super::super::provider::currency::essentials::CurrencyEssentialsV1;
-use super::CurrencyCode;
+use crate::dimension::provider::currency::essentials::CurrencyEssentialsV1;
+use crate::dimension::currency::CurrencyCode;
 use super::options::CurrencyFormatterOptions;
 use icu_pattern::DoublePlaceholderPattern;
 
@@ -139,7 +141,7 @@ impl CurrencyFormatter {
     ///
     /// # Examples
     /// ```
-    /// use icu::experimental::dimension::currency::formatter::CurrencyFormatter;
+    /// use icu::experimental::dimension::currency::legacy::formatter::CurrencyFormatter;
     /// use icu::experimental::dimension::currency::CurrencyCode;
     /// use icu::locale::locale;
     /// use tinystr::*;

--- a/components/experimental/src/dimension/currency/legacy/long_compact_format.rs
+++ b/components/experimental/src/dimension/currency/legacy/long_compact_format.rs
@@ -2,6 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+// TODO: Legacy code. Should be removed after implementing the new implementation of https://hackmd.io/@younies/number_formatter_4x
+
 #[cfg(test)]
 mod tests {
     use icu_locale_core::locale;
@@ -9,7 +11,7 @@ mod tests {
     use writeable::assert_writeable_eq;
 
     use crate::dimension::currency::CurrencyCode;
-    use crate::dimension::currency::long_compact_formatter::LongCompactCurrencyFormatter;
+    use crate::dimension::currency::legacy::long_compact_formatter::LongCompactCurrencyFormatter;
 
     #[test]
     pub fn test_en_us() {

--- a/components/experimental/src/dimension/currency/legacy/long_compact_formatter.rs
+++ b/components/experimental/src/dimension/currency/legacy/long_compact_formatter.rs
@@ -2,6 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+// TODO: Legacy code. Should be removed after implementing the new implementation of https://hackmd.io/@younies/number_formatter_4x
+
 use core::fmt::Display;
 
 use fixed_decimal::Decimal;
@@ -10,12 +12,12 @@ use icu_plurals::PluralRules;
 use icu_provider::prelude::*;
 use writeable::Writeable;
 
-use crate::dimension::currency::compact_formatter::CompactCurrencyFormatterPreferences;
+use crate::dimension::currency::legacy::compact_formatter::CompactCurrencyFormatterPreferences;
 use crate::dimension::provider::currency::{
     extended::CurrencyExtendedDataV1, patterns::CurrencyPatternsDataV1,
 };
 
-use super::CurrencyCode;
+use crate::dimension::currency::CurrencyCode;
 
 extern crate alloc;
 
@@ -180,7 +182,7 @@ impl LongCompactCurrencyFormatter {
     ///
     /// # Examples
     /// ```
-    /// use icu::experimental::dimension::currency::long_compact_formatter::LongCompactCurrencyFormatter;
+    /// use icu::experimental::dimension::currency::legacy::long_compact_formatter::LongCompactCurrencyFormatter;
     /// use icu::experimental::dimension::currency::CurrencyCode;
     /// use icu::locale::locale;
     /// use tinystr::*;

--- a/components/experimental/src/dimension/currency/legacy/long_format.rs
+++ b/components/experimental/src/dimension/currency/legacy/long_format.rs
@@ -2,6 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+// TODO: Legacy code. Should be removed after implementing the new implementation of https://hackmd.io/@younies/number_formatter_4x
+
 // TODO: add more tests for this module to cover more locales & currencies.
 #[cfg(test)]
 mod tests {
@@ -9,7 +11,7 @@ mod tests {
     use tinystr::*;
     use writeable::assert_writeable_eq;
 
-    use crate::dimension::currency::{CurrencyCode, long_formatter::LongCurrencyFormatter};
+    use crate::dimension::currency::{CurrencyCode, legacy::long_formatter::LongCurrencyFormatter};
 
     #[test]
     pub fn test_en_us() {

--- a/components/experimental/src/dimension/currency/legacy/long_formatter.rs
+++ b/components/experimental/src/dimension/currency/legacy/long_formatter.rs
@@ -16,8 +16,8 @@ use crate::dimension::provider::currency::{
     extended::CurrencyExtendedDataV1, patterns::CurrencyPatternsDataV1,
 };
 
-use crate::dimension::currency::CurrencyCode;
 use super::formatter::CurrencyFormatterPreferences;
+use crate::dimension::currency::CurrencyCode;
 
 extern crate alloc;
 

--- a/components/experimental/src/dimension/currency/legacy/long_formatter.rs
+++ b/components/experimental/src/dimension/currency/legacy/long_formatter.rs
@@ -2,6 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+// TODO: Legacy code. Should be removed after implementing the new implementation of https://hackmd.io/@younies/number_formatter_4x
+
 use core::fmt::Display;
 
 use fixed_decimal::Decimal;
@@ -14,7 +16,8 @@ use crate::dimension::provider::currency::{
     extended::CurrencyExtendedDataV1, patterns::CurrencyPatternsDataV1,
 };
 
-use super::{CurrencyCode, formatter::CurrencyFormatterPreferences};
+use crate::dimension::currency::CurrencyCode;
+use super::formatter::CurrencyFormatterPreferences;
 
 extern crate alloc;
 
@@ -147,7 +150,7 @@ impl LongCurrencyFormatter {
     ///
     /// # Examples
     /// ```
-    /// use icu::experimental::dimension::currency::long_formatter::LongCurrencyFormatter;
+    /// use icu::experimental::dimension::currency::legacy::long_formatter::LongCurrencyFormatter;
     /// use icu::experimental::dimension::currency::CurrencyCode;
     /// use icu::locale::locale;
     /// use tinystr::*;

--- a/components/experimental/src/dimension/currency/legacy/mod.rs
+++ b/components/experimental/src/dimension/currency/legacy/mod.rs
@@ -1,0 +1,64 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+// TODO: Legacy code. Should be removed after implementing the new implementation of https://hackmd.io/@younies/number_formatter_4x
+
+pub mod compact_format;
+pub mod compact_formatter;
+pub mod format;
+pub mod formatter;
+pub mod long_compact_format;
+pub mod long_compact_formatter;
+pub mod long_format;
+pub mod long_formatter;
+pub mod options;
+
+use crate::dimension::currency::CurrencyCode;
+use crate::dimension::currency::legacy::options::Width;
+use crate::dimension::provider::currency::essentials::{
+    CurrencyEssentials, PatternSelection, PlaceholderValue,
+};
+use icu_pattern::DoublePlaceholderPattern;
+
+impl<'a> CurrencyEssentials<'a> {
+    pub(crate) fn name_and_pattern(
+        &'a self,
+        width: Width,
+        currency: &'a CurrencyCode,
+    ) -> (
+        &'a str,
+        Option<&'a DoublePlaceholderPattern>,
+        PatternSelection,
+    ) {
+        let config = self
+            .pattern_config_map
+            .get_copied(&currency.0.to_unvalidated())
+            .unwrap_or(self.default_pattern_config);
+
+        let placeholder_val = match width {
+            Width::Short => config.short_placeholder_value,
+            Width::Narrow => config.narrow_placeholder_value,
+        };
+
+        let currency = match placeholder_val {
+            Some(PlaceholderValue::Index(index)) => self.placeholders.get(index.into()),
+            Some(PlaceholderValue::ISO) | None => None,
+        }
+        .unwrap_or(currency.0.as_str());
+
+        let pattern_selection = match width {
+            Width::Short => config.short_pattern_selection,
+            Width::Narrow => config.narrow_pattern_selection,
+        };
+
+        let pattern = match pattern_selection {
+            PatternSelection::Standard => self.standard_pattern(),
+            PatternSelection::StandardAlphaNextToNumber => {
+                self.standard_alpha_next_to_number_pattern()
+            }
+        };
+
+        (currency, pattern, pattern_selection)
+    }
+}

--- a/components/experimental/src/dimension/currency/legacy/options.rs
+++ b/components/experimental/src/dimension/currency/legacy/options.rs
@@ -2,13 +2,15 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-//! Options for [`CurrencyFormatter`](crate::dimension::currency::formatter::CurrencyFormatter).
+// TODO: Legacy code. Should be removed after implementing the new implementation of https://hackmd.io/@younies/number_formatter_4x
+
+//! Options for [`CurrencyFormatter`](crate::dimension::currency::legacy::formatter::CurrencyFormatter).
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// A collection of configuration options that determine the formatting behavior of
-/// [`CurrencyFormatter`](crate::dimension::currency::formatter::CurrencyFormatter).
+/// [`CurrencyFormatter`](crate::dimension::currency::legacy::formatter::CurrencyFormatter).
 #[derive(Copy, Debug, Eq, PartialEq, Clone, Default, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[non_exhaustive]

--- a/components/experimental/src/dimension/currency/mod.rs
+++ b/components/experimental/src/dimension/currency/mod.rs
@@ -4,15 +4,7 @@
 
 use tinystr::TinyAsciiStr;
 
-pub mod compact_format;
-pub mod compact_formatter;
-pub mod format;
-pub mod formatter;
-pub mod long_compact_format;
-pub mod long_compact_formatter;
-pub mod long_format;
-pub mod long_formatter;
-pub mod options;
+pub mod legacy;
 
 /// A currency code, such as "USD" or "EUR".
 #[derive(Clone, Copy, Debug)]

--- a/components/experimental/src/dimension/provider/currency/essentials.rs
+++ b/components/experimental/src/dimension/provider/currency/essentials.rs
@@ -12,8 +12,7 @@ use zerovec::{VarZeroVec, ZeroMap};
 
 use icu_pattern::DoublePlaceholderPattern;
 
-use crate::dimension::currency::CurrencyCode;
-use crate::dimension::currency::options::Width;
+
 
 #[cfg(feature = "compiled_data")]
 /// Baked data
@@ -134,48 +133,6 @@ pub struct CurrencyPatternConfig {
 }
 
 impl<'a> CurrencyEssentials<'a> {
-    /// Returns the formatted currency name/symbol,
-    /// the currency pattern for the given width and currency,
-    /// and the pattern selection.
-    pub(crate) fn name_and_pattern(
-        &'a self,
-        width: Width,
-        currency: &'a CurrencyCode,
-    ) -> (
-        &'a str,
-        Option<&'a DoublePlaceholderPattern>,
-        PatternSelection,
-    ) {
-        let config = self
-            .pattern_config_map
-            .get_copied(&currency.0.to_unvalidated())
-            .unwrap_or(self.default_pattern_config);
-
-        let placeholder_val = match width {
-            Width::Short => config.short_placeholder_value,
-            Width::Narrow => config.narrow_placeholder_value,
-        };
-
-        let currency = match placeholder_val {
-            Some(PlaceholderValue::Index(index)) => self.placeholders.get(index.into()),
-            Some(PlaceholderValue::ISO) | None => None,
-        }
-        .unwrap_or(currency.0.as_str());
-
-        let pattern_selection = match width {
-            Width::Short => config.short_pattern_selection,
-            Width::Narrow => config.narrow_pattern_selection,
-        };
-
-        let pattern = match pattern_selection {
-            PatternSelection::Standard => self.standard_pattern(),
-            PatternSelection::StandardAlphaNextToNumber => {
-                self.standard_alpha_next_to_number_pattern()
-            }
-        };
-
-        (currency, pattern, pattern_selection)
-    }
 
     /// Returns the standard pattern.
     pub fn standard_pattern(&self) -> Option<&DoublePlaceholderPattern> {

--- a/components/experimental/src/dimension/provider/currency/essentials.rs
+++ b/components/experimental/src/dimension/provider/currency/essentials.rs
@@ -12,8 +12,6 @@ use zerovec::{VarZeroVec, ZeroMap};
 
 use icu_pattern::DoublePlaceholderPattern;
 
-
-
 #[cfg(feature = "compiled_data")]
 /// Baked data
 ///
@@ -133,7 +131,6 @@ pub struct CurrencyPatternConfig {
 }
 
 impl<'a> CurrencyEssentials<'a> {
-
     /// Returns the standard pattern.
     pub fn standard_pattern(&self) -> Option<&DoublePlaceholderPattern> {
         self.patterns


### PR DESCRIPTION
## Changelog

This PR moves the existing experimental currency formatting implementation to a `legacy` subdirectory/module. This is in preparation for a new implementation based on the design at https://hackmd.io/@younies/number_formatter_4x.

Changes:
- Moved all files (except `mod.rs`) from `components/experimental/src/dimension/currency` to a new `legacy` subdirectory.
- Added a TODO comment to each moved file indicating it is legacy code to be removed.
- Refactored `name_and_pattern` out of `essentials.rs` into `legacy/mod.rs` to ensure that data provider structs do not depend on legacy code.
- Updated imports and module structure accordingly.

