### PR TITLE
Add iterator-based parse_ucd_lines helper

### DIFF
--- a/provider/source/src/properties/bidi.rs
+++ b/provider/source/src/properties/bidi.rs
@@ -46,8 +46,7 @@ impl DataProvider<PropertyEnumBidiMirroringGlyphV1> for SourceDataProvider {
         let bidi_mirroring = self
             .parse_ucd_lines("ucd/BidiMirroring.txt")?
             .filter_map(|line| {
-                let line = line.skip_missing_rule()?;
-                let mut fields = line.fields();
+                let mut fields = line.skip_missing_rule()?.fields();
                 let cp_range = fields.next().unwrap().trim();
                 let prop_value = fields.next().unwrap().trim();
                 let value = ucd_helpers::parse_cp(prop_value);
@@ -57,8 +56,7 @@ impl DataProvider<PropertyEnumBidiMirroringGlyphV1> for SourceDataProvider {
             .collect::<HashMap<_, _>>();
 
         let paired_brackets = self.parse_ucd_lines("ucd/BidiBrackets.txt")?.filter_map(|line| {
-                let line = line.skip_missing_rule()?;
-                let mut parts = line.fields();
+                let mut parts = line.skip_missing_rule()?.fields();
                 let cp = ucd_helpers::parse_cp(parts.next().unwrap().trim());
                 let mirror = ucd_helpers::parse_cp(parts.next().unwrap().trim());
 

--- a/provider/source/src/properties/bidi.rs
+++ b/provider/source/src/properties/bidi.rs
@@ -43,34 +43,21 @@ impl DataProvider<PropertyEnumBidiMirroringGlyphV1> for SourceDataProvider {
         let bidi_m_cpinvlist = self.get_binary_prop("Bidi_Mirrored", "Bidi_M")?;
 
         let bidi_mirroring = self
-            .unicode()?
-            .read_to_string("ucd/BidiMirroring.txt")?
-            .lines()
+            .parse_ucd_lines("ucd/BidiMirroring.txt")?
             .filter_map(|line| {
-                let line = line.split('#').next().unwrap().trim();
-                if line.is_empty() {
-                    return None;
-                }
-                let mut fields = line.split(';');
+                let line = line.skip_missing_rule()?;
+                let mut fields = line.fields();
                 let cp_range = fields.next().unwrap().trim();
                 let prop_value = fields.next().unwrap().trim();
                 let value = u32::from_str_radix(prop_value, 16).expect(prop_value);
-
                 let cp = u32::from_str_radix(cp_range, 16).unwrap();
                 Some((cp, char::from_u32(value).unwrap()))
             })
             .collect::<HashMap<_, _>>();
 
-        let paired_brackets = self
-           .unicode()?
-            .read_to_string("ucd/BidiBrackets.txt")?
-            .lines()
-            .filter_map(|line| {
-                let line = line.split('#').next().unwrap().trim();
-                if line.is_empty() {
-                    return None;
-                }
-                let mut parts = line.split(';');
+        let paired_brackets = self.parse_ucd_lines("ucd/BidiBrackets.txt")?.filter_map(|line| {
+                let line = line.skip_missing_rule()?;
+                let mut parts = line.fields();
                 let cp = u32::from_str_radix(parts.next().unwrap().trim(), 16).unwrap();
                 let mirror = u32::from_str_radix(parts.next().unwrap().trim(), 16).unwrap();
 
@@ -88,8 +75,8 @@ impl DataProvider<PropertyEnumBidiMirroringGlyphV1> for SourceDataProvider {
                     _ => unreachable!(),
                 };
                 Some((cp, typ))
-            })
-            .collect::<HashMap<_, _>>();
+
+        }).collect::<HashMap<_, _>>();
 
         let mut builder = CodePointTrieBuilder::new(
             BidiMirroringGlyph::default(),

--- a/provider/source/src/properties/bidi.rs
+++ b/provider/source/src/properties/bidi.rs
@@ -4,6 +4,7 @@
 
 use std::collections::HashSet;
 
+use super::ucd_helpers;
 use crate::SourceDataProvider;
 use icu::properties::provider::PropertyEnumBidiMirroringGlyphV1;
 use icu_provider::prelude::*;
@@ -45,21 +46,19 @@ impl DataProvider<PropertyEnumBidiMirroringGlyphV1> for SourceDataProvider {
         let bidi_mirroring = self
             .parse_ucd_lines("ucd/BidiMirroring.txt")?
             .filter_map(|line| {
-                let line = line.skip_missing_rule()?;
-                let mut fields = line.fields();
+                let mut fields = line.skip_missing_rule()?.fields();
                 let cp_range = fields.next().unwrap().trim();
                 let prop_value = fields.next().unwrap().trim();
-                let value = u32::from_str_radix(prop_value, 16).expect(prop_value);
-                let cp = u32::from_str_radix(cp_range, 16).unwrap();
+                let value = ucd_helpers::parse_cp(prop_value);
+                let cp = ucd_helpers::parse_cp(cp_range);
                 Some((cp, char::from_u32(value).unwrap()))
             })
             .collect::<HashMap<_, _>>();
 
         let paired_brackets = self.parse_ucd_lines("ucd/BidiBrackets.txt")?.filter_map(|line| {
-                let line = line.skip_missing_rule()?;
-                let mut parts = line.fields();
-                let cp = u32::from_str_radix(parts.next().unwrap().trim(), 16).unwrap();
-                let mirror = u32::from_str_radix(parts.next().unwrap().trim(), 16).unwrap();
+                let mut parts = line.skip_missing_rule()?.fields();
+                let cp = ucd_helpers::parse_cp(parts.next().unwrap().trim());
+                let mirror = ucd_helpers::parse_cp(parts.next().unwrap().trim());
 
                 if bidi_mirroring[&cp] as u32 != mirror {
                     log::warn!(

--- a/provider/source/src/properties/bidi.rs
+++ b/provider/source/src/properties/bidi.rs
@@ -4,7 +4,6 @@
 
 use std::collections::HashSet;
 
-use super::ucd_helpers;
 use crate::SourceDataProvider;
 use icu::properties::provider::PropertyEnumBidiMirroringGlyphV1;
 use icu_provider::prelude::*;
@@ -17,6 +16,7 @@ impl DataProvider<PropertyEnumBidiMirroringGlyphV1> for SourceDataProvider {
         &self,
         req: DataRequest,
     ) -> Result<DataResponse<PropertyEnumBidiMirroringGlyphV1>, DataError> {
+        use super::ucd_helpers;
         use icu::collections::codepointtrie::TrieType;
         use icu::properties::props::BidiMirroringGlyph;
         use icu::properties::props::BidiPairedBracketType;
@@ -46,7 +46,8 @@ impl DataProvider<PropertyEnumBidiMirroringGlyphV1> for SourceDataProvider {
         let bidi_mirroring = self
             .parse_ucd_lines("ucd/BidiMirroring.txt")?
             .filter_map(|line| {
-                let mut fields = line.skip_missing_rule()?.fields();
+                let line = line.skip_missing_rule()?;
+                let mut fields = line.fields();
                 let cp_range = fields.next().unwrap().trim();
                 let prop_value = fields.next().unwrap().trim();
                 let value = ucd_helpers::parse_cp(prop_value);
@@ -56,7 +57,8 @@ impl DataProvider<PropertyEnumBidiMirroringGlyphV1> for SourceDataProvider {
             .collect::<HashMap<_, _>>();
 
         let paired_brackets = self.parse_ucd_lines("ucd/BidiBrackets.txt")?.filter_map(|line| {
-                let mut parts = line.skip_missing_rule()?.fields();
+                let line = line.skip_missing_rule()?;
+                let mut parts = line.fields();
                 let cp = ucd_helpers::parse_cp(parts.next().unwrap().trim());
                 let mirror = ucd_helpers::parse_cp(parts.next().unwrap().trim());
 

--- a/provider/source/src/properties/bin_cp_set.rs
+++ b/provider/source/src/properties/bin_cp_set.rs
@@ -18,15 +18,13 @@ impl SourceDataProvider {
         short_name: &str,
     ) -> Result<(), DataError> {
         let sn = self
-            .unicode()?
-            .read_to_string("ucd/PropertyAliases.txt")?
-            .lines()
-            .filter_map(|l| Some(l.split('#').next().unwrap().trim()).filter(|l| !l.is_empty()))
-            .find_map(|l| {
-                let mut fields = l.split(';').map(str::trim);
-                let sn = fields.next()?;
-                let n = fields.next()?;
-                if n == name { Some(sn) } else { None }
+            .parse_ucd_lines("ucd/PropertyAliases.txt")?
+            .filter_map(|line| line.skip_missing_rule())
+            .find_map(|line| {
+                let mut fields = line.fields();
+                let sn = fields.next();
+                let n = fields.next();
+                if Some(name) == n { sn } else { None }
             });
 
         if let Some(sn) = sn
@@ -83,23 +81,17 @@ impl SourceDataProvider {
             _ => "ucd/PropList.txt",
         };
 
-        for line in self.unicode()?.read_to_string(file)?.lines() {
-            let line = line.split('#').next().unwrap().trim();
-            if line.is_empty() {
+        for line in self.parse_ucd_lines(file)? {
+            let Some(line) = line.skip_missing_rule() else {
+                continue;
+            };
+            let mut fields = line.fields();
+            let range = fields.next().unwrap();
+            if fields.next() != Some(name) {
                 continue;
             }
 
-            let mut parts = line.split(';').map(str::trim);
-            let range = parts.next().unwrap();
-            if parts.next() != Some(name) {
-                continue;
-            }
-
-            let (a, b) = range.split_once("..").unwrap_or((range, range));
-            let a = u32::from_str_radix(a, 16).unwrap();
-            let b = u32::from_str_radix(b, 16).unwrap();
-
-            builder.add_range32(a..=b);
+            builder.add_range32(super::ucd_helpers::parse_range(range));
         }
 
         Ok(builder.build())

--- a/provider/source/src/properties/emoji_set.rs
+++ b/provider/source/src/properties/emoji_set.rs
@@ -2,6 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use super::ucd_helpers;
 use crate::SourceDataProvider;
 use icu::collections::codepointinvlist::CodePointInversionListBuilder;
 use icu::collections::codepointinvliststringlist::CodePointInversionListAndStringList;
@@ -38,17 +39,15 @@ impl SourceDataProvider {
                 continue;
             }
             if let Some((a, b)) = seq.split_once("..") {
-                inv_list.add_range32(
-                    u32::from_str_radix(a, 16).unwrap()..=u32::from_str_radix(b, 16).unwrap(),
-                );
+                inv_list.add_range32(ucd_helpers::parse_cp(a)..=ucd_helpers::parse_cp(b));
             } else if seq.contains(' ') {
                 strings.insert(
                     seq.split(' ')
-                        .map(|cp| char::from_u32(u32::from_str_radix(cp, 16).unwrap()).unwrap())
+                        .map(|cp| char::from_u32(ucd_helpers::parse_cp(cp)).unwrap())
                         .collect::<String>(),
                 );
             } else {
-                inv_list.add32(u32::from_str_radix(seq, 16).unwrap());
+                inv_list.add32(ucd_helpers::parse_cp(seq));
             }
         }
 

--- a/provider/source/src/properties/enum_codepointtrie.rs
+++ b/provider/source/src/properties/enum_codepointtrie.rs
@@ -8,6 +8,7 @@
 )]
 
 use crate::SourceDataProvider;
+use crate::properties::ucd_helpers::{self, UcdLine};
 use icu::collections::codepointtrie::{CodePointTrie, TrieValue};
 use icu::properties::props::EnumeratedProperty;
 use icu::properties::provider::{names::*, *};
@@ -29,7 +30,7 @@ impl SourceDataProvider {
 
         self.validate_property_name(name, short_name)?;
 
-        let (names_to_short_names, maybe_default) = self.enumerated_prop_names(name, short_name)?;
+        let (names_to_short_names, _) = self.enumerated_prop_names(name, short_name)?;
 
         let file = match name {
             "Indic_Conjunct_Break" => "ucd/DerivedCoreProperties.txt".into(),
@@ -57,82 +58,82 @@ impl SourceDataProvider {
             ),
         };
 
-        let read_to_string = self.unicode()?.read_to_string(&file)?;
-
-        let ucd_default = read_to_string
-            .lines()
-            .find_map(|l| {
-                let mut fields = l
-                    .strip_prefix("# @missing: 0000..10FFFF; ")?
-                    .split(';')
-                    .map(str::trim);
-                if &file == "ucd/DerivedCoreProperties.txt" {
-                    // This is a file containing multiple properties, so we need to check
-                    // the second column for the property name
-                    if fields.next().unwrap() != short_name {
-                        return None;
-                    }
-                }
-                let value = fields.next().unwrap();
-                let value = names_to_short_names
-                    .get(value)
-                    .expect("file should only use names from PropertyValueAliases.txt")
-                    .0;
-                Some(value)
-            })
-            .or_else(|| maybe_default.map(|n| names_to_short_names[n].0))
-            .expect(short_name);
-
-        // @missing entries might use long or short names.
-        let ucd_default = *names_to_short_names
-            .get(ucd_default)
-            .map(|(n, _)| n)
-            .unwrap_or(&ucd_default);
-
-        assert_eq!(
-            *short_name_to_t.get(ucd_default).expect(ucd_default),
-            T::default()
-        );
-
         let mut builder = icu_codepointtrie_builder::CodePointTrieBuilder::new(
             T::default(),
             T::default(),
             self.trie_type().into(),
         );
 
-        for line in read_to_string.lines() {
-            let line = line.strip_prefix("# @missing: ").unwrap_or(line);
-            let line = line.split('#').next().unwrap().trim();
-            if line.is_empty() {
-                continue;
-            }
-            let mut fields = line.split(';');
-            let cp_range = fields.next().unwrap().trim();
-            if &file == "ucd/DerivedCoreProperties.txt" {
-                // This is a file containing multiple properties, so we need to check
-                // the second column for the property name
-                if fields.next().unwrap().trim() != short_name {
-                    continue;
-                }
-            }
-            let value = fields.next().unwrap().trim();
-            let value = names_to_short_names
-                .get(value)
-                .expect("file should only use names from PropertyValueAliases.txt")
-                .0;
-            let Some(&value) = short_name_to_t.get(value) else {
-                // Don't log an error for every code point, the name data marker code
-                // will log an error that there's an unknown variant.
-                continue;
-            };
+        let mut last_seen_cp = -1i32;
 
-            if let Some((start, end)) = cp_range.split_once("..") {
-                let start = u32::from_str_radix(start, 16).unwrap();
-                let end = u32::from_str_radix(end, 16).unwrap();
-                builder.set_range_value(start..=end, value);
-            } else {
-                let cp = u32::from_str_radix(cp_range, 16).unwrap();
-                builder.set_value(cp, value);
+        for line in self.parse_ucd_lines(&file)? {
+            match line {
+                UcdLine::Missing(fields) => {
+                    let mut fields = fields.fields();
+                    let cps = fields.next().unwrap();
+                    if &file == "ucd/DerivedCoreProperties.txt" {
+                        // This is a file containing multiple properties, so we need to check
+                        // the second column for the property name
+                        if fields.next().unwrap() != short_name {
+                            continue;
+                        }
+                    }
+                    let value = fields.next().unwrap();
+                    let value = names_to_short_names
+                        .get(value)
+                        .expect("file should only use names from PropertyValueAliases.txt")
+                        .0;
+
+                    let Some(&value) = short_name_to_t.get(value) else {
+                        // Don't log an error for every code point, the name data marker code
+                        // will log an error that there's an unknown variant.
+                        continue;
+                    };
+
+                    if cps == "0000..10FFFF" {
+                        // This is a statement of default. just check that we're using the same one
+                        assert_eq!(value, T::default());
+                    } else {
+                        let range = ucd_helpers::parse_range(cps);
+                        assert!(
+                            *range.start() as i32 > last_seen_cp,
+                            "Found @missing rule after data in its block in {file}, we don't currently handle it"
+                        );
+                        builder.set_range_value(range, value);
+                    }
+                }
+                UcdLine::Fields(fields) => {
+                    let mut fields = fields.fields();
+                    let cp_range = fields.next().unwrap();
+                    if &file == "ucd/DerivedCoreProperties.txt" {
+                        // This is a file containing multiple properties, so we need to check
+                        // the second column for the property name
+                        if fields.next().unwrap() != short_name {
+                            continue;
+                        }
+                    }
+
+                    let value = fields.next().unwrap();
+                    let value = names_to_short_names
+                        .get(value)
+                        .expect("file should only use names from PropertyValueAliases.txt")
+                        .0;
+                    let Some(&value) = short_name_to_t.get(value) else {
+                        // Don't log an error for every code point, the name data marker code
+                        // will log an error that there's an unknown variant.
+                        continue;
+                    };
+
+                    if cp_range.contains("..") {
+                        let range = ucd_helpers::parse_range(cp_range);
+                        last_seen_cp = *range.end() as i32;
+                        builder.set_range_value(range, value);
+                    } else {
+                        let cp = u32::from_str_radix(cp_range, 16).unwrap();
+                        last_seen_cp = cp as i32;
+                        builder.set_value(cp, value);
+                    }
+                }
             }
         }
 
@@ -149,38 +150,39 @@ impl SourceDataProvider {
         let mut names = BTreeMap::new();
         let mut default = None;
 
-        for line in self
-            .unicode()?
-            .read_to_string("ucd/PropertyValueAliases.txt")?
-            .lines()
-        {
-            if let Some(line) = line.strip_prefix("# @missing: 0000..10FFFF; ") {
-                let mut parts = line.split(';').map(str::trim);
-                if parts.next().unwrap() != name {
-                    continue;
+        for line in self.parse_ucd_lines("ucd/PropertyValueAliases.txt")? {
+            match line {
+                UcdLine::Missing(fields) => {
+                    let mut fields = fields.fields();
+                    assert_eq!(
+                        fields.next().unwrap(),
+                        "0000..10FFFF",
+                        "We only expect full-range @missing values in PropertyValueAliases.txt"
+                    );
+                    if fields.next().unwrap() != name {
+                        continue;
+                    }
+                    default = Some(fields.next().unwrap())
                 }
-                default = Some(parts.next().unwrap());
-            };
-            let line = line.split('#').next().unwrap().trim();
-            if line.is_empty() {
-                continue;
-            }
-            let mut parts = line.split(';').map(str::trim);
-            if parts.next().unwrap() != short_name {
-                continue;
-            }
-            let numeric_name = (short_name.as_bytes()
-                == icu::properties::props::CanonicalCombiningClass::SHORT_NAME)
-                .then(|| parts.next().unwrap());
-            let short = parts.next().unwrap();
-            let long = parts.next().unwrap();
-            names.insert(short, (short, NameType::Short));
-            names.insert(long, (short, NameType::Long));
-            for alias in parts {
-                names.insert(alias, (short, NameType::Alias));
-            }
-            if let Some(numeric_name) = numeric_name {
-                names.insert(numeric_name, (short, NameType::Numeric));
+                UcdLine::Fields(fields) => {
+                    let mut fields = fields.fields();
+                    if fields.next().unwrap() != short_name {
+                        continue;
+                    }
+                    let numeric_name = (short_name.as_bytes()
+                        == icu::properties::props::CanonicalCombiningClass::SHORT_NAME)
+                        .then(|| fields.next().unwrap());
+                    let short = fields.next().unwrap();
+                    let long = fields.next().unwrap();
+                    names.insert(short, (short, NameType::Short));
+                    names.insert(long, (short, NameType::Long));
+                    for alias in fields {
+                        names.insert(alias, (short, NameType::Alias));
+                    }
+                    if let Some(numeric_name) = numeric_name {
+                        names.insert(numeric_name, (short, NameType::Numeric));
+                    }
+                }
             }
         }
 

--- a/provider/source/src/properties/enum_codepointtrie.rs
+++ b/provider/source/src/properties/enum_codepointtrie.rs
@@ -90,11 +90,11 @@ impl SourceDataProvider {
                         continue;
                     };
 
-                    if cps == "0000..10FFFF" {
+                    let range = ucd_helpers::parse_range(cps);
+                    if range == (0..=0x10FFFF) {
                         // This is a statement of default. just check that we're using the same one
                         assert_eq!(value, T::default());
                     } else {
-                        let range = ucd_helpers::parse_range(cps);
                         assert!(
                             *range.start() as i32 > last_seen_cp,
                             "Found @missing rule after data in its block in {file}, we don't currently handle it"
@@ -124,15 +124,9 @@ impl SourceDataProvider {
                         continue;
                     };
 
-                    if cp_range.contains("..") {
-                        let range = ucd_helpers::parse_range(cp_range);
-                        last_seen_cp = *range.end() as i32;
-                        builder.set_range_value(range, value);
-                    } else {
-                        let cp = u32::from_str_radix(cp_range, 16).unwrap();
-                        last_seen_cp = cp as i32;
-                        builder.set_value(cp, value);
-                    }
+                    let range = ucd_helpers::parse_range(cp_range);
+                    last_seen_cp = *range.end() as i32;
+                    builder.set_range_value(range, value);
                 }
             }
         }

--- a/provider/source/src/properties/mod.rs
+++ b/provider/source/src/properties/mod.rs
@@ -10,4 +10,5 @@ mod bin_cp_set;
 mod emoji_set;
 mod enum_codepointtrie;
 mod script;
+pub(crate) mod ucd_helpers;
 mod uprops_serde;

--- a/provider/source/src/properties/script.rs
+++ b/provider/source/src/properties/script.rs
@@ -54,18 +54,13 @@ impl DataProvider<PropertyScriptWithExtensionsV1> for SourceDataProvider {
 
                 let mut char_with_extensions = HashMap::new();
 
-                for line in self
-                    .unicode()?
-                    .read_to_string("ucd/ScriptExtensions.txt")?
-                    .lines()
-                {
-                    let line = line.split('#').next().unwrap().trim();
-                    if line.is_empty() {
+                for line in self.parse_ucd_lines("ucd/ScriptExtensions.txt")? {
+                    let Some(line) = line.skip_missing_rule() else {
                         continue;
-                    }
-                    let mut fields = line.split(';');
-                    let cp_range = fields.next().unwrap().trim();
-                    let values = fields.next().unwrap().trim();
+                    };
+                    let mut fields = line.fields();
+                    let cp_range = fields.next().unwrap();
+                    let values = fields.next().unwrap();
                     let mut value = values
                         .split_ascii_whitespace()
                         .filter_map(|s| script_parser.as_borrowed().get_strict(s))
@@ -73,11 +68,9 @@ impl DataProvider<PropertyScriptWithExtensionsV1> for SourceDataProvider {
                     // Sort in discriminant order
                     value.sort();
 
-                    let (start, end) = cp_range.split_once("..").unwrap_or((cp_range, cp_range));
-                    let start = u32::from_str_radix(start, 16).unwrap();
-                    let end = u32::from_str_radix(end, 16).unwrap();
+                    let cp_range = super::ucd_helpers::parse_range(cp_range);
 
-                    for cp in start..=end {
+                    for cp in cp_range {
                         let mut value = value.clone();
 
                         let script = script.as_borrowed().get32(cp);

--- a/provider/source/src/properties/ucd_helpers.rs
+++ b/provider/source/src/properties/ucd_helpers.rs
@@ -28,14 +28,14 @@ pub(crate) enum UcdLine<'a> {
 }
 
 impl<'a> UcdFields<'a> {
-    pub(crate) fn fields(&self) -> impl Iterator<Item = &'a str> + 'a {
+    pub(crate) fn fields(self) -> impl Iterator<Item = &'a str> + 'a {
         self.0.split(';').map(str::trim)
     }
 }
 
 impl<'a> UcdLine<'a> {
-    pub(crate) fn skip_missing_rule(&self) -> Option<UcdFields<'a>> {
-        if let Self::Fields(c) = *self {
+    pub(crate) fn skip_missing_rule(self) -> Option<UcdFields<'a>> {
+        if let Self::Fields(c) = self {
             Some(c)
         } else {
             None

--- a/provider/source/src/properties/ucd_helpers.rs
+++ b/provider/source/src/properties/ucd_helpers.rs
@@ -9,9 +9,13 @@ use icu_provider::prelude::*;
 
 pub(crate) fn parse_range(range_str: &str) -> std::ops::RangeInclusive<u32> {
     let (a, b) = range_str.split_once("..").unwrap_or((range_str, range_str));
-    let a = u32::from_str_radix(a, 16).unwrap();
-    let b = u32::from_str_radix(b, 16).unwrap();
+    let a = parse_cp(a);
+    let b = parse_cp(b);
     a..=b
+}
+
+pub(crate) fn parse_cp(cp: &str) -> u32 {
+    u32::from_str_radix(cp, 16).unwrap()
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -43,11 +47,9 @@ impl SourceDataProvider {
     /// Helper to parse UCD files line-by-line, providing an iterator over the fields of each line.
     ///
     /// It reads the file, strips comments (lines starting with `#` or anything after `#`),
-    /// skips empty lines, and passes a mutable reference to an iterator over the trimmed,
-    /// semicolon-separated fields to the callback.
+    /// skips empty lines, and returns an iterator over each line.
     ///
-    /// **Important:** Eagerly strips all comments, so it **cannot** be used for parsing
-    /// `@missing` rules which are semantically significant comments starting with `# @missing`.
+    /// It handles `# @missing` rules by returning them as `UcdLine::Missing`
     pub(crate) fn parse_ucd_lines<'a>(
         &'a self,
         file: &str,

--- a/provider/source/src/properties/ucd_helpers.rs
+++ b/provider/source/src/properties/ucd_helpers.rs
@@ -1,0 +1,71 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+//! This module contains helpers for parsing files from the UCD
+
+use crate::SourceDataProvider;
+use icu_provider::prelude::*;
+
+pub(crate) fn parse_range(range_str: &str) -> std::ops::RangeInclusive<u32> {
+    let (a, b) = range_str.split_once("..").unwrap_or((range_str, range_str));
+    let a = u32::from_str_radix(a, 16).unwrap();
+    let b = u32::from_str_radix(b, 16).unwrap();
+    a..=b
+}
+
+#[derive(Copy, Clone, Debug)]
+pub(crate) struct UcdFields<'a>(&'a str);
+
+#[derive(Copy, Clone, Debug)]
+pub(crate) enum UcdLine<'a> {
+    Fields(UcdFields<'a>),
+    Missing(UcdFields<'a>),
+}
+
+impl<'a> UcdFields<'a> {
+    pub(crate) fn fields(&self) -> impl Iterator<Item = &'a str> {
+        self.0.split(';').map(str::trim)
+    }
+}
+
+impl<'a> UcdLine<'a> {
+    pub(crate) fn skip_missing_rule(&self) -> Option<UcdFields<'a>> {
+        if let Self::Fields(c) = *self {
+            Some(c)
+        } else {
+            None
+        }
+    }
+}
+
+impl SourceDataProvider {
+    /// Helper to parse UCD files line-by-line, providing an iterator over the fields of each line.
+    ///
+    /// It reads the file, strips comments (lines starting with `#` or anything after `#`),
+    /// skips empty lines, and passes a mutable reference to an iterator over the trimmed,
+    /// semicolon-separated fields to the callback.
+    ///
+    /// **Important:** Eagerly strips all comments, so it **cannot** be used for parsing
+    /// `@missing` rules which are semantically significant comments starting with `# @missing`.
+    pub(crate) fn parse_ucd_lines<'a>(
+        &'a self,
+        file: &str,
+    ) -> Result<impl Iterator<Item = UcdLine<'a>>, DataError> {
+        Ok(self
+            .unicode()?
+            .read_to_string(file)?
+            .lines()
+            .filter_map(|line| {
+                if let Some(l) = line.strip_prefix("# @missing: ") {
+                    Some(UcdLine::Missing(UcdFields(l)))
+                } else {
+                    let line = line.split('#').next().unwrap().trim();
+                    if line.is_empty() {
+                        return None;
+                    }
+                    Some(UcdLine::Fields(UcdFields(line)))
+                }
+            }))
+    }
+}

--- a/provider/source/src/properties/ucd_helpers.rs
+++ b/provider/source/src/properties/ucd_helpers.rs
@@ -28,7 +28,7 @@ pub(crate) enum UcdLine<'a> {
 }
 
 impl<'a> UcdFields<'a> {
-    pub(crate) fn fields(&self) -> impl Iterator<Item = &'a str> {
+    pub(crate) fn fields(&self) -> impl Iterator<Item = &'a str> + 'a {
         self.0.split(';').map(str::trim)
     }
 }


### PR DESCRIPTION
Take 2 at https://github.com/unicode-org/icu4x/pull/8077

Fixes https://github.com/unicode-org/icu4x/issues/7947

My original attempt was predicated on "I want all of this parsery code in one file", and _then_ doing cleanups on top of that. But I think after going through that, it seems like we can actually design a pretty lightweight internal iteratory abstraction that handles all of the parsing complexities (including `@missing`), so that the caller can just have the processing step.

I've tried to make it so that it's abundantly clear when e.g. an `@missing` line is being explicitly ignored.

I think this code is much easier to read: the processing code doesn't need to muck with file syntax anymore. We still need to e.g. make it clear that we expect `@missing` rules before the data in the ranges they represent, but now it's much clearer that we make that assumption.

Also the main property parsing function becomes single-pass.

## Changelog: N/A
