### PR TITLE
Replace magic numbers with constants in CollationSpecialPrimaries deserialization

### DIFF
--- a/components/collator/src/provider.rs
+++ b/components/collator/src/provider.rs
@@ -611,6 +611,15 @@ pub struct CollationSpecialPrimaries<'data> {
 }
 
 #[cfg(feature = "serde")]
+impl CollationSpecialPrimaries<'_> {
+    /// The number of real special primaries (Space, Punctuation, Symbol, Currency).
+    pub(crate) const NUM_PRIMARIES: usize = MaxVariable::Currency as usize + 1; // 4
+
+    /// The length of the compressible bytes array (256 bits packed in 16 u16s).
+    pub(crate) const COMPRESSIBLE_BYTES_LEN: usize = 16;
+}
+
+#[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for CollationSpecialPrimaries<'de> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -632,7 +641,7 @@ impl<'de> serde::Deserialize<'de> for CollationSpecialPrimaries<'de> {
             .as_ule_slice()
             // `variant_count` isn't stable yet:
             // https://github.com/rust-lang/rust/issues/73662
-            .split_at_checked(MaxVariable::Currency as usize + 1)
+            .split_at_checked(CollationSpecialPrimaries::NUM_PRIMARIES)
         else {
             return Err(serde::de::Error::custom("invalid"));
         };
@@ -640,7 +649,7 @@ impl<'de> serde::Deserialize<'de> for CollationSpecialPrimaries<'de> {
         let last_primaries = ZeroSlice::from_ule_slice(l).as_zerovec();
         let mut compressible_bytes = ZeroSlice::from_ule_slice(c).as_zerovec();
 
-        if c.len() != 16 {
+        if c.len() != CollationSpecialPrimaries::COMPRESSIBLE_BYTES_LEN {
             compressible_bytes = zerovec::zerovec!(
                 u16; <u16 as AsULE>::ULE::from_unsigned; [
                 0b0000_0000_0000_0000,


### PR DESCRIPTION
See #8075

Defines `NUM_PRIMARIES` and `COMPRESSIBLE_BYTES_LEN` constants on `CollationSpecialPrimaries` and uses them in the custom `Deserialize` implementation to avoid magic numbers, making the deserialization logic self-documenting.

This addresses reviewer feedback regarding magic numbers in the collation data handling.

🤖 This pull request was created by an AI agent working with @sffc.

## Changelog

N/A (Replace magic numbers with constants in `CollationSpecialPrimaries` deserialization.)