### PR TITLE
Remove `und` -> `en-Latn-US` expansion

### DIFF
--- a/components/locale/src/expander.rs
+++ b/components/locale/src/expander.rs
@@ -399,16 +399,23 @@ impl LocaleExpander {
         }
         if let Some(script) = langid.script {
             if let Some(region) = langid.region
-                && let Some(language) = data.get_sr(script, region)
+                && let Some(language) = data
+                    .get_sr(script, region)
+                    .or_else(|| ((script, region) == (und_s, und_r)).then_some(und_l))
             {
                 return update_langid(language, None, None, langid);
             }
-            if let Some((language, region)) = data.get_s(script) {
+            if let Some((language, region)) = data
+                .get_s(script)
+                .or_else(|| (script == und_s).then_some((und_l, und_r)))
+            {
                 return update_langid(language, None, Some(region), langid);
             }
         }
         if let Some(region) = langid.region
-            && let Some((language, script)) = data.get_r(region)
+            && let Some((language, script)) = data
+                .get_r(region)
+                .or_else(|| (region == und_r).then_some((und_l, und_s)))
         {
             return update_langid(language, Some(script), None, langid);
         }
@@ -417,9 +424,7 @@ impl LocaleExpander {
         // to fall back to bare "und"
         debug_assert!(langid.language.is_unknown());
 
-        // und expands to `und_l-und_s-und_r`
-        // TODO: remove this behavior: https://unicode-org.atlassian.net/browse/CLDR-14524
-        update_langid(und_l, Some(und_s), Some(und_r), langid)
+        TransformResult::Unmodified
     }
 
     /// This returns a new Locale that is the result of running the
@@ -543,7 +548,7 @@ impl LocaleExpander {
     fn infer_likely_script(&self, language: Language, region: Option<Region>) -> Option<Script> {
         // This is an inlined and simplified `maximize`.
         let data = self.as_borrowed();
-        let (_, und_s, _) = data.get_und();
+        let (und_l, und_s, und_r) = data.get_und();
 
         if !language.is_unknown() {
             if let Some(region) = region
@@ -558,7 +563,9 @@ impl LocaleExpander {
             return None;
         }
         if let Some(region) = region
-            && let Some((_, script)) = data.get_r(region)
+            && let Some((_, script)) = data
+                .get_r(region)
+                .or_else(|| (region == und_r).then_some((und_l, und_s)))
         {
             return Some(script);
         }
@@ -567,9 +574,7 @@ impl LocaleExpander {
         // to fall back to bare "und"
         debug_assert!(language.is_unknown());
 
-        // und expands to `und_l-und_s-und_r`
-        // TODO: remove this behavior: https://unicode-org.atlassian.net/browse/CLDR-14524
-        Some(und_s)
+        None
     }
 }
 
@@ -608,10 +613,7 @@ mod tests {
     fn test_get_likely_script() {
         let lc = LocaleExpander::new_common();
 
-        assert_eq!(
-            lc.get_likely_script(&locale!("und").id),
-            Some(script!("Latn"))
-        );
+        assert_eq!(lc.get_likely_script(&locale!("und").id), None);
 
         assert_eq!(
             lc.get_likely_script(&locale!("en").id),
@@ -643,8 +645,7 @@ mod tests {
         let mut locale;
 
         locale = locale!("und");
-        assert_eq!(lc.maximize(&mut locale.id), TransformResult::Modified);
-        assert_eq!(locale, locale!("en-Latn-US"));
+        assert_eq!(lc.maximize(&mut locale.id), TransformResult::Unmodified);
 
         locale = locale!("en");
         assert_eq!(lc.maximize(&mut locale.id), TransformResult::Modified);

--- a/components/locale/src/provider.rs
+++ b/components/locale/src/provider.rs
@@ -331,7 +331,9 @@ pub struct LikelySubtagsForLanguage<'data> {
     /// Undefined.
     ///
     /// This entry is treated as the following expansions:
-    /// * und->LSR
+    /// * und-S->LSR
+    /// * und-R->LSR
+    /// * und-S-R->LSR
     pub und: (Language, Script, Region),
 }
 

--- a/components/locale/tests/fixtures/maximize.json
+++ b/components/locale/tests/fixtures/maximize.json
@@ -161,6 +161,14 @@
   },
   {
     "input": "und",
+    "output": "und"
+  },
+  {
+    "input": "und-US",
+    "output": "en-Latn-US"
+  },
+  {
+    "input": "und-Latn",
     "output": "en-Latn-US"
   },
   {
@@ -177,11 +185,11 @@
   },
   {
     "input": "und-001",
-    "output": "en-Latn-001"
+    "output": "und-001"
   },
   {
     "input": "und-150",
-    "output": "en-Latn-150"
+    "output": "und-150"
   },
   {
     "input": "und-419",
@@ -197,15 +205,15 @@
   },
   {
     "input": "und-XZ",
-    "output": "en-Latn-XZ"
+    "output": "und-XZ"
   },
   {
     "input": "und-Qaaz",
-    "output": "en-Qaaz-US"
+    "output": "und-Qaaz"
   },
   {
     "input": "und-Qaaz-XZ",
-    "output": "en-Qaaz-XZ"
+    "output": "und-Qaaz-XZ"
   },
   {
     "input": "qaa",

--- a/components/locale/tests/fixtures/minimize.json
+++ b/components/locale/tests/fixtures/minimize.json
@@ -13,6 +13,14 @@
   },
   {
     "input": "und",
+    "output": "und"
+  },
+  {
+    "input": "und-Latn",
+    "output": "en"
+  },
+  {
+    "input": "und-US",
     "output": "en"
   },
   {

--- a/examples/c/locale.c
+++ b/examples/c/locale.c
@@ -249,8 +249,8 @@ int main() {
     // Test maximize.
     write = diplomat_simple_write(output, 40);
     struct DiplomatStringView und_str = {
-        "und",
-        3
+        "und-US",
+        6
     };
     locale_result = icu4x_Locale_from_string_mv1(und_str);
     if (!locale_result.is_ok) {

--- a/provider/source/src/cldr_cache.rs
+++ b/provider/source/src/cldr_cache.rs
@@ -190,6 +190,8 @@ impl CldrCache {
     /// # Example
     ///  - "en-US" -> "US"
     ///  - "en" -> "US"
+    ///  - "ar" -> "EG"
+    ///  - "und" -> "US" // TODO: change
     #[cfg(feature = "unstable")]
     pub(crate) fn extract_or_infer_region(&self, locale: &DataLocale) -> Result<Region, DataError> {
         if let Some(region) = locale.region {
@@ -198,7 +200,9 @@ impl CldrCache {
 
         let mut lang_id = LanguageIdentifier::from((locale.language, locale.script, locale.region));
         let _ = self.extended_locale_expander()?.maximize(&mut lang_id);
-        Ok(lang_id.region.unwrap())
+        Ok(lang_id
+            .region
+            .unwrap_or(icu::locale::subtags::region!("US")))
     }
 
     /// Computes the script-based locale group for a given locale.
@@ -213,6 +217,10 @@ impl CldrCache {
     /// - "ar-SA" -> "ar-Arab-SA" -> "und-Arab" -> "ar-Arab-EG" -> "ar"
     /// - "bm-Nkoo" -> "bm-Nkoo-ML" -> "und-Nkoo" -> "man-Nkoo-GN" -> "man-Nkoo"
     /// - "nqo" -> "nqo-Nkoo-GN" -> "und-Nkoo" -> "man-Nkoo-GN" -> "man-Nkoo"
+    /// - "und-Latn" -> "en-Latn-US" -> "en"
+    /// - "und-Arab" -> "ar-Arab-EG" -> "ar"
+    /// - "und-US" -> "en-Latn-US" -> "en"
+    /// - "und" -> "und"
     pub(crate) fn script_based_locale_group(
         &self,
         locale: &DataLocale,

--- a/provider/source/src/cldr_cache.rs
+++ b/provider/source/src/cldr_cache.rs
@@ -10,9 +10,6 @@ use crate::datetime::DatagenCalendar;
 use crate::source::{AbstractFs, SerdeCache};
 use icu::locale::LanguageIdentifier;
 use icu::locale::LocaleExpander;
-use icu::locale::provider::{
-    LocaleLikelySubtagsExtendedV1, LocaleLikelySubtagsLanguageV1, LocaleLikelySubtagsScriptRegionV1,
-};
 use icu::locale::subtags::Language;
 #[cfg(feature = "unstable")]
 use icu::locale::subtags::Region;
@@ -136,58 +133,13 @@ impl CldrCache {
         use super::locale::likely_subtags::*;
         self.extended_locale_expander
             .get_or_init(|| {
-                use icu_provider::prelude::*;
-                struct Provider {
-                    common: TransformResult,
-                    extended: TransformResult,
-                }
-                impl DataProvider<LocaleLikelySubtagsLanguageV1> for Provider {
-                    fn load(
-                        &self,
-                        _req: DataRequest,
-                    ) -> Result<DataResponse<LocaleLikelySubtagsLanguageV1>, DataError>
-                    {
-                        Ok(DataResponse {
-                            payload: DataPayload::from_owned(self.common.as_langs()),
-                            metadata: Default::default(),
-                        })
-                    }
-                }
-                impl DataProvider<LocaleLikelySubtagsScriptRegionV1> for Provider {
-                    fn load(
-                        &self,
-                        _req: DataRequest,
-                    ) -> Result<DataResponse<LocaleLikelySubtagsScriptRegionV1>, DataError>
-                    {
-                        Ok(DataResponse {
-                            payload: DataPayload::from_owned(self.common.as_script_region()),
-                            metadata: Default::default(),
-                        })
-                    }
-                }
-                impl DataProvider<LocaleLikelySubtagsExtendedV1> for Provider {
-                    fn load(
-                        &self,
-                        _req: DataRequest,
-                    ) -> Result<DataResponse<LocaleLikelySubtagsExtendedV1>, DataError>
-                    {
-                        Ok(DataResponse {
-                            payload: DataPayload::from_owned(self.extended.as_extended()),
-                            metadata: Default::default(),
-                        })
-                    }
-                }
-                let common =
-                    transform(LikelySubtagsResources::try_from_cldr_cache(self)?.get_common());
-                let extended =
-                    transform(LikelySubtagsResources::try_from_cldr_cache(self)?.get_extended());
-
-                LocaleExpander::try_new_extended_unstable(&Provider { common, extended }).map_err(
-                    |e| {
-                        DataError::custom("creating LocaleExpander in CldrCache")
-                            .with_display_context(&e)
-                    },
+                LocaleExpander::try_new_extended_unstable(
+                    &LikelySubtagsResources::try_from_cldr_cache(self)?,
                 )
+                .map_err(|e| {
+                    DataError::custom("creating LocaleExpander in CldrCache")
+                        .with_display_context(&e)
+                })
             })
             .as_ref()
             .map_err(|&e| e)

--- a/provider/source/src/locale/likely_subtags.rs
+++ b/provider/source/src/locale/likely_subtags.rs
@@ -10,7 +10,6 @@ use icu::locale::provider::*;
 use icu::locale::subtags::{Language, Region, Script};
 use icu_provider::prelude::*;
 use std::collections::{BTreeMap, HashSet};
-use tinystr::TinyAsciiStr;
 
 impl DataProvider<LocaleLikelySubtagsExtendedV1> for SourceDataProvider {
     fn load(
@@ -142,12 +141,12 @@ impl<'a> LikelySubtagsResources<'a> {
 
 #[derive(Default)]
 pub(crate) struct TransformResult {
-    language_script: BTreeMap<(TinyAsciiStr<3>, TinyAsciiStr<4>), Region>,
-    language_region: BTreeMap<(TinyAsciiStr<3>, TinyAsciiStr<3>), Script>,
-    language: BTreeMap<TinyAsciiStr<3>, (Script, Region)>,
-    script_region: BTreeMap<(TinyAsciiStr<4>, TinyAsciiStr<3>), Language>,
-    script: BTreeMap<TinyAsciiStr<4>, (Language, Region)>,
-    region: BTreeMap<TinyAsciiStr<3>, (Language, Script)>,
+    language_script: BTreeMap<(Language, Script), Region>,
+    language_region: BTreeMap<(Language, Region), Script>,
+    language: BTreeMap<Language, (Script, Region)>,
+    script_region: BTreeMap<(Script, Region), Language>,
+    script: BTreeMap<Script, (Language, Region)>,
+    region: BTreeMap<Region, (Language, Script)>,
     und: Option<(Language, Script, Region)>,
 }
 
@@ -157,17 +156,33 @@ impl TransformResult {
             language_script: self
                 .language_script
                 .iter()
-                .map(|((k1, k2), v)| ((k1.to_unvalidated(), k2.to_unvalidated()), v))
+                .map(|((k1, k2), v)| {
+                    (
+                        (
+                            k1.to_tinystr().to_unvalidated(),
+                            k2.to_tinystr().to_unvalidated(),
+                        ),
+                        v,
+                    )
+                })
                 .collect(),
             language_region: self
                 .language_region
                 .iter()
-                .map(|((k1, k2), v)| ((k1.to_unvalidated(), k2.to_unvalidated()), v))
+                .map(|((k1, k2), v)| {
+                    (
+                        (
+                            k1.to_tinystr().to_unvalidated(),
+                            k2.to_tinystr().to_unvalidated(),
+                        ),
+                        v,
+                    )
+                })
                 .collect(),
             language: self
                 .language
                 .iter()
-                .map(|(k, v)| (k.to_unvalidated(), v))
+                .map(|(k, v)| (k.to_tinystr().to_unvalidated(), v))
                 .collect(),
             und: self.und.unwrap_or((
                 icu::locale::subtags::language!("und"),
@@ -182,17 +197,25 @@ impl TransformResult {
             script_region: self
                 .script_region
                 .iter()
-                .map(|((k1, k2), v)| ((k1.to_unvalidated(), k2.to_unvalidated()), v))
+                .map(|((k1, k2), v)| {
+                    (
+                        (
+                            k1.to_tinystr().to_unvalidated(),
+                            k2.to_tinystr().to_unvalidated(),
+                        ),
+                        v,
+                    )
+                })
                 .collect(),
             script: self
                 .script
                 .iter()
-                .map(|(k, v)| (k.to_unvalidated(), v))
+                .map(|(k, v)| (k.to_tinystr().to_unvalidated(), v))
                 .collect(),
             region: self
                 .region
                 .iter()
-                .map(|(k, v)| (k.to_unvalidated(), v))
+                .map(|(k, v)| (k.to_tinystr().to_unvalidated(), v))
                 .collect(),
         }
     }
@@ -202,32 +225,56 @@ impl TransformResult {
             language_script: self
                 .language_script
                 .iter()
-                .map(|((k1, k2), v)| ((k1.to_unvalidated(), k2.to_unvalidated()), v))
+                .map(|((k1, k2), v)| {
+                    (
+                        (
+                            k1.to_tinystr().to_unvalidated(),
+                            k2.to_tinystr().to_unvalidated(),
+                        ),
+                        v,
+                    )
+                })
                 .collect(),
             language_region: self
                 .language_region
                 .iter()
-                .map(|((k1, k2), v)| ((k1.to_unvalidated(), k2.to_unvalidated()), v))
+                .map(|((k1, k2), v)| {
+                    (
+                        (
+                            k1.to_tinystr().to_unvalidated(),
+                            k2.to_tinystr().to_unvalidated(),
+                        ),
+                        v,
+                    )
+                })
                 .collect(),
             language: self
                 .language
                 .iter()
-                .map(|(k, v)| (k.to_unvalidated(), v))
+                .map(|(k, v)| (k.to_tinystr().to_unvalidated(), v))
                 .collect(),
             script_region: self
                 .script_region
                 .iter()
-                .map(|((k1, k2), v)| ((k1.to_unvalidated(), k2.to_unvalidated()), v))
+                .map(|((k1, k2), v)| {
+                    (
+                        (
+                            k1.to_tinystr().to_unvalidated(),
+                            k2.to_tinystr().to_unvalidated(),
+                        ),
+                        v,
+                    )
+                })
                 .collect(),
             script: self
                 .script
                 .iter()
-                .map(|(k, v)| (k.to_unvalidated(), v))
+                .map(|(k, v)| (k.to_tinystr().to_unvalidated(), v))
                 .collect(),
             region: self
                 .region
                 .iter()
-                .map(|(k, v)| (k.to_unvalidated(), v))
+                .map(|(k, v)| (k.to_tinystr().to_unvalidated(), v))
                 .collect(),
         }
     }
@@ -279,26 +326,26 @@ pub(crate) fn transform<'x>(
         }
 
         if !entry.0.language.is_unknown() {
-            let lang = entry.0.language;
-            if let Some(script) = entry.0.script {
-                with_diff!((Language::UNKNOWN, None, Some(region)) => language_script.insert((lang.to_tinystr(), script.to_tinystr()), region));
-            } else if let Some(region) = entry.0.region {
-                with_diff!((Language::UNKNOWN, Some(script), None) => language_region.insert((lang.to_tinystr(), region.to_tinystr()), script));
+            let l = entry.0.language;
+            if let Some(s) = entry.0.script {
+                with_diff!((Language::UNKNOWN, None, Some(r)) => language_script.insert((l, s), r));
+            } else if let Some(r) = entry.0.region {
+                with_diff!((Language::UNKNOWN, Some(s), None) => language_region.insert((l, r), s));
             } else {
-                with_diff!((Language::UNKNOWN, Some(script), Some(region)) => language.insert(lang.to_tinystr(), (script, region)));
+                with_diff!((Language::UNKNOWN, Some(s), Some(r)) => language.insert(l, (s, r)));
             }
-        } else if let Some(scr) = entry.0.script {
-            if let Some(region) = entry.0.region {
+        } else if let Some(s) = entry.0.script {
+            if let Some(r) = entry.0.region {
                 // Some of the target regions here are not equal to the source, such as und-Latn-001 -> en-Latn-US.
                 // However in the `maximize` method we do not replace tags, so we don't need to store the region.
-                with_diff!((language, None, _) => script_region.insert((scr.to_tinystr(), region.to_tinystr()), language));
+                with_diff!((l, None, _) => script_region.insert((s, r), l));
             } else {
-                with_diff!((language, None, Some(region)) => script.insert(scr.to_tinystr(), (language, region)));
+                with_diff!((l, None, Some(r)) => script.insert(s, (l, r)));
             }
-        } else if let Some(reg) = entry.0.region {
+        } else if let Some(r) = entry.0.region {
             // Some of the target regions here are not equal to the source, such as und-002 -> en-Latn-NG.
             // However in the `maximize` method we do not replace tags, so we don't need to store the region.
-            with_diff!((language, Some(script), _) => region.insert(reg.to_tinystr(), (language, script)));
+            with_diff!((l, Some(s), _) => region.insert(r, (l, s)));
         } else {
             und = Some((
                 entry.1.language,

--- a/provider/source/src/locale/likely_subtags.rs
+++ b/provider/source/src/locale/likely_subtags.rs
@@ -17,12 +17,7 @@ impl DataProvider<LocaleLikelySubtagsExtendedV1> for SourceDataProvider {
         req: DataRequest,
     ) -> Result<DataResponse<LocaleLikelySubtagsExtendedV1>, DataError> {
         self.check_req::<LocaleLikelySubtagsExtendedV1>(req)?;
-        let resources = LikelySubtagsResources::try_from_cldr_cache(self.cldr()?)?;
-
-        Ok(DataResponse {
-            metadata: Default::default(),
-            payload: DataPayload::from_owned(transform(resources.get_extended()).as_extended()),
-        })
+        LikelySubtagsResources::try_from_cldr_cache(self.cldr()?)?.load(req)
     }
 }
 
@@ -38,12 +33,7 @@ impl DataProvider<LocaleLikelySubtagsLanguageV1> for SourceDataProvider {
         req: DataRequest,
     ) -> Result<DataResponse<LocaleLikelySubtagsLanguageV1>, DataError> {
         self.check_req::<LocaleLikelySubtagsLanguageV1>(req)?;
-        let resources = LikelySubtagsResources::try_from_cldr_cache(self.cldr()?)?;
-
-        Ok(DataResponse {
-            metadata: Default::default(),
-            payload: DataPayload::from_owned(transform(resources.get_common()).as_langs()),
-        })
+        LikelySubtagsResources::try_from_cldr_cache(self.cldr()?)?.load(req)
     }
 }
 
@@ -59,12 +49,7 @@ impl DataProvider<LocaleLikelySubtagsScriptRegionV1> for SourceDataProvider {
         req: DataRequest,
     ) -> Result<DataResponse<LocaleLikelySubtagsScriptRegionV1>, DataError> {
         self.check_req::<LocaleLikelySubtagsScriptRegionV1>(req)?;
-        let resources = LikelySubtagsResources::try_from_cldr_cache(self.cldr()?)?;
-
-        Ok(DataResponse {
-            metadata: Default::default(),
-            payload: DataPayload::from_owned(transform(resources.get_common()).as_script_region()),
-        })
+        LikelySubtagsResources::try_from_cldr_cache(self.cldr()?)?.load(req)
     }
 }
 
@@ -74,73 +59,31 @@ impl crate::IterableDataProviderCached<LocaleLikelySubtagsScriptRegionV1> for So
     }
 }
 
-pub(crate) struct LikelySubtagsResources<'a> {
-    likely_subtags: &'a cldr_serde::likely_subtags::Resource,
-    basic_plus_languages: HashSet<Language>,
-}
-
-impl<'a> LikelySubtagsResources<'a> {
+impl LikelySubtagsResources {
     pub(crate) fn try_from_cldr_cache(
-        cache: &'a super::super::CldrCache,
-    ) -> Result<LikelySubtagsResources<'a>, DataError> {
+        cache: &super::super::CldrCache,
+    ) -> Result<LikelySubtagsResources, DataError> {
         let likely_subtags: &cldr_serde::likely_subtags::Resource = cache
             .core()
             .read_and_parse("supplemental/likelySubtags.json")?;
-        let coverage_levels: &cldr_serde::coverage_levels::Resource =
-            cache.core().read_and_parse("coverageLevels.json")?;
-        let basic_plus_languages = Self::get_basic_plus_languages(coverage_levels);
-        Ok(Self {
-            likely_subtags,
-            basic_plus_languages,
-        })
-    }
-
-    fn get_basic_plus_languages(
-        coverage_levels: &cldr_serde::coverage_levels::Resource,
-    ) -> HashSet<Language> {
-        #[expect(clippy::unnecessary_filter_map)] // better for future refactoring
-        coverage_levels
-            .coverage_levels
-            .iter()
-            .filter_map(|(langid, level)| {
-                match level {
-                    // NOTE: If more coverage levels get added, ones below Basic should be filtered here
-                    CoverageLevel::Basic | CoverageLevel::Moderate | CoverageLevel::Modern => {
-                        Some(langid.language)
-                    }
-                }
-            })
-            .collect()
-    }
-
-    fn common_predicate(&self, min_max: &(&LanguageIdentifier, &LanguageIdentifier)) -> bool {
-        let (minimized, maximized) = min_max;
-        self.basic_plus_languages.contains(&maximized.language) || minimized.is_unknown()
-    }
-
-    pub(crate) fn get_common(
-        &self,
-    ) -> impl Iterator<Item = (&LanguageIdentifier, &LanguageIdentifier)> + '_ {
-        self.likely_subtags
-            .supplemental
-            .likely_subtags
-            .iter()
-            .filter(|min_max| self.common_predicate(min_max))
-    }
-
-    pub(crate) fn get_extended(
-        &self,
-    ) -> impl Iterator<Item = (&LanguageIdentifier, &LanguageIdentifier)> + '_ {
-        self.likely_subtags
-            .supplemental
-            .likely_subtags
-            .iter()
-            .filter(|min_max| !self.common_predicate(min_max))
+        let core_languages = cache
+            .locales([
+                CoverageLevel::Basic,
+                CoverageLevel::Moderate,
+                CoverageLevel::Modern,
+            ])?
+            .into_iter()
+            .map(|l| l.language)
+            .filter(|l| !l.is_unknown())
+            .collect();
+        Ok(transform(
+            likely_subtags.supplemental.likely_subtags.iter(),
+            core_languages,
+        ))
     }
 }
 
-#[derive(Default)]
-pub(crate) struct TransformResult {
+pub(crate) struct LikelySubtagsResources {
     language_script: BTreeMap<(Language, Script), Region>,
     language_region: BTreeMap<(Language, Region), Script>,
     language: BTreeMap<Language, (Script, Region)>,
@@ -148,14 +91,19 @@ pub(crate) struct TransformResult {
     script: BTreeMap<Script, (Language, Region)>,
     region: BTreeMap<Region, (Language, Script)>,
     und: Option<(Language, Script, Region)>,
+    core_languages: HashSet<Language>,
 }
 
-impl TransformResult {
-    pub(crate) fn as_langs(&self) -> LikelySubtagsForLanguage<'static> {
-        LikelySubtagsForLanguage {
+impl DataProvider<LocaleLikelySubtagsLanguageV1> for LikelySubtagsResources {
+    fn load(
+        &self,
+        _req: DataRequest,
+    ) -> Result<DataResponse<LocaleLikelySubtagsLanguageV1>, DataError> {
+        let langs = LikelySubtagsForLanguage {
             language_script: self
                 .language_script
                 .iter()
+                .filter(|&(&(l, _), _)| self.core_languages.contains(&l))
                 .map(|((k1, k2), v)| {
                     (
                         (
@@ -169,6 +117,7 @@ impl TransformResult {
             language_region: self
                 .language_region
                 .iter()
+                .filter(|&(&(l, _), _)| self.core_languages.contains(&l))
                 .map(|((k1, k2), v)| {
                     (
                         (
@@ -182,6 +131,7 @@ impl TransformResult {
             language: self
                 .language
                 .iter()
+                .filter(|&(&l, _)| self.core_languages.contains(&l))
                 .map(|(k, v)| (k.to_tinystr().to_unvalidated(), v))
                 .collect(),
             und: self.und.unwrap_or((
@@ -189,14 +139,25 @@ impl TransformResult {
                 icu::locale::subtags::script!("Zzzz"),
                 icu::locale::subtags::region!("ZZ"),
             )),
-        }
-    }
+        };
 
-    pub(crate) fn as_script_region(&self) -> LikelySubtagsForScriptRegion<'static> {
-        LikelySubtagsForScriptRegion {
+        Ok(DataResponse {
+            payload: DataPayload::from_owned(langs),
+            metadata: Default::default(),
+        })
+    }
+}
+
+impl DataProvider<LocaleLikelySubtagsScriptRegionV1> for LikelySubtagsResources {
+    fn load(
+        &self,
+        _req: DataRequest,
+    ) -> Result<DataResponse<LocaleLikelySubtagsScriptRegionV1>, DataError> {
+        let script_region = LikelySubtagsForScriptRegion {
             script_region: self
                 .script_region
                 .iter()
+                .filter(|&(_, &l)| self.core_languages.contains(&l))
                 .map(|((k1, k2), v)| {
                     (
                         (
@@ -210,21 +171,34 @@ impl TransformResult {
             script: self
                 .script
                 .iter()
+                .filter(|&(_, &(l, _))| self.core_languages.contains(&l))
                 .map(|(k, v)| (k.to_tinystr().to_unvalidated(), v))
                 .collect(),
             region: self
                 .region
                 .iter()
+                .filter(|&(_, &(l, _))| self.core_languages.contains(&l))
                 .map(|(k, v)| (k.to_tinystr().to_unvalidated(), v))
                 .collect(),
-        }
-    }
+        };
 
-    pub(crate) fn as_extended(&self) -> LikelySubtagsExtended<'static> {
-        LikelySubtagsExtended {
+        Ok(DataResponse {
+            payload: DataPayload::from_owned(script_region),
+            metadata: Default::default(),
+        })
+    }
+}
+
+impl DataProvider<LocaleLikelySubtagsExtendedV1> for LikelySubtagsResources {
+    fn load(
+        &self,
+        _req: DataRequest,
+    ) -> Result<DataResponse<LocaleLikelySubtagsExtendedV1>, DataError> {
+        let extended = LikelySubtagsExtended {
             language_script: self
                 .language_script
                 .iter()
+                .filter(|&(&(l, _), _)| !self.core_languages.contains(&l))
                 .map(|((k1, k2), v)| {
                     (
                         (
@@ -238,6 +212,7 @@ impl TransformResult {
             language_region: self
                 .language_region
                 .iter()
+                .filter(|&(&(l, _), _)| !self.core_languages.contains(&l))
                 .map(|((k1, k2), v)| {
                     (
                         (
@@ -251,11 +226,13 @@ impl TransformResult {
             language: self
                 .language
                 .iter()
+                .filter(|&(&l, _)| !self.core_languages.contains(&l))
                 .map(|(k, v)| (k.to_tinystr().to_unvalidated(), v))
                 .collect(),
             script_region: self
                 .script_region
                 .iter()
+                .filter(|&(_, &l)| !self.core_languages.contains(&l))
                 .map(|((k1, k2), v)| {
                     (
                         (
@@ -269,20 +246,28 @@ impl TransformResult {
             script: self
                 .script
                 .iter()
+                .filter(|&(_, &(l, _))| !self.core_languages.contains(&l))
                 .map(|(k, v)| (k.to_tinystr().to_unvalidated(), v))
                 .collect(),
             region: self
                 .region
                 .iter()
+                .filter(|&(_, &(l, _))| !self.core_languages.contains(&l))
                 .map(|(k, v)| (k.to_tinystr().to_unvalidated(), v))
                 .collect(),
-        }
+        };
+
+        Ok(DataResponse {
+            payload: DataPayload::from_owned(extended),
+            metadata: Default::default(),
+        })
     }
 }
 
 pub(crate) fn transform<'x>(
     it: impl Iterator<Item = (&'x LanguageIdentifier, &'x LanguageIdentifier)> + 'x,
-) -> TransformResult {
+    core_languages: HashSet<Language>,
+) -> LikelySubtagsResources {
     let mut language_script = BTreeMap::new();
     let mut language_region = BTreeMap::new();
     let mut language = BTreeMap::new();
@@ -352,7 +337,7 @@ pub(crate) fn transform<'x>(
         }
     }
 
-    TransformResult {
+    LikelySubtagsResources {
         language_script,
         language_region,
         language,
@@ -360,6 +345,7 @@ pub(crate) fn transform<'x>(
         script,
         region,
         und,
+        core_languages,
     }
 }
 

--- a/provider/source/src/locale/likely_subtags.rs
+++ b/provider/source/src/locale/likely_subtags.rs
@@ -417,7 +417,7 @@ fn test_exhaustive() {
     let provider = SourceDataProvider::new_testing();
     let expander = icu::locale::LocaleExpander::try_new_extended_unstable(&provider).unwrap();
 
-    for (source, expected) in provider
+    for (source, mut expected) in provider
         .cldr()
         .unwrap()
         .core()
@@ -435,6 +435,10 @@ fn test_exhaustive() {
             (langid!("tlh-SA"), langid!("tlh-SA")),
         ])
     {
+        if source.is_unknown() {
+            expected = LanguageIdentifier::UNKNOWN;
+        }
+
         let mut actual = source.clone();
         let r = expander.maximize(&mut actual);
         assert_eq!(

--- a/provider/source/src/locale/likely_subtags.rs
+++ b/provider/source/src/locale/likely_subtags.rs
@@ -315,12 +315,13 @@ pub(crate) fn transform<'x>(
                 ) {
                     $stmt;
                 } else {
-                    panic!(
-                        "The expansion {:?} -> {:?} can not be stored in the pattern {}",
+                    log::error!(
+                        "The expansion {:?} -> {:?} can not be stored in the pattern {}, skipping",
                         entry.0,
                         entry.1,
                         stringify!($pat)
                     );
+                    continue;
                 }
             };
         }
@@ -336,16 +337,12 @@ pub(crate) fn transform<'x>(
             }
         } else if let Some(s) = entry.0.script {
             if let Some(r) = entry.0.region {
-                // Some of the target regions here are not equal to the source, such as und-Latn-001 -> en-Latn-US.
-                // However in the `maximize` method we do not replace tags, so we don't need to store the region.
-                with_diff!((l, None, _) => script_region.insert((s, r), l));
+                with_diff!((l, None, None) => script_region.insert((s, r), l));
             } else {
                 with_diff!((l, None, Some(r)) => script.insert(s, (l, r)));
             }
         } else if let Some(r) = entry.0.region {
-            // Some of the target regions here are not equal to the source, such as und-002 -> en-Latn-NG.
-            // However in the `maximize` method we do not replace tags, so we don't need to store the region.
-            with_diff!((l, Some(s), _) => region.insert(r, (l, s)));
+            with_diff!((l, Some(s), None) => region.insert(r, (l, s)));
         } else {
             und = Some((
                 entry.1.language,

--- a/provider/source/src/locale/likely_subtags.rs
+++ b/provider/source/src/locale/likely_subtags.rs
@@ -7,7 +7,7 @@ use crate::SourceDataProvider;
 use crate::cldr_serde;
 use icu::locale::LanguageIdentifier;
 use icu::locale::provider::*;
-use icu::locale::subtags::{Language, Region, Script};
+use icu::locale::subtags::{Language, Region, Script, region, script};
 use icu_provider::prelude::*;
 use std::collections::{BTreeMap, HashSet};
 
@@ -60,6 +60,10 @@ impl crate::IterableDataProviderCached<LocaleLikelySubtagsScriptRegionV1> for So
 }
 
 impl LikelySubtagsResources {
+    // We need to store some und-S-R/und-S/und-R -> LSR expansion in `LikelySubtagsForLanguage::und`. For backward
+    // compatibility, this is und-Latn-US.
+    const UND_SR: (Script, Region) = (script!("Latn"), region!("US"));
+
     pub(crate) fn try_from_cldr_cache(
         cache: &super::super::CldrCache,
     ) -> Result<LikelySubtagsResources, DataError> {
@@ -90,7 +94,7 @@ pub(crate) struct LikelySubtagsResources {
     script_region: BTreeMap<(Script, Region), Language>,
     script: BTreeMap<Script, (Language, Region)>,
     region: BTreeMap<Region, (Language, Script)>,
-    und: Option<(Language, Script, Region)>,
+    und_l: Language,
     core_languages: HashSet<Language>,
 }
 
@@ -134,11 +138,7 @@ impl DataProvider<LocaleLikelySubtagsLanguageV1> for LikelySubtagsResources {
                 .filter(|&(&l, _)| self.core_languages.contains(&l))
                 .map(|(k, v)| (k.to_tinystr().to_unvalidated(), v))
                 .collect(),
-            und: self.und.unwrap_or((
-                icu::locale::subtags::language!("und"),
-                icu::locale::subtags::script!("Zzzz"),
-                icu::locale::subtags::region!("ZZ"),
-            )),
+            und: (self.und_l, Self::UND_SR.0, Self::UND_SR.1),
         };
 
         Ok(DataResponse {
@@ -274,7 +274,6 @@ pub(crate) fn transform<'x>(
     let mut script_region = BTreeMap::new();
     let mut script = BTreeMap::new();
     let mut region = BTreeMap::new();
-    let mut und = None;
 
     for entry in it {
         // Computes the delta of the entry and assigns to the pattern.
@@ -329,12 +328,45 @@ pub(crate) fn transform<'x>(
         } else if let Some(r) = entry.0.region {
             with_diff!((l, Some(s), None) => region.insert(r, (l, s)));
         } else {
-            und = Some((
-                entry.1.language,
-                entry.1.script.expect("targets are complete language codes"),
-                entry.1.region.expect("targets are complete language codes"),
-            ));
+            // Treat the und->LSR expansion as und-S-R->LSR, und-S->LSR, and und-R->LSR. CLDR 50+
+            // will contain these expansions (https://unicode-org.atlassian.net/browse/CLDR-14524).
+            with_diff!((l, Some(s), Some(r)) => {
+                script_region.insert((s, r), l);
+                script.insert(s, (l, r));
+                region.insert(r, (l, s));
+
+            });
         }
+    }
+
+    let und_l = script_region
+        .remove(&LikelySubtagsResources::UND_SR)
+        .unwrap();
+    let und_s = LikelySubtagsResources::UND_SR.0;
+    let und_r = LikelySubtagsResources::UND_SR.1;
+
+    let ls = region.remove(&und_r);
+    if ls != Some((und_l, und_s)) {
+        log::warn!(
+            "cannot store in und: und-{und_s}-{und_r} -> {und_l}-{und_s}-{und_r}, but {}",
+            if let Some((l, s)) = ls {
+                format!("und-{und_r} -> {l}-{s}-{und_r}")
+            } else {
+                format!("no mapping for und-{und_r}")
+            }
+        );
+    }
+
+    let lr = script.remove(&und_s);
+    if lr != Some((und_l, und_r)) {
+        log::warn!(
+            "cannot store in und: und-{und_s}-{und_r} -> {und_l}-{und_s}-{und_r}, but {}",
+            if let Some((l, r)) = lr {
+                format!("und-{und_s} -> {l}-{und_s}-{r}")
+            } else {
+                format!("no mapping for und-{und_s}")
+            }
+        );
     }
 
     LikelySubtagsResources {
@@ -344,7 +376,7 @@ pub(crate) fn transform<'x>(
         script_region,
         script,
         region,
-        und,
+        und_l,
         core_languages,
     }
 }

--- a/provider/source/src/time_zones/convert.rs
+++ b/provider/source/src/time_zones/convert.rs
@@ -185,7 +185,12 @@ impl SourceDataProvider {
         Ok((locations, exemplar_cities))
     }
 
-    fn dedupe_group(&self, locale: DataLocale) -> Result<DataLocale, DataError> {
+    fn dedupe_group(&self, mut locale: DataLocale) -> Result<DataLocale, DataError> {
+        // und stores the und-Latn group.
+        if locale == icu::locale::langid!("und").into() {
+            locale = icu::locale::langid!("und-Latn").into();
+        }
+
         let group = self.cldr()?.script_based_locale_group(&locale)?;
         if self
             .cldr()


### PR DESCRIPTION
As the data struct requires us to have a `und -> aa-Bbbb-CC` mapping, this is actually a change to the code. Instead of interpreting this entry as `und -> aa-Bbbb-CC`, we now interpret it as `und-Bbbb -> aa-Bbbb-CC`, `und-CC -> aa-Bbbb-CC`, and `und-Bbbb-CC -> aa-Bbbb-CC`, and we put the `Latn-US` mappings in it for data backward compatibility.

Datagen was updated to generate the same data from either `und -> aa-Bbbb-CC`, or `und-Bbbb -> aa-Bbbb-CC`, `und-CC -> aa-Bbbb-CC`, and `und-Bbbb-CC -> aa-Bbbb-CC`, as this will change in the next CLDR version (https://unicode-org.atlassian.net/browse/CLDR-14524)

## Changelog

`icu_locale`:
* `LocaleExpander::maximize` no longer maximizes `und` to `en-Latn-US`
