### PR TITLE
Install cargo-rdme at 1.5.1

### DIFF
--- a/tools/make/tidy.toml
+++ b/tools/make/tidy.toml
@@ -129,6 +129,8 @@ echo "License header check complete"
 [tasks.generate-readmes]
 description = "Automatically generate README.md for each component."
 install_crate = { crate_name = "cargo-rdme", test_arg = ["--help"] }
+# cargo-rdme 2.0 uses rustdoc-json and is tied to Rust versions
+install_crate_args = ["--version", "=1.5.1"]
 category = "ICU4X Development"
 script_runner = "@duckscript"
 script = '''

--- a/tools/make/tidy.toml
+++ b/tools/make/tidy.toml
@@ -130,7 +130,7 @@ echo "License header check complete"
 description = "Automatically generate README.md for each component."
 install_crate = { crate_name = "cargo-rdme", test_arg = ["--help"] }
 # cargo-rdme 2.0 uses rustdoc-json and is tied to Rust versions
-install_crate_args = ["--version", "=1.5.1"]
+install_crate_args = ["--version", "1.5.1"]
 category = "ICU4X Development"
 script_runner = "@duckscript"
 script = '''


### PR DESCRIPTION
Different from https://github.com/unicode-org/icu4x/pull/8117 in that it doesn't _force_ a particular version, but if it is installing fresh it installs the right one. Allows users to have flexibility in their local environments. But not as watertight.

## Changelog: N/A