### PR TITLE
release/2.2: Fix off-by-one errors in CollationSpecialPrimariesValidated

### DIFF
--- a/components/collator/src/comparison.rs
+++ b/components/collator/src/comparison.rs
@@ -39,6 +39,7 @@ use crate::provider::CollationMetadataV1;
 use crate::provider::CollationReordering;
 use crate::provider::CollationReorderingV1;
 use crate::provider::CollationRootV1;
+use crate::provider::CollationSpecialPrimaries;
 use crate::provider::CollationSpecialPrimariesV1;
 use crate::provider::CollationSpecialPrimariesValidated;
 use crate::provider::CollationTailoringV1;
@@ -661,12 +662,12 @@ impl Collator {
         }
         let special_primaries = special_primaries.map_project(|csp, _| {
             let compressible_bytes = (csp.last_primaries.len()
-                == MaxVariable::Currency as usize + 16)
+                == CollationSpecialPrimaries::TOTAL_LEN_WITH_COMPRESSIBLE_BYTES)
                 .then(|| {
                     csp.last_primaries
                         .as_maybe_borrowed()?
                         .as_ule_slice()
-                        .get((MaxVariable::Currency as usize)..)?
+                        .get(MaxVariable::VARIANT_COUNT..)?
                         .try_into()
                         .ok()
                 })
@@ -676,7 +677,7 @@ impl Collator {
                 );
 
             CollationSpecialPrimariesValidated {
-                last_primaries: csp.last_primaries.truncated(MaxVariable::Currency as usize),
+                last_primaries: csp.last_primaries.truncated(MaxVariable::VARIANT_COUNT),
                 numeric_primary: csp.numeric_primary,
                 compressible_bytes,
             }
@@ -784,7 +785,7 @@ impl CollatorBorrowed<'static> {
                         .last_primaries
                         .as_slice()
                         .as_ule_slice()
-                        .split_at(MaxVariable::Currency as usize)
+                        .split_at(MaxVariable::VARIANT_COUNT)
                         .0,
                 )
                 .as_zerovec(),
@@ -796,8 +797,8 @@ impl CollatorBorrowed<'static> {
                             .last_primaries
                             .as_slice()
                             .as_ule_slice();
-                    if C.len() == MaxVariable::Currency as usize + 16 {
-                        let i = MaxVariable::Currency as usize;
+                    if C.len() == CollationSpecialPrimaries::TOTAL_LEN_WITH_COMPRESSIBLE_BYTES {
+                        let i = MaxVariable::VARIANT_COUNT;
                         #[allow(clippy::indexing_slicing)] // protected, const
                         &[
                             C[i],

--- a/components/collator/src/options.rs
+++ b/components/collator/src/options.rs
@@ -250,6 +250,15 @@ pub enum MaxVariable {
     Currency = 3,
 }
 
+impl MaxVariable {
+    /// The number of variants in `MaxVariable` (Space, Punctuation, Symbol, Currency),
+    /// which correspond to the "real" special primaries.
+    ///
+    /// `variant_count` isn't stable yet:
+    /// <https://github.com/rust-lang/rust/issues/73662>
+    pub(crate) const VARIANT_COUNT: usize = MaxVariable::Currency as usize + 1;
+}
+
 /// Whether to distinguish case in sorting, even for sorting levels higher
 /// than tertiary, without having to use tertiary level just to enable case level differences.
 #[derive(Eq, PartialEq, Debug, Copy, Clone)]

--- a/components/collator/src/provider.rs
+++ b/components/collator/src/provider.rs
@@ -570,6 +570,16 @@ pub struct CollationSpecialPrimaries<'data> {
     pub numeric_primary: u8,
 }
 
+impl CollationSpecialPrimaries<'_> {
+    /// The length of the compressible bytes array (256 bits packed in `u16`s).
+    pub(crate) const COMPRESSIBLE_BYTES_LEN: usize = 256 / (u16::BITS as usize);
+
+    /// The expected total length of `last_primaries` when it contains both the
+    /// real primaries and the compressible bytes.
+    pub(crate) const TOTAL_LEN_WITH_COMPRESSIBLE_BYTES: usize =
+        MaxVariable::VARIANT_COUNT + Self::COMPRESSIBLE_BYTES_LEN;
+}
+
 #[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
 pub(crate) struct CollationSpecialPrimariesValidated<'data> {
     /// The primaries corresponding to `MaxVariable`
@@ -581,11 +591,13 @@ pub(crate) struct CollationSpecialPrimariesValidated<'data> {
     pub numeric_primary: u8,
     /// 256 bits (packed in 16 u16s) to classify every possible
     /// byte into compressible or non-compressible.
-    pub compressible_bytes: &'data [<u16 as AsULE>::ULE; 16],
+    pub compressible_bytes:
+        &'data [<u16 as AsULE>::ULE; CollationSpecialPrimaries::COMPRESSIBLE_BYTES_LEN],
 }
 
 impl CollationSpecialPrimariesValidated<'static> {
-    pub(crate) const HARDCODED_COMPRESSIBLE_BYTES_FALLBACK: &'static [<u16 as AsULE>::ULE; 16] = &[
+    pub(crate) const HARDCODED_COMPRESSIBLE_BYTES_FALLBACK:
+        &'static [<u16 as AsULE>::ULE; CollationSpecialPrimaries::COMPRESSIBLE_BYTES_LEN] = &[
         <u16 as AsULE>::ULE::from_unsigned(0b0000_0000_0000_0000),
         <u16 as AsULE>::ULE::from_unsigned(0b0000_0000_0000_0000),
         <u16 as AsULE>::ULE::from_unsigned(0b0000_0000_0000_0000),

--- a/components/collator/tests/tests.rs
+++ b/components/collator/tests/tests.rs
@@ -2160,3 +2160,20 @@ fn test_numeric_zeros() {
 // TODO: Test that nn and nb are aliases for no
 
 // TODO: Consider testing ff-Adlm for supplementary-plane tailoring, including contractions
+
+#[test]
+// Regression test for a bug where setting `AlternateHandling::Shifted` and
+// `MaxVariable::Currency` caused a panic during collation.
+// The bug was due to an off-by-one error when validating special primaries,
+// which truncated the `last_primaries` vector and removed the `Currency` element.
+// This test verifies that the collator can be successfully constructed with these
+// options and that it correctly compares an empty string and a space as equal
+// (since space is shifted and ignored at the default Tertiary strength).
+fn test_shifted_max_variable_currency() {
+    let prefs = CollatorPreferences::default();
+    let mut options = CollatorOptions::default();
+    options.alternate_handling = Some(AlternateHandling::Shifted);
+    options.max_variable = Some(MaxVariable::Currency);
+    let collator = Collator::try_new(prefs, options).unwrap();
+    assert_eq!(collator.compare("", " "), Ordering::Equal);
+}


### PR DESCRIPTION
Port of #8075 to the `release/2.2` branch.

Fixes a critical off-by-one bug in `icu_collator` 2.2.x that causes a panic when using `AlternateHandling::Shifted` with `MaxVariable::Currency`.

When converting `CollationSpecialPrimaries` to `CollationSpecialPrimariesValidated`, the `last_primaries` vector was incorrectly truncated to `MaxVariable::Currency as usize` (3) instead of `MaxVariable::Currency as usize + 1` (4). This resulted in `last_primaries` lacking the 4th element (index 3, for `Currency`), causing a panic (`unwrap` on `None`) during comparison when `last_primary_for_group` was called.
Additionally, `compressible_bytes` extraction was misaligned by one index and failed the length check, causing it to always fall back to hardcoded defaults.

This PR also includes the regression test `test_shifted_max_variable_currency`.

🤖 This pull request was created by an AI agent working with @sffc.

## Changelog
- Fix panic when using `AlternateHandling::Shifted` with `MaxVariable::Currency` (off-by-one in special primaries validation).
