### PR TITLE
`UnitsConverter`: accept inputs by value, return correct error type

### DIFF
--- a/components/experimental/src/units/converter.rs
+++ b/components/experimental/src/units/converter.rs
@@ -25,11 +25,9 @@ where
     /// Converts the given value from the input unit to the output unit.
     pub fn convert(&self, value: N) -> N::Result {
         match &self.0 {
-            UnitsConverterInner::Proportional { factor } => value.mul_ratio_bigint(factor),
-            UnitsConverterInner::Reciprocal { factor } => value.reciprocal_mul_ratio_bigint(factor),
-            UnitsConverterInner::Offset { factor, offset } => {
-                value.add_mul_ratio_bigint(factor, offset)
-            }
+            UnitsConverterInner::Proportional { factor } => value.mul(factor),
+            UnitsConverterInner::Reciprocal { factor } => value.reciprocal_mul(factor),
+            UnitsConverterInner::Offset { factor, offset } => value.mul_add(factor, offset),
         }
     }
 }

--- a/components/experimental/src/units/converter.rs
+++ b/components/experimental/src/units/converter.rs
@@ -23,12 +23,12 @@ where
     N: Convertible,
 {
     /// Converts the given value from the input unit to the output unit.
-    pub fn convert(&self, value: &N) -> N {
+    pub fn convert(&self, value: N) -> N::Result {
         match &self.0 {
-            UnitsConverterInner::Proportional { factor } => value.mul_refs(factor),
-            UnitsConverterInner::Reciprocal { factor } => value.mul_refs(factor).reciprocal(),
+            UnitsConverterInner::Proportional { factor } => value.mul_ratio_bigint(factor),
+            UnitsConverterInner::Reciprocal { factor } => value.reciprocal_mul_ratio_bigint(factor),
             UnitsConverterInner::Offset { factor, offset } => {
-                value.mul_refs(factor).add_refs(offset)
+                value.add_mul_ratio_bigint(factor, offset)
             }
         }
     }
@@ -51,12 +51,15 @@ where
     /// such as `celsius` to `fahrenheit` and `mile-per-gallon` to `liter-per-100-kilometer`.
     ///
     /// Also, it cannot convert between two units that are not single, such as `meter` to `foot-and-inch`.
-    Proportional { factor: N },
+    Proportional { factor: N::Factor },
     /// A converter for converting between two units that are reciprocal.
     /// For example:
     ///    1 - `meter-per-second` to `second-per-meter`.
     ///    2 - `mile-per-gallon` to `liter-per-100-kilometer`.
-    Reciprocal { factor: N },
+    Reciprocal { factor: N::Factor },
     /// A converter for converting between two units that require an offset.
-    Offset { factor: N, offset: N },
+    Offset {
+        factor: N::Factor,
+        offset: N::Addend,
+    },
 }

--- a/components/experimental/src/units/converter.rs
+++ b/components/experimental/src/units/converter.rs
@@ -24,7 +24,13 @@ where
 {
     /// Converts the given value from the input unit to the output unit.
     pub fn convert(&self, value: &N) -> N {
-        self.0.convert(value)
+        match &self.0 {
+            UnitsConverterInner::Proportional { factor } => value.mul_refs(factor),
+            UnitsConverterInner::Reciprocal { factor } => value.mul_refs(factor).reciprocal(),
+            UnitsConverterInner::Offset { factor, offset } => {
+                value.mul_refs(factor).add_refs(offset)
+            }
+        }
     }
 }
 
@@ -37,93 +43,20 @@ pub(crate) enum UnitsConverterInner<N>
 where
     N: Convertible,
 {
-    Proportional(ProportionalConverter<N>),
-    Reciprocal(ReciprocalConverter<N>),
-    Offset(OffsetConverter<N>),
-}
-
-impl<N> UnitsConverterInner<N>
-where
-    N: Convertible,
-{
-    /// Converts the given value from the input unit to the output unit based on the inner converter type.
-    fn convert(&self, value: &N) -> N {
-        match self {
-            UnitsConverterInner::Proportional(converter) => converter.convert(value),
-            UnitsConverterInner::Reciprocal(converter) => converter.convert(value),
-            UnitsConverterInner::Offset(converter) => converter.convert(value),
-        }
-    }
-}
-
-/// A converter for converting between two units that are reciprocal.
-/// For example:
-///    1 - `meter-per-second` to `second-per-meter`.
-///    2 - `mile-per-gallon` to `liter-per-100-kilometer`.
-#[derive(Debug, Clone)]
-pub(crate) struct ReciprocalConverter<N>
-where
-    N: Convertible,
-{
-    pub(crate) proportional: ProportionalConverter<N>,
-}
-
-impl<N> ReciprocalConverter<N>
-where
-    N: Convertible,
-{
-    /// Converts the given value from the input unit to the output unit.
-    pub(crate) fn convert(&self, value: &N) -> N {
-        self.proportional.convert(value).reciprocal()
-    }
-}
-
-/// A converter for converting between two units that require an offset.
-#[derive(Debug, Clone)]
-pub(crate) struct OffsetConverter<N>
-where
-    N: Convertible,
-{
-    /// The proportional converter.
-    pub(crate) proportional: ProportionalConverter<N>,
-
-    /// The offset value to be added to the result of the proportional converter.
-    pub(crate) offset: N,
-}
-
-impl<N> OffsetConverter<N>
-where
-    N: Convertible,
-{
-    /// Converts the given value from the input unit to the output unit.
-    pub(crate) fn convert(&self, value: &N) -> N {
-        self.proportional.convert(value).add_refs(&self.offset)
-    }
-}
-
-/// `ProportionalConverter` is responsible for converting between two units that are proportionally related.
-/// For example: 1- `meter` to `foot`.
-///              2- `square-meter` to `square-foot`.
-///
-/// However, it cannot convert between two units that are not proportionally related,
-/// such as `celsius` to `fahrenheit` and `mile-per-gallon` to `liter-per-100-kilometer`.
-///
-/// Also, it cannot convert between two units that are not single, such as `meter` to `foot-and-inch`.
-#[derive(Debug, Clone)]
-pub(crate) struct ProportionalConverter<N>
-where
-    N: Convertible,
-{
-    /// The conversion rate between the input and output units.
-    pub(crate) conversion_rate: N,
-}
-
-impl<N> ProportionalConverter<N>
-where
-    N: Convertible,
-{
-    /// Converts the given value from the input unit to the output unit.
-    pub fn convert(&self, value: &N) -> N {
-        value.mul_refs(&self.conversion_rate)
-    }
+    /// `ProportionalConverter` is responsible for converting between two units that are proportionally related.
+    /// For example: 1- `meter` to `foot`.
+    ///              2- `square-meter` to `square-foot`.
+    ///
+    /// However, it cannot convert between two units that are not proportionally related,
+    /// such as `celsius` to `fahrenheit` and `mile-per-gallon` to `liter-per-100-kilometer`.
+    ///
+    /// Also, it cannot convert between two units that are not single, such as `meter` to `foot-and-inch`.
+    Proportional { factor: N },
+    /// A converter for converting between two units that are reciprocal.
+    /// For example:
+    ///    1 - `meter-per-second` to `second-per-meter`.
+    ///    2 - `mile-per-gallon` to `liter-per-100-kilometer`.
+    Reciprocal { factor: N },
+    /// A converter for converting between two units that require an offset.
+    Offset { factor: N, offset: N },
 }

--- a/components/experimental/src/units/converter.rs
+++ b/components/experimental/src/units/converter.rs
@@ -2,9 +2,6 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use num_bigint::BigInt;
-use num_rational::Ratio;
-
 use crate::units::convertible::Convertible;
 
 /// A converter for converting between two single or compound units.
@@ -17,11 +14,16 @@ use crate::units::convertible::Convertible;
 ///     This converter does not support conversions between mixed units,
 ///     for example, from "meter" to "foot-and-inch".
 #[derive(Debug, Clone)]
-pub struct UnitsConverter(pub(crate) UnitsConverterInner);
+pub struct UnitsConverter<N>(pub(crate) UnitsConverterInner<N>)
+where
+    N: Convertible;
 
-impl UnitsConverter {
+impl<N> UnitsConverter<N>
+where
+    N: Convertible,
+{
     /// Converts the given value from the input unit to the output unit.
-    pub fn convert<N: Convertible>(&self, value: N) -> N::Result {
+    pub fn convert(&self, value: N) -> N::Result {
         match &self.0 {
             UnitsConverterInner::Proportional { factor } => value.mul_ratio_bigint(factor),
             UnitsConverterInner::Reciprocal { factor } => value.reciprocal_mul_ratio_bigint(factor),
@@ -37,7 +39,10 @@ impl UnitsConverter {
 ///    2 - Reciprocal: Converts between two units that are reciprocal (e.g. `mile-per-gallon` to `liter-per-100-kilometer`).
 ///    3 - Offset: Converts between two units that require an offset (e.g. `celsius` to `fahrenheit`).
 #[derive(Debug, Clone)]
-pub(crate) enum UnitsConverterInner {
+pub(crate) enum UnitsConverterInner<N>
+where
+    N: Convertible,
+{
     /// `ProportionalConverter` is responsible for converting between two units that are proportionally related.
     /// For example: 1- `meter` to `foot`.
     ///              2- `square-meter` to `square-foot`.
@@ -46,15 +51,15 @@ pub(crate) enum UnitsConverterInner {
     /// such as `celsius` to `fahrenheit` and `mile-per-gallon` to `liter-per-100-kilometer`.
     ///
     /// Also, it cannot convert between two units that are not single, such as `meter` to `foot-and-inch`.
-    Proportional { factor: Ratio<BigInt> },
+    Proportional { factor: N::Factor },
     /// A converter for converting between two units that are reciprocal.
     /// For example:
     ///    1 - `meter-per-second` to `second-per-meter`.
     ///    2 - `mile-per-gallon` to `liter-per-100-kilometer`.
-    Reciprocal { factor: Ratio<BigInt> },
+    Reciprocal { factor: N::Factor },
     /// A converter for converting between two units that require an offset.
     Offset {
-        factor: Ratio<BigInt>,
-        offset: Ratio<BigInt>,
+        factor: N::Factor,
+        offset: N::Addend,
     },
 }

--- a/components/experimental/src/units/converter.rs
+++ b/components/experimental/src/units/converter.rs
@@ -2,6 +2,9 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use num_bigint::BigInt;
+use num_rational::Ratio;
+
 use crate::units::convertible::Convertible;
 
 /// A converter for converting between two single or compound units.
@@ -14,16 +17,11 @@ use crate::units::convertible::Convertible;
 ///     This converter does not support conversions between mixed units,
 ///     for example, from "meter" to "foot-and-inch".
 #[derive(Debug, Clone)]
-pub struct UnitsConverter<N>(pub(crate) UnitsConverterInner<N>)
-where
-    N: Convertible;
+pub struct UnitsConverter(pub(crate) UnitsConverterInner);
 
-impl<N> UnitsConverter<N>
-where
-    N: Convertible,
-{
+impl UnitsConverter {
     /// Converts the given value from the input unit to the output unit.
-    pub fn convert(&self, value: N) -> N::Result {
+    pub fn convert<N: Convertible>(&self, value: N) -> N::Result {
         match &self.0 {
             UnitsConverterInner::Proportional { factor } => value.mul_ratio_bigint(factor),
             UnitsConverterInner::Reciprocal { factor } => value.reciprocal_mul_ratio_bigint(factor),
@@ -39,10 +37,7 @@ where
 ///    2 - Reciprocal: Converts between two units that are reciprocal (e.g. `mile-per-gallon` to `liter-per-100-kilometer`).
 ///    3 - Offset: Converts between two units that require an offset (e.g. `celsius` to `fahrenheit`).
 #[derive(Debug, Clone)]
-pub(crate) enum UnitsConverterInner<N>
-where
-    N: Convertible,
-{
+pub(crate) enum UnitsConverterInner {
     /// `ProportionalConverter` is responsible for converting between two units that are proportionally related.
     /// For example: 1- `meter` to `foot`.
     ///              2- `square-meter` to `square-foot`.
@@ -51,15 +46,15 @@ where
     /// such as `celsius` to `fahrenheit` and `mile-per-gallon` to `liter-per-100-kilometer`.
     ///
     /// Also, it cannot convert between two units that are not single, such as `meter` to `foot-and-inch`.
-    Proportional { factor: N::Factor },
+    Proportional { factor: Ratio<BigInt> },
     /// A converter for converting between two units that are reciprocal.
     /// For example:
     ///    1 - `meter-per-second` to `second-per-meter`.
     ///    2 - `mile-per-gallon` to `liter-per-100-kilometer`.
-    Reciprocal { factor: N::Factor },
+    Reciprocal { factor: Ratio<BigInt> },
     /// A converter for converting between two units that require an offset.
     Offset {
-        factor: N::Factor,
-        offset: N::Addend,
+        factor: Ratio<BigInt>,
+        offset: Ratio<BigInt>,
     },
 }

--- a/components/experimental/src/units/converter_factory.rs
+++ b/components/experimental/src/units/converter_factory.rs
@@ -191,13 +191,14 @@ impl ConverterFactory {
                     .get()
                     .conversion_info_by_unit_id(single_unit.unit_id);
 
-                debug_assert!(conversion_info.is_some(), "Failed to get convert info");
-
                 match conversion_info {
                     Some(items) => {
                         insert_base_units(items.basic_units(), single_unit.power as i16, sign, map)
                     }
-                    None => return Err(InvalidConversionError),
+                    None => {
+                        debug_assert!(false, "Failed to get convert info");
+                        return Err(InvalidConversionError);
+                    }
                 }
             }
 
@@ -284,18 +285,20 @@ impl ConverterFactory {
         &self,
         input_unit: &MeasureUnit,
         output_unit: &MeasureUnit,
-    ) -> Option<UnitsConverter<T>> {
-        let is_reciprocal = match self.is_reciprocal(input_unit, output_unit) {
-            Ok(is_reciprocal) => is_reciprocal,
-            Err(InvalidConversionError) => return None,
-        };
+    ) -> Result<UnitsConverter<T>, InvalidConversionError> {
+        let is_reciprocal = self.is_reciprocal(input_unit, output_unit)?;
+
+        // is_reciprocal checked that all simple units can be loaded, so we can ignore load errors after this.
 
         // Determine the sign of the powers of the units from root to unit2.
         let root_to_unit2_direction_sign = if is_reciprocal { 1 } else { -1 };
 
         let mut conversion_rate = IcuRatio::one();
         for &input_single_unit in input_unit.single_units.as_slice() {
-            conversion_rate *= Self::compute_conversion_term(self, input_single_unit, 1)?;
+            let Some(t) = Self::compute_conversion_term(self, input_single_unit, 1) else {
+                continue;
+            };
+            conversion_rate *= t;
         }
 
         if input_unit.constant_denominator() != 0 {
@@ -303,11 +306,14 @@ impl ConverterFactory {
         }
 
         for &output_single_unit in output_unit.single_units.as_slice() {
-            conversion_rate *= Self::compute_conversion_term(
+            let Some(t) = Self::compute_conversion_term(
                 self,
                 output_single_unit,
                 root_to_unit2_direction_sign,
-            )?;
+            ) else {
+                continue;
+            };
+            conversion_rate *= t;
         }
 
         if output_unit.constant_denominator() != 0 {
@@ -318,29 +324,29 @@ impl ConverterFactory {
             }
         }
 
-        let offset = self.compute_offset(input_unit, output_unit)?;
+        let offset = self
+            .compute_offset(input_unit, output_unit)
+            .unwrap_or_else(IcuRatio::zero);
 
         if is_reciprocal && !offset.is_zero() {
             debug_assert!(
                 false,
                 "The units are reciprocal, but the offset is not zero. This is should not happen!.",
             );
-            return None;
         }
 
-        Some(if is_reciprocal {
+        Ok(if is_reciprocal {
             UnitsConverter(UnitsConverterInner::Reciprocal {
-                factor: T::from_ratio_bigint(conversion_rate.get_ratio())?,
+                factor: T::from_ratio_bigint(conversion_rate.get_ratio()),
             })
         } else if offset.is_zero() {
             UnitsConverter(UnitsConverterInner::Proportional {
-                factor: T::from_ratio_bigint(conversion_rate.get_ratio())?,
+                factor: T::from_ratio_bigint(conversion_rate.get_ratio()),
             })
         } else {
-            let offset = T::from_ratio_bigint(offset.get_ratio())?;
             UnitsConverter(UnitsConverterInner::Offset {
-                factor: T::from_ratio_bigint(conversion_rate.get_ratio())?,
-                offset,
+                factor: T::from_ratio_bigint(conversion_rate.get_ratio()),
+                offset: T::from_ratio_bigint(offset.get_ratio()),
             })
         })
     }

--- a/components/experimental/src/units/converter_factory.rs
+++ b/components/experimental/src/units/converter_factory.rs
@@ -7,10 +7,7 @@ use crate::measure::provider::single_unit::SingleUnit;
 use crate::units::ratio::IcuRatio;
 use crate::units::{InvalidConversionError, provider};
 use crate::units::{
-    converter::{
-        OffsetConverter, ProportionalConverter, ReciprocalConverter, UnitsConverter,
-        UnitsConverterInner,
-    },
+    converter::{UnitsConverter, UnitsConverterInner},
     provider::Sign,
 };
 
@@ -331,26 +328,21 @@ impl ConverterFactory {
             return None;
         }
 
-        let conversion_rate = T::from_ratio_bigint(conversion_rate.get_ratio())?;
-        let proportional = ProportionalConverter { conversion_rate };
-
-        if is_reciprocal {
-            Some(UnitsConverter(UnitsConverterInner::Reciprocal(
-                ReciprocalConverter { proportional },
-            )))
+        Some(if is_reciprocal {
+            UnitsConverter(UnitsConverterInner::Reciprocal {
+                factor: T::from_ratio_bigint(conversion_rate.get_ratio())?,
+            })
         } else if offset.is_zero() {
-            Some(UnitsConverter(UnitsConverterInner::Proportional(
-                proportional,
-            )))
+            UnitsConverter(UnitsConverterInner::Proportional {
+                factor: T::from_ratio_bigint(conversion_rate.get_ratio())?,
+            })
         } else {
             let offset = T::from_ratio_bigint(offset.get_ratio())?;
-            Some(UnitsConverter(UnitsConverterInner::Offset(
-                OffsetConverter {
-                    proportional,
-                    offset,
-                },
-            )))
-        }
+            UnitsConverter(UnitsConverterInner::Offset {
+                factor: T::from_ratio_bigint(conversion_rate.get_ratio())?,
+                offset,
+            })
+        })
     }
 }
 

--- a/components/experimental/src/units/converter_factory.rs
+++ b/components/experimental/src/units/converter_factory.rs
@@ -18,6 +18,7 @@ use num_traits::Pow;
 use num_traits::{One, Zero};
 use zerovec::ZeroSlice;
 
+use super::convertible::Convertible;
 /// `ConverterFactory` is responsible for creating converters.
 #[derive(Debug)]
 pub struct ConverterFactory {
@@ -280,11 +281,11 @@ impl ConverterFactory {
     /// NOTE:
     ///    This converter does not support conversions between mixed units,
     ///    such as, from "meter" to "foot-and-inch".
-    pub fn converter(
+    pub fn converter<T: Convertible>(
         &self,
         input_unit: &MeasureUnit,
         output_unit: &MeasureUnit,
-    ) -> Result<UnitsConverter, InvalidConversionError> {
+    ) -> Result<UnitsConverter<T>, InvalidConversionError> {
         let is_reciprocal = self.is_reciprocal(input_unit, output_unit)?;
 
         // is_reciprocal checked that all simple units can be loaded, so we can ignore load errors after this.
@@ -336,16 +337,16 @@ impl ConverterFactory {
 
         Ok(if is_reciprocal {
             UnitsConverter(UnitsConverterInner::Reciprocal {
-                factor: conversion_rate.get_ratio(),
+                factor: T::factor_from_ratio_bigint(conversion_rate.get_ratio()),
             })
         } else if offset.is_zero() {
             UnitsConverter(UnitsConverterInner::Proportional {
-                factor: conversion_rate.get_ratio(),
+                factor: T::factor_from_ratio_bigint(conversion_rate.get_ratio()),
             })
         } else {
             UnitsConverter(UnitsConverterInner::Offset {
-                factor: conversion_rate.get_ratio(),
-                offset: offset.get_ratio(),
+                factor: T::factor_from_ratio_bigint(conversion_rate.get_ratio()),
+                offset: T::addend_from_ratio_bigint(offset.get_ratio()),
             })
         })
     }
@@ -361,7 +362,7 @@ mod tests {
         let factory = ConverterFactory::new();
         let input_unit = MeasureUnit::try_from_str("meter").unwrap();
         let output_unit = MeasureUnit::try_from_str("foot").unwrap();
-        let converter = factory.converter(&input_unit, &output_unit).unwrap();
+        let converter = factory.converter::<f64>(&input_unit, &output_unit).unwrap();
         let result = converter.convert(1000.0);
         assert!(
             ((result - 3280.84) / 3280.84).abs() < 0.00001,
@@ -375,7 +376,7 @@ mod tests {
         let factory = ConverterFactory::new();
         let input_unit = MeasureUnit::try_from_str("liter-per-100-kilometer").unwrap();
         let output_unit = MeasureUnit::try_from_str("mile-per-gallon").unwrap();
-        let converter = factory.converter(&input_unit, &output_unit).unwrap();
+        let converter = factory.converter::<f64>(&input_unit, &output_unit).unwrap();
         let result = converter.convert(1.0);
         assert!(
             ((result - 235.21) / 235.21).abs() < 0.0001,
@@ -389,7 +390,7 @@ mod tests {
         let factory = ConverterFactory::new();
         let input_unit = MeasureUnit::try_from_str("celsius").unwrap();
         let output_unit = MeasureUnit::try_from_str("fahrenheit").unwrap();
-        let converter = factory.converter(&input_unit, &output_unit).unwrap();
+        let converter = factory.converter::<f64>(&input_unit, &output_unit).unwrap();
         let result = converter.convert(0.0);
         assert!(
             ((result - 32.0) / 32.0).abs() < 0.00001,

--- a/components/experimental/src/units/converter_factory.rs
+++ b/components/experimental/src/units/converter_factory.rs
@@ -18,7 +18,6 @@ use num_traits::Pow;
 use num_traits::{One, Zero};
 use zerovec::ZeroSlice;
 
-use super::convertible::Convertible;
 /// `ConverterFactory` is responsible for creating converters.
 #[derive(Debug)]
 pub struct ConverterFactory {
@@ -281,11 +280,11 @@ impl ConverterFactory {
     /// NOTE:
     ///    This converter does not support conversions between mixed units,
     ///    such as, from "meter" to "foot-and-inch".
-    pub fn converter<T: Convertible>(
+    pub fn converter(
         &self,
         input_unit: &MeasureUnit,
         output_unit: &MeasureUnit,
-    ) -> Result<UnitsConverter<T>, InvalidConversionError> {
+    ) -> Result<UnitsConverter, InvalidConversionError> {
         let is_reciprocal = self.is_reciprocal(input_unit, output_unit)?;
 
         // is_reciprocal checked that all simple units can be loaded, so we can ignore load errors after this.
@@ -337,16 +336,16 @@ impl ConverterFactory {
 
         Ok(if is_reciprocal {
             UnitsConverter(UnitsConverterInner::Reciprocal {
-                factor: T::factor_from_ratio_bigint(conversion_rate.get_ratio()),
+                factor: conversion_rate.get_ratio(),
             })
         } else if offset.is_zero() {
             UnitsConverter(UnitsConverterInner::Proportional {
-                factor: T::factor_from_ratio_bigint(conversion_rate.get_ratio()),
+                factor: conversion_rate.get_ratio(),
             })
         } else {
             UnitsConverter(UnitsConverterInner::Offset {
-                factor: T::factor_from_ratio_bigint(conversion_rate.get_ratio()),
-                offset: T::addend_from_ratio_bigint(offset.get_ratio()),
+                factor: conversion_rate.get_ratio(),
+                offset: offset.get_ratio(),
             })
         })
     }
@@ -362,7 +361,7 @@ mod tests {
         let factory = ConverterFactory::new();
         let input_unit = MeasureUnit::try_from_str("meter").unwrap();
         let output_unit = MeasureUnit::try_from_str("foot").unwrap();
-        let converter = factory.converter::<f64>(&input_unit, &output_unit).unwrap();
+        let converter = factory.converter(&input_unit, &output_unit).unwrap();
         let result = converter.convert(1000.0);
         assert!(
             ((result - 3280.84) / 3280.84).abs() < 0.00001,
@@ -376,7 +375,7 @@ mod tests {
         let factory = ConverterFactory::new();
         let input_unit = MeasureUnit::try_from_str("liter-per-100-kilometer").unwrap();
         let output_unit = MeasureUnit::try_from_str("mile-per-gallon").unwrap();
-        let converter = factory.converter::<f64>(&input_unit, &output_unit).unwrap();
+        let converter = factory.converter(&input_unit, &output_unit).unwrap();
         let result = converter.convert(1.0);
         assert!(
             ((result - 235.21) / 235.21).abs() < 0.0001,
@@ -390,7 +389,7 @@ mod tests {
         let factory = ConverterFactory::new();
         let input_unit = MeasureUnit::try_from_str("celsius").unwrap();
         let output_unit = MeasureUnit::try_from_str("fahrenheit").unwrap();
-        let converter = factory.converter::<f64>(&input_unit, &output_unit).unwrap();
+        let converter = factory.converter(&input_unit, &output_unit).unwrap();
         let result = converter.convert(0.0);
         assert!(
             ((result - 32.0) / 32.0).abs() < 0.00001,

--- a/components/experimental/src/units/converter_factory.rs
+++ b/components/experimental/src/units/converter_factory.rs
@@ -337,16 +337,16 @@ impl ConverterFactory {
 
         Ok(if is_reciprocal {
             UnitsConverter(UnitsConverterInner::Reciprocal {
-                factor: T::from_ratio_bigint(conversion_rate.get_ratio()),
+                factor: T::factor_from_ratio_bigint(conversion_rate.get_ratio()),
             })
         } else if offset.is_zero() {
             UnitsConverter(UnitsConverterInner::Proportional {
-                factor: T::from_ratio_bigint(conversion_rate.get_ratio()),
+                factor: T::factor_from_ratio_bigint(conversion_rate.get_ratio()),
             })
         } else {
             UnitsConverter(UnitsConverterInner::Offset {
-                factor: T::from_ratio_bigint(conversion_rate.get_ratio()),
-                offset: T::from_ratio_bigint(offset.get_ratio()),
+                factor: T::factor_from_ratio_bigint(conversion_rate.get_ratio()),
+                offset: T::addend_from_ratio_bigint(offset.get_ratio()),
             })
         })
     }
@@ -363,7 +363,7 @@ mod tests {
         let input_unit = MeasureUnit::try_from_str("meter").unwrap();
         let output_unit = MeasureUnit::try_from_str("foot").unwrap();
         let converter = factory.converter::<f64>(&input_unit, &output_unit).unwrap();
-        let result = converter.convert(&1000.0);
+        let result = converter.convert(1000.0);
         assert!(
             ((result - 3280.84) / 3280.84).abs() < 0.00001,
             "The relative difference between the result and the expected value is too large: {}",
@@ -377,7 +377,7 @@ mod tests {
         let input_unit = MeasureUnit::try_from_str("liter-per-100-kilometer").unwrap();
         let output_unit = MeasureUnit::try_from_str("mile-per-gallon").unwrap();
         let converter = factory.converter::<f64>(&input_unit, &output_unit).unwrap();
-        let result = converter.convert(&1.0);
+        let result = converter.convert(1.0);
         assert!(
             ((result - 235.21) / 235.21).abs() < 0.0001,
             "The relative difference between the result and the expected value is too large: {}",
@@ -391,7 +391,7 @@ mod tests {
         let input_unit = MeasureUnit::try_from_str("celsius").unwrap();
         let output_unit = MeasureUnit::try_from_str("fahrenheit").unwrap();
         let converter = factory.converter::<f64>(&input_unit, &output_unit).unwrap();
-        let result = converter.convert(&0.0);
+        let result = converter.convert(0.0);
         assert!(
             ((result - 32.0) / 32.0).abs() < 0.00001,
             "The relative difference between the result and the expected value is too large: {}",

--- a/components/experimental/src/units/convertible.rs
+++ b/components/experimental/src/units/convertible.rs
@@ -16,7 +16,7 @@ pub trait Convertible: Clone {
     fn mul_refs(&self, other: &Self) -> Self;
 
     /// Converts a [`Ratio<BigInt>`] to the implementing type.
-    fn from_ratio_bigint(ratio: Ratio<BigInt>) -> Option<Self>;
+    fn from_ratio_bigint(ratio: Ratio<BigInt>) -> Self;
 
     /// Returns the reciprocal of the implementing type.
     fn reciprocal(&self) -> Self;
@@ -31,8 +31,8 @@ impl Convertible for Ratio<BigInt> {
         self + other
     }
 
-    fn from_ratio_bigint(ratio: Ratio<BigInt>) -> Option<Self> {
-        Some(ratio)
+    fn from_ratio_bigint(ratio: Ratio<BigInt>) -> Self {
+        ratio
     }
 
     fn reciprocal(&self) -> Self {
@@ -49,8 +49,8 @@ impl Convertible for f64 {
         self + other
     }
 
-    fn from_ratio_bigint(ratio: Ratio<BigInt>) -> Option<Self> {
-        ratio.to_f64()
+    fn from_ratio_bigint(ratio: Ratio<BigInt>) -> Self {
+        ratio.to_f64().unwrap_or(f64::NAN)
     }
 
     fn reciprocal(&self) -> Self {

--- a/components/experimental/src/units/convertible.rs
+++ b/components/experimental/src/units/convertible.rs
@@ -8,55 +8,82 @@ use num_traits::ToPrimitive;
 
 /// A trait for types that can be converted between two units.
 pub trait Convertible: Clone {
+    type Factor: core::fmt::Debug + Clone;
+    type Addend: core::fmt::Debug + Clone;
     type Result: core::fmt::Debug;
 
     /// Computes `self * factor + addend`.
-    fn add_mul_ratio_bigint(&self, factor: &Ratio<BigInt>, addend: &Ratio<BigInt>) -> Self::Result;
+    fn add_mul_ratio_bigint(self, factor: &Self::Factor, addend: &Self::Addend) -> Self::Result;
 
     /// Computes `self * factor`
-    fn mul_ratio_bigint(&self, factor: &Ratio<BigInt>) -> Self::Result;
+    fn mul_ratio_bigint(self, factor: &Self::Factor) -> Self::Result;
 
     /// Computes `1/(self * factor)`
-    fn reciprocal_mul_ratio_bigint(&self, factor: &Ratio<BigInt>) -> Self::Result;
+    fn reciprocal_mul_ratio_bigint(self, factor: &Self::Factor) -> Self::Result;
+
+    /// Converts a [`Ratio<BigInt>`] to a [`Self::Factor`].
+    fn factor_from_ratio_bigint(factor: Ratio<BigInt>) -> Self::Factor;
+
+    /// Converts a [`Ratio<BigInt>`] to a [`Self::Addend`].
+    fn addend_from_ratio_bigint(addend: Ratio<BigInt>) -> Self::Addend;
 }
 
 impl Convertible for &'_ Ratio<BigInt> {
+    type Factor = Ratio<BigInt>;
+    type Addend = Ratio<BigInt>;
     type Result = Ratio<BigInt>;
 
     // Exact
-    fn mul_ratio_bigint(&self, factor: &Ratio<BigInt>) -> Self::Result {
-        *self * factor
+    fn mul_ratio_bigint(self, factor: &Self::Factor) -> Self::Result {
+        self * factor
     }
 
     // Exact
-    fn add_mul_ratio_bigint(&self, factor: &Ratio<BigInt>, addend: &Ratio<BigInt>) -> Self::Result {
-        *self * factor + addend
+    fn add_mul_ratio_bigint(self, factor: &Self::Factor, addend: &Self::Addend) -> Self::Result {
+        self * factor + addend
     }
 
     // Exact
-    fn reciprocal_mul_ratio_bigint(&self, factor: &Ratio<BigInt>) -> Self::Result {
-        (*self * factor).recip()
+    fn reciprocal_mul_ratio_bigint(self, factor: &Self::Factor) -> Self::Result {
+        (self * factor).recip()
+    }
+
+    fn factor_from_ratio_bigint(factor: Ratio<BigInt>) -> Self::Factor {
+        factor
+    }
+
+    fn addend_from_ratio_bigint(addend: Ratio<BigInt>) -> Self::Addend {
+        addend
     }
 }
 
 impl Convertible for f64 {
-    type Result = Self;
+    type Factor = f64;
+    type Addend = f64;
+    type Result = f64;
 
     // TODO: reduce error
-    fn mul_ratio_bigint(&self, factor: &Ratio<BigInt>) -> Self::Result {
-        // Ratio::<BigInt>::to_f64 is infallible
-        self * factor.to_f64().unwrap_or(f64::NAN)
+    fn mul_ratio_bigint(self, factor: &Self::Factor) -> Self::Result {
+        self * factor
     }
 
     // TODO: reduce error
-    fn add_mul_ratio_bigint(&self, factor: &Ratio<BigInt>, addend: &Ratio<BigInt>) -> Self::Result {
-        // Ratio::<BigInt>::to_f64 is infallible
-        self * factor.to_f64().unwrap_or(f64::NAN) + addend.to_f64().unwrap_or(f64::NAN)
+    fn add_mul_ratio_bigint(self, factor: &Self::Factor, addend: &Self::Addend) -> Self::Result {
+        self * factor + addend
     }
 
     // TODO: reduce error
-    fn reciprocal_mul_ratio_bigint(&self, factor: &Ratio<BigInt>) -> Self::Result {
+    fn reciprocal_mul_ratio_bigint(self, factor: &Self::Factor) -> Self::Result {
+        1.0 / (self * factor)
+    }
+
+    fn factor_from_ratio_bigint(factor: Ratio<BigInt>) -> Self::Factor {
         // Ratio::<BigInt>::to_f64 is infallible
-        1.0 / (self * factor.to_f64().unwrap_or(f64::NAN))
+        factor.to_f64().unwrap_or(f64::NAN)
+    }
+
+    fn addend_from_ratio_bigint(addend: Ratio<BigInt>) -> Self::Addend {
+        // Ratio::<BigInt>::to_f64 is infallible
+        addend.to_f64().unwrap_or(f64::NAN)
     }
 }

--- a/components/experimental/src/units/convertible.rs
+++ b/components/experimental/src/units/convertible.rs
@@ -13,13 +13,13 @@ pub trait Convertible: Clone {
     type Result: core::fmt::Debug;
 
     /// Computes `self * factor + addend`.
-    fn add_mul_ratio_bigint(self, factor: &Self::Factor, addend: &Self::Addend) -> Self::Result;
+    fn mul_add(self, factor: &Self::Factor, addend: &Self::Addend) -> Self::Result;
 
     /// Computes `self * factor`
-    fn mul_ratio_bigint(self, factor: &Self::Factor) -> Self::Result;
+    fn mul(self, factor: &Self::Factor) -> Self::Result;
 
     /// Computes `1/(self * factor)`
-    fn reciprocal_mul_ratio_bigint(self, factor: &Self::Factor) -> Self::Result;
+    fn reciprocal_mul(self, factor: &Self::Factor) -> Self::Result;
 
     /// Converts a [`Ratio<BigInt>`] to a [`Self::Factor`].
     fn factor_from_ratio_bigint(factor: Ratio<BigInt>) -> Self::Factor;
@@ -34,17 +34,17 @@ impl Convertible for &'_ Ratio<BigInt> {
     type Result = Ratio<BigInt>;
 
     // Exact
-    fn mul_ratio_bigint(self, factor: &Self::Factor) -> Self::Result {
+    fn mul(self, factor: &Self::Factor) -> Self::Result {
         self * factor
     }
 
     // Exact
-    fn add_mul_ratio_bigint(self, factor: &Self::Factor, addend: &Self::Addend) -> Self::Result {
+    fn mul_add(self, factor: &Self::Factor, addend: &Self::Addend) -> Self::Result {
         self * factor + addend
     }
 
     // Exact
-    fn reciprocal_mul_ratio_bigint(self, factor: &Self::Factor) -> Self::Result {
+    fn reciprocal_mul(self, factor: &Self::Factor) -> Self::Result {
         (self * factor).recip()
     }
 
@@ -63,17 +63,17 @@ impl Convertible for f64 {
     type Result = f64;
 
     // TODO: reduce error
-    fn mul_ratio_bigint(self, factor: &Self::Factor) -> Self::Result {
+    fn mul(self, factor: &Self::Factor) -> Self::Result {
         self * factor
     }
 
     // TODO: reduce error
-    fn add_mul_ratio_bigint(self, factor: &Self::Factor, addend: &Self::Addend) -> Self::Result {
+    fn mul_add(self, factor: &Self::Factor, addend: &Self::Addend) -> Self::Result {
         self * factor + addend
     }
 
     // TODO: reduce error
-    fn reciprocal_mul_ratio_bigint(self, factor: &Self::Factor) -> Self::Result {
+    fn reciprocal_mul(self, factor: &Self::Factor) -> Self::Result {
         1.0 / (self * factor)
     }
 

--- a/components/experimental/src/units/convertible.rs
+++ b/components/experimental/src/units/convertible.rs
@@ -6,54 +6,84 @@ use num_bigint::BigInt;
 use num_rational::Ratio;
 use num_traits::ToPrimitive;
 
-// TODO: add Mul & Add for references to avoid cloning.
 /// A trait for types that can be converted between two units.
 pub trait Convertible: Clone {
-    /// Adds two values by reference, avoiding data cloning.
-    fn add_refs(&self, other: &Self) -> Self;
+    type Factor: core::fmt::Debug + Clone;
+    type Addend: core::fmt::Debug + Clone;
+    type Result: core::fmt::Debug;
 
-    /// Multiplies two values by reference, avoiding data cloning.
-    fn mul_refs(&self, other: &Self) -> Self;
+    /// Computes `self * factor + addend`.
+    fn add_mul_ratio_bigint(self, factor: &Self::Factor, addend: &Self::Addend) -> Self::Result;
 
-    /// Converts a [`Ratio<BigInt>`] to the implementing type.
-    fn from_ratio_bigint(ratio: Ratio<BigInt>) -> Self;
+    /// Computes `self * factor`
+    fn mul_ratio_bigint(self, factor: &Self::Factor) -> Self::Result;
 
-    /// Returns the reciprocal of the implementing type.
-    fn reciprocal(&self) -> Self;
+    /// Computes `1/(self * factor)`
+    fn reciprocal_mul_ratio_bigint(self, factor: &Self::Factor) -> Self::Result;
+
+    /// Converts a [`Ratio<BigInt>`] to a [`Self::Factor`].
+    fn factor_from_ratio_bigint(factor: Ratio<BigInt>) -> Self::Factor;
+
+    /// Converts a [`Ratio<BigInt>`] to a [`Self::Addend`].
+    fn addend_from_ratio_bigint(addend: Ratio<BigInt>) -> Self::Addend;
 }
 
-impl Convertible for Ratio<BigInt> {
-    fn mul_refs(&self, other: &Self) -> Self {
-        self * other
+impl Convertible for &'_ Ratio<BigInt> {
+    type Factor = Ratio<BigInt>;
+    type Addend = Ratio<BigInt>;
+    type Result = Ratio<BigInt>;
+
+    // Exact
+    fn mul_ratio_bigint(self, factor: &Self::Factor) -> Self::Result {
+        self * factor
     }
 
-    fn add_refs(&self, other: &Self) -> Self {
-        self + other
+    // Exact
+    fn add_mul_ratio_bigint(self, factor: &Self::Factor, addend: &Self::Addend) -> Self::Result {
+        self * factor + addend
     }
 
-    fn from_ratio_bigint(ratio: Ratio<BigInt>) -> Self {
-        ratio
+    // Exact
+    fn reciprocal_mul_ratio_bigint(self, factor: &Self::Factor) -> Self::Result {
+        (self * factor).recip()
     }
 
-    fn reciprocal(&self) -> Self {
-        self.recip()
+    fn factor_from_ratio_bigint(factor: Ratio<BigInt>) -> Self::Factor {
+        factor
+    }
+
+    fn addend_from_ratio_bigint(addend: Ratio<BigInt>) -> Self::Addend {
+        addend
     }
 }
 
 impl Convertible for f64 {
-    fn mul_refs(&self, other: &Self) -> Self {
-        self * other
+    type Factor = f64;
+    type Addend = f64;
+    type Result = f64;
+
+    // TODO: reduce error
+    fn mul_ratio_bigint(self, factor: &Self::Factor) -> Self::Result {
+        self * factor
     }
 
-    fn add_refs(&self, other: &Self) -> Self {
-        self + other
+    // TODO: reduce error
+    fn add_mul_ratio_bigint(self, factor: &Self::Factor, addend: &Self::Addend) -> Self::Result {
+        self * factor + addend
     }
 
-    fn from_ratio_bigint(ratio: Ratio<BigInt>) -> Self {
-        ratio.to_f64().unwrap_or(f64::NAN)
+    // TODO: reduce error
+    fn reciprocal_mul_ratio_bigint(self, factor: &Self::Factor) -> Self::Result {
+        1.0 / (self * factor)
     }
 
-    fn reciprocal(&self) -> Self {
-        self.recip()
+    fn factor_from_ratio_bigint(factor: Ratio<BigInt>) -> Self::Factor {
+        // Ratio::<BigInt>::to_f64 is infallible
+        factor.to_f64().unwrap_or(f64::NAN)
+    }
+
+    fn addend_from_ratio_bigint(addend: Ratio<BigInt>) -> Self::Addend {
+        // Ratio::<BigInt>::to_f64 is infallible
+        addend.to_f64().unwrap_or(f64::NAN)
     }
 }

--- a/components/experimental/src/units/convertible.rs
+++ b/components/experimental/src/units/convertible.rs
@@ -8,82 +8,55 @@ use num_traits::ToPrimitive;
 
 /// A trait for types that can be converted between two units.
 pub trait Convertible: Clone {
-    type Factor: core::fmt::Debug + Clone;
-    type Addend: core::fmt::Debug + Clone;
     type Result: core::fmt::Debug;
 
     /// Computes `self * factor + addend`.
-    fn add_mul_ratio_bigint(self, factor: &Self::Factor, addend: &Self::Addend) -> Self::Result;
+    fn add_mul_ratio_bigint(&self, factor: &Ratio<BigInt>, addend: &Ratio<BigInt>) -> Self::Result;
 
     /// Computes `self * factor`
-    fn mul_ratio_bigint(self, factor: &Self::Factor) -> Self::Result;
+    fn mul_ratio_bigint(&self, factor: &Ratio<BigInt>) -> Self::Result;
 
     /// Computes `1/(self * factor)`
-    fn reciprocal_mul_ratio_bigint(self, factor: &Self::Factor) -> Self::Result;
-
-    /// Converts a [`Ratio<BigInt>`] to a [`Self::Factor`].
-    fn factor_from_ratio_bigint(factor: Ratio<BigInt>) -> Self::Factor;
-
-    /// Converts a [`Ratio<BigInt>`] to a [`Self::Addend`].
-    fn addend_from_ratio_bigint(addend: Ratio<BigInt>) -> Self::Addend;
+    fn reciprocal_mul_ratio_bigint(&self, factor: &Ratio<BigInt>) -> Self::Result;
 }
 
 impl Convertible for &'_ Ratio<BigInt> {
-    type Factor = Ratio<BigInt>;
-    type Addend = Ratio<BigInt>;
     type Result = Ratio<BigInt>;
 
     // Exact
-    fn mul_ratio_bigint(self, factor: &Self::Factor) -> Self::Result {
-        self * factor
+    fn mul_ratio_bigint(&self, factor: &Ratio<BigInt>) -> Self::Result {
+        *self * factor
     }
 
     // Exact
-    fn add_mul_ratio_bigint(self, factor: &Self::Factor, addend: &Self::Addend) -> Self::Result {
-        self * factor + addend
+    fn add_mul_ratio_bigint(&self, factor: &Ratio<BigInt>, addend: &Ratio<BigInt>) -> Self::Result {
+        *self * factor + addend
     }
 
     // Exact
-    fn reciprocal_mul_ratio_bigint(self, factor: &Self::Factor) -> Self::Result {
-        (self * factor).recip()
-    }
-
-    fn factor_from_ratio_bigint(factor: Ratio<BigInt>) -> Self::Factor {
-        factor
-    }
-
-    fn addend_from_ratio_bigint(addend: Ratio<BigInt>) -> Self::Addend {
-        addend
+    fn reciprocal_mul_ratio_bigint(&self, factor: &Ratio<BigInt>) -> Self::Result {
+        (*self * factor).recip()
     }
 }
 
 impl Convertible for f64 {
-    type Factor = f64;
-    type Addend = f64;
-    type Result = f64;
+    type Result = Self;
 
     // TODO: reduce error
-    fn mul_ratio_bigint(self, factor: &Self::Factor) -> Self::Result {
-        self * factor
-    }
-
-    // TODO: reduce error
-    fn add_mul_ratio_bigint(self, factor: &Self::Factor, addend: &Self::Addend) -> Self::Result {
-        self * factor + addend
-    }
-
-    // TODO: reduce error
-    fn reciprocal_mul_ratio_bigint(self, factor: &Self::Factor) -> Self::Result {
-        1.0 / (self * factor)
-    }
-
-    fn factor_from_ratio_bigint(factor: Ratio<BigInt>) -> Self::Factor {
+    fn mul_ratio_bigint(&self, factor: &Ratio<BigInt>) -> Self::Result {
         // Ratio::<BigInt>::to_f64 is infallible
-        factor.to_f64().unwrap_or(f64::NAN)
+        self * factor.to_f64().unwrap_or(f64::NAN)
     }
 
-    fn addend_from_ratio_bigint(addend: Ratio<BigInt>) -> Self::Addend {
+    // TODO: reduce error
+    fn add_mul_ratio_bigint(&self, factor: &Ratio<BigInt>, addend: &Ratio<BigInt>) -> Self::Result {
         // Ratio::<BigInt>::to_f64 is infallible
-        addend.to_f64().unwrap_or(f64::NAN)
+        self * factor.to_f64().unwrap_or(f64::NAN) + addend.to_f64().unwrap_or(f64::NAN)
+    }
+
+    // TODO: reduce error
+    fn reciprocal_mul_ratio_bigint(&self, factor: &Ratio<BigInt>) -> Self::Result {
+        // Ratio::<BigInt>::to_f64 is infallible
+        1.0 / (self * factor.to_f64().unwrap_or(f64::NAN))
     }
 }

--- a/components/experimental/tests/units/units_test.rs
+++ b/components/experimental/tests/units/units_test.rs
@@ -46,16 +46,13 @@ fn test_cldr_unit_tests() {
         let output_unit =
             MeasureUnit::try_from_str(&test.output_unit).expect("Failed to parse output unit");
 
-        let converter: UnitsConverter<&Ratio<BigInt>> = converter_factory
+        let converter: UnitsConverter = converter_factory
             .converter(&input_unit, &output_unit)
             .expect("Failed to create converter");
         let result =
             converter.convert(&Ratio::<BigInt>::from_str("1000").expect("Failed to parse ratio"));
 
-        let converter_f64: UnitsConverter<f64> = converter_factory
-            .converter(&input_unit, &output_unit)
-            .expect("Failed to create converter for f64");
-        let result_f64 = converter_f64.convert(1000.0);
+        let result_f64 = converter.convert(1000.0);
 
         let diff_ratio = ((result.clone() - test.result.clone().get_ratio())
             / test.result.clone().get_ratio())
@@ -218,8 +215,8 @@ fn test_units_non_convertible() {
         let input_unit = MeasureUnit::try_from_str(input).expect("Failed to parse input unit");
         let output_unit = MeasureUnit::try_from_str(output).expect("Failed to parse output unit");
 
-        let result: Result<UnitsConverter<f64>, InvalidConversionError> =
-            converter_factory.converter::<f64>(&input_unit, &output_unit);
+        let result: Result<UnitsConverter, InvalidConversionError> =
+            converter_factory.converter(&input_unit, &output_unit);
         assert!(
             result.is_err(),
             "Conversion should not be possible between {input:?} and {output:?}"

--- a/components/experimental/tests/units/units_test.rs
+++ b/components/experimental/tests/units/units_test.rs
@@ -46,7 +46,7 @@ fn test_cldr_unit_tests() {
         let output_unit =
             MeasureUnit::try_from_str(&test.output_unit).expect("Failed to parse output unit");
 
-        let converter: UnitsConverter<Ratio<BigInt>> = converter_factory
+        let converter: UnitsConverter<&Ratio<BigInt>> = converter_factory
             .converter(&input_unit, &output_unit)
             .expect("Failed to create converter");
         let result =
@@ -55,7 +55,7 @@ fn test_cldr_unit_tests() {
         let converter_f64: UnitsConverter<f64> = converter_factory
             .converter(&input_unit, &output_unit)
             .expect("Failed to create converter for f64");
-        let result_f64 = converter_f64.convert(&1000.0);
+        let result_f64 = converter_f64.convert(1000.0);
 
         let diff_ratio = ((result.clone() - test.result.clone().get_ratio())
             / test.result.clone().get_ratio())

--- a/components/experimental/tests/units/units_test.rs
+++ b/components/experimental/tests/units/units_test.rs
@@ -4,6 +4,7 @@
 
 use core::str::FromStr;
 
+use icu_experimental::units::InvalidConversionError;
 use icu_experimental::units::converter_factory::ConverterFactory;
 use icu_experimental::units::ratio::IcuRatio;
 use icu_experimental::{measure::measureunit::MeasureUnit, units::converter::UnitsConverter};
@@ -217,10 +218,10 @@ fn test_units_non_convertible() {
         let input_unit = MeasureUnit::try_from_str(input).expect("Failed to parse input unit");
         let output_unit = MeasureUnit::try_from_str(output).expect("Failed to parse output unit");
 
-        let result: Option<UnitsConverter<f64>> =
-            converter_factory.converter(&input_unit, &output_unit);
+        let result: Result<UnitsConverter<f64>, InvalidConversionError> =
+            converter_factory.converter::<f64>(&input_unit, &output_unit);
         assert!(
-            result.is_none(),
+            result.is_err(),
             "Conversion should not be possible between {input:?} and {output:?}"
         );
     }

--- a/components/experimental/tests/units/units_test.rs
+++ b/components/experimental/tests/units/units_test.rs
@@ -46,13 +46,16 @@ fn test_cldr_unit_tests() {
         let output_unit =
             MeasureUnit::try_from_str(&test.output_unit).expect("Failed to parse output unit");
 
-        let converter: UnitsConverter = converter_factory
+        let converter: UnitsConverter<&Ratio<BigInt>> = converter_factory
             .converter(&input_unit, &output_unit)
             .expect("Failed to create converter");
         let result =
             converter.convert(&Ratio::<BigInt>::from_str("1000").expect("Failed to parse ratio"));
 
-        let result_f64 = converter.convert(1000.0);
+        let converter_f64: UnitsConverter<f64> = converter_factory
+            .converter(&input_unit, &output_unit)
+            .expect("Failed to create converter for f64");
+        let result_f64 = converter_f64.convert(1000.0);
 
         let diff_ratio = ((result.clone() - test.result.clone().get_ratio())
             / test.result.clone().get_ratio())
@@ -215,8 +218,8 @@ fn test_units_non_convertible() {
         let input_unit = MeasureUnit::try_from_str(input).expect("Failed to parse input unit");
         let output_unit = MeasureUnit::try_from_str(output).expect("Failed to parse output unit");
 
-        let result: Result<UnitsConverter, InvalidConversionError> =
-            converter_factory.converter(&input_unit, &output_unit);
+        let result: Result<UnitsConverter<f64>, InvalidConversionError> =
+            converter_factory.converter::<f64>(&input_unit, &output_unit);
         assert!(
             result.is_err(),
             "Conversion should not be possible between {input:?} and {output:?}"


### PR DESCRIPTION
~Currently we have `UnitsConverter<N: Convertible>`. This is because we convert the conversion factors to the `N` type during construction, which both loses precision and means we cannot use the same converter for multiple `N`.~

~This PR moves the conversion into the `convert` call, and into the `Convertible` trait, which now defines the three operations we need for proportional, reciprocal, and offset converters. For each type, such as `f64`, those operations can be holistically improved.~

It also changes the `UnitsConverter` constructor to return `InvalidConversionError` instead of just an `Option`, and changes the bounds on `convert` so that `f64` can be passed by value.

## Changelog

`icu_experimental/units`
* `Convertibles`s are now passed by value, and for `Ratio<BigInt>` the `Convertible` impl is now on the reference
* The `Convertibles` trait was completely overhauled to allow for more accurate calculations