### PR TITLE
More accurate `f64` unit conversions

### DIFF
--- a/components/experimental/src/units/convertible.rs
+++ b/components/experimental/src/units/convertible.rs
@@ -57,33 +57,136 @@ impl Convertible for &'_ Ratio<BigInt> {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+#[doc(hidden)]
+pub struct RatioF64 {
+    numerator: f64,
+    denominator: f64,
+}
+
 impl Convertible for f64 {
-    type Factor = f64;
+    type Factor = RatioF64;
     type Addend = f64;
     type Result = f64;
 
-    // TODO: reduce error
+    // This code performs up to 4 rounding operations:
+    // * factor numerator and denominator from BigInt to f64 (factor_from_ratio_bigint)
+    //   * this will be exact in most cases, but may be inexact for conversions involving
+    //     large SI prefixes
+    // * a single rounding for the multiplication and division
+    //   * if the intermediate error is not representable, it falls back to double-rounding
+    //     the multiplication and division
     fn mul(self, factor: &Self::Factor) -> Self::Result {
-        self * factor
+        let double_rounded = self * factor.numerator / factor.denominator;
+        // The multiplication error is the difference of the rounded multiplication
+        // and the multiplication evaluated in full precision (FMA)
+        let multiplication_error = self.mul_add(factor.numerator, -(self * factor.numerator));
+        // The total error is the difference between the rounded multiplication+division
+        // and the multiplication evaluated in full precision, plus the multiplication
+        // error divided by the denominator, all evaluated in times-den-space.
+        let total_error = (double_rounded.mul_add(-factor.denominator, self * factor.numerator)
+            + multiplication_error)
+            / factor.denominator;
+
+        if total_error.is_finite() {
+            double_rounded + total_error
+        } else {
+            self * (factor.numerator / factor.denominator)
+        }
     }
 
-    // TODO: reduce error
+    // This code performs up to 5 rounding operations:
+    // * factor numerator and denominator from BigInt to f64 (factor_from_ratio_bigint)
+    //   * this will be exact in most cases, but may be inexact for conversions involving
+    //     large SI prefixes
+    // * addend from Ratio<BigInt> to f64 (addend_from_ratio_bigint)
+    //   * this is exact for the known cases (Celsius/Fahrenheit/Kelvin)
+    // * a single rounding for the multiplication and division
+    //   * if the intermediate error is not representable, it falls back to double-rounding
+    //     the multiplication and division
+    // * a single rounding for the addition
     fn mul_add(self, factor: &Self::Factor, addend: &Self::Addend) -> Self::Result {
-        self * factor + addend
+        Convertible::mul(self, factor) + addend
     }
 
-    // TODO: reduce error
+    // This code performs up to 4 rounding operations:
+    // * factor numerator and denominator from BigInt to f64 (factor_from_ratio_bigint)
+    //   * this will be exact in most cases, but may be inexact for conversions involving
+    //     large SI prefixes
+    // * two roundings for the two divisions
     fn reciprocal_mul(self, factor: &Self::Factor) -> Self::Result {
-        1.0 / (self * factor)
+        factor.denominator / self / factor.numerator
     }
 
     fn factor_from_ratio_bigint(factor: Ratio<BigInt>) -> Self::Factor {
-        // Ratio::<BigInt>::to_f64 is infallible
-        factor.to_f64().unwrap_or(f64::NAN)
+        RatioF64 {
+            // BigInt::to_f64 is infallible
+            numerator: factor.numer().to_f64().unwrap_or(f64::NAN),
+            // BigInt::to_f64 is infallible
+            denominator: factor.denom().to_f64().unwrap_or(f64::NAN),
+        }
     }
 
     fn addend_from_ratio_bigint(addend: Ratio<BigInt>) -> Self::Addend {
         // Ratio::<BigInt>::to_f64 is infallible
         addend.to_f64().unwrap_or(f64::NAN)
     }
+}
+
+#[test]
+#[rustfmt::skip]
+fn test_convertible_mul_precision() {
+    let val = 5.0;
+    let factor = RatioF64 {
+        numerator: 1.0,
+        denominator: 1_000_000.0,
+    };
+    assert_eq!(Convertible::mul(val, &factor), 0.000005);
+    assert_eq!(val * (factor.numerator / factor.denominator), 0.0000049999999999999996);
+
+    let val = 0.1;
+    let factor = RatioF64 {
+        numerator: 1.0,
+        denominator: 10.0,
+    };
+    assert_eq!(Convertible::mul(val, &factor), 0.01);
+    assert_eq!(val * (factor.numerator / factor.denominator), 0.010000000000000002);
+
+    let val = 0.1;
+    let factor = RatioF64 {
+        numerator: 1.0,
+        denominator: 5.0,
+    };
+    assert_eq!(Convertible::mul(val, &factor), 0.02);
+    assert_eq!(val * (factor.numerator / factor.denominator), 0.020000000000000004);
+}
+
+#[test]
+#[rustfmt::skip]
+fn test_convertible_mul_extreme_cases() {
+    // These extreme cases verify that the function safely propagates to NaN
+    // for non-finite inputs, division by zero, and intermediate overflows.
+
+    // If we pass NaN, it should return NaN
+    assert!(Convertible::mul(f64::NAN, &RatioF64 { numerator: 1.0, denominator: 2.0 }).is_nan());
+    assert!(Convertible::mul(1.0, &RatioF64 { numerator: f64::NAN, denominator: 2.0 }).is_nan());
+    assert!(Convertible::mul(1.0, &RatioF64 { numerator: 1.0, denominator: f64::NAN }).is_nan());
+
+    // If we pass Infinity, it does the correct thing
+    assert_eq!(Convertible::mul(f64::INFINITY, &RatioF64 { numerator: 1.0, denominator: 2.0 }), f64::INFINITY);
+    assert_eq!(Convertible::mul(1.0, &RatioF64 { numerator: f64::INFINITY, denominator: 2.0 }), f64::INFINITY);
+    assert_eq!(Convertible::mul(1.0, &RatioF64 { numerator: 1.0, denominator: f64::INFINITY }), 0.0);
+
+    assert_eq!(Convertible::mul(f64::NEG_INFINITY, &RatioF64 { numerator: 1.0, denominator: 2.0 }), f64::NEG_INFINITY);
+    assert_eq!(Convertible::mul(1.0, &RatioF64 { numerator: f64::NEG_INFINITY, denominator: 2.0 }), f64::NEG_INFINITY);
+    assert_eq!(Convertible::mul(1.0, &RatioF64 { numerator: 1.0, denominator: f64::NEG_INFINITY }), -0.0);
+
+    // Division by zero
+    assert_eq!(Convertible::mul(1.0, &RatioF64 { numerator: 1.0, denominator: 0.0 }), f64::INFINITY);
+    assert!(Convertible::mul(0.0, &RatioF64 { numerator: 1.0, denominator: 0.0 }).is_nan());
+    assert!(Convertible::mul(1.0, &RatioF64 { numerator: 0.0, denominator: 0.0 }).is_nan());
+    assert!(Convertible::mul(0.0, &RatioF64 { numerator: 0.0, denominator: 0.0 }).is_nan());
+
+    // Intermediate overflow, which is handled by the fallback path
+    assert_eq!(Convertible::mul(1e300, &RatioF64 { numerator: 1e300, denominator: 1e300 }), 1e300);
 }

--- a/components/experimental/tests/units/units_test.rs
+++ b/components/experimental/tests/units/units_test.rs
@@ -10,7 +10,7 @@ use icu_experimental::units::ratio::IcuRatio;
 use icu_experimental::{measure::measureunit::MeasureUnit, units::converter::UnitsConverter};
 use num_bigint::BigInt;
 use num_rational::Ratio;
-use num_traits::{Signed, ToPrimitive};
+use num_traits::{FromPrimitive, Signed, ToPrimitive};
 
 #[test]
 fn test_cldr_unit_tests() {
@@ -290,4 +290,48 @@ fn test_unparsable_units() {
             "Unit '{unit}' should be unparsable but was parsed successfully."
         );
     });
+}
+
+#[test]
+fn test_f64_precision() {
+    let factory = ConverterFactory::new();
+
+    let tonne = MeasureUnit::try_from_str("tonne").unwrap();
+    let g = MeasureUnit::try_from_str("gram").unwrap();
+    let kg = MeasureUnit::try_from_str("kilogram").unwrap();
+    let inch = MeasureUnit::try_from_str("inch").unwrap();
+    let cm = MeasureUnit::try_from_str("centimeter").unwrap();
+    let foot = MeasureUnit::try_from_str("foot").unwrap();
+
+    // 5 g to tonnes (factor 1/1000000)
+    let converter_f64 = factory.converter::<f64>(&g, &tonne).unwrap();
+    let converter_exact = factory.converter::<&Ratio<BigInt>>(&g, &tonne).unwrap();
+    let result = converter_f64.convert(5.0);
+    let result_exact = converter_exact.convert(&Ratio::from_i64(5).unwrap());
+    assert_eq!(result, 5e-6);
+    assert_eq!(result, result_exact.to_f64().unwrap());
+
+    // 825 g to kg (factor 1/1000)
+    let converter_f64 = factory.converter::<f64>(&g, &kg).unwrap();
+    let converter_exact = factory.converter::<&Ratio<BigInt>>(&g, &kg).unwrap();
+    let result = converter_f64.convert(825.0);
+    let result_exact = converter_exact.convert(&Ratio::from_i64(825).unwrap());
+    assert_eq!(result, 0.825);
+    assert_eq!(result, result_exact.to_f64().unwrap());
+
+    // 5 in to cm (factor 127/50)
+    let converter_f64 = factory.converter::<f64>(&inch, &cm).unwrap();
+    let converter_exact = factory.converter::<&Ratio<BigInt>>(&inch, &cm).unwrap();
+    let result = converter_f64.convert(5.0);
+    let result_exact = converter_exact.convert(&Ratio::from_i64(5).unwrap());
+    assert_eq!(result, 12.7);
+    assert_eq!(result, result_exact.to_f64().unwrap());
+
+    // 84 in to ft (factor 1/12)
+    let converter_f64 = factory.converter::<f64>(&inch, &foot).unwrap();
+    let converter_exact = factory.converter::<&Ratio<BigInt>>(&inch, &foot).unwrap();
+    let result = converter_f64.convert(84.0);
+    let result_exact = converter_exact.convert(&Ratio::from_i64(84).unwrap());
+    assert_eq!(result, 7.0);
+    assert_eq!(result, result_exact.to_f64().unwrap());
 }


### PR DESCRIPTION
Document `f64` rounding semantics, and improve accuracy. Tested against the `Ratio<BigInt>` code path.

#8058 

## Changelog

icu_experimental:
units:
    * document `f64` semantics and improve accuracy