### PR TITLE
release/2.1: Bump icu_collator to 2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ Several crates have had patch releases in the 2.1 stream:
 - Components
     - (2.1.1) General
         - Fix `icu_locale_core` dependency (unicode-org#7191)
-    - (2.1.2)`icu_properties`
+    - (2.1.2) `icu_collator`
+        - Fix panic when using `AlternateHandling::Shifted` with `MaxVariable::Currency` (off-by-one in special primaries validation). (unicode-org#8075)
+    - (2.1.2) `icu_properties`
         - Fix some property constants (unicode-org#7269, unicode-org#7281, unicode-org#7284)
         - Add conversions for `unicode_bidi::BidiClass` (unicode-org#7272)
         - Add `IndicConjunctBreak` (unicode-org#7280)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1293,7 +1293,7 @@ dependencies = [
 
 [[package]]
 name = "icu_collator"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "arraystring",
  "atoi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,7 +140,7 @@ icu_pattern = { version = "0.4.1", path = "components/pattern", default-features
 icu = { version = "~2.1.1", path = "components/icu", default-features = false }
 icu_calendar = { version = "~2.1.1", path = "components/calendar", default-features = false }
 icu_casemap = { version = "~2.1.1", path = "components/casemap", default-features = false }
-icu_collator = { version = "~2.1.1", path = "components/collator", default-features = false }
+icu_collator = { version = "~2.1.2", path = "components/collator", default-features = false }
 icu_collections = { version = "~2.1.1", path = "components/collections", default-features = false }
 icu_codepointtrie_builder = { version = "~0.5.0", path = "components/collections/codepointtrie_builder", default-features = false }
 icu_datetime = { version = "~2.1.1", path = "components/datetime", default-features = false }

--- a/components/collator/Cargo.toml
+++ b/components/collator/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_collator"
 description = "API for comparing strings according to language-dependent conventions"
-version.workspace = true
+version = "2.1.2"
 
 authors.workspace = true
 categories.workspace = true


### PR DESCRIPTION
This PR bumps the version of `icu_collator` to `2.1.2` on the `release/2.1` branch to release the fix for the off-by-one panic (merged in #8075).

This breaks the version inheritance for `icu_collator` in the workspace to allow bumping it individually, as requested.

🤖 This pull request was created by an AI agent working with @sffc.

## Changelog
- `icu_collator`: 2.1.2
  - Bump version to 2.1.2.
