### PR TITLE
Fix CI by running apt-get update before installing LLVM 20

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -267,7 +267,9 @@ jobs:
 
     # Job-specific dependencies
     - name: Install LLD and Clang
-      run: sudo apt-get install lld-20 clang-20
+      run: |
+        sudo apt-get update
+        sudo apt-get install lld-20 clang-20
 
     # Actual job
     - name: Run `cargo make ci-job-test-c`
@@ -301,7 +303,9 @@ jobs:
 
     # Job-specific dependencies
     - name: Install LLD
-      run: sudo apt-get install lld-20
+      run: |
+        sudo apt-get update
+        sudo apt-get install lld-20
 
     # Actual job
     - name: Run `cargo make ci-job-test-js`


### PR DESCRIPTION
Fixes the CI failures on the `test-c` and `test-js` jobs, which were failing with 404 errors during the installation of `lld-20` and `clang-20`. 

By running `sudo apt-get update` before `apt-get install`, we ensure the package cache is refreshed and the runner can successfully locate and download the LLVM 20 packages.

🤖 This pull request was created by an AI agent working with @sffc.

## Changelog (N/A)
