### PR TITLE
Improve complex segmenter hot paths

### DIFF
--- a/components/collections/src/char16trie/trie.rs
+++ b/components/collections/src/char16trie/trie.rs
@@ -197,6 +197,7 @@ impl<'a> Char16TrieIterator<'a> {
     /// let res = iter.next('c');
     /// assert_eq!(res, TrieResult::NoMatch);
     /// ```
+    #[inline]
     pub fn next(&mut self, c: char) -> TrieResult {
         if (c as u32) <= 0xffff {
             self.next16(c as u16)
@@ -230,6 +231,7 @@ impl<'a> Char16TrieIterator<'a> {
     /// let res = iter.next('c');
     /// assert_eq!(res, TrieResult::NoMatch);
     /// ```
+    #[inline]
     pub fn next32(&mut self, c: u32) -> TrieResult {
         if c <= 0xffff {
             self.next16(c as u16)
@@ -263,6 +265,7 @@ impl<'a> Char16TrieIterator<'a> {
     /// let res = iter.next16('c' as u16);
     /// assert_eq!(res, TrieResult::NoMatch);
     /// ```
+    #[inline]
     pub fn next16(&mut self, c: u16) -> TrieResult {
         let mut pos = match self.pos {
             Some(p) => p,
@@ -291,6 +294,7 @@ impl<'a> Char16TrieIterator<'a> {
         }
     }
 
+    #[inline]
     fn branch_next(&mut self, pos: usize, length: usize, in_unit: u16) -> TrieResult {
         let mut pos = pos;
         let mut length = length;
@@ -365,6 +369,7 @@ impl<'a> Char16TrieIterator<'a> {
         }
     }
 
+    #[inline]
     fn next_impl(&mut self, pos: usize, in_unit: u16) -> TrieResult {
         let mut node = trie_unwrap!(self.trie.get(pos));
         let mut pos = pos + 1;
@@ -404,6 +409,7 @@ impl<'a> Char16TrieIterator<'a> {
         TrieResult::NoMatch
     }
 
+    #[inline]
     fn stop(&mut self) {
         self.pos = None;
     }
@@ -445,6 +451,7 @@ impl<'a> Char16TrieIterator<'a> {
         Some(v)
     }
 
+    #[inline]
     fn value_result(&self, pos: usize) -> TrieResult {
         match self.get_value(pos) {
             Some(result) => result,

--- a/components/segmenter/src/grapheme.rs
+++ b/components/segmenter/src/grapheme.rs
@@ -2,7 +2,6 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use alloc::vec::Vec;
 use icu_provider::prelude::*;
 
 use crate::indices::{Latin1Indices, Utf16Indices};
@@ -168,9 +167,10 @@ impl<'data> GraphemeClusterSegmenterBorrowed<'data> {
     pub fn segment_str<'s>(self, input: &'s str) -> GraphemeClusterBreakIterator<'data, 's, Utf8> {
         GraphemeClusterBreakIterator(RuleBreakIterator {
             iter: input.char_indices(),
+            str_input: None,
             len: input.len(),
             current_pos_data: None,
-            result_cache: Vec::new(),
+            result_cache: ResultCache::new(),
             data: self.data,
             complex: None,
             boundary_property: 0,
@@ -189,9 +189,10 @@ impl<'data> GraphemeClusterSegmenterBorrowed<'data> {
     ) -> GraphemeClusterBreakIterator<'data, 's, PotentiallyIllFormedUtf8> {
         GraphemeClusterBreakIterator(RuleBreakIterator {
             iter: Utf8CharIndices::new(input),
+            str_input: None,
             len: input.len(),
             current_pos_data: None,
-            result_cache: Vec::new(),
+            result_cache: ResultCache::new(),
             data: self.data,
             complex: None,
             boundary_property: 0,
@@ -208,9 +209,10 @@ impl<'data> GraphemeClusterSegmenterBorrowed<'data> {
     ) -> GraphemeClusterBreakIterator<'data, 's, Latin1> {
         GraphemeClusterBreakIterator(RuleBreakIterator {
             iter: Latin1Indices::new(input),
+            str_input: None,
             len: input.len(),
             current_pos_data: None,
-            result_cache: Vec::new(),
+            result_cache: ResultCache::new(),
             data: self.data,
             complex: None,
             boundary_property: 0,
@@ -228,9 +230,10 @@ impl<'data> GraphemeClusterSegmenterBorrowed<'data> {
     ) -> GraphemeClusterBreakIterator<'data, 's, Utf16> {
         GraphemeClusterBreakIterator(RuleBreakIterator {
             iter: Utf16Indices::new(input),
+            str_input: None,
             len: input.len(),
             current_pos_data: None,
-            result_cache: Vec::new(),
+            result_cache: ResultCache::new(),
             data: self.data,
             complex: None,
             boundary_property: 0,

--- a/components/segmenter/src/line.rs
+++ b/components/segmenter/src/line.rs
@@ -8,7 +8,6 @@ use crate::provider::*;
 use crate::rule_segmenter::*;
 use alloc::string::String;
 use alloc::vec;
-use alloc::vec::Vec;
 use core::char;
 use icu_locale_core::LanguageIdentifier;
 use icu_locale_core::subtags::{Language, language};
@@ -603,13 +602,14 @@ impl<'data> LineSegmenterBorrowed<'data> {
     pub fn segment_str<'s>(self, input: &'s str) -> LineBreakIterator<'data, 's, Utf8> {
         LineBreakIterator {
             iter: input.char_indices(),
+            str_input: Some(input),
             len: input.len(),
             current_pos_data: None,
-            result_cache: Vec::new(),
+            result_cache: ResultCache::new(),
             data: self.data,
             options: self.options,
             complex: self.complex,
-            handle_complex_language: line_handle_complex_language_utf8,
+            handle_complex_language: line_handle_complex_language_str,
         }
     }
     /// Creates a line break iterator for a potentially ill-formed UTF8 string
@@ -623,9 +623,10 @@ impl<'data> LineSegmenterBorrowed<'data> {
     ) -> LineBreakIterator<'data, 's, PotentiallyIllFormedUtf8> {
         LineBreakIterator {
             iter: Utf8CharIndices::new(input),
+            str_input: None,
             len: input.len(),
             current_pos_data: None,
-            result_cache: Vec::new(),
+            result_cache: ResultCache::new(),
             data: self.data,
             options: self.options,
             complex: self.complex,
@@ -638,9 +639,10 @@ impl<'data> LineSegmenterBorrowed<'data> {
     pub fn segment_latin1<'s>(self, input: &'s [u8]) -> LineBreakIterator<'data, 's, Latin1> {
         LineBreakIterator {
             iter: Latin1Indices::new(input),
+            str_input: None,
             len: input.len(),
             current_pos_data: None,
-            result_cache: Vec::new(),
+            result_cache: ResultCache::new(),
             data: self.data,
             options: self.options,
             complex: self.complex,
@@ -654,9 +656,10 @@ impl<'data> LineSegmenterBorrowed<'data> {
     pub fn segment_utf16<'s>(self, input: &'s [u16]) -> LineBreakIterator<'data, 's, Utf16> {
         LineBreakIterator {
             iter: Utf16Indices::new(input),
+            str_input: None,
             len: input.len(),
             current_pos_data: None,
-            result_cache: Vec::new(),
+            result_cache: ResultCache::new(),
             data: self.data,
             options: self.options,
             complex: self.complex,
@@ -767,9 +770,11 @@ fn is_break_utf32_by_loose(
 #[derive(Debug)]
 pub struct LineBreakIterator<'data, 's, Y: RuleBreakType> {
     iter: Y::IterAttr<'s>,
+    // Original UTF-8 input for `segment_str`, used by complex handlers to borrow run slices.
+    str_input: Option<&'s str>,
     len: usize,
     current_pos_data: Option<(usize, Y::CharType)>,
-    result_cache: Vec<usize>,
+    result_cache: ResultCache,
     data: &'data RuleBreakData<'data>,
     options: ResolvedLineBreakOptions,
     complex: ComplexPayloadsBorrowed<'data>,
@@ -785,10 +790,11 @@ impl<Y: RuleBreakType> Iterator for LineBreakIterator<'_, '_, Y> {
         if self.options.strictness == LineBreakStrictness::Anywhere {
             let mut grapheme_iter: RuleBreakIterator<'_, '_, Y> = RuleBreakIterator {
                 iter: self.iter.clone(),
+                str_input: None,
                 len: self.len,
                 current_pos_data: self.current_pos_data,
                 data: self.complex.grapheme.data,
-                result_cache: Default::default(),
+                result_cache: ResultCache::new(),
                 complex: None,
                 boundary_property: 0,
                 locale_override: None,
@@ -808,11 +814,11 @@ impl<Y: RuleBreakType> Iterator for LineBreakIterator<'_, '_, Y> {
         }
 
         // If we have break point cache by previous run, return this result
-        if let Some(&first_pos) = self.result_cache.first() {
+        if let Some(first_pos) = self.result_cache.next_relative() {
             let mut i = 0;
             loop {
                 if i == first_pos {
-                    self.result_cache = self.result_cache.iter().skip(1).map(|r| r - i).collect();
+                    self.result_cache.consume(i);
                     return self.get_current_position();
                 }
                 i += self.get_current_codepoint().map_or(0, Y::char_len);
@@ -1133,7 +1139,7 @@ fn line_handle_complex_language_utf8<T>(
 where
     T: RuleBreakType<CharType = char>,
 {
-    // word segmenter doesn't define break rules for some languages such as Thai.
+    // UAX 14 relies on dictionary segmentation for complex languages such as Thai.
     let start_iter = iter.iter.clone();
     let start_point = iter.current_pos_data;
     let mut s = String::new();
@@ -1156,13 +1162,13 @@ where
     iter.iter = start_iter;
     iter.current_pos_data = start_point;
     let breaks = iter.complex.complex_language_segment_str(&s);
-    iter.result_cache = breaks;
-    let first_pos = *iter.result_cache.first()?;
+    iter.result_cache.set(breaks);
+    let first_pos = iter.result_cache.next_relative()?;
     let mut i = left_codepoint.len_utf8();
     loop {
         if i == first_pos {
             // Re-calculate breaking offset
-            iter.result_cache = iter.result_cache.iter().skip(1).map(|r| r - i).collect();
+            iter.result_cache.consume(i);
             return iter.get_current_position();
         }
         debug_assert!(
@@ -1179,6 +1185,65 @@ where
     }
 }
 
+fn line_handle_complex_language_str(
+    iter: &mut LineBreakIterator<'_, '_, Utf8>,
+    left_codepoint: char,
+) -> Option<usize> {
+    // `segment_str` only receives well-formed UTF-8, so the complex-language
+    // run can be borrowed directly from the original input. Keep this separate
+    // from `line_handle_complex_language_utf8`, which also handles potentially
+    // ill-formed UTF-8 and must preserve replacement-character semantics.
+    let Some(input) = iter.str_input else {
+        return line_handle_complex_language_utf8(iter, left_codepoint);
+    };
+
+    // UAX 14 relies on dictionary segmentation for complex languages such as Thai.
+    let start_iter = iter.iter.clone();
+    let start_point = iter.current_pos_data;
+    let (right_pos, _) = start_point?;
+    let start = right_pos.checked_sub(left_codepoint.len_utf8())?;
+    loop {
+        debug_assert!(!iter.is_eof());
+        iter.advance_iter();
+        if let Some(current_codepoint) = iter.get_current_codepoint() {
+            if iter.get_linebreak_property(current_codepoint) != iter.data.complex_property {
+                break;
+            }
+        } else {
+            // EOF
+            break;
+        }
+    }
+    let end = iter.get_current_position().unwrap_or(iter.len);
+    let s = input.get(start..end)?;
+
+    // Restore iterator to move to head of complex string
+    iter.iter = start_iter;
+    iter.current_pos_data = start_point;
+    let breaks = iter.complex.complex_language_segment_str(s);
+    iter.result_cache.set(breaks);
+    let first_pos = iter.result_cache.next_relative()?;
+    let mut i = left_codepoint.len_utf8();
+    loop {
+        if i == first_pos {
+            // Re-calculate breaking offset
+            iter.result_cache.consume(i);
+            return iter.get_current_position();
+        }
+        debug_assert!(
+            i < first_pos,
+            "we should always arrive at first_pos: near index {:?}",
+            iter.get_current_position()
+        );
+        i += iter.get_current_codepoint().map_or(0, Utf8::char_len);
+        iter.advance_iter();
+        if iter.is_eof() {
+            iter.result_cache.clear();
+            return Some(iter.len);
+        }
+    }
+}
+
 fn line_handle_complex_language_utf16<T>(
     iterator: &mut LineBreakIterator<'_, '_, T>,
     left_codepoint: T::CharType,
@@ -1186,7 +1251,7 @@ fn line_handle_complex_language_utf16<T>(
 where
     T: RuleBreakType<CharType = u32>,
 {
-    // word segmenter doesn't define break rules for some languages such as Thai.
+    // UAX 14 relies on dictionary segmentation for complex languages such as Thai.
     let start_iter = iterator.iter.clone();
     let start_point = iterator.current_pos_data;
     let mut s = vec![left_codepoint as u16];
@@ -1209,19 +1274,14 @@ where
     iterator.iter = start_iter;
     iterator.current_pos_data = start_point;
     let breaks = iterator.complex.complex_language_segment_utf16(&s);
-    iterator.result_cache = breaks;
+    iterator.result_cache.set(breaks);
     // result_cache vector is utf-16 index that is in BMP.
-    let first_pos = *iterator.result_cache.first()?;
+    let first_pos = iterator.result_cache.next_relative()?;
     let mut i = 1;
     loop {
         if i == first_pos {
             // Re-calculate breaking offset
-            iterator.result_cache = iterator
-                .result_cache
-                .iter()
-                .skip(1)
-                .map(|r| r - i)
-                .collect();
+            iterator.result_cache.consume(i);
             return iterator.get_current_position();
         }
         debug_assert!(

--- a/components/segmenter/src/rule_segmenter.rs
+++ b/components/segmenter/src/rule_segmenter.rs
@@ -80,9 +80,11 @@ pub trait RuleBreakType: crate::private::Sealed + Sized {
 #[derive(Debug)]
 pub struct RuleBreakIterator<'data, 's, Y: RuleBreakType> {
     pub(crate) iter: Y::IterAttr<'s>,
+    // Original UTF-8 input for `segment_str`, used by complex handlers to borrow run slices.
+    pub(crate) str_input: Option<&'s str>,
     pub(crate) len: usize,
     pub(crate) current_pos_data: Option<(usize, Y::CharType)>,
-    pub(crate) result_cache: Vec<usize>,
+    pub(crate) result_cache: ResultCache,
     pub(crate) data: &'data RuleBreakData<'data>,
     pub(crate) complex: Option<ComplexPayloadsBorrowed<'data>>,
     // The property associated with the previous break
@@ -91,6 +93,72 @@ pub struct RuleBreakIterator<'data, 's, Y: RuleBreakType> {
     // Should return None if there is no complex language handling
     pub(crate) handle_complex_language:
         fn(&mut RuleBreakIterator<'data, 's, Y>, Y::CharType) -> Option<usize>,
+}
+
+/// Cached dictionary break offsets for the current complex-language run.
+///
+/// Dictionary segmentation returns offsets from the start of the complex run.
+/// The rule iterator yields one break at a time, so this cache keeps the
+/// original offsets plus a cursor instead of rebuilding a shortened `Vec` after
+/// every yielded break.
+#[derive(Debug)]
+pub(crate) struct ResultCache {
+    breaks: Vec<usize>,
+    index: usize,
+    offset: usize,
+}
+
+impl ResultCache {
+    /// Creates an empty cache for a newly constructed break iterator.
+    #[inline]
+    pub(crate) fn new() -> Self {
+        Self {
+            breaks: Vec::new(),
+            index: 0,
+            offset: 0,
+        }
+    }
+
+    /// Replaces the cache with the break offsets for a new complex-language run.
+    ///
+    /// The offsets are absolute within the run. `offset` tracks how much of the
+    /// run has already been consumed by the outer iterator.
+    #[inline]
+    pub(crate) fn set(&mut self, breaks: Vec<usize>) {
+        self.breaks = breaks;
+        self.index = 0;
+        self.offset = 0;
+    }
+
+    /// Returns the next cached break relative to the current iterator position.
+    #[inline]
+    pub(crate) fn next_relative(&self) -> Option<usize> {
+        self.breaks.get(self.index).map(|&result| {
+            debug_assert!(result >= self.offset);
+            result - self.offset
+        })
+    }
+
+    /// Marks the current cached break as yielded.
+    ///
+    /// `offset` is the number of code units advanced by the outer iterator while
+    /// reaching that break.
+    #[inline]
+    pub(crate) fn consume(&mut self, offset: usize) {
+        self.index += 1;
+        self.offset += offset;
+        if self.index >= self.breaks.len() {
+            self.clear();
+        }
+    }
+
+    /// Empties the cache when the run is exhausted or the iterator reaches EOF.
+    #[inline]
+    pub(crate) fn clear(&mut self) {
+        self.breaks.clear();
+        self.index = 0;
+        self.offset = 0;
+    }
 }
 
 pub(crate) fn empty_handle_complex_language<Y: RuleBreakType>(
@@ -109,11 +177,11 @@ impl<Y: RuleBreakType> Iterator for RuleBreakIterator<'_, '_, Y> {
 
     fn next(&mut self) -> Option<Self::Item> {
         // If we have break point cache by previous run, return this result
-        if let Some(&first_result) = self.result_cache.first() {
+        if let Some(first_result) = self.result_cache.next_relative() {
             let mut i = 0;
             loop {
                 if i == first_result {
-                    self.result_cache = self.result_cache.iter().skip(1).map(|r| r - i).collect();
+                    self.result_cache.consume(i);
                     return self.get_current_position();
                 }
                 i += self.get_current_codepoint().map_or(0, Y::char_len);

--- a/components/segmenter/src/sentence.rs
+++ b/components/segmenter/src/sentence.rs
@@ -2,7 +2,6 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use alloc::vec::Vec;
 use icu_locale_core::LanguageIdentifier;
 use icu_provider::prelude::*;
 
@@ -247,9 +246,10 @@ impl<'data> SentenceSegmenterBorrowed<'data> {
     pub fn segment_str<'s>(self, input: &'s str) -> SentenceBreakIterator<'data, 's, Utf8> {
         SentenceBreakIterator(RuleBreakIterator {
             iter: input.char_indices(),
+            str_input: None,
             len: input.len(),
             current_pos_data: None,
-            result_cache: Vec::new(),
+            result_cache: ResultCache::new(),
             data: self.data,
             complex: None,
             boundary_property: 0,
@@ -268,9 +268,10 @@ impl<'data> SentenceSegmenterBorrowed<'data> {
     ) -> SentenceBreakIterator<'data, 's, PotentiallyIllFormedUtf8> {
         SentenceBreakIterator(RuleBreakIterator {
             iter: Utf8CharIndices::new(input),
+            str_input: None,
             len: input.len(),
             current_pos_data: None,
-            result_cache: Vec::new(),
+            result_cache: ResultCache::new(),
             data: self.data,
             complex: None,
             boundary_property: 0,
@@ -284,9 +285,10 @@ impl<'data> SentenceSegmenterBorrowed<'data> {
     pub fn segment_latin1<'s>(self, input: &'s [u8]) -> SentenceBreakIterator<'data, 's, Latin1> {
         SentenceBreakIterator(RuleBreakIterator {
             iter: Latin1Indices::new(input),
+            str_input: None,
             len: input.len(),
             current_pos_data: None,
-            result_cache: Vec::new(),
+            result_cache: ResultCache::new(),
             data: self.data,
             complex: None,
             boundary_property: 0,
@@ -301,9 +303,10 @@ impl<'data> SentenceSegmenterBorrowed<'data> {
     pub fn segment_utf16<'s>(self, input: &'s [u16]) -> SentenceBreakIterator<'data, 's, Utf16> {
         SentenceBreakIterator(RuleBreakIterator {
             iter: Utf16Indices::new(input),
+            str_input: None,
             len: input.len(),
             current_pos_data: None,
-            result_cache: Vec::new(),
+            result_cache: ResultCache::new(),
             data: self.data,
             complex: None,
             boundary_property: 0,

--- a/components/segmenter/src/word.rs
+++ b/components/segmenter/src/word.rs
@@ -9,7 +9,6 @@ use crate::provider::*;
 use crate::rule_segmenter::*;
 use alloc::string::String;
 use alloc::vec;
-use alloc::vec::Vec;
 use icu_locale_core::LanguageIdentifier;
 use icu_provider::prelude::*;
 use utf8_iter::Utf8CharIndices;
@@ -600,14 +599,15 @@ impl<'data> WordSegmenterBorrowed<'data> {
     pub fn segment_str<'s>(self, input: &'s str) -> WordBreakIterator<'data, 's, Utf8> {
         WordBreakIterator(RuleBreakIterator {
             iter: input.char_indices(),
+            str_input: Some(input),
             len: input.len(),
             current_pos_data: None,
-            result_cache: Vec::new(),
+            result_cache: ResultCache::new(),
             data: self.data,
             complex: Some(self.complex),
             boundary_property: 0,
             locale_override: self.locale_override,
-            handle_complex_language: handle_complex_language_utf8,
+            handle_complex_language: handle_complex_language_str,
         })
     }
 
@@ -622,9 +622,10 @@ impl<'data> WordSegmenterBorrowed<'data> {
     ) -> WordBreakIterator<'data, 's, PotentiallyIllFormedUtf8> {
         WordBreakIterator(RuleBreakIterator {
             iter: Utf8CharIndices::new(input),
+            str_input: None,
             len: input.len(),
             current_pos_data: None,
-            result_cache: Vec::new(),
+            result_cache: ResultCache::new(),
             data: self.data,
             complex: Some(self.complex),
             boundary_property: 0,
@@ -639,9 +640,10 @@ impl<'data> WordSegmenterBorrowed<'data> {
     pub fn segment_latin1<'s>(self, input: &'s [u8]) -> WordBreakIterator<'data, 's, Latin1> {
         WordBreakIterator(RuleBreakIterator {
             iter: Latin1Indices::new(input),
+            str_input: None,
             len: input.len(),
             current_pos_data: None,
-            result_cache: Vec::new(),
+            result_cache: ResultCache::new(),
             data: self.data,
             complex: Some(self.complex),
             boundary_property: 0,
@@ -656,9 +658,10 @@ impl<'data> WordSegmenterBorrowed<'data> {
     pub fn segment_utf16<'s>(self, input: &'s [u16]) -> WordBreakIterator<'data, 's, Utf16> {
         WordBreakIterator(RuleBreakIterator {
             iter: Utf16Indices::new(input),
+            str_input: None,
             len: input.len(),
             current_pos_data: None,
-            result_cache: Vec::new(),
+            result_cache: ResultCache::new(),
             data: self.data,
             complex: Some(self.complex),
             boundary_property: 0,
@@ -703,6 +706,66 @@ impl WordSegmenterBorrowed<'static> {
     }
 }
 
+fn handle_complex_language_str(
+    iter: &mut RuleBreakIterator<'_, '_, Utf8>,
+    left_codepoint: char,
+) -> Option<usize> {
+    // `segment_str` only receives well-formed UTF-8, so the complex-language
+    // run can be borrowed directly from the original input. Keep this separate
+    // from `handle_complex_language_utf8`, which also handles potentially
+    // ill-formed UTF-8 and must preserve replacement-character semantics.
+    let Some(input) = iter.str_input else {
+        return handle_complex_language_utf8(iter, left_codepoint);
+    };
+
+    // word segmenter doesn't define break rules for some languages such as Thai.
+    let start_iter = iter.iter.clone();
+    let start_point = iter.current_pos_data;
+    let (right_pos, _) = start_point?;
+    let start = right_pos.checked_sub(left_codepoint.len_utf8())?;
+    loop {
+        debug_assert!(!iter.is_eof());
+        iter.advance_iter();
+        if let Some(current_break_property) = iter.get_current_break_property() {
+            if current_break_property != iter.data.complex_property {
+                break;
+            }
+        } else {
+            // EOF
+            break;
+        }
+    }
+    let end = iter.get_current_position().unwrap_or(iter.len);
+    let s = input.get(start..end)?;
+
+    // Restore iterator to move to head of complex string
+    iter.iter = start_iter;
+    iter.current_pos_data = start_point;
+    #[expect(clippy::unwrap_used)] // iter.complex present for word segmenter
+    let breaks = iter.complex.unwrap().complex_language_segment_str(s);
+    iter.result_cache.set(breaks);
+    let first_pos = iter.result_cache.next_relative()?;
+    let mut i = left_codepoint.len_utf8();
+    loop {
+        if i == first_pos {
+            // Re-calculate breaking offset
+            iter.result_cache.consume(i);
+            return iter.get_current_position();
+        }
+        debug_assert!(
+            i < first_pos,
+            "we should always arrive at first_pos: near index {:?}",
+            iter.get_current_position()
+        );
+        i += iter.get_current_codepoint().map_or(0, Utf8::char_len);
+        iter.advance_iter();
+        if iter.is_eof() {
+            iter.result_cache.clear();
+            return Some(iter.len);
+        }
+    }
+}
+
 fn handle_complex_language_utf8<T>(
     iter: &mut RuleBreakIterator<'_, '_, T>,
     left_codepoint: T::CharType,
@@ -734,13 +797,13 @@ where
     iter.current_pos_data = start_point;
     #[expect(clippy::unwrap_used)] // iter.complex present for word segmenter
     let breaks = iter.complex.unwrap().complex_language_segment_str(&s);
-    iter.result_cache = breaks;
-    let first_pos = *iter.result_cache.first()?;
+    iter.result_cache.set(breaks);
+    let first_pos = iter.result_cache.next_relative()?;
     let mut i = left_codepoint.len_utf8();
     loop {
         if i == first_pos {
             // Re-calculate breaking offset
-            iter.result_cache = iter.result_cache.iter().skip(1).map(|r| r - i).collect();
+            iter.result_cache.consume(i);
             return iter.get_current_position();
         }
         debug_assert!(
@@ -787,14 +850,14 @@ where
     iter.current_pos_data = start_point;
     #[expect(clippy::unwrap_used)] // iter.complex present for word segmenter
     let breaks = iter.complex.unwrap().complex_language_segment_utf16(&s);
-    iter.result_cache = breaks;
+    iter.result_cache.set(breaks);
     // result_cache vector is utf-16 index that is in BMP.
-    let first_pos = *iter.result_cache.first()?;
+    let first_pos = iter.result_cache.next_relative()?;
     let mut i = 1;
     loop {
         if i == first_pos {
             // Re-calculate breaking offset
-            iter.result_cache = iter.result_cache.iter().skip(1).map(|r| r - i).collect();
+            iter.result_cache.consume(i);
             return iter.get_current_position();
         }
         debug_assert!(


### PR DESCRIPTION
This PR improves ICU4X segmenter hot paths observed in dictionary-backed complex-script segmentation. The profile that motivated this work showed a large share of CPU time under `RuleBreakIterator::next`, complex-language word segmentation, and `Char16TrieIterator::next16`.

What changed:

- Replaced repeated cached-break rebuilding with a `ResultCache` cursor. Previously each cached break consumption rebuilt a shortened `Vec` with adjusted offsets. The new cache keeps the original dictionary break offsets and tracks the consumed cursor/offset.
- Added zero-copy complex-run handling for `segment_str` in word and line segmenters. Since `segment_str` receives well-formed UTF-8, the complex-language run can be borrowed from the original `&str`. `segment_utf8` and `segment_utf16` keep their existing allocation paths to preserve ill-formed UTF-8 and UTF-16 behavior.
- Marked `Char16TrieIterator` hot traversal methods as inlineable to reduce call overhead in dictionary trie walking.
- Kept public APIs unchanged. The new state and helpers are internal to the iterator implementation.

Why:

Dictionary-backed segmentation can enter a complex-language run, compute all break offsets for that run, and then yield those offsets one at a time from the rule iterator. The previous implementation allocated and copied while consuming cached offsets, and `segment_str` also copied complex runs into temporary strings even though the input was already a valid `&str`. These costs show up strongly in mixed Thai/CJK/Japanese workloads such as full-text indexing tokenization.

Performance results:

Measured with a temporary release-mode probe on the same machine, comparing this branch against a clean `origin/main` worktree. Each case runs 10,000 iterations; timing values are the median of 3 runs. Allocation numbers are total allocated bytes during those 10,000 iterations, excluding result collection by the probe.

| Case | Time before | Time after | Speedup | Allocation before | Allocation after | Allocation reduction |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `word_english` | 8.95 ms | 8.81 ms | 1.02x | 0 B | 0 B | 0% |
| `word_thai` | 34.93 ms | 25.84 ms | 1.35x | 49.76 MB | 4.80 MB | 90.4% |
| `word_japanese` | 47.34 ms | 33.03 ms | 1.43x | 30.24 MB | 7.68 MB | 74.6% |
| `word_han` | 45.51 ms | 32.08 ms | 1.42x | 34.88 MB | 8.96 MB | 74.3% |
| `word_mixed` | 85.25 ms | 69.39 ms | 1.23x | 693.68 MB | 40.64 MB | 94.1% |
| `line_english` | 13.80 ms | 13.44 ms | 1.03x | 0 B | 0 B | 0% |
| `line_thai` | 36.25 ms | 25.84 ms | 1.40x | 49.76 MB | 4.80 MB | 90.4% |
| `line_mixed` | 82.12 ms | 60.51 ms | 1.36x | 99.52 MB | 9.60 MB | 90.4% |

Validation:

- `cargo fmt -p icu_segmenter -p icu_collections`
- `git diff --check`
- `cargo test -p icu_segmenter --features unstable`
- `cargo test -p icu_collections --features serde,databake`

## Changelog

icu_segmenter/icu_collections: Improve dictionary-backed word and line segmentation performance for complex scripts without public API changes.
