### PR TITLE
Add regression test for Collator AlternateHandling::Shifted with MaxVariable::Currency

### DIFF
--- a/components/collator/tests/tests.rs
+++ b/components/collator/tests/tests.rs
@@ -2175,3 +2175,20 @@ fn emoji() {
 // TODO: Test that nn and nb are aliases for no
 
 // TODO: Consider testing ff-Adlm for supplementary-plane tailoring, including contractions
+
+#[test]
+// Regression test for a bug where setting `AlternateHandling::Shifted` and
+// `MaxVariable::Currency` caused a panic during collation.
+// The bug was due to an off-by-one error when validating special primaries,
+// which truncated the `last_primaries` vector and removed the `Currency` element.
+// This test verifies that the collator can be successfully constructed with these
+// options and that it correctly compares an empty string and a space as equal
+// (since space is shifted and ignored at the default Tertiary strength).
+fn test_shifted_max_variable_currency() {
+    let prefs = CollatorPreferences::default();
+    let mut options = CollatorOptions::default();
+    options.alternate_handling = Some(AlternateHandling::Shifted);
+    options.max_variable = Some(MaxVariable::Currency);
+    let collator = Collator::try_new(prefs, options).unwrap();
+    assert_eq!(collator.compare("", " "), Ordering::Equal);
+}


### PR DESCRIPTION
See #8075, #8081

Adds a regression test to verify that the collator can be successfully constructed with `AlternateHandling::Shifted` and `MaxVariable::Currency` options, and that it behaves correctly.

This bug was present in 2.1 and 2.2 but is naturally avoided in 2.3 (main) due to refactoring. This test ensures we do not regress.

🤖 This pull request was created by an AI agent working with @sffc.

## Changelog

N/A