### PR TITLE
Address post-merge feedback on CollationSpecialPrimaries

### DIFF
--- a/components/collator/src/options.rs
+++ b/components/collator/src/options.rs
@@ -250,6 +250,14 @@ pub enum MaxVariable {
     Currency = 3,
 }
 
+impl MaxVariable {
+    /// The number of variants in `MaxVariable`.
+    ///
+    /// `variant_count` isn't stable yet:
+    /// https://github.com/rust-lang/rust/issues/73662
+    pub(crate) const VARIANT_COUNT: usize = MaxVariable::Currency as usize + 1;
+}
+
 /// Whether to distinguish case in sorting, even for sorting levels higher
 /// than tertiary, without having to use tertiary level just to enable case level differences.
 #[derive(Eq, PartialEq, Debug, Copy, Clone)]

--- a/components/collator/src/options.rs
+++ b/components/collator/src/options.rs
@@ -251,7 +251,8 @@ pub enum MaxVariable {
 }
 
 impl MaxVariable {
-    /// The number of variants in `MaxVariable`.
+    /// The number of variants in `MaxVariable` (Space, Punctuation, Symbol, Currency),
+    /// which correspond to the "real" special primaries.
     ///
     /// `variant_count` isn't stable yet:
     /// https://github.com/rust-lang/rust/issues/73662

--- a/components/collator/src/options.rs
+++ b/components/collator/src/options.rs
@@ -250,12 +250,13 @@ pub enum MaxVariable {
     Currency = 3,
 }
 
+#[cfg(feature = "serde")]
 impl MaxVariable {
     /// The number of variants in `MaxVariable` (Space, Punctuation, Symbol, Currency),
     /// which correspond to the "real" special primaries.
     ///
     /// `variant_count` isn't stable yet:
-    /// https://github.com/rust-lang/rust/issues/73662
+    /// <https://github.com/rust-lang/rust/issues/73662>
     pub(crate) const VARIANT_COUNT: usize = MaxVariable::Currency as usize + 1;
 }
 

--- a/components/collator/src/provider.rs
+++ b/components/collator/src/provider.rs
@@ -612,9 +612,6 @@ pub struct CollationSpecialPrimaries<'data> {
 
 #[cfg(feature = "serde")]
 impl CollationSpecialPrimaries<'_> {
-    /// The number of real special primaries (Space, Punctuation, Symbol, Currency).
-    pub(crate) const NUM_PRIMARIES: usize = MaxVariable::VARIANT_COUNT;
-
     /// The length of the compressible bytes array (256 bits packed in `u16`s).
     pub(crate) const COMPRESSIBLE_BYTES_LEN: usize = 256 / (u16::BITS as usize);
 }
@@ -639,7 +636,7 @@ impl<'de> serde::Deserialize<'de> for CollationSpecialPrimaries<'de> {
 
         let Some((l, c)) = concatenated
             .as_ule_slice()
-            .split_at_checked(CollationSpecialPrimaries::NUM_PRIMARIES)
+            .split_at_checked(MaxVariable::VARIANT_COUNT)
         else {
             return Err(serde::de::Error::custom("invalid"));
         };

--- a/components/collator/src/provider.rs
+++ b/components/collator/src/provider.rs
@@ -613,10 +613,10 @@ pub struct CollationSpecialPrimaries<'data> {
 #[cfg(feature = "serde")]
 impl CollationSpecialPrimaries<'_> {
     /// The number of real special primaries (Space, Punctuation, Symbol, Currency).
-    pub(crate) const NUM_PRIMARIES: usize = MaxVariable::Currency as usize + 1; // 4
+    pub(crate) const NUM_PRIMARIES: usize = MaxVariable::VARIANT_COUNT;
 
-    /// The length of the compressible bytes array (256 bits packed in 16 u16s).
-    pub(crate) const COMPRESSIBLE_BYTES_LEN: usize = 16;
+    /// The length of the compressible bytes array (256 bits packed in `u16`s).
+    pub(crate) const COMPRESSIBLE_BYTES_LEN: usize = 256 / (u16::BITS as usize);
 }
 
 #[cfg(feature = "serde")]

--- a/components/collator/src/provider.rs
+++ b/components/collator/src/provider.rs
@@ -639,8 +639,6 @@ impl<'de> serde::Deserialize<'de> for CollationSpecialPrimaries<'de> {
 
         let Some((l, c)) = concatenated
             .as_ule_slice()
-            // `variant_count` isn't stable yet:
-            // https://github.com/rust-lang/rust/issues/73662
             .split_at_checked(CollationSpecialPrimaries::NUM_PRIMARIES)
         else {
             return Err(serde::de::Error::custom("invalid"));


### PR DESCRIPTION
Addresses post-merge feedback from @robertbastan on PR #8083:
- Moves the `variant_count` stability comment and defines `VARIANT_COUNT` on `MaxVariable` in `options.rs`.
- Updates `CollationSpecialPrimaries::NUM_PRIMARIES` to use `MaxVariable::VARIANT_COUNT`.
- Refactors `CollationSpecialPrimaries::COMPRESSIBLE_BYTES_LEN` to use a formula `256 / (u16::BITS as usize)` and updates its comment.

🤖 This pull request was created by an AI agent working with @sffc.

## Changelog

N/A