### PR TITLE
Fix pre-existing CI failures on release/2.1 branch (experimental docs & tidy)

### DIFF
--- a/components/experimental/src/duration/validated_options.rs
+++ b/components/experimental/src/duration/validated_options.rs
@@ -4,7 +4,7 @@
 
 use crate::duration::options::*;
 
-/// Validated options for [DurationFormatter](DurationFormatter).
+/// Validated options for [`DurationFormatter`](crate::duration::DurationFormatter).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ValidatedDurationFormatterOptions {
     /// The style that will be applied to units
@@ -86,6 +86,7 @@ pub enum DurationFormatterOptionsError {
 impl core::error::Error for DurationFormatterOptionsError {}
 
 impl ValidatedDurationFormatterOptions {
+    /// Validates the given [`DurationFormatterOptions`] and returns a [`ValidatedDurationFormatterOptions`].
     pub fn validate(
         value: DurationFormatterOptions,
     ) -> Result<Self, DurationFormatterOptionsError> {

--- a/tools/make/tidy.toml
+++ b/tools/make/tidy.toml
@@ -133,9 +133,22 @@ end
 echo "License header check complete"
 '''
 
+[tasks.install-cargo-rdme]
+description = "Install cargo-rdme"
+private = true
+script_runner = "@duckscript"
+script = '''
+cargo_list = exec cargo --list
+if not contains ${cargo_list.stdout} "rdme"
+    echo "Installing cargo-rdme..."
+    exec cargo install cargo-rdme --locked
+end
+'''
+
 [tasks.generate-readmes]
 description = "Automatically generate README.md for each component."
-install_crate = { crate_name = "cargo-rdme", test_arg = ["--help"] }
+install_crate = false
+dependencies = ["install-cargo-rdme"]
 category = "ICU4X Development"
 script_runner = "@duckscript"
 script = '''


### PR DESCRIPTION
This PR fixes pre-existing CI failures on the `release/2.1` branch by addressing two independent issues:

### 1. missing docs and unresolved link in `icu_experimental`
*   **The Problem**: A recent commit on the `release/2.1` branch ([#7616](https://github.com/unicode-org/icu4x/pull/7616)) re-exported `ValidatedDurationFormatterOptions`, making it part of the public API. This suddenly subjected it to strict documentation checks, exposing two issues:
    1.  A missing doc comment on the `pub fn validate` function (triggering `missing_docs` lint).
    2.  A broken intra-doc link `[DurationFormatter](DurationFormatter)` that could not be resolved in that scope.
*   **The Impact**: Because CI runs with `-D warnings` (deny warnings), these two issues caused the **`clippy`**, **`doc`**, and **`msrv`** jobs to fail.
*   **The Fix**: Added the missing doc comment to `ValidatedDurationFormatterOptions::validate` and corrected the intra-doc link to use the proper path (`crate::duration::DurationFormatter`), which unblocks all three jobs.

### 2. cargo-rdme installation failure in `tidy`
*   **The Problem**: The `tidy` job in CI automatically installs `cargo-rdme`. Recently, a new version of `cargo-rdme` (or its dependencies) was released on crates.io that requires Rust 1.91. However, the `release/2.1` branch is pinned to Rust 1.90. This caused the automatic installation to fail in CI.
*   **The Impact**: This caused the **`tidy`** job to fail.
*   **The Fix**: Updated the installation command in `tidy.toml` to use `cargo install cargo-rdme --locked`. This forces Cargo to respect the locked, compatible dependency versions that still support Rust 1.90, unblocking the `tidy` job.

***

Both of these fixes are required to make the CI green for any PR targeted to `release/2.1`. They are combined here because checking them in separately would require each one to not pass CI.

🤖 This pull request was created by an AI agent working with @sffc.

## Changelog

N/A