### PR TITLE
Datagen: Use structured keys with alt and menu variants for display names

### DIFF
--- a/provider/source/src/cldr_serde/displaynames/language.rs
+++ b/provider/source/src/cldr_serde/displaynames/language.rs
@@ -7,14 +7,14 @@
 //! Sample file:
 //! <https://github.com/unicode-org/cldr-json/blob/main/cldr-json/cldr-localenames-full/main/en/languages.json>
 
-use super::SubtagWithOptionalAltVariant;
+use super::ModifiedSubtag;
 use icu::locale::LanguageIdentifier;
 use serde::Deserialize;
 use std::collections::HashMap;
 
 #[derive(PartialEq, Debug, Deserialize)]
 pub(crate) struct Languages {
-    pub(crate) languages: HashMap<SubtagWithOptionalAltVariant<LanguageIdentifier>, String>,
+    pub(crate) languages: HashMap<ModifiedSubtag<LanguageIdentifier>, String>,
 }
 
 #[derive(PartialEq, Debug, Deserialize)]

--- a/provider/source/src/cldr_serde/displaynames/language.rs
+++ b/provider/source/src/cldr_serde/displaynames/language.rs
@@ -7,14 +7,14 @@
 //! Sample file:
 //! <https://github.com/unicode-org/cldr-json/blob/main/cldr-json/cldr-localenames-full/main/en/languages.json>
 
-use super::ModifiedSubtag;
+use super::WithAlt;
 use icu::locale::LanguageIdentifier;
 use serde::Deserialize;
 use std::collections::HashMap;
 
 #[derive(PartialEq, Debug, Deserialize)]
 pub(crate) struct Languages {
-    pub(crate) languages: HashMap<ModifiedSubtag<LanguageIdentifier>, String>,
+    pub(crate) languages: HashMap<WithAlt<LanguageIdentifier>, String>,
 }
 
 #[derive(PartialEq, Debug, Deserialize)]

--- a/provider/source/src/cldr_serde/displaynames/language.rs
+++ b/provider/source/src/cldr_serde/displaynames/language.rs
@@ -7,12 +7,14 @@
 //! Sample file:
 //! <https://github.com/unicode-org/cldr-json/blob/main/cldr-json/cldr-localenames-full/main/en/languages.json>
 
+use super::SubtagWithOptionalAltVariant;
+use icu::locale::LanguageIdentifier;
 use serde::Deserialize;
 use std::collections::HashMap;
 
 #[derive(PartialEq, Debug, Deserialize)]
 pub(crate) struct Languages {
-    pub(crate) languages: HashMap<String, String>,
+    pub(crate) languages: HashMap<SubtagWithOptionalAltVariant<LanguageIdentifier>, String>,
 }
 
 #[derive(PartialEq, Debug, Deserialize)]

--- a/provider/source/src/cldr_serde/displaynames/mod.rs
+++ b/provider/source/src/cldr_serde/displaynames/mod.rs
@@ -12,13 +12,13 @@ use core::str::FromStr;
 use serde::{Deserialize, Deserializer};
 
 #[derive(Hash, Eq, PartialEq, Clone, Debug)]
-pub(crate) struct SubtagWithOptionalAltVariant<T> {
+pub(crate) struct ModifiedSubtag<T> {
     pub(crate) subtag: T,
     pub(crate) alt_variant: Option<String>,
     pub(crate) menu_variant: Option<String>,
 }
 
-impl<'de, T> Deserialize<'de> for SubtagWithOptionalAltVariant<T>
+impl<'de, T> Deserialize<'de> for ModifiedSubtag<T>
 where
     T: FromStr,
     T::Err: core::fmt::Display,
@@ -34,7 +34,7 @@ where
             T: FromStr,
             T::Err: core::fmt::Display,
         {
-            type Value = SubtagWithOptionalAltVariant<T>;
+            type Value = ModifiedSubtag<T>;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
                 formatter.write_str("a string with optional -alt- or -menu- suffix")
@@ -48,7 +48,7 @@ where
                     let (subtag_str, menu_str) = v.split_at(index);
                     let menu_variant = menu_str.strip_prefix("-menu-").unwrap().to_string();
                     let subtag = T::from_str(subtag_str).map_err(E::custom)?;
-                    Ok(SubtagWithOptionalAltVariant {
+                    Ok(ModifiedSubtag {
                         subtag,
                         alt_variant: None,
                         menu_variant: Some(menu_variant),
@@ -57,14 +57,14 @@ where
                     let (subtag_str, alt_str) = v.split_at(index);
                     let alt_variant = alt_str.strip_prefix("-alt-").unwrap().to_string();
                     let subtag = T::from_str(subtag_str).map_err(E::custom)?;
-                    Ok(SubtagWithOptionalAltVariant {
+                    Ok(ModifiedSubtag {
                         subtag,
                         alt_variant: Some(alt_variant),
                         menu_variant: None,
                     })
                 } else {
                     let subtag = T::from_str(v).map_err(E::custom)?;
-                    Ok(SubtagWithOptionalAltVariant {
+                    Ok(ModifiedSubtag {
                         subtag,
                         alt_variant: None,
                         menu_variant: None,

--- a/provider/source/src/cldr_serde/displaynames/mod.rs
+++ b/provider/source/src/cldr_serde/displaynames/mod.rs
@@ -12,12 +12,61 @@ const ALT_SEPARATOR: &str = "-alt-";
 const MENU_SEPARATOR: &str = "-menu-";
 use core::str::FromStr;
 use serde::{Deserialize, Deserializer};
+#[derive(Hash, Eq, PartialEq, Clone, Copy, Debug)]
+pub(crate) enum Alt {
+    Short,
+    Long,
+    Variant,
+    StandAlone,
+    Official,
+    Secondary,
+    Biot,
+    Chagos,
+    Menu,
+    Unknown,
+}
+
+impl FromStr for Alt {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "short" => Ok(Alt::Short),
+            "long" => Ok(Alt::Long),
+            "variant" => Ok(Alt::Variant),
+            "stand-alone" => Ok(Alt::StandAlone),
+            "official" => Ok(Alt::Official),
+            "secondary" => Ok(Alt::Secondary),
+            "biot" => Ok(Alt::Biot),
+            "chagos" => Ok(Alt::Chagos),
+            "menu" => Ok(Alt::Menu),
+            _ => Err(()),
+        }
+    }
+}
+
+#[derive(Hash, Eq, PartialEq, Clone, Copy, Debug)]
+pub(crate) enum Menu {
+    Core,
+    Extension,
+    Unknown,
+}
+
+impl FromStr for Menu {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "core" => Ok(Menu::Core),
+            "extension" => Ok(Menu::Extension),
+            _ => Err(()),
+        }
+    }
+}
 
 #[derive(Hash, Eq, PartialEq, Clone, Debug)]
 pub(crate) struct WithAlt<T> {
     pub(crate) subtag: T,
-    pub(crate) alt: Option<std::borrow::Cow<'static, str>>,
-    pub(crate) menu: Option<std::borrow::Cow<'static, str>>,
+    pub(crate) alt: Option<Alt>,
+    pub(crate) menu: Option<Menu>,
 }
 
 impl<'de, T> Deserialize<'de> for WithAlt<T>
@@ -51,13 +100,13 @@ where
                     Ok(WithAlt {
                         subtag,
                         alt: None,
-                        menu: Some(std::borrow::Cow::Owned(menu_str.to_string())),
+                        menu: Some(Menu::from_str(menu_str).unwrap_or(Menu::Unknown)),
                     })
                 } else if let Some((subtag_str, alt_str)) = v.split_once(ALT_SEPARATOR) {
                     let subtag = T::from_str(subtag_str).map_err(E::custom)?;
                     Ok(WithAlt {
                         subtag,
-                        alt: Some(std::borrow::Cow::Owned(alt_str.to_string())),
+                        alt: Some(Alt::from_str(alt_str).unwrap_or(Alt::Unknown)),
                         menu: None,
                     })
                 } else {

--- a/provider/source/src/cldr_serde/displaynames/mod.rs
+++ b/provider/source/src/cldr_serde/displaynames/mod.rs
@@ -8,7 +8,8 @@ pub(crate) mod region;
 pub(crate) mod script;
 pub(crate) mod variant;
 
-use crate::displaynames::{ALT_SEPARATOR, MENU_SEPARATOR};
+const ALT_SEPARATOR: &str = "-alt-";
+const MENU_SEPARATOR: &str = "-menu-";
 use core::str::FromStr;
 use serde::{Deserialize, Deserializer};
 

--- a/provider/source/src/cldr_serde/displaynames/mod.rs
+++ b/provider/source/src/cldr_serde/displaynames/mod.rs
@@ -16,8 +16,8 @@ use serde::{Deserialize, Deserializer};
 #[derive(Hash, Eq, PartialEq, Clone, Debug)]
 pub(crate) struct WithAlt<T> {
     pub(crate) subtag: T,
-    pub(crate) alt: Option<String>,
-    pub(crate) menu: Option<String>,
+    pub(crate) alt: Option<std::borrow::Cow<'static, str>>,
+    pub(crate) menu: Option<std::borrow::Cow<'static, str>>,
 }
 
 impl<'de, T> Deserialize<'de> for WithAlt<T>
@@ -51,13 +51,13 @@ where
                     Ok(WithAlt {
                         subtag,
                         alt: None,
-                        menu: Some(menu_str.to_string()),
+                        menu: Some(std::borrow::Cow::Owned(menu_str.to_string())),
                     })
                 } else if let Some((subtag_str, alt_str)) = v.split_once(ALT_SEPARATOR) {
                     let subtag = T::from_str(subtag_str).map_err(E::custom)?;
                     Ok(WithAlt {
                         subtag,
-                        alt: Some(alt_str.to_string()),
+                        alt: Some(std::borrow::Cow::Owned(alt_str.to_string())),
                         menu: None,
                     })
                 } else {

--- a/provider/source/src/cldr_serde/displaynames/mod.rs
+++ b/provider/source/src/cldr_serde/displaynames/mod.rs
@@ -19,9 +19,13 @@ pub(crate) enum Alt {
     Variant,
     StandAlone,
     Official,
+    /// Secondary name variant, used in languages and scripts.
     Secondary,
+    /// Abbreviation for territory code `IO` (British Indian Ocean Territory).
     Biot,
+    /// Alternate name for territory code `IO` (British Indian Ocean Territory) mapping to "Chagos Archipelago".
     Chagos,
+    /// "menu" variant, which is being replaced by menu=core|extension, but is still in CLDR.
     Menu,
     Unknown,
 }

--- a/provider/source/src/cldr_serde/displaynames/mod.rs
+++ b/provider/source/src/cldr_serde/displaynames/mod.rs
@@ -10,6 +10,8 @@ pub(crate) mod variant;
 
 const ALT_SEPARATOR: &str = "-alt-";
 const MENU_SEPARATOR: &str = "-menu-";
+use core::fmt::{self, Display};
+use core::marker::PhantomData;
 use core::str::FromStr;
 use serde::{Deserialize, Deserializer};
 #[derive(Hash, Eq, PartialEq, Clone, Copy, Debug)]
@@ -76,22 +78,22 @@ pub(crate) struct WithAlt<T> {
 impl<'de, T> Deserialize<'de> for WithAlt<T>
 where
     T: FromStr,
-    T::Err: core::fmt::Display,
+    T::Err: Display,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        struct Visitor<T>(std::marker::PhantomData<T>);
+        struct Visitor<T>(PhantomData<T>);
 
         impl<'de, T> serde::de::Visitor<'de> for Visitor<T>
         where
             T: FromStr,
-            T::Err: core::fmt::Display,
+            T::Err: Display,
         {
             type Value = WithAlt<T>;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                 formatter.write_str("a string with optional -alt- or -menu- suffix")
             }
 
@@ -138,6 +140,6 @@ where
             }
         }
 
-        deserializer.deserialize_str(Visitor(std::marker::PhantomData))
+        deserializer.deserialize_str(Visitor(PhantomData))
     }
 }

--- a/provider/source/src/cldr_serde/displaynames/mod.rs
+++ b/provider/source/src/cldr_serde/displaynames/mod.rs
@@ -14,6 +14,7 @@ use core::str::FromStr;
 use serde::{Deserialize, Deserializer};
 #[derive(Hash, Eq, PartialEq, Clone, Copy, Debug)]
 pub(crate) enum Alt {
+    Unknown,
     Short,
     Long,
     Variant,
@@ -27,7 +28,6 @@ pub(crate) enum Alt {
     Chagos,
     /// "menu" variant, which is being replaced by menu=core|extension, but is still in CLDR.
     Menu,
-    Unknown,
 }
 
 impl FromStr for Alt {
@@ -50,9 +50,9 @@ impl FromStr for Alt {
 
 #[derive(Hash, Eq, PartialEq, Clone, Copy, Debug)]
 pub(crate) enum Menu {
+    Unknown,
     Core,
     Extension,
-    Unknown,
 }
 
 impl FromStr for Menu {
@@ -101,16 +101,30 @@ where
             {
                 if let Some((subtag_str, menu_str)) = v.split_once(MENU_SEPARATOR) {
                     let subtag = T::from_str(subtag_str).map_err(E::custom)?;
+                    let menu = match Menu::from_str(menu_str) {
+                        Ok(m) => m,
+                        Err(_) => {
+                            log::warn!("Unknown menu variant: {}", menu_str);
+                            Menu::Unknown
+                        }
+                    };
                     Ok(WithAlt {
                         subtag,
                         alt: None,
-                        menu: Some(Menu::from_str(menu_str).unwrap_or(Menu::Unknown)),
+                        menu: Some(menu),
                     })
                 } else if let Some((subtag_str, alt_str)) = v.split_once(ALT_SEPARATOR) {
                     let subtag = T::from_str(subtag_str).map_err(E::custom)?;
+                    let alt = match Alt::from_str(alt_str) {
+                        Ok(a) => a,
+                        Err(_) => {
+                            log::warn!("Unknown alt variant: {}", alt_str);
+                            Alt::Unknown
+                        }
+                    };
                     Ok(WithAlt {
                         subtag,
-                        alt: Some(Alt::from_str(alt_str).unwrap_or(Alt::Unknown)),
+                        alt: Some(alt),
                         menu: None,
                     })
                 } else {

--- a/provider/source/src/cldr_serde/displaynames/mod.rs
+++ b/provider/source/src/cldr_serde/displaynames/mod.rs
@@ -7,3 +7,72 @@ pub(crate) mod locale_display_pattern;
 pub(crate) mod region;
 pub(crate) mod script;
 pub(crate) mod variant;
+
+use core::str::FromStr;
+use serde::{Deserialize, Deserializer};
+
+#[derive(Hash, Eq, PartialEq, Clone, Debug)]
+pub(crate) struct SubtagWithOptionalAltVariant<T> {
+    pub(crate) subtag: T,
+    pub(crate) alt_variant: Option<String>,
+    pub(crate) menu_variant: Option<String>,
+}
+
+impl<'de, T> Deserialize<'de> for SubtagWithOptionalAltVariant<T>
+where
+    T: FromStr,
+    T::Err: core::fmt::Display,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct Visitor<T>(std::marker::PhantomData<T>);
+
+        impl<'de, T> serde::de::Visitor<'de> for Visitor<T>
+        where
+            T: FromStr,
+            T::Err: core::fmt::Display,
+        {
+            type Value = SubtagWithOptionalAltVariant<T>;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a string with optional -alt- or -menu- suffix")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                if let Some(index) = v.rfind("-menu-") {
+                    let (subtag_str, menu_str) = v.split_at(index);
+                    let menu_variant = menu_str.strip_prefix("-menu-").unwrap().to_string();
+                    let subtag = T::from_str(subtag_str).map_err(E::custom)?;
+                    Ok(SubtagWithOptionalAltVariant {
+                        subtag,
+                        alt_variant: None,
+                        menu_variant: Some(menu_variant),
+                    })
+                } else if let Some(index) = v.rfind("-alt-") {
+                    let (subtag_str, alt_str) = v.split_at(index);
+                    let alt_variant = alt_str.strip_prefix("-alt-").unwrap().to_string();
+                    let subtag = T::from_str(subtag_str).map_err(E::custom)?;
+                    Ok(SubtagWithOptionalAltVariant {
+                        subtag,
+                        alt_variant: Some(alt_variant),
+                        menu_variant: None,
+                    })
+                } else {
+                    let subtag = T::from_str(v).map_err(E::custom)?;
+                    Ok(SubtagWithOptionalAltVariant {
+                        subtag,
+                        alt_variant: None,
+                        menu_variant: None,
+                    })
+                }
+            }
+        }
+
+        deserializer.deserialize_str(Visitor(std::marker::PhantomData))
+    }
+}

--- a/provider/source/src/cldr_serde/displaynames/mod.rs
+++ b/provider/source/src/cldr_serde/displaynames/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod region;
 pub(crate) mod script;
 pub(crate) mod variant;
 
+use crate::displaynames::{ALT_SEPARATOR, MENU_SEPARATOR};
 use core::str::FromStr;
 use serde::{Deserialize, Deserializer};
 
@@ -44,18 +45,18 @@ where
             where
                 E: serde::de::Error,
             {
-                if let Some(index) = v.rfind("-menu-") {
+                if let Some(index) = v.rfind(MENU_SEPARATOR) {
                     let (subtag_str, menu_str) = v.split_at(index);
-                    let menu_variant = menu_str.strip_prefix("-menu-").unwrap().to_string();
+                    let menu_variant = menu_str.strip_prefix(MENU_SEPARATOR).unwrap().to_string();
                     let subtag = T::from_str(subtag_str).map_err(E::custom)?;
                     Ok(ModifiedSubtag {
                         subtag,
                         alt_variant: None,
                         menu_variant: Some(menu_variant),
                     })
-                } else if let Some(index) = v.rfind("-alt-") {
+                } else if let Some(index) = v.rfind(ALT_SEPARATOR) {
                     let (subtag_str, alt_str) = v.split_at(index);
-                    let alt_variant = alt_str.strip_prefix("-alt-").unwrap().to_string();
+                    let alt_variant = alt_str.strip_prefix(ALT_SEPARATOR).unwrap().to_string();
                     let subtag = T::from_str(subtag_str).map_err(E::custom)?;
                     Ok(ModifiedSubtag {
                         subtag,

--- a/provider/source/src/cldr_serde/displaynames/mod.rs
+++ b/provider/source/src/cldr_serde/displaynames/mod.rs
@@ -13,13 +13,13 @@ use core::str::FromStr;
 use serde::{Deserialize, Deserializer};
 
 #[derive(Hash, Eq, PartialEq, Clone, Debug)]
-pub(crate) struct ModifiedSubtag<T> {
+pub(crate) struct WithAlt<T> {
     pub(crate) subtag: T,
-    pub(crate) alt_variant: Option<String>,
-    pub(crate) menu_variant: Option<String>,
+    pub(crate) alt: Option<String>,
+    pub(crate) menu: Option<String>,
 }
 
-impl<'de, T> Deserialize<'de> for ModifiedSubtag<T>
+impl<'de, T> Deserialize<'de> for WithAlt<T>
 where
     T: FromStr,
     T::Err: core::fmt::Display,
@@ -35,7 +35,7 @@ where
             T: FromStr,
             T::Err: core::fmt::Display,
         {
-            type Value = ModifiedSubtag<T>;
+            type Value = WithAlt<T>;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
                 formatter.write_str("a string with optional -alt- or -menu- suffix")
@@ -45,30 +45,26 @@ where
             where
                 E: serde::de::Error,
             {
-                if let Some(index) = v.rfind(MENU_SEPARATOR) {
-                    let (subtag_str, menu_str) = v.split_at(index);
-                    let menu_variant = menu_str.strip_prefix(MENU_SEPARATOR).unwrap().to_string();
+                if let Some((subtag_str, menu_str)) = v.split_once(MENU_SEPARATOR) {
                     let subtag = T::from_str(subtag_str).map_err(E::custom)?;
-                    Ok(ModifiedSubtag {
+                    Ok(WithAlt {
                         subtag,
-                        alt_variant: None,
-                        menu_variant: Some(menu_variant),
+                        alt: None,
+                        menu: Some(menu_str.to_string()),
                     })
-                } else if let Some(index) = v.rfind(ALT_SEPARATOR) {
-                    let (subtag_str, alt_str) = v.split_at(index);
-                    let alt_variant = alt_str.strip_prefix(ALT_SEPARATOR).unwrap().to_string();
+                } else if let Some((subtag_str, alt_str)) = v.split_once(ALT_SEPARATOR) {
                     let subtag = T::from_str(subtag_str).map_err(E::custom)?;
-                    Ok(ModifiedSubtag {
+                    Ok(WithAlt {
                         subtag,
-                        alt_variant: Some(alt_variant),
-                        menu_variant: None,
+                        alt: Some(alt_str.to_string()),
+                        menu: None,
                     })
                 } else {
                     let subtag = T::from_str(v).map_err(E::custom)?;
-                    Ok(ModifiedSubtag {
+                    Ok(WithAlt {
                         subtag,
-                        alt_variant: None,
-                        menu_variant: None,
+                        alt: None,
+                        menu: None,
                     })
                 }
             }

--- a/provider/source/src/cldr_serde/displaynames/region.rs
+++ b/provider/source/src/cldr_serde/displaynames/region.rs
@@ -7,7 +7,7 @@
 //! Sample file:
 //! <https://github.com/unicode-org/cldr-json/blob/main/cldr-json/cldr-localenames-full/main/en/territories.json>
 
-use super::ModifiedSubtag;
+use super::WithAlt;
 use icu::locale::subtags::Region;
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -15,7 +15,7 @@ use std::collections::HashMap;
 #[derive(PartialEq, Debug, Deserialize)]
 pub(crate) struct Regions {
     #[serde(rename = "territories")]
-    pub(crate) regions: HashMap<ModifiedSubtag<Region>, String>,
+    pub(crate) regions: HashMap<WithAlt<Region>, String>,
 }
 
 #[derive(PartialEq, Debug, Deserialize)]

--- a/provider/source/src/cldr_serde/displaynames/region.rs
+++ b/provider/source/src/cldr_serde/displaynames/region.rs
@@ -7,7 +7,7 @@
 //! Sample file:
 //! <https://github.com/unicode-org/cldr-json/blob/main/cldr-json/cldr-localenames-full/main/en/territories.json>
 
-use super::SubtagWithOptionalAltVariant;
+use super::ModifiedSubtag;
 use icu::locale::subtags::Region;
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -15,7 +15,7 @@ use std::collections::HashMap;
 #[derive(PartialEq, Debug, Deserialize)]
 pub(crate) struct Regions {
     #[serde(rename = "territories")]
-    pub(crate) regions: HashMap<SubtagWithOptionalAltVariant<Region>, String>,
+    pub(crate) regions: HashMap<ModifiedSubtag<Region>, String>,
 }
 
 #[derive(PartialEq, Debug, Deserialize)]

--- a/provider/source/src/cldr_serde/displaynames/region.rs
+++ b/provider/source/src/cldr_serde/displaynames/region.rs
@@ -7,13 +7,15 @@
 //! Sample file:
 //! <https://github.com/unicode-org/cldr-json/blob/main/cldr-json/cldr-localenames-full/main/en/territories.json>
 
+use super::SubtagWithOptionalAltVariant;
+use icu::locale::subtags::Region;
 use serde::Deserialize;
 use std::collections::HashMap;
 
 #[derive(PartialEq, Debug, Deserialize)]
 pub(crate) struct Regions {
     #[serde(rename = "territories")]
-    pub(crate) regions: HashMap<String, String>,
+    pub(crate) regions: HashMap<SubtagWithOptionalAltVariant<Region>, String>,
 }
 
 #[derive(PartialEq, Debug, Deserialize)]

--- a/provider/source/src/cldr_serde/displaynames/script.rs
+++ b/provider/source/src/cldr_serde/displaynames/script.rs
@@ -7,14 +7,14 @@
 //! Sample file:
 //! <https://github.com/unicode-org/cldr-json/blob/main/cldr-json/cldr-localenames-full/main/en/scripts.json>
 
-use super::ModifiedSubtag;
+use super::WithAlt;
 use icu::locale::subtags::Script;
 use serde::Deserialize;
 use std::collections::HashMap;
 
 #[derive(PartialEq, Debug, Deserialize)]
 pub(crate) struct Scripts {
-    pub(crate) scripts: HashMap<ModifiedSubtag<Script>, String>,
+    pub(crate) scripts: HashMap<WithAlt<Script>, String>,
 }
 
 #[derive(PartialEq, Debug, Deserialize)]

--- a/provider/source/src/cldr_serde/displaynames/script.rs
+++ b/provider/source/src/cldr_serde/displaynames/script.rs
@@ -7,12 +7,14 @@
 //! Sample file:
 //! <https://github.com/unicode-org/cldr-json/blob/main/cldr-json/cldr-localenames-full/main/en/scripts.json>
 
+use super::SubtagWithOptionalAltVariant;
+use icu::locale::subtags::Script;
 use serde::Deserialize;
 use std::collections::HashMap;
 
 #[derive(PartialEq, Debug, Deserialize)]
 pub(crate) struct Scripts {
-    pub(crate) scripts: HashMap<String, String>,
+    pub(crate) scripts: HashMap<SubtagWithOptionalAltVariant<Script>, String>,
 }
 
 #[derive(PartialEq, Debug, Deserialize)]

--- a/provider/source/src/cldr_serde/displaynames/script.rs
+++ b/provider/source/src/cldr_serde/displaynames/script.rs
@@ -7,14 +7,14 @@
 //! Sample file:
 //! <https://github.com/unicode-org/cldr-json/blob/main/cldr-json/cldr-localenames-full/main/en/scripts.json>
 
-use super::SubtagWithOptionalAltVariant;
+use super::ModifiedSubtag;
 use icu::locale::subtags::Script;
 use serde::Deserialize;
 use std::collections::HashMap;
 
 #[derive(PartialEq, Debug, Deserialize)]
 pub(crate) struct Scripts {
-    pub(crate) scripts: HashMap<SubtagWithOptionalAltVariant<Script>, String>,
+    pub(crate) scripts: HashMap<ModifiedSubtag<Script>, String>,
 }
 
 #[derive(PartialEq, Debug, Deserialize)]

--- a/provider/source/src/cldr_serde/displaynames/variant.rs
+++ b/provider/source/src/cldr_serde/displaynames/variant.rs
@@ -7,14 +7,14 @@
 //! Sample file:
 //! <https://github.com/unicode-org/cldr-json/blob/main/cldr-json/cldr-localenames-full/main/en/variants.json>
 
-use super::ModifiedSubtag;
+use super::WithAlt;
 use icu::locale::subtags::Variant;
 use serde::Deserialize;
 use std::collections::HashMap;
 
 #[derive(PartialEq, Debug, Deserialize)]
 pub(crate) struct Variants {
-    pub(crate) variants: HashMap<ModifiedSubtag<Variant>, String>,
+    pub(crate) variants: HashMap<WithAlt<Variant>, String>,
 }
 
 #[derive(PartialEq, Debug, Deserialize)]

--- a/provider/source/src/cldr_serde/displaynames/variant.rs
+++ b/provider/source/src/cldr_serde/displaynames/variant.rs
@@ -7,14 +7,14 @@
 //! Sample file:
 //! <https://github.com/unicode-org/cldr-json/blob/main/cldr-json/cldr-localenames-full/main/en/variants.json>
 
-use super::SubtagWithOptionalAltVariant;
+use super::ModifiedSubtag;
 use icu::locale::subtags::Variant;
 use serde::Deserialize;
 use std::collections::HashMap;
 
 #[derive(PartialEq, Debug, Deserialize)]
 pub(crate) struct Variants {
-    pub(crate) variants: HashMap<SubtagWithOptionalAltVariant<Variant>, String>,
+    pub(crate) variants: HashMap<ModifiedSubtag<Variant>, String>,
 }
 
 #[derive(PartialEq, Debug, Deserialize)]

--- a/provider/source/src/cldr_serde/displaynames/variant.rs
+++ b/provider/source/src/cldr_serde/displaynames/variant.rs
@@ -7,13 +7,14 @@
 //! Sample file:
 //! <https://github.com/unicode-org/cldr-json/blob/main/cldr-json/cldr-localenames-full/main/en/variants.json>
 
-use serde::{Deserialize, Deserializer};
+use super::SubtagWithOptionalAltVariant;
+use icu::locale::subtags::Variant;
+use serde::Deserialize;
 use std::collections::HashMap;
 
 #[derive(PartialEq, Debug, Deserialize)]
 pub(crate) struct Variants {
-    #[serde(deserialize_with = "deserialize_normalized_keys")]
-    pub(crate) variants: HashMap<String, String>,
+    pub(crate) variants: HashMap<SubtagWithOptionalAltVariant<Variant>, String>,
 }
 
 #[derive(PartialEq, Debug, Deserialize)]
@@ -23,14 +24,3 @@ pub(crate) struct LangDisplayNames {
 }
 
 pub(crate) type Resource = super::super::LocaleResource<LangDisplayNames>;
-
-fn deserialize_normalized_keys<'de, D>(deserializer: D) -> Result<HashMap<String, String>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let map = HashMap::<String, String>::deserialize(deserializer)?;
-    Ok(map
-        .into_iter()
-        .map(|(k, v)| (k.to_ascii_lowercase(), v))
-        .collect())
-}

--- a/provider/source/src/cldr_serde/displaynames/variant.rs
+++ b/provider/source/src/cldr_serde/displaynames/variant.rs
@@ -7,11 +7,12 @@
 //! Sample file:
 //! <https://github.com/unicode-org/cldr-json/blob/main/cldr-json/cldr-localenames-full/main/en/variants.json>
 
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 use std::collections::HashMap;
 
 #[derive(PartialEq, Debug, Deserialize)]
 pub(crate) struct Variants {
+    #[serde(deserialize_with = "deserialize_normalized_keys")]
     pub(crate) variants: HashMap<String, String>,
 }
 
@@ -22,3 +23,14 @@ pub(crate) struct LangDisplayNames {
 }
 
 pub(crate) type Resource = super::super::LocaleResource<LangDisplayNames>;
+
+fn deserialize_normalized_keys<'de, D>(deserializer: D) -> Result<HashMap<String, String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let map = HashMap::<String, String>::deserialize(deserializer)?;
+    Ok(map
+        .into_iter()
+        .map(|(k, v)| (k.to_ascii_lowercase(), v))
+        .collect())
+}

--- a/provider/source/src/displaynames/language.rs
+++ b/provider/source/src/displaynames/language.rs
@@ -5,17 +5,15 @@
 use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
-use crate::cldr_serde::displaynames::WithAlt;
-use crate::displaynames::{
-    ALT_LONG, ALT_OFFICIAL, ALT_SECONDARY, ALT_SHORT, ALT_VARIANT, extract_names_for_zeromap_struct,
-};
+use crate::cldr_serde::displaynames::{Alt, WithAlt};
+use crate::displaynames::extract_names_for_zeromap_struct;
 
 use icu::experimental::displaynames::provider::*;
 use icu_provider::prelude::*;
 use potential_utf::PotentialUtf8;
 use std::collections::{BTreeMap, HashSet};
 use tinystr::TinyAsciiStr;
-use zerovec::{VarZeroCow, ZeroMap};
+use zerovec::VarZeroCow;
 
 impl DataProvider<LanguageDisplayNamesV1> for SourceDataProvider {
     fn load(&self, req: DataRequest) -> Result<DataResponse<LanguageDisplayNamesV1>, DataError> {
@@ -57,7 +55,7 @@ crate::displaynames::impl_displaynames_v1!(
     cldr_serde::displaynames::language::Resource,
     "languages.json",
     languages,
-    None::<&str>,
+    None,
 );
 
 crate::displaynames::impl_displaynames_v1!(
@@ -66,7 +64,7 @@ crate::displaynames::impl_displaynames_v1!(
     cldr_serde::displaynames::language::Resource,
     "languages.json",
     languages,
-    Some(ALT_SHORT),
+    Some(Alt::Short),
 );
 
 crate::displaynames::impl_displaynames_v1!(
@@ -75,7 +73,7 @@ crate::displaynames::impl_displaynames_v1!(
     cldr_serde::displaynames::language::Resource,
     "languages.json",
     languages,
-    Some(ALT_LONG),
+    Some(Alt::Long),
 );
 
 crate::displaynames::impl_displaynames_menu_v1!(
@@ -90,7 +88,7 @@ impl From<&cldr_serde::displaynames::language::Resource> for LanguageDisplayName
     fn from(other: &cldr_serde::displaynames::language::Resource) -> Self {
         let extracted = extract_names_for_zeromap_struct(
             &other.main.value.localedisplaynames.languages,
-            &[ALT_VARIANT, ALT_SECONDARY, ALT_OFFICIAL],
+            &[Alt::Variant, Alt::Secondary, Alt::Official],
             "language",
             |langid| {
                 // LanguageDisplayNames contains display names for language subtags without other subtags
@@ -122,7 +120,7 @@ impl From<&cldr_serde::displaynames::language::Resource> for LocaleDisplayNames<
     fn from(other: &cldr_serde::displaynames::language::Resource) -> Self {
         let extracted = extract_names_for_zeromap_struct(
             &other.main.value.localedisplaynames.languages,
-            &[ALT_VARIANT, ALT_SECONDARY, ALT_OFFICIAL],
+            &[Alt::Variant, Alt::Secondary, Alt::Official],
             "language",
             |langid| {
                 // LocaleDisplayNames contains display names for languages with other subtags,
@@ -137,11 +135,9 @@ impl From<&cldr_serde::displaynames::language::Resource> for LocaleDisplayNames<
         );
 
         let to_zero_map = |map: BTreeMap<String, &str>| {
-            let mut zero_map = ZeroMap::new();
-            for (k, v) in map.into_iter() {
-                zero_map.insert(PotentialUtf8::from_str(&k), v);
-            }
-            zero_map
+            map.iter()
+                .map(|(k, v)| (PotentialUtf8::from_str(k), *v))
+                .collect()
         };
 
         Self {

--- a/provider/source/src/displaynames/language.rs
+++ b/provider/source/src/displaynames/language.rs
@@ -14,6 +14,7 @@ use icu::experimental::displaynames::provider::*;
 use icu_provider::prelude::*;
 use potential_utf::PotentialUtf8;
 use std::collections::{BTreeMap, HashSet};
+use tinystr::TinyAsciiStr;
 use zerovec::{VarZeroCow, ZeroMap};
 
 impl DataProvider<LanguageDisplayNamesV1> for SourceDataProvider {
@@ -91,25 +92,19 @@ impl From<&cldr_serde::displaynames::language::Resource> for LanguageDisplayName
             &other.main.value.localedisplaynames.languages,
             &[ALT_VARIANT, ALT_SECONDARY, ALT_OFFICIAL],
             "language",
-            |langid, val| {
+            |langid| {
                 if langid.script.is_some() || langid.region.is_some() || !langid.variants.is_empty()
                 {
                     None
                 } else {
-                    let lang = langid.language;
-                    // Old CLDR versions may contain trivial entries, so filter
-                    if lang.as_str() == val {
-                        None
-                    } else {
-                        Some(lang)
-                    }
+                    Some(langid.language.to_tinystr())
                 }
             },
         );
 
-        let to_zero_map = |map: BTreeMap<icu::locale::subtags::Language, &str>| {
+        let to_zero_map = |map: BTreeMap<TinyAsciiStr<3>, &str>| {
             map.into_iter()
-                .map(|(k, v)| (k.to_tinystr().to_unvalidated(), v))
+                .map(|(k, v)| (k.to_unvalidated(), v))
                 .collect()
         };
 
@@ -128,18 +123,12 @@ impl From<&cldr_serde::displaynames::language::Resource> for LocaleDisplayNames<
             &other.main.value.localedisplaynames.languages,
             &[ALT_VARIANT, ALT_SECONDARY, ALT_OFFICIAL],
             "language",
-            |langid, val| {
+            |langid| {
                 if langid.script.is_none() && langid.region.is_none() && langid.variants.is_empty()
                 {
                     None
                 } else {
-                    let locale_str = langid.to_string();
-                    // Old CLDR versions may contain trivial entries, so filter
-                    if locale_str == val {
-                        None
-                    } else {
-                        Some(locale_str)
-                    }
+                    Some(langid.to_string())
                 }
             },
         );

--- a/provider/source/src/displaynames/language.rs
+++ b/provider/source/src/displaynames/language.rs
@@ -6,6 +6,9 @@ use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
 use crate::cldr_serde::displaynames::ModifiedSubtag;
+use crate::displaynames::{
+    ALT_LONG, ALT_MENU, ALT_OFFICIAL, ALT_SECONDARY, ALT_SHORT, ALT_VARIANT,
+};
 
 use icu::experimental::displaynames::provider::*;
 use icu_provider::prelude::*;
@@ -62,7 +65,7 @@ crate::displaynames::impl_displaynames_v1!(
     cldr_serde::displaynames::language::Resource,
     "languages.json",
     languages,
-    Some("short"),
+    Some(ALT_SHORT),
 );
 
 crate::displaynames::impl_displaynames_v1!(
@@ -71,7 +74,7 @@ crate::displaynames::impl_displaynames_v1!(
     cldr_serde::displaynames::language::Resource,
     "languages.json",
     languages,
-    Some("long"),
+    Some(ALT_LONG),
 );
 
 crate::displaynames::impl_displaynames_menu_v1!(
@@ -100,19 +103,19 @@ impl From<&cldr_serde::displaynames::language::Resource> for LanguageDisplayName
             let lang = langid.language;
 
             match key.alt_variant.as_deref() {
-                Some("short") => {
+                Some(ALT_SHORT) => {
                     short_names.insert(lang.to_tinystr(), value.as_ref());
                 }
-                Some("long") => {
+                Some(ALT_LONG) => {
                     long_names.insert(lang.to_tinystr(), value.as_ref());
                 }
-                Some("menu") => {
+                Some(ALT_MENU) => {
                     menu_names.insert(lang.to_tinystr(), value.as_ref());
                 }
                 None => {
                     names.insert(lang.to_tinystr(), value.as_ref());
                 }
-                Some("variant") | Some("secondary") | Some("official") => {
+                Some(ALT_VARIANT) | Some(ALT_SECONDARY) | Some(ALT_OFFICIAL) => {
                     // TODO(#8012): Handle preference-specific alt variants.
                 }
                 Some(alt) => {
@@ -172,13 +175,13 @@ impl From<&cldr_serde::displaynames::language::Resource> for LocaleDisplayNames<
             let pot_utf8 = PotentialUtf8::from_str(&locale_str);
 
             match key.alt_variant.as_deref() {
-                Some("short") => {
+                Some(ALT_SHORT) => {
                     short_names.insert(pot_utf8, val_str);
                 }
-                Some("long") => {
+                Some(ALT_LONG) => {
                     long_names.insert(pot_utf8, val_str);
                 }
-                Some("menu") => {
+                Some(ALT_MENU) => {
                     menu_names.insert(pot_utf8, val_str);
                 }
                 None => {

--- a/provider/source/src/displaynames/language.rs
+++ b/provider/source/src/displaynames/language.rs
@@ -7,7 +7,7 @@ use crate::SourceDataProvider;
 use crate::cldr_serde;
 use crate::cldr_serde::displaynames::WithAlt;
 use crate::displaynames::{
-    ALT_LONG, ALT_OFFICIAL, ALT_SECONDARY, ALT_SHORT, ALT_VARIANT, extract_names,
+    ALT_LONG, ALT_OFFICIAL, ALT_SECONDARY, ALT_SHORT, ALT_VARIANT, extract_names_for_zeromap_struct,
 };
 
 use icu::experimental::displaynames::provider::*;
@@ -87,7 +87,7 @@ crate::displaynames::impl_displaynames_menu_v1!(
 
 impl From<&cldr_serde::displaynames::language::Resource> for LanguageDisplayNames<'static> {
     fn from(other: &cldr_serde::displaynames::language::Resource) -> Self {
-        let extracted = extract_names(
+        let extracted = extract_names_for_zeromap_struct(
             &other.main.value.localedisplaynames.languages,
             &[ALT_VARIANT, ALT_SECONDARY, ALT_OFFICIAL],
             "language",
@@ -97,6 +97,7 @@ impl From<&cldr_serde::displaynames::language::Resource> for LanguageDisplayName
                     None
                 } else {
                     let lang = langid.language;
+                    // Old CLDR versions may contain trivial entries, so filter
                     if lang.as_str() == val {
                         None
                     } else {
@@ -123,7 +124,7 @@ impl From<&cldr_serde::displaynames::language::Resource> for LanguageDisplayName
 
 impl From<&cldr_serde::displaynames::language::Resource> for LocaleDisplayNames<'static> {
     fn from(other: &cldr_serde::displaynames::language::Resource) -> Self {
-        let extracted = extract_names(
+        let extracted = extract_names_for_zeromap_struct(
             &other.main.value.localedisplaynames.languages,
             &[ALT_VARIANT, ALT_SECONDARY, ALT_OFFICIAL],
             "language",
@@ -133,6 +134,7 @@ impl From<&cldr_serde::displaynames::language::Resource> for LocaleDisplayNames<
                     None
                 } else {
                     let locale_str = langid.to_string();
+                    // Old CLDR versions may contain trivial entries, so filter
                     if locale_str == val {
                         None
                     } else {

--- a/provider/source/src/displaynames/language.rs
+++ b/provider/source/src/displaynames/language.rs
@@ -5,17 +5,12 @@
 use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
-use crate::displaynames::{
-    ALT_LONG_SUBSTRING, ALT_MENU_SUBSTRING, ALT_OFFICIAL_SUBSTRING, ALT_SECONDARY_SUBSTRING,
-    ALT_SHORT_SUBSTRING, ALT_SUBSTRING, ALT_VARIANT_SUBSTRING,
-};
 
 use icu::experimental::displaynames::provider::*;
-use icu::locale::subtags::Language;
 use icu_provider::prelude::*;
 use potential_utf::PotentialUtf8;
 use std::collections::{BTreeMap, HashSet};
-use zerovec::VarZeroCow;
+use zerovec::{VarZeroCow, ZeroMap};
 
 impl DataProvider<LanguageDisplayNamesV1> for SourceDataProvider {
     fn load(&self, req: DataRequest) -> Result<DataResponse<LanguageDisplayNamesV1>, DataError> {
@@ -53,6 +48,7 @@ crate::displaynames::impl_displaynames_legacy_iter_v1!(LocaleDisplayNamesV1, "la
 
 crate::displaynames::impl_displaynames_v1!(
     LocaleNamesLanguageMediumV1,
+    icu::locale::LanguageIdentifier,
     cldr_serde::displaynames::language::Resource,
     "languages.json",
     languages,
@@ -61,22 +57,25 @@ crate::displaynames::impl_displaynames_v1!(
 
 crate::displaynames::impl_displaynames_v1!(
     LocaleNamesLanguageShortV1,
+    icu::locale::LanguageIdentifier,
     cldr_serde::displaynames::language::Resource,
     "languages.json",
     languages,
-    Some(ALT_SHORT_SUBSTRING),
+    Some("short"),
 );
 
 crate::displaynames::impl_displaynames_v1!(
     LocaleNamesLanguageLongV1,
+    icu::locale::LanguageIdentifier,
     cldr_serde::displaynames::language::Resource,
     "languages.json",
     languages,
-    Some(ALT_LONG_SUBSTRING),
+    Some("long"),
 );
 
 crate::displaynames::impl_displaynames_menu_v1!(
     LocaleNamesLanguageMenuMediumV1,
+    icu::locale::LanguageIdentifier,
     cldr_serde::displaynames::language::Resource,
     "languages.json",
     languages,
@@ -89,27 +88,35 @@ impl From<&cldr_serde::displaynames::language::Resource> for LanguageDisplayName
         let mut long_names = BTreeMap::new();
         let mut menu_names = BTreeMap::new();
         for (key, value) in other.main.value.localedisplaynames.languages.iter() {
-            if let Some(lang) = key.strip_suffix(ALT_SHORT_SUBSTRING) {
-                if let Ok(lang) = lang.parse::<Language>() {
+            if key.menu_variant.is_some() {
+                continue;
+            }
+
+            let langid = &key.subtag;
+            if langid.script.is_some() || langid.region.is_some() || !langid.variants.is_empty() {
+                continue;
+            }
+            let lang = langid.language;
+
+            match key.alt_variant.as_deref() {
+                Some("short") => {
                     short_names.insert(lang.to_tinystr(), value.as_ref());
                 }
-            } else if let Some(lang) = key.strip_suffix(ALT_LONG_SUBSTRING) {
-                if let Ok(lang) = lang.parse::<Language>() {
+                Some("long") => {
                     long_names.insert(lang.to_tinystr(), value.as_ref());
                 }
-            } else if let Some(lang) = key.strip_suffix(ALT_MENU_SUBSTRING) {
-                if let Ok(lang) = lang.parse::<Language>() {
+                Some("menu") => {
                     menu_names.insert(lang.to_tinystr(), value.as_ref());
                 }
-            } else if let Ok(lang) = key.parse::<Language>() {
-                names.insert(lang.to_tinystr(), value.as_ref());
-            } else if key.ends_with(ALT_VARIANT_SUBSTRING)
-                || key.ends_with(ALT_SECONDARY_SUBSTRING)
-                || key.ends_with(ALT_OFFICIAL_SUBSTRING)
-            {
-                // TODO(#8012): Handle preference-specific alt variants.
-            } else if key.contains(ALT_SUBSTRING) {
-                log::warn!("Unknown alt variant for language: {}", key);
+                None => {
+                    names.insert(lang.to_tinystr(), value.as_ref());
+                }
+                Some("variant") | Some("secondary") | Some("official") => {
+                    // TODO(#8012): Handle preference-specific alt variants.
+                }
+                Some(alt) => {
+                    log::warn!("Unknown alt variant for language: {}", alt);
+                }
             }
         }
         Self {
@@ -140,59 +147,52 @@ impl From<&cldr_serde::displaynames::language::Resource> for LanguageDisplayName
 
 impl From<&cldr_serde::displaynames::language::Resource> for LocaleDisplayNames<'static> {
     fn from(other: &cldr_serde::displaynames::language::Resource) -> Self {
-        let mut names = BTreeMap::new();
-        let mut short_names = BTreeMap::new();
-        let mut long_names = BTreeMap::new();
-        let mut menu_names = BTreeMap::new();
+        let mut names = ZeroMap::new();
+        let mut short_names = ZeroMap::new();
+        let mut long_names = ZeroMap::new();
+        let mut menu_names = ZeroMap::new();
         for (key, value) in other.main.value.localedisplaynames.languages.iter() {
-            if key.contains("-menu-") {
-                // TODO: handle -menu-core and -menu-extension
+            if key.menu_variant.is_some() {
                 continue;
             }
-            #[expect(clippy::collapsible_if)] // consistency
-            if let Some(locale) = key.strip_suffix(ALT_SHORT_SUBSTRING) {
-                if locale.contains('-') {
-                    short_names.insert(locale, value.as_ref());
+
+            let langid = &key.subtag;
+            if langid.script.is_none() && langid.region.is_none() && langid.variants.is_empty() {
+                continue;
+            }
+
+            let locale_str = langid.to_string();
+            let val_str = value.as_str();
+            if locale_str == val_str {
+                continue;
+            }
+
+            let pot_utf8 = PotentialUtf8::from_str(&locale_str);
+
+            match key.alt_variant.as_deref() {
+                Some("short") => {
+                    short_names.insert(pot_utf8, val_str);
                 }
-            } else if let Some(locale) = key.strip_suffix(ALT_LONG_SUBSTRING) {
-                if locale.contains('-') {
-                    long_names.insert(locale, value.as_ref());
+                Some("long") => {
+                    long_names.insert(pot_utf8, val_str);
                 }
-            } else if let Some(locale) = key.strip_suffix(ALT_MENU_SUBSTRING) {
-                if locale.contains('-') {
-                    menu_names.insert(locale, value.as_ref());
+                Some("menu") => {
+                    menu_names.insert(pot_utf8, val_str);
                 }
-            } else if !key.contains(ALT_SUBSTRING) {
-                if key.contains('-') {
-                    names.insert(key, value.as_ref());
+                None => {
+                    names.insert(pot_utf8, val_str);
                 }
+                _ => {}
             }
         }
         Self {
-            names: names
-                .into_iter()
-                .filter(|&(k, v)| k != v)
-                .map(|(k, v)| (PotentialUtf8::from_str(k), v))
-                .collect(),
-            short_names: short_names
-                .into_iter()
-                .filter(|&(k, v)| k != v)
-                .map(|(k, v)| (PotentialUtf8::from_str(k), v))
-                .collect(),
-            long_names: long_names
-                .into_iter()
-                .filter(|&(k, v)| k != v)
-                .map(|(k, v)| (PotentialUtf8::from_str(k), v))
-                .collect(),
-            menu_names: menu_names
-                .into_iter()
-                .filter(|&(k, v)| k != v)
-                .map(|(k, v)| (PotentialUtf8::from_str(k), v))
-                .collect(),
+            names,
+            short_names,
+            long_names,
+            menu_names,
         }
     }
 }
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/provider/source/src/displaynames/language.rs
+++ b/provider/source/src/displaynames/language.rs
@@ -85,15 +85,17 @@ crate::displaynames::impl_displaynames_menu_v1!(
     languages,
 );
 
-fn extract_names<K, F>(
-    resource: &cldr_serde::displaynames::language::Resource,
+struct ExtractedNames<'a, K> {
+    names: BTreeMap<K, &'a str>,
+    short_names: BTreeMap<K, &'a str>,
+    long_names: BTreeMap<K, &'a str>,
+    menu_names: BTreeMap<K, &'a str>,
+}
+
+fn extract_names<'a, K, F>(
+    resource: &'a cldr_serde::displaynames::language::Resource,
     filter_project: F,
-) -> (
-    BTreeMap<K, &str>,
-    BTreeMap<K, &str>,
-    BTreeMap<K, &str>,
-    BTreeMap<K, &str>,
-)
+) -> ExtractedNames<'a, K>
 where
     K: Ord,
     F: Fn(&icu::locale::LanguageIdentifier, &str) -> Option<K>,
@@ -130,12 +132,17 @@ where
             }
         }
     }
-    (names, short_names, long_names, menu_names)
+    ExtractedNames {
+        names,
+        short_names,
+        long_names,
+        menu_names,
+    }
 }
 
 impl From<&cldr_serde::displaynames::language::Resource> for LanguageDisplayNames<'static> {
     fn from(other: &cldr_serde::displaynames::language::Resource) -> Self {
-        let (names, short_names, long_names, menu_names) = extract_names(other, |langid, val| {
+        let extracted = extract_names(other, |langid, val| {
             if langid.script.is_some() || langid.region.is_some() || !langid.variants.is_empty() {
                 None
             } else {
@@ -155,17 +162,17 @@ impl From<&cldr_serde::displaynames::language::Resource> for LanguageDisplayName
         };
 
         Self {
-            names: to_zero_map(names),
-            short_names: to_zero_map(short_names),
-            long_names: to_zero_map(long_names),
-            menu_names: to_zero_map(menu_names),
+            names: to_zero_map(extracted.names),
+            short_names: to_zero_map(extracted.short_names),
+            long_names: to_zero_map(extracted.long_names),
+            menu_names: to_zero_map(extracted.menu_names),
         }
     }
 }
 
 impl From<&cldr_serde::displaynames::language::Resource> for LocaleDisplayNames<'static> {
     fn from(other: &cldr_serde::displaynames::language::Resource) -> Self {
-        let (names, short_names, long_names, menu_names) = extract_names(other, |langid, val| {
+        let extracted = extract_names(other, |langid, val| {
             if langid.script.is_none() && langid.region.is_none() && langid.variants.is_empty() {
                 None
             } else {
@@ -187,10 +194,10 @@ impl From<&cldr_serde::displaynames::language::Resource> for LocaleDisplayNames<
         };
 
         Self {
-            names: to_zero_map(names),
-            short_names: to_zero_map(short_names),
-            long_names: to_zero_map(long_names),
-            menu_names: to_zero_map(menu_names),
+            names: to_zero_map(extracted.names),
+            short_names: to_zero_map(extracted.short_names),
+            long_names: to_zero_map(extracted.long_names),
+            menu_names: to_zero_map(extracted.menu_names),
         }
     }
 }

--- a/provider/source/src/displaynames/language.rs
+++ b/provider/source/src/displaynames/language.rs
@@ -7,7 +7,7 @@ use crate::SourceDataProvider;
 use crate::cldr_serde;
 use crate::cldr_serde::displaynames::WithAlt;
 use crate::displaynames::{
-    ALT_LONG, ALT_MENU, ALT_OFFICIAL, ALT_SECONDARY, ALT_SHORT, ALT_VARIANT,
+    extract_names, ALT_LONG, ALT_OFFICIAL, ALT_SECONDARY, ALT_SHORT, ALT_VARIANT,
 };
 
 use icu::experimental::displaynames::provider::*;
@@ -85,75 +85,26 @@ crate::displaynames::impl_displaynames_menu_v1!(
     languages,
 );
 
-struct ExtractedNames<'a, K> {
-    names: BTreeMap<K, &'a str>,
-    short_names: BTreeMap<K, &'a str>,
-    long_names: BTreeMap<K, &'a str>,
-    menu_names: BTreeMap<K, &'a str>,
-}
-
-fn extract_names<'a, K, F>(
-    resource: &'a cldr_serde::displaynames::language::Resource,
-    filter_project: F,
-) -> ExtractedNames<'a, K>
-where
-    K: Ord,
-    F: Fn(&icu::locale::LanguageIdentifier, &str) -> Option<K>,
-{
-    let mut names = BTreeMap::new();
-    let mut short_names = BTreeMap::new();
-    let mut long_names = BTreeMap::new();
-    let mut menu_names = BTreeMap::new();
-    for (key, value) in resource.main.value.localedisplaynames.languages.iter() {
-        if key.menu.is_some() {
-            continue;
-        }
-        let val_str = value.as_str();
-        if let Some(k) = filter_project(&key.subtag, val_str) {
-            match key.alt.as_deref() {
-                Some(ALT_SHORT) => {
-                    short_names.insert(k, val_str);
-                }
-                Some(ALT_LONG) => {
-                    long_names.insert(k, val_str);
-                }
-                Some(ALT_MENU) => {
-                    menu_names.insert(k, val_str);
-                }
-                None => {
-                    names.insert(k, val_str);
-                }
-                Some(ALT_VARIANT) | Some(ALT_SECONDARY) | Some(ALT_OFFICIAL) => {
-                    // TODO(#8012): Handle preference-specific alt variants.
-                }
-                Some(alt) => {
-                    log::warn!("Unknown alt variant for language: {}", alt);
-                }
-            }
-        }
-    }
-    ExtractedNames {
-        names,
-        short_names,
-        long_names,
-        menu_names,
-    }
-}
-
 impl From<&cldr_serde::displaynames::language::Resource> for LanguageDisplayNames<'static> {
     fn from(other: &cldr_serde::displaynames::language::Resource) -> Self {
-        let extracted = extract_names(other, |langid, val| {
-            if langid.script.is_some() || langid.region.is_some() || !langid.variants.is_empty() {
-                None
-            } else {
-                let lang = langid.language;
-                if lang.as_str() == val {
+        let extracted = extract_names(
+            &other.main.value.localedisplaynames.languages,
+            &[ALT_VARIANT, ALT_SECONDARY, ALT_OFFICIAL],
+            "language",
+            |langid, val| {
+                if langid.script.is_some() || langid.region.is_some() || !langid.variants.is_empty()
+                {
                     None
                 } else {
-                    Some(lang)
+                    let lang = langid.language;
+                    if lang.as_str() == val {
+                        None
+                    } else {
+                        Some(lang)
+                    }
                 }
-            }
-        });
+            },
+        );
 
         let to_zero_map = |map: BTreeMap<icu::locale::subtags::Language, &str>| {
             map.into_iter()
@@ -172,18 +123,24 @@ impl From<&cldr_serde::displaynames::language::Resource> for LanguageDisplayName
 
 impl From<&cldr_serde::displaynames::language::Resource> for LocaleDisplayNames<'static> {
     fn from(other: &cldr_serde::displaynames::language::Resource) -> Self {
-        let extracted = extract_names(other, |langid, val| {
-            if langid.script.is_none() && langid.region.is_none() && langid.variants.is_empty() {
-                None
-            } else {
-                let locale_str = langid.to_string();
-                if locale_str == val {
+        let extracted = extract_names(
+            &other.main.value.localedisplaynames.languages,
+            &[ALT_VARIANT, ALT_SECONDARY, ALT_OFFICIAL],
+            "language",
+            |langid, val| {
+                if langid.script.is_none() && langid.region.is_none() && langid.variants.is_empty()
+                {
                     None
                 } else {
-                    Some(locale_str)
+                    let locale_str = langid.to_string();
+                    if locale_str == val {
+                        None
+                    } else {
+                        Some(locale_str)
+                    }
                 }
-            }
-        });
+            },
+        );
 
         let to_zero_map = |map: BTreeMap<String, &str>| {
             let mut zero_map = ZeroMap::new();

--- a/provider/source/src/displaynames/language.rs
+++ b/provider/source/src/displaynames/language.rs
@@ -7,7 +7,7 @@ use crate::SourceDataProvider;
 use crate::cldr_serde;
 use crate::cldr_serde::displaynames::WithAlt;
 use crate::displaynames::{
-    extract_names, ALT_LONG, ALT_OFFICIAL, ALT_SECONDARY, ALT_SHORT, ALT_VARIANT,
+    ALT_LONG, ALT_OFFICIAL, ALT_SECONDARY, ALT_SHORT, ALT_VARIANT, extract_names,
 };
 
 use icu::experimental::displaynames::provider::*;

--- a/provider/source/src/displaynames/language.rs
+++ b/provider/source/src/displaynames/language.rs
@@ -85,35 +85,41 @@ crate::displaynames::impl_displaynames_menu_v1!(
     languages,
 );
 
-impl From<&cldr_serde::displaynames::language::Resource> for LanguageDisplayNames<'static> {
-    fn from(other: &cldr_serde::displaynames::language::Resource) -> Self {
-        let mut names = BTreeMap::new();
-        let mut short_names = BTreeMap::new();
-        let mut long_names = BTreeMap::new();
-        let mut menu_names = BTreeMap::new();
-        for (key, value) in other.main.value.localedisplaynames.languages.iter() {
-            if key.menu.is_some() {
-                continue;
-            }
-
-            let langid = &key.subtag;
-            if langid.script.is_some() || langid.region.is_some() || !langid.variants.is_empty() {
-                continue;
-            }
-            let lang = langid.language;
-
+fn extract_names<K, F>(
+    resource: &cldr_serde::displaynames::language::Resource,
+    filter_project: F,
+) -> (
+    BTreeMap<K, &str>,
+    BTreeMap<K, &str>,
+    BTreeMap<K, &str>,
+    BTreeMap<K, &str>,
+)
+where
+    K: Ord,
+    F: Fn(&icu::locale::LanguageIdentifier, &str) -> Option<K>,
+{
+    let mut names = BTreeMap::new();
+    let mut short_names = BTreeMap::new();
+    let mut long_names = BTreeMap::new();
+    let mut menu_names = BTreeMap::new();
+    for (key, value) in resource.main.value.localedisplaynames.languages.iter() {
+        if key.menu.is_some() {
+            continue;
+        }
+        let val_str = value.as_str();
+        if let Some(k) = filter_project(&key.subtag, val_str) {
             match key.alt.as_deref() {
                 Some(ALT_SHORT) => {
-                    short_names.insert(lang, value.as_ref());
+                    short_names.insert(k, val_str);
                 }
                 Some(ALT_LONG) => {
-                    long_names.insert(lang, value.as_ref());
+                    long_names.insert(k, val_str);
                 }
                 Some(ALT_MENU) => {
-                    menu_names.insert(lang, value.as_ref());
+                    menu_names.insert(k, val_str);
                 }
                 None => {
-                    names.insert(lang, value.as_ref());
+                    names.insert(k, val_str);
                 }
                 Some(ALT_VARIANT) | Some(ALT_SECONDARY) | Some(ALT_OFFICIAL) => {
                     // TODO(#8012): Handle preference-specific alt variants.
@@ -123,72 +129,54 @@ impl From<&cldr_serde::displaynames::language::Resource> for LanguageDisplayName
                 }
             }
         }
+    }
+    (names, short_names, long_names, menu_names)
+}
+
+impl From<&cldr_serde::displaynames::language::Resource> for LanguageDisplayNames<'static> {
+    fn from(other: &cldr_serde::displaynames::language::Resource) -> Self {
+        let (names, short_names, long_names, menu_names) = extract_names(other, |langid, val| {
+            if langid.script.is_some() || langid.region.is_some() || !langid.variants.is_empty() {
+                None
+            } else {
+                let lang = langid.language;
+                if lang.as_str() == val {
+                    None
+                } else {
+                    Some(lang)
+                }
+            }
+        });
+
+        let to_zero_map = |map: BTreeMap<icu::locale::subtags::Language, &str>| {
+            map.into_iter()
+                .map(|(k, v)| (k.to_tinystr().to_unvalidated(), v))
+                .collect()
+        };
+
         Self {
-            // Old CLDR versions may contain trivial entries, so filter
-            names: names
-                .into_iter()
-                .filter(|&(k, v)| k.as_str() != v)
-                .map(|(k, v)| (k.to_tinystr().to_unvalidated(), v))
-                .collect(),
-            short_names: short_names
-                .into_iter()
-                .filter(|&(k, v)| k.as_str() != v)
-                .map(|(k, v)| (k.to_tinystr().to_unvalidated(), v))
-                .collect(),
-            long_names: long_names
-                .into_iter()
-                .filter(|&(k, v)| k.as_str() != v)
-                .map(|(k, v)| (k.to_tinystr().to_unvalidated(), v))
-                .collect(),
-            menu_names: menu_names
-                .into_iter()
-                .filter(|&(k, v)| k.as_str() != v)
-                .map(|(k, v)| (k.to_tinystr().to_unvalidated(), v))
-                .collect(),
+            names: to_zero_map(names),
+            short_names: to_zero_map(short_names),
+            long_names: to_zero_map(long_names),
+            menu_names: to_zero_map(menu_names),
         }
     }
 }
 
 impl From<&cldr_serde::displaynames::language::Resource> for LocaleDisplayNames<'static> {
     fn from(other: &cldr_serde::displaynames::language::Resource) -> Self {
-        let mut names = BTreeMap::new();
-        let mut short_names = BTreeMap::new();
-        let mut long_names = BTreeMap::new();
-        let mut menu_names = BTreeMap::new();
-        for (key, value) in other.main.value.localedisplaynames.languages.iter() {
-            if key.menu.is_some() {
-                // Note: we don't handle -menu-core and -menu-extension here,
-                // but we handle them in the new LocaleNames markers.
-                continue;
-            }
-
-            let langid = &key.subtag;
+        let (names, short_names, long_names, menu_names) = extract_names(other, |langid, val| {
             if langid.script.is_none() && langid.region.is_none() && langid.variants.is_empty() {
-                continue;
+                None
+            } else {
+                let locale_str = langid.to_string();
+                if locale_str == val {
+                    None
+                } else {
+                    Some(locale_str)
+                }
             }
-
-            let locale_str = langid.to_string();
-            let val_str = value.as_str();
-            if locale_str == val_str {
-                continue;
-            }
-
-            match key.alt.as_deref() {
-                Some(ALT_SHORT) => {
-                    short_names.insert(locale_str, val_str);
-                }
-                Some(ALT_LONG) => {
-                    long_names.insert(locale_str, val_str);
-                }
-                Some(ALT_MENU) => {
-                    menu_names.insert(locale_str, val_str);
-                }
-                None => {
-                    names.insert(locale_str, val_str);
-                }
-                _ => {}
-            }
-        }
+        });
 
         let to_zero_map = |map: BTreeMap<String, &str>| {
             let mut zero_map = ZeroMap::new();

--- a/provider/source/src/displaynames/language.rs
+++ b/provider/source/src/displaynames/language.rs
@@ -5,7 +5,7 @@
 use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
-use crate::cldr_serde::displaynames::ModifiedSubtag;
+use crate::cldr_serde::displaynames::WithAlt;
 use crate::displaynames::{
     ALT_LONG, ALT_MENU, ALT_OFFICIAL, ALT_SECONDARY, ALT_SHORT, ALT_VARIANT,
 };
@@ -92,7 +92,7 @@ impl From<&cldr_serde::displaynames::language::Resource> for LanguageDisplayName
         let mut long_names = BTreeMap::new();
         let mut menu_names = BTreeMap::new();
         for (key, value) in other.main.value.localedisplaynames.languages.iter() {
-            if key.menu_variant.is_some() {
+            if key.menu.is_some() {
                 continue;
             }
 
@@ -102,18 +102,18 @@ impl From<&cldr_serde::displaynames::language::Resource> for LanguageDisplayName
             }
             let lang = langid.language;
 
-            match key.alt_variant.as_deref() {
+            match key.alt.as_deref() {
                 Some(ALT_SHORT) => {
-                    short_names.insert(lang.to_tinystr(), value.as_ref());
+                    short_names.insert(lang, value.as_ref());
                 }
                 Some(ALT_LONG) => {
-                    long_names.insert(lang.to_tinystr(), value.as_ref());
+                    long_names.insert(lang, value.as_ref());
                 }
                 Some(ALT_MENU) => {
-                    menu_names.insert(lang.to_tinystr(), value.as_ref());
+                    menu_names.insert(lang, value.as_ref());
                 }
                 None => {
-                    names.insert(lang.to_tinystr(), value.as_ref());
+                    names.insert(lang, value.as_ref());
                 }
                 Some(ALT_VARIANT) | Some(ALT_SECONDARY) | Some(ALT_OFFICIAL) => {
                     // TODO(#8012): Handle preference-specific alt variants.
@@ -127,23 +127,23 @@ impl From<&cldr_serde::displaynames::language::Resource> for LanguageDisplayName
             // Old CLDR versions may contain trivial entries, so filter
             names: names
                 .into_iter()
-                .filter(|&(k, v)| k != v)
-                .map(|(k, v)| (k.to_unvalidated(), v))
+                .filter(|&(k, v)| k.as_str() != v)
+                .map(|(k, v)| (k.to_tinystr().to_unvalidated(), v))
                 .collect(),
             short_names: short_names
                 .into_iter()
-                .filter(|&(k, v)| k != v)
-                .map(|(k, v)| (k.to_unvalidated(), v))
+                .filter(|&(k, v)| k.as_str() != v)
+                .map(|(k, v)| (k.to_tinystr().to_unvalidated(), v))
                 .collect(),
             long_names: long_names
                 .into_iter()
-                .filter(|&(k, v)| k != v)
-                .map(|(k, v)| (k.to_unvalidated(), v))
+                .filter(|&(k, v)| k.as_str() != v)
+                .map(|(k, v)| (k.to_tinystr().to_unvalidated(), v))
                 .collect(),
             menu_names: menu_names
                 .into_iter()
-                .filter(|&(k, v)| k != v)
-                .map(|(k, v)| (k.to_unvalidated(), v))
+                .filter(|&(k, v)| k.as_str() != v)
+                .map(|(k, v)| (k.to_tinystr().to_unvalidated(), v))
                 .collect(),
         }
     }
@@ -151,12 +151,12 @@ impl From<&cldr_serde::displaynames::language::Resource> for LanguageDisplayName
 
 impl From<&cldr_serde::displaynames::language::Resource> for LocaleDisplayNames<'static> {
     fn from(other: &cldr_serde::displaynames::language::Resource) -> Self {
-        let mut names = ZeroMap::new();
-        let mut short_names = ZeroMap::new();
-        let mut long_names = ZeroMap::new();
-        let mut menu_names = ZeroMap::new();
+        let mut names = BTreeMap::new();
+        let mut short_names = BTreeMap::new();
+        let mut long_names = BTreeMap::new();
+        let mut menu_names = BTreeMap::new();
         for (key, value) in other.main.value.localedisplaynames.languages.iter() {
-            if key.menu_variant.is_some() {
+            if key.menu.is_some() {
                 // Note: we don't handle -menu-core and -menu-extension here,
                 // but we handle them in the new LocaleNames markers.
                 continue;
@@ -173,29 +173,36 @@ impl From<&cldr_serde::displaynames::language::Resource> for LocaleDisplayNames<
                 continue;
             }
 
-            let pot_utf8 = PotentialUtf8::from_str(&locale_str);
-
-            match key.alt_variant.as_deref() {
+            match key.alt.as_deref() {
                 Some(ALT_SHORT) => {
-                    short_names.insert(pot_utf8, val_str);
+                    short_names.insert(locale_str, val_str);
                 }
                 Some(ALT_LONG) => {
-                    long_names.insert(pot_utf8, val_str);
+                    long_names.insert(locale_str, val_str);
                 }
                 Some(ALT_MENU) => {
-                    menu_names.insert(pot_utf8, val_str);
+                    menu_names.insert(locale_str, val_str);
                 }
                 None => {
-                    names.insert(pot_utf8, val_str);
+                    names.insert(locale_str, val_str);
                 }
                 _ => {}
             }
         }
+
+        let to_zero_map = |map: BTreeMap<String, &str>| {
+            let mut zero_map = ZeroMap::new();
+            for (k, v) in map.into_iter() {
+                zero_map.insert(PotentialUtf8::from_str(&k), v);
+            }
+            zero_map
+        };
+
         Self {
-            names,
-            short_names,
-            long_names,
-            menu_names,
+            names: to_zero_map(names),
+            short_names: to_zero_map(short_names),
+            long_names: to_zero_map(long_names),
+            menu_names: to_zero_map(menu_names),
         }
     }
 }

--- a/provider/source/src/displaynames/language.rs
+++ b/provider/source/src/displaynames/language.rs
@@ -9,6 +9,7 @@ use crate::cldr_serde::displaynames::{Alt, WithAlt};
 use crate::displaynames::extract_names_for_zeromap_struct;
 
 use icu::experimental::displaynames::provider::*;
+use icu::locale::LanguageIdentifier;
 use icu_provider::prelude::*;
 use potential_utf::PotentialUtf8;
 use std::collections::{BTreeMap, HashSet};
@@ -51,7 +52,7 @@ crate::displaynames::impl_displaynames_legacy_iter_v1!(LocaleDisplayNamesV1, "la
 
 crate::displaynames::impl_displaynames_v1!(
     LocaleNamesLanguageMediumV1,
-    icu::locale::LanguageIdentifier,
+    LanguageIdentifier,
     cldr_serde::displaynames::language::Resource,
     "languages.json",
     languages,
@@ -60,7 +61,7 @@ crate::displaynames::impl_displaynames_v1!(
 
 crate::displaynames::impl_displaynames_v1!(
     LocaleNamesLanguageShortV1,
-    icu::locale::LanguageIdentifier,
+    LanguageIdentifier,
     cldr_serde::displaynames::language::Resource,
     "languages.json",
     languages,
@@ -69,7 +70,7 @@ crate::displaynames::impl_displaynames_v1!(
 
 crate::displaynames::impl_displaynames_v1!(
     LocaleNamesLanguageLongV1,
-    icu::locale::LanguageIdentifier,
+    LanguageIdentifier,
     cldr_serde::displaynames::language::Resource,
     "languages.json",
     languages,
@@ -78,7 +79,7 @@ crate::displaynames::impl_displaynames_v1!(
 
 crate::displaynames::impl_displaynames_menu_v1!(
     LocaleNamesLanguageMenuMediumV1,
-    icu::locale::LanguageIdentifier,
+    LanguageIdentifier,
     cldr_serde::displaynames::language::Resource,
     "languages.json",
     languages,

--- a/provider/source/src/displaynames/language.rs
+++ b/provider/source/src/displaynames/language.rs
@@ -5,6 +5,7 @@
 use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
+use crate::cldr_serde::displaynames::ModifiedSubtag;
 
 use icu::experimental::displaynames::provider::*;
 use icu_provider::prelude::*;
@@ -153,6 +154,7 @@ impl From<&cldr_serde::displaynames::language::Resource> for LocaleDisplayNames<
         let mut menu_names = ZeroMap::new();
         for (key, value) in other.main.value.localedisplaynames.languages.iter() {
             if key.menu_variant.is_some() {
+                // Skip menu keys as they are handled by the menu provider
                 continue;
             }
 

--- a/provider/source/src/displaynames/language.rs
+++ b/provider/source/src/displaynames/language.rs
@@ -157,7 +157,8 @@ impl From<&cldr_serde::displaynames::language::Resource> for LocaleDisplayNames<
         let mut menu_names = ZeroMap::new();
         for (key, value) in other.main.value.localedisplaynames.languages.iter() {
             if key.menu_variant.is_some() {
-                // Skip menu keys as they are handled by the menu provider
+                // Note: we don't handle -menu-core and -menu-extension here,
+                // but we handle them in the new LocaleNames markers.
                 continue;
             }
 

--- a/provider/source/src/displaynames/language.rs
+++ b/provider/source/src/displaynames/language.rs
@@ -93,6 +93,7 @@ impl From<&cldr_serde::displaynames::language::Resource> for LanguageDisplayName
             &[ALT_VARIANT, ALT_SECONDARY, ALT_OFFICIAL],
             "language",
             |langid| {
+                // LanguageDisplayNames contains display names for language subtags without other subtags
                 if langid.script.is_some() || langid.region.is_some() || !langid.variants.is_empty()
                 {
                     None
@@ -124,6 +125,8 @@ impl From<&cldr_serde::displaynames::language::Resource> for LocaleDisplayNames<
             &[ALT_VARIANT, ALT_SECONDARY, ALT_OFFICIAL],
             "language",
             |langid| {
+                // LocaleDisplayNames contains display names for languages with other subtags,
+                // not duplicating the display names found in LanguageDisplayNames
                 if langid.script.is_none() && langid.region.is_none() && langid.variants.is_empty()
                 {
                     None

--- a/provider/source/src/displaynames/mod.rs
+++ b/provider/source/src/displaynames/mod.rs
@@ -22,6 +22,7 @@ pub(crate) const ALT_SECONDARY: &str = "secondary";
 pub(crate) const ALT_BIOT: &str = "biot";
 /// Alternate name for territory code `IO` (British Indian Ocean Territory) mapping to "Chagos Archipelago".
 pub(crate) const ALT_CHAGOS: &str = "chagos";
+// ALT_MENU is being replaced by menu=core|extension, but it is still in CLDR
 pub(crate) const ALT_MENU: &str = "menu";
 
 pub(crate) const MENU_CORE: &str = "core";
@@ -34,7 +35,12 @@ pub(crate) struct ExtractedNames<'a, K> {
     pub(crate) menu_names: BTreeMap<K, &'a str>,
 }
 
-pub(crate) fn extract_names<'a, T, K, F>(
+/// Process locale display names from a cldr_serde struct to BTreeMaps
+/// ready to be converted to ZeroMaps.
+///
+/// This fn is used by the zeromap-based structs, not the LocaleNames
+/// attributes-based structs.
+pub(crate) fn extract_names_for_zeromap_struct<'a, T, K, F>(
     map: &'a HashMap<WithAlt<T>, String>,
     ignored_alts: &[&str],
     log_context: &str,
@@ -50,6 +56,8 @@ where
     let mut menu_names = BTreeMap::new();
     for (key, value) in map.iter() {
         if key.menu.is_some() {
+            // Menu core|extension is handled in LocaleNamesLanguageMenu,
+            // and not in the zeromap-based struct.
             continue;
         }
         let val_str = value.as_str();
@@ -69,7 +77,9 @@ where
                 }
                 Some(alt) => {
                     if ignored_alts.contains(&alt) {
-                        // TODO(#8012): Handle preference-specific alt variants.
+                        // TODO(#8012): Handle preference-specific alt variants,
+                        //   perhaps with datagen alt flags.
+                        // TODO(#8011): Support standalone display names.
                     } else {
                         log::warn!("Unknown alt variant for {}: {}", log_context, alt);
                     }

--- a/provider/source/src/displaynames/mod.rs
+++ b/provider/source/src/displaynames/mod.rs
@@ -53,10 +53,10 @@ macro_rules! impl_displaynames_v1 {
                             DataError::custom("failed to parse subtag").with_req($marker::INFO, req)
                         })?;
 
-                let key = ModifiedSubtag {
+                let key = WithAlt {
                     subtag,
-                    alt_variant: $alt_variant.map(String::from),
-                    menu_variant: None,
+                    alt: $alt_variant.map(String::from),
+                    menu: None,
                 };
 
                 let name = data
@@ -112,19 +112,19 @@ macro_rules! impl_displaynames_menu_v1 {
                             DataError::custom("failed to parse subtag").with_req($marker::INFO, req)
                         })?;
 
-                let key_core = ModifiedSubtag {
+                let key_core = WithAlt {
                     subtag: subtag.clone(),
-                    alt_variant: None,
-                    menu_variant: Some($crate::displaynames::MENU_CORE.to_string()),
+                    alt: None,
+                    menu: Some($crate::displaynames::MENU_CORE.to_string()),
                 };
 
                 let map = &data.main.value.localedisplaynames.$field;
 
                 let (name_core, name_extension) = if let Some(core) = map.get(&key_core) {
-                    let key_extension = ModifiedSubtag {
+                    let key_extension = WithAlt {
                         subtag,
-                        alt_variant: None,
-                        menu_variant: Some($crate::displaynames::MENU_EXTENSION.to_string()),
+                        alt: None,
+                        menu: Some($crate::displaynames::MENU_EXTENSION.to_string()),
                     };
                     let extension = map.get(&key_extension).ok_or_else(|| {
                         DataError::custom("found menu-core but missing menu-extension")
@@ -133,10 +133,10 @@ macro_rules! impl_displaynames_menu_v1 {
                     (core.as_str(), extension.as_str())
                 } else {
                     // Fallback to alt-menu
-                    let key_alt_menu = ModifiedSubtag {
+                    let key_alt_menu = WithAlt {
                         subtag,
-                        alt_variant: Some($crate::displaynames::ALT_MENU.to_string()),
-                        menu_variant: None,
+                        alt: Some($crate::displaynames::ALT_MENU.to_string()),
+                        menu: None,
                     };
                     let alt_menu = map.get(&key_alt_menu).ok_or_else(|| {
                         DataError::custom("failed to find menu-core or alt-menu")
@@ -169,9 +169,8 @@ macro_rules! impl_displaynames_menu_v1 {
                 }) {
                     let data: &$resource = displaynames.read_and_parse(&locale, $file)?;
                     for key in data.main.value.localedisplaynames.$field.keys() {
-                        let matches = key.menu_variant.as_deref()
-                            == Some($crate::displaynames::MENU_CORE)
-                            || key.alt_variant.as_deref() == Some($crate::displaynames::ALT_MENU);
+                        let matches = key.menu.as_deref() == Some($crate::displaynames::MENU_CORE)
+                            || key.alt.as_deref() == Some($crate::displaynames::ALT_MENU);
 
                         if matches {
                             let data_identifier = DataIdentifierCow::from_owned(
@@ -217,11 +216,11 @@ macro_rules! impl_displaynames_iter_v1 {
                 }) {
                     let data: &$resource = displaynames.read_and_parse(&locale, $file)?;
                     for key in data.main.value.localedisplaynames.$field.keys() {
-                        let matches = match ($alt_variant, &key.alt_variant) {
+                        let matches = match ($alt_variant, &key.alt) {
                             (Some(expected), Some(actual)) => expected == actual,
                             (None, None) => true,
                             _ => false,
-                        } && key.menu_variant.is_none();
+                        } && key.menu.is_none();
 
                         if matches {
                             let data_identifier = DataIdentifierCow::from_owned(

--- a/provider/source/src/displaynames/mod.rs
+++ b/provider/source/src/displaynames/mod.rs
@@ -8,7 +8,6 @@ pub(crate) mod region;
 pub(crate) mod script;
 pub(crate) mod variant;
 
-
 pub(crate) const ALT_SHORT: &str = "short";
 pub(crate) const ALT_LONG: &str = "long";
 pub(crate) const ALT_VARIANT: &str = "variant";

--- a/provider/source/src/displaynames/mod.rs
+++ b/provider/source/src/displaynames/mod.rs
@@ -34,7 +34,7 @@ macro_rules! impl_displaynames_v1 {
                             DataError::custom("failed to parse subtag").with_req($marker::INFO, req)
                         })?;
 
-                let key = $crate::cldr_serde::displaynames::SubtagWithOptionalAltVariant {
+                let key = ModifiedSubtag {
                     subtag,
                     alt_variant: $alt_variant.map(String::from),
                     menu_variant: None,
@@ -93,17 +93,16 @@ macro_rules! impl_displaynames_menu_v1 {
                             DataError::custom("failed to parse subtag").with_req($marker::INFO, req)
                         })?;
 
-                let key_core = $crate::cldr_serde::displaynames::SubtagWithOptionalAltVariant {
+                let key_core = ModifiedSubtag {
                     subtag: subtag.clone(),
                     alt_variant: None,
                     menu_variant: Some("core".to_string()),
                 };
-                let key_extension =
-                    $crate::cldr_serde::displaynames::SubtagWithOptionalAltVariant {
-                        subtag: subtag.clone(),
-                        alt_variant: None,
-                        menu_variant: Some("extension".to_string()),
-                    };
+                let key_extension = ModifiedSubtag {
+                    subtag: subtag.clone(),
+                    alt_variant: None,
+                    menu_variant: Some("extension".to_string()),
+                };
 
                 let map = &data.main.value.localedisplaynames.$field;
 
@@ -115,12 +114,11 @@ macro_rules! impl_displaynames_menu_v1 {
                     (core.as_str(), extension.as_str())
                 } else {
                     // Fallback to alt-menu
-                    let key_alt_menu =
-                        $crate::cldr_serde::displaynames::SubtagWithOptionalAltVariant {
-                            subtag,
-                            alt_variant: Some("menu".to_string()),
-                            menu_variant: None,
-                        };
+                    let key_alt_menu = ModifiedSubtag {
+                        subtag,
+                        alt_variant: Some("menu".to_string()),
+                        menu_variant: None,
+                    };
                     let alt_menu = map.get(&key_alt_menu).ok_or_else(|| {
                         DataError::custom("failed to find menu-core or alt-menu")
                             .with_req($marker::INFO, req)

--- a/provider/source/src/displaynames/mod.rs
+++ b/provider/source/src/displaynames/mod.rs
@@ -8,8 +8,6 @@ pub(crate) mod region;
 pub(crate) mod script;
 pub(crate) mod variant;
 
-pub(crate) const ALT_SEPARATOR: &str = "-alt-";
-pub(crate) const MENU_SEPARATOR: &str = "-menu-";
 
 pub(crate) const ALT_SHORT: &str = "short";
 pub(crate) const ALT_LONG: &str = "long";

--- a/provider/source/src/displaynames/mod.rs
+++ b/provider/source/src/displaynames/mod.rs
@@ -8,6 +8,25 @@ pub(crate) mod region;
 pub(crate) mod script;
 pub(crate) mod variant;
 
+pub(crate) const ALT_SEPARATOR: &str = "-alt-";
+pub(crate) const MENU_SEPARATOR: &str = "-menu-";
+
+pub(crate) const ALT_SHORT: &str = "short";
+pub(crate) const ALT_LONG: &str = "long";
+pub(crate) const ALT_VARIANT: &str = "variant";
+pub(crate) const ALT_STANDALONE: &str = "stand-alone";
+pub(crate) const ALT_OFFICIAL: &str = "official";
+/// Secondary name variant, used in languages and scripts.
+pub(crate) const ALT_SECONDARY: &str = "secondary";
+/// Abbreviation for territory code `IO` (British Indian Ocean Territory).
+pub(crate) const ALT_BIOT: &str = "biot";
+/// Alternate name for territory code `IO` (British Indian Ocean Territory) mapping to "Chagos Archipelago".
+pub(crate) const ALT_CHAGOS: &str = "chagos";
+pub(crate) const ALT_MENU: &str = "menu";
+
+pub(crate) const MENU_CORE: &str = "core";
+pub(crate) const MENU_EXTENSION: &str = "extension";
+
 /// Macro for implementing a single-name display names data provider.
 ///
 /// Parameters:
@@ -96,12 +115,12 @@ macro_rules! impl_displaynames_menu_v1 {
                 let key_core = ModifiedSubtag {
                     subtag: subtag.clone(),
                     alt_variant: None,
-                    menu_variant: Some("core".to_string()),
+                    menu_variant: Some($crate::displaynames::MENU_CORE.to_string()),
                 };
                 let key_extension = ModifiedSubtag {
                     subtag: subtag.clone(),
                     alt_variant: None,
-                    menu_variant: Some("extension".to_string()),
+                    menu_variant: Some($crate::displaynames::MENU_EXTENSION.to_string()),
                 };
 
                 let map = &data.main.value.localedisplaynames.$field;
@@ -116,7 +135,7 @@ macro_rules! impl_displaynames_menu_v1 {
                     // Fallback to alt-menu
                     let key_alt_menu = ModifiedSubtag {
                         subtag,
-                        alt_variant: Some("menu".to_string()),
+                        alt_variant: Some($crate::displaynames::ALT_MENU.to_string()),
                         menu_variant: None,
                     };
                     let alt_menu = map.get(&key_alt_menu).ok_or_else(|| {
@@ -141,6 +160,7 @@ macro_rules! impl_displaynames_menu_v1 {
                 let mut result = HashSet::new();
                 let displaynames = self.cldr()?.displaynames();
                 for locale in displaynames.list_locales()?.filter(|locale| {
+                    // The directory might exist without the file
                     self.cldr()
                         .unwrap()
                         .displaynames()
@@ -149,8 +169,9 @@ macro_rules! impl_displaynames_menu_v1 {
                 }) {
                     let data: &$resource = displaynames.read_and_parse(&locale, $file)?;
                     for key in data.main.value.localedisplaynames.$field.keys() {
-                        let matches = key.menu_variant.as_deref() == Some("core")
-                            || key.alt_variant.as_deref() == Some("menu");
+                        let matches = key.menu_variant.as_deref()
+                            == Some($crate::displaynames::MENU_CORE)
+                            || key.alt_variant.as_deref() == Some($crate::displaynames::ALT_MENU);
 
                         if matches {
                             let attr_str = key.subtag.to_string();
@@ -189,6 +210,7 @@ macro_rules! impl_displaynames_iter_v1 {
                 let mut result = HashSet::new();
                 let displaynames = self.cldr()?.displaynames();
                 for locale in displaynames.list_locales()?.filter(|locale| {
+                    // The directory might exist without the file
                     self.cldr()
                         .unwrap()
                         .displaynames()

--- a/provider/source/src/displaynames/mod.rs
+++ b/provider/source/src/displaynames/mod.rs
@@ -122,7 +122,7 @@ macro_rules! impl_displaynames_menu_v1 {
 
                 let (name_core, name_extension) = if let Some(core) = map.get(&key_core) {
                     let key_extension = ModifiedSubtag {
-                        subtag, // Consume subtag
+                        subtag,
                         alt_variant: None,
                         menu_variant: Some($crate::displaynames::MENU_EXTENSION.to_string()),
                     };
@@ -134,7 +134,7 @@ macro_rules! impl_displaynames_menu_v1 {
                 } else {
                     // Fallback to alt-menu
                     let key_alt_menu = ModifiedSubtag {
-                        subtag, // Consume subtag
+                        subtag,
                         alt_variant: Some($crate::displaynames::ALT_MENU.to_string()),
                         menu_variant: None,
                     };

--- a/provider/source/src/displaynames/mod.rs
+++ b/provider/source/src/displaynames/mod.rs
@@ -35,10 +35,10 @@ pub(crate) struct ExtractedNames<'a, K> {
     pub(crate) menu_names: BTreeMap<K, &'a str>,
 }
 
-/// Process locale display names from a cldr_serde struct to BTreeMaps
-/// ready to be converted to ZeroMaps.
+/// Process locale display names from a `cldr_serde` struct to `BTreeMaps`
+/// ready to be converted to `ZeroMaps`.
 ///
-/// This fn is used by the zeromap-based structs, not the LocaleNames
+/// This fn is used by the zeromap-based structs, not the `LocaleNames`
 /// attributes-based structs.
 pub(crate) fn extract_names_for_zeromap_struct<'a, T, K, F>(
     map: &'a HashMap<WithAlt<T>, String>,

--- a/provider/source/src/displaynames/mod.rs
+++ b/provider/source/src/displaynames/mod.rs
@@ -8,25 +8,8 @@ pub(crate) mod region;
 pub(crate) mod script;
 pub(crate) mod variant;
 
-use crate::cldr_serde::displaynames::WithAlt;
+use crate::cldr_serde::displaynames::{Alt, WithAlt};
 use std::collections::{BTreeMap, HashMap};
-
-pub(crate) const ALT_SHORT: &str = "short";
-pub(crate) const ALT_LONG: &str = "long";
-pub(crate) const ALT_VARIANT: &str = "variant";
-pub(crate) const ALT_STANDALONE: &str = "stand-alone";
-pub(crate) const ALT_OFFICIAL: &str = "official";
-/// Secondary name variant, used in languages and scripts.
-pub(crate) const ALT_SECONDARY: &str = "secondary";
-/// Abbreviation for territory code `IO` (British Indian Ocean Territory).
-pub(crate) const ALT_BIOT: &str = "biot";
-/// Alternate name for territory code `IO` (British Indian Ocean Territory) mapping to "Chagos Archipelago".
-pub(crate) const ALT_CHAGOS: &str = "chagos";
-// ALT_MENU is being replaced by menu=core|extension, but it is still in CLDR
-pub(crate) const ALT_MENU: &str = "menu";
-
-pub(crate) const MENU_CORE: &str = "core";
-pub(crate) const MENU_EXTENSION: &str = "extension";
 
 pub(crate) struct ExtractedNames<'a, K> {
     pub(crate) names: BTreeMap<K, &'a str>,
@@ -35,14 +18,13 @@ pub(crate) struct ExtractedNames<'a, K> {
     pub(crate) menu_names: BTreeMap<K, &'a str>,
 }
 
-/// Process locale display names from a `cldr_serde` struct to `BTreeMaps`
-/// ready to be converted to `ZeroMaps`.
+/// Extracts locale display names from a `cldr_serde` struct into `BTreeMap`s.
 ///
-/// This fn is used by the zeromap-based structs, not the `LocaleNames`
-/// attributes-based structs.
+/// This helper is used by the legacy (ZeroMap-based) providers, rather than the newer
+/// attributes-based providers.
 pub(crate) fn extract_names_for_zeromap_struct<'a, T, K, F>(
     map: &'a HashMap<WithAlt<T>, String>,
-    ignored_alts: &[&str],
+    ignored_alts: &[Alt],
     log_context: &str,
     filter_project: F,
 ) -> ExtractedNames<'a, K>
@@ -66,26 +48,28 @@ where
             if k == *val_str {
                 continue;
             }
-            match key.alt.as_deref() {
-                Some(ALT_SHORT) => {
+            match key.alt {
+                Some(Alt::Short) => {
                     short_names.insert(k, val_str);
                 }
-                Some(ALT_LONG) => {
+                Some(Alt::Long) => {
                     long_names.insert(k, val_str);
                 }
-                Some(ALT_MENU) => {
+                Some(Alt::Menu) => {
                     menu_names.insert(k, val_str);
                 }
                 None => {
                     names.insert(k, val_str);
                 }
                 Some(alt) => {
-                    if ignored_alts.contains(&alt) {
+                    if alt == Alt::Unknown {
+                        // Discard unknown alts
+                    } else if ignored_alts.contains(&alt) {
                         // TODO(#8012): Handle preference-specific alt variants,
                         //   perhaps with datagen alt flags.
                         // TODO(#8011): Support standalone display names.
                     } else {
-                        log::warn!("Unknown alt variant for {}: {}", log_context, alt);
+                        log::warn!("Unhandled alt variant for {}: {:?}", log_context, alt);
                     }
                 }
             }
@@ -107,7 +91,7 @@ where
 /// - `$resource`: The CLDR serde resource type.
 /// - `$file`: The JSON file name in CLDR.
 /// - `$field`: The field name in `LocaleDisplayNames` containing the data.
-/// - `$alt_variant`: The alt variant string (e.g., `None`, `Some("short")`).
+/// - `$alt_variant`: The alt variant (e.g., `None`, `Some(Alt::Short)`).
 macro_rules! impl_displaynames_v1 {
     ($marker:ident, $subtag_ty:ty, $resource:path, $file:literal, $field:ident, $alt_variant:expr,) => {
         impl DataProvider<$marker> for SourceDataProvider {
@@ -127,7 +111,7 @@ macro_rules! impl_displaynames_v1 {
 
                 let key = WithAlt {
                     subtag,
-                    alt: $alt_variant.map(std::borrow::Cow::Borrowed),
+                    alt: $alt_variant,
                     menu: None,
                 };
 
@@ -187,7 +171,7 @@ macro_rules! impl_displaynames_menu_v1 {
                 let key_core = WithAlt {
                     subtag: subtag.clone(),
                     alt: None,
-                    menu: Some(std::borrow::Cow::Borrowed($crate::displaynames::MENU_CORE)),
+                    menu: Some($crate::cldr_serde::displaynames::Menu::Core),
                 };
 
                 let map = &data.main.value.localedisplaynames.$field;
@@ -196,9 +180,7 @@ macro_rules! impl_displaynames_menu_v1 {
                     let key_extension = WithAlt {
                         subtag,
                         alt: None,
-                        menu: Some(std::borrow::Cow::Borrowed(
-                            $crate::displaynames::MENU_EXTENSION,
-                        )),
+                        menu: Some($crate::cldr_serde::displaynames::Menu::Extension),
                     };
                     let extension = map.get(&key_extension).ok_or_else(|| {
                         DataError::custom("found menu-core but missing menu-extension")
@@ -209,7 +191,7 @@ macro_rules! impl_displaynames_menu_v1 {
                     // Fallback to alt-menu
                     let key_alt_menu = WithAlt {
                         subtag,
-                        alt: Some(std::borrow::Cow::Borrowed($crate::displaynames::ALT_MENU)),
+                        alt: Some($crate::cldr_serde::displaynames::Alt::Menu),
                         menu: None,
                     };
                     let alt_menu = map.get(&key_alt_menu).ok_or_else(|| {
@@ -239,8 +221,9 @@ macro_rules! impl_displaynames_menu_v1 {
                 }) {
                     let data: &$resource = displaynames.read_and_parse(&locale, $file)?;
                     for key in data.main.value.localedisplaynames.$field.keys() {
-                        let matches = key.menu.as_deref() == Some($crate::displaynames::MENU_CORE)
-                            || key.alt.as_deref() == Some($crate::displaynames::ALT_MENU);
+                        let matches = key.menu
+                            == Some($crate::cldr_serde::displaynames::Menu::Core)
+                            || key.alt == Some($crate::cldr_serde::displaynames::Alt::Menu);
 
                         if matches {
                             let data_identifier = DataIdentifierCow::from_owned(
@@ -269,7 +252,7 @@ macro_rules! impl_displaynames_menu_v1 {
 /// - `$resource`: The CLDR serde resource type.
 /// - `$file`: The JSON file name in CLDR.
 /// - `$field`: The field name in `LocaleDisplayNames` containing the data.
-/// - `$alt_variant`: The alt variant string (e.g., `None`, `Some("short")`).
+/// - `$alt_variant`: The alt variant (e.g., `None`, `Some(Alt::Short)`).
 macro_rules! impl_displaynames_iter_v1 {
     ($marker:ident, $subtag_ty:ty, $resource:path, $file:literal, $field:ident, $alt_variant:expr) => {
         impl IterableDataProviderCached<$marker> for SourceDataProvider {
@@ -282,11 +265,7 @@ macro_rules! impl_displaynames_iter_v1 {
                 }) {
                     let data: &$resource = displaynames.read_and_parse(&locale, $file)?;
                     for key in data.main.value.localedisplaynames.$field.keys() {
-                        let matches = match ($alt_variant, &key.alt) {
-                            (Some(expected), Some(actual)) => expected == actual,
-                            (None, None) => true,
-                            _ => false,
-                        } && key.menu.is_none();
+                        let matches = $alt_variant == key.alt && key.menu.is_none();
 
                         if matches {
                             let data_identifier = DataIdentifierCow::from_owned(

--- a/provider/source/src/displaynames/mod.rs
+++ b/provider/source/src/displaynames/mod.rs
@@ -295,17 +295,12 @@ macro_rules! impl_displaynames_legacy_iter_v1 {
     ($marker:ident, $file:literal) => {
         impl IterableDataProviderCached<$marker> for SourceDataProvider {
             fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
-                Ok(self
-                    .cldr()?
-                    .displaynames()
+                let displaynames = self.cldr()?.displaynames();
+                Ok(displaynames
                     .list_locales()?
                     .filter(|locale| {
                         // The directory might exist without the file
-                        self.cldr()
-                            .unwrap()
-                            .displaynames()
-                            .file_exists(locale, $file)
-                            .unwrap_or_default()
+                        displaynames.file_exists(locale, $file).unwrap_or_default()
                     })
                     .map(DataIdentifierCow::from_locale)
                     .collect())

--- a/provider/source/src/displaynames/mod.rs
+++ b/provider/source/src/displaynames/mod.rs
@@ -219,9 +219,7 @@ macro_rules! impl_displaynames_menu_v1 {
                 let displaynames = self.cldr()?.displaynames();
                 for locale in displaynames.list_locales()?.filter(|locale| {
                     // The directory might exist without the file
-                    self.cldr()
-                        .unwrap()
-                        .displaynames()
+                    displaynames
                         .file_exists(locale, $file)
                         .unwrap_or_default()
                 }) {
@@ -266,9 +264,7 @@ macro_rules! impl_displaynames_iter_v1 {
                 let displaynames = self.cldr()?.displaynames();
                 for locale in displaynames.list_locales()?.filter(|locale| {
                     // The directory might exist without the file
-                    self.cldr()
-                        .unwrap()
-                        .displaynames()
+                    displaynames
                         .file_exists(locale, $file)
                         .unwrap_or_default()
                 }) {

--- a/provider/source/src/displaynames/mod.rs
+++ b/provider/source/src/displaynames/mod.rs
@@ -35,29 +35,8 @@ pub(crate) const ALT_MENU_SUBSTRING: &str = "-alt-menu";
 /// - `$file`: The JSON file name in CLDR.
 /// - `$field`: The field name in `LocaleDisplayNames` containing the data.
 /// - `$suffix`: An optional string to append to the marker attribute to form the CLDR key.
-/// - `$key_transform`: (Optional) A closure of type `Fn(String) -> String` to transform the marker attribute into the CLDR key.
-/// - `$attr_transform`: (Optional) A closure of type `Fn(String) -> String` to transform the CLDR key back into the marker attribute.
 macro_rules! impl_displaynames_v1 {
     ($marker:ident, $resource:path, $file:literal, $field:ident, $suffix:expr,) => {
-        $crate::displaynames::impl_displaynames_v1!(
-            $marker,
-            $resource,
-            $file,
-            $field,
-            $suffix,
-            |k: String| k,
-            |k: String| k
-        );
-    };
-    (
-        $marker:ident,
-        $resource:path,
-        $file:literal,
-        $field:ident,
-        $suffix:expr,
-        $key_transform:expr,
-        $attr_transform:expr
-    ) => {
         impl DataProvider<$marker> for SourceDataProvider {
             fn load(&self, req: DataRequest) -> Result<DataResponse<$marker>, DataError> {
                 self.check_req::<$marker>(req)?;
@@ -71,8 +50,6 @@ macro_rules! impl_displaynames_v1 {
                 if let Some(suffix) = $suffix {
                     key.push_str(suffix);
                 }
-
-                let key = ($key_transform)(key);
 
                 let name = data
                     .main
@@ -92,12 +69,7 @@ macro_rules! impl_displaynames_v1 {
         }
 
         $crate::displaynames::impl_displaynames_iter_v1!(
-            $marker,
-            $resource,
-            $file,
-            $field,
-            $suffix,
-            $attr_transform
+            $marker, $resource, $file, $field, $suffix
         );
     };
 }
@@ -208,7 +180,7 @@ macro_rules! impl_displaynames_menu_v1 {
 /// - `$field`: The field name in `LocaleDisplayNames` containing the data.
 /// - `$suffix`: An optional string that marks which entries to include in this provider.
 macro_rules! impl_displaynames_iter_v1 {
-    ($marker:ident, $resource:path, $file:literal, $field:ident, $suffix:expr, $attr_transform:expr) => {
+    ($marker:ident, $resource:path, $file:literal, $field:ident, $suffix:expr) => {
         impl IterableDataProviderCached<$marker> for SourceDataProvider {
             fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
                 let mut result = HashSet::new();
@@ -234,14 +206,14 @@ macro_rules! impl_displaynames_iter_v1 {
                         };
 
                         if let Some(attr_str) = attr {
-                            let attr_str = ($attr_transform)(attr_str.to_string());
-                            if let Err(_) = DataMarkerAttributes::try_from_str(&attr_str) {
-                                return Err(DataError::custom("Failed to parse attribute")
-                                    .with_debug_context(&attr_str));
-                            }
-                            let boxed = DataMarkerAttributes::try_from_string(attr_str)
-                                .expect("Validated above");
-                            let data_identifier = DataIdentifierCow::from_owned(boxed, locale);
+                            let data_identifier = DataIdentifierCow::from_owned(
+                                DataMarkerAttributes::try_from_string(attr_str.to_string())
+                                    .map_err(|_| {
+                                        DataError::custom("Failed to parse attribute")
+                                            .with_debug_context(&attr_str)
+                                    })?,
+                                locale,
+                            );
                             result.insert(data_identifier);
                         }
                     }

--- a/provider/source/src/displaynames/mod.rs
+++ b/provider/source/src/displaynames/mod.rs
@@ -47,8 +47,8 @@ pub(crate) fn extract_names_for_zeromap_struct<'a, T, K, F>(
     filter_project: F,
 ) -> ExtractedNames<'a, K>
 where
-    K: Ord,
-    F: Fn(&T, &str) -> Option<K>,
+    K: Ord + PartialEq<str>,
+    F: Fn(&T) -> Option<K>,
 {
     let mut names = BTreeMap::new();
     let mut short_names = BTreeMap::new();
@@ -61,7 +61,11 @@ where
             continue;
         }
         let val_str = value.as_str();
-        if let Some(k) = filter_project(&key.subtag, val_str) {
+        if let Some(k) = filter_project(&key.subtag) {
+            // Old CLDR versions may contain trivial entries, so filter
+            if k == *val_str {
+                continue;
+            }
             match key.alt.as_deref() {
                 Some(ALT_SHORT) => {
                     short_names.insert(k, val_str);

--- a/provider/source/src/displaynames/mod.rs
+++ b/provider/source/src/displaynames/mod.rs
@@ -219,9 +219,7 @@ macro_rules! impl_displaynames_menu_v1 {
                 let displaynames = self.cldr()?.displaynames();
                 for locale in displaynames.list_locales()?.filter(|locale| {
                     // The directory might exist without the file
-                    displaynames
-                        .file_exists(locale, $file)
-                        .unwrap_or_default()
+                    displaynames.file_exists(locale, $file).unwrap_or_default()
                 }) {
                     let data: &$resource = displaynames.read_and_parse(&locale, $file)?;
                     for key in data.main.value.localedisplaynames.$field.keys() {
@@ -264,9 +262,7 @@ macro_rules! impl_displaynames_iter_v1 {
                 let displaynames = self.cldr()?.displaynames();
                 for locale in displaynames.list_locales()?.filter(|locale| {
                     // The directory might exist without the file
-                    displaynames
-                        .file_exists(locale, $file)
-                        .unwrap_or_default()
+                    displaynames.file_exists(locale, $file).unwrap_or_default()
                 }) {
                     let data: &$resource = displaynames.read_and_parse(&locale, $file)?;
                     for key in data.main.value.localedisplaynames.$field.keys() {

--- a/provider/source/src/displaynames/mod.rs
+++ b/provider/source/src/displaynames/mod.rs
@@ -8,35 +8,17 @@ pub(crate) mod region;
 pub(crate) mod script;
 pub(crate) mod variant;
 
-pub(crate) const ALT_SUBSTRING: &str = "-alt-";
-pub(crate) const ALT_SHORT_SUBSTRING: &str = "-alt-short";
-pub(crate) const ALT_LONG_SUBSTRING: &str = "-alt-long";
-pub(crate) const ALT_VARIANT_SUBSTRING: &str = "-alt-variant";
-pub(crate) const ALT_STANDALONE_SUBSTRING: &str = "-alt-stand-alone";
-pub(crate) const ALT_OFFICIAL_SUBSTRING: &str = "-alt-official";
-/// Secondary name variant, used in languages and scripts.
-pub(crate) const ALT_SECONDARY_SUBSTRING: &str = "-alt-secondary";
-/// Abbreviation for territory code `IO` (British Indian Ocean Territory).
-pub(crate) const ALT_BIOT_SUBSTRING: &str = "-alt-biot";
-/// Alternate name for territory code `IO` (British Indian Ocean Territory) mapping to "Chagos Archipelago".
-pub(crate) const ALT_CHAGOS_SUBSTRING: &str = "-alt-chagos";
-pub(crate) const MENU_SUBSTRING: &str = "-menu-";
-pub(crate) const MENU_CORE_SUBSTRING: &str = "-menu-core";
-pub(crate) const MENU_EXTENSION_SUBSTRING: &str = "-menu-extension";
-
-// TODO: ALT_MENU_SUBSTRING should be dead. Remove when possible.
-pub(crate) const ALT_MENU_SUBSTRING: &str = "-alt-menu";
-
 /// Macro for implementing a single-name display names data provider.
 ///
 /// Parameters:
 /// - `$marker`: The data marker type.
+/// - `$subtag_ty`: The subtag type (e.g., `Language`, `Script`).
 /// - `$resource`: The CLDR serde resource type.
 /// - `$file`: The JSON file name in CLDR.
 /// - `$field`: The field name in `LocaleDisplayNames` containing the data.
-/// - `$suffix`: An optional string to append to the marker attribute to form the CLDR key.
+/// - `$alt_variant`: The alt variant string (e.g., `None`, `Some("short")`).
 macro_rules! impl_displaynames_v1 {
-    ($marker:ident, $resource:path, $file:literal, $field:ident, $suffix:expr,) => {
+    ($marker:ident, $subtag_ty:ty, $resource:path, $file:literal, $field:ident, $alt_variant:expr,) => {
         impl DataProvider<$marker> for SourceDataProvider {
             fn load(&self, req: DataRequest) -> Result<DataResponse<$marker>, DataError> {
                 self.check_req::<$marker>(req)?;
@@ -46,10 +28,17 @@ macro_rules! impl_displaynames_v1 {
                     .displaynames()
                     .read_and_parse(req.id.locale, $file)?;
 
-                let mut key = req.id.marker_attributes.as_str().to_string();
-                if let Some(suffix) = $suffix {
-                    key.push_str(suffix);
-                }
+                let subtag =
+                    <$subtag_ty as core::str::FromStr>::from_str(req.id.marker_attributes.as_str())
+                        .map_err(|_| {
+                            DataError::custom("failed to parse subtag").with_req($marker::INFO, req)
+                        })?;
+
+                let key = $crate::cldr_serde::displaynames::SubtagWithOptionalAltVariant {
+                    subtag,
+                    alt_variant: $alt_variant.map(String::from),
+                    menu_variant: None,
+                };
 
                 let name = data
                     .main
@@ -69,7 +58,12 @@ macro_rules! impl_displaynames_v1 {
         }
 
         $crate::displaynames::impl_displaynames_iter_v1!(
-            $marker, $resource, $file, $field, $suffix
+            $marker,
+            $subtag_ty,
+            $resource,
+            $file,
+            $field,
+            $alt_variant
         );
     };
 }
@@ -78,11 +72,12 @@ macro_rules! impl_displaynames_v1 {
 ///
 /// Parameters:
 /// - `$marker`: The data marker type.
+/// - `$subtag_ty`: The subtag type.
 /// - `$resource`: The CLDR serde resource type.
 /// - `$file`: The JSON file name in CLDR.
 /// - `$field`: The field name in `LocaleDisplayNames` containing the data.
 macro_rules! impl_displaynames_menu_v1 {
-    ($marker:ident, $resource:path, $file:literal, $field:ident,) => {
+    ($marker:ident, $subtag_ty:ty, $resource:path, $file:literal, $field:ident,) => {
         impl DataProvider<$marker> for SourceDataProvider {
             fn load(&self, req: DataRequest) -> Result<DataResponse<$marker>, DataError> {
                 self.check_req::<$marker>(req)?;
@@ -92,10 +87,23 @@ macro_rules! impl_displaynames_menu_v1 {
                     .displaynames()
                     .read_and_parse(req.id.locale, $file)?;
 
-                let mut key_core = req.id.marker_attributes.as_str().to_string();
-                let mut key_extension = key_core.clone();
-                key_core.push_str($crate::displaynames::MENU_CORE_SUBSTRING);
-                key_extension.push_str($crate::displaynames::MENU_EXTENSION_SUBSTRING);
+                let subtag =
+                    <$subtag_ty as core::str::FromStr>::from_str(req.id.marker_attributes.as_str())
+                        .map_err(|_| {
+                            DataError::custom("failed to parse subtag").with_req($marker::INFO, req)
+                        })?;
+
+                let key_core = $crate::cldr_serde::displaynames::SubtagWithOptionalAltVariant {
+                    subtag: subtag.clone(),
+                    alt_variant: None,
+                    menu_variant: Some("core".to_string()),
+                };
+                let key_extension =
+                    $crate::cldr_serde::displaynames::SubtagWithOptionalAltVariant {
+                        subtag: subtag.clone(),
+                        alt_variant: None,
+                        menu_variant: Some("extension".to_string()),
+                    };
 
                 let map = &data.main.value.localedisplaynames.$field;
 
@@ -107,8 +115,12 @@ macro_rules! impl_displaynames_menu_v1 {
                     (core.as_str(), extension.as_str())
                 } else {
                     // Fallback to alt-menu
-                    let mut key_alt_menu = req.id.marker_attributes.as_str().to_string();
-                    key_alt_menu.push_str($crate::displaynames::ALT_MENU_SUBSTRING);
+                    let key_alt_menu =
+                        $crate::cldr_serde::displaynames::SubtagWithOptionalAltVariant {
+                            subtag,
+                            alt_variant: Some("menu".to_string()),
+                            menu_variant: None,
+                        };
                     let alt_menu = map.get(&key_alt_menu).ok_or_else(|| {
                         DataError::custom("failed to find menu-core or alt-menu")
                             .with_req($marker::INFO, req)
@@ -131,7 +143,6 @@ macro_rules! impl_displaynames_menu_v1 {
                 let mut result = HashSet::new();
                 let displaynames = self.cldr()?.displaynames();
                 for locale in displaynames.list_locales()?.filter(|locale| {
-                    // The directory might exist without the file
                     self.cldr()
                         .unwrap()
                         .displaynames()
@@ -139,26 +150,19 @@ macro_rules! impl_displaynames_menu_v1 {
                         .unwrap_or_default()
                 }) {
                     let data: &$resource = displaynames.read_and_parse(&locale, $file)?;
-                    for key_str in data.main.value.localedisplaynames.$field.keys() {
-                        let attr = if let Some(attr_str) =
-                            key_str.strip_suffix($crate::displaynames::MENU_CORE_SUBSTRING)
-                        {
-                            Some(attr_str)
-                        } else if let Some(attr_str) =
-                            key_str.strip_suffix($crate::displaynames::ALT_MENU_SUBSTRING)
-                        {
-                            Some(attr_str)
-                        } else {
-                            None
-                        };
+                    for key in data.main.value.localedisplaynames.$field.keys() {
+                        let matches = key.menu_variant.as_deref() == Some("core")
+                            || key.alt_variant.as_deref() == Some("menu");
 
-                        if let Some(attr_str) = attr {
+                        if matches {
+                            let attr_str = key.subtag.to_string();
                             let data_identifier = DataIdentifierCow::from_owned(
-                                DataMarkerAttributes::try_from_string(attr_str.to_string())
-                                    .map_err(|_| {
+                                DataMarkerAttributes::try_from_string(attr_str.clone()).map_err(
+                                    |_| {
                                         DataError::custom("Failed to parse attribute")
                                             .with_debug_context(&attr_str)
-                                    })?,
+                                    },
+                                )?,
                                 locale,
                             );
                             result.insert(data_identifier);
@@ -175,18 +179,18 @@ macro_rules! impl_displaynames_menu_v1 {
 ///
 /// Parameters:
 /// - `$marker`: The data marker type.
+/// - `$subtag_ty`: The subtag type.
 /// - `$resource`: The CLDR serde resource type.
 /// - `$file`: The JSON file name in CLDR.
 /// - `$field`: The field name in `LocaleDisplayNames` containing the data.
-/// - `$suffix`: An optional string that marks which entries to include in this provider.
+/// - `$alt_variant`: The alt variant string (e.g., `None`, `Some("short")`).
 macro_rules! impl_displaynames_iter_v1 {
-    ($marker:ident, $resource:path, $file:literal, $field:ident, $suffix:expr) => {
+    ($marker:ident, $subtag_ty:ty, $resource:path, $file:literal, $field:ident, $alt_variant:expr) => {
         impl IterableDataProviderCached<$marker> for SourceDataProvider {
             fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
                 let mut result = HashSet::new();
                 let displaynames = self.cldr()?.displaynames();
                 for locale in displaynames.list_locales()?.filter(|locale| {
-                    // The directory might exist without the file
                     self.cldr()
                         .unwrap()
                         .displaynames()
@@ -194,24 +198,22 @@ macro_rules! impl_displaynames_iter_v1 {
                         .unwrap_or_default()
                 }) {
                     let data: &$resource = displaynames.read_and_parse(&locale, $file)?;
-                    for key_str in data.main.value.localedisplaynames.$field.keys() {
-                        let attr = if let Some(suffix) = $suffix {
-                            key_str.strip_suffix(suffix)
-                        } else if key_str.contains(crate::displaynames::ALT_SUBSTRING)
-                            || key_str.contains(crate::displaynames::MENU_SUBSTRING)
-                        {
-                            None
-                        } else {
-                            Some(key_str.as_str())
-                        };
+                    for key in data.main.value.localedisplaynames.$field.keys() {
+                        let matches = match ($alt_variant, &key.alt_variant) {
+                            (Some(expected), Some(actual)) => expected == actual,
+                            (None, None) => true,
+                            _ => false,
+                        } && key.menu_variant.is_none();
 
-                        if let Some(attr_str) = attr {
+                        if matches {
+                            let attr_str = key.subtag.to_string();
                             let data_identifier = DataIdentifierCow::from_owned(
-                                DataMarkerAttributes::try_from_string(attr_str.to_string())
-                                    .map_err(|_| {
+                                DataMarkerAttributes::try_from_string(attr_str.clone()).map_err(
+                                    |_| {
                                         DataError::custom("Failed to parse attribute")
                                             .with_debug_context(&attr_str)
-                                    })?,
+                                    },
+                                )?,
                                 locale,
                             );
                             result.insert(data_identifier);

--- a/provider/source/src/displaynames/mod.rs
+++ b/provider/source/src/displaynames/mod.rs
@@ -113,7 +113,7 @@ macro_rules! impl_displaynames_v1 {
 
                 let key = WithAlt {
                     subtag,
-                    alt: $alt_variant.map(String::from),
+                    alt: $alt_variant.map(std::borrow::Cow::Borrowed),
                     menu: None,
                 };
 
@@ -173,7 +173,7 @@ macro_rules! impl_displaynames_menu_v1 {
                 let key_core = WithAlt {
                     subtag: subtag.clone(),
                     alt: None,
-                    menu: Some($crate::displaynames::MENU_CORE.to_string()),
+                    menu: Some(std::borrow::Cow::Borrowed($crate::displaynames::MENU_CORE)),
                 };
 
                 let map = &data.main.value.localedisplaynames.$field;
@@ -182,7 +182,9 @@ macro_rules! impl_displaynames_menu_v1 {
                     let key_extension = WithAlt {
                         subtag,
                         alt: None,
-                        menu: Some($crate::displaynames::MENU_EXTENSION.to_string()),
+                        menu: Some(std::borrow::Cow::Borrowed(
+                            $crate::displaynames::MENU_EXTENSION,
+                        )),
                     };
                     let extension = map.get(&key_extension).ok_or_else(|| {
                         DataError::custom("found menu-core but missing menu-extension")
@@ -193,7 +195,7 @@ macro_rules! impl_displaynames_menu_v1 {
                     // Fallback to alt-menu
                     let key_alt_menu = WithAlt {
                         subtag,
-                        alt: Some($crate::displaynames::ALT_MENU.to_string()),
+                        alt: Some(std::borrow::Cow::Borrowed($crate::displaynames::ALT_MENU)),
                         menu: None,
                     };
                     let alt_menu = map.get(&key_alt_menu).ok_or_else(|| {

--- a/provider/source/src/displaynames/mod.rs
+++ b/provider/source/src/displaynames/mod.rs
@@ -35,6 +35,8 @@ pub(crate) const ALT_MENU_SUBSTRING: &str = "-alt-menu";
 /// - `$file`: The JSON file name in CLDR.
 /// - `$field`: The field name in `LocaleDisplayNames` containing the data.
 /// - `$suffix`: An optional string to append to the marker attribute to form the CLDR key.
+/// - `$key_transform`: (Optional) A closure of type `Fn(String) -> String` to transform the marker attribute into the CLDR key.
+/// - `$attr_transform`: (Optional) A closure of type `Fn(String) -> String` to transform the CLDR key back into the marker attribute.
 macro_rules! impl_displaynames_v1 {
     ($marker:ident, $resource:path, $file:literal, $field:ident, $suffix:expr,) => {
         $crate::displaynames::impl_displaynames_v1!(

--- a/provider/source/src/displaynames/mod.rs
+++ b/provider/source/src/displaynames/mod.rs
@@ -117,15 +117,15 @@ macro_rules! impl_displaynames_menu_v1 {
                     alt_variant: None,
                     menu_variant: Some($crate::displaynames::MENU_CORE.to_string()),
                 };
-                let key_extension = ModifiedSubtag {
-                    subtag: subtag.clone(),
-                    alt_variant: None,
-                    menu_variant: Some($crate::displaynames::MENU_EXTENSION.to_string()),
-                };
 
                 let map = &data.main.value.localedisplaynames.$field;
 
                 let (name_core, name_extension) = if let Some(core) = map.get(&key_core) {
+                    let key_extension = ModifiedSubtag {
+                        subtag, // Consume subtag
+                        alt_variant: None,
+                        menu_variant: Some($crate::displaynames::MENU_EXTENSION.to_string()),
+                    };
                     let extension = map.get(&key_extension).ok_or_else(|| {
                         DataError::custom("found menu-core but missing menu-extension")
                             .with_req($marker::INFO, req)
@@ -134,7 +134,7 @@ macro_rules! impl_displaynames_menu_v1 {
                 } else {
                     // Fallback to alt-menu
                     let key_alt_menu = ModifiedSubtag {
-                        subtag,
+                        subtag, // Consume subtag
                         alt_variant: Some($crate::displaynames::ALT_MENU.to_string()),
                         menu_variant: None,
                     };
@@ -174,14 +174,12 @@ macro_rules! impl_displaynames_menu_v1 {
                             || key.alt_variant.as_deref() == Some($crate::displaynames::ALT_MENU);
 
                         if matches {
-                            let attr_str = key.subtag.to_string();
                             let data_identifier = DataIdentifierCow::from_owned(
-                                DataMarkerAttributes::try_from_string(attr_str.clone()).map_err(
-                                    |_| {
+                                DataMarkerAttributes::try_from_string(key.subtag.to_string())
+                                    .map_err(|_| {
                                         DataError::custom("Failed to parse attribute")
-                                            .with_debug_context(&attr_str)
-                                    },
-                                )?,
+                                            .with_debug_context(&key.subtag.to_string())
+                                    })?,
                                 locale,
                             );
                             result.insert(data_identifier);
@@ -226,14 +224,12 @@ macro_rules! impl_displaynames_iter_v1 {
                         } && key.menu_variant.is_none();
 
                         if matches {
-                            let attr_str = key.subtag.to_string();
                             let data_identifier = DataIdentifierCow::from_owned(
-                                DataMarkerAttributes::try_from_string(attr_str.clone()).map_err(
-                                    |_| {
+                                DataMarkerAttributes::try_from_string(key.subtag.to_string())
+                                    .map_err(|_| {
                                         DataError::custom("Failed to parse attribute")
-                                            .with_debug_context(&attr_str)
-                                    },
-                                )?,
+                                            .with_debug_context(&key.subtag.to_string())
+                                    })?,
                                 locale,
                             );
                             result.insert(data_identifier);

--- a/provider/source/src/displaynames/mod.rs
+++ b/provider/source/src/displaynames/mod.rs
@@ -8,6 +8,9 @@ pub(crate) mod region;
 pub(crate) mod script;
 pub(crate) mod variant;
 
+use crate::cldr_serde::displaynames::WithAlt;
+use std::collections::{BTreeMap, HashMap};
+
 pub(crate) const ALT_SHORT: &str = "short";
 pub(crate) const ALT_LONG: &str = "long";
 pub(crate) const ALT_VARIANT: &str = "variant";
@@ -23,6 +26,64 @@ pub(crate) const ALT_MENU: &str = "menu";
 
 pub(crate) const MENU_CORE: &str = "core";
 pub(crate) const MENU_EXTENSION: &str = "extension";
+
+pub(crate) struct ExtractedNames<'a, K> {
+    pub(crate) names: BTreeMap<K, &'a str>,
+    pub(crate) short_names: BTreeMap<K, &'a str>,
+    pub(crate) long_names: BTreeMap<K, &'a str>,
+    pub(crate) menu_names: BTreeMap<K, &'a str>,
+}
+
+pub(crate) fn extract_names<'a, T, K, F>(
+    map: &'a HashMap<WithAlt<T>, String>,
+    ignored_alts: &[&str],
+    log_context: &str,
+    filter_project: F,
+) -> ExtractedNames<'a, K>
+where
+    K: Ord,
+    F: Fn(&T, &str) -> Option<K>,
+{
+    let mut names = BTreeMap::new();
+    let mut short_names = BTreeMap::new();
+    let mut long_names = BTreeMap::new();
+    let mut menu_names = BTreeMap::new();
+    for (key, value) in map.iter() {
+        if key.menu.is_some() {
+            continue;
+        }
+        let val_str = value.as_str();
+        if let Some(k) = filter_project(&key.subtag, val_str) {
+            match key.alt.as_deref() {
+                Some(ALT_SHORT) => {
+                    short_names.insert(k, val_str);
+                }
+                Some(ALT_LONG) => {
+                    long_names.insert(k, val_str);
+                }
+                Some(ALT_MENU) => {
+                    menu_names.insert(k, val_str);
+                }
+                None => {
+                    names.insert(k, val_str);
+                }
+                Some(alt) => {
+                    if ignored_alts.contains(&alt) {
+                        // TODO(#8012): Handle preference-specific alt variants.
+                    } else {
+                        log::warn!("Unknown alt variant for {}: {}", log_context, alt);
+                    }
+                }
+            }
+        }
+    }
+    ExtractedNames {
+        names,
+        short_names,
+        long_names,
+        menu_names,
+    }
+}
 
 /// Macro for implementing a single-name display names data provider.
 ///

--- a/provider/source/src/displaynames/region.rs
+++ b/provider/source/src/displaynames/region.rs
@@ -5,7 +5,7 @@
 use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
-use crate::cldr_serde::displaynames::ModifiedSubtag;
+use crate::cldr_serde::displaynames::WithAlt;
 use crate::displaynames::{ALT_BIOT, ALT_CHAGOS, ALT_SHORT, ALT_VARIANT};
 use icu::experimental::displaynames::provider::*;
 use icu_provider::prelude::*;
@@ -53,13 +53,13 @@ impl From<&cldr_serde::displaynames::region::Resource> for RegionDisplayNames<'s
         let mut names = BTreeMap::new();
         let mut short_names = BTreeMap::new();
         for (key, value) in other.main.value.localedisplaynames.regions.iter() {
-            if key.menu_variant.is_some() {
+            if key.menu.is_some() {
                 continue;
             }
 
             let region = key.subtag;
 
-            match key.alt_variant.as_deref() {
+            match key.alt.as_deref() {
                 Some(ALT_SHORT) => {
                     short_names.insert(region.to_tinystr(), value.as_str());
                 }

--- a/provider/source/src/displaynames/region.rs
+++ b/provider/source/src/displaynames/region.rs
@@ -6,6 +6,7 @@ use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
 use crate::cldr_serde::displaynames::ModifiedSubtag;
+use crate::displaynames::{ALT_BIOT, ALT_CHAGOS, ALT_SHORT, ALT_VARIANT};
 use icu::experimental::displaynames::provider::*;
 use icu_provider::prelude::*;
 use std::collections::{BTreeMap, HashSet};
@@ -44,7 +45,7 @@ crate::displaynames::impl_displaynames_v1!(
     cldr_serde::displaynames::region::Resource,
     "territories.json",
     regions,
-    Some("short"),
+    Some(ALT_SHORT),
 );
 
 impl From<&cldr_serde::displaynames::region::Resource> for RegionDisplayNames<'static> {
@@ -59,13 +60,13 @@ impl From<&cldr_serde::displaynames::region::Resource> for RegionDisplayNames<'s
             let region = key.subtag;
 
             match key.alt_variant.as_deref() {
-                Some("short") => {
+                Some(ALT_SHORT) => {
                     short_names.insert(region.to_tinystr(), value.as_str());
                 }
                 None => {
                     names.insert(region.to_tinystr(), value.as_str());
                 }
-                Some("variant") | Some("chagos") | Some("biot") => {
+                Some(ALT_VARIANT) | Some(ALT_CHAGOS) | Some(ALT_BIOT) => {
                     // TODO(#8012): Handle this with datagen alt flags.
                 }
                 Some(alt) => {

--- a/provider/source/src/displaynames/region.rs
+++ b/provider/source/src/displaynames/region.rs
@@ -6,7 +6,9 @@ use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
 use crate::cldr_serde::displaynames::WithAlt;
-use crate::displaynames::{ALT_BIOT, ALT_CHAGOS, ALT_SHORT, ALT_VARIANT, extract_names};
+use crate::displaynames::{
+    ALT_BIOT, ALT_CHAGOS, ALT_SHORT, ALT_VARIANT, extract_names_for_zeromap_struct,
+};
 use icu::experimental::displaynames::provider::*;
 use icu_provider::prelude::*;
 use std::collections::{BTreeMap, HashSet};
@@ -50,7 +52,7 @@ crate::displaynames::impl_displaynames_v1!(
 
 impl From<&cldr_serde::displaynames::region::Resource> for RegionDisplayNames<'static> {
     fn from(other: &cldr_serde::displaynames::region::Resource) -> Self {
-        let extracted = extract_names(
+        let extracted = extract_names_for_zeromap_struct(
             &other.main.value.localedisplaynames.regions,
             &[ALT_VARIANT, ALT_CHAGOS, ALT_BIOT],
             "region",

--- a/provider/source/src/displaynames/region.rs
+++ b/provider/source/src/displaynames/region.rs
@@ -56,14 +56,7 @@ impl From<&cldr_serde::displaynames::region::Resource> for RegionDisplayNames<'s
             &other.main.value.localedisplaynames.regions,
             &[ALT_VARIANT, ALT_CHAGOS, ALT_BIOT],
             "region",
-            |region, val| {
-                let region_str = region.to_tinystr();
-                if region_str.as_str() == val {
-                    None
-                } else {
-                    Some(region_str)
-                }
-            },
+            |region| Some(region.to_tinystr()),
         );
 
         let to_zero_map = |map: BTreeMap<tinystr::TinyAsciiStr<3>, &str>| {

--- a/provider/source/src/displaynames/region.rs
+++ b/provider/source/src/displaynames/region.rs
@@ -5,13 +5,7 @@
 use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
-use crate::displaynames::{
-    ALT_BIOT_SUBSTRING, ALT_CHAGOS_SUBSTRING, ALT_SHORT_SUBSTRING, ALT_SUBSTRING,
-    ALT_VARIANT_SUBSTRING,
-};
-use core::convert::TryFrom;
 use icu::experimental::displaynames::provider::*;
-use icu::locale::subtags::Region;
 use icu_provider::prelude::*;
 use std::collections::{BTreeMap, HashSet};
 use zerovec::VarZeroCow;
@@ -27,9 +21,7 @@ impl DataProvider<RegionDisplayNamesV1> for SourceDataProvider {
 
         Ok(DataResponse {
             metadata: Default::default(),
-            payload: DataPayload::from_owned(RegionDisplayNames::try_from(data).map_err(|e| {
-                DataError::custom("data for RegionDisplayNames").with_display_context(&e)
-            })?),
+            payload: DataPayload::from_owned(RegionDisplayNames::from(data)),
         })
     }
 }
@@ -38,6 +30,7 @@ crate::displaynames::impl_displaynames_legacy_iter_v1!(RegionDisplayNamesV1, "te
 
 crate::displaynames::impl_displaynames_v1!(
     LocaleNamesRegionMediumV1,
+    icu::locale::subtags::Region,
     cldr_serde::displaynames::region::Resource,
     "territories.json",
     regions,
@@ -46,32 +39,40 @@ crate::displaynames::impl_displaynames_v1!(
 
 crate::displaynames::impl_displaynames_v1!(
     LocaleNamesRegionShortV1,
+    icu::locale::subtags::Region,
     cldr_serde::displaynames::region::Resource,
     "territories.json",
     regions,
-    Some(ALT_SHORT_SUBSTRING),
+    Some("short"),
 );
 
-impl TryFrom<&cldr_serde::displaynames::region::Resource> for RegionDisplayNames<'static> {
-    type Error = icu::locale::ParseError;
-    fn try_from(other: &cldr_serde::displaynames::region::Resource) -> Result<Self, Self::Error> {
+impl From<&cldr_serde::displaynames::region::Resource> for RegionDisplayNames<'static> {
+    fn from(other: &cldr_serde::displaynames::region::Resource) -> Self {
         let mut names = BTreeMap::new();
         let mut short_names = BTreeMap::new();
-        for (region, value) in other.main.value.localedisplaynames.regions.iter() {
-            if let Some(region) = region.strip_suffix(ALT_SHORT_SUBSTRING) {
-                short_names.insert(Region::try_from_str(region)?.to_tinystr(), value.as_str());
-            } else if !region.contains(ALT_SUBSTRING) {
-                names.insert(Region::try_from_str(region)?.to_tinystr(), value.as_str());
-            } else if region.ends_with(ALT_VARIANT_SUBSTRING)
-                || region.ends_with(ALT_CHAGOS_SUBSTRING)
-                || region.ends_with(ALT_BIOT_SUBSTRING)
-            {
-                // TODO(#8012): Handle this with datagen alt flags.
-            } else {
-                log::warn!("Unknown alt variant for region: {}", region);
+        for (key, value) in other.main.value.localedisplaynames.regions.iter() {
+            if key.menu_variant.is_some() {
+                continue;
+            }
+
+            let region = key.subtag;
+
+            match key.alt_variant.as_deref() {
+                Some("short") => {
+                    short_names.insert(region.to_tinystr(), value.as_str());
+                }
+                None => {
+                    names.insert(region.to_tinystr(), value.as_str());
+                }
+                Some("variant") | Some("chagos") | Some("biot") => {
+                    // TODO(#8012): Handle this with datagen alt flags.
+                }
+                Some(alt) => {
+                    log::warn!("Unknown alt variant for region: {}", alt);
+                }
             }
         }
-        Ok(Self {
+        Self {
             // Old CLDR versions may contain trivial entries, so filter
             names: names
                 .into_iter()
@@ -83,10 +84,9 @@ impl TryFrom<&cldr_serde::displaynames::region::Resource> for RegionDisplayNames
                 .filter(|&(k, v)| k != v)
                 .map(|(k, v)| (k.to_unvalidated(), v))
                 .collect(),
-        })
+        }
     }
 }
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/provider/source/src/displaynames/region.rs
+++ b/provider/source/src/displaynames/region.rs
@@ -8,6 +8,7 @@ use crate::cldr_serde;
 use crate::cldr_serde::displaynames::{Alt, WithAlt};
 use crate::displaynames::extract_names_for_zeromap_struct;
 use icu::experimental::displaynames::provider::*;
+use icu::locale::subtags::Region;
 use icu_provider::prelude::*;
 use std::collections::{BTreeMap, HashSet};
 use zerovec::VarZeroCow;
@@ -32,7 +33,7 @@ crate::displaynames::impl_displaynames_legacy_iter_v1!(RegionDisplayNamesV1, "te
 
 crate::displaynames::impl_displaynames_v1!(
     LocaleNamesRegionMediumV1,
-    icu::locale::subtags::Region,
+    Region,
     cldr_serde::displaynames::region::Resource,
     "territories.json",
     regions,
@@ -41,7 +42,7 @@ crate::displaynames::impl_displaynames_v1!(
 
 crate::displaynames::impl_displaynames_v1!(
     LocaleNamesRegionShortV1,
-    icu::locale::subtags::Region,
+    Region,
     cldr_serde::displaynames::region::Resource,
     "territories.json",
     regions,

--- a/provider/source/src/displaynames/region.rs
+++ b/provider/source/src/displaynames/region.rs
@@ -6,7 +6,7 @@ use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
 use crate::cldr_serde::displaynames::WithAlt;
-use crate::displaynames::{ALT_BIOT, ALT_CHAGOS, ALT_SHORT, ALT_VARIANT};
+use crate::displaynames::{ALT_BIOT, ALT_CHAGOS, ALT_SHORT, ALT_VARIANT, extract_names};
 use icu::experimental::displaynames::provider::*;
 use icu_provider::prelude::*;
 use std::collections::{BTreeMap, HashSet};
@@ -50,42 +50,29 @@ crate::displaynames::impl_displaynames_v1!(
 
 impl From<&cldr_serde::displaynames::region::Resource> for RegionDisplayNames<'static> {
     fn from(other: &cldr_serde::displaynames::region::Resource) -> Self {
-        let mut names = BTreeMap::new();
-        let mut short_names = BTreeMap::new();
-        for (key, value) in other.main.value.localedisplaynames.regions.iter() {
-            if key.menu.is_some() {
-                continue;
-            }
+        let extracted = extract_names(
+            &other.main.value.localedisplaynames.regions,
+            &[ALT_VARIANT, ALT_CHAGOS, ALT_BIOT],
+            "region",
+            |region, val| {
+                let region_str = region.to_tinystr();
+                if region_str.as_str() == val {
+                    None
+                } else {
+                    Some(region_str)
+                }
+            },
+        );
 
-            let region = key.subtag;
+        let to_zero_map = |map: BTreeMap<tinystr::TinyAsciiStr<3>, &str>| {
+            map.into_iter()
+                .map(|(k, v)| (k.to_unvalidated(), v))
+                .collect()
+        };
 
-            match key.alt.as_deref() {
-                Some(ALT_SHORT) => {
-                    short_names.insert(region.to_tinystr(), value.as_str());
-                }
-                None => {
-                    names.insert(region.to_tinystr(), value.as_str());
-                }
-                Some(ALT_VARIANT) | Some(ALT_CHAGOS) | Some(ALT_BIOT) => {
-                    // TODO(#8012): Handle this with datagen alt flags.
-                }
-                Some(alt) => {
-                    log::warn!("Unknown alt variant for region: {}", alt);
-                }
-            }
-        }
         Self {
-            // Old CLDR versions may contain trivial entries, so filter
-            names: names
-                .into_iter()
-                .filter(|&(k, v)| k != v)
-                .map(|(k, v)| (k.to_unvalidated(), v))
-                .collect(),
-            short_names: short_names
-                .into_iter()
-                .filter(|&(k, v)| k != v)
-                .map(|(k, v)| (k.to_unvalidated(), v))
-                .collect(),
+            names: to_zero_map(extracted.names),
+            short_names: to_zero_map(extracted.short_names),
         }
     }
 }

--- a/provider/source/src/displaynames/region.rs
+++ b/provider/source/src/displaynames/region.rs
@@ -5,6 +5,7 @@
 use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
+use crate::cldr_serde::displaynames::ModifiedSubtag;
 use icu::experimental::displaynames::provider::*;
 use icu_provider::prelude::*;
 use std::collections::{BTreeMap, HashSet};

--- a/provider/source/src/displaynames/region.rs
+++ b/provider/source/src/displaynames/region.rs
@@ -5,10 +5,8 @@
 use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
-use crate::cldr_serde::displaynames::WithAlt;
-use crate::displaynames::{
-    ALT_BIOT, ALT_CHAGOS, ALT_SHORT, ALT_VARIANT, extract_names_for_zeromap_struct,
-};
+use crate::cldr_serde::displaynames::{Alt, WithAlt};
+use crate::displaynames::extract_names_for_zeromap_struct;
 use icu::experimental::displaynames::provider::*;
 use icu_provider::prelude::*;
 use std::collections::{BTreeMap, HashSet};
@@ -38,7 +36,7 @@ crate::displaynames::impl_displaynames_v1!(
     cldr_serde::displaynames::region::Resource,
     "territories.json",
     regions,
-    None::<&str>,
+    None,
 );
 
 crate::displaynames::impl_displaynames_v1!(
@@ -47,14 +45,14 @@ crate::displaynames::impl_displaynames_v1!(
     cldr_serde::displaynames::region::Resource,
     "territories.json",
     regions,
-    Some(ALT_SHORT),
+    Some(Alt::Short),
 );
 
 impl From<&cldr_serde::displaynames::region::Resource> for RegionDisplayNames<'static> {
     fn from(other: &cldr_serde::displaynames::region::Resource) -> Self {
         let extracted = extract_names_for_zeromap_struct(
             &other.main.value.localedisplaynames.regions,
-            &[ALT_VARIANT, ALT_CHAGOS, ALT_BIOT],
+            &[Alt::Variant, Alt::Chagos, Alt::Biot],
             "region",
             |region| Some(region.to_tinystr()),
         );

--- a/provider/source/src/displaynames/script.rs
+++ b/provider/source/src/displaynames/script.rs
@@ -5,13 +5,7 @@
 use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
-use crate::displaynames::{
-    ALT_SECONDARY_SUBSTRING, ALT_SHORT_SUBSTRING, ALT_STANDALONE_SUBSTRING, ALT_SUBSTRING,
-    ALT_VARIANT_SUBSTRING,
-};
-use core::convert::TryFrom;
 use icu::experimental::displaynames::provider::*;
-use icu::locale::{ParseError, subtags::Script};
 use icu_provider::prelude::*;
 use std::collections::{BTreeMap, HashSet};
 use zerovec::VarZeroCow;
@@ -27,15 +21,14 @@ impl DataProvider<ScriptDisplayNamesV1> for SourceDataProvider {
 
         Ok(DataResponse {
             metadata: Default::default(),
-            payload: DataPayload::from_owned(ScriptDisplayNames::try_from(data).map_err(|e| {
-                DataError::custom("data for ScriptDisplayNames").with_display_context(&e)
-            })?),
+            payload: DataPayload::from_owned(ScriptDisplayNames::from(data)),
         })
     }
 }
 
 crate::displaynames::impl_displaynames_v1!(
     LocaleNamesScriptMediumV1,
+    icu::locale::subtags::Script,
     cldr_serde::displaynames::script::Resource,
     "scripts.json",
     scripts,
@@ -44,39 +37,45 @@ crate::displaynames::impl_displaynames_v1!(
 
 crate::displaynames::impl_displaynames_v1!(
     LocaleNamesScriptShortV1,
+    icu::locale::subtags::Script,
     cldr_serde::displaynames::script::Resource,
     "scripts.json",
     scripts,
-    Some(ALT_SHORT_SUBSTRING),
+    Some("short"),
 );
 
 crate::displaynames::impl_displaynames_legacy_iter_v1!(ScriptDisplayNamesV1, "scripts.json");
 
-impl TryFrom<&cldr_serde::displaynames::script::Resource> for ScriptDisplayNames<'static> {
-    type Error = ParseError;
-
-    fn try_from(other: &cldr_serde::displaynames::script::Resource) -> Result<Self, Self::Error> {
+impl From<&cldr_serde::displaynames::script::Resource> for ScriptDisplayNames<'static> {
+    fn from(other: &cldr_serde::displaynames::script::Resource) -> Self {
         let mut names = BTreeMap::new();
         let mut short_names = BTreeMap::new();
-        for entry in other.main.value.localedisplaynames.scripts.iter() {
-            if let Some(script) = entry.0.strip_suffix(ALT_SHORT_SUBSTRING) {
-                short_names.insert(Script::try_from_str(script)?.to_tinystr(), entry.1.as_str());
-            } else if !entry.0.contains(ALT_SUBSTRING) {
-                names.insert(
-                    Script::try_from_str(entry.0)?.to_tinystr(),
-                    entry.1.as_str(),
-                );
-            } else if entry.0.ends_with(ALT_VARIANT_SUBSTRING)
-                || entry.0.ends_with(ALT_SECONDARY_SUBSTRING)
-            {
-                // TODO(#8012): Handle this with datagen alt flags.
-            } else if entry.0.ends_with(ALT_STANDALONE_SUBSTRING) {
-                // TODO(#8011): Support standalone display names.
-            } else {
-                log::warn!("Unknown alt variant for script: {}", entry.0);
+        for (key, value) in other.main.value.localedisplaynames.scripts.iter() {
+            if key.menu_variant.is_some() {
+                continue;
+            }
+
+            let script = key.subtag;
+
+            match key.alt_variant.as_deref() {
+                Some("short") => {
+                    short_names.insert(script.to_tinystr(), value.as_str());
+                }
+                None => {
+                    names.insert(script.to_tinystr(), value.as_str());
+                }
+                Some("variant") | Some("secondary") => {
+                    // TODO(#8012): Handle this with datagen alt flags.
+                }
+                Some("stand-alone") => {
+                    // TODO(#8011): Support standalone display names.
+                }
+                Some(alt) => {
+                    log::warn!("Unknown alt variant for script: {}", alt);
+                }
             }
         }
-        Ok(Self {
+        Self {
             // Old CLDR versions may contain trivial entries, so filter
             names: names
                 .into_iter()
@@ -88,10 +87,9 @@ impl TryFrom<&cldr_serde::displaynames::script::Resource> for ScriptDisplayNames
                 .filter(|&(k, v)| k != v)
                 .map(|(k, v)| (k.to_unvalidated(), v))
                 .collect(),
-        })
+        }
     }
 }
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/provider/source/src/displaynames/script.rs
+++ b/provider/source/src/displaynames/script.rs
@@ -6,6 +6,7 @@ use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
 use crate::cldr_serde::displaynames::ModifiedSubtag;
+use crate::displaynames::{ALT_SECONDARY, ALT_SHORT, ALT_STANDALONE, ALT_VARIANT};
 use icu::experimental::displaynames::provider::*;
 use icu_provider::prelude::*;
 use std::collections::{BTreeMap, HashSet};
@@ -42,7 +43,7 @@ crate::displaynames::impl_displaynames_v1!(
     cldr_serde::displaynames::script::Resource,
     "scripts.json",
     scripts,
-    Some("short"),
+    Some(ALT_SHORT),
 );
 
 crate::displaynames::impl_displaynames_legacy_iter_v1!(ScriptDisplayNamesV1, "scripts.json");
@@ -59,16 +60,16 @@ impl From<&cldr_serde::displaynames::script::Resource> for ScriptDisplayNames<'s
             let script = key.subtag;
 
             match key.alt_variant.as_deref() {
-                Some("short") => {
+                Some(ALT_SHORT) => {
                     short_names.insert(script.to_tinystr(), value.as_str());
                 }
                 None => {
                     names.insert(script.to_tinystr(), value.as_str());
                 }
-                Some("variant") | Some("secondary") => {
+                Some(ALT_VARIANT) | Some(ALT_SECONDARY) => {
                     // TODO(#8012): Handle this with datagen alt flags.
                 }
-                Some("stand-alone") => {
+                Some(ALT_STANDALONE) => {
                     // TODO(#8011): Support standalone display names.
                 }
                 Some(alt) => {

--- a/provider/source/src/displaynames/script.rs
+++ b/provider/source/src/displaynames/script.rs
@@ -5,7 +5,7 @@
 use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
-use crate::cldr_serde::displaynames::ModifiedSubtag;
+use crate::cldr_serde::displaynames::WithAlt;
 use crate::displaynames::{ALT_SECONDARY, ALT_SHORT, ALT_STANDALONE, ALT_VARIANT};
 use icu::experimental::displaynames::provider::*;
 use icu_provider::prelude::*;
@@ -53,13 +53,13 @@ impl From<&cldr_serde::displaynames::script::Resource> for ScriptDisplayNames<'s
         let mut names = BTreeMap::new();
         let mut short_names = BTreeMap::new();
         for (key, value) in other.main.value.localedisplaynames.scripts.iter() {
-            if key.menu_variant.is_some() {
+            if key.menu.is_some() {
                 continue;
             }
 
             let script = key.subtag;
 
-            match key.alt_variant.as_deref() {
+            match key.alt.as_deref() {
                 Some(ALT_SHORT) => {
                     short_names.insert(script.to_tinystr(), value.as_str());
                 }

--- a/provider/source/src/displaynames/script.rs
+++ b/provider/source/src/displaynames/script.rs
@@ -56,14 +56,7 @@ impl From<&cldr_serde::displaynames::script::Resource> for ScriptDisplayNames<'s
             &other.main.value.localedisplaynames.scripts,
             &[ALT_VARIANT, ALT_SECONDARY, ALT_STANDALONE],
             "script",
-            |script, val| {
-                let script_str = script.to_tinystr();
-                if script_str.as_str() == val {
-                    None
-                } else {
-                    Some(script_str)
-                }
-            },
+            |script| Some(script.to_tinystr()),
         );
 
         let to_zero_map = |map: BTreeMap<tinystr::TinyAsciiStr<4>, &str>| {

--- a/provider/source/src/displaynames/script.rs
+++ b/provider/source/src/displaynames/script.rs
@@ -6,7 +6,9 @@ use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
 use crate::cldr_serde::displaynames::WithAlt;
-use crate::displaynames::{ALT_SECONDARY, ALT_SHORT, ALT_STANDALONE, ALT_VARIANT, extract_names};
+use crate::displaynames::{
+    ALT_SECONDARY, ALT_SHORT, ALT_STANDALONE, ALT_VARIANT, extract_names_for_zeromap_struct,
+};
 use icu::experimental::displaynames::provider::*;
 use icu_provider::prelude::*;
 use std::collections::{BTreeMap, HashSet};
@@ -50,7 +52,7 @@ crate::displaynames::impl_displaynames_legacy_iter_v1!(ScriptDisplayNamesV1, "sc
 
 impl From<&cldr_serde::displaynames::script::Resource> for ScriptDisplayNames<'static> {
     fn from(other: &cldr_serde::displaynames::script::Resource) -> Self {
-        let extracted = extract_names(
+        let extracted = extract_names_for_zeromap_struct(
             &other.main.value.localedisplaynames.scripts,
             &[ALT_VARIANT, ALT_SECONDARY, ALT_STANDALONE],
             "script",

--- a/provider/source/src/displaynames/script.rs
+++ b/provider/source/src/displaynames/script.rs
@@ -5,10 +5,8 @@
 use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
-use crate::cldr_serde::displaynames::WithAlt;
-use crate::displaynames::{
-    ALT_SECONDARY, ALT_SHORT, ALT_STANDALONE, ALT_VARIANT, extract_names_for_zeromap_struct,
-};
+use crate::cldr_serde::displaynames::{Alt, WithAlt};
+use crate::displaynames::extract_names_for_zeromap_struct;
 use icu::experimental::displaynames::provider::*;
 use icu_provider::prelude::*;
 use std::collections::{BTreeMap, HashSet};
@@ -36,7 +34,7 @@ crate::displaynames::impl_displaynames_v1!(
     cldr_serde::displaynames::script::Resource,
     "scripts.json",
     scripts,
-    None::<&str>,
+    None,
 );
 
 crate::displaynames::impl_displaynames_v1!(
@@ -45,7 +43,7 @@ crate::displaynames::impl_displaynames_v1!(
     cldr_serde::displaynames::script::Resource,
     "scripts.json",
     scripts,
-    Some(ALT_SHORT),
+    Some(Alt::Short),
 );
 
 crate::displaynames::impl_displaynames_legacy_iter_v1!(ScriptDisplayNamesV1, "scripts.json");
@@ -54,7 +52,7 @@ impl From<&cldr_serde::displaynames::script::Resource> for ScriptDisplayNames<'s
     fn from(other: &cldr_serde::displaynames::script::Resource) -> Self {
         let extracted = extract_names_for_zeromap_struct(
             &other.main.value.localedisplaynames.scripts,
-            &[ALT_VARIANT, ALT_SECONDARY, ALT_STANDALONE],
+            &[Alt::Variant, Alt::Secondary, Alt::StandAlone],
             "script",
             |script| Some(script.to_tinystr()),
         );

--- a/provider/source/src/displaynames/script.rs
+++ b/provider/source/src/displaynames/script.rs
@@ -8,6 +8,7 @@ use crate::cldr_serde;
 use crate::cldr_serde::displaynames::{Alt, WithAlt};
 use crate::displaynames::extract_names_for_zeromap_struct;
 use icu::experimental::displaynames::provider::*;
+use icu::locale::subtags::Script;
 use icu_provider::prelude::*;
 use std::collections::{BTreeMap, HashSet};
 use zerovec::VarZeroCow;
@@ -30,7 +31,7 @@ impl DataProvider<ScriptDisplayNamesV1> for SourceDataProvider {
 
 crate::displaynames::impl_displaynames_v1!(
     LocaleNamesScriptMediumV1,
-    icu::locale::subtags::Script,
+    Script,
     cldr_serde::displaynames::script::Resource,
     "scripts.json",
     scripts,
@@ -39,7 +40,7 @@ crate::displaynames::impl_displaynames_v1!(
 
 crate::displaynames::impl_displaynames_v1!(
     LocaleNamesScriptShortV1,
-    icu::locale::subtags::Script,
+    Script,
     cldr_serde::displaynames::script::Resource,
     "scripts.json",
     scripts,

--- a/provider/source/src/displaynames/script.rs
+++ b/provider/source/src/displaynames/script.rs
@@ -5,6 +5,7 @@
 use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
+use crate::cldr_serde::displaynames::ModifiedSubtag;
 use icu::experimental::displaynames::provider::*;
 use icu_provider::prelude::*;
 use std::collections::{BTreeMap, HashSet};

--- a/provider/source/src/displaynames/script.rs
+++ b/provider/source/src/displaynames/script.rs
@@ -6,7 +6,7 @@ use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
 use crate::cldr_serde::displaynames::WithAlt;
-use crate::displaynames::{ALT_SECONDARY, ALT_SHORT, ALT_STANDALONE, ALT_VARIANT};
+use crate::displaynames::{ALT_SECONDARY, ALT_SHORT, ALT_STANDALONE, ALT_VARIANT, extract_names};
 use icu::experimental::displaynames::provider::*;
 use icu_provider::prelude::*;
 use std::collections::{BTreeMap, HashSet};
@@ -50,45 +50,29 @@ crate::displaynames::impl_displaynames_legacy_iter_v1!(ScriptDisplayNamesV1, "sc
 
 impl From<&cldr_serde::displaynames::script::Resource> for ScriptDisplayNames<'static> {
     fn from(other: &cldr_serde::displaynames::script::Resource) -> Self {
-        let mut names = BTreeMap::new();
-        let mut short_names = BTreeMap::new();
-        for (key, value) in other.main.value.localedisplaynames.scripts.iter() {
-            if key.menu.is_some() {
-                continue;
-            }
+        let extracted = extract_names(
+            &other.main.value.localedisplaynames.scripts,
+            &[ALT_VARIANT, ALT_SECONDARY, ALT_STANDALONE],
+            "script",
+            |script, val| {
+                let script_str = script.to_tinystr();
+                if script_str.as_str() == val {
+                    None
+                } else {
+                    Some(script_str)
+                }
+            },
+        );
 
-            let script = key.subtag;
+        let to_zero_map = |map: BTreeMap<tinystr::TinyAsciiStr<4>, &str>| {
+            map.into_iter()
+                .map(|(k, v)| (k.to_unvalidated(), v))
+                .collect()
+        };
 
-            match key.alt.as_deref() {
-                Some(ALT_SHORT) => {
-                    short_names.insert(script.to_tinystr(), value.as_str());
-                }
-                None => {
-                    names.insert(script.to_tinystr(), value.as_str());
-                }
-                Some(ALT_VARIANT) | Some(ALT_SECONDARY) => {
-                    // TODO(#8012): Handle this with datagen alt flags.
-                }
-                Some(ALT_STANDALONE) => {
-                    // TODO(#8011): Support standalone display names.
-                }
-                Some(alt) => {
-                    log::warn!("Unknown alt variant for script: {}", alt);
-                }
-            }
-        }
         Self {
-            // Old CLDR versions may contain trivial entries, so filter
-            names: names
-                .into_iter()
-                .filter(|&(k, v)| k != v)
-                .map(|(k, v)| (k.to_unvalidated(), v))
-                .collect(),
-            short_names: short_names
-                .into_iter()
-                .filter(|&(k, v)| k != v)
-                .map(|(k, v)| (k.to_unvalidated(), v))
-                .collect(),
+            names: to_zero_map(extracted.names),
+            short_names: to_zero_map(extracted.short_names),
         }
     }
 }

--- a/provider/source/src/displaynames/variant.rs
+++ b/provider/source/src/displaynames/variant.rs
@@ -38,6 +38,7 @@ crate::displaynames::impl_displaynames_v1!(
 
 crate::displaynames::impl_displaynames_legacy_iter_v1!(VariantDisplayNamesV1, "variants.json");
 
+// TODO: Support alt variants for variant display names.
 impl From<&cldr_serde::displaynames::variant::Resource> for VariantDisplayNames<'static> {
     fn from(other: &cldr_serde::displaynames::variant::Resource) -> Self {
         let mut names = BTreeMap::new();

--- a/provider/source/src/displaynames/variant.rs
+++ b/provider/source/src/displaynames/variant.rs
@@ -46,14 +46,7 @@ impl From<&cldr_serde::displaynames::variant::Resource> for VariantDisplayNames<
             &other.main.value.localedisplaynames.variants,
             &[ALT_SECONDARY],
             "variant",
-            |variant, val| {
-                let variant_str = variant.to_tinystr();
-                if variant_str.as_str() == val {
-                    None
-                } else {
-                    Some(variant_str)
-                }
-            },
+            |variant| Some(variant.to_tinystr()),
         );
 
         let to_zero_map = |map: BTreeMap<tinystr::TinyAsciiStr<8>, &str>| {

--- a/provider/source/src/displaynames/variant.rs
+++ b/provider/source/src/displaynames/variant.rs
@@ -6,6 +6,7 @@ use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
 use crate::cldr_serde::displaynames::WithAlt;
+use crate::displaynames::{ALT_SECONDARY, extract_names};
 use icu::experimental::displaynames::provider::*;
 use icu_provider::prelude::*;
 use std::collections::{BTreeMap, HashSet};
@@ -41,33 +42,28 @@ crate::displaynames::impl_displaynames_legacy_iter_v1!(VariantDisplayNamesV1, "v
 // TODO: Support alt variants for variant display names.
 impl From<&cldr_serde::displaynames::variant::Resource> for VariantDisplayNames<'static> {
     fn from(other: &cldr_serde::displaynames::variant::Resource) -> Self {
-        let mut names = BTreeMap::new();
-        for (key, value) in other.main.value.localedisplaynames.variants.iter() {
-            if key.menu.is_some() {
-                continue;
-            }
+        let extracted = extract_names(
+            &other.main.value.localedisplaynames.variants,
+            &[ALT_SECONDARY],
+            "variant",
+            |variant, val| {
+                let variant_str = variant.to_tinystr();
+                if variant_str.as_str() == val {
+                    None
+                } else {
+                    Some(variant_str)
+                }
+            },
+        );
 
-            let variant = key.subtag;
-
-            match key.alt.as_deref() {
-                None => {
-                    names.insert(variant.to_tinystr(), value.as_str());
-                }
-                Some("secondary") => {
-                    // TODO(#8012): Handle this with datagen alt flags.
-                }
-                Some(alt) => {
-                    log::warn!("Unknown alt variant for variant: {}", alt);
-                }
-            }
-        }
-        Self {
-            // Old CLDR versions may contain trivial entries, so filter
-            names: names
-                .into_iter()
-                .filter(|&(k, v)| k != v)
+        let to_zero_map = |map: BTreeMap<tinystr::TinyAsciiStr<8>, &str>| {
+            map.into_iter()
                 .map(|(k, v)| (k.to_unvalidated(), v))
-                .collect(),
+                .collect()
+        };
+
+        Self {
+            names: to_zero_map(extracted.names),
         }
     }
 }

--- a/provider/source/src/displaynames/variant.rs
+++ b/provider/source/src/displaynames/variant.rs
@@ -6,7 +6,7 @@ use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
 use crate::cldr_serde::displaynames::WithAlt;
-use crate::displaynames::{ALT_SECONDARY, extract_names};
+use crate::displaynames::{ALT_SECONDARY, extract_names_for_zeromap_struct};
 use icu::experimental::displaynames::provider::*;
 use icu_provider::prelude::*;
 use std::collections::{BTreeMap, HashSet};
@@ -42,7 +42,7 @@ crate::displaynames::impl_displaynames_legacy_iter_v1!(VariantDisplayNamesV1, "v
 // TODO: Support alt variants for variant display names.
 impl From<&cldr_serde::displaynames::variant::Resource> for VariantDisplayNames<'static> {
     fn from(other: &cldr_serde::displaynames::variant::Resource) -> Self {
-        let extracted = extract_names(
+        let extracted = extract_names_for_zeromap_struct(
             &other.main.value.localedisplaynames.variants,
             &[ALT_SECONDARY],
             "variant",

--- a/provider/source/src/displaynames/variant.rs
+++ b/provider/source/src/displaynames/variant.rs
@@ -8,6 +8,7 @@ use crate::cldr_serde;
 use crate::cldr_serde::displaynames::{Alt, WithAlt};
 use crate::displaynames::extract_names_for_zeromap_struct;
 use icu::experimental::displaynames::provider::*;
+use icu::locale::subtags::Variant;
 use icu_provider::prelude::*;
 use std::collections::{BTreeMap, HashSet};
 use zerovec::VarZeroCow;
@@ -30,7 +31,7 @@ impl DataProvider<VariantDisplayNamesV1> for SourceDataProvider {
 
 crate::displaynames::impl_displaynames_v1!(
     LocaleNamesVariantMediumV1,
-    icu::locale::subtags::Variant,
+    Variant,
     cldr_serde::displaynames::variant::Resource,
     "variants.json",
     variants,

--- a/provider/source/src/displaynames/variant.rs
+++ b/provider/source/src/displaynames/variant.rs
@@ -5,10 +5,7 @@
 use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
-use crate::displaynames::{ALT_SECONDARY_SUBSTRING, ALT_SUBSTRING};
-use core::convert::TryFrom;
 use icu::experimental::displaynames::provider::*;
-use icu::locale::{ParseError, subtags::Variant};
 use icu_provider::prelude::*;
 use std::collections::{BTreeMap, HashSet};
 use zerovec::VarZeroCow;
@@ -24,15 +21,14 @@ impl DataProvider<VariantDisplayNamesV1> for SourceDataProvider {
 
         Ok(DataResponse {
             metadata: Default::default(),
-            payload: DataPayload::from_owned(VariantDisplayNames::try_from(data).map_err(|e| {
-                DataError::custom("data for VariantDisplayNames").with_display_context(&e)
-            })?),
+            payload: DataPayload::from_owned(VariantDisplayNames::from(data)),
         })
     }
 }
 
 crate::displaynames::impl_displaynames_v1!(
     LocaleNamesVariantMediumV1,
+    icu::locale::subtags::Variant,
     cldr_serde::displaynames::variant::Resource,
     "variants.json",
     variants,
@@ -41,35 +37,38 @@ crate::displaynames::impl_displaynames_v1!(
 
 crate::displaynames::impl_displaynames_legacy_iter_v1!(VariantDisplayNamesV1, "variants.json");
 
-impl TryFrom<&cldr_serde::displaynames::variant::Resource> for VariantDisplayNames<'static> {
-    type Error = ParseError;
-
-    fn try_from(other: &cldr_serde::displaynames::variant::Resource) -> Result<Self, Self::Error> {
+impl From<&cldr_serde::displaynames::variant::Resource> for VariantDisplayNames<'static> {
+    fn from(other: &cldr_serde::displaynames::variant::Resource) -> Self {
         let mut names = BTreeMap::new();
-        for entry in other.main.value.localedisplaynames.variants.iter() {
-            // TODO: Support alt variants for variant display names.
-            if !entry.0.contains(ALT_SUBSTRING) {
-                names.insert(
-                    Variant::try_from_str(entry.0)?.to_tinystr(),
-                    entry.1.as_str(),
-                );
-            } else if entry.0.ends_with(ALT_SECONDARY_SUBSTRING) {
-                // TODO(#8012): Handle this with datagen alt flags.
-            } else {
-                log::warn!("Unknown alt variant for variant: {}", entry.0);
+        for (key, value) in other.main.value.localedisplaynames.variants.iter() {
+            if key.menu_variant.is_some() {
+                continue;
+            }
+
+            let variant = key.subtag;
+
+            match key.alt_variant.as_deref() {
+                None => {
+                    names.insert(variant.to_tinystr(), value.as_str());
+                }
+                Some("secondary") => {
+                    // TODO(#8012): Handle this with datagen alt flags.
+                }
+                Some(alt) => {
+                    log::warn!("Unknown alt variant for variant: {}", alt);
+                }
             }
         }
-        Ok(Self {
+        Self {
             // Old CLDR versions may contain trivial entries, so filter
             names: names
                 .into_iter()
                 .filter(|&(k, v)| k != v)
                 .map(|(k, v)| (k.to_unvalidated(), v))
                 .collect(),
-        })
+        }
     }
 }
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/provider/source/src/displaynames/variant.rs
+++ b/provider/source/src/displaynames/variant.rs
@@ -5,6 +5,7 @@
 use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
+use crate::cldr_serde::displaynames::ModifiedSubtag;
 use icu::experimental::displaynames::provider::*;
 use icu_provider::prelude::*;
 use std::collections::{BTreeMap, HashSet};

--- a/provider/source/src/displaynames/variant.rs
+++ b/provider/source/src/displaynames/variant.rs
@@ -37,8 +37,6 @@ crate::displaynames::impl_displaynames_v1!(
     "variants.json",
     variants,
     None::<&str>,
-    |k: String| k.to_ascii_uppercase(), // load: BCP-47 (lowercase) -> CLDR (uppercase)
-    |k: String| k.to_ascii_lowercase()  // iter: CLDR (uppercase) -> BCP-47 (lowercase)
 );
 
 crate::displaynames::impl_displaynames_legacy_iter_v1!(VariantDisplayNamesV1, "variants.json");

--- a/provider/source/src/displaynames/variant.rs
+++ b/provider/source/src/displaynames/variant.rs
@@ -5,7 +5,7 @@
 use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
-use crate::cldr_serde::displaynames::ModifiedSubtag;
+use crate::cldr_serde::displaynames::WithAlt;
 use icu::experimental::displaynames::provider::*;
 use icu_provider::prelude::*;
 use std::collections::{BTreeMap, HashSet};
@@ -43,13 +43,13 @@ impl From<&cldr_serde::displaynames::variant::Resource> for VariantDisplayNames<
     fn from(other: &cldr_serde::displaynames::variant::Resource) -> Self {
         let mut names = BTreeMap::new();
         for (key, value) in other.main.value.localedisplaynames.variants.iter() {
-            if key.menu_variant.is_some() {
+            if key.menu.is_some() {
                 continue;
             }
 
             let variant = key.subtag;
 
-            match key.alt_variant.as_deref() {
+            match key.alt.as_deref() {
                 None => {
                     names.insert(variant.to_tinystr(), value.as_str());
                 }

--- a/provider/source/src/displaynames/variant.rs
+++ b/provider/source/src/displaynames/variant.rs
@@ -5,8 +5,8 @@
 use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
-use crate::cldr_serde::displaynames::WithAlt;
-use crate::displaynames::{ALT_SECONDARY, extract_names_for_zeromap_struct};
+use crate::cldr_serde::displaynames::{Alt, WithAlt};
+use crate::displaynames::extract_names_for_zeromap_struct;
 use icu::experimental::displaynames::provider::*;
 use icu_provider::prelude::*;
 use std::collections::{BTreeMap, HashSet};
@@ -34,7 +34,7 @@ crate::displaynames::impl_displaynames_v1!(
     cldr_serde::displaynames::variant::Resource,
     "variants.json",
     variants,
-    None::<&str>,
+    None,
 );
 
 crate::displaynames::impl_displaynames_legacy_iter_v1!(VariantDisplayNamesV1, "variants.json");
@@ -44,7 +44,7 @@ impl From<&cldr_serde::displaynames::variant::Resource> for VariantDisplayNames<
     fn from(other: &cldr_serde::displaynames::variant::Resource) -> Self {
         let extracted = extract_names_for_zeromap_struct(
             &other.main.value.localedisplaynames.variants,
-            &[ALT_SECONDARY],
+            &[Alt::Secondary],
             "variant",
             |variant| Some(variant.to_tinystr()),
         );

--- a/provider/source/src/time_zones/convert.rs
+++ b/provider/source/src/time_zones/convert.rs
@@ -5,6 +5,7 @@
 use super::{MetazoneInfo, MzMembership};
 use crate::SourceDataProvider;
 use crate::cldr_serde;
+use crate::cldr_serde::displaynames::Alt;
 use cldr_serde::time_zones::time_zone_names::*;
 use core::cmp::Ordering;
 use icu::datetime::provider::time_zones::*;
@@ -152,7 +153,7 @@ impl SourceDataProvider {
                 })
                 // Overwrite with short names, as we want to use those
                 .chain(regions.iter().filter_map(|(key, value)| {
-                    if key.alt.as_deref() == Some("short") && key.menu.is_none() {
+                    if key.alt == Some(Alt::Short) && key.menu.is_none() {
                         Some((key.subtag, value.as_str()))
                     } else {
                         None

--- a/provider/source/src/time_zones/convert.rs
+++ b/provider/source/src/time_zones/convert.rs
@@ -143,21 +143,20 @@ impl SourceDataProvider {
                 .regions;
             regions
                 .iter()
-                .filter_map(|(region, value)| {
-                    Some((
-                        icu::locale::subtags::Region::try_from_str(region).ok()?,
-                        value.as_str(),
-                    ))
+                .filter_map(|(key, value)| {
+                    if key.alt_variant.is_none() && key.menu_variant.is_none() {
+                        Some((key.subtag, value.as_str()))
+                    } else {
+                        None
+                    }
                 })
                 // Overwrite with short names, as we want to use those
-                .chain(regions.iter().filter_map(|(region, value)| {
-                    Some((
-                        icu::locale::subtags::Region::try_from_str(
-                            region.strip_suffix("-alt-short")?,
-                        )
-                        .ok()?,
-                        value.as_str(),
-                    ))
+                .chain(regions.iter().filter_map(|(key, value)| {
+                    if key.alt_variant.as_deref() == Some("short") && key.menu_variant.is_none() {
+                        Some((key.subtag, value.as_str()))
+                    } else {
+                        None
+                    }
                 }))
                 .filter(|(r, _)| primary_zones_values.contains(r))
                 .collect()

--- a/provider/source/src/time_zones/convert.rs
+++ b/provider/source/src/time_zones/convert.rs
@@ -144,7 +144,7 @@ impl SourceDataProvider {
             regions
                 .iter()
                 .filter_map(|(key, value)| {
-                    if key.alt_variant.is_none() && key.menu_variant.is_none() {
+                    if key.alt.is_none() && key.menu.is_none() {
                         Some((key.subtag, value.as_str()))
                     } else {
                         None
@@ -152,7 +152,7 @@ impl SourceDataProvider {
                 })
                 // Overwrite with short names, as we want to use those
                 .chain(regions.iter().filter_map(|(key, value)| {
-                    if key.alt_variant.as_deref() == Some("short") && key.menu_variant.is_none() {
+                    if key.alt.as_deref() == Some("short") && key.menu.is_none() {
                         Some((key.subtag, value.as_str()))
                     } else {
                         None


### PR DESCRIPTION
This PR refactors the `icu_provider_source` crate to migrate CLDR Serde display names to a new structured key type `WithAlt<T>`.

This replaces fragile string parsing at the provider layer with type-safe deserialization at the Serde layer, and introduces clean support for `menu` variants.

### Key Changes
1.  **Structured Key (`WithAlt<T>`)**: Defined a new key type that wraps a subtag `T` and carries optional `alt` and `menu` fields.
2.  **Smart Deserialization**: Implemented a custom `Deserialize` for `WithAlt<T>` that uses `split_once` to safely strip and extract `"-menu-"` and `"-alt-"` suffixes before parsing the subtag `T`.
3.  **Typed Keys**: Migrated all display name Serde maps (languages, regions, scripts, variants) to use `WithAlt<T>` with their respective typed subtags (`LanguageIdentifier`, `Region`, `Script`, `Variant`) instead of raw `String`s.
4.  **Infallible Providers**: Simplified the provider `TryFrom` implementations to infallible `From` implementations since all validation and parsing now happen during deserialization.
5.  **Macro Updates**: Preserved and updated the `impl_displaynames_v1!`, `impl_displaynames_iter_v1!`, and `impl_displaynames_menu_v1!` macros to be generic over the subtag type `T`. Removed the fully qualified path from the macros and imported `WithAlt` at the call sites.
6.  **Timezone Provider Update**: Updated `time_zones/convert.rs` to use the new structured keys for `territories.json`, replacing string suffix stripping with clean field checks.

## Changelog

N/A
