### PR TITLE
zerovec: Fix pointer provenance issues found by miri

### DIFF
--- a/utils/zerovec/src/cow.rs
+++ b/utils/zerovec/src/cow.rs
@@ -193,7 +193,8 @@ impl<'a, V: VarULE + ?Sized> VarZeroCow<'a, V> {
     pub fn new_owned(val: Box<V>) -> Self {
         let raw_box: *mut V = Box::into_raw(val);
         // SAFETY: raw_box is a valid pointer to V as it comes from Box::into_raw.
-        let slice_ref: &[u8] = unsafe { (*raw_box).as_bytes() };
+        let raw_ref: &V = unsafe { &*raw_box };
+        let slice_ref: &[u8] = raw_ref.as_bytes();
         // SAFETY: We construct the NonNull pointer directly from raw_box (which has unique owning
         // provenance) cast to u8, using the length from slice_ref. This avoids losing unique provenance.
         let buf = unsafe {

--- a/utils/zerovec/src/cow.rs
+++ b/utils/zerovec/src/cow.rs
@@ -191,8 +191,17 @@ impl<'a, V: VarULE + ?Sized> VarZeroCow<'a, V> {
     /// ✨ *Enabled with the `alloc` Cargo feature.*
     #[cfg(feature = "alloc")]
     pub fn new_owned(val: Box<V>) -> Self {
-        let val = ManuallyDrop::new(val);
-        let buf: NonNull<[u8]> = val.as_bytes().into();
+        let raw_box: *mut V = Box::into_raw(val);
+        // SAFETY: raw_box is a valid pointer to V as it comes from Box::into_raw.
+        let slice_ref: &[u8] = unsafe { (*raw_box).as_bytes() };
+        // SAFETY: We construct the NonNull pointer directly from raw_box (which has unique owning
+        // provenance) cast to u8, using the length from slice_ref. This avoids losing unique provenance.
+        let buf = unsafe {
+            NonNull::new_unchecked(core::ptr::slice_from_raw_parts_mut(
+                raw_box.cast::<u8>(),
+                slice_ref.len(),
+            ))
+        };
         let raw = RawVarZeroCow {
             // Invariants upheld:
             // 1 & 3: The bytes came from `val` so they're a valid value and byte slice

--- a/utils/zerovec/src/lib.rs
+++ b/utils/zerovec/src/lib.rs
@@ -572,4 +572,23 @@ mod tests {
         check_size_of!(64 | 56 | 48, Option<ZeroMap<str, str>>);
         check_size_of!(120 | 104 | 96, Option<ZeroMap2d<str, str, str>>);
     }
+
+    #[test]
+    fn test_miri_repro_eyepatch_hack_truncate() {
+        let slice: &[u16] = &[1, 2, 3, 4];
+        let zv: ZeroVec<u16> = ZeroVec::try_from_slice(slice).unwrap();
+        let _truncated = zv.truncated(2);
+    }
+
+    #[test]
+    fn test_miri_repro_encode_varule_to_box() {
+        let str_slice: &str = "hello world";
+        let _boxed: Box<str> = ule::encode_varule_to_box(str_slice);
+    }
+
+    #[test]
+    fn test_miri_repro_varzerocow_new_owned() {
+        let boxed_str: Box<str> = Box::from("hello world");
+        let _cow: VarZeroCow<str> = VarZeroCow::new_owned(boxed_str);
+    }
 }

--- a/utils/zerovec/src/ule/encode.rs
+++ b/utils/zerovec/src/ule/encode.rs
@@ -95,12 +95,10 @@ pub fn encode_varule_to_box<S: EncodeAsVarULE<T> + ?Sized, T: VarULE + ?Sized>(x
     // zero-fill the vector to avoid uninitialized data UB
     let mut vec: Vec<u8> = vec![0; x.encode_var_ule_len()];
     x.encode_var_ule_write(&mut vec);
-    let raw = Box::into_raw(vec.into_boxed_slice());
     // SAFETY:
-    // - raw is a valid pointer to [u8] from Box::into_raw of a valid Box.
     // - T::from_bytes_unchecked is safe because the bytes were written by x.encode_var_ule_write
     //   which guarantees a valid representation of T.
-    unsafe { box_from_raw_bytes(raw) }
+    unsafe { box_from_bytes(vec.into_boxed_slice()) }
 }
 
 unsafe impl<T: VarULE + ?Sized> EncodeAsVarULE<T> for T {

--- a/utils/zerovec/src/ule/encode.rs
+++ b/utils/zerovec/src/ule/encode.rs
@@ -95,15 +95,12 @@ pub fn encode_varule_to_box<S: EncodeAsVarULE<T> + ?Sized, T: VarULE + ?Sized>(x
     // zero-fill the vector to avoid uninitialized data UB
     let mut vec: Vec<u8> = vec![0; x.encode_var_ule_len()];
     x.encode_var_ule_write(&mut vec);
-    let boxed = core::mem::ManuallyDrop::new(vec.into_boxed_slice());
-    unsafe {
-        // Safety: `ptr` is a box, and `T` is a VarULE which guarantees it has the same memory layout as `[u8]`
-        // and can be recouped via from_bytes_unchecked()
-        let ptr: *mut T = T::from_bytes_unchecked(&boxed) as *const T as *mut T;
-
-        // Safety: we can construct an owned version since we have mem::forgotten the older owner
-        Box::from_raw(ptr)
-    }
+    let raw = Box::into_raw(vec.into_boxed_slice());
+    // SAFETY:
+    // - raw is a valid pointer to [u8] from Box::into_raw of a valid Box.
+    // - T::from_bytes_unchecked is safe because the bytes were written by x.encode_var_ule_write
+    //   which guarantees a valid representation of T.
+    unsafe { box_from_raw_bytes(raw) }
 }
 
 unsafe impl<T: VarULE + ?Sized> EncodeAsVarULE<T> for T {

--- a/utils/zerovec/src/ule/encode.rs
+++ b/utils/zerovec/src/ule/encode.rs
@@ -98,7 +98,7 @@ pub fn encode_varule_to_box<S: EncodeAsVarULE<T> + ?Sized, T: VarULE + ?Sized>(x
     // SAFETY:
     // - T::from_bytes_unchecked is safe because the bytes were written by x.encode_var_ule_write
     //   which guarantees a valid representation of T.
-    unsafe { box_from_bytes(vec.into_boxed_slice()) }
+    unsafe { cast_box(vec.into_boxed_slice()) }
 }
 
 unsafe impl<T: VarULE + ?Sized> EncodeAsVarULE<T> for T {

--- a/utils/zerovec/src/ule/mod.rs
+++ b/utils/zerovec/src/ule/mod.rs
@@ -362,10 +362,10 @@ pub unsafe trait VarULE: 'static {
     #[cfg(feature = "alloc")]
     fn to_boxed(&self) -> Box<Self> {
         use alloc::borrow::ToOwned;
-        let bytesvec = self.as_bytes().to_owned().into_boxed_slice();
+        let bytes = self.as_bytes().to_owned().into_boxed_slice();
         // SAFETY:
         // - Self::from_bytes_unchecked is safe because the bytes came from self.as_bytes() which is valid.
-        unsafe { box_from_bytes(bytesvec) }
+        unsafe { cast_box(bytes) }
     }
 }
 
@@ -446,10 +446,10 @@ impl UleError {
 impl core::error::Error for UleError {}
 
 #[cfg(feature = "alloc")]
-/// Reconstructs a `Box<T>` from an allocated byte slice while preserving unique pointer provenance
+/// Reconstructs a `Box<T>` from a `Box<[u8]>` while preserving unique pointer provenance
 /// and correctly resolving DST metadata.
 ///
-/// This is an internal helper used to safely convert a heap-allocated byte buffer (e.g., from a `Vec<u8>`)
+/// This is an internal helper used to safely convert a heap-allocated byte buffer
 /// into an owned `Box<T>` where `T` is an unsized `VarULE` type.
 ///
 /// ### Why this is needed
@@ -467,10 +467,10 @@ impl core::error::Error for UleError {}
 /// ### Safety
 ///
 /// - `T::from_bytes_unchecked` must be safe to call on the slice behind bytes
-pub(crate) unsafe fn box_from_bytes<T: VarULE + ?Sized>(bytes: Box<[u8]>) -> Box<T> {
+pub(crate) unsafe fn cast_box<T: VarULE + ?Sized>(bytes: Box<[u8]>) -> Box<T> {
     use core::alloc::Layout;
     let raw = Box::into_raw(bytes);
-    // SAFETY: caller guarantees `raw` is valid.
+    // SAFETY: we just produced `raw`; it is valid
     let slice: &[u8] = unsafe { &*raw };
     // SAFETY: caller guarantees `from_bytes_unchecked` is safe.
     let ref_t: &T = unsafe { T::from_bytes_unchecked(slice) };

--- a/utils/zerovec/src/ule/mod.rs
+++ b/utils/zerovec/src/ule/mod.rs
@@ -362,16 +362,12 @@ pub unsafe trait VarULE: 'static {
     #[cfg(feature = "alloc")]
     fn to_boxed(&self) -> Box<Self> {
         use alloc::borrow::ToOwned;
-        use core::alloc::Layout;
         let bytesvec = self.as_bytes().to_owned().into_boxed_slice();
-        let bytesvec = core::mem::ManuallyDrop::new(bytesvec);
-        unsafe {
-            // Get the pointer representation
-            let ptr: *mut Self = Self::from_bytes_unchecked(&bytesvec) as *const Self as *mut Self;
-            assert_eq!(Layout::for_value(&*ptr), Layout::for_value(&**bytesvec));
-            // Transmute the pointer to an owned pointer
-            Box::from_raw(ptr)
-        }
+        let raw = Box::into_raw(bytesvec);
+        // SAFETY:
+        // - raw is a valid pointer to [u8] from Box::into_raw of a valid Box.
+        // - Self::from_bytes_unchecked is safe because the bytes came from self.as_bytes() which is valid.
+        unsafe { box_from_raw_bytes(raw) }
     }
 }
 
@@ -450,3 +446,51 @@ impl UleError {
 }
 
 impl core::error::Error for UleError {}
+
+#[cfg(feature = "alloc")]
+/// Reconstructs a `Box<T>` from a raw byte slice pointer while preserving unique pointer provenance
+/// and correctly resolving DST metadata.
+///
+/// This is an internal helper used to safely convert a heap-allocated byte buffer (e.g., from a `Vec<u8>`)
+/// into an owned `Box<T>` where `T` is an unsized `VarULE` type.
+///
+/// ### Why this is needed
+///
+/// Reconstructing a `Box<T>` from a raw pointer is tricky because:
+/// 1. **Provenance**: If we derive the pointer from a temporary shared reference (e.g., `&[u8]`),
+///    Miri/Stacked Borrows will tag the pointer as `SharedReadOnly`. Reclaiming unique ownership
+///    and deallocating through a pointer with shared provenance is Undefined Behavior. To avoid this,
+///    we must derive the final pointer directly from `Box::into_raw` (which carries `Unique` provenance).
+/// 2. **DST Metadata**: Unsized types (like `VarTupleULE`) may have custom metadata that is *not*
+///    simply the byte length of the allocation. We must use `T::from_bytes_unchecked` to construct
+///    a reference with the correct metadata, and then combine that metadata with the unique thin
+///    pointer from `Box::into_raw` without clobbering the provenance.
+///
+/// ### Safety
+///
+/// - `raw` must be a valid pointer to `[u8]` obtained from `Box::into_raw` of a box that contains
+///   a valid representation of `T`.
+/// - `T::from_bytes_unchecked` must be safe to call on the slice representation of `raw`.
+pub(crate) unsafe fn box_from_raw_bytes<T: VarULE + ?Sized>(raw: *mut [u8]) -> Box<T> {
+    use core::alloc::Layout;
+    // SAFETY: caller guarantees `raw` is valid.
+    let slice: &[u8] = unsafe { &*raw };
+    // SAFETY: caller guarantees `from_bytes_unchecked` is safe.
+    let ref_t: &T = unsafe { T::from_bytes_unchecked(slice) };
+
+    // Extract metadata from ref_t.
+    debug_assert_eq!(size_of::<&T>(), size_of::<(*const u8, usize)>());
+    let (_, metadata) = unsafe { core::mem::transmute_copy::<&T, (*const u8, usize)>(&ref_t) };
+
+    // Construct *mut T from (raw_data_ptr, metadata).
+    debug_assert_eq!(size_of::<*mut T>(), size_of::<(*mut u8, usize)>());
+    let ptr: *mut T = unsafe {
+        core::mem::transmute_copy::<(*mut u8, usize), *mut T>(&(raw.cast::<u8>(), metadata))
+    };
+
+    let expected_layout = Layout::for_value(slice);
+    // SAFETY: ptr was reconstructed with the correct metadata and the unique pointer from Box::into_raw.
+    let boxed = unsafe { Box::from_raw(ptr) };
+    assert_eq!(Layout::for_value(&*boxed), expected_layout);
+    boxed
+}

--- a/utils/zerovec/src/ule/mod.rs
+++ b/utils/zerovec/src/ule/mod.rs
@@ -363,11 +363,9 @@ pub unsafe trait VarULE: 'static {
     fn to_boxed(&self) -> Box<Self> {
         use alloc::borrow::ToOwned;
         let bytesvec = self.as_bytes().to_owned().into_boxed_slice();
-        let raw = Box::into_raw(bytesvec);
         // SAFETY:
-        // - raw is a valid pointer to [u8] from Box::into_raw of a valid Box.
         // - Self::from_bytes_unchecked is safe because the bytes came from self.as_bytes() which is valid.
-        unsafe { box_from_raw_bytes(raw) }
+        unsafe { box_from_bytes(bytesvec) }
     }
 }
 
@@ -448,7 +446,7 @@ impl UleError {
 impl core::error::Error for UleError {}
 
 #[cfg(feature = "alloc")]
-/// Reconstructs a `Box<T>` from a raw byte slice pointer while preserving unique pointer provenance
+/// Reconstructs a `Box<T>` from an allocated byte slice while preserving unique pointer provenance
 /// and correctly resolving DST metadata.
 ///
 /// This is an internal helper used to safely convert a heap-allocated byte buffer (e.g., from a `Vec<u8>`)
@@ -456,7 +454,7 @@ impl core::error::Error for UleError {}
 ///
 /// ### Why this is needed
 ///
-/// Reconstructing a `Box<T>` from a raw pointer is tricky because:
+/// Reconstructing a `Box<T>` is tricky because:
 /// 1. **Provenance**: If we derive the pointer from a temporary shared reference (e.g., `&[u8]`),
 ///    Miri/Stacked Borrows will tag the pointer as `SharedReadOnly`. Reclaiming unique ownership
 ///    and deallocating through a pointer with shared provenance is Undefined Behavior. To avoid this,
@@ -468,11 +466,10 @@ impl core::error::Error for UleError {}
 ///
 /// ### Safety
 ///
-/// - `raw` must be a valid pointer to `[u8]` obtained from `Box::into_raw` of a box that contains
-///   a valid representation of `T`.
-/// - `T::from_bytes_unchecked` must be safe to call on the slice representation of `raw`.
-pub(crate) unsafe fn box_from_raw_bytes<T: VarULE + ?Sized>(raw: *mut [u8]) -> Box<T> {
+/// - `T::from_bytes_unchecked` must be safe to call on the slice behind bytes
+pub(crate) unsafe fn box_from_bytes<T: VarULE + ?Sized>(bytes: Box<[u8]>) -> Box<T> {
     use core::alloc::Layout;
+    let raw = Box::into_raw(bytes);
     // SAFETY: caller guarantees `raw` is valid.
     let slice: &[u8] = unsafe { &*raw };
     // SAFETY: caller guarantees `from_bytes_unchecked` is safe.

--- a/utils/zerovec/src/zerovec/mod.rs
+++ b/utils/zerovec/src/zerovec/mod.rs
@@ -167,6 +167,9 @@ impl<U> EyepatchHackVector<U> {
     }
 
     fn truncate(&mut self, max: usize) {
+        // We must take care not to materialize an `&mut` here, otherwise we will
+        // have overlapping references
+        let buf_ptr: *mut [U] = self.buf.as_ptr();
         // SAFETY:
         // - The elements in buf are `ULE`, so they don't need to be dropped even if we own them.
         // - self.buf is a valid, nonnull slice pointer, since it comes from a NonNull and the struct
@@ -175,7 +178,8 @@ impl<U> EyepatchHackVector<U> {
         //   smaller, from the same pointer, so it will be valid as well, and similarly non-null.
         self.buf = unsafe {
             NonNull::new_unchecked(core::ptr::slice_from_raw_parts_mut(
-                self.buf.as_ptr().cast::<U>(),
+                // Remove the DST
+                buf_ptr.cast::<U>(),
                 core::cmp::min(max, self.buf.as_ref().len()),
             ))
         };

--- a/utils/zerovec/src/zerovec/mod.rs
+++ b/utils/zerovec/src/zerovec/mod.rs
@@ -175,7 +175,7 @@ impl<U> EyepatchHackVector<U> {
         //   smaller, from the same pointer, so it will be valid as well, and similarly non-null.
         self.buf = unsafe {
             NonNull::new_unchecked(core::ptr::slice_from_raw_parts_mut(
-                self.buf.as_mut().as_mut_ptr(),
+                self.buf.as_ptr().cast::<U>(),
                 core::cmp::min(max, self.buf.as_ref().len()),
             ))
         };


### PR DESCRIPTION
This is mostly "minor UB but still worth fixing" since eventually rustc will do more optimizations based on pointer provenance.

The general issue with pointer provenance is you have to be pretty careful of the pedigree of your pointers, making sure they were calculated through the right "path", even if the value is correct.


## Changelog: N/A