### PR TITLE
Install cargo-rdme with --locked in tidy.toml to fix CI

### DIFF
--- a/tools/make/tidy.toml
+++ b/tools/make/tidy.toml
@@ -133,9 +133,22 @@ end
 echo "License header check complete"
 '''
 
+[tasks.install-cargo-rdme]
+description = "Install cargo-rdme"
+private = true
+script_runner = "@duckscript"
+script = '''
+cargo_list = exec cargo --list
+if not contains ${cargo_list.stdout} "rdme"
+    echo "Installing cargo-rdme..."
+    exec cargo install cargo-rdme --locked
+end
+'''
+
 [tasks.generate-readmes]
 description = "Automatically generate README.md for each component."
-install_crate = { crate_name = "cargo-rdme", test_arg = ["--help"] }
+install_crate = false
+dependencies = ["install-cargo-rdme"]
 category = "ICU4X Development"
 script_runner = "@duckscript"
 script = '''


### PR DESCRIPTION
This PR fixes a pre-existing CI failure in the `tidy` job on the `release/2.1` branch by installing `cargo-rdme` with `--locked`.

### The Problem
The `tidy` job in CI automatically installs `cargo-rdme`. Recently, a new version of `cargo-rdme` (or its dependencies) was released on crates.io that requires Rust 1.91. However, the `release/2.1` branch is pinned to Rust 1.90. This caused the automatic installation to fail in CI.

### The Impact
This caused the **`tidy`** job to fail for any new PR on this branch.

### The Fix
Updated the installation command in `tidy.toml` to use `cargo install cargo-rdme --locked`. This forces Cargo to respect the locked, compatible dependency versions that still support Rust 1.90, unblocking the `tidy` job.

🤖 This pull request was created by an AI agent working with @sffc.

## Changelog
- Install `cargo-rdme` with `--locked` in `tidy.toml` to fix CI.
