### PR TITLE
Pin cargo-rdme to v1.5.1 in tidy job

### DIFF
--- a/tools/make/tidy.toml
+++ b/tools/make/tidy.toml
@@ -126,9 +126,17 @@ end
 echo "License header check complete"
 '''
 
+[tasks.install-cargo-rdme]
+description = "Install cargo-rdme v1.5.1"
+category = "ICU4X Development"
+script_runner = "@shell"
+script = '''
+cargo rdme --version | grep 1.5.1 || cargo install cargo-rdme --version 1.5.1
+'''
+
 [tasks.generate-readmes]
 description = "Automatically generate README.md for each component."
-install_crate = { crate_name = "cargo-rdme", test_arg = ["--help"] }
+dependencies = ["install-cargo-rdme"]
 category = "ICU4X Development"
 script_runner = "@duckscript"
 script = '''


### PR DESCRIPTION
Fixes tidy CI failures by pinning `cargo-rdme` to `v1.5.1` and splitting the installation into a separate task.

Recently, `cargo-rdme` released `v2.0.0` which introduced incompatibilities with the rustdoc JSON generated by our current toolchain, causing tidy CI to fail in all PRs.

To resolve this:
1. We pin `cargo-rdme` to `v1.5.1` (the last known working version).
2. We split the installation of `cargo-rdme` into a separate `install-cargo-rdme` task using the `@shell` runner. This ensures that the installation command runs in a proper shell environment, while the main `generate-readmes` task can continue to run in `@duckscript` without "command not found" errors.

🤖 This pull request was created by an AI agent working with @sffc.

## Changelog (N/A)

Internal CI configuration change.
