### PR TITLE
Upgrade dependencies for Dart ICU4X package

### DIFF
--- a/.github/workflows/artifacts-build.yml
+++ b/.github/workflows/artifacts-build.yml
@@ -238,9 +238,6 @@ jobs:
 
     - name: Install Dart
       uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672 # v1.6.5
-      with:
-        # Keep in sync with build-test.yml
-        sdk: 3.13.0-215.0.dev
         
     - name: Build docs
       run: |

--- a/.github/workflows/artifacts-build.yml
+++ b/.github/workflows/artifacts-build.yml
@@ -238,6 +238,9 @@ jobs:
 
     - name: Install Dart
       uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672 # v1.6.5
+      with:
+        # Keep in sync with build-test.yml
+        sdk: 3.13.0-215.0.dev
         
     - name: Build docs
       run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -339,12 +339,11 @@ jobs:
     # Job-specific dependencies
     - uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672 # v1.6.5
       with:
-        # Keep in sync with artifacts-build.yml
         sdk: 3.13.0-215.0.dev
         # Currently disabled: There are a lot of incoming changes to Dart native-assets' JSON format,
         # so we won't do nightly builds for now. The first failing build is 3.12.0-62.0.dev.
         # Tracked upstream in https://github.com/orgs/dart-lang/projects/99
-        # Revisit in April 2026.
+        # Revisit in August 2026.
         # sdk: ${{ github.event_name == 'schedule' && github.event.schedule == '0 14 * * *' && 'dev' || '3.11.0-46.0.dev' }}
     - name: Install yq if Windows
       if: ${{ matrix.os == 'windows-latest' }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -340,7 +340,7 @@ jobs:
     - uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672 # v1.6.5
       with:
         # Keep in sync with artifacts-build.yml
-        sdk: 3.11.0-46.0.dev
+        sdk: 3.13.0-215.0.dev
         # Currently disabled: There are a lot of incoming changes to Dart native-assets' JSON format,
         # so we won't do nightly builds for now. The first failing build is 3.12.0-62.0.dev.
         # Tracked upstream in https://github.com/orgs/dart-lang/projects/99

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -768,7 +768,7 @@ dependencies = [
 [[package]]
 name = "diplomat"
 version = "0.15.0"
-source = "git+https://github.com/rust-diplomat/diplomat?rev=dbbfc3e089a280fbaa996150d8ca9087b7e1b3d3#dbbfc3e089a280fbaa996150d8ca9087b7e1b3d3"
+source = "git+https://github.com/rust-diplomat/diplomat?rev=e827245abb92f19cd253f462ac9a9cab3fc9b548#e827245abb92f19cd253f462ac9a9cab3fc9b548"
 dependencies = [
  "diplomat_core",
  "proc-macro2",
@@ -799,7 +799,7 @@ dependencies = [
 [[package]]
 name = "diplomat-runtime"
 version = "0.15.1"
-source = "git+https://github.com/rust-diplomat/diplomat?rev=dbbfc3e089a280fbaa996150d8ca9087b7e1b3d3#dbbfc3e089a280fbaa996150d8ca9087b7e1b3d3"
+source = "git+https://github.com/rust-diplomat/diplomat?rev=e827245abb92f19cd253f462ac9a9cab3fc9b548#e827245abb92f19cd253f462ac9a9cab3fc9b548"
 dependencies = [
  "log",
 ]
@@ -807,7 +807,7 @@ dependencies = [
 [[package]]
 name = "diplomat-tool"
 version = "0.15.0"
-source = "git+https://github.com/rust-diplomat/diplomat?rev=dbbfc3e089a280fbaa996150d8ca9087b7e1b3d3#dbbfc3e089a280fbaa996150d8ca9087b7e1b3d3"
+source = "git+https://github.com/rust-diplomat/diplomat?rev=e827245abb92f19cd253f462ac9a9cab3fc9b548#e827245abb92f19cd253f462ac9a9cab3fc9b548"
 dependencies = [
  "askama",
  "clap",
@@ -826,7 +826,7 @@ dependencies = [
 [[package]]
 name = "diplomat_core"
 version = "0.15.0"
-source = "git+https://github.com/rust-diplomat/diplomat?rev=dbbfc3e089a280fbaa996150d8ca9087b7e1b3d3#dbbfc3e089a280fbaa996150d8ca9087b7e1b3d3"
+source = "git+https://github.com/rust-diplomat/diplomat?rev=e827245abb92f19cd253f462ac9a9cab3fc9b548#e827245abb92f19cd253f462ac9a9cab3fc9b548"
 dependencies = [
  "annotate-snippets",
  "either",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -218,10 +218,10 @@ icu_benchmark_macros = { path = "tools/benchmark/macros" }
 
 # The version here can either be a `version = ".."` spec or `git = "https://github.com/rust-diplomat/diplomat", rev = ".."`
 # Diplomat must be published preceding a new ICU4X release but may use git versions in between
-diplomat = { git = "https://github.com/rust-diplomat/diplomat", rev = "dbbfc3e089a280fbaa996150d8ca9087b7e1b3d3", default-features = false }
-diplomat-runtime = { git = "https://github.com/rust-diplomat/diplomat", rev = "dbbfc3e089a280fbaa996150d8ca9087b7e1b3d3", default-features = false }
-diplomat_core = { git = "https://github.com/rust-diplomat/diplomat", rev = "dbbfc3e089a280fbaa996150d8ca9087b7e1b3d3", default-features = false }
-diplomat-tool = { git = "https://github.com/rust-diplomat/diplomat", rev = "dbbfc3e089a280fbaa996150d8ca9087b7e1b3d3" }
+diplomat = { git = "https://github.com/rust-diplomat/diplomat", rev = "e827245abb92f19cd253f462ac9a9cab3fc9b548", default-features = false }
+diplomat-runtime = { git = "https://github.com/rust-diplomat/diplomat", rev = "e827245abb92f19cd253f462ac9a9cab3fc9b548", default-features = false }
+diplomat_core = { git = "https://github.com/rust-diplomat/diplomat", rev = "e827245abb92f19cd253f462ac9a9cab3fc9b548", default-features = false }
+diplomat-tool = { git = "https://github.com/rust-diplomat/diplomat", rev = "e827245abb92f19cd253f462ac9a9cab3fc9b548" }
 
 # EXTERNAL DEPENDENCIES
 #

--- a/Cargo.toml.patch
+++ b/Cargo.toml.patch
@@ -1,0 +1,5 @@
+[patch."https://github.com/rust-diplomat/diplomat"]
+diplomat = { path = "../diplomat/macro" }
+diplomat-runtime = { path = "../diplomat/runtime" }
+diplomat_core = { path = "../diplomat/core" }
+diplomat-tool = { path = "../diplomat/tool" }

--- a/Cargo.toml.patch
+++ b/Cargo.toml.patch
@@ -1,5 +1,0 @@
-[patch."https://github.com/rust-diplomat/diplomat"]
-diplomat = { path = "../diplomat/macro" }
-diplomat-runtime = { path = "../diplomat/runtime" }
-diplomat_core = { path = "../diplomat/core" }
-diplomat-tool = { path = "../diplomat/tool" }

--- a/ffi/dart/analysis_options.yaml
+++ b/ffi/dart/analysis_options.yaml
@@ -10,8 +10,6 @@ analyzer:
   language:
     strict-casts: true
     strict-inference: true
-  errors:
-    use_null_aware_elements: ignore
 
 linter:
   rules:

--- a/ffi/dart/analysis_options.yaml
+++ b/ffi/dart/analysis_options.yaml
@@ -11,9 +11,7 @@ analyzer:
     strict-casts: true
     strict-inference: true
   errors:
-    # this lint is overzealous (fixing would break semver)
-    # in 3.10, which breaks our perfect pub.dev score
-    deprecated_member_use_from_same_package: false
+    use_null_aware_elements: ignore
 
 linter:
   rules:

--- a/ffi/dart/hook/link.dart
+++ b/ffi/dart/hook/link.dart
@@ -2,12 +2,9 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-import 'dart:convert';
-import 'dart:io';
-
 import 'package:code_assets/code_assets.dart'
     show CodeAsset, HookConfigCodeConfig, LinkInputCodeAssets, OS;
-import 'package:hooks/hooks.dart' show LinkInput, link;
+import 'package:hooks/hooks.dart' show link;
 import 'package:logging/logging.dart' show Level, Logger;
 import 'package:native_toolchain_c/native_toolchain_c.dart'
     show CLinker, LinkerOptions;
@@ -27,14 +24,21 @@ Future<void> main(List<String> args) async {
       return;
     }
 
-    final usedSymbols = input.usages
-        ?.constantsOf(
-          record_use.Identifier(
-            importUri: staticLib.id,
-            name: '_DiplomatFfiUse',
-          ),
+    final usedSymbols = input
+        // ignore: experimental_member_use
+        .recordedUses
+        ?.instances[const record_use.Class(
+          '_DiplomatFfiUse',
+          record_use.Library('package:icu4x/src/bindings/lib.g.dart'),
+        )]
+        ?.whereType<record_use.InstanceConstantReference>()
+        .map((instance) => instance.instanceConstant)
+        .whereType<record_use.InstanceConstant>()
+        .map(
+          (instanceConstant) =>
+              instanceConstant.fields['symbol'] as record_use.StringConstant,
         )
-        .map((instance) => instance['symbol'] as String);
+        .map((stringConstant) => stringConstant.value);
 
     print('''
 ### Using symbols:
@@ -63,18 +67,4 @@ Future<void> main(List<String> args) async {
         ..onRecord.listen((record) => print(record.message)),
     );
   });
-}
-
-extension on LinkInput {
-  record_use.RecordedUsages? get usages {
-    // the hooks package is pinned
-    // ignore: experimental_member_use
-    final records = recordedUsagesFile;
-    if (records == null) {
-      return null;
-    }
-    final usagesContent = File.fromUri(records).readAsStringSync();
-    final usagesJson = jsonDecode(usagesContent) as Map<String, dynamic>;
-    return record_use.RecordedUsages.fromJson(usagesJson);
-  }
 }

--- a/ffi/dart/hook/link.dart
+++ b/ffi/dart/hook/link.dart
@@ -5,6 +5,7 @@
 import 'package:code_assets/code_assets.dart'
     show CodeAsset, HookConfigCodeConfig, LinkInputCodeAssets, OS;
 import 'package:hooks/hooks.dart' show link;
+import 'package:icu4x/src/bindings/lib.g.dart' show symbolMapping;
 import 'package:logging/logging.dart' show Level, Logger;
 import 'package:native_toolchain_c/native_toolchain_c.dart'
     show CLinker, LinkerOptions;
@@ -24,25 +25,28 @@ Future<void> main(List<String> args) async {
       return;
     }
 
-    final usedSymbols = input
+    final recordedUses = input
         // ignore: experimental_member_use
-        .recordedUses
-        ?.instances[const record_use.Class(
-          '_DiplomatFfiUse',
-          record_use.Library('package:icu4x/src/bindings/lib.g.dart'),
-        )]
-        ?.whereType<record_use.InstanceConstantReference>()
-        .map((instance) => instance.instanceConstant)
-        .whereType<record_use.InstanceConstant>()
-        .map(
-          (instanceConstant) =>
-              instanceConstant.fields['symbol'] as record_use.StringConstant,
+        .recordedUses;
+    if (recordedUses == null) {
+      throw ArgumentError(
+        'Enable the --enable-experiment=record-use experiment'
+        ' to use this app.',
+      );
+    }
+    final usedSymbols = recordedUses.calls.keys
+        .where(
+          (id) =>
+              id.library ==
+              const record_use.Library('package:icu4x/src/bindings/lib.g.dart'),
         )
-        .map((stringConstant) => stringConstant.value);
+        .map((id) => id.name)
+        .map((methodName) => symbolMapping[methodName])
+        .nonNulls;
 
     print('''
 ### Using symbols:
-  ${usedSymbols?.join('\n')}
+  ${usedSymbols.join('\n')}
 ### End using symbols
 ''');
 

--- a/ffi/dart/hook/link.dart
+++ b/ffi/dart/hook/link.dart
@@ -5,7 +5,6 @@
 import 'package:code_assets/code_assets.dart'
     show CodeAsset, HookConfigCodeConfig, LinkInputCodeAssets, OS;
 import 'package:hooks/hooks.dart' show link;
-import 'package:icu4x/src/bindings/lib.g.dart' show symbolMapping;
 import 'package:logging/logging.dart' show Level, Logger;
 import 'package:native_toolchain_c/native_toolchain_c.dart'
     show CLinker, LinkerOptions;
@@ -28,25 +27,29 @@ Future<void> main(List<String> args) async {
     final recordedUses = input
         // ignore: experimental_member_use
         .recordedUses;
+    Iterable<String>? usedSymbols;
     if (recordedUses == null) {
-      throw ArgumentError(
+      print(
         'Enable the --enable-experiment=record-use experiment'
-        ' to use this app.',
+        ' to use treeshake unused symbols.',
       );
+    } else {
+      usedSymbols = recordedUses.calls.keys
+          .where(
+            (id) =>
+                id.library ==
+                const record_use.Library(
+                  'package:icu4x/src/bindings/lib.g.dart',
+                ),
+          )
+          .map((id) => id.name)
+          .where((methodName) => methodName.startsWith('_'))
+          .map((methodName) => methodName.substring(1));
     }
-    final usedSymbols = recordedUses.calls.keys
-        .where(
-          (id) =>
-              id.library ==
-              const record_use.Library('package:icu4x/src/bindings/lib.g.dart'),
-        )
-        .map((id) => id.name)
-        .map((methodName) => symbolMapping[methodName])
-        .nonNulls;
 
     print('''
 ### Using symbols:
-  ${usedSymbols.join('\n')}
+  ${usedSymbols?.join('\n') ?? 'Treeshaking disabled, using all symbols.'}
 ### End using symbols
 ''');
 

--- a/ffi/dart/lib/icu4x.dart
+++ b/ffi/dart/lib/icu4x.dart
@@ -2,4 +2,4 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-export 'src/bindings/lib.g.dart' hide symbolMapping;
+export 'src/bindings/lib.g.dart';

--- a/ffi/dart/lib/icu4x.dart
+++ b/ffi/dart/lib/icu4x.dart
@@ -2,4 +2,4 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-export 'src/bindings/lib.g.dart';
+export 'src/bindings/lib.g.dart' hide symbolMapping;

--- a/ffi/dart/lib/src/bindings/Bidi.g.dart
+++ b/ffi/dart/lib/src/bindings/Bidi.g.dart
@@ -19,12 +19,16 @@ final class Bidi implements ffi.Finalizable {
   // maintain borrow validity.
   Bidi._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_Bidi_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_Bidi_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_Bidi_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_Bidi_destroy_mv1(Bidi cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_Bidi_destroy_mv1));
 
   /// Creates a new [Bidi] from locale data using compiled data.
   factory Bidi() {
@@ -110,47 +114,56 @@ final class Bidi implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_Bidi_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_Bidi_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_Bidi_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_Bidi_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_Bidi_create_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_Bidi_create_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_Bidi_create_mv1();
 
-@_DiplomatFfiUse('icu4x_Bidi_create_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Bidi_create_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_Bidi_create_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_Bidi_for_text_valid_utf8_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8, _ResultUint8Void)>(isLeaf: true, symbol: 'icu4x_Bidi_for_text_valid_utf8_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_Bidi_for_text_valid_utf8_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUtf8 text, _ResultUint8Void defaultLevel);
 
-@_DiplomatFfiUse('icu4x_Bidi_reorder_visual_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, _SliceUint8)>(isLeaf: true, symbol: 'icu4x_Bidi_reorder_visual_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_Bidi_reorder_visual_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUint8 levels);
 
-@_DiplomatFfiUse('icu4x_Bidi_level_is_rtl_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint8)>(isLeaf: true, symbol: 'icu4x_Bidi_level_is_rtl_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_Bidi_level_is_rtl_mv1(int level);
 
-@_DiplomatFfiUse('icu4x_Bidi_level_is_ltr_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint8)>(isLeaf: true, symbol: 'icu4x_Bidi_level_is_ltr_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_Bidi_level_is_ltr_mv1(int level);
 
-@_DiplomatFfiUse('icu4x_Bidi_level_rtl_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint8 Function()>(isLeaf: true, symbol: 'icu4x_Bidi_level_rtl_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_Bidi_level_rtl_mv1();
 
-@_DiplomatFfiUse('icu4x_Bidi_level_ltr_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint8 Function()>(isLeaf: true, symbol: 'icu4x_Bidi_level_ltr_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_Bidi_level_ltr_mv1();

--- a/ffi/dart/lib/src/bindings/BidiClass.g.dart
+++ b/ffi/dart/lib/src/bindings/BidiClass.g.dart
@@ -110,32 +110,38 @@ enum BidiClass {
 
 }
 
-@_DiplomatFfiUse('icu4x_BidiClass_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_BidiClass_for_char_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_BidiClass_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_BidiClass_long_name_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultSliceUtf8Void Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_BidiClass_long_name_mv1')
 // ignore: non_constant_identifier_names
 external _ResultSliceUtf8Void _icu4x_BidiClass_long_name_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_BidiClass_short_name_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultSliceUtf8Void Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_BidiClass_short_name_mv1')
 // ignore: non_constant_identifier_names
 external _ResultSliceUtf8Void _icu4x_BidiClass_short_name_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_BidiClass_to_integer_value_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint8 Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_BidiClass_to_integer_value_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_BidiClass_to_integer_value_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_BidiClass_from_integer_value_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultInt32Void Function(ffi.Uint8)>(isLeaf: true, symbol: 'icu4x_BidiClass_from_integer_value_mv1')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _icu4x_BidiClass_from_integer_value_mv1(int other);
 
-@_DiplomatFfiUse('icu4x_BidiClass_try_from_str_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultInt32Void Function(_SliceUtf8)>(isLeaf: true, symbol: 'icu4x_BidiClass_try_from_str_mv1')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _icu4x_BidiClass_try_from_str_mv1(_SliceUtf8 s);

--- a/ffi/dart/lib/src/bindings/BidiInfo.g.dart
+++ b/ffi/dart/lib/src/bindings/BidiInfo.g.dart
@@ -21,12 +21,16 @@ final class BidiInfo implements ffi.Finalizable {
   // maintain borrow validity.
   BidiInfo._fromFfi(this._ffi, this._selfEdge, this._textEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_BidiInfo_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_BidiInfo_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_BidiInfo_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_BidiInfo_destroy_mv1(BidiInfo cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_BidiInfo_destroy_mv1));
 
   /// The number of paragraphs contained here
   int get paragraphCount {
@@ -60,27 +64,32 @@ final class BidiInfo implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_BidiInfo_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_BidiInfo_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_BidiInfo_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_BidiInfo_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_BidiInfo_paragraph_count_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Size Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_BidiInfo_paragraph_count_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_BidiInfo_paragraph_count_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_BidiInfo_paragraph_at_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Size)>(isLeaf: true, symbol: 'icu4x_BidiInfo_paragraph_at_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_BidiInfo_paragraph_at_mv1(ffi.Pointer<ffi.Opaque> self, int n);
 
-@_DiplomatFfiUse('icu4x_BidiInfo_size_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Size Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_BidiInfo_size_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_BidiInfo_size_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_BidiInfo_level_at_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint8 Function(ffi.Pointer<ffi.Opaque>, ffi.Size)>(isLeaf: true, symbol: 'icu4x_BidiInfo_level_at_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_BidiInfo_level_at_mv1(ffi.Pointer<ffi.Opaque> self, int pos);

--- a/ffi/dart/lib/src/bindings/BidiMirroringGlyph.g.dart
+++ b/ffi/dart/lib/src/bindings/BidiMirroringGlyph.g.dart
@@ -66,7 +66,8 @@ final class BidiMirroringGlyph {
       ]);
 }
 
-@_DiplomatFfiUse('icu4x_BidiMirroringGlyph_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_BidiMirroringGlyphFfi Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_BidiMirroringGlyph_for_char_mv1')
 // ignore: non_constant_identifier_names
 external _BidiMirroringGlyphFfi _icu4x_BidiMirroringGlyph_for_char_mv1(Rune ch);

--- a/ffi/dart/lib/src/bindings/BidiParagraph.g.dart
+++ b/ffi/dart/lib/src/bindings/BidiParagraph.g.dart
@@ -19,12 +19,16 @@ final class BidiParagraph implements ffi.Finalizable {
   // maintain borrow validity.
   BidiParagraph._fromFfi(this._ffi, this._selfEdge, this._infoEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_BidiParagraph_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_BidiParagraph_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_BidiParagraph_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_BidiParagraph_destroy_mv1(BidiParagraph cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_BidiParagraph_destroy_mv1));
 
   /// Given a paragraph index `n` within the surrounding text, this sets this
   /// object to the paragraph at that index. Returns nothing when out of bounds.
@@ -91,42 +95,50 @@ final class BidiParagraph implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_BidiParagraph_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_BidiParagraph_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_BidiParagraph_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_BidiParagraph_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_BidiParagraph_set_paragraph_in_text_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Pointer<ffi.Opaque>, ffi.Size)>(isLeaf: true, symbol: 'icu4x_BidiParagraph_set_paragraph_in_text_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_BidiParagraph_set_paragraph_in_text_mv1(ffi.Pointer<ffi.Opaque> self, int n);
 
-@_DiplomatFfiUse('icu4x_BidiParagraph_direction_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_BidiParagraph_direction_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_BidiParagraph_direction_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_BidiParagraph_size_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Size Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_BidiParagraph_size_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_BidiParagraph_size_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_BidiParagraph_range_start_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Size Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_BidiParagraph_range_start_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_BidiParagraph_range_start_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_BidiParagraph_range_end_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Size Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_BidiParagraph_range_end_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_BidiParagraph_range_end_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_BidiParagraph_reorder_line_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultVoidVoid Function(ffi.Pointer<ffi.Opaque>, ffi.Size, ffi.Size, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_BidiParagraph_reorder_line_mv1')
 // ignore: non_constant_identifier_names
 external _ResultVoidVoid _icu4x_BidiParagraph_reorder_line_mv1(ffi.Pointer<ffi.Opaque> self, int rangeStart, int rangeEnd, ffi.Pointer<ffi.Opaque> write);
 
-@_DiplomatFfiUse('icu4x_BidiParagraph_level_at_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint8 Function(ffi.Pointer<ffi.Opaque>, ffi.Size)>(isLeaf: true, symbol: 'icu4x_BidiParagraph_level_at_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_BidiParagraph_level_at_mv1(ffi.Pointer<ffi.Opaque> self, int pos);

--- a/ffi/dart/lib/src/bindings/Calendar.g.dart
+++ b/ffi/dart/lib/src/bindings/Calendar.g.dart
@@ -17,12 +17,16 @@ final class Calendar implements ffi.Finalizable {
   // maintain borrow validity.
   Calendar._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_Calendar_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_Calendar_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_Calendar_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_Calendar_destroy_mv1(Calendar cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_Calendar_destroy_mv1));
 
   /// Creates a new [Calendar] for the specified kind, using compiled data.
   ///
@@ -55,22 +59,26 @@ final class Calendar implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_Calendar_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_Calendar_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_Calendar_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_Calendar_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_Calendar_create_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_Calendar_create_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_Calendar_create_mv1(int kind);
 
-@_DiplomatFfiUse('icu4x_Calendar_create_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Int32)>(isLeaf: true, symbol: 'icu4x_Calendar_create_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_Calendar_create_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, int kind);
 
-@_DiplomatFfiUse('icu4x_Calendar_kind_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Calendar_kind_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_Calendar_kind_mv1(ffi.Pointer<ffi.Opaque> self);

--- a/ffi/dart/lib/src/bindings/CalendarKind.g.dart
+++ b/ffi/dart/lib/src/bindings/CalendarKind.g.dart
@@ -100,7 +100,8 @@ enum CalendarKind {
 
 }
 
-@_DiplomatFfiUse('icu4x_CalendarKind_create_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CalendarKind_create_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_CalendarKind_create_mv1(ffi.Pointer<ffi.Opaque> locale);

--- a/ffi/dart/lib/src/bindings/CanonicalCombiningClass.g.dart
+++ b/ffi/dart/lib/src/bindings/CanonicalCombiningClass.g.dart
@@ -301,32 +301,38 @@ enum CanonicalCombiningClass {
 
 }
 
-@_DiplomatFfiUse('icu4x_CanonicalCombiningClass_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CanonicalCombiningClass_for_char_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_CanonicalCombiningClass_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CanonicalCombiningClass_long_name_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultSliceUtf8Void Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_CanonicalCombiningClass_long_name_mv1')
 // ignore: non_constant_identifier_names
 external _ResultSliceUtf8Void _icu4x_CanonicalCombiningClass_long_name_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_CanonicalCombiningClass_short_name_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultSliceUtf8Void Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_CanonicalCombiningClass_short_name_mv1')
 // ignore: non_constant_identifier_names
 external _ResultSliceUtf8Void _icu4x_CanonicalCombiningClass_short_name_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_CanonicalCombiningClass_to_integer_value_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint8 Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_CanonicalCombiningClass_to_integer_value_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_CanonicalCombiningClass_to_integer_value_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_CanonicalCombiningClass_from_integer_value_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultInt32Void Function(ffi.Uint8)>(isLeaf: true, symbol: 'icu4x_CanonicalCombiningClass_from_integer_value_mv1')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _icu4x_CanonicalCombiningClass_from_integer_value_mv1(int other);
 
-@_DiplomatFfiUse('icu4x_CanonicalCombiningClass_try_from_str_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultInt32Void Function(_SliceUtf8)>(isLeaf: true, symbol: 'icu4x_CanonicalCombiningClass_try_from_str_mv1')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _icu4x_CanonicalCombiningClass_try_from_str_mv1(_SliceUtf8 s);

--- a/ffi/dart/lib/src/bindings/CanonicalCombiningClassMap.g.dart
+++ b/ffi/dart/lib/src/bindings/CanonicalCombiningClassMap.g.dart
@@ -19,12 +19,16 @@ final class CanonicalCombiningClassMap implements ffi.Finalizable {
   // maintain borrow validity.
   CanonicalCombiningClassMap._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_CanonicalCombiningClassMap_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_CanonicalCombiningClassMap_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_CanonicalCombiningClassMap_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_CanonicalCombiningClassMap_destroy_mv1(CanonicalCombiningClassMap cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_CanonicalCombiningClassMap_destroy_mv1));
 
   /// Construct a new `CanonicalCombiningClassMap` instance for NFC using compiled data.
   ///
@@ -57,22 +61,26 @@ final class CanonicalCombiningClassMap implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_CanonicalCombiningClassMap_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_CanonicalCombiningClassMap_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_CanonicalCombiningClassMap_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_CanonicalCombiningClassMap_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_CanonicalCombiningClassMap_create_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CanonicalCombiningClassMap_create_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CanonicalCombiningClassMap_create_mv1();
 
-@_DiplomatFfiUse('icu4x_CanonicalCombiningClassMap_create_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CanonicalCombiningClassMap_create_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CanonicalCombiningClassMap_create_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CanonicalCombiningClassMap_get_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint8 Function(ffi.Pointer<ffi.Opaque>, ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CanonicalCombiningClassMap_get_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_CanonicalCombiningClassMap_get_mv1(ffi.Pointer<ffi.Opaque> self, Rune ch);

--- a/ffi/dart/lib/src/bindings/CanonicalComposition.g.dart
+++ b/ffi/dart/lib/src/bindings/CanonicalComposition.g.dart
@@ -21,12 +21,16 @@ final class CanonicalComposition implements ffi.Finalizable {
   // maintain borrow validity.
   CanonicalComposition._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_CanonicalComposition_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_CanonicalComposition_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_CanonicalComposition_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_CanonicalComposition_destroy_mv1(CanonicalComposition cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_CanonicalComposition_destroy_mv1));
 
   /// Construct a new `CanonicalComposition` instance for NFC using compiled data.
   ///
@@ -60,22 +64,26 @@ final class CanonicalComposition implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_CanonicalComposition_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_CanonicalComposition_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_CanonicalComposition_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_CanonicalComposition_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_CanonicalComposition_create_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CanonicalComposition_create_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CanonicalComposition_create_mv1();
 
-@_DiplomatFfiUse('icu4x_CanonicalComposition_create_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CanonicalComposition_create_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CanonicalComposition_create_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CanonicalComposition_compose_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint32 Function(ffi.Pointer<ffi.Opaque>, ffi.Uint32, ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CanonicalComposition_compose_mv1')
 // ignore: non_constant_identifier_names
 external Rune _icu4x_CanonicalComposition_compose_mv1(ffi.Pointer<ffi.Opaque> self, Rune starter, Rune second);

--- a/ffi/dart/lib/src/bindings/CanonicalDecomposition.g.dart
+++ b/ffi/dart/lib/src/bindings/CanonicalDecomposition.g.dart
@@ -21,12 +21,16 @@ final class CanonicalDecomposition implements ffi.Finalizable {
   // maintain borrow validity.
   CanonicalDecomposition._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_CanonicalDecomposition_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_CanonicalDecomposition_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_CanonicalDecomposition_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_CanonicalDecomposition_destroy_mv1(CanonicalDecomposition cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_CanonicalDecomposition_destroy_mv1));
 
   /// Construct a new `CanonicalDecomposition` instance for NFC using compiled data.
   ///
@@ -59,22 +63,26 @@ final class CanonicalDecomposition implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_CanonicalDecomposition_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_CanonicalDecomposition_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_CanonicalDecomposition_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_CanonicalDecomposition_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_CanonicalDecomposition_create_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CanonicalDecomposition_create_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CanonicalDecomposition_create_mv1();
 
-@_DiplomatFfiUse('icu4x_CanonicalDecomposition_create_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CanonicalDecomposition_create_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CanonicalDecomposition_create_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CanonicalDecomposition_decompose_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_DecomposedFfi Function(ffi.Pointer<ffi.Opaque>, ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CanonicalDecomposition_decompose_mv1')
 // ignore: non_constant_identifier_names
 external _DecomposedFfi _icu4x_CanonicalDecomposition_decompose_mv1(ffi.Pointer<ffi.Opaque> self, Rune c);

--- a/ffi/dart/lib/src/bindings/CaseMapCloser.g.dart
+++ b/ffi/dart/lib/src/bindings/CaseMapCloser.g.dart
@@ -17,12 +17,16 @@ final class CaseMapCloser implements ffi.Finalizable {
   // maintain borrow validity.
   CaseMapCloser._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_CaseMapCloser_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_CaseMapCloser_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_CaseMapCloser_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_CaseMapCloser_destroy_mv1(CaseMapCloser cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_CaseMapCloser_destroy_mv1));
 
   /// Construct a new `CaseMapCloser` instance using compiled data.
   ///
@@ -72,27 +76,32 @@ final class CaseMapCloser implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_CaseMapCloser_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_CaseMapCloser_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_CaseMapCloser_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_CaseMapCloser_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_CaseMapCloser_create_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function()>(isLeaf: true, symbol: 'icu4x_CaseMapCloser_create_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CaseMapCloser_create_mv1();
 
-@_DiplomatFfiUse('icu4x_CaseMapCloser_create_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CaseMapCloser_create_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CaseMapCloser_create_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CaseMapCloser_add_case_closure_to_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Uint32, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CaseMapCloser_add_case_closure_to_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_CaseMapCloser_add_case_closure_to_mv1(ffi.Pointer<ffi.Opaque> self, Rune c, ffi.Pointer<ffi.Opaque> builder);
 
-@_DiplomatFfiUse('icu4x_CaseMapCloser_add_string_case_closure_to_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CaseMapCloser_add_string_case_closure_to_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CaseMapCloser_add_string_case_closure_to_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUtf8 s, ffi.Pointer<ffi.Opaque> builder);

--- a/ffi/dart/lib/src/bindings/CaseMapper.g.dart
+++ b/ffi/dart/lib/src/bindings/CaseMapper.g.dart
@@ -17,12 +17,16 @@ final class CaseMapper implements ffi.Finalizable {
   // maintain borrow validity.
   CaseMapper._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_CaseMapper_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_CaseMapper_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_CaseMapper_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_CaseMapper_destroy_mv1(CaseMapper cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_CaseMapper_destroy_mv1));
 
   /// Construct a new `CaseMapper` instance using compiled data.
   ///
@@ -252,112 +256,134 @@ final class CaseMapper implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_CaseMapper_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_CaseMapper_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_CaseMapper_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_CaseMapper_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_CaseMapper_create_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CaseMapper_create_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CaseMapper_create_mv1();
 
-@_DiplomatFfiUse('icu4x_CaseMapper_create_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CaseMapper_create_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CaseMapper_create_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CaseMapper_lowercase_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CaseMapper_lowercase_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_CaseMapper_lowercase_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUtf8 s, ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> write);
 
-@_DiplomatFfiUse('icu4x_CaseMapper_uppercase_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CaseMapper_uppercase_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_CaseMapper_uppercase_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUtf8 s, ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> write);
 
-@_DiplomatFfiUse('icu4x_CaseMapper_lowercase_with_compiled_data_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(_SliceUtf8, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CaseMapper_lowercase_with_compiled_data_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_CaseMapper_lowercase_with_compiled_data_mv1(_SliceUtf8 s, ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> write);
 
-@_DiplomatFfiUse('icu4x_CaseMapper_uppercase_with_compiled_data_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(_SliceUtf8, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CaseMapper_uppercase_with_compiled_data_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_CaseMapper_uppercase_with_compiled_data_mv1(_SliceUtf8 s, ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> write);
 
-@_DiplomatFfiUse('icu4x_CaseMapper_titlecase_segment_with_only_case_data_v1_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8, ffi.Pointer<ffi.Opaque>, _TitlecaseOptionsFfi, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CaseMapper_titlecase_segment_with_only_case_data_v1_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_CaseMapper_titlecase_segment_with_only_case_data_v1_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUtf8 s, ffi.Pointer<ffi.Opaque> locale, _TitlecaseOptionsFfi options, ffi.Pointer<ffi.Opaque> write);
 
-@_DiplomatFfiUse('icu4x_CaseMapper_titlecase_segment_with_only_case_compiled_data_v1_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(_SliceUtf8, ffi.Pointer<ffi.Opaque>, _TitlecaseOptionsFfi, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CaseMapper_titlecase_segment_with_only_case_compiled_data_v1_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_CaseMapper_titlecase_segment_with_only_case_compiled_data_v1_mv1(_SliceUtf8 s, ffi.Pointer<ffi.Opaque> locale, _TitlecaseOptionsFfi options, ffi.Pointer<ffi.Opaque> write);
 
-@_DiplomatFfiUse('icu4x_CaseMapper_fold_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CaseMapper_fold_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_CaseMapper_fold_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUtf8 s, ffi.Pointer<ffi.Opaque> write);
 
-@_DiplomatFfiUse('icu4x_CaseMapper_fold_turkic_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CaseMapper_fold_turkic_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_CaseMapper_fold_turkic_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUtf8 s, ffi.Pointer<ffi.Opaque> write);
 
-@_DiplomatFfiUse('icu4x_CaseMapper_add_case_closure_to_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Uint32, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CaseMapper_add_case_closure_to_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_CaseMapper_add_case_closure_to_mv1(ffi.Pointer<ffi.Opaque> self, Rune c, ffi.Pointer<ffi.Opaque> builder);
 
-@_DiplomatFfiUse('icu4x_CaseMapper_simple_lowercase_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint32 Function(ffi.Pointer<ffi.Opaque>, ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CaseMapper_simple_lowercase_mv1')
 // ignore: non_constant_identifier_names
 external Rune _icu4x_CaseMapper_simple_lowercase_mv1(ffi.Pointer<ffi.Opaque> self, Rune ch);
 
-@_DiplomatFfiUse('icu4x_CaseMapper_simple_lowercase_with_compiled_data_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint32 Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CaseMapper_simple_lowercase_with_compiled_data_mv1')
 // ignore: non_constant_identifier_names
 external Rune _icu4x_CaseMapper_simple_lowercase_with_compiled_data_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CaseMapper_simple_uppercase_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint32 Function(ffi.Pointer<ffi.Opaque>, ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CaseMapper_simple_uppercase_mv1')
 // ignore: non_constant_identifier_names
 external Rune _icu4x_CaseMapper_simple_uppercase_mv1(ffi.Pointer<ffi.Opaque> self, Rune ch);
 
-@_DiplomatFfiUse('icu4x_CaseMapper_simple_uppercase_with_compiled_data_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint32 Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CaseMapper_simple_uppercase_with_compiled_data_mv1')
 // ignore: non_constant_identifier_names
 external Rune _icu4x_CaseMapper_simple_uppercase_with_compiled_data_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CaseMapper_simple_titlecase_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint32 Function(ffi.Pointer<ffi.Opaque>, ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CaseMapper_simple_titlecase_mv1')
 // ignore: non_constant_identifier_names
 external Rune _icu4x_CaseMapper_simple_titlecase_mv1(ffi.Pointer<ffi.Opaque> self, Rune ch);
 
-@_DiplomatFfiUse('icu4x_CaseMapper_simple_titlecase_with_compiled_data_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint32 Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CaseMapper_simple_titlecase_with_compiled_data_mv1')
 // ignore: non_constant_identifier_names
 external Rune _icu4x_CaseMapper_simple_titlecase_with_compiled_data_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CaseMapper_simple_fold_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint32 Function(ffi.Pointer<ffi.Opaque>, ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CaseMapper_simple_fold_mv1')
 // ignore: non_constant_identifier_names
 external Rune _icu4x_CaseMapper_simple_fold_mv1(ffi.Pointer<ffi.Opaque> self, Rune ch);
 
-@_DiplomatFfiUse('icu4x_CaseMapper_simple_fold_with_compiled_data_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint32 Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CaseMapper_simple_fold_with_compiled_data_mv1')
 // ignore: non_constant_identifier_names
 external Rune _icu4x_CaseMapper_simple_fold_with_compiled_data_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CaseMapper_simple_fold_turkic_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint32 Function(ffi.Pointer<ffi.Opaque>, ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CaseMapper_simple_fold_turkic_mv1')
 // ignore: non_constant_identifier_names
 external Rune _icu4x_CaseMapper_simple_fold_turkic_mv1(ffi.Pointer<ffi.Opaque> self, Rune ch);
 
-@_DiplomatFfiUse('icu4x_CaseMapper_simple_fold_turkic_with_compiled_data_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint32 Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CaseMapper_simple_fold_turkic_with_compiled_data_mv1')
 // ignore: non_constant_identifier_names
 external Rune _icu4x_CaseMapper_simple_fold_turkic_with_compiled_data_mv1(Rune ch);

--- a/ffi/dart/lib/src/bindings/CodePointMapData16.g.dart
+++ b/ffi/dart/lib/src/bindings/CodePointMapData16.g.dart
@@ -25,12 +25,16 @@ final class CodePointMapData16 implements ffi.Finalizable {
   // maintain borrow validity.
   CodePointMapData16._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_CodePointMapData16_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_CodePointMapData16_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_CodePointMapData16_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_CodePointMapData16_destroy_mv1(CodePointMapData16 cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_CodePointMapData16_destroy_mv1));
 
   /// Gets the value for a code point.
   ///
@@ -91,37 +95,44 @@ final class CodePointMapData16 implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_CodePointMapData16_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_CodePointMapData16_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_CodePointMapData16_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_CodePointMapData16_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_CodePointMapData16_get_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint16 Function(ffi.Pointer<ffi.Opaque>, ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointMapData16_get_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_CodePointMapData16_get_mv1(ffi.Pointer<ffi.Opaque> self, Rune cp);
 
-@_DiplomatFfiUse('icu4x_CodePointMapData16_iter_ranges_for_value_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Uint16)>(isLeaf: true, symbol: 'icu4x_CodePointMapData16_iter_ranges_for_value_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointMapData16_iter_ranges_for_value_mv1(ffi.Pointer<ffi.Opaque> self, int value);
 
-@_DiplomatFfiUse('icu4x_CodePointMapData16_iter_ranges_for_value_complemented_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Uint16)>(isLeaf: true, symbol: 'icu4x_CodePointMapData16_iter_ranges_for_value_complemented_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointMapData16_iter_ranges_for_value_complemented_mv1(ffi.Pointer<ffi.Opaque> self, int value);
 
-@_DiplomatFfiUse('icu4x_CodePointMapData16_get_set_for_value_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Uint16)>(isLeaf: true, symbol: 'icu4x_CodePointMapData16_get_set_for_value_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointMapData16_get_set_for_value_mv1(ffi.Pointer<ffi.Opaque> self, int value);
 
-@_DiplomatFfiUse('icu4x_CodePointMapData16_create_script_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointMapData16_create_script_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointMapData16_create_script_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointMapData16_create_script_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointMapData16_create_script_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointMapData16_create_script_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);

--- a/ffi/dart/lib/src/bindings/CodePointMapData8.g.dart
+++ b/ffi/dart/lib/src/bindings/CodePointMapData8.g.dart
@@ -25,12 +25,16 @@ final class CodePointMapData8 implements ffi.Finalizable {
   // maintain borrow validity.
   CodePointMapData8._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_CodePointMapData8_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_CodePointMapData8_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_CodePointMapData8_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_CodePointMapData8_destroy_mv1(CodePointMapData8 cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_CodePointMapData8_destroy_mv1));
 
   /// Gets the value for a code point.
   ///
@@ -403,182 +407,218 @@ final class CodePointMapData8 implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_CodePointMapData8_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_CodePointMapData8_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_CodePointMapData8_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_CodePointMapData8_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_CodePointMapData8_get_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint8 Function(ffi.Pointer<ffi.Opaque>, ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointMapData8_get_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_CodePointMapData8_get_mv1(ffi.Pointer<ffi.Opaque> self, Rune cp);
 
-@_DiplomatFfiUse('icu4x_CodePointMapData8_iter_ranges_for_value_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Uint8)>(isLeaf: true, symbol: 'icu4x_CodePointMapData8_iter_ranges_for_value_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointMapData8_iter_ranges_for_value_mv1(ffi.Pointer<ffi.Opaque> self, int value);
 
-@_DiplomatFfiUse('icu4x_CodePointMapData8_iter_ranges_for_value_complemented_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Uint8)>(isLeaf: true, symbol: 'icu4x_CodePointMapData8_iter_ranges_for_value_complemented_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointMapData8_iter_ranges_for_value_complemented_mv1(ffi.Pointer<ffi.Opaque> self, int value);
 
-@_DiplomatFfiUse('icu4x_CodePointMapData8_iter_ranges_for_group_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, _GeneralCategoryGroupFfi)>(isLeaf: true, symbol: 'icu4x_CodePointMapData8_iter_ranges_for_group_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointMapData8_iter_ranges_for_group_mv1(ffi.Pointer<ffi.Opaque> self, _GeneralCategoryGroupFfi group);
 
-@_DiplomatFfiUse('icu4x_CodePointMapData8_get_set_for_value_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Uint8)>(isLeaf: true, symbol: 'icu4x_CodePointMapData8_get_set_for_value_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointMapData8_get_set_for_value_mv1(ffi.Pointer<ffi.Opaque> self, int value);
 
-@_DiplomatFfiUse('icu4x_CodePointMapData8_create_bidi_class_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointMapData8_create_bidi_class_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointMapData8_create_bidi_class_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointMapData8_create_bidi_class_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointMapData8_create_bidi_class_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointMapData8_create_bidi_class_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointMapData8_create_canonical_combining_class_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointMapData8_create_canonical_combining_class_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointMapData8_create_canonical_combining_class_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointMapData8_create_canonical_combining_class_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointMapData8_create_canonical_combining_class_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointMapData8_create_canonical_combining_class_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointMapData8_create_east_asian_width_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointMapData8_create_east_asian_width_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointMapData8_create_east_asian_width_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointMapData8_create_east_asian_width_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointMapData8_create_east_asian_width_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointMapData8_create_east_asian_width_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointMapData8_create_general_category_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointMapData8_create_general_category_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointMapData8_create_general_category_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointMapData8_create_general_category_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointMapData8_create_general_category_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointMapData8_create_general_category_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointMapData8_create_grapheme_cluster_break_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointMapData8_create_grapheme_cluster_break_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointMapData8_create_grapheme_cluster_break_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointMapData8_create_grapheme_cluster_break_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointMapData8_create_grapheme_cluster_break_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointMapData8_create_grapheme_cluster_break_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointMapData8_create_hangul_syllable_type_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointMapData8_create_hangul_syllable_type_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointMapData8_create_hangul_syllable_type_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointMapData8_create_hangul_syllable_type_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointMapData8_create_hangul_syllable_type_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointMapData8_create_hangul_syllable_type_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointMapData8_create_indic_conjunct_break_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointMapData8_create_indic_conjunct_break_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointMapData8_create_indic_conjunct_break_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointMapData8_create_indic_conjunct_break_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointMapData8_create_indic_conjunct_break_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointMapData8_create_indic_conjunct_break_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointMapData8_create_indic_syllabic_category_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointMapData8_create_indic_syllabic_category_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointMapData8_create_indic_syllabic_category_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointMapData8_create_indic_syllabic_category_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointMapData8_create_indic_syllabic_category_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointMapData8_create_indic_syllabic_category_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointMapData8_create_joining_group_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointMapData8_create_joining_group_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointMapData8_create_joining_group_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointMapData8_create_joining_group_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointMapData8_create_joining_group_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointMapData8_create_joining_group_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointMapData8_create_joining_type_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointMapData8_create_joining_type_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointMapData8_create_joining_type_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointMapData8_create_joining_type_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointMapData8_create_joining_type_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointMapData8_create_joining_type_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointMapData8_create_line_break_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointMapData8_create_line_break_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointMapData8_create_line_break_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointMapData8_create_line_break_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointMapData8_create_line_break_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointMapData8_create_line_break_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointMapData8_create_numeric_type_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointMapData8_create_numeric_type_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointMapData8_create_numeric_type_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointMapData8_create_numeric_type_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointMapData8_create_numeric_type_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointMapData8_create_numeric_type_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointMapData8_create_sentence_break_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointMapData8_create_sentence_break_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointMapData8_create_sentence_break_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointMapData8_create_sentence_break_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointMapData8_create_sentence_break_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointMapData8_create_sentence_break_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointMapData8_create_vertical_orientation_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointMapData8_create_vertical_orientation_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointMapData8_create_vertical_orientation_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointMapData8_create_vertical_orientation_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointMapData8_create_vertical_orientation_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointMapData8_create_vertical_orientation_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointMapData8_create_word_break_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointMapData8_create_word_break_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointMapData8_create_word_break_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointMapData8_create_word_break_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointMapData8_create_word_break_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointMapData8_create_word_break_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);

--- a/ffi/dart/lib/src/bindings/CodePointRangeIterator.g.dart
+++ b/ffi/dart/lib/src/bindings/CodePointRangeIterator.g.dart
@@ -20,12 +20,16 @@ final class CodePointRangeIterator implements ffi.Finalizable {
   // maintain borrow validity.
   CodePointRangeIterator._fromFfi(this._ffi, this._selfEdge, this._aEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_CodePointRangeIterator_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_CodePointRangeIterator_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_CodePointRangeIterator_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_CodePointRangeIterator_destroy_mv1(CodePointRangeIterator cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_CodePointRangeIterator_destroy_mv1));
 
   /// Advance the iterator by one and return the next range.
   ///
@@ -37,12 +41,14 @@ final class CodePointRangeIterator implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_CodePointRangeIterator_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_CodePointRangeIterator_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_CodePointRangeIterator_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_CodePointRangeIterator_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_CodePointRangeIterator_next_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_CodePointRangeIteratorResultFfi Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointRangeIterator_next_mv1')
 // ignore: non_constant_identifier_names
 external _CodePointRangeIteratorResultFfi _icu4x_CodePointRangeIterator_next_mv1(ffi.Pointer<ffi.Opaque> self);

--- a/ffi/dart/lib/src/bindings/CodePointSetBuilder.g.dart
+++ b/ffi/dart/lib/src/bindings/CodePointSetBuilder.g.dart
@@ -17,12 +17,16 @@ final class CodePointSetBuilder implements ffi.Finalizable {
   // maintain borrow validity.
   CodePointSetBuilder._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_CodePointSetBuilder_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_CodePointSetBuilder_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_CodePointSetBuilder_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_CodePointSetBuilder_destroy_mv1(CodePointSetBuilder cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_CodePointSetBuilder_destroy_mv1));
 
   /// Make a new set builder containing nothing
   ///
@@ -151,87 +155,104 @@ final class CodePointSetBuilder implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_CodePointSetBuilder_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_CodePointSetBuilder_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_CodePointSetBuilder_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_CodePointSetBuilder_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_CodePointSetBuilder_create_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetBuilder_create_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetBuilder_create_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetBuilder_build_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetBuilder_build_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetBuilder_build_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_CodePointSetBuilder_complement_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetBuilder_complement_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_CodePointSetBuilder_complement_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_CodePointSetBuilder_is_empty_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetBuilder_is_empty_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetBuilder_is_empty_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_CodePointSetBuilder_add_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetBuilder_add_char_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_CodePointSetBuilder_add_char_mv1(ffi.Pointer<ffi.Opaque> self, Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetBuilder_add_inclusive_range_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Uint32, ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetBuilder_add_inclusive_range_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_CodePointSetBuilder_add_inclusive_range_mv1(ffi.Pointer<ffi.Opaque> self, Rune start, Rune end);
 
-@_DiplomatFfiUse('icu4x_CodePointSetBuilder_add_set_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetBuilder_add_set_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_CodePointSetBuilder_add_set_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> data);
 
-@_DiplomatFfiUse('icu4x_CodePointSetBuilder_remove_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetBuilder_remove_char_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_CodePointSetBuilder_remove_char_mv1(ffi.Pointer<ffi.Opaque> self, Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetBuilder_remove_inclusive_range_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Uint32, ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetBuilder_remove_inclusive_range_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_CodePointSetBuilder_remove_inclusive_range_mv1(ffi.Pointer<ffi.Opaque> self, Rune start, Rune end);
 
-@_DiplomatFfiUse('icu4x_CodePointSetBuilder_remove_set_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetBuilder_remove_set_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_CodePointSetBuilder_remove_set_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> data);
 
-@_DiplomatFfiUse('icu4x_CodePointSetBuilder_retain_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetBuilder_retain_char_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_CodePointSetBuilder_retain_char_mv1(ffi.Pointer<ffi.Opaque> self, Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetBuilder_retain_inclusive_range_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Uint32, ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetBuilder_retain_inclusive_range_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_CodePointSetBuilder_retain_inclusive_range_mv1(ffi.Pointer<ffi.Opaque> self, Rune start, Rune end);
 
-@_DiplomatFfiUse('icu4x_CodePointSetBuilder_retain_set_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetBuilder_retain_set_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_CodePointSetBuilder_retain_set_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> data);
 
-@_DiplomatFfiUse('icu4x_CodePointSetBuilder_complement_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetBuilder_complement_char_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_CodePointSetBuilder_complement_char_mv1(ffi.Pointer<ffi.Opaque> self, Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetBuilder_complement_inclusive_range_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Uint32, ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetBuilder_complement_inclusive_range_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_CodePointSetBuilder_complement_inclusive_range_mv1(ffi.Pointer<ffi.Opaque> self, Rune start, Rune end);
 
-@_DiplomatFfiUse('icu4x_CodePointSetBuilder_complement_set_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetBuilder_complement_set_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_CodePointSetBuilder_complement_set_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> data);

--- a/ffi/dart/lib/src/bindings/CodePointSetData.g.dart
+++ b/ffi/dart/lib/src/bindings/CodePointSetData.g.dart
@@ -23,12 +23,16 @@ final class CodePointSetData implements ffi.Finalizable {
   // maintain borrow validity.
   CodePointSetData._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_CodePointSetData_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_CodePointSetData_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_CodePointSetData_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_CodePointSetData_destroy_mv1(CodePointSetData cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_CodePointSetData_destroy_mv1));
 
   /// Checks whether the code point is in the set.
   ///
@@ -2135,1077 +2139,1292 @@ final class CodePointSetData implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_CodePointSetData_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_CodePointSetData_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_contains_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Pointer<ffi.Opaque>, ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_contains_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_contains_mv1(ffi.Pointer<ffi.Opaque> self, Rune cp);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_iter_ranges_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_iter_ranges_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_iter_ranges_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_iter_ranges_complemented_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_iter_ranges_complemented_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_iter_ranges_complemented_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_general_category_group_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_GeneralCategoryGroupFfi)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_general_category_group_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_general_category_group_mv1(_GeneralCategoryGroupFfi group);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_general_category_group_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_general_category_group_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_general_category_group_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, int group);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_ascii_hex_digit_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_ascii_hex_digit_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_ascii_hex_digit_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_ascii_hex_digit_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_ascii_hex_digit_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_ascii_hex_digit_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_ascii_hex_digit_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_ascii_hex_digit_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_ascii_hex_digit_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_alnum_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_alnum_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_alnum_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_alnum_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_alnum_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_alnum_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_alnum_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_alnum_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_alnum_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_alphabetic_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_alphabetic_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_alphabetic_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_alphabetic_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_alphabetic_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_alphabetic_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_alphabetic_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_alphabetic_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_alphabetic_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_bidi_control_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_bidi_control_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_bidi_control_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_bidi_control_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_bidi_control_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_bidi_control_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_bidi_control_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_bidi_control_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_bidi_control_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_bidi_mirrored_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_bidi_mirrored_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_bidi_mirrored_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_bidi_mirrored_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_bidi_mirrored_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_bidi_mirrored_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_bidi_mirrored_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_bidi_mirrored_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_bidi_mirrored_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_blank_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_blank_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_blank_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_blank_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_blank_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_blank_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_blank_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_blank_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_blank_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_cased_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_cased_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_cased_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_cased_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_cased_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_cased_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_cased_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_cased_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_cased_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_case_ignorable_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_case_ignorable_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_case_ignorable_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_case_ignorable_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_case_ignorable_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_case_ignorable_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_case_ignorable_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_case_ignorable_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_case_ignorable_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_full_composition_exclusion_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_full_composition_exclusion_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_full_composition_exclusion_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_full_composition_exclusion_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_full_composition_exclusion_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_full_composition_exclusion_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_full_composition_exclusion_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_full_composition_exclusion_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_full_composition_exclusion_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_changes_when_casefolded_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_changes_when_casefolded_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_changes_when_casefolded_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_changes_when_casefolded_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_changes_when_casefolded_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_changes_when_casefolded_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_changes_when_casefolded_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_changes_when_casefolded_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_changes_when_casefolded_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_changes_when_casemapped_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_changes_when_casemapped_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_changes_when_casemapped_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_changes_when_casemapped_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_changes_when_casemapped_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_changes_when_casemapped_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_changes_when_casemapped_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_changes_when_casemapped_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_changes_when_casemapped_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_changes_when_nfkc_casefolded_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_changes_when_nfkc_casefolded_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_changes_when_nfkc_casefolded_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_changes_when_nfkc_casefolded_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_changes_when_nfkc_casefolded_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_changes_when_nfkc_casefolded_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_changes_when_nfkc_casefolded_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_changes_when_nfkc_casefolded_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_changes_when_nfkc_casefolded_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_changes_when_lowercased_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_changes_when_lowercased_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_changes_when_lowercased_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_changes_when_lowercased_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_changes_when_lowercased_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_changes_when_lowercased_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_changes_when_lowercased_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_changes_when_lowercased_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_changes_when_lowercased_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_changes_when_titlecased_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_changes_when_titlecased_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_changes_when_titlecased_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_changes_when_titlecased_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_changes_when_titlecased_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_changes_when_titlecased_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_changes_when_titlecased_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_changes_when_titlecased_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_changes_when_titlecased_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_changes_when_uppercased_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_changes_when_uppercased_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_changes_when_uppercased_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_changes_when_uppercased_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_changes_when_uppercased_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_changes_when_uppercased_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_changes_when_uppercased_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_changes_when_uppercased_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_changes_when_uppercased_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_dash_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_dash_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_dash_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_dash_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_dash_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_dash_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_dash_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_dash_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_dash_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_deprecated_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_deprecated_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_deprecated_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_deprecated_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_deprecated_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_deprecated_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_deprecated_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_deprecated_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_deprecated_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_default_ignorable_code_point_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_default_ignorable_code_point_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_default_ignorable_code_point_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_default_ignorable_code_point_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_default_ignorable_code_point_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_default_ignorable_code_point_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_default_ignorable_code_point_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_default_ignorable_code_point_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_default_ignorable_code_point_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_diacritic_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_diacritic_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_diacritic_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_diacritic_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_diacritic_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_diacritic_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_diacritic_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_diacritic_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_diacritic_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_emoji_modifier_base_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_emoji_modifier_base_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_emoji_modifier_base_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_emoji_modifier_base_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_emoji_modifier_base_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_emoji_modifier_base_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_emoji_modifier_base_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_emoji_modifier_base_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_emoji_modifier_base_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_emoji_component_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_emoji_component_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_emoji_component_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_emoji_component_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_emoji_component_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_emoji_component_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_emoji_component_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_emoji_component_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_emoji_component_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_emoji_modifier_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_emoji_modifier_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_emoji_modifier_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_emoji_modifier_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_emoji_modifier_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_emoji_modifier_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_emoji_modifier_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_emoji_modifier_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_emoji_modifier_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_emoji_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_emoji_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_emoji_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_emoji_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_emoji_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_emoji_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_emoji_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_emoji_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_emoji_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_emoji_presentation_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_emoji_presentation_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_emoji_presentation_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_emoji_presentation_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_emoji_presentation_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_emoji_presentation_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_emoji_presentation_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_emoji_presentation_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_emoji_presentation_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_extender_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_extender_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_extender_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_extender_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_extender_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_extender_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_extender_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_extender_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_extender_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_extended_pictographic_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_extended_pictographic_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_extended_pictographic_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_extended_pictographic_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_extended_pictographic_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_extended_pictographic_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_extended_pictographic_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_extended_pictographic_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_extended_pictographic_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_graph_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_graph_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_graph_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_graph_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_graph_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_graph_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_graph_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_graph_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_graph_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_grapheme_base_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_grapheme_base_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_grapheme_base_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_grapheme_base_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_grapheme_base_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_grapheme_base_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_grapheme_base_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_grapheme_base_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_grapheme_base_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_grapheme_extend_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_grapheme_extend_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_grapheme_extend_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_grapheme_extend_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_grapheme_extend_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_grapheme_extend_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_grapheme_extend_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_grapheme_extend_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_grapheme_extend_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_grapheme_link_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_grapheme_link_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_grapheme_link_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_grapheme_link_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_grapheme_link_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_grapheme_link_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_grapheme_link_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_grapheme_link_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_grapheme_link_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_hex_digit_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_hex_digit_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_hex_digit_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_hex_digit_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_hex_digit_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_hex_digit_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_hex_digit_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_hex_digit_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_hex_digit_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_hyphen_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_hyphen_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_hyphen_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_hyphen_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_hyphen_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_hyphen_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_hyphen_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_hyphen_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_hyphen_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_id_compat_math_continue_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_id_compat_math_continue_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_id_compat_math_continue_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_id_compat_math_continue_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_id_compat_math_continue_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_id_compat_math_continue_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_id_compat_math_continue_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_id_compat_math_continue_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_id_compat_math_continue_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_id_compat_math_start_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_id_compat_math_start_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_id_compat_math_start_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_id_compat_math_start_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_id_compat_math_start_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_id_compat_math_start_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_id_compat_math_start_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_id_compat_math_start_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_id_compat_math_start_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_id_continue_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_id_continue_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_id_continue_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_id_continue_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_id_continue_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_id_continue_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_id_continue_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_id_continue_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_id_continue_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_ideographic_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_ideographic_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_ideographic_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_ideographic_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_ideographic_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_ideographic_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_ideographic_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_ideographic_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_ideographic_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_id_start_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_id_start_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_id_start_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_id_start_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_id_start_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_id_start_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_id_start_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_id_start_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_id_start_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_ids_binary_operator_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_ids_binary_operator_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_ids_binary_operator_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_ids_binary_operator_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_ids_binary_operator_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_ids_binary_operator_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_ids_binary_operator_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_ids_binary_operator_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_ids_binary_operator_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_ids_trinary_operator_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_ids_trinary_operator_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_ids_trinary_operator_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_ids_trinary_operator_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_ids_trinary_operator_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_ids_trinary_operator_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_ids_trinary_operator_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_ids_trinary_operator_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_ids_trinary_operator_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_ids_unary_operator_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_ids_unary_operator_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_ids_unary_operator_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_ids_unary_operator_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_ids_unary_operator_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_ids_unary_operator_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_ids_unary_operator_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_ids_unary_operator_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_ids_unary_operator_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_join_control_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_join_control_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_join_control_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_join_control_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_join_control_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_join_control_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_join_control_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_join_control_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_join_control_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_logical_order_exception_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_logical_order_exception_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_logical_order_exception_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_logical_order_exception_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_logical_order_exception_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_logical_order_exception_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_logical_order_exception_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_logical_order_exception_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_logical_order_exception_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_lowercase_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_lowercase_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_lowercase_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_lowercase_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_lowercase_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_lowercase_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_lowercase_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_lowercase_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_lowercase_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_math_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_math_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_math_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_math_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_math_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_math_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_math_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_math_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_math_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_modifier_combining_mark_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_modifier_combining_mark_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_modifier_combining_mark_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_modifier_combining_mark_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_modifier_combining_mark_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_modifier_combining_mark_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_modifier_combining_mark_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_modifier_combining_mark_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_modifier_combining_mark_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_noncharacter_code_point_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_noncharacter_code_point_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_noncharacter_code_point_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_noncharacter_code_point_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_noncharacter_code_point_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_noncharacter_code_point_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_noncharacter_code_point_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_noncharacter_code_point_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_noncharacter_code_point_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_nfc_inert_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_nfc_inert_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_nfc_inert_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_nfc_inert_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_nfc_inert_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_nfc_inert_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_nfc_inert_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_nfc_inert_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_nfc_inert_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_nfd_inert_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_nfd_inert_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_nfd_inert_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_nfd_inert_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_nfd_inert_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_nfd_inert_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_nfd_inert_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_nfd_inert_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_nfd_inert_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_nfkc_inert_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_nfkc_inert_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_nfkc_inert_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_nfkc_inert_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_nfkc_inert_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_nfkc_inert_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_nfkc_inert_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_nfkc_inert_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_nfkc_inert_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_nfkd_inert_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_nfkd_inert_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_nfkd_inert_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_nfkd_inert_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_nfkd_inert_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_nfkd_inert_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_nfkd_inert_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_nfkd_inert_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_nfkd_inert_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_pattern_syntax_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_pattern_syntax_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_pattern_syntax_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_pattern_syntax_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_pattern_syntax_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_pattern_syntax_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_pattern_syntax_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_pattern_syntax_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_pattern_syntax_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_pattern_white_space_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_pattern_white_space_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_pattern_white_space_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_pattern_white_space_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_pattern_white_space_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_pattern_white_space_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_pattern_white_space_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_pattern_white_space_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_pattern_white_space_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_prepended_concatenation_mark_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_prepended_concatenation_mark_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_prepended_concatenation_mark_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_prepended_concatenation_mark_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_prepended_concatenation_mark_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_prepended_concatenation_mark_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_prepended_concatenation_mark_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_prepended_concatenation_mark_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_prepended_concatenation_mark_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_print_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_print_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_print_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_print_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_print_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_print_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_print_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_print_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_print_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_quotation_mark_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_quotation_mark_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_quotation_mark_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_quotation_mark_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_quotation_mark_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_quotation_mark_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_quotation_mark_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_quotation_mark_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_quotation_mark_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_radical_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_radical_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_radical_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_radical_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_radical_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_radical_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_radical_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_radical_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_radical_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_regional_indicator_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_regional_indicator_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_regional_indicator_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_regional_indicator_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_regional_indicator_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_regional_indicator_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_regional_indicator_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_regional_indicator_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_regional_indicator_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_soft_dotted_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_soft_dotted_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_soft_dotted_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_soft_dotted_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_soft_dotted_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_soft_dotted_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_soft_dotted_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_soft_dotted_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_soft_dotted_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_segment_starter_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_segment_starter_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_segment_starter_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_segment_starter_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_segment_starter_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_segment_starter_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_segment_starter_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_segment_starter_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_segment_starter_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_case_sensitive_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_case_sensitive_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_case_sensitive_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_case_sensitive_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_case_sensitive_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_case_sensitive_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_case_sensitive_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_case_sensitive_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_case_sensitive_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_sentence_terminal_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_sentence_terminal_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_sentence_terminal_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_sentence_terminal_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_sentence_terminal_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_sentence_terminal_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_sentence_terminal_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_sentence_terminal_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_sentence_terminal_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_terminal_punctuation_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_terminal_punctuation_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_terminal_punctuation_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_terminal_punctuation_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_terminal_punctuation_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_terminal_punctuation_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_terminal_punctuation_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_terminal_punctuation_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_terminal_punctuation_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_unified_ideograph_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_unified_ideograph_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_unified_ideograph_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_unified_ideograph_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_unified_ideograph_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_unified_ideograph_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_unified_ideograph_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_unified_ideograph_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_unified_ideograph_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_uppercase_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_uppercase_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_uppercase_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_uppercase_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_uppercase_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_uppercase_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_uppercase_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_uppercase_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_uppercase_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_variation_selector_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_variation_selector_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_variation_selector_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_variation_selector_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_variation_selector_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_variation_selector_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_variation_selector_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_variation_selector_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_variation_selector_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_white_space_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_white_space_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_white_space_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_white_space_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_white_space_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_white_space_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_white_space_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_white_space_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_white_space_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_xdigit_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_xdigit_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_xdigit_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_xdigit_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_xdigit_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_xdigit_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_xdigit_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_xdigit_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_xdigit_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_xid_continue_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_xid_continue_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_xid_continue_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_xid_continue_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_xid_continue_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_xid_continue_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_xid_continue_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_xid_continue_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_xid_continue_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_xid_start_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_xid_start_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_CodePointSetData_xid_start_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_xid_start_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_xid_start_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_CodePointSetData_create_xid_start_mv1();
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_xid_start_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_xid_start_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_xid_start_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_for_ecma262_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(_SliceUtf8)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_for_ecma262_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_for_ecma262_mv1(_SliceUtf8 propertyName);
 
-@_DiplomatFfiUse('icu4x_CodePointSetData_create_for_ecma262_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8)>(isLeaf: true, symbol: 'icu4x_CodePointSetData_create_for_ecma262_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_CodePointSetData_create_for_ecma262_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, _SliceUtf8 propertyName);

--- a/ffi/dart/lib/src/bindings/Collator.g.dart
+++ b/ffi/dart/lib/src/bindings/Collator.g.dart
@@ -17,12 +17,16 @@ final class Collator implements ffi.Finalizable {
   // maintain borrow validity.
   Collator._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_Collator_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_Collator_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_Collator_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_Collator_destroy_mv1(Collator cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_Collator_destroy_mv1));
 
   /// Construct a new Collator instance using compiled data.
   ///
@@ -76,27 +80,32 @@ final class Collator implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_Collator_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_Collator_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_Collator_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_Collator_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_Collator_create_v1_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _CollatorOptionsFfi)>(isLeaf: true, symbol: 'icu4x_Collator_create_v1_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_Collator_create_v1_mv1(ffi.Pointer<ffi.Opaque> locale, _CollatorOptionsFfi options);
 
-@_DiplomatFfiUse('icu4x_Collator_create_v1_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _CollatorOptionsFfi)>(isLeaf: true, symbol: 'icu4x_Collator_create_v1_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_Collator_create_v1_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _CollatorOptionsFfi options);
 
-@_DiplomatFfiUse('icu4x_Collator_compare_utf16_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int8 Function(ffi.Pointer<ffi.Opaque>, _SliceUtf16, _SliceUtf16)>(isLeaf: true, symbol: 'icu4x_Collator_compare_utf16_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_Collator_compare_utf16_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUtf16 left, _SliceUtf16 right);
 
-@_DiplomatFfiUse('icu4x_Collator_resolved_options_v1_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_CollatorResolvedOptionsFfi Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Collator_resolved_options_v1_mv1')
 // ignore: non_constant_identifier_names
 external _CollatorResolvedOptionsFfi _icu4x_Collator_resolved_options_v1_mv1(ffi.Pointer<ffi.Opaque> self);

--- a/ffi/dart/lib/src/bindings/ComposingNormalizer.g.dart
+++ b/ffi/dart/lib/src/bindings/ComposingNormalizer.g.dart
@@ -17,12 +17,16 @@ final class ComposingNormalizer implements ffi.Finalizable {
   // maintain borrow validity.
   ComposingNormalizer._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_ComposingNormalizer_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_ComposingNormalizer_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_ComposingNormalizer_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_ComposingNormalizer_destroy_mv1(ComposingNormalizer cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_ComposingNormalizer_destroy_mv1));
 
   /// Construct a new `ComposingNormalizer` instance for NFC using compiled data.
   ///
@@ -102,42 +106,50 @@ final class ComposingNormalizer implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_ComposingNormalizer_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_ComposingNormalizer_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_ComposingNormalizer_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_ComposingNormalizer_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_ComposingNormalizer_create_nfc_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_ComposingNormalizer_create_nfc_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_ComposingNormalizer_create_nfc_mv1();
 
-@_DiplomatFfiUse('icu4x_ComposingNormalizer_create_nfc_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ComposingNormalizer_create_nfc_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ComposingNormalizer_create_nfc_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_ComposingNormalizer_create_nfkc_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_ComposingNormalizer_create_nfkc_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_ComposingNormalizer_create_nfkc_mv1();
 
-@_DiplomatFfiUse('icu4x_ComposingNormalizer_create_nfkc_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ComposingNormalizer_create_nfkc_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ComposingNormalizer_create_nfkc_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_ComposingNormalizer_normalize_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ComposingNormalizer_normalize_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_ComposingNormalizer_normalize_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUtf8 s, ffi.Pointer<ffi.Opaque> write);
 
-@_DiplomatFfiUse('icu4x_ComposingNormalizer_is_normalized_utf16_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Pointer<ffi.Opaque>, _SliceUtf16)>(isLeaf: true, symbol: 'icu4x_ComposingNormalizer_is_normalized_utf16_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_ComposingNormalizer_is_normalized_utf16_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUtf16 s);
 
-@_DiplomatFfiUse('icu4x_ComposingNormalizer_is_normalized_utf16_up_to_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Size Function(ffi.Pointer<ffi.Opaque>, _SliceUtf16)>(isLeaf: true, symbol: 'icu4x_ComposingNormalizer_is_normalized_utf16_up_to_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_ComposingNormalizer_is_normalized_utf16_up_to_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUtf16 s);

--- a/ffi/dart/lib/src/bindings/DataProvider.g.dart
+++ b/ffi/dart/lib/src/bindings/DataProvider.g.dart
@@ -24,12 +24,16 @@ final class DataProvider implements ffi.Finalizable {
   // maintain borrow validity.
   DataProvider._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_DataProvider_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_DataProvider_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_DataProvider_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_DataProvider_destroy_mv1(DataProvider cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_DataProvider_destroy_mv1));
 
   /// See the [Rust documentation for `try_new_from_blob`](https://docs.rs/icu_provider_blob/2.2.0/icu_provider_blob/struct.BlobDataProvider.html#method.try_new_from_blob) for more information.
   ///
@@ -83,27 +87,32 @@ final class DataProvider implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_DataProvider_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_DataProvider_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_DataProvider_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_DataProvider_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_DataProvider_from_owned_byte_slice_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(_SliceUint8)>(isLeaf: true, symbol: 'icu4x_DataProvider_from_owned_byte_slice_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DataProvider_from_owned_byte_slice_mv1(_SliceUint8 blob);
 
-@_DiplomatFfiUse('icu4x_DataProvider_fork_by_marker_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultVoidInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_DataProvider_fork_by_marker_mv1')
 // ignore: non_constant_identifier_names
 external _ResultVoidInt32 _icu4x_DataProvider_fork_by_marker_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> other);
 
-@_DiplomatFfiUse('icu4x_DataProvider_fork_by_locale_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultVoidInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_DataProvider_fork_by_locale_mv1')
 // ignore: non_constant_identifier_names
 external _ResultVoidInt32 _icu4x_DataProvider_fork_by_locale_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> other);
 
-@_DiplomatFfiUse('icu4x_DataProvider_enable_locale_fallback_with_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultVoidInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_DataProvider_enable_locale_fallback_with_mv1')
 // ignore: non_constant_identifier_names
 external _ResultVoidInt32 _icu4x_DataProvider_enable_locale_fallback_with_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> fallbacker);

--- a/ffi/dart/lib/src/bindings/Date.g.dart
+++ b/ffi/dart/lib/src/bindings/Date.g.dart
@@ -19,12 +19,16 @@ final class Date implements ffi.Finalizable {
   // maintain borrow validity.
   Date._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_Date_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_Date_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_Date_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_Date_destroy_mv1(Date cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_Date_destroy_mv1));
 
   /// Creates a new [Date] representing the ISO date
   /// given but in a given calendar
@@ -308,137 +312,164 @@ final class Date implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_Date_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_Date_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_Date_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_Date_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_Date_from_iso_in_calendar_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Int32, ffi.Uint8, ffi.Uint8, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Date_from_iso_in_calendar_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_Date_from_iso_in_calendar_mv1(int isoYear, int isoMonth, int isoDay, ffi.Pointer<ffi.Opaque> calendar);
 
-@_DiplomatFfiUse('icu4x_Date_from_fields_in_calendar_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(_DateFieldsFfi, _DateFromFieldsOptionsFfi, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Date_from_fields_in_calendar_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_Date_from_fields_in_calendar_mv1(_DateFieldsFfi fields, _DateFromFieldsOptionsFfi options, ffi.Pointer<ffi.Opaque> calendar);
 
-@_DiplomatFfiUse('icu4x_Date_from_codes_in_calendar_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(_SliceUtf8, ffi.Int32, _SliceUtf8, ffi.Uint8, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Date_from_codes_in_calendar_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_Date_from_codes_in_calendar_mv1(_SliceUtf8 eraCode, int year, _SliceUtf8 monthCode, int day, ffi.Pointer<ffi.Opaque> calendar);
 
-@_DiplomatFfiUse('icu4x_Date_from_rata_die_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Int64, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Date_from_rata_die_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_Date_from_rata_die_mv1(int rd, ffi.Pointer<ffi.Opaque> calendar);
 
-@_DiplomatFfiUse('icu4x_Date_from_string_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(_SliceUtf8, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Date_from_string_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_Date_from_string_mv1(_SliceUtf8 v, ffi.Pointer<ffi.Opaque> calendar);
 
-@_DiplomatFfiUse('icu4x_Date_to_calendar_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Date_to_calendar_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_Date_to_calendar_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> calendar);
 
-@_DiplomatFfiUse('icu4x_Date_to_iso_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Date_to_iso_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_Date_to_iso_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_Date_to_rata_die_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int64 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Date_to_rata_die_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_Date_to_rata_die_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_Date_day_of_year_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint16 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Date_day_of_year_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_Date_day_of_year_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_Date_day_of_month_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint8 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Date_day_of_month_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_Date_day_of_month_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_Date_day_of_week_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Date_day_of_week_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_Date_day_of_week_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_Date_weekday_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Date_weekday_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_Date_weekday_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_Date_ordinal_month_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint8 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Date_ordinal_month_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_Date_ordinal_month_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_Date_month_code_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Date_month_code_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_Date_month_code_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> write);
 
-@_DiplomatFfiUse('icu4x_Date_month_number_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint8 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Date_month_number_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_Date_month_number_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_Date_month_is_leap_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Date_month_is_leap_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_Date_month_is_leap_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_Date_era_year_or_related_iso_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Date_era_year_or_related_iso_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_Date_era_year_or_related_iso_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_Date_extended_year_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Date_extended_year_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_Date_extended_year_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_Date_era_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Date_era_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_Date_era_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> write);
 
-@_DiplomatFfiUse('icu4x_Date_months_in_year_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint8 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Date_months_in_year_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_Date_months_in_year_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_Date_days_in_month_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint8 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Date_days_in_month_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_Date_days_in_month_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_Date_days_in_year_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint16 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Date_days_in_year_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_Date_days_in_year_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_Date_is_in_leap_year_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Date_is_in_leap_year_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_Date_is_in_leap_year_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_Date_calendar_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Date_calendar_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_Date_calendar_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_Date_try_add_with_options_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _DateDurationFfi, _DateAddOptionsFfi)>(isLeaf: true, symbol: 'icu4x_Date_try_add_with_options_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_Date_try_add_with_options_mv1(ffi.Pointer<ffi.Opaque> self, _DateDurationFfi duration, _DateAddOptionsFfi options);
 
-@_DiplomatFfiUse('icu4x_Date_try_until_with_options_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultDateDurationFfiCalendarMismatchedCalendarErrorFfi Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _DateDifferenceOptionsFfi)>(isLeaf: true, symbol: 'icu4x_Date_try_until_with_options_mv1')
 // ignore: non_constant_identifier_names
 external _ResultDateDurationFfiCalendarMismatchedCalendarErrorFfi _icu4x_Date_try_until_with_options_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> other, _DateDifferenceOptionsFfi options);

--- a/ffi/dart/lib/src/bindings/DateDuration.g.dart
+++ b/ffi/dart/lib/src/bindings/DateDuration.g.dart
@@ -122,27 +122,32 @@ final class DateDuration {
       ]);
 }
 
-@_DiplomatFfiUse('icu4x_DateDuration_from_string_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultDateDurationFfiInt32 Function(_SliceUtf8)>(isLeaf: true, symbol: 'icu4x_DateDuration_from_string_mv1')
 // ignore: non_constant_identifier_names
 external _ResultDateDurationFfiInt32 _icu4x_DateDuration_from_string_mv1(_SliceUtf8 v);
 
-@_DiplomatFfiUse('icu4x_DateDuration_for_years_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_DateDurationFfi Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_DateDuration_for_years_mv1')
 // ignore: non_constant_identifier_names
 external _DateDurationFfi _icu4x_DateDuration_for_years_mv1(int years);
 
-@_DiplomatFfiUse('icu4x_DateDuration_for_months_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_DateDurationFfi Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_DateDuration_for_months_mv1')
 // ignore: non_constant_identifier_names
 external _DateDurationFfi _icu4x_DateDuration_for_months_mv1(int months);
 
-@_DiplomatFfiUse('icu4x_DateDuration_for_weeks_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_DateDurationFfi Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_DateDuration_for_weeks_mv1')
 // ignore: non_constant_identifier_names
 external _DateDurationFfi _icu4x_DateDuration_for_weeks_mv1(int weeks);
 
-@_DiplomatFfiUse('icu4x_DateDuration_for_days_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_DateDurationFfi Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_DateDuration_for_days_mv1')
 // ignore: non_constant_identifier_names
 external _DateDurationFfi _icu4x_DateDuration_for_days_mv1(int days);

--- a/ffi/dart/lib/src/bindings/DateFields.g.dart
+++ b/ffi/dart/lib/src/bindings/DateFields.g.dart
@@ -88,7 +88,7 @@ final class DateFields {
   // assuming that there are no `'other: a`. bounds. In case of such bounds,
   // the caller should take care to also call _fieldsForLifetimeOther
   // ignore: unused_element
-  core.List<Object> get _fieldsForLifetimeA => [if (era != null) era!, if (monthCode != null) monthCode!];
+  core.List<Object> get _fieldsForLifetimeA => [?era, ?monthCode];
 }
 
 // dart format on

--- a/ffi/dart/lib/src/bindings/DateFormatter.g.dart
+++ b/ffi/dart/lib/src/bindings/DateFormatter.g.dart
@@ -17,12 +17,16 @@ final class DateFormatter implements ffi.Finalizable {
   // maintain borrow validity.
   DateFormatter._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_DateFormatter_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_DateFormatter_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_DateFormatter_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_DateFormatter_destroy_mv1(DateFormatter cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_DateFormatter_destroy_mv1));
 
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.2.0/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
   ///
@@ -345,117 +349,140 @@ final class DateFormatter implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_DateFormatter_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_DateFormatter_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_DateFormatter_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_DateFormatter_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_DateFormatter_create_d_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateFormatter_create_d_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateFormatter_create_d_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_DateFormatter_create_d_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateFormatter_create_d_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateFormatter_create_d_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_DateFormatter_create_md_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateFormatter_create_md_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateFormatter_create_md_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_DateFormatter_create_md_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateFormatter_create_md_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateFormatter_create_md_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_DateFormatter_create_ymd_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateFormatter_create_ymd_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateFormatter_create_ymd_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void alignment, _ResultInt32Void yearStyle);
 
-@_DiplomatFfiUse('icu4x_DateFormatter_create_ymd_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateFormatter_create_ymd_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateFormatter_create_ymd_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void alignment, _ResultInt32Void yearStyle);
 
-@_DiplomatFfiUse('icu4x_DateFormatter_create_de_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateFormatter_create_de_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateFormatter_create_de_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_DateFormatter_create_de_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateFormatter_create_de_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateFormatter_create_de_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_DateFormatter_create_mde_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateFormatter_create_mde_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateFormatter_create_mde_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_DateFormatter_create_mde_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateFormatter_create_mde_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateFormatter_create_mde_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_DateFormatter_create_ymde_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateFormatter_create_ymde_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateFormatter_create_ymde_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void alignment, _ResultInt32Void yearStyle);
 
-@_DiplomatFfiUse('icu4x_DateFormatter_create_ymde_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateFormatter_create_ymde_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateFormatter_create_ymde_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void alignment, _ResultInt32Void yearStyle);
 
-@_DiplomatFfiUse('icu4x_DateFormatter_create_e_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateFormatter_create_e_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateFormatter_create_e_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length);
 
-@_DiplomatFfiUse('icu4x_DateFormatter_create_e_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateFormatter_create_e_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateFormatter_create_e_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length);
 
-@_DiplomatFfiUse('icu4x_DateFormatter_create_m_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateFormatter_create_m_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateFormatter_create_m_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_DateFormatter_create_m_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateFormatter_create_m_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateFormatter_create_m_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_DateFormatter_create_ym_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateFormatter_create_ym_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateFormatter_create_ym_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void alignment, _ResultInt32Void yearStyle);
 
-@_DiplomatFfiUse('icu4x_DateFormatter_create_ym_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateFormatter_create_ym_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateFormatter_create_ym_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void alignment, _ResultInt32Void yearStyle);
 
-@_DiplomatFfiUse('icu4x_DateFormatter_create_y_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateFormatter_create_y_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateFormatter_create_y_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void alignment, _ResultInt32Void yearStyle);
 
-@_DiplomatFfiUse('icu4x_DateFormatter_create_y_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateFormatter_create_y_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateFormatter_create_y_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void alignment, _ResultInt32Void yearStyle);
 
-@_DiplomatFfiUse('icu4x_DateFormatter_format_iso_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_DateFormatter_format_iso_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_DateFormatter_format_iso_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> isoDate, ffi.Pointer<ffi.Opaque> write);
 
-@_DiplomatFfiUse('icu4x_DateFormatter_format_same_calendar_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultVoidDateTimeMismatchedCalendarErrorFfi Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_DateFormatter_format_same_calendar_mv1')
 // ignore: non_constant_identifier_names
 external _ResultVoidDateTimeMismatchedCalendarErrorFfi _icu4x_DateFormatter_format_same_calendar_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> date, ffi.Pointer<ffi.Opaque> write);

--- a/ffi/dart/lib/src/bindings/DateFormatterGregorian.g.dart
+++ b/ffi/dart/lib/src/bindings/DateFormatterGregorian.g.dart
@@ -17,12 +17,16 @@ final class DateFormatterGregorian implements ffi.Finalizable {
   // maintain borrow validity.
   DateFormatterGregorian._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_DateFormatterGregorian_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_DateFormatterGregorian_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_DateFormatterGregorian_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_DateFormatterGregorian_destroy_mv1(DateFormatterGregorian cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_DateFormatterGregorian_destroy_mv1));
 
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.2.0/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
   ///
@@ -333,112 +337,134 @@ final class DateFormatterGregorian implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_DateFormatterGregorian_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_DateFormatterGregorian_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_DateFormatterGregorian_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_DateFormatterGregorian_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_DateFormatterGregorian_create_d_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateFormatterGregorian_create_d_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateFormatterGregorian_create_d_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_DateFormatterGregorian_create_d_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateFormatterGregorian_create_d_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateFormatterGregorian_create_d_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_DateFormatterGregorian_create_md_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateFormatterGregorian_create_md_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateFormatterGregorian_create_md_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_DateFormatterGregorian_create_md_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateFormatterGregorian_create_md_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateFormatterGregorian_create_md_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_DateFormatterGregorian_create_ymd_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateFormatterGregorian_create_ymd_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateFormatterGregorian_create_ymd_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void alignment, _ResultInt32Void yearStyle);
 
-@_DiplomatFfiUse('icu4x_DateFormatterGregorian_create_ymd_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateFormatterGregorian_create_ymd_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateFormatterGregorian_create_ymd_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void alignment, _ResultInt32Void yearStyle);
 
-@_DiplomatFfiUse('icu4x_DateFormatterGregorian_create_de_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateFormatterGregorian_create_de_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateFormatterGregorian_create_de_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_DateFormatterGregorian_create_de_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateFormatterGregorian_create_de_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateFormatterGregorian_create_de_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_DateFormatterGregorian_create_mde_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateFormatterGregorian_create_mde_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateFormatterGregorian_create_mde_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_DateFormatterGregorian_create_mde_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateFormatterGregorian_create_mde_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateFormatterGregorian_create_mde_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_DateFormatterGregorian_create_ymde_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateFormatterGregorian_create_ymde_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateFormatterGregorian_create_ymde_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void alignment, _ResultInt32Void yearStyle);
 
-@_DiplomatFfiUse('icu4x_DateFormatterGregorian_create_ymde_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateFormatterGregorian_create_ymde_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateFormatterGregorian_create_ymde_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void alignment, _ResultInt32Void yearStyle);
 
-@_DiplomatFfiUse('icu4x_DateFormatterGregorian_create_e_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateFormatterGregorian_create_e_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateFormatterGregorian_create_e_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length);
 
-@_DiplomatFfiUse('icu4x_DateFormatterGregorian_create_e_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateFormatterGregorian_create_e_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateFormatterGregorian_create_e_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length);
 
-@_DiplomatFfiUse('icu4x_DateFormatterGregorian_create_m_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateFormatterGregorian_create_m_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateFormatterGregorian_create_m_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_DateFormatterGregorian_create_m_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateFormatterGregorian_create_m_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateFormatterGregorian_create_m_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_DateFormatterGregorian_create_ym_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateFormatterGregorian_create_ym_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateFormatterGregorian_create_ym_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void alignment, _ResultInt32Void yearStyle);
 
-@_DiplomatFfiUse('icu4x_DateFormatterGregorian_create_ym_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateFormatterGregorian_create_ym_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateFormatterGregorian_create_ym_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void alignment, _ResultInt32Void yearStyle);
 
-@_DiplomatFfiUse('icu4x_DateFormatterGregorian_create_y_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateFormatterGregorian_create_y_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateFormatterGregorian_create_y_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void alignment, _ResultInt32Void yearStyle);
 
-@_DiplomatFfiUse('icu4x_DateFormatterGregorian_create_y_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateFormatterGregorian_create_y_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateFormatterGregorian_create_y_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void alignment, _ResultInt32Void yearStyle);
 
-@_DiplomatFfiUse('icu4x_DateFormatterGregorian_format_iso_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_DateFormatterGregorian_format_iso_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_DateFormatterGregorian_format_iso_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> isoDate, ffi.Pointer<ffi.Opaque> write);

--- a/ffi/dart/lib/src/bindings/DateTime.g.dart
+++ b/ffi/dart/lib/src/bindings/DateTime.g.dart
@@ -63,7 +63,8 @@ final class DateTime {
       ]);
 }
 
-@_DiplomatFfiUse('icu4x_DateTime_from_string_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultDateTimeFfiInt32 Function(_SliceUtf8, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_DateTime_from_string_mv1')
 // ignore: non_constant_identifier_names
 external _ResultDateTimeFfiInt32 _icu4x_DateTime_from_string_mv1(_SliceUtf8 v, ffi.Pointer<ffi.Opaque> calendar);

--- a/ffi/dart/lib/src/bindings/DateTimeFormatter.g.dart
+++ b/ffi/dart/lib/src/bindings/DateTimeFormatter.g.dart
@@ -17,12 +17,16 @@ final class DateTimeFormatter implements ffi.Finalizable {
   // maintain borrow validity.
   DateTimeFormatter._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_DateTimeFormatter_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_DateTimeFormatter_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_DateTimeFormatter_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_DateTimeFormatter_destroy_mv1(DateTimeFormatter cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_DateTimeFormatter_destroy_mv1));
 
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.2.0/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
   ///
@@ -255,87 +259,104 @@ final class DateTimeFormatter implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_DateTimeFormatter_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_DateTimeFormatter_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_DateTimeFormatter_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_DateTimeFormatter_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_DateTimeFormatter_create_dt_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateTimeFormatter_create_dt_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateTimeFormatter_create_dt_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_DateTimeFormatter_create_dt_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateTimeFormatter_create_dt_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateTimeFormatter_create_dt_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_DateTimeFormatter_create_mdt_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateTimeFormatter_create_mdt_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateTimeFormatter_create_mdt_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_DateTimeFormatter_create_mdt_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateTimeFormatter_create_mdt_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateTimeFormatter_create_mdt_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_DateTimeFormatter_create_ymdt_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateTimeFormatter_create_ymdt_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateTimeFormatter_create_ymdt_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment, _ResultInt32Void yearStyle);
 
-@_DiplomatFfiUse('icu4x_DateTimeFormatter_create_ymdt_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateTimeFormatter_create_ymdt_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateTimeFormatter_create_ymdt_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment, _ResultInt32Void yearStyle);
 
-@_DiplomatFfiUse('icu4x_DateTimeFormatter_create_det_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateTimeFormatter_create_det_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateTimeFormatter_create_det_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_DateTimeFormatter_create_det_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateTimeFormatter_create_det_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateTimeFormatter_create_det_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_DateTimeFormatter_create_mdet_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateTimeFormatter_create_mdet_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateTimeFormatter_create_mdet_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_DateTimeFormatter_create_mdet_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateTimeFormatter_create_mdet_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateTimeFormatter_create_mdet_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_DateTimeFormatter_create_ymdet_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateTimeFormatter_create_ymdet_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateTimeFormatter_create_ymdet_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment, _ResultInt32Void yearStyle);
 
-@_DiplomatFfiUse('icu4x_DateTimeFormatter_create_ymdet_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateTimeFormatter_create_ymdet_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateTimeFormatter_create_ymdet_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment, _ResultInt32Void yearStyle);
 
-@_DiplomatFfiUse('icu4x_DateTimeFormatter_create_et_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateTimeFormatter_create_et_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateTimeFormatter_create_et_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_DateTimeFormatter_create_et_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateTimeFormatter_create_et_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateTimeFormatter_create_et_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_DateTimeFormatter_format_iso_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_DateTimeFormatter_format_iso_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_DateTimeFormatter_format_iso_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> isoDate, ffi.Pointer<ffi.Opaque> time, ffi.Pointer<ffi.Opaque> write);
 
-@_DiplomatFfiUse('icu4x_DateTimeFormatter_format_same_calendar_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultVoidDateTimeMismatchedCalendarErrorFfi Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_DateTimeFormatter_format_same_calendar_mv1')
 // ignore: non_constant_identifier_names
 external _ResultVoidDateTimeMismatchedCalendarErrorFfi _icu4x_DateTimeFormatter_format_same_calendar_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> date, ffi.Pointer<ffi.Opaque> time, ffi.Pointer<ffi.Opaque> write);

--- a/ffi/dart/lib/src/bindings/DateTimeFormatterGregorian.g.dart
+++ b/ffi/dart/lib/src/bindings/DateTimeFormatterGregorian.g.dart
@@ -17,12 +17,16 @@ final class DateTimeFormatterGregorian implements ffi.Finalizable {
   // maintain borrow validity.
   DateTimeFormatterGregorian._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_DateTimeFormatterGregorian_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_DateTimeFormatterGregorian_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_DateTimeFormatterGregorian_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_DateTimeFormatterGregorian_destroy_mv1(DateTimeFormatterGregorian cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_DateTimeFormatterGregorian_destroy_mv1));
 
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.2.0/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
   ///
@@ -243,82 +247,98 @@ final class DateTimeFormatterGregorian implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_DateTimeFormatterGregorian_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_DateTimeFormatterGregorian_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_DateTimeFormatterGregorian_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_DateTimeFormatterGregorian_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_DateTimeFormatterGregorian_create_dt_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateTimeFormatterGregorian_create_dt_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateTimeFormatterGregorian_create_dt_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_DateTimeFormatterGregorian_create_dt_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateTimeFormatterGregorian_create_dt_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateTimeFormatterGregorian_create_dt_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_DateTimeFormatterGregorian_create_mdt_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateTimeFormatterGregorian_create_mdt_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateTimeFormatterGregorian_create_mdt_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_DateTimeFormatterGregorian_create_mdt_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateTimeFormatterGregorian_create_mdt_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateTimeFormatterGregorian_create_mdt_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_DateTimeFormatterGregorian_create_ymdt_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateTimeFormatterGregorian_create_ymdt_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateTimeFormatterGregorian_create_ymdt_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment, _ResultInt32Void yearStyle);
 
-@_DiplomatFfiUse('icu4x_DateTimeFormatterGregorian_create_ymdt_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateTimeFormatterGregorian_create_ymdt_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateTimeFormatterGregorian_create_ymdt_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment, _ResultInt32Void yearStyle);
 
-@_DiplomatFfiUse('icu4x_DateTimeFormatterGregorian_create_det_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateTimeFormatterGregorian_create_det_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateTimeFormatterGregorian_create_det_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_DateTimeFormatterGregorian_create_det_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateTimeFormatterGregorian_create_det_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateTimeFormatterGregorian_create_det_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_DateTimeFormatterGregorian_create_mdet_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateTimeFormatterGregorian_create_mdet_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateTimeFormatterGregorian_create_mdet_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_DateTimeFormatterGregorian_create_mdet_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateTimeFormatterGregorian_create_mdet_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateTimeFormatterGregorian_create_mdet_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_DateTimeFormatterGregorian_create_ymdet_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateTimeFormatterGregorian_create_ymdet_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateTimeFormatterGregorian_create_ymdet_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment, _ResultInt32Void yearStyle);
 
-@_DiplomatFfiUse('icu4x_DateTimeFormatterGregorian_create_ymdet_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateTimeFormatterGregorian_create_ymdet_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateTimeFormatterGregorian_create_ymdet_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment, _ResultInt32Void yearStyle);
 
-@_DiplomatFfiUse('icu4x_DateTimeFormatterGregorian_create_et_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateTimeFormatterGregorian_create_et_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateTimeFormatterGregorian_create_et_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_DateTimeFormatterGregorian_create_et_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DateTimeFormatterGregorian_create_et_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DateTimeFormatterGregorian_create_et_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_DateTimeFormatterGregorian_format_iso_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_DateTimeFormatterGregorian_format_iso_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_DateTimeFormatterGregorian_format_iso_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> isoDate, ffi.Pointer<ffi.Opaque> time, ffi.Pointer<ffi.Opaque> write);

--- a/ffi/dart/lib/src/bindings/Decimal.g.dart
+++ b/ffi/dart/lib/src/bindings/Decimal.g.dart
@@ -17,12 +17,16 @@ final class Decimal implements ffi.Finalizable {
   // maintain borrow validity.
   Decimal._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_Decimal_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_Decimal_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_Decimal_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_Decimal_destroy_mv1(Decimal cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_Decimal_destroy_mv1));
 
   /// Construct an [Decimal] from an integer.
   ///
@@ -254,157 +258,188 @@ final class Decimal implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_Decimal_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_Decimal_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_Decimal_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_Decimal_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_Decimal_from_int64_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Int64)>(isLeaf: true, symbol: 'icu4x_Decimal_from_int64_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_Decimal_from_int64_mv1(int v);
 
-@_DiplomatFfiUse('icu4x_Decimal_from_double_with_lower_magnitude_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueDecimalLimitErrorFfi Function(ffi.Double, ffi.Int16)>(isLeaf: true, symbol: 'icu4x_Decimal_from_double_with_lower_magnitude_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueDecimalLimitErrorFfi _icu4x_Decimal_from_double_with_lower_magnitude_mv1(double f, int magnitude);
 
-@_DiplomatFfiUse('icu4x_Decimal_from_double_with_significant_digits_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueDecimalLimitErrorFfi Function(ffi.Double, ffi.Uint8)>(isLeaf: true, symbol: 'icu4x_Decimal_from_double_with_significant_digits_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueDecimalLimitErrorFfi _icu4x_Decimal_from_double_with_significant_digits_mv1(double f, int digits);
 
-@_DiplomatFfiUse('icu4x_Decimal_from_double_with_round_trip_precision_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueDecimalLimitErrorFfi Function(ffi.Double)>(isLeaf: true, symbol: 'icu4x_Decimal_from_double_with_round_trip_precision_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueDecimalLimitErrorFfi _icu4x_Decimal_from_double_with_round_trip_precision_mv1(double f);
 
-@_DiplomatFfiUse('icu4x_Decimal_from_string_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(_SliceUtf8)>(isLeaf: true, symbol: 'icu4x_Decimal_from_string_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_Decimal_from_string_mv1(_SliceUtf8 v);
 
-@_DiplomatFfiUse('icu4x_Decimal_digit_at_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint8 Function(ffi.Pointer<ffi.Opaque>, ffi.Int16)>(isLeaf: true, symbol: 'icu4x_Decimal_digit_at_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_Decimal_digit_at_mv1(ffi.Pointer<ffi.Opaque> self, int magnitude);
 
-@_DiplomatFfiUse('icu4x_Decimal_magnitude_start_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int16 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Decimal_magnitude_start_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_Decimal_magnitude_start_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_Decimal_magnitude_end_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int16 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Decimal_magnitude_end_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_Decimal_magnitude_end_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_Decimal_nonzero_magnitude_start_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int16 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Decimal_nonzero_magnitude_start_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_Decimal_nonzero_magnitude_start_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_Decimal_nonzero_magnitude_end_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int16 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Decimal_nonzero_magnitude_end_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_Decimal_nonzero_magnitude_end_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_Decimal_is_zero_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Decimal_is_zero_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_Decimal_is_zero_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_Decimal_multiply_pow10_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Int16)>(isLeaf: true, symbol: 'icu4x_Decimal_multiply_pow10_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_Decimal_multiply_pow10_mv1(ffi.Pointer<ffi.Opaque> self, int power);
 
-@_DiplomatFfiUse('icu4x_Decimal_sign_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Decimal_sign_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_Decimal_sign_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_Decimal_set_sign_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Int32)>(isLeaf: true, symbol: 'icu4x_Decimal_set_sign_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_Decimal_set_sign_mv1(ffi.Pointer<ffi.Opaque> self, int sign);
 
-@_DiplomatFfiUse('icu4x_Decimal_apply_sign_display_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Int32)>(isLeaf: true, symbol: 'icu4x_Decimal_apply_sign_display_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_Decimal_apply_sign_display_mv1(ffi.Pointer<ffi.Opaque> self, int signDisplay);
 
-@_DiplomatFfiUse('icu4x_Decimal_trim_start_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Decimal_trim_start_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_Decimal_trim_start_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_Decimal_trim_end_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Decimal_trim_end_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_Decimal_trim_end_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_Decimal_trim_end_if_integer_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Decimal_trim_end_if_integer_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_Decimal_trim_end_if_integer_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_Decimal_pad_start_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Int16)>(isLeaf: true, symbol: 'icu4x_Decimal_pad_start_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_Decimal_pad_start_mv1(ffi.Pointer<ffi.Opaque> self, int position);
 
-@_DiplomatFfiUse('icu4x_Decimal_pad_end_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Int16)>(isLeaf: true, symbol: 'icu4x_Decimal_pad_end_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_Decimal_pad_end_mv1(ffi.Pointer<ffi.Opaque> self, int position);
 
-@_DiplomatFfiUse('icu4x_Decimal_set_max_position_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Int16)>(isLeaf: true, symbol: 'icu4x_Decimal_set_max_position_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_Decimal_set_max_position_mv1(ffi.Pointer<ffi.Opaque> self, int position);
 
-@_DiplomatFfiUse('icu4x_Decimal_round_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Int16)>(isLeaf: true, symbol: 'icu4x_Decimal_round_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_Decimal_round_mv1(ffi.Pointer<ffi.Opaque> self, int position);
 
-@_DiplomatFfiUse('icu4x_Decimal_ceil_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Int16)>(isLeaf: true, symbol: 'icu4x_Decimal_ceil_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_Decimal_ceil_mv1(ffi.Pointer<ffi.Opaque> self, int position);
 
-@_DiplomatFfiUse('icu4x_Decimal_expand_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Int16)>(isLeaf: true, symbol: 'icu4x_Decimal_expand_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_Decimal_expand_mv1(ffi.Pointer<ffi.Opaque> self, int position);
 
-@_DiplomatFfiUse('icu4x_Decimal_floor_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Int16)>(isLeaf: true, symbol: 'icu4x_Decimal_floor_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_Decimal_floor_mv1(ffi.Pointer<ffi.Opaque> self, int position);
 
-@_DiplomatFfiUse('icu4x_Decimal_trunc_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Int16)>(isLeaf: true, symbol: 'icu4x_Decimal_trunc_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_Decimal_trunc_mv1(ffi.Pointer<ffi.Opaque> self, int position);
 
-@_DiplomatFfiUse('icu4x_Decimal_round_with_mode_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Int16, ffi.Int32)>(isLeaf: true, symbol: 'icu4x_Decimal_round_with_mode_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_Decimal_round_with_mode_mv1(ffi.Pointer<ffi.Opaque> self, int position, int mode);
 
-@_DiplomatFfiUse('icu4x_Decimal_round_with_mode_and_increment_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Int16, ffi.Int32, ffi.Int32)>(isLeaf: true, symbol: 'icu4x_Decimal_round_with_mode_and_increment_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_Decimal_round_with_mode_and_increment_mv1(ffi.Pointer<ffi.Opaque> self, int position, int mode, int increment);
 
-@_DiplomatFfiUse('icu4x_Decimal_concatenate_end_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultVoidVoid Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Decimal_concatenate_end_mv1')
 // ignore: non_constant_identifier_names
 external _ResultVoidVoid _icu4x_Decimal_concatenate_end_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> other);
 
-@_DiplomatFfiUse('icu4x_Decimal_to_string_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Decimal_to_string_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_Decimal_to_string_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> write);

--- a/ffi/dart/lib/src/bindings/DecimalFormatter.g.dart
+++ b/ffi/dart/lib/src/bindings/DecimalFormatter.g.dart
@@ -19,12 +19,16 @@ final class DecimalFormatter implements ffi.Finalizable {
   // maintain borrow validity.
   DecimalFormatter._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_DecimalFormatter_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_DecimalFormatter_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_DecimalFormatter_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_DecimalFormatter_destroy_mv1(DecimalFormatter cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_DecimalFormatter_destroy_mv1));
 
   /// Creates a new [DecimalFormatter], using compiled data
   ///
@@ -77,27 +81,32 @@ final class DecimalFormatter implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_DecimalFormatter_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_DecimalFormatter_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_DecimalFormatter_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_DecimalFormatter_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_DecimalFormatter_create_with_grouping_strategy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DecimalFormatter_create_with_grouping_strategy_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DecimalFormatter_create_with_grouping_strategy_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void groupingStrategy);
 
-@_DiplomatFfiUse('icu4x_DecimalFormatter_create_with_grouping_strategy_and_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DecimalFormatter_create_with_grouping_strategy_and_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DecimalFormatter_create_with_grouping_strategy_and_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void groupingStrategy);
 
-@_DiplomatFfiUse('icu4x_DecimalFormatter_create_with_manual_data_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(_SliceUtf8, _SliceUtf8, _SliceUtf8, _SliceUtf8, _SliceUtf8, _SliceUtf8, ffi.Uint8, ffi.Uint8, ffi.Uint8, _SliceRune, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_DecimalFormatter_create_with_manual_data_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DecimalFormatter_create_with_manual_data_mv1(_SliceUtf8 plusSignPrefix, _SliceUtf8 plusSignSuffix, _SliceUtf8 minusSignPrefix, _SliceUtf8 minusSignSuffix, _SliceUtf8 decimalSeparator, _SliceUtf8 groupingSeparator, int primaryGroupSize, int secondaryGroupSize, int minGroupSize, _SliceRune digits, _ResultInt32Void groupingStrategy);
 
-@_DiplomatFfiUse('icu4x_DecimalFormatter_format_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_DecimalFormatter_format_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_DecimalFormatter_format_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> value, ffi.Pointer<ffi.Opaque> write);

--- a/ffi/dart/lib/src/bindings/DecomposingNormalizer.g.dart
+++ b/ffi/dart/lib/src/bindings/DecomposingNormalizer.g.dart
@@ -17,12 +17,16 @@ final class DecomposingNormalizer implements ffi.Finalizable {
   // maintain borrow validity.
   DecomposingNormalizer._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_DecomposingNormalizer_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_DecomposingNormalizer_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_DecomposingNormalizer_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_DecomposingNormalizer_destroy_mv1(DecomposingNormalizer cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_DecomposingNormalizer_destroy_mv1));
 
   /// Construct a new `DecomposingNormalizer` instance for NFD using compiled data.
   ///
@@ -102,42 +106,50 @@ final class DecomposingNormalizer implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_DecomposingNormalizer_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_DecomposingNormalizer_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_DecomposingNormalizer_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_DecomposingNormalizer_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_DecomposingNormalizer_create_nfd_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_DecomposingNormalizer_create_nfd_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_DecomposingNormalizer_create_nfd_mv1();
 
-@_DiplomatFfiUse('icu4x_DecomposingNormalizer_create_nfd_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_DecomposingNormalizer_create_nfd_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DecomposingNormalizer_create_nfd_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_DecomposingNormalizer_create_nfkd_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_DecomposingNormalizer_create_nfkd_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_DecomposingNormalizer_create_nfkd_mv1();
 
-@_DiplomatFfiUse('icu4x_DecomposingNormalizer_create_nfkd_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_DecomposingNormalizer_create_nfkd_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_DecomposingNormalizer_create_nfkd_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_DecomposingNormalizer_normalize_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_DecomposingNormalizer_normalize_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_DecomposingNormalizer_normalize_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUtf8 s, ffi.Pointer<ffi.Opaque> write);
 
-@_DiplomatFfiUse('icu4x_DecomposingNormalizer_is_normalized_utf16_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Pointer<ffi.Opaque>, _SliceUtf16)>(isLeaf: true, symbol: 'icu4x_DecomposingNormalizer_is_normalized_utf16_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_DecomposingNormalizer_is_normalized_utf16_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUtf16 s);
 
-@_DiplomatFfiUse('icu4x_DecomposingNormalizer_is_normalized_utf16_up_to_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Size Function(ffi.Pointer<ffi.Opaque>, _SliceUtf16)>(isLeaf: true, symbol: 'icu4x_DecomposingNormalizer_is_normalized_utf16_up_to_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_DecomposingNormalizer_is_normalized_utf16_up_to_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUtf16 s);

--- a/ffi/dart/lib/src/bindings/EastAsianWidth.g.dart
+++ b/ffi/dart/lib/src/bindings/EastAsianWidth.g.dart
@@ -76,32 +76,38 @@ enum EastAsianWidth {
 
 }
 
-@_DiplomatFfiUse('icu4x_EastAsianWidth_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_EastAsianWidth_for_char_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_EastAsianWidth_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_EastAsianWidth_long_name_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultSliceUtf8Void Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_EastAsianWidth_long_name_mv1')
 // ignore: non_constant_identifier_names
 external _ResultSliceUtf8Void _icu4x_EastAsianWidth_long_name_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_EastAsianWidth_short_name_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultSliceUtf8Void Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_EastAsianWidth_short_name_mv1')
 // ignore: non_constant_identifier_names
 external _ResultSliceUtf8Void _icu4x_EastAsianWidth_short_name_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_EastAsianWidth_to_integer_value_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint8 Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_EastAsianWidth_to_integer_value_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_EastAsianWidth_to_integer_value_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_EastAsianWidth_from_integer_value_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultInt32Void Function(ffi.Uint8)>(isLeaf: true, symbol: 'icu4x_EastAsianWidth_from_integer_value_mv1')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _icu4x_EastAsianWidth_from_integer_value_mv1(int other);
 
-@_DiplomatFfiUse('icu4x_EastAsianWidth_try_from_str_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultInt32Void Function(_SliceUtf8)>(isLeaf: true, symbol: 'icu4x_EastAsianWidth_try_from_str_mv1')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _icu4x_EastAsianWidth_try_from_str_mv1(_SliceUtf8 s);

--- a/ffi/dart/lib/src/bindings/EmojiSetData.g.dart
+++ b/ffi/dart/lib/src/bindings/EmojiSetData.g.dart
@@ -25,12 +25,16 @@ final class EmojiSetData implements ffi.Finalizable {
   // maintain borrow validity.
   EmojiSetData._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_EmojiSetData_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_EmojiSetData_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_EmojiSetData_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_EmojiSetData_destroy_mv1(EmojiSetData cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_EmojiSetData_destroy_mv1));
 
   /// Checks whether the string is in the set.
   ///
@@ -89,37 +93,44 @@ final class EmojiSetData implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_EmojiSetData_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_EmojiSetData_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_EmojiSetData_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_EmojiSetData_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_EmojiSetData_contains_str_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8)>(isLeaf: true, symbol: 'icu4x_EmojiSetData_contains_str_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_EmojiSetData_contains_str_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUtf8 s);
 
-@_DiplomatFfiUse('icu4x_EmojiSetData_contains_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Pointer<ffi.Opaque>, ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_EmojiSetData_contains_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_EmojiSetData_contains_mv1(ffi.Pointer<ffi.Opaque> self, Rune cp);
 
-@_DiplomatFfiUse('icu4x_EmojiSetData_create_basic_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_EmojiSetData_create_basic_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_EmojiSetData_create_basic_mv1();
 
-@_DiplomatFfiUse('icu4x_EmojiSetData_create_basic_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_EmojiSetData_create_basic_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_EmojiSetData_create_basic_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_EmojiSetData_basic_emoji_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_EmojiSetData_basic_emoji_for_char_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_EmojiSetData_basic_emoji_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_EmojiSetData_basic_emoji_for_str_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(_SliceUtf8)>(isLeaf: true, symbol: 'icu4x_EmojiSetData_basic_emoji_for_str_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_EmojiSetData_basic_emoji_for_str_mv1(_SliceUtf8 s);

--- a/ffi/dart/lib/src/bindings/ExemplarCharacters.g.dart
+++ b/ffi/dart/lib/src/bindings/ExemplarCharacters.g.dart
@@ -23,12 +23,16 @@ final class ExemplarCharacters implements ffi.Finalizable {
   // maintain borrow validity.
   ExemplarCharacters._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_ExemplarCharacters_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_ExemplarCharacters_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_ExemplarCharacters_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_ExemplarCharacters_destroy_mv1(ExemplarCharacters cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_ExemplarCharacters_destroy_mv1));
 
   /// Checks whether the string is in the set.
   ///
@@ -179,67 +183,80 @@ final class ExemplarCharacters implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_ExemplarCharacters_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_ExemplarCharacters_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_ExemplarCharacters_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_ExemplarCharacters_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_ExemplarCharacters_contains_str_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8)>(isLeaf: true, symbol: 'icu4x_ExemplarCharacters_contains_str_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_ExemplarCharacters_contains_str_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUtf8 s);
 
-@_DiplomatFfiUse('icu4x_ExemplarCharacters_contains_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Pointer<ffi.Opaque>, ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_ExemplarCharacters_contains_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_ExemplarCharacters_contains_mv1(ffi.Pointer<ffi.Opaque> self, Rune cp);
 
-@_DiplomatFfiUse('icu4x_ExemplarCharacters_create_main_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ExemplarCharacters_create_main_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ExemplarCharacters_create_main_mv1(ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_ExemplarCharacters_create_main_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ExemplarCharacters_create_main_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ExemplarCharacters_create_main_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_ExemplarCharacters_create_auxiliary_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ExemplarCharacters_create_auxiliary_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ExemplarCharacters_create_auxiliary_mv1(ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_ExemplarCharacters_create_auxiliary_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ExemplarCharacters_create_auxiliary_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ExemplarCharacters_create_auxiliary_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_ExemplarCharacters_create_punctuation_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ExemplarCharacters_create_punctuation_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ExemplarCharacters_create_punctuation_mv1(ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_ExemplarCharacters_create_punctuation_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ExemplarCharacters_create_punctuation_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ExemplarCharacters_create_punctuation_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_ExemplarCharacters_create_numbers_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ExemplarCharacters_create_numbers_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ExemplarCharacters_create_numbers_mv1(ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_ExemplarCharacters_create_numbers_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ExemplarCharacters_create_numbers_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ExemplarCharacters_create_numbers_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_ExemplarCharacters_create_index_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ExemplarCharacters_create_index_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ExemplarCharacters_create_index_mv1(ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_ExemplarCharacters_create_index_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ExemplarCharacters_create_index_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ExemplarCharacters_create_index_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale);

--- a/ffi/dart/lib/src/bindings/GeneralCategory.g.dart
+++ b/ffi/dart/lib/src/bindings/GeneralCategory.g.dart
@@ -132,37 +132,44 @@ enum GeneralCategory {
 
 }
 
-@_DiplomatFfiUse('icu4x_GeneralCategory_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_GeneralCategory_for_char_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_GeneralCategory_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_GeneralCategory_long_name_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultSliceUtf8Void Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_GeneralCategory_long_name_mv1')
 // ignore: non_constant_identifier_names
 external _ResultSliceUtf8Void _icu4x_GeneralCategory_long_name_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_GeneralCategory_short_name_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultSliceUtf8Void Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_GeneralCategory_short_name_mv1')
 // ignore: non_constant_identifier_names
 external _ResultSliceUtf8Void _icu4x_GeneralCategory_short_name_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_GeneralCategory_to_integer_value_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint8 Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_GeneralCategory_to_integer_value_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_GeneralCategory_to_integer_value_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_GeneralCategory_from_integer_value_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultInt32Void Function(ffi.Uint8)>(isLeaf: true, symbol: 'icu4x_GeneralCategory_from_integer_value_mv1')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _icu4x_GeneralCategory_from_integer_value_mv1(int other);
 
-@_DiplomatFfiUse('icu4x_GeneralCategory_try_from_str_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultInt32Void Function(_SliceUtf8)>(isLeaf: true, symbol: 'icu4x_GeneralCategory_try_from_str_mv1')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _icu4x_GeneralCategory_try_from_str_mv1(_SliceUtf8 s);
 
-@_DiplomatFfiUse('icu4x_GeneralCategory_to_group_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_GeneralCategoryGroupFfi Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_GeneralCategory_to_group_mv1')
 // ignore: non_constant_identifier_names
 external _GeneralCategoryGroupFfi _icu4x_GeneralCategory_to_group_mv1(int self);

--- a/ffi/dart/lib/src/bindings/GeneralCategoryGroup.g.dart
+++ b/ffi/dart/lib/src/bindings/GeneralCategoryGroup.g.dart
@@ -134,72 +134,86 @@ final class GeneralCategoryGroup {
       ]);
 }
 
-@_DiplomatFfiUse('icu4x_GeneralCategoryGroup_contains_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(_GeneralCategoryGroupFfi, ffi.Int32)>(isLeaf: true, symbol: 'icu4x_GeneralCategoryGroup_contains_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_GeneralCategoryGroup_contains_mv1(_GeneralCategoryGroupFfi self, int val);
 
-@_DiplomatFfiUse('icu4x_GeneralCategoryGroup_complement_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_GeneralCategoryGroupFfi Function(_GeneralCategoryGroupFfi)>(isLeaf: true, symbol: 'icu4x_GeneralCategoryGroup_complement_mv1')
 // ignore: non_constant_identifier_names
 external _GeneralCategoryGroupFfi _icu4x_GeneralCategoryGroup_complement_mv1(_GeneralCategoryGroupFfi self);
 
-@_DiplomatFfiUse('icu4x_GeneralCategoryGroup_all_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_GeneralCategoryGroupFfi Function()>(isLeaf: true, symbol: 'icu4x_GeneralCategoryGroup_all_mv1')
 // ignore: non_constant_identifier_names
 external _GeneralCategoryGroupFfi _icu4x_GeneralCategoryGroup_all_mv1();
 
-@_DiplomatFfiUse('icu4x_GeneralCategoryGroup_empty_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_GeneralCategoryGroupFfi Function()>(isLeaf: true, symbol: 'icu4x_GeneralCategoryGroup_empty_mv1')
 // ignore: non_constant_identifier_names
 external _GeneralCategoryGroupFfi _icu4x_GeneralCategoryGroup_empty_mv1();
 
-@_DiplomatFfiUse('icu4x_GeneralCategoryGroup_union_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_GeneralCategoryGroupFfi Function(_GeneralCategoryGroupFfi, _GeneralCategoryGroupFfi)>(isLeaf: true, symbol: 'icu4x_GeneralCategoryGroup_union_mv1')
 // ignore: non_constant_identifier_names
 external _GeneralCategoryGroupFfi _icu4x_GeneralCategoryGroup_union_mv1(_GeneralCategoryGroupFfi self, _GeneralCategoryGroupFfi other);
 
-@_DiplomatFfiUse('icu4x_GeneralCategoryGroup_intersection_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_GeneralCategoryGroupFfi Function(_GeneralCategoryGroupFfi, _GeneralCategoryGroupFfi)>(isLeaf: true, symbol: 'icu4x_GeneralCategoryGroup_intersection_mv1')
 // ignore: non_constant_identifier_names
 external _GeneralCategoryGroupFfi _icu4x_GeneralCategoryGroup_intersection_mv1(_GeneralCategoryGroupFfi self, _GeneralCategoryGroupFfi other);
 
-@_DiplomatFfiUse('icu4x_GeneralCategoryGroup_cased_letter_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_GeneralCategoryGroupFfi Function()>(isLeaf: true, symbol: 'icu4x_GeneralCategoryGroup_cased_letter_mv1')
 // ignore: non_constant_identifier_names
 external _GeneralCategoryGroupFfi _icu4x_GeneralCategoryGroup_cased_letter_mv1();
 
-@_DiplomatFfiUse('icu4x_GeneralCategoryGroup_letter_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_GeneralCategoryGroupFfi Function()>(isLeaf: true, symbol: 'icu4x_GeneralCategoryGroup_letter_mv1')
 // ignore: non_constant_identifier_names
 external _GeneralCategoryGroupFfi _icu4x_GeneralCategoryGroup_letter_mv1();
 
-@_DiplomatFfiUse('icu4x_GeneralCategoryGroup_mark_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_GeneralCategoryGroupFfi Function()>(isLeaf: true, symbol: 'icu4x_GeneralCategoryGroup_mark_mv1')
 // ignore: non_constant_identifier_names
 external _GeneralCategoryGroupFfi _icu4x_GeneralCategoryGroup_mark_mv1();
 
-@_DiplomatFfiUse('icu4x_GeneralCategoryGroup_number_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_GeneralCategoryGroupFfi Function()>(isLeaf: true, symbol: 'icu4x_GeneralCategoryGroup_number_mv1')
 // ignore: non_constant_identifier_names
 external _GeneralCategoryGroupFfi _icu4x_GeneralCategoryGroup_number_mv1();
 
-@_DiplomatFfiUse('icu4x_GeneralCategoryGroup_separator_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_GeneralCategoryGroupFfi Function()>(isLeaf: true, symbol: 'icu4x_GeneralCategoryGroup_separator_mv1')
 // ignore: non_constant_identifier_names
 external _GeneralCategoryGroupFfi _icu4x_GeneralCategoryGroup_separator_mv1();
 
-@_DiplomatFfiUse('icu4x_GeneralCategoryGroup_other_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_GeneralCategoryGroupFfi Function()>(isLeaf: true, symbol: 'icu4x_GeneralCategoryGroup_other_mv1')
 // ignore: non_constant_identifier_names
 external _GeneralCategoryGroupFfi _icu4x_GeneralCategoryGroup_other_mv1();
 
-@_DiplomatFfiUse('icu4x_GeneralCategoryGroup_punctuation_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_GeneralCategoryGroupFfi Function()>(isLeaf: true, symbol: 'icu4x_GeneralCategoryGroup_punctuation_mv1')
 // ignore: non_constant_identifier_names
 external _GeneralCategoryGroupFfi _icu4x_GeneralCategoryGroup_punctuation_mv1();
 
-@_DiplomatFfiUse('icu4x_GeneralCategoryGroup_symbol_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_GeneralCategoryGroupFfi Function()>(isLeaf: true, symbol: 'icu4x_GeneralCategoryGroup_symbol_mv1')
 // ignore: non_constant_identifier_names
 external _GeneralCategoryGroupFfi _icu4x_GeneralCategoryGroup_symbol_mv1();

--- a/ffi/dart/lib/src/bindings/GeneralCategoryNameToGroupMapper.g.dart
+++ b/ffi/dart/lib/src/bindings/GeneralCategoryNameToGroupMapper.g.dart
@@ -21,12 +21,16 @@ final class GeneralCategoryNameToGroupMapper implements ffi.Finalizable {
   // maintain borrow validity.
   GeneralCategoryNameToGroupMapper._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_GeneralCategoryNameToGroupMapper_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_GeneralCategoryNameToGroupMapper_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_GeneralCategoryNameToGroupMapper_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_GeneralCategoryNameToGroupMapper_destroy_mv1(GeneralCategoryNameToGroupMapper cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_GeneralCategoryNameToGroupMapper_destroy_mv1));
 
   /// Get the mask value matching the given name, using strict matching
   ///
@@ -73,27 +77,32 @@ final class GeneralCategoryNameToGroupMapper implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_GeneralCategoryNameToGroupMapper_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_GeneralCategoryNameToGroupMapper_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_GeneralCategoryNameToGroupMapper_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_GeneralCategoryNameToGroupMapper_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_GeneralCategoryNameToGroupMapper_get_strict_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_GeneralCategoryGroupFfi Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8)>(isLeaf: true, symbol: 'icu4x_GeneralCategoryNameToGroupMapper_get_strict_mv1')
 // ignore: non_constant_identifier_names
 external _GeneralCategoryGroupFfi _icu4x_GeneralCategoryNameToGroupMapper_get_strict_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUtf8 name);
 
-@_DiplomatFfiUse('icu4x_GeneralCategoryNameToGroupMapper_get_loose_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_GeneralCategoryGroupFfi Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8)>(isLeaf: true, symbol: 'icu4x_GeneralCategoryNameToGroupMapper_get_loose_mv1')
 // ignore: non_constant_identifier_names
 external _GeneralCategoryGroupFfi _icu4x_GeneralCategoryNameToGroupMapper_get_loose_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUtf8 name);
 
-@_DiplomatFfiUse('icu4x_GeneralCategoryNameToGroupMapper_create_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_GeneralCategoryNameToGroupMapper_create_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_GeneralCategoryNameToGroupMapper_create_mv1();
 
-@_DiplomatFfiUse('icu4x_GeneralCategoryNameToGroupMapper_create_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_GeneralCategoryNameToGroupMapper_create_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_GeneralCategoryNameToGroupMapper_create_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);

--- a/ffi/dart/lib/src/bindings/GraphemeClusterBreak.g.dart
+++ b/ffi/dart/lib/src/bindings/GraphemeClusterBreak.g.dart
@@ -100,32 +100,38 @@ enum GraphemeClusterBreak {
 
 }
 
-@_DiplomatFfiUse('icu4x_GraphemeClusterBreak_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_GraphemeClusterBreak_for_char_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_GraphemeClusterBreak_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_GraphemeClusterBreak_long_name_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultSliceUtf8Void Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_GraphemeClusterBreak_long_name_mv1')
 // ignore: non_constant_identifier_names
 external _ResultSliceUtf8Void _icu4x_GraphemeClusterBreak_long_name_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_GraphemeClusterBreak_short_name_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultSliceUtf8Void Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_GraphemeClusterBreak_short_name_mv1')
 // ignore: non_constant_identifier_names
 external _ResultSliceUtf8Void _icu4x_GraphemeClusterBreak_short_name_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_GraphemeClusterBreak_to_integer_value_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint8 Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_GraphemeClusterBreak_to_integer_value_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_GraphemeClusterBreak_to_integer_value_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_GraphemeClusterBreak_from_integer_value_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultInt32Void Function(ffi.Uint8)>(isLeaf: true, symbol: 'icu4x_GraphemeClusterBreak_from_integer_value_mv1')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _icu4x_GraphemeClusterBreak_from_integer_value_mv1(int other);
 
-@_DiplomatFfiUse('icu4x_GraphemeClusterBreak_try_from_str_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultInt32Void Function(_SliceUtf8)>(isLeaf: true, symbol: 'icu4x_GraphemeClusterBreak_try_from_str_mv1')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _icu4x_GraphemeClusterBreak_try_from_str_mv1(_SliceUtf8 s);

--- a/ffi/dart/lib/src/bindings/GraphemeClusterBreakIteratorLatin1.g.dart
+++ b/ffi/dart/lib/src/bindings/GraphemeClusterBreakIteratorLatin1.g.dart
@@ -19,12 +19,16 @@ final class GraphemeClusterBreakIteratorLatin1 implements ffi.Finalizable {
   // maintain borrow validity.
   GraphemeClusterBreakIteratorLatin1._fromFfi(this._ffi, this._selfEdge, this._aEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_GraphemeClusterBreakIteratorLatin1_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_GraphemeClusterBreakIteratorLatin1_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_GraphemeClusterBreakIteratorLatin1_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_GraphemeClusterBreakIteratorLatin1_destroy_mv1(GraphemeClusterBreakIteratorLatin1 cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_GraphemeClusterBreakIteratorLatin1_destroy_mv1));
 
   /// Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
   /// out of range of a 32-bit signed integer.
@@ -37,12 +41,14 @@ final class GraphemeClusterBreakIteratorLatin1 implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_GraphemeClusterBreakIteratorLatin1_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_GraphemeClusterBreakIteratorLatin1_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_GraphemeClusterBreakIteratorLatin1_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_GraphemeClusterBreakIteratorLatin1_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_GraphemeClusterBreakIteratorLatin1_next_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_GraphemeClusterBreakIteratorLatin1_next_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_GraphemeClusterBreakIteratorLatin1_next_mv1(ffi.Pointer<ffi.Opaque> self);

--- a/ffi/dart/lib/src/bindings/GraphemeClusterBreakIteratorUtf16.g.dart
+++ b/ffi/dart/lib/src/bindings/GraphemeClusterBreakIteratorUtf16.g.dart
@@ -19,12 +19,16 @@ final class GraphemeClusterBreakIteratorUtf16 implements ffi.Finalizable {
   // maintain borrow validity.
   GraphemeClusterBreakIteratorUtf16._fromFfi(this._ffi, this._selfEdge, this._aEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_GraphemeClusterBreakIteratorUtf16_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_GraphemeClusterBreakIteratorUtf16_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_GraphemeClusterBreakIteratorUtf16_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_GraphemeClusterBreakIteratorUtf16_destroy_mv1(GraphemeClusterBreakIteratorUtf16 cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_GraphemeClusterBreakIteratorUtf16_destroy_mv1));
 
   /// Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
   /// out of range of a 32-bit signed integer.
@@ -37,12 +41,14 @@ final class GraphemeClusterBreakIteratorUtf16 implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_GraphemeClusterBreakIteratorUtf16_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_GraphemeClusterBreakIteratorUtf16_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_GraphemeClusterBreakIteratorUtf16_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_GraphemeClusterBreakIteratorUtf16_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_GraphemeClusterBreakIteratorUtf16_next_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_GraphemeClusterBreakIteratorUtf16_next_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_GraphemeClusterBreakIteratorUtf16_next_mv1(ffi.Pointer<ffi.Opaque> self);

--- a/ffi/dart/lib/src/bindings/GraphemeClusterBreakIteratorUtf8.g.dart
+++ b/ffi/dart/lib/src/bindings/GraphemeClusterBreakIteratorUtf8.g.dart
@@ -19,12 +19,16 @@ final class GraphemeClusterBreakIteratorUtf8 implements ffi.Finalizable {
   // maintain borrow validity.
   GraphemeClusterBreakIteratorUtf8._fromFfi(this._ffi, this._selfEdge, this._aEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_GraphemeClusterBreakIteratorUtf8_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_GraphemeClusterBreakIteratorUtf8_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_GraphemeClusterBreakIteratorUtf8_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_GraphemeClusterBreakIteratorUtf8_destroy_mv1(GraphemeClusterBreakIteratorUtf8 cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_GraphemeClusterBreakIteratorUtf8_destroy_mv1));
 
   /// Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
   /// out of range of a 32-bit signed integer.
@@ -37,12 +41,14 @@ final class GraphemeClusterBreakIteratorUtf8 implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_GraphemeClusterBreakIteratorUtf8_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_GraphemeClusterBreakIteratorUtf8_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_GraphemeClusterBreakIteratorUtf8_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_GraphemeClusterBreakIteratorUtf8_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_GraphemeClusterBreakIteratorUtf8_next_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_GraphemeClusterBreakIteratorUtf8_next_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_GraphemeClusterBreakIteratorUtf8_next_mv1(ffi.Pointer<ffi.Opaque> self);

--- a/ffi/dart/lib/src/bindings/GraphemeClusterSegmenter.g.dart
+++ b/ffi/dart/lib/src/bindings/GraphemeClusterSegmenter.g.dart
@@ -20,12 +20,16 @@ final class GraphemeClusterSegmenter implements ffi.Finalizable {
   // maintain borrow validity.
   GraphemeClusterSegmenter._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_GraphemeClusterSegmenter_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_GraphemeClusterSegmenter_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_GraphemeClusterSegmenter_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_GraphemeClusterSegmenter_destroy_mv1(GraphemeClusterSegmenter cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_GraphemeClusterSegmenter_destroy_mv1));
 
   /// Construct an [GraphemeClusterSegmenter] using compiled data.
   ///
@@ -64,22 +68,26 @@ final class GraphemeClusterSegmenter implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_GraphemeClusterSegmenter_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_GraphemeClusterSegmenter_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_GraphemeClusterSegmenter_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_GraphemeClusterSegmenter_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_GraphemeClusterSegmenter_create_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_GraphemeClusterSegmenter_create_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_GraphemeClusterSegmenter_create_mv1();
 
-@_DiplomatFfiUse('icu4x_GraphemeClusterSegmenter_create_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_GraphemeClusterSegmenter_create_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_GraphemeClusterSegmenter_create_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_GraphemeClusterSegmenter_segment_utf16_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, _SliceUtf16)>(isLeaf: true, symbol: 'icu4x_GraphemeClusterSegmenter_segment_utf16_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_GraphemeClusterSegmenter_segment_utf16_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUtf16 input);

--- a/ffi/dart/lib/src/bindings/HangulSyllableType.g.dart
+++ b/ffi/dart/lib/src/bindings/HangulSyllableType.g.dart
@@ -76,32 +76,38 @@ enum HangulSyllableType {
 
 }
 
-@_DiplomatFfiUse('icu4x_HangulSyllableType_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_HangulSyllableType_for_char_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_HangulSyllableType_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_HangulSyllableType_long_name_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultSliceUtf8Void Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_HangulSyllableType_long_name_mv1')
 // ignore: non_constant_identifier_names
 external _ResultSliceUtf8Void _icu4x_HangulSyllableType_long_name_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_HangulSyllableType_short_name_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultSliceUtf8Void Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_HangulSyllableType_short_name_mv1')
 // ignore: non_constant_identifier_names
 external _ResultSliceUtf8Void _icu4x_HangulSyllableType_short_name_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_HangulSyllableType_to_integer_value_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint8 Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_HangulSyllableType_to_integer_value_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_HangulSyllableType_to_integer_value_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_HangulSyllableType_from_integer_value_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultInt32Void Function(ffi.Uint8)>(isLeaf: true, symbol: 'icu4x_HangulSyllableType_from_integer_value_mv1')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _icu4x_HangulSyllableType_from_integer_value_mv1(int other);
 
-@_DiplomatFfiUse('icu4x_HangulSyllableType_try_from_str_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultInt32Void Function(_SliceUtf8)>(isLeaf: true, symbol: 'icu4x_HangulSyllableType_try_from_str_mv1')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _icu4x_HangulSyllableType_try_from_str_mv1(_SliceUtf8 s);

--- a/ffi/dart/lib/src/bindings/IanaParser.g.dart
+++ b/ffi/dart/lib/src/bindings/IanaParser.g.dart
@@ -22,12 +22,16 @@ final class IanaParser implements ffi.Finalizable {
   // maintain borrow validity.
   IanaParser._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_IanaParser_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_IanaParser_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_IanaParser_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_IanaParser_destroy_mv1(IanaParser cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_IanaParser_destroy_mv1));
 
   /// Create a new [IanaParser] using compiled data
   ///
@@ -67,27 +71,32 @@ final class IanaParser implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_IanaParser_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_IanaParser_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_IanaParser_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_IanaParser_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_IanaParser_create_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_IanaParser_create_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_IanaParser_create_mv1();
 
-@_DiplomatFfiUse('icu4x_IanaParser_create_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_IanaParser_create_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_IanaParser_create_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_IanaParser_parse_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8)>(isLeaf: true, symbol: 'icu4x_IanaParser_parse_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_IanaParser_parse_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUtf8 value);
 
-@_DiplomatFfiUse('icu4x_IanaParser_iter_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_IanaParser_iter_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_IanaParser_iter_mv1(ffi.Pointer<ffi.Opaque> self);

--- a/ffi/dart/lib/src/bindings/IanaParserExtended.g.dart
+++ b/ffi/dart/lib/src/bindings/IanaParserExtended.g.dart
@@ -22,12 +22,16 @@ final class IanaParserExtended implements ffi.Finalizable {
   // maintain borrow validity.
   IanaParserExtended._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_IanaParserExtended_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_IanaParserExtended_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_IanaParserExtended_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_IanaParserExtended_destroy_mv1(IanaParserExtended cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_IanaParserExtended_destroy_mv1));
 
   /// Create a new [IanaParserExtended] using compiled data
   ///
@@ -77,32 +81,38 @@ final class IanaParserExtended implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_IanaParserExtended_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_IanaParserExtended_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_IanaParserExtended_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_IanaParserExtended_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_IanaParserExtended_create_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_IanaParserExtended_create_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_IanaParserExtended_create_mv1();
 
-@_DiplomatFfiUse('icu4x_IanaParserExtended_create_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_IanaParserExtended_create_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_IanaParserExtended_create_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_IanaParserExtended_parse_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_TimeZoneAndCanonicalAndNormalizedFfi Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8)>(isLeaf: true, symbol: 'icu4x_IanaParserExtended_parse_mv1')
 // ignore: non_constant_identifier_names
 external _TimeZoneAndCanonicalAndNormalizedFfi _icu4x_IanaParserExtended_parse_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUtf8 value);
 
-@_DiplomatFfiUse('icu4x_IanaParserExtended_iter_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_IanaParserExtended_iter_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_IanaParserExtended_iter_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_IanaParserExtended_iter_all_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_IanaParserExtended_iter_all_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_IanaParserExtended_iter_all_mv1(ffi.Pointer<ffi.Opaque> self);

--- a/ffi/dart/lib/src/bindings/IndicConjunctBreak.g.dart
+++ b/ffi/dart/lib/src/bindings/IndicConjunctBreak.g.dart
@@ -72,32 +72,38 @@ enum IndicConjunctBreak {
 
 }
 
-@_DiplomatFfiUse('icu4x_IndicConjunctBreak_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_IndicConjunctBreak_for_char_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_IndicConjunctBreak_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_IndicConjunctBreak_long_name_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultSliceUtf8Void Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_IndicConjunctBreak_long_name_mv1')
 // ignore: non_constant_identifier_names
 external _ResultSliceUtf8Void _icu4x_IndicConjunctBreak_long_name_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_IndicConjunctBreak_short_name_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultSliceUtf8Void Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_IndicConjunctBreak_short_name_mv1')
 // ignore: non_constant_identifier_names
 external _ResultSliceUtf8Void _icu4x_IndicConjunctBreak_short_name_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_IndicConjunctBreak_to_integer_value_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint8 Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_IndicConjunctBreak_to_integer_value_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_IndicConjunctBreak_to_integer_value_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_IndicConjunctBreak_from_integer_value_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultInt32Void Function(ffi.Uint8)>(isLeaf: true, symbol: 'icu4x_IndicConjunctBreak_from_integer_value_mv1')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _icu4x_IndicConjunctBreak_from_integer_value_mv1(int other);
 
-@_DiplomatFfiUse('icu4x_IndicConjunctBreak_try_from_str_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultInt32Void Function(_SliceUtf8)>(isLeaf: true, symbol: 'icu4x_IndicConjunctBreak_try_from_str_mv1')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _icu4x_IndicConjunctBreak_try_from_str_mv1(_SliceUtf8 s);

--- a/ffi/dart/lib/src/bindings/IndicSyllabicCategory.g.dart
+++ b/ffi/dart/lib/src/bindings/IndicSyllabicCategory.g.dart
@@ -138,32 +138,38 @@ enum IndicSyllabicCategory {
 
 }
 
-@_DiplomatFfiUse('icu4x_IndicSyllabicCategory_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_IndicSyllabicCategory_for_char_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_IndicSyllabicCategory_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_IndicSyllabicCategory_long_name_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultSliceUtf8Void Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_IndicSyllabicCategory_long_name_mv1')
 // ignore: non_constant_identifier_names
 external _ResultSliceUtf8Void _icu4x_IndicSyllabicCategory_long_name_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_IndicSyllabicCategory_short_name_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultSliceUtf8Void Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_IndicSyllabicCategory_short_name_mv1')
 // ignore: non_constant_identifier_names
 external _ResultSliceUtf8Void _icu4x_IndicSyllabicCategory_short_name_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_IndicSyllabicCategory_to_integer_value_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint8 Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_IndicSyllabicCategory_to_integer_value_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_IndicSyllabicCategory_to_integer_value_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_IndicSyllabicCategory_from_integer_value_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultInt32Void Function(ffi.Uint8)>(isLeaf: true, symbol: 'icu4x_IndicSyllabicCategory_from_integer_value_mv1')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _icu4x_IndicSyllabicCategory_from_integer_value_mv1(int other);
 
-@_DiplomatFfiUse('icu4x_IndicSyllabicCategory_try_from_str_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultInt32Void Function(_SliceUtf8)>(isLeaf: true, symbol: 'icu4x_IndicSyllabicCategory_try_from_str_mv1')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _icu4x_IndicSyllabicCategory_try_from_str_mv1(_SliceUtf8 s);

--- a/ffi/dart/lib/src/bindings/IsoDate.g.dart
+++ b/ffi/dart/lib/src/bindings/IsoDate.g.dart
@@ -19,12 +19,16 @@ final class IsoDate implements ffi.Finalizable {
   // maintain borrow validity.
   IsoDate._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_IsoDate_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_IsoDate_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_IsoDate_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_IsoDate_destroy_mv1(IsoDate cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_IsoDate_destroy_mv1));
 
   /// Creates a new [IsoDate] from the specified date.
   ///
@@ -204,102 +208,122 @@ final class IsoDate implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_IsoDate_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_IsoDate_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_IsoDate_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_IsoDate_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_IsoDate_create_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Int32, ffi.Uint8, ffi.Uint8)>(isLeaf: true, symbol: 'icu4x_IsoDate_create_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_IsoDate_create_mv1(int year, int month, int day);
 
-@_DiplomatFfiUse('icu4x_IsoDate_from_rata_die_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Int64)>(isLeaf: true, symbol: 'icu4x_IsoDate_from_rata_die_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_IsoDate_from_rata_die_mv1(int rd);
 
-@_DiplomatFfiUse('icu4x_IsoDate_from_string_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(_SliceUtf8)>(isLeaf: true, symbol: 'icu4x_IsoDate_from_string_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_IsoDate_from_string_mv1(_SliceUtf8 v);
 
-@_DiplomatFfiUse('icu4x_IsoDate_to_calendar_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_IsoDate_to_calendar_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_IsoDate_to_calendar_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> calendar);
 
-@_DiplomatFfiUse('icu4x_IsoDate_to_any_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_IsoDate_to_any_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_IsoDate_to_any_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_IsoDate_to_rata_die_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int64 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_IsoDate_to_rata_die_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_IsoDate_to_rata_die_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_IsoDate_day_of_year_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint16 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_IsoDate_day_of_year_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_IsoDate_day_of_year_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_IsoDate_day_of_month_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint8 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_IsoDate_day_of_month_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_IsoDate_day_of_month_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_IsoDate_day_of_week_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_IsoDate_day_of_week_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_IsoDate_day_of_week_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_IsoDate_weekday_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_IsoDate_weekday_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_IsoDate_weekday_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_IsoDate_week_of_year_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_IsoWeekOfYearFfi Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_IsoDate_week_of_year_mv1')
 // ignore: non_constant_identifier_names
 external _IsoWeekOfYearFfi _icu4x_IsoDate_week_of_year_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_IsoDate_month_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint8 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_IsoDate_month_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_IsoDate_month_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_IsoDate_year_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_IsoDate_year_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_IsoDate_year_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_IsoDate_is_in_leap_year_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_IsoDate_is_in_leap_year_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_IsoDate_is_in_leap_year_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_IsoDate_months_in_year_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint8 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_IsoDate_months_in_year_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_IsoDate_months_in_year_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_IsoDate_days_in_month_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint8 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_IsoDate_days_in_month_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_IsoDate_days_in_month_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_IsoDate_days_in_year_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint16 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_IsoDate_days_in_year_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_IsoDate_days_in_year_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_IsoDate_try_add_with_options_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _DateDurationFfi, _DateAddOptionsFfi)>(isLeaf: true, symbol: 'icu4x_IsoDate_try_add_with_options_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_IsoDate_try_add_with_options_mv1(ffi.Pointer<ffi.Opaque> self, _DateDurationFfi duration, _DateAddOptionsFfi options);
 
-@_DiplomatFfiUse('icu4x_IsoDate_until_with_options_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_DateDurationFfi Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _DateDifferenceOptionsFfi)>(isLeaf: true, symbol: 'icu4x_IsoDate_until_with_options_mv1')
 // ignore: non_constant_identifier_names
 external _DateDurationFfi _icu4x_IsoDate_until_with_options_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> other, _DateDifferenceOptionsFfi options);

--- a/ffi/dart/lib/src/bindings/IsoDateTime.g.dart
+++ b/ffi/dart/lib/src/bindings/IsoDateTime.g.dart
@@ -63,7 +63,8 @@ final class IsoDateTime {
       ]);
 }
 
-@_DiplomatFfiUse('icu4x_IsoDateTime_from_string_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultIsoDateTimeFfiInt32 Function(_SliceUtf8)>(isLeaf: true, symbol: 'icu4x_IsoDateTime_from_string_mv1')
 // ignore: non_constant_identifier_names
 external _ResultIsoDateTimeFfiInt32 _icu4x_IsoDateTime_from_string_mv1(_SliceUtf8 v);

--- a/ffi/dart/lib/src/bindings/JoiningGroup.g.dart
+++ b/ffi/dart/lib/src/bindings/JoiningGroup.g.dart
@@ -276,32 +276,38 @@ enum JoiningGroup {
 
 }
 
-@_DiplomatFfiUse('icu4x_JoiningGroup_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_JoiningGroup_for_char_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_JoiningGroup_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_JoiningGroup_long_name_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultSliceUtf8Void Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_JoiningGroup_long_name_mv1')
 // ignore: non_constant_identifier_names
 external _ResultSliceUtf8Void _icu4x_JoiningGroup_long_name_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_JoiningGroup_short_name_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultSliceUtf8Void Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_JoiningGroup_short_name_mv1')
 // ignore: non_constant_identifier_names
 external _ResultSliceUtf8Void _icu4x_JoiningGroup_short_name_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_JoiningGroup_to_integer_value_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint8 Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_JoiningGroup_to_integer_value_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_JoiningGroup_to_integer_value_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_JoiningGroup_from_integer_value_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultInt32Void Function(ffi.Uint8)>(isLeaf: true, symbol: 'icu4x_JoiningGroup_from_integer_value_mv1')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _icu4x_JoiningGroup_from_integer_value_mv1(int other);
 
-@_DiplomatFfiUse('icu4x_JoiningGroup_try_from_str_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultInt32Void Function(_SliceUtf8)>(isLeaf: true, symbol: 'icu4x_JoiningGroup_try_from_str_mv1')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _icu4x_JoiningGroup_try_from_str_mv1(_SliceUtf8 s);

--- a/ffi/dart/lib/src/bindings/JoiningType.g.dart
+++ b/ffi/dart/lib/src/bindings/JoiningType.g.dart
@@ -76,32 +76,38 @@ enum JoiningType {
 
 }
 
-@_DiplomatFfiUse('icu4x_JoiningType_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_JoiningType_for_char_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_JoiningType_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_JoiningType_long_name_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultSliceUtf8Void Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_JoiningType_long_name_mv1')
 // ignore: non_constant_identifier_names
 external _ResultSliceUtf8Void _icu4x_JoiningType_long_name_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_JoiningType_short_name_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultSliceUtf8Void Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_JoiningType_short_name_mv1')
 // ignore: non_constant_identifier_names
 external _ResultSliceUtf8Void _icu4x_JoiningType_short_name_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_JoiningType_to_integer_value_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint8 Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_JoiningType_to_integer_value_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_JoiningType_to_integer_value_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_JoiningType_from_integer_value_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultInt32Void Function(ffi.Uint8)>(isLeaf: true, symbol: 'icu4x_JoiningType_from_integer_value_mv1')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _icu4x_JoiningType_from_integer_value_mv1(int other);
 
-@_DiplomatFfiUse('icu4x_JoiningType_try_from_str_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultInt32Void Function(_SliceUtf8)>(isLeaf: true, symbol: 'icu4x_JoiningType_try_from_str_mv1')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _icu4x_JoiningType_try_from_str_mv1(_SliceUtf8 s);

--- a/ffi/dart/lib/src/bindings/LineBreak.g.dart
+++ b/ffi/dart/lib/src/bindings/LineBreak.g.dart
@@ -162,32 +162,38 @@ enum LineBreak {
 
 }
 
-@_DiplomatFfiUse('icu4x_LineBreak_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_LineBreak_for_char_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_LineBreak_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_LineBreak_long_name_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultSliceUtf8Void Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_LineBreak_long_name_mv1')
 // ignore: non_constant_identifier_names
 external _ResultSliceUtf8Void _icu4x_LineBreak_long_name_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_LineBreak_short_name_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultSliceUtf8Void Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_LineBreak_short_name_mv1')
 // ignore: non_constant_identifier_names
 external _ResultSliceUtf8Void _icu4x_LineBreak_short_name_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_LineBreak_to_integer_value_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint8 Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_LineBreak_to_integer_value_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_LineBreak_to_integer_value_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_LineBreak_from_integer_value_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultInt32Void Function(ffi.Uint8)>(isLeaf: true, symbol: 'icu4x_LineBreak_from_integer_value_mv1')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _icu4x_LineBreak_from_integer_value_mv1(int other);
 
-@_DiplomatFfiUse('icu4x_LineBreak_try_from_str_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultInt32Void Function(_SliceUtf8)>(isLeaf: true, symbol: 'icu4x_LineBreak_try_from_str_mv1')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _icu4x_LineBreak_try_from_str_mv1(_SliceUtf8 s);

--- a/ffi/dart/lib/src/bindings/LineBreakIteratorLatin1.g.dart
+++ b/ffi/dart/lib/src/bindings/LineBreakIteratorLatin1.g.dart
@@ -19,12 +19,16 @@ final class LineBreakIteratorLatin1 implements ffi.Finalizable {
   // maintain borrow validity.
   LineBreakIteratorLatin1._fromFfi(this._ffi, this._selfEdge, this._aEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_LineBreakIteratorLatin1_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_LineBreakIteratorLatin1_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_LineBreakIteratorLatin1_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_LineBreakIteratorLatin1_destroy_mv1(LineBreakIteratorLatin1 cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_LineBreakIteratorLatin1_destroy_mv1));
 
   /// Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
   /// out of range of a 32-bit signed integer.
@@ -37,12 +41,14 @@ final class LineBreakIteratorLatin1 implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_LineBreakIteratorLatin1_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_LineBreakIteratorLatin1_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_LineBreakIteratorLatin1_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_LineBreakIteratorLatin1_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_LineBreakIteratorLatin1_next_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_LineBreakIteratorLatin1_next_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_LineBreakIteratorLatin1_next_mv1(ffi.Pointer<ffi.Opaque> self);

--- a/ffi/dart/lib/src/bindings/LineBreakIteratorUtf16.g.dart
+++ b/ffi/dart/lib/src/bindings/LineBreakIteratorUtf16.g.dart
@@ -19,12 +19,16 @@ final class LineBreakIteratorUtf16 implements ffi.Finalizable {
   // maintain borrow validity.
   LineBreakIteratorUtf16._fromFfi(this._ffi, this._selfEdge, this._aEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_LineBreakIteratorUtf16_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_LineBreakIteratorUtf16_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_LineBreakIteratorUtf16_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_LineBreakIteratorUtf16_destroy_mv1(LineBreakIteratorUtf16 cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_LineBreakIteratorUtf16_destroy_mv1));
 
   /// Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
   /// out of range of a 32-bit signed integer.
@@ -37,12 +41,14 @@ final class LineBreakIteratorUtf16 implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_LineBreakIteratorUtf16_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_LineBreakIteratorUtf16_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_LineBreakIteratorUtf16_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_LineBreakIteratorUtf16_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_LineBreakIteratorUtf16_next_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_LineBreakIteratorUtf16_next_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_LineBreakIteratorUtf16_next_mv1(ffi.Pointer<ffi.Opaque> self);

--- a/ffi/dart/lib/src/bindings/LineBreakIteratorUtf8.g.dart
+++ b/ffi/dart/lib/src/bindings/LineBreakIteratorUtf8.g.dart
@@ -19,12 +19,16 @@ final class LineBreakIteratorUtf8 implements ffi.Finalizable {
   // maintain borrow validity.
   LineBreakIteratorUtf8._fromFfi(this._ffi, this._selfEdge, this._aEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_LineBreakIteratorUtf8_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_LineBreakIteratorUtf8_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_LineBreakIteratorUtf8_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_LineBreakIteratorUtf8_destroy_mv1(LineBreakIteratorUtf8 cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_LineBreakIteratorUtf8_destroy_mv1));
 
   /// Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
   /// out of range of a 32-bit signed integer.
@@ -37,12 +41,14 @@ final class LineBreakIteratorUtf8 implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_LineBreakIteratorUtf8_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_LineBreakIteratorUtf8_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_LineBreakIteratorUtf8_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_LineBreakIteratorUtf8_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_LineBreakIteratorUtf8_next_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_LineBreakIteratorUtf8_next_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_LineBreakIteratorUtf8_next_mv1(ffi.Pointer<ffi.Opaque> self);

--- a/ffi/dart/lib/src/bindings/LineSegmenter.g.dart
+++ b/ffi/dart/lib/src/bindings/LineSegmenter.g.dart
@@ -19,12 +19,16 @@ final class LineSegmenter implements ffi.Finalizable {
   // maintain borrow validity.
   LineSegmenter._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_LineSegmenter_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_LineSegmenter_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_LineSegmenter_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_LineSegmenter_destroy_mv1(LineSegmenter cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_LineSegmenter_destroy_mv1));
 
   /// Construct a [LineSegmenter] with default options (no locale-based tailoring) using compiled data. It automatically loads the best
   /// available payload data for Burmese, Khmer, Lao, and Thai.
@@ -178,72 +182,86 @@ final class LineSegmenter implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_LineSegmenter_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_LineSegmenter_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_LineSegmenter_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_LineSegmenter_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_LineSegmenter_create_auto_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_LineSegmenter_create_auto_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_LineSegmenter_create_auto_mv1();
 
-@_DiplomatFfiUse('icu4x_LineSegmenter_create_lstm_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_LineSegmenter_create_lstm_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_LineSegmenter_create_lstm_mv1();
 
-@_DiplomatFfiUse('icu4x_LineSegmenter_create_dictionary_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_LineSegmenter_create_dictionary_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_LineSegmenter_create_dictionary_mv1();
 
-@_DiplomatFfiUse('icu4x_LineSegmenter_create_for_non_complex_scripts_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_LineSegmenter_create_for_non_complex_scripts_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_LineSegmenter_create_for_non_complex_scripts_mv1();
 
-@_DiplomatFfiUse('icu4x_LineSegmenter_create_auto_with_options_v2_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, _LineBreakOptionsFfi)>(isLeaf: true, symbol: 'icu4x_LineSegmenter_create_auto_with_options_v2_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_LineSegmenter_create_auto_with_options_v2_mv1(ffi.Pointer<ffi.Opaque> contentLocale, _LineBreakOptionsFfi options);
 
-@_DiplomatFfiUse('icu4x_LineSegmenter_create_auto_with_options_v2_and_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _LineBreakOptionsFfi)>(isLeaf: true, symbol: 'icu4x_LineSegmenter_create_auto_with_options_v2_and_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_LineSegmenter_create_auto_with_options_v2_and_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> contentLocale, _LineBreakOptionsFfi options);
 
-@_DiplomatFfiUse('icu4x_LineSegmenter_create_lstm_with_options_v2_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, _LineBreakOptionsFfi)>(isLeaf: true, symbol: 'icu4x_LineSegmenter_create_lstm_with_options_v2_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_LineSegmenter_create_lstm_with_options_v2_mv1(ffi.Pointer<ffi.Opaque> contentLocale, _LineBreakOptionsFfi options);
 
-@_DiplomatFfiUse('icu4x_LineSegmenter_create_lstm_with_options_v2_and_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _LineBreakOptionsFfi)>(isLeaf: true, symbol: 'icu4x_LineSegmenter_create_lstm_with_options_v2_and_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_LineSegmenter_create_lstm_with_options_v2_and_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> contentLocale, _LineBreakOptionsFfi options);
 
-@_DiplomatFfiUse('icu4x_LineSegmenter_create_dictionary_with_options_v2_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, _LineBreakOptionsFfi)>(isLeaf: true, symbol: 'icu4x_LineSegmenter_create_dictionary_with_options_v2_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_LineSegmenter_create_dictionary_with_options_v2_mv1(ffi.Pointer<ffi.Opaque> contentLocale, _LineBreakOptionsFfi options);
 
-@_DiplomatFfiUse('icu4x_LineSegmenter_create_dictionary_with_options_v2_and_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _LineBreakOptionsFfi)>(isLeaf: true, symbol: 'icu4x_LineSegmenter_create_dictionary_with_options_v2_and_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_LineSegmenter_create_dictionary_with_options_v2_and_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> contentLocale, _LineBreakOptionsFfi options);
 
-@_DiplomatFfiUse('icu4x_LineSegmenter_create_for_non_complex_scripts_with_options_v2_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, _LineBreakOptionsFfi)>(isLeaf: true, symbol: 'icu4x_LineSegmenter_create_for_non_complex_scripts_with_options_v2_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_LineSegmenter_create_for_non_complex_scripts_with_options_v2_mv1(ffi.Pointer<ffi.Opaque> contentLocale, _LineBreakOptionsFfi options);
 
-@_DiplomatFfiUse('icu4x_LineSegmenter_create_for_non_complex_scripts_with_options_v2_and_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _LineBreakOptionsFfi)>(isLeaf: true, symbol: 'icu4x_LineSegmenter_create_for_non_complex_scripts_with_options_v2_and_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_LineSegmenter_create_for_non_complex_scripts_with_options_v2_and_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> contentLocale, _LineBreakOptionsFfi options);
 
-@_DiplomatFfiUse('icu4x_LineSegmenter_segment_utf16_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, _SliceUtf16)>(isLeaf: true, symbol: 'icu4x_LineSegmenter_segment_utf16_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_LineSegmenter_segment_utf16_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUtf16 input);

--- a/ffi/dart/lib/src/bindings/ListFormatter.g.dart
+++ b/ffi/dart/lib/src/bindings/ListFormatter.g.dart
@@ -17,12 +17,16 @@ final class ListFormatter implements ffi.Finalizable {
   // maintain borrow validity.
   ListFormatter._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_ListFormatter_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_ListFormatter_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_ListFormatter_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_ListFormatter_destroy_mv1(ListFormatter cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_ListFormatter_destroy_mv1));
 
   /// Construct a new `ListFormatter` instance for And patterns from compiled data.
   ///
@@ -112,42 +116,50 @@ final class ListFormatter implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_ListFormatter_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_ListFormatter_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_ListFormatter_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_ListFormatter_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_ListFormatter_create_and_with_length_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Int32)>(isLeaf: true, symbol: 'icu4x_ListFormatter_create_and_with_length_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ListFormatter_create_and_with_length_mv1(ffi.Pointer<ffi.Opaque> locale, int length);
 
-@_DiplomatFfiUse('icu4x_ListFormatter_create_and_with_length_and_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Int32)>(isLeaf: true, symbol: 'icu4x_ListFormatter_create_and_with_length_and_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ListFormatter_create_and_with_length_and_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, int length);
 
-@_DiplomatFfiUse('icu4x_ListFormatter_create_or_with_length_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Int32)>(isLeaf: true, symbol: 'icu4x_ListFormatter_create_or_with_length_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ListFormatter_create_or_with_length_mv1(ffi.Pointer<ffi.Opaque> locale, int length);
 
-@_DiplomatFfiUse('icu4x_ListFormatter_create_or_with_length_and_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Int32)>(isLeaf: true, symbol: 'icu4x_ListFormatter_create_or_with_length_and_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ListFormatter_create_or_with_length_and_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, int length);
 
-@_DiplomatFfiUse('icu4x_ListFormatter_create_unit_with_length_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Int32)>(isLeaf: true, symbol: 'icu4x_ListFormatter_create_unit_with_length_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ListFormatter_create_unit_with_length_mv1(ffi.Pointer<ffi.Opaque> locale, int length);
 
-@_DiplomatFfiUse('icu4x_ListFormatter_create_unit_with_length_and_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Int32)>(isLeaf: true, symbol: 'icu4x_ListFormatter_create_unit_with_length_and_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ListFormatter_create_unit_with_length_and_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, int length);
 
-@_DiplomatFfiUse('icu4x_ListFormatter_format_utf16_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, _SliceSliceUtf16, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ListFormatter_format_utf16_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_ListFormatter_format_utf16_mv1(ffi.Pointer<ffi.Opaque> self, _SliceSliceUtf16 list, ffi.Pointer<ffi.Opaque> write);

--- a/ffi/dart/lib/src/bindings/Locale.g.dart
+++ b/ffi/dart/lib/src/bindings/Locale.g.dart
@@ -19,12 +19,16 @@ final class Locale implements ffi.Finalizable, core.Comparable<Locale> {
   // maintain borrow validity.
   Locale._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_Locale_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_Locale_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_Locale_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_Locale_destroy_mv1(Locale cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_Locale_destroy_mv1));
 
   /// Construct an [Locale] from an locale identifier.
   ///
@@ -291,127 +295,152 @@ final class Locale implements ffi.Finalizable, core.Comparable<Locale> {
   int get hashCode => 42; // Cannot get hash from Rust, so a constant is the only correct impl
 }
 
-@_DiplomatFfiUse('icu4x_Locale_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_Locale_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_Locale_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_Locale_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_Locale_from_string_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(_SliceUtf8)>(isLeaf: true, symbol: 'icu4x_Locale_from_string_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_Locale_from_string_mv1(_SliceUtf8 name);
 
-@_DiplomatFfiUse('icu4x_Locale_unknown_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_Locale_unknown_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_Locale_unknown_mv1();
 
-@_DiplomatFfiUse('icu4x_Locale_clone_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Locale_clone_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_Locale_clone_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_Locale_basename_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Locale_basename_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_Locale_basename_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> write);
 
-@_DiplomatFfiUse('icu4x_Locale_get_unicode_extension_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultVoidVoid Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Locale_get_unicode_extension_mv1')
 // ignore: non_constant_identifier_names
 external _ResultVoidVoid _icu4x_Locale_get_unicode_extension_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUtf8 s, ffi.Pointer<ffi.Opaque> write);
 
-@_DiplomatFfiUse('icu4x_Locale_set_unicode_extension_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultVoidVoid Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8, _SliceUtf8)>(isLeaf: true, symbol: 'icu4x_Locale_set_unicode_extension_mv1')
 // ignore: non_constant_identifier_names
 external _ResultVoidVoid _icu4x_Locale_set_unicode_extension_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUtf8 k, _SliceUtf8 v);
 
-@_DiplomatFfiUse('icu4x_Locale_language_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Locale_language_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_Locale_language_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> write);
 
-@_DiplomatFfiUse('icu4x_Locale_set_language_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultVoidInt32 Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8)>(isLeaf: true, symbol: 'icu4x_Locale_set_language_mv1')
 // ignore: non_constant_identifier_names
 external _ResultVoidInt32 _icu4x_Locale_set_language_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUtf8 s);
 
-@_DiplomatFfiUse('icu4x_Locale_region_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultVoidVoid Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Locale_region_mv1')
 // ignore: non_constant_identifier_names
 external _ResultVoidVoid _icu4x_Locale_region_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> write);
 
-@_DiplomatFfiUse('icu4x_Locale_set_region_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultVoidInt32 Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8)>(isLeaf: true, symbol: 'icu4x_Locale_set_region_mv1')
 // ignore: non_constant_identifier_names
 external _ResultVoidInt32 _icu4x_Locale_set_region_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUtf8 s);
 
-@_DiplomatFfiUse('icu4x_Locale_script_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultVoidVoid Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Locale_script_mv1')
 // ignore: non_constant_identifier_names
 external _ResultVoidVoid _icu4x_Locale_script_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> write);
 
-@_DiplomatFfiUse('icu4x_Locale_set_script_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultVoidInt32 Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8)>(isLeaf: true, symbol: 'icu4x_Locale_set_script_mv1')
 // ignore: non_constant_identifier_names
 external _ResultVoidInt32 _icu4x_Locale_set_script_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUtf8 s);
 
-@_DiplomatFfiUse('icu4x_Locale_variants_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Locale_variants_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_Locale_variants_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> write);
 
-@_DiplomatFfiUse('icu4x_Locale_variant_count_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Size Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Locale_variant_count_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_Locale_variant_count_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_Locale_variant_at_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultVoidVoid Function(ffi.Pointer<ffi.Opaque>, ffi.Size, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Locale_variant_at_mv1')
 // ignore: non_constant_identifier_names
 external _ResultVoidVoid _icu4x_Locale_variant_at_mv1(ffi.Pointer<ffi.Opaque> self, int index, ffi.Pointer<ffi.Opaque> write);
 
-@_DiplomatFfiUse('icu4x_Locale_has_variant_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8)>(isLeaf: true, symbol: 'icu4x_Locale_has_variant_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_Locale_has_variant_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUtf8 s);
 
-@_DiplomatFfiUse('icu4x_Locale_add_variant_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultBoolInt32 Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8)>(isLeaf: true, symbol: 'icu4x_Locale_add_variant_mv1')
 // ignore: non_constant_identifier_names
 external _ResultBoolInt32 _icu4x_Locale_add_variant_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUtf8 s);
 
-@_DiplomatFfiUse('icu4x_Locale_remove_variant_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8)>(isLeaf: true, symbol: 'icu4x_Locale_remove_variant_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_Locale_remove_variant_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUtf8 s);
 
-@_DiplomatFfiUse('icu4x_Locale_clear_variants_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Locale_clear_variants_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_Locale_clear_variants_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_Locale_normalize_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultVoidInt32 Function(_SliceUtf8, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Locale_normalize_mv1')
 // ignore: non_constant_identifier_names
 external _ResultVoidInt32 _icu4x_Locale_normalize_mv1(_SliceUtf8 s, ffi.Pointer<ffi.Opaque> write);
 
-@_DiplomatFfiUse('icu4x_Locale_to_string_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Locale_to_string_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_Locale_to_string_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> write);
 
-@_DiplomatFfiUse('icu4x_Locale_normalizing_eq_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8)>(isLeaf: true, symbol: 'icu4x_Locale_normalizing_eq_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_Locale_normalizing_eq_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUtf8 other);
 
-@_DiplomatFfiUse('icu4x_Locale_compare_to_string_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int8 Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8)>(isLeaf: true, symbol: 'icu4x_Locale_compare_to_string_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_Locale_compare_to_string_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUtf8 other);
 
-@_DiplomatFfiUse('icu4x_Locale_compare_to_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int8 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Locale_compare_to_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_Locale_compare_to_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> other);

--- a/ffi/dart/lib/src/bindings/LocaleCanonicalizer.g.dart
+++ b/ffi/dart/lib/src/bindings/LocaleCanonicalizer.g.dart
@@ -19,12 +19,16 @@ final class LocaleCanonicalizer implements ffi.Finalizable {
   // maintain borrow validity.
   LocaleCanonicalizer._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_LocaleCanonicalizer_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_LocaleCanonicalizer_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_LocaleCanonicalizer_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_LocaleCanonicalizer_destroy_mv1(LocaleCanonicalizer cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_LocaleCanonicalizer_destroy_mv1));
 
   /// Create a new [LocaleCanonicalizer] using compiled data.
   ///
@@ -76,32 +80,38 @@ final class LocaleCanonicalizer implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_LocaleCanonicalizer_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_LocaleCanonicalizer_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_LocaleCanonicalizer_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_LocaleCanonicalizer_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_LocaleCanonicalizer_create_common_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_LocaleCanonicalizer_create_common_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_LocaleCanonicalizer_create_common_mv1();
 
-@_DiplomatFfiUse('icu4x_LocaleCanonicalizer_create_common_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_LocaleCanonicalizer_create_common_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_LocaleCanonicalizer_create_common_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_LocaleCanonicalizer_create_extended_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_LocaleCanonicalizer_create_extended_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_LocaleCanonicalizer_create_extended_mv1();
 
-@_DiplomatFfiUse('icu4x_LocaleCanonicalizer_create_extended_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_LocaleCanonicalizer_create_extended_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_LocaleCanonicalizer_create_extended_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_LocaleCanonicalizer_canonicalize_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_LocaleCanonicalizer_canonicalize_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_LocaleCanonicalizer_canonicalize_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> locale);

--- a/ffi/dart/lib/src/bindings/LocaleDirectionality.g.dart
+++ b/ffi/dart/lib/src/bindings/LocaleDirectionality.g.dart
@@ -17,12 +17,16 @@ final class LocaleDirectionality implements ffi.Finalizable {
   // maintain borrow validity.
   LocaleDirectionality._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_LocaleDirectionality_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_LocaleDirectionality_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_LocaleDirectionality_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_LocaleDirectionality_destroy_mv1(LocaleDirectionality cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_LocaleDirectionality_destroy_mv1));
 
   /// Construct a new `LocaleDirectionality` instance using compiled data.
   ///
@@ -86,42 +90,50 @@ final class LocaleDirectionality implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_LocaleDirectionality_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_LocaleDirectionality_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_LocaleDirectionality_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_LocaleDirectionality_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_LocaleDirectionality_create_common_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_LocaleDirectionality_create_common_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_LocaleDirectionality_create_common_mv1();
 
-@_DiplomatFfiUse('icu4x_LocaleDirectionality_create_common_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_LocaleDirectionality_create_common_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_LocaleDirectionality_create_common_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_LocaleDirectionality_create_extended_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_LocaleDirectionality_create_extended_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_LocaleDirectionality_create_extended_mv1();
 
-@_DiplomatFfiUse('icu4x_LocaleDirectionality_create_extended_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_LocaleDirectionality_create_extended_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_LocaleDirectionality_create_extended_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_LocaleDirectionality_get_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_LocaleDirectionality_get_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_LocaleDirectionality_get_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_LocaleDirectionality_is_left_to_right_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_LocaleDirectionality_is_left_to_right_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_LocaleDirectionality_is_left_to_right_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_LocaleDirectionality_is_right_to_left_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_LocaleDirectionality_is_right_to_left_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_LocaleDirectionality_is_right_to_left_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> locale);

--- a/ffi/dart/lib/src/bindings/LocaleDisplayNamesFormatter.g.dart
+++ b/ffi/dart/lib/src/bindings/LocaleDisplayNamesFormatter.g.dart
@@ -19,12 +19,16 @@ final class LocaleDisplayNamesFormatter implements ffi.Finalizable {
   // maintain borrow validity.
   LocaleDisplayNamesFormatter._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_LocaleDisplayNamesFormatter_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_LocaleDisplayNamesFormatter_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_LocaleDisplayNamesFormatter_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_LocaleDisplayNamesFormatter_destroy_mv1(LocaleDisplayNamesFormatter cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_LocaleDisplayNamesFormatter_destroy_mv1));
 
   /// 🚧 This API is unstable and may experience breaking changes outside major releases.
   ///
@@ -72,22 +76,26 @@ final class LocaleDisplayNamesFormatter implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_LocaleDisplayNamesFormatter_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_LocaleDisplayNamesFormatter_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_LocaleDisplayNamesFormatter_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_LocaleDisplayNamesFormatter_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_LocaleDisplayNamesFormatter_create_v1_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _DisplayNamesOptionsFfi)>(isLeaf: true, symbol: 'icu4x_LocaleDisplayNamesFormatter_create_v1_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_LocaleDisplayNamesFormatter_create_v1_mv1(ffi.Pointer<ffi.Opaque> locale, _DisplayNamesOptionsFfi options);
 
-@_DiplomatFfiUse('icu4x_LocaleDisplayNamesFormatter_create_v1_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _DisplayNamesOptionsFfi)>(isLeaf: true, symbol: 'icu4x_LocaleDisplayNamesFormatter_create_v1_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_LocaleDisplayNamesFormatter_create_v1_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _DisplayNamesOptionsFfi options);
 
-@_DiplomatFfiUse('icu4x_LocaleDisplayNamesFormatter_of_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_LocaleDisplayNamesFormatter_of_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_LocaleDisplayNamesFormatter_of_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> write);

--- a/ffi/dart/lib/src/bindings/LocaleExpander.g.dart
+++ b/ffi/dart/lib/src/bindings/LocaleExpander.g.dart
@@ -19,12 +19,16 @@ final class LocaleExpander implements ffi.Finalizable {
   // maintain borrow validity.
   LocaleExpander._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_LocaleExpander_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_LocaleExpander_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_LocaleExpander_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_LocaleExpander_destroy_mv1(LocaleExpander cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_LocaleExpander_destroy_mv1));
 
   /// Create a new [LocaleExpander] using compiled data.
   ///
@@ -88,42 +92,50 @@ final class LocaleExpander implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_LocaleExpander_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_LocaleExpander_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_LocaleExpander_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_LocaleExpander_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_LocaleExpander_create_common_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_LocaleExpander_create_common_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_LocaleExpander_create_common_mv1();
 
-@_DiplomatFfiUse('icu4x_LocaleExpander_create_common_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_LocaleExpander_create_common_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_LocaleExpander_create_common_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_LocaleExpander_create_extended_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_LocaleExpander_create_extended_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_LocaleExpander_create_extended_mv1();
 
-@_DiplomatFfiUse('icu4x_LocaleExpander_create_extended_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_LocaleExpander_create_extended_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_LocaleExpander_create_extended_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_LocaleExpander_maximize_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_LocaleExpander_maximize_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_LocaleExpander_maximize_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_LocaleExpander_minimize_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_LocaleExpander_minimize_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_LocaleExpander_minimize_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_LocaleExpander_minimize_favor_script_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_LocaleExpander_minimize_favor_script_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_LocaleExpander_minimize_favor_script_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> locale);

--- a/ffi/dart/lib/src/bindings/LocaleFallbackIterator.g.dart
+++ b/ffi/dart/lib/src/bindings/LocaleFallbackIterator.g.dart
@@ -21,12 +21,16 @@ final class LocaleFallbackIterator implements ffi.Finalizable, core.Iterator<Loc
   // maintain borrow validity.
   LocaleFallbackIterator._fromFfi(this._ffi, this._selfEdge, this._aEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_LocaleFallbackIterator_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_LocaleFallbackIterator_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_LocaleFallbackIterator_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_LocaleFallbackIterator_destroy_mv1(LocaleFallbackIterator cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_LocaleFallbackIterator_destroy_mv1));
 
   Locale? _current;
 
@@ -46,12 +50,14 @@ final class LocaleFallbackIterator implements ffi.Finalizable, core.Iterator<Loc
 
 }
 
-@_DiplomatFfiUse('icu4x_LocaleFallbackIterator_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_LocaleFallbackIterator_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_LocaleFallbackIterator_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_LocaleFallbackIterator_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_LocaleFallbackIterator_next_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_LocaleFallbackIterator_next_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_LocaleFallbackIterator_next_mv1(ffi.Pointer<ffi.Opaque> self);

--- a/ffi/dart/lib/src/bindings/LocaleFallbacker.g.dart
+++ b/ffi/dart/lib/src/bindings/LocaleFallbacker.g.dart
@@ -19,12 +19,16 @@ final class LocaleFallbacker implements ffi.Finalizable {
   // maintain borrow validity.
   LocaleFallbacker._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_LocaleFallbacker_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_LocaleFallbacker_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_LocaleFallbacker_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_LocaleFallbacker_destroy_mv1(LocaleFallbacker cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_LocaleFallbacker_destroy_mv1));
 
   /// Creates a new `LocaleFallbacker` from compiled data.
   ///
@@ -68,27 +72,32 @@ final class LocaleFallbacker implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_LocaleFallbacker_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_LocaleFallbacker_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_LocaleFallbacker_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_LocaleFallbacker_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_LocaleFallbacker_create_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_LocaleFallbacker_create_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_LocaleFallbacker_create_mv1();
 
-@_DiplomatFfiUse('icu4x_LocaleFallbacker_create_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_LocaleFallbacker_create_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_LocaleFallbacker_create_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_LocaleFallbacker_without_data_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_LocaleFallbacker_without_data_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_LocaleFallbacker_without_data_mv1();
 
-@_DiplomatFfiUse('icu4x_LocaleFallbacker_for_config_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, _LocaleFallbackConfigFfi)>(isLeaf: true, symbol: 'icu4x_LocaleFallbacker_for_config_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_LocaleFallbacker_for_config_mv1(ffi.Pointer<ffi.Opaque> self, _LocaleFallbackConfigFfi config);

--- a/ffi/dart/lib/src/bindings/LocaleFallbackerWithConfig.g.dart
+++ b/ffi/dart/lib/src/bindings/LocaleFallbackerWithConfig.g.dart
@@ -23,12 +23,16 @@ final class LocaleFallbackerWithConfig implements ffi.Finalizable {
   // maintain borrow validity.
   LocaleFallbackerWithConfig._fromFfi(this._ffi, this._selfEdge, this._aEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_LocaleFallbackerWithConfig_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_LocaleFallbackerWithConfig_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_LocaleFallbackerWithConfig_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_LocaleFallbackerWithConfig_destroy_mv1(LocaleFallbackerWithConfig cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_LocaleFallbackerWithConfig_destroy_mv1));
 
   /// Creates an iterator from a locale with each step of fallback.
   ///
@@ -42,12 +46,14 @@ final class LocaleFallbackerWithConfig implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_LocaleFallbackerWithConfig_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_LocaleFallbackerWithConfig_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_LocaleFallbackerWithConfig_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_LocaleFallbackerWithConfig_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_LocaleFallbackerWithConfig_fallback_for_locale_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_LocaleFallbackerWithConfig_fallback_for_locale_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_LocaleFallbackerWithConfig_fallback_for_locale_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> locale);

--- a/ffi/dart/lib/src/bindings/Logger.g.dart
+++ b/ffi/dart/lib/src/bindings/Logger.g.dart
@@ -17,12 +17,16 @@ final class Logger implements ffi.Finalizable {
   // maintain borrow validity.
   Logger._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_Logger_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_Logger_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_Logger_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_Logger_destroy_mv1(Logger cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_Logger_destroy_mv1));
 
   /// Initialize the logger using `simple_logger`
   ///
@@ -36,12 +40,14 @@ final class Logger implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_Logger_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_Logger_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_Logger_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_Logger_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_Logger_init_simple_logger_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function()>(isLeaf: true, symbol: 'icu4x_Logger_init_simple_logger_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_Logger_init_simple_logger_mv1();

--- a/ffi/dart/lib/src/bindings/NumericType.g.dart
+++ b/ffi/dart/lib/src/bindings/NumericType.g.dart
@@ -72,32 +72,38 @@ enum NumericType {
 
 }
 
-@_DiplomatFfiUse('icu4x_NumericType_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_NumericType_for_char_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_NumericType_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_NumericType_long_name_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultSliceUtf8Void Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_NumericType_long_name_mv1')
 // ignore: non_constant_identifier_names
 external _ResultSliceUtf8Void _icu4x_NumericType_long_name_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_NumericType_short_name_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultSliceUtf8Void Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_NumericType_short_name_mv1')
 // ignore: non_constant_identifier_names
 external _ResultSliceUtf8Void _icu4x_NumericType_short_name_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_NumericType_to_integer_value_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint8 Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_NumericType_to_integer_value_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_NumericType_to_integer_value_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_NumericType_from_integer_value_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultInt32Void Function(ffi.Uint8)>(isLeaf: true, symbol: 'icu4x_NumericType_from_integer_value_mv1')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _icu4x_NumericType_from_integer_value_mv1(int other);
 
-@_DiplomatFfiUse('icu4x_NumericType_try_from_str_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultInt32Void Function(_SliceUtf8)>(isLeaf: true, symbol: 'icu4x_NumericType_try_from_str_mv1')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _icu4x_NumericType_try_from_str_mv1(_SliceUtf8 s);

--- a/ffi/dart/lib/src/bindings/PluralCategory.g.dart
+++ b/ffi/dart/lib/src/bindings/PluralCategory.g.dart
@@ -35,7 +35,8 @@ enum PluralCategory {
 
 }
 
-@_DiplomatFfiUse('icu4x_PluralCategory_get_for_cldr_string_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultInt32Void Function(_SliceUtf8)>(isLeaf: true, symbol: 'icu4x_PluralCategory_get_for_cldr_string_mv1')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _icu4x_PluralCategory_get_for_cldr_string_mv1(_SliceUtf8 s);

--- a/ffi/dart/lib/src/bindings/PluralOperands.g.dart
+++ b/ffi/dart/lib/src/bindings/PluralOperands.g.dart
@@ -17,12 +17,16 @@ final class PluralOperands implements ffi.Finalizable {
   // maintain borrow validity.
   PluralOperands._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_PluralOperands_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_PluralOperands_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_PluralOperands_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_PluralOperands_destroy_mv1(PluralOperands cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_PluralOperands_destroy_mv1));
 
   /// Construct for a given string representing a number
   ///
@@ -54,22 +58,26 @@ final class PluralOperands implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_PluralOperands_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_PluralOperands_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_PluralOperands_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_PluralOperands_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_PluralOperands_from_string_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(_SliceUtf8)>(isLeaf: true, symbol: 'icu4x_PluralOperands_from_string_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_PluralOperands_from_string_mv1(_SliceUtf8 s);
 
-@_DiplomatFfiUse('icu4x_PluralOperands_from_int64_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Int64)>(isLeaf: true, symbol: 'icu4x_PluralOperands_from_int64_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_PluralOperands_from_int64_mv1(int i);
 
-@_DiplomatFfiUse('icu4x_PluralOperands_from_fixed_decimal_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_PluralOperands_from_fixed_decimal_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_PluralOperands_from_fixed_decimal_mv1(ffi.Pointer<ffi.Opaque> x);

--- a/ffi/dart/lib/src/bindings/PluralRules.g.dart
+++ b/ffi/dart/lib/src/bindings/PluralRules.g.dart
@@ -17,12 +17,16 @@ final class PluralRules implements ffi.Finalizable {
   // maintain borrow validity.
   PluralRules._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_PluralRules_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_PluralRules_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_PluralRules_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_PluralRules_destroy_mv1(PluralRules cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_PluralRules_destroy_mv1));
 
   /// Construct an [PluralRules] for the given locale, for cardinal numbers, using compiled data.
   ///
@@ -94,37 +98,44 @@ final class PluralRules implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_PluralRules_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_PluralRules_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_PluralRules_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_PluralRules_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_PluralRules_create_cardinal_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_PluralRules_create_cardinal_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_PluralRules_create_cardinal_mv1(ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_PluralRules_create_cardinal_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_PluralRules_create_cardinal_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_PluralRules_create_cardinal_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_PluralRules_create_ordinal_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_PluralRules_create_ordinal_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_PluralRules_create_ordinal_mv1(ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_PluralRules_create_ordinal_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_PluralRules_create_ordinal_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_PluralRules_create_ordinal_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_PluralRules_category_for_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_PluralRules_category_for_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_PluralRules_category_for_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> op);
 
-@_DiplomatFfiUse('icu4x_PluralRules_categories_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_PluralCategoriesFfi Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_PluralRules_categories_mv1')
 // ignore: non_constant_identifier_names
 external _PluralCategoriesFfi _icu4x_PluralRules_categories_mv1(ffi.Pointer<ffi.Opaque> self);

--- a/ffi/dart/lib/src/bindings/PluralRulesWithRanges.g.dart
+++ b/ffi/dart/lib/src/bindings/PluralRulesWithRanges.g.dart
@@ -17,12 +17,16 @@ final class PluralRulesWithRanges implements ffi.Finalizable {
   // maintain borrow validity.
   PluralRulesWithRanges._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_PluralRulesWithRanges_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_PluralRulesWithRanges_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_PluralRulesWithRanges_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_PluralRulesWithRanges_destroy_mv1(PluralRulesWithRanges cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_PluralRulesWithRanges_destroy_mv1));
 
   /// construct a [PluralRulesWithRanges] for the given locale, for cardinal numbers, using compiled data.
   ///
@@ -86,32 +90,38 @@ final class PluralRulesWithRanges implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_PluralRulesWithRanges_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_PluralRulesWithRanges_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_PluralRulesWithRanges_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_PluralRulesWithRanges_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_PluralRulesWithRanges_create_cardinal_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_PluralRulesWithRanges_create_cardinal_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_PluralRulesWithRanges_create_cardinal_mv1(ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_PluralRulesWithRanges_create_cardinal_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_PluralRulesWithRanges_create_cardinal_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_PluralRulesWithRanges_create_cardinal_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_PluralRulesWithRanges_create_ordinal_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_PluralRulesWithRanges_create_ordinal_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_PluralRulesWithRanges_create_ordinal_mv1(ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_PluralRulesWithRanges_create_ordinal_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_PluralRulesWithRanges_create_ordinal_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_PluralRulesWithRanges_create_ordinal_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_PluralRulesWithRanges_category_for_range_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_PluralRulesWithRanges_category_for_range_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_PluralRulesWithRanges_category_for_range_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> start, ffi.Pointer<ffi.Opaque> end);

--- a/ffi/dart/lib/src/bindings/PropertyValueNameToEnumMapper.g.dart
+++ b/ffi/dart/lib/src/bindings/PropertyValueNameToEnumMapper.g.dart
@@ -23,12 +23,16 @@ final class PropertyValueNameToEnumMapper implements ffi.Finalizable {
   // maintain borrow validity.
   PropertyValueNameToEnumMapper._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_PropertyValueNameToEnumMapper_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_PropertyValueNameToEnumMapper_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_PropertyValueNameToEnumMapper_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_PropertyValueNameToEnumMapper_destroy_mv1(PropertyValueNameToEnumMapper cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_PropertyValueNameToEnumMapper_destroy_mv1));
 
   /// Get the property value matching the given name, using strict matching
   ///
@@ -390,177 +394,212 @@ final class PropertyValueNameToEnumMapper implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_PropertyValueNameToEnumMapper_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_PropertyValueNameToEnumMapper_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_PropertyValueNameToEnumMapper_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_PropertyValueNameToEnumMapper_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_PropertyValueNameToEnumMapper_get_strict_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int16 Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8)>(isLeaf: true, symbol: 'icu4x_PropertyValueNameToEnumMapper_get_strict_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_PropertyValueNameToEnumMapper_get_strict_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUtf8 name);
 
-@_DiplomatFfiUse('icu4x_PropertyValueNameToEnumMapper_get_loose_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int16 Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8)>(isLeaf: true, symbol: 'icu4x_PropertyValueNameToEnumMapper_get_loose_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_PropertyValueNameToEnumMapper_get_loose_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUtf8 name);
 
-@_DiplomatFfiUse('icu4x_PropertyValueNameToEnumMapper_create_bidi_class_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_PropertyValueNameToEnumMapper_create_bidi_class_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_PropertyValueNameToEnumMapper_create_bidi_class_mv1();
 
-@_DiplomatFfiUse('icu4x_PropertyValueNameToEnumMapper_create_bidi_class_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_PropertyValueNameToEnumMapper_create_bidi_class_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_PropertyValueNameToEnumMapper_create_bidi_class_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_PropertyValueNameToEnumMapper_create_canonical_combining_class_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_PropertyValueNameToEnumMapper_create_canonical_combining_class_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_PropertyValueNameToEnumMapper_create_canonical_combining_class_mv1();
 
-@_DiplomatFfiUse('icu4x_PropertyValueNameToEnumMapper_create_canonical_combining_class_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_PropertyValueNameToEnumMapper_create_canonical_combining_class_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_PropertyValueNameToEnumMapper_create_canonical_combining_class_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_PropertyValueNameToEnumMapper_create_east_asian_width_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_PropertyValueNameToEnumMapper_create_east_asian_width_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_PropertyValueNameToEnumMapper_create_east_asian_width_mv1();
 
-@_DiplomatFfiUse('icu4x_PropertyValueNameToEnumMapper_create_east_asian_width_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_PropertyValueNameToEnumMapper_create_east_asian_width_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_PropertyValueNameToEnumMapper_create_east_asian_width_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_PropertyValueNameToEnumMapper_create_general_category_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_PropertyValueNameToEnumMapper_create_general_category_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_PropertyValueNameToEnumMapper_create_general_category_mv1();
 
-@_DiplomatFfiUse('icu4x_PropertyValueNameToEnumMapper_create_general_category_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_PropertyValueNameToEnumMapper_create_general_category_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_PropertyValueNameToEnumMapper_create_general_category_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_PropertyValueNameToEnumMapper_create_grapheme_cluster_break_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_PropertyValueNameToEnumMapper_create_grapheme_cluster_break_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_PropertyValueNameToEnumMapper_create_grapheme_cluster_break_mv1();
 
-@_DiplomatFfiUse('icu4x_PropertyValueNameToEnumMapper_create_grapheme_cluster_break_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_PropertyValueNameToEnumMapper_create_grapheme_cluster_break_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_PropertyValueNameToEnumMapper_create_grapheme_cluster_break_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_PropertyValueNameToEnumMapper_create_hangul_syllable_type_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_PropertyValueNameToEnumMapper_create_hangul_syllable_type_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_PropertyValueNameToEnumMapper_create_hangul_syllable_type_mv1();
 
-@_DiplomatFfiUse('icu4x_PropertyValueNameToEnumMapper_create_hangul_syllable_type_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_PropertyValueNameToEnumMapper_create_hangul_syllable_type_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_PropertyValueNameToEnumMapper_create_hangul_syllable_type_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_PropertyValueNameToEnumMapper_create_indic_conjunct_break_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_PropertyValueNameToEnumMapper_create_indic_conjunct_break_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_PropertyValueNameToEnumMapper_create_indic_conjunct_break_mv1();
 
-@_DiplomatFfiUse('icu4x_PropertyValueNameToEnumMapper_create_indic_conjunct_break_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_PropertyValueNameToEnumMapper_create_indic_conjunct_break_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_PropertyValueNameToEnumMapper_create_indic_conjunct_break_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_PropertyValueNameToEnumMapper_create_indic_syllabic_category_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_PropertyValueNameToEnumMapper_create_indic_syllabic_category_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_PropertyValueNameToEnumMapper_create_indic_syllabic_category_mv1();
 
-@_DiplomatFfiUse('icu4x_PropertyValueNameToEnumMapper_create_indic_syllabic_category_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_PropertyValueNameToEnumMapper_create_indic_syllabic_category_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_PropertyValueNameToEnumMapper_create_indic_syllabic_category_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_PropertyValueNameToEnumMapper_create_joining_group_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_PropertyValueNameToEnumMapper_create_joining_group_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_PropertyValueNameToEnumMapper_create_joining_group_mv1();
 
-@_DiplomatFfiUse('icu4x_PropertyValueNameToEnumMapper_create_joining_group_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_PropertyValueNameToEnumMapper_create_joining_group_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_PropertyValueNameToEnumMapper_create_joining_group_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_PropertyValueNameToEnumMapper_create_joining_type_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_PropertyValueNameToEnumMapper_create_joining_type_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_PropertyValueNameToEnumMapper_create_joining_type_mv1();
 
-@_DiplomatFfiUse('icu4x_PropertyValueNameToEnumMapper_create_joining_type_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_PropertyValueNameToEnumMapper_create_joining_type_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_PropertyValueNameToEnumMapper_create_joining_type_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_PropertyValueNameToEnumMapper_create_line_break_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_PropertyValueNameToEnumMapper_create_line_break_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_PropertyValueNameToEnumMapper_create_line_break_mv1();
 
-@_DiplomatFfiUse('icu4x_PropertyValueNameToEnumMapper_create_line_break_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_PropertyValueNameToEnumMapper_create_line_break_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_PropertyValueNameToEnumMapper_create_line_break_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_PropertyValueNameToEnumMapper_create_numeric_type_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_PropertyValueNameToEnumMapper_create_numeric_type_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_PropertyValueNameToEnumMapper_create_numeric_type_mv1();
 
-@_DiplomatFfiUse('icu4x_PropertyValueNameToEnumMapper_create_numeric_type_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_PropertyValueNameToEnumMapper_create_numeric_type_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_PropertyValueNameToEnumMapper_create_numeric_type_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_PropertyValueNameToEnumMapper_create_script_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_PropertyValueNameToEnumMapper_create_script_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_PropertyValueNameToEnumMapper_create_script_mv1();
 
-@_DiplomatFfiUse('icu4x_PropertyValueNameToEnumMapper_create_script_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_PropertyValueNameToEnumMapper_create_script_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_PropertyValueNameToEnumMapper_create_script_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_PropertyValueNameToEnumMapper_create_sentence_break_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_PropertyValueNameToEnumMapper_create_sentence_break_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_PropertyValueNameToEnumMapper_create_sentence_break_mv1();
 
-@_DiplomatFfiUse('icu4x_PropertyValueNameToEnumMapper_create_sentence_break_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_PropertyValueNameToEnumMapper_create_sentence_break_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_PropertyValueNameToEnumMapper_create_sentence_break_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_PropertyValueNameToEnumMapper_create_vertical_orientation_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_PropertyValueNameToEnumMapper_create_vertical_orientation_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_PropertyValueNameToEnumMapper_create_vertical_orientation_mv1();
 
-@_DiplomatFfiUse('icu4x_PropertyValueNameToEnumMapper_create_vertical_orientation_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_PropertyValueNameToEnumMapper_create_vertical_orientation_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_PropertyValueNameToEnumMapper_create_vertical_orientation_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_PropertyValueNameToEnumMapper_create_word_break_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_PropertyValueNameToEnumMapper_create_word_break_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_PropertyValueNameToEnumMapper_create_word_break_mv1();
 
-@_DiplomatFfiUse('icu4x_PropertyValueNameToEnumMapper_create_word_break_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_PropertyValueNameToEnumMapper_create_word_break_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_PropertyValueNameToEnumMapper_create_word_break_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);

--- a/ffi/dart/lib/src/bindings/RegionDisplayNames.g.dart
+++ b/ffi/dart/lib/src/bindings/RegionDisplayNames.g.dart
@@ -19,12 +19,16 @@ final class RegionDisplayNames implements ffi.Finalizable {
   // maintain borrow validity.
   RegionDisplayNames._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_RegionDisplayNames_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_RegionDisplayNames_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_RegionDisplayNames_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_RegionDisplayNames_destroy_mv1(RegionDisplayNames cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_RegionDisplayNames_destroy_mv1));
 
   /// 🚧 This API is unstable and may experience breaking changes outside major releases.
   ///
@@ -79,22 +83,26 @@ final class RegionDisplayNames implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_RegionDisplayNames_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_RegionDisplayNames_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_RegionDisplayNames_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_RegionDisplayNames_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_RegionDisplayNames_create_v1_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _DisplayNamesOptionsFfi)>(isLeaf: true, symbol: 'icu4x_RegionDisplayNames_create_v1_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_RegionDisplayNames_create_v1_mv1(ffi.Pointer<ffi.Opaque> locale, _DisplayNamesOptionsFfi options);
 
-@_DiplomatFfiUse('icu4x_RegionDisplayNames_create_v1_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _DisplayNamesOptionsFfi)>(isLeaf: true, symbol: 'icu4x_RegionDisplayNames_create_v1_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_RegionDisplayNames_create_v1_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _DisplayNamesOptionsFfi options);
 
-@_DiplomatFfiUse('icu4x_RegionDisplayNames_of_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultVoidInt32 Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_RegionDisplayNames_of_mv1')
 // ignore: non_constant_identifier_names
 external _ResultVoidInt32 _icu4x_RegionDisplayNames_of_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUtf8 region, ffi.Pointer<ffi.Opaque> write);

--- a/ffi/dart/lib/src/bindings/ReorderedIndexMap.g.dart
+++ b/ffi/dart/lib/src/bindings/ReorderedIndexMap.g.dart
@@ -21,12 +21,16 @@ final class ReorderedIndexMap implements ffi.Finalizable {
   // maintain borrow validity.
   ReorderedIndexMap._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_ReorderedIndexMap_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_ReorderedIndexMap_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_ReorderedIndexMap_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_ReorderedIndexMap_destroy_mv1(ReorderedIndexMap cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_ReorderedIndexMap_destroy_mv1));
 
   /// Get this as a slice/array of indices
   core.List<int> get asSlice {
@@ -58,27 +62,32 @@ final class ReorderedIndexMap implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_ReorderedIndexMap_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_ReorderedIndexMap_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_ReorderedIndexMap_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_ReorderedIndexMap_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_ReorderedIndexMap_as_slice_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_SliceUsize Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ReorderedIndexMap_as_slice_mv1')
 // ignore: non_constant_identifier_names
 external _SliceUsize _icu4x_ReorderedIndexMap_as_slice_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_ReorderedIndexMap_len_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Size Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ReorderedIndexMap_len_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_ReorderedIndexMap_len_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_ReorderedIndexMap_is_empty_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ReorderedIndexMap_is_empty_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_ReorderedIndexMap_is_empty_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_ReorderedIndexMap_get_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Size Function(ffi.Pointer<ffi.Opaque>, ffi.Size)>(isLeaf: true, symbol: 'icu4x_ReorderedIndexMap_get_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_ReorderedIndexMap_get_mv1(ffi.Pointer<ffi.Opaque> self, int index);

--- a/ffi/dart/lib/src/bindings/Script.g.dart
+++ b/ffi/dart/lib/src/bindings/Script.g.dart
@@ -925,32 +925,38 @@ enum Script {
 
 }
 
-@_DiplomatFfiUse('icu4x_Script_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_Script_for_char_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_Script_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_Script_long_name_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultSliceUtf8Void Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_Script_long_name_mv1')
 // ignore: non_constant_identifier_names
 external _ResultSliceUtf8Void _icu4x_Script_long_name_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_Script_short_name_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultSliceUtf8Void Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_Script_short_name_mv1')
 // ignore: non_constant_identifier_names
 external _ResultSliceUtf8Void _icu4x_Script_short_name_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_Script_to_integer_value_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint16 Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_Script_to_integer_value_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_Script_to_integer_value_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_Script_from_integer_value_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultInt32Void Function(ffi.Uint16)>(isLeaf: true, symbol: 'icu4x_Script_from_integer_value_mv1')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _icu4x_Script_from_integer_value_mv1(int other);
 
-@_DiplomatFfiUse('icu4x_Script_try_from_str_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultInt32Void Function(_SliceUtf8)>(isLeaf: true, symbol: 'icu4x_Script_try_from_str_mv1')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _icu4x_Script_try_from_str_mv1(_SliceUtf8 s);

--- a/ffi/dart/lib/src/bindings/ScriptExtensionsSet.g.dart
+++ b/ffi/dart/lib/src/bindings/ScriptExtensionsSet.g.dart
@@ -21,12 +21,16 @@ final class ScriptExtensionsSet implements ffi.Finalizable {
   // maintain borrow validity.
   ScriptExtensionsSet._fromFfi(this._ffi, this._selfEdge, this._aEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_ScriptExtensionsSet_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_ScriptExtensionsSet_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_ScriptExtensionsSet_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_ScriptExtensionsSet_destroy_mv1(ScriptExtensionsSet cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_ScriptExtensionsSet_destroy_mv1));
 
   /// Check if the `Script_Extensions` property of the given code point covers the given script
   ///
@@ -57,22 +61,26 @@ final class ScriptExtensionsSet implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_ScriptExtensionsSet_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_ScriptExtensionsSet_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_ScriptExtensionsSet_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_ScriptExtensionsSet_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_ScriptExtensionsSet_contains_mv2')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Pointer<ffi.Opaque>, ffi.Int32)>(isLeaf: true, symbol: 'icu4x_ScriptExtensionsSet_contains_mv2')
 // ignore: non_constant_identifier_names
 external bool _icu4x_ScriptExtensionsSet_contains_mv2(ffi.Pointer<ffi.Opaque> self, int script);
 
-@_DiplomatFfiUse('icu4x_ScriptExtensionsSet_count_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Size Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ScriptExtensionsSet_count_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_ScriptExtensionsSet_count_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_ScriptExtensionsSet_script_at_mv2')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultInt32Void Function(ffi.Pointer<ffi.Opaque>, ffi.Size)>(isLeaf: true, symbol: 'icu4x_ScriptExtensionsSet_script_at_mv2')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _icu4x_ScriptExtensionsSet_script_at_mv2(ffi.Pointer<ffi.Opaque> self, int index);

--- a/ffi/dart/lib/src/bindings/ScriptWithExtensions.g.dart
+++ b/ffi/dart/lib/src/bindings/ScriptWithExtensions.g.dart
@@ -19,12 +19,16 @@ final class ScriptWithExtensions implements ffi.Finalizable {
   // maintain borrow validity.
   ScriptWithExtensions._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_ScriptWithExtensions_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_ScriptWithExtensions_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_ScriptWithExtensions_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_ScriptWithExtensions_destroy_mv1(ScriptWithExtensions cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_ScriptWithExtensions_destroy_mv1));
 
   /// Create a map for the `Script`/`Script_Extensions` properties, using compiled data.
   ///
@@ -85,37 +89,44 @@ final class ScriptWithExtensions implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_ScriptWithExtensions_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_ScriptWithExtensions_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_ScriptWithExtensions_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_ScriptWithExtensions_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_ScriptWithExtensions_create_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_ScriptWithExtensions_create_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_ScriptWithExtensions_create_mv1();
 
-@_DiplomatFfiUse('icu4x_ScriptWithExtensions_create_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ScriptWithExtensions_create_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ScriptWithExtensions_create_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_ScriptWithExtensions_get_script_val_mv2')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>, ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_ScriptWithExtensions_get_script_val_mv2')
 // ignore: non_constant_identifier_names
 external int _icu4x_ScriptWithExtensions_get_script_val_mv2(ffi.Pointer<ffi.Opaque> self, Rune ch);
 
-@_DiplomatFfiUse('icu4x_ScriptWithExtensions_has_script_mv2')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Pointer<ffi.Opaque>, ffi.Uint32, ffi.Int32)>(isLeaf: true, symbol: 'icu4x_ScriptWithExtensions_has_script_mv2')
 // ignore: non_constant_identifier_names
 external bool _icu4x_ScriptWithExtensions_has_script_mv2(ffi.Pointer<ffi.Opaque> self, Rune ch, int script);
 
-@_DiplomatFfiUse('icu4x_ScriptWithExtensions_as_borrowed_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ScriptWithExtensions_as_borrowed_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_ScriptWithExtensions_as_borrowed_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_ScriptWithExtensions_iter_ranges_for_script_mv2')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Int32)>(isLeaf: true, symbol: 'icu4x_ScriptWithExtensions_iter_ranges_for_script_mv2')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_ScriptWithExtensions_iter_ranges_for_script_mv2(ffi.Pointer<ffi.Opaque> self, int script);

--- a/ffi/dart/lib/src/bindings/ScriptWithExtensionsBorrowed.g.dart
+++ b/ffi/dart/lib/src/bindings/ScriptWithExtensionsBorrowed.g.dart
@@ -21,12 +21,16 @@ final class ScriptWithExtensionsBorrowed implements ffi.Finalizable {
   // maintain borrow validity.
   ScriptWithExtensionsBorrowed._fromFfi(this._ffi, this._selfEdge, this._aEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_ScriptWithExtensionsBorrowed_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_ScriptWithExtensionsBorrowed_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_ScriptWithExtensionsBorrowed_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_ScriptWithExtensionsBorrowed_destroy_mv1(ScriptWithExtensionsBorrowed cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_ScriptWithExtensionsBorrowed_destroy_mv1));
 
   /// Get the Script property value for a code point
   ///
@@ -65,27 +69,32 @@ final class ScriptWithExtensionsBorrowed implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_ScriptWithExtensionsBorrowed_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_ScriptWithExtensionsBorrowed_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_ScriptWithExtensionsBorrowed_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_ScriptWithExtensionsBorrowed_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_ScriptWithExtensionsBorrowed_get_script_val_mv2')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>, ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_ScriptWithExtensionsBorrowed_get_script_val_mv2')
 // ignore: non_constant_identifier_names
 external int _icu4x_ScriptWithExtensionsBorrowed_get_script_val_mv2(ffi.Pointer<ffi.Opaque> self, Rune ch);
 
-@_DiplomatFfiUse('icu4x_ScriptWithExtensionsBorrowed_get_script_extensions_val_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_ScriptWithExtensionsBorrowed_get_script_extensions_val_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_ScriptWithExtensionsBorrowed_get_script_extensions_val_mv1(ffi.Pointer<ffi.Opaque> self, Rune ch);
 
-@_DiplomatFfiUse('icu4x_ScriptWithExtensionsBorrowed_has_script_mv2')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Pointer<ffi.Opaque>, ffi.Uint32, ffi.Int32)>(isLeaf: true, symbol: 'icu4x_ScriptWithExtensionsBorrowed_has_script_mv2')
 // ignore: non_constant_identifier_names
 external bool _icu4x_ScriptWithExtensionsBorrowed_has_script_mv2(ffi.Pointer<ffi.Opaque> self, Rune ch, int script);
 
-@_DiplomatFfiUse('icu4x_ScriptWithExtensionsBorrowed_get_script_extensions_set_mv2')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Int32)>(isLeaf: true, symbol: 'icu4x_ScriptWithExtensionsBorrowed_get_script_extensions_set_mv2')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_ScriptWithExtensionsBorrowed_get_script_extensions_set_mv2(ffi.Pointer<ffi.Opaque> self, int script);

--- a/ffi/dart/lib/src/bindings/SegmenterWordType.g.dart
+++ b/ffi/dart/lib/src/bindings/SegmenterWordType.g.dart
@@ -20,7 +20,8 @@ enum SegmenterWordType {
 
 }
 
-@_DiplomatFfiUse('icu4x_SegmenterWordType_is_word_like_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_SegmenterWordType_is_word_like_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_SegmenterWordType_is_word_like_mv1(int self);

--- a/ffi/dart/lib/src/bindings/SentenceBreak.g.dart
+++ b/ffi/dart/lib/src/bindings/SentenceBreak.g.dart
@@ -94,32 +94,38 @@ enum SentenceBreak {
 
 }
 
-@_DiplomatFfiUse('icu4x_SentenceBreak_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_SentenceBreak_for_char_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_SentenceBreak_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_SentenceBreak_long_name_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultSliceUtf8Void Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_SentenceBreak_long_name_mv1')
 // ignore: non_constant_identifier_names
 external _ResultSliceUtf8Void _icu4x_SentenceBreak_long_name_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_SentenceBreak_short_name_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultSliceUtf8Void Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_SentenceBreak_short_name_mv1')
 // ignore: non_constant_identifier_names
 external _ResultSliceUtf8Void _icu4x_SentenceBreak_short_name_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_SentenceBreak_to_integer_value_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint8 Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_SentenceBreak_to_integer_value_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_SentenceBreak_to_integer_value_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_SentenceBreak_from_integer_value_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultInt32Void Function(ffi.Uint8)>(isLeaf: true, symbol: 'icu4x_SentenceBreak_from_integer_value_mv1')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _icu4x_SentenceBreak_from_integer_value_mv1(int other);
 
-@_DiplomatFfiUse('icu4x_SentenceBreak_try_from_str_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultInt32Void Function(_SliceUtf8)>(isLeaf: true, symbol: 'icu4x_SentenceBreak_try_from_str_mv1')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _icu4x_SentenceBreak_try_from_str_mv1(_SliceUtf8 s);

--- a/ffi/dart/lib/src/bindings/SentenceBreakIteratorLatin1.g.dart
+++ b/ffi/dart/lib/src/bindings/SentenceBreakIteratorLatin1.g.dart
@@ -19,12 +19,16 @@ final class SentenceBreakIteratorLatin1 implements ffi.Finalizable {
   // maintain borrow validity.
   SentenceBreakIteratorLatin1._fromFfi(this._ffi, this._selfEdge, this._aEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_SentenceBreakIteratorLatin1_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_SentenceBreakIteratorLatin1_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_SentenceBreakIteratorLatin1_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_SentenceBreakIteratorLatin1_destroy_mv1(SentenceBreakIteratorLatin1 cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_SentenceBreakIteratorLatin1_destroy_mv1));
 
   /// Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
   /// out of range of a 32-bit signed integer.
@@ -37,12 +41,14 @@ final class SentenceBreakIteratorLatin1 implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_SentenceBreakIteratorLatin1_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_SentenceBreakIteratorLatin1_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_SentenceBreakIteratorLatin1_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_SentenceBreakIteratorLatin1_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_SentenceBreakIteratorLatin1_next_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_SentenceBreakIteratorLatin1_next_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_SentenceBreakIteratorLatin1_next_mv1(ffi.Pointer<ffi.Opaque> self);

--- a/ffi/dart/lib/src/bindings/SentenceBreakIteratorUtf16.g.dart
+++ b/ffi/dart/lib/src/bindings/SentenceBreakIteratorUtf16.g.dart
@@ -19,12 +19,16 @@ final class SentenceBreakIteratorUtf16 implements ffi.Finalizable {
   // maintain borrow validity.
   SentenceBreakIteratorUtf16._fromFfi(this._ffi, this._selfEdge, this._aEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_SentenceBreakIteratorUtf16_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_SentenceBreakIteratorUtf16_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_SentenceBreakIteratorUtf16_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_SentenceBreakIteratorUtf16_destroy_mv1(SentenceBreakIteratorUtf16 cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_SentenceBreakIteratorUtf16_destroy_mv1));
 
   /// Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
   /// out of range of a 32-bit signed integer.
@@ -37,12 +41,14 @@ final class SentenceBreakIteratorUtf16 implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_SentenceBreakIteratorUtf16_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_SentenceBreakIteratorUtf16_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_SentenceBreakIteratorUtf16_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_SentenceBreakIteratorUtf16_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_SentenceBreakIteratorUtf16_next_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_SentenceBreakIteratorUtf16_next_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_SentenceBreakIteratorUtf16_next_mv1(ffi.Pointer<ffi.Opaque> self);

--- a/ffi/dart/lib/src/bindings/SentenceBreakIteratorUtf8.g.dart
+++ b/ffi/dart/lib/src/bindings/SentenceBreakIteratorUtf8.g.dart
@@ -19,12 +19,16 @@ final class SentenceBreakIteratorUtf8 implements ffi.Finalizable {
   // maintain borrow validity.
   SentenceBreakIteratorUtf8._fromFfi(this._ffi, this._selfEdge, this._aEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_SentenceBreakIteratorUtf8_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_SentenceBreakIteratorUtf8_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_SentenceBreakIteratorUtf8_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_SentenceBreakIteratorUtf8_destroy_mv1(SentenceBreakIteratorUtf8 cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_SentenceBreakIteratorUtf8_destroy_mv1));
 
   /// Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
   /// out of range of a 32-bit signed integer.
@@ -37,12 +41,14 @@ final class SentenceBreakIteratorUtf8 implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_SentenceBreakIteratorUtf8_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_SentenceBreakIteratorUtf8_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_SentenceBreakIteratorUtf8_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_SentenceBreakIteratorUtf8_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_SentenceBreakIteratorUtf8_next_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_SentenceBreakIteratorUtf8_next_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_SentenceBreakIteratorUtf8_next_mv1(ffi.Pointer<ffi.Opaque> self);

--- a/ffi/dart/lib/src/bindings/SentenceSegmenter.g.dart
+++ b/ffi/dart/lib/src/bindings/SentenceSegmenter.g.dart
@@ -19,12 +19,16 @@ final class SentenceSegmenter implements ffi.Finalizable {
   // maintain borrow validity.
   SentenceSegmenter._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_SentenceSegmenter_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_SentenceSegmenter_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_SentenceSegmenter_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_SentenceSegmenter_destroy_mv1(SentenceSegmenter cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_SentenceSegmenter_destroy_mv1));
 
   /// Construct a [SentenceSegmenter] using compiled data. This does not assume any content locale.
   ///
@@ -72,27 +76,32 @@ final class SentenceSegmenter implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_SentenceSegmenter_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_SentenceSegmenter_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_SentenceSegmenter_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_SentenceSegmenter_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_SentenceSegmenter_create_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_SentenceSegmenter_create_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_SentenceSegmenter_create_mv1();
 
-@_DiplomatFfiUse('icu4x_SentenceSegmenter_create_with_content_locale_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_SentenceSegmenter_create_with_content_locale_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_SentenceSegmenter_create_with_content_locale_mv1(ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_SentenceSegmenter_create_with_content_locale_and_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_SentenceSegmenter_create_with_content_locale_and_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_SentenceSegmenter_create_with_content_locale_and_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_SentenceSegmenter_segment_utf16_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, _SliceUtf16)>(isLeaf: true, symbol: 'icu4x_SentenceSegmenter_segment_utf16_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_SentenceSegmenter_segment_utf16_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUtf16 input);

--- a/ffi/dart/lib/src/bindings/Time.g.dart
+++ b/ffi/dart/lib/src/bindings/Time.g.dart
@@ -19,12 +19,16 @@ final class Time implements ffi.Finalizable {
   // maintain borrow validity.
   Time._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_Time_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_Time_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_Time_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_Time_destroy_mv1(Time cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_Time_destroy_mv1));
 
   /// Creates a new [Time] given field values
   ///
@@ -113,47 +117,56 @@ final class Time implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_Time_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_Time_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_Time_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_Time_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_Time_create_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Uint8, ffi.Uint8, ffi.Uint8, ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_Time_create_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_Time_create_mv1(int hour, int minute, int second, int subsecond);
 
-@_DiplomatFfiUse('icu4x_Time_from_string_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(_SliceUtf8)>(isLeaf: true, symbol: 'icu4x_Time_from_string_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_Time_from_string_mv1(_SliceUtf8 v);
 
-@_DiplomatFfiUse('icu4x_Time_start_of_day_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function()>(isLeaf: true, symbol: 'icu4x_Time_start_of_day_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_Time_start_of_day_mv1();
 
-@_DiplomatFfiUse('icu4x_Time_noon_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function()>(isLeaf: true, symbol: 'icu4x_Time_noon_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_Time_noon_mv1();
 
-@_DiplomatFfiUse('icu4x_Time_hour_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint8 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Time_hour_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_Time_hour_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_Time_minute_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint8 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Time_minute_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_Time_minute_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_Time_second_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint8 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Time_second_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_Time_second_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_Time_subsecond_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_Time_subsecond_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_Time_subsecond_mv1(ffi.Pointer<ffi.Opaque> self);

--- a/ffi/dart/lib/src/bindings/TimeFormatter.g.dart
+++ b/ffi/dart/lib/src/bindings/TimeFormatter.g.dart
@@ -17,12 +17,16 @@ final class TimeFormatter implements ffi.Finalizable {
   // maintain borrow validity.
   TimeFormatter._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_TimeFormatter_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_TimeFormatter_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_TimeFormatter_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_TimeFormatter_destroy_mv1(TimeFormatter cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_TimeFormatter_destroy_mv1));
 
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.2.0/icu/datetime/type.NoCalendarFormatter.html#method.try_new) for more information.
   ///
@@ -63,22 +67,26 @@ final class TimeFormatter implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_TimeFormatter_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_TimeFormatter_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_TimeFormatter_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_TimeFormatter_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_TimeFormatter_create_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_TimeFormatter_create_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_TimeFormatter_create_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_TimeFormatter_create_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_TimeFormatter_create_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_TimeFormatter_create_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_TimeFormatter_format_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_TimeFormatter_format_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_TimeFormatter_format_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> time, ffi.Pointer<ffi.Opaque> write);

--- a/ffi/dart/lib/src/bindings/TimePrecision.g.dart
+++ b/ffi/dart/lib/src/bindings/TimePrecision.g.dart
@@ -45,7 +45,8 @@ enum TimePrecision {
 
 }
 
-@_DiplomatFfiUse('icu4x_TimePrecision_from_subsecond_digits_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultInt32Void Function(ffi.Uint8)>(isLeaf: true, symbol: 'icu4x_TimePrecision_from_subsecond_digits_mv1')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _icu4x_TimePrecision_from_subsecond_digits_mv1(int digits);

--- a/ffi/dart/lib/src/bindings/TimeZone.g.dart
+++ b/ffi/dart/lib/src/bindings/TimeZone.g.dart
@@ -17,12 +17,16 @@ final class TimeZone implements ffi.Finalizable {
   // maintain borrow validity.
   TimeZone._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_TimeZone_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_TimeZone_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_TimeZone_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_TimeZone_destroy_mv1(TimeZone cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_TimeZone_destroy_mv1));
 
   /// The unknown time zone.
   ///
@@ -92,47 +96,56 @@ final class TimeZone implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_TimeZone_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_TimeZone_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_TimeZone_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_TimeZone_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_TimeZone_unknown_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_TimeZone_unknown_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_TimeZone_unknown_mv1();
 
-@_DiplomatFfiUse('icu4x_TimeZone_is_unknown_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_TimeZone_is_unknown_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_TimeZone_is_unknown_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_TimeZone_create_from_iana_id_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_SliceUtf8)>(isLeaf: true, symbol: 'icu4x_TimeZone_create_from_iana_id_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_TimeZone_create_from_iana_id_mv1(_SliceUtf8 ianaId);
 
-@_DiplomatFfiUse('icu4x_TimeZone_create_from_windows_id_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_SliceUtf8, _SliceUtf8)>(isLeaf: true, symbol: 'icu4x_TimeZone_create_from_windows_id_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_TimeZone_create_from_windows_id_mv1(_SliceUtf8 windowsId, _SliceUtf8 region);
 
-@_DiplomatFfiUse('icu4x_TimeZone_create_from_system_id_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_SliceUtf8, _SliceUtf8)>(isLeaf: true, symbol: 'icu4x_TimeZone_create_from_system_id_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_TimeZone_create_from_system_id_mv1(_SliceUtf8 id, _SliceUtf8 region);
 
-@_DiplomatFfiUse('icu4x_TimeZone_create_from_bcp47_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(_SliceUtf8)>(isLeaf: true, symbol: 'icu4x_TimeZone_create_from_bcp47_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_TimeZone_create_from_bcp47_mv1(_SliceUtf8 id);
 
-@_DiplomatFfiUse('icu4x_TimeZone_with_offset_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_TimeZone_with_offset_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_TimeZone_with_offset_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> offset);
 
-@_DiplomatFfiUse('icu4x_TimeZone_without_offset_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_TimeZone_without_offset_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_TimeZone_without_offset_mv1(ffi.Pointer<ffi.Opaque> self);

--- a/ffi/dart/lib/src/bindings/TimeZoneAndCanonicalAndNormalizedIterator.g.dart
+++ b/ffi/dart/lib/src/bindings/TimeZoneAndCanonicalAndNormalizedIterator.g.dart
@@ -19,12 +19,16 @@ final class TimeZoneAndCanonicalAndNormalizedIterator implements ffi.Finalizable
   // maintain borrow validity.
   TimeZoneAndCanonicalAndNormalizedIterator._fromFfi(this._ffi, this._selfEdge, this._aEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_TimeZoneAndCanonicalAndNormalizedIterator_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_TimeZoneAndCanonicalAndNormalizedIterator_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_TimeZoneAndCanonicalAndNormalizedIterator_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_TimeZoneAndCanonicalAndNormalizedIterator_destroy_mv1(TimeZoneAndCanonicalAndNormalizedIterator cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_TimeZoneAndCanonicalAndNormalizedIterator_destroy_mv1));
 
   TimeZoneAndCanonicalAndNormalized? _current;
 
@@ -50,12 +54,14 @@ final class TimeZoneAndCanonicalAndNormalizedIterator implements ffi.Finalizable
 
 }
 
-@_DiplomatFfiUse('icu4x_TimeZoneAndCanonicalAndNormalizedIterator_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_TimeZoneAndCanonicalAndNormalizedIterator_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_TimeZoneAndCanonicalAndNormalizedIterator_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_TimeZoneAndCanonicalAndNormalizedIterator_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_TimeZoneAndCanonicalAndNormalizedIterator_next_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultTimeZoneAndCanonicalAndNormalizedFfiVoid Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_TimeZoneAndCanonicalAndNormalizedIterator_next_mv1')
 // ignore: non_constant_identifier_names
 external _ResultTimeZoneAndCanonicalAndNormalizedFfiVoid _icu4x_TimeZoneAndCanonicalAndNormalizedIterator_next_mv1(ffi.Pointer<ffi.Opaque> self);

--- a/ffi/dart/lib/src/bindings/TimeZoneAndCanonicalIterator.g.dart
+++ b/ffi/dart/lib/src/bindings/TimeZoneAndCanonicalIterator.g.dart
@@ -19,12 +19,16 @@ final class TimeZoneAndCanonicalIterator implements ffi.Finalizable, core.Iterat
   // maintain borrow validity.
   TimeZoneAndCanonicalIterator._fromFfi(this._ffi, this._selfEdge, this._aEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_TimeZoneAndCanonicalIterator_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_TimeZoneAndCanonicalIterator_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_TimeZoneAndCanonicalIterator_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_TimeZoneAndCanonicalIterator_destroy_mv1(TimeZoneAndCanonicalIterator cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_TimeZoneAndCanonicalIterator_destroy_mv1));
 
   TimeZoneAndCanonical? _current;
 
@@ -50,12 +54,14 @@ final class TimeZoneAndCanonicalIterator implements ffi.Finalizable, core.Iterat
 
 }
 
-@_DiplomatFfiUse('icu4x_TimeZoneAndCanonicalIterator_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_TimeZoneAndCanonicalIterator_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_TimeZoneAndCanonicalIterator_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_TimeZoneAndCanonicalIterator_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_TimeZoneAndCanonicalIterator_next_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultTimeZoneAndCanonicalFfiVoid Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_TimeZoneAndCanonicalIterator_next_mv1')
 // ignore: non_constant_identifier_names
 external _ResultTimeZoneAndCanonicalFfiVoid _icu4x_TimeZoneAndCanonicalIterator_next_mv1(ffi.Pointer<ffi.Opaque> self);

--- a/ffi/dart/lib/src/bindings/TimeZoneFormatter.g.dart
+++ b/ffi/dart/lib/src/bindings/TimeZoneFormatter.g.dart
@@ -17,12 +17,16 @@ final class TimeZoneFormatter implements ffi.Finalizable {
   // maintain borrow validity.
   TimeZoneFormatter._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_TimeZoneFormatter_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_TimeZoneFormatter_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_TimeZoneFormatter_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_TimeZoneFormatter_destroy_mv1(TimeZoneFormatter cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_TimeZoneFormatter_destroy_mv1));
 
   /// Creates a zoned formatter based on a non-zoned formatter.
   ///
@@ -294,92 +298,110 @@ final class TimeZoneFormatter implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_TimeZoneFormatter_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_TimeZoneFormatter_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_TimeZoneFormatter_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_TimeZoneFormatter_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_TimeZoneFormatter_create_specific_long_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_TimeZoneFormatter_create_specific_long_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_TimeZoneFormatter_create_specific_long_mv1(ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_TimeZoneFormatter_create_specific_long_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_TimeZoneFormatter_create_specific_long_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_TimeZoneFormatter_create_specific_long_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_TimeZoneFormatter_create_specific_short_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_TimeZoneFormatter_create_specific_short_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_TimeZoneFormatter_create_specific_short_mv1(ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_TimeZoneFormatter_create_specific_short_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_TimeZoneFormatter_create_specific_short_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_TimeZoneFormatter_create_specific_short_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_TimeZoneFormatter_create_localized_offset_long_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_TimeZoneFormatter_create_localized_offset_long_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_TimeZoneFormatter_create_localized_offset_long_mv1(ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_TimeZoneFormatter_create_localized_offset_long_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_TimeZoneFormatter_create_localized_offset_long_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_TimeZoneFormatter_create_localized_offset_long_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_TimeZoneFormatter_create_localized_offset_short_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_TimeZoneFormatter_create_localized_offset_short_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_TimeZoneFormatter_create_localized_offset_short_mv1(ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_TimeZoneFormatter_create_localized_offset_short_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_TimeZoneFormatter_create_localized_offset_short_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_TimeZoneFormatter_create_localized_offset_short_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_TimeZoneFormatter_create_generic_long_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_TimeZoneFormatter_create_generic_long_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_TimeZoneFormatter_create_generic_long_mv1(ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_TimeZoneFormatter_create_generic_long_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_TimeZoneFormatter_create_generic_long_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_TimeZoneFormatter_create_generic_long_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_TimeZoneFormatter_create_generic_short_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_TimeZoneFormatter_create_generic_short_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_TimeZoneFormatter_create_generic_short_mv1(ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_TimeZoneFormatter_create_generic_short_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_TimeZoneFormatter_create_generic_short_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_TimeZoneFormatter_create_generic_short_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_TimeZoneFormatter_create_location_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_TimeZoneFormatter_create_location_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_TimeZoneFormatter_create_location_mv1(ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_TimeZoneFormatter_create_location_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_TimeZoneFormatter_create_location_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_TimeZoneFormatter_create_location_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_TimeZoneFormatter_create_exemplar_city_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_TimeZoneFormatter_create_exemplar_city_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_TimeZoneFormatter_create_exemplar_city_mv1(ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_TimeZoneFormatter_create_exemplar_city_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_TimeZoneFormatter_create_exemplar_city_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_TimeZoneFormatter_create_exemplar_city_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_TimeZoneFormatter_format_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultVoidInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_TimeZoneFormatter_format_mv1')
 // ignore: non_constant_identifier_names
 external _ResultVoidInt32 _icu4x_TimeZoneFormatter_format_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> zone, ffi.Pointer<ffi.Opaque> write);

--- a/ffi/dart/lib/src/bindings/TimeZoneInfo.g.dart
+++ b/ffi/dart/lib/src/bindings/TimeZoneInfo.g.dart
@@ -17,12 +17,16 @@ final class TimeZoneInfo implements ffi.Finalizable {
   // maintain borrow validity.
   TimeZoneInfo._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_TimeZoneInfo_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_TimeZoneInfo_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_TimeZoneInfo_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_TimeZoneInfo_destroy_mv1(TimeZoneInfo cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_TimeZoneInfo_destroy_mv1));
 
   /// Creates a time zone for UTC (Coordinated Universal Time).
   ///
@@ -109,42 +113,50 @@ final class TimeZoneInfo implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_TimeZoneInfo_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_TimeZoneInfo_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_TimeZoneInfo_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_TimeZoneInfo_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_TimeZoneInfo_utc_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_TimeZoneInfo_utc_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_TimeZoneInfo_utc_mv1();
 
-@_DiplomatFfiUse('icu4x_TimeZoneInfo_id_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_TimeZoneInfo_id_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_TimeZoneInfo_id_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_TimeZoneInfo_at_date_time_iso_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_TimeZoneInfo_at_date_time_iso_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_TimeZoneInfo_at_date_time_iso_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> date, ffi.Pointer<ffi.Opaque> time);
 
-@_DiplomatFfiUse('icu4x_TimeZoneInfo_at_date_time_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_TimeZoneInfo_at_date_time_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_TimeZoneInfo_at_date_time_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> date, ffi.Pointer<ffi.Opaque> time);
 
-@_DiplomatFfiUse('icu4x_TimeZoneInfo_at_timestamp_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, ffi.Int64)>(isLeaf: true, symbol: 'icu4x_TimeZoneInfo_at_timestamp_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_TimeZoneInfo_at_timestamp_mv1(ffi.Pointer<ffi.Opaque> self, int timestamp);
 
-@_DiplomatFfiUse('icu4x_TimeZoneInfo_zone_name_date_time_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultIsoDateTimeFfiVoid Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_TimeZoneInfo_zone_name_date_time_mv1')
 // ignore: non_constant_identifier_names
 external _ResultIsoDateTimeFfiVoid _icu4x_TimeZoneInfo_zone_name_date_time_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_TimeZoneInfo_offset_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_TimeZoneInfo_offset_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_TimeZoneInfo_offset_mv1(ffi.Pointer<ffi.Opaque> self);

--- a/ffi/dart/lib/src/bindings/TimeZoneIterator.g.dart
+++ b/ffi/dart/lib/src/bindings/TimeZoneIterator.g.dart
@@ -19,12 +19,16 @@ final class TimeZoneIterator implements ffi.Finalizable, core.Iterator<TimeZone>
   // maintain borrow validity.
   TimeZoneIterator._fromFfi(this._ffi, this._selfEdge, this._aEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_TimeZoneIterator_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_TimeZoneIterator_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_TimeZoneIterator_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_TimeZoneIterator_destroy_mv1(TimeZoneIterator cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_TimeZoneIterator_destroy_mv1));
 
   TimeZone? _current;
 
@@ -45,12 +49,14 @@ final class TimeZoneIterator implements ffi.Finalizable, core.Iterator<TimeZone>
 
 }
 
-@_DiplomatFfiUse('icu4x_TimeZoneIterator_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_TimeZoneIterator_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_TimeZoneIterator_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_TimeZoneIterator_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_TimeZoneIterator_next_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_TimeZoneIterator_next_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_TimeZoneIterator_next_mv1(ffi.Pointer<ffi.Opaque> self);

--- a/ffi/dart/lib/src/bindings/TitlecaseMapper.g.dart
+++ b/ffi/dart/lib/src/bindings/TitlecaseMapper.g.dart
@@ -17,12 +17,16 @@ final class TitlecaseMapper implements ffi.Finalizable {
   // maintain borrow validity.
   TitlecaseMapper._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_TitlecaseMapper_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_TitlecaseMapper_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_TitlecaseMapper_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_TitlecaseMapper_destroy_mv1(TitlecaseMapper cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_TitlecaseMapper_destroy_mv1));
 
   /// Construct a new `TitlecaseMapper` instance using compiled data.
   ///
@@ -76,27 +80,32 @@ final class TitlecaseMapper implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_TitlecaseMapper_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_TitlecaseMapper_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_TitlecaseMapper_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_TitlecaseMapper_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_TitlecaseMapper_create_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function()>(isLeaf: true, symbol: 'icu4x_TitlecaseMapper_create_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_TitlecaseMapper_create_mv1();
 
-@_DiplomatFfiUse('icu4x_TitlecaseMapper_create_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_TitlecaseMapper_create_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_TitlecaseMapper_create_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_TitlecaseMapper_titlecase_segment_v1_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8, ffi.Pointer<ffi.Opaque>, _TitlecaseOptionsFfi, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_TitlecaseMapper_titlecase_segment_v1_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_TitlecaseMapper_titlecase_segment_v1_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUtf8 s, ffi.Pointer<ffi.Opaque> locale, _TitlecaseOptionsFfi options, ffi.Pointer<ffi.Opaque> write);
 
-@_DiplomatFfiUse('icu4x_TitlecaseMapper_titlecase_segment_with_compiled_data_v1_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(_SliceUtf8, ffi.Pointer<ffi.Opaque>, _TitlecaseOptionsFfi, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_TitlecaseMapper_titlecase_segment_with_compiled_data_v1_mv1')
 // ignore: non_constant_identifier_names
 external void _icu4x_TitlecaseMapper_titlecase_segment_with_compiled_data_v1_mv1(_SliceUtf8 s, ffi.Pointer<ffi.Opaque> locale, _TitlecaseOptionsFfi options, ffi.Pointer<ffi.Opaque> write);

--- a/ffi/dart/lib/src/bindings/TitlecaseOptions.g.dart
+++ b/ffi/dart/lib/src/bindings/TitlecaseOptions.g.dart
@@ -62,7 +62,8 @@ final class TitlecaseOptions {
       ]);
 }
 
-@_DiplomatFfiUse('icu4x_TitlecaseOptionsV1_default_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_TitlecaseOptionsFfi Function()>(isLeaf: true, symbol: 'icu4x_TitlecaseOptionsV1_default_mv1')
 // ignore: non_constant_identifier_names
 external _TitlecaseOptionsFfi _icu4x_TitlecaseOptionsV1_default_mv1();

--- a/ffi/dart/lib/src/bindings/UtcOffset.g.dart
+++ b/ffi/dart/lib/src/bindings/UtcOffset.g.dart
@@ -17,12 +17,16 @@ final class UtcOffset implements ffi.Finalizable {
   // maintain borrow validity.
   UtcOffset._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_UtcOffset_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_UtcOffset_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_UtcOffset_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_UtcOffset_destroy_mv1(UtcOffset cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_UtcOffset_destroy_mv1));
 
   /// Creates an offset from seconds.
   ///
@@ -119,47 +123,56 @@ final class UtcOffset implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_UtcOffset_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_UtcOffset_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_UtcOffset_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_UtcOffset_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_UtcOffset_from_seconds_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueTimeZoneInvalidOffsetErrorFfi Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_UtcOffset_from_seconds_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueTimeZoneInvalidOffsetErrorFfi _icu4x_UtcOffset_from_seconds_mv1(int seconds);
 
-@_DiplomatFfiUse('icu4x_UtcOffset_from_string_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueTimeZoneInvalidOffsetErrorFfi Function(_SliceUtf8)>(isLeaf: true, symbol: 'icu4x_UtcOffset_from_string_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueTimeZoneInvalidOffsetErrorFfi _icu4x_UtcOffset_from_string_mv1(_SliceUtf8 offset);
 
-@_DiplomatFfiUse('icu4x_UtcOffset_seconds_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_UtcOffset_seconds_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_UtcOffset_seconds_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_UtcOffset_is_non_negative_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_UtcOffset_is_non_negative_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_UtcOffset_is_non_negative_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_UtcOffset_is_zero_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_UtcOffset_is_zero_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_UtcOffset_is_zero_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_UtcOffset_hours_part_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_UtcOffset_hours_part_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_UtcOffset_hours_part_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_UtcOffset_minutes_part_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_UtcOffset_minutes_part_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_UtcOffset_minutes_part_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_UtcOffset_seconds_part_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_UtcOffset_seconds_part_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_UtcOffset_seconds_part_mv1(ffi.Pointer<ffi.Opaque> self);

--- a/ffi/dart/lib/src/bindings/VerticalOrientation.g.dart
+++ b/ffi/dart/lib/src/bindings/VerticalOrientation.g.dart
@@ -72,32 +72,38 @@ enum VerticalOrientation {
 
 }
 
-@_DiplomatFfiUse('icu4x_VerticalOrientation_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_VerticalOrientation_for_char_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_VerticalOrientation_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_VerticalOrientation_long_name_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultSliceUtf8Void Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_VerticalOrientation_long_name_mv1')
 // ignore: non_constant_identifier_names
 external _ResultSliceUtf8Void _icu4x_VerticalOrientation_long_name_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_VerticalOrientation_short_name_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultSliceUtf8Void Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_VerticalOrientation_short_name_mv1')
 // ignore: non_constant_identifier_names
 external _ResultSliceUtf8Void _icu4x_VerticalOrientation_short_name_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_VerticalOrientation_to_integer_value_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint8 Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_VerticalOrientation_to_integer_value_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_VerticalOrientation_to_integer_value_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_VerticalOrientation_from_integer_value_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultInt32Void Function(ffi.Uint8)>(isLeaf: true, symbol: 'icu4x_VerticalOrientation_from_integer_value_mv1')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _icu4x_VerticalOrientation_from_integer_value_mv1(int other);
 
-@_DiplomatFfiUse('icu4x_VerticalOrientation_try_from_str_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultInt32Void Function(_SliceUtf8)>(isLeaf: true, symbol: 'icu4x_VerticalOrientation_try_from_str_mv1')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _icu4x_VerticalOrientation_try_from_str_mv1(_SliceUtf8 s);

--- a/ffi/dart/lib/src/bindings/WeekInformation.g.dart
+++ b/ffi/dart/lib/src/bindings/WeekInformation.g.dart
@@ -19,12 +19,16 @@ final class WeekInformation implements ffi.Finalizable {
   // maintain borrow validity.
   WeekInformation._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_WeekInformation_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_WeekInformation_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_WeekInformation_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_WeekInformation_destroy_mv1(WeekInformation cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_WeekInformation_destroy_mv1));
 
   /// Creates a new [WeekInformation] from locale data using compiled data.
   ///
@@ -76,32 +80,38 @@ final class WeekInformation implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_WeekInformation_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_WeekInformation_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_WeekInformation_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_WeekInformation_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_WeekInformation_create_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_WeekInformation_create_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_WeekInformation_create_mv1(ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_WeekInformation_create_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_WeekInformation_create_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_WeekInformation_create_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_WeekInformation_first_weekday_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_WeekInformation_first_weekday_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_WeekInformation_first_weekday_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_WeekInformation_is_weekend_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Pointer<ffi.Opaque>, ffi.Int32)>(isLeaf: true, symbol: 'icu4x_WeekInformation_is_weekend_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_WeekInformation_is_weekend_mv1(ffi.Pointer<ffi.Opaque> self, int day);
 
-@_DiplomatFfiUse('icu4x_WeekInformation_weekend_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_WeekInformation_weekend_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_WeekInformation_weekend_mv1(ffi.Pointer<ffi.Opaque> self);

--- a/ffi/dart/lib/src/bindings/WeekdaySetIterator.g.dart
+++ b/ffi/dart/lib/src/bindings/WeekdaySetIterator.g.dart
@@ -19,12 +19,16 @@ final class WeekdaySetIterator implements ffi.Finalizable, core.Iterator<Weekday
   // maintain borrow validity.
   WeekdaySetIterator._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_WeekdaySetIterator_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_WeekdaySetIterator_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_WeekdaySetIterator_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_WeekdaySetIterator_destroy_mv1(WeekdaySetIterator cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_WeekdaySetIterator_destroy_mv1));
 
   Weekday? _current;
 
@@ -48,12 +52,14 @@ final class WeekdaySetIterator implements ffi.Finalizable, core.Iterator<Weekday
 
 }
 
-@_DiplomatFfiUse('icu4x_WeekdaySetIterator_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_WeekdaySetIterator_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_WeekdaySetIterator_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_WeekdaySetIterator_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_WeekdaySetIterator_next_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultInt32Void Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_WeekdaySetIterator_next_mv1')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _icu4x_WeekdaySetIterator_next_mv1(ffi.Pointer<ffi.Opaque> self);

--- a/ffi/dart/lib/src/bindings/WindowsParser.g.dart
+++ b/ffi/dart/lib/src/bindings/WindowsParser.g.dart
@@ -22,12 +22,16 @@ final class WindowsParser implements ffi.Finalizable {
   // maintain borrow validity.
   WindowsParser._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_WindowsParser_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_WindowsParser_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_WindowsParser_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_WindowsParser_destroy_mv1(WindowsParser cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_WindowsParser_destroy_mv1));
 
   /// Create a new [WindowsParser] using compiled data
   ///
@@ -59,22 +63,26 @@ final class WindowsParser implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_WindowsParser_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_WindowsParser_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_WindowsParser_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_WindowsParser_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_WindowsParser_create_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_WindowsParser_create_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_WindowsParser_create_mv1();
 
-@_DiplomatFfiUse('icu4x_WindowsParser_create_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_WindowsParser_create_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_WindowsParser_create_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider);
 
-@_DiplomatFfiUse('icu4x_WindowsParser_parse_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8, _SliceUtf8)>(isLeaf: true, symbol: 'icu4x_WindowsParser_parse_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_WindowsParser_parse_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUtf8 value, _SliceUtf8 region);

--- a/ffi/dart/lib/src/bindings/WordBreak.g.dart
+++ b/ffi/dart/lib/src/bindings/WordBreak.g.dart
@@ -110,32 +110,38 @@ enum WordBreak {
 
 }
 
-@_DiplomatFfiUse('icu4x_WordBreak_for_char_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Uint32)>(isLeaf: true, symbol: 'icu4x_WordBreak_for_char_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_WordBreak_for_char_mv1(Rune ch);
 
-@_DiplomatFfiUse('icu4x_WordBreak_long_name_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultSliceUtf8Void Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_WordBreak_long_name_mv1')
 // ignore: non_constant_identifier_names
 external _ResultSliceUtf8Void _icu4x_WordBreak_long_name_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_WordBreak_short_name_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultSliceUtf8Void Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_WordBreak_short_name_mv1')
 // ignore: non_constant_identifier_names
 external _ResultSliceUtf8Void _icu4x_WordBreak_short_name_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_WordBreak_to_integer_value_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Uint8 Function(ffi.Int32)>(isLeaf: true, symbol: 'icu4x_WordBreak_to_integer_value_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_WordBreak_to_integer_value_mv1(int self);
 
-@_DiplomatFfiUse('icu4x_WordBreak_from_integer_value_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultInt32Void Function(ffi.Uint8)>(isLeaf: true, symbol: 'icu4x_WordBreak_from_integer_value_mv1')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _icu4x_WordBreak_from_integer_value_mv1(int other);
 
-@_DiplomatFfiUse('icu4x_WordBreak_try_from_str_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultInt32Void Function(_SliceUtf8)>(isLeaf: true, symbol: 'icu4x_WordBreak_try_from_str_mv1')
 // ignore: non_constant_identifier_names
 external _ResultInt32Void _icu4x_WordBreak_try_from_str_mv1(_SliceUtf8 s);

--- a/ffi/dart/lib/src/bindings/WordBreakIteratorLatin1.g.dart
+++ b/ffi/dart/lib/src/bindings/WordBreakIteratorLatin1.g.dart
@@ -19,12 +19,16 @@ final class WordBreakIteratorLatin1 implements ffi.Finalizable {
   // maintain borrow validity.
   WordBreakIteratorLatin1._fromFfi(this._ffi, this._selfEdge, this._aEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_WordBreakIteratorLatin1_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_WordBreakIteratorLatin1_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_WordBreakIteratorLatin1_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_WordBreakIteratorLatin1_destroy_mv1(WordBreakIteratorLatin1 cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_WordBreakIteratorLatin1_destroy_mv1));
 
   /// Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
   /// out of range of a 32-bit signed integer.
@@ -53,22 +57,26 @@ final class WordBreakIteratorLatin1 implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_WordBreakIteratorLatin1_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_WordBreakIteratorLatin1_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_WordBreakIteratorLatin1_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_WordBreakIteratorLatin1_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_WordBreakIteratorLatin1_next_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_WordBreakIteratorLatin1_next_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_WordBreakIteratorLatin1_next_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_WordBreakIteratorLatin1_word_type_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_WordBreakIteratorLatin1_word_type_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_WordBreakIteratorLatin1_word_type_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_WordBreakIteratorLatin1_is_word_like_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_WordBreakIteratorLatin1_is_word_like_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_WordBreakIteratorLatin1_is_word_like_mv1(ffi.Pointer<ffi.Opaque> self);

--- a/ffi/dart/lib/src/bindings/WordBreakIteratorUtf16.g.dart
+++ b/ffi/dart/lib/src/bindings/WordBreakIteratorUtf16.g.dart
@@ -19,12 +19,16 @@ final class WordBreakIteratorUtf16 implements ffi.Finalizable {
   // maintain borrow validity.
   WordBreakIteratorUtf16._fromFfi(this._ffi, this._selfEdge, this._aEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_WordBreakIteratorUtf16_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_WordBreakIteratorUtf16_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_WordBreakIteratorUtf16_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_WordBreakIteratorUtf16_destroy_mv1(WordBreakIteratorUtf16 cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_WordBreakIteratorUtf16_destroy_mv1));
 
   /// Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
   /// out of range of a 32-bit signed integer.
@@ -53,22 +57,26 @@ final class WordBreakIteratorUtf16 implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_WordBreakIteratorUtf16_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_WordBreakIteratorUtf16_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_WordBreakIteratorUtf16_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_WordBreakIteratorUtf16_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_WordBreakIteratorUtf16_next_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_WordBreakIteratorUtf16_next_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_WordBreakIteratorUtf16_next_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_WordBreakIteratorUtf16_word_type_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_WordBreakIteratorUtf16_word_type_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_WordBreakIteratorUtf16_word_type_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_WordBreakIteratorUtf16_is_word_like_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_WordBreakIteratorUtf16_is_word_like_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_WordBreakIteratorUtf16_is_word_like_mv1(ffi.Pointer<ffi.Opaque> self);

--- a/ffi/dart/lib/src/bindings/WordBreakIteratorUtf8.g.dart
+++ b/ffi/dart/lib/src/bindings/WordBreakIteratorUtf8.g.dart
@@ -19,12 +19,16 @@ final class WordBreakIteratorUtf8 implements ffi.Finalizable {
   // maintain borrow validity.
   WordBreakIteratorUtf8._fromFfi(this._ffi, this._selfEdge, this._aEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_WordBreakIteratorUtf8_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_WordBreakIteratorUtf8_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_WordBreakIteratorUtf8_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_WordBreakIteratorUtf8_destroy_mv1(WordBreakIteratorUtf8 cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_WordBreakIteratorUtf8_destroy_mv1));
 
   /// Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
   /// out of range of a 32-bit signed integer.
@@ -53,22 +57,26 @@ final class WordBreakIteratorUtf8 implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_WordBreakIteratorUtf8_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_WordBreakIteratorUtf8_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_WordBreakIteratorUtf8_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_WordBreakIteratorUtf8_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_WordBreakIteratorUtf8_next_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_WordBreakIteratorUtf8_next_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_WordBreakIteratorUtf8_next_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_WordBreakIteratorUtf8_word_type_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Int32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_WordBreakIteratorUtf8_word_type_mv1')
 // ignore: non_constant_identifier_names
 external int _icu4x_WordBreakIteratorUtf8_word_type_mv1(ffi.Pointer<ffi.Opaque> self);
 
-@_DiplomatFfiUse('icu4x_WordBreakIteratorUtf8_is_word_like_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Bool Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_WordBreakIteratorUtf8_is_word_like_mv1')
 // ignore: non_constant_identifier_names
 external bool _icu4x_WordBreakIteratorUtf8_is_word_like_mv1(ffi.Pointer<ffi.Opaque> self);

--- a/ffi/dart/lib/src/bindings/WordSegmenter.g.dart
+++ b/ffi/dart/lib/src/bindings/WordSegmenter.g.dart
@@ -19,12 +19,16 @@ final class WordSegmenter implements ffi.Finalizable {
   // maintain borrow validity.
   WordSegmenter._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_WordSegmenter_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_WordSegmenter_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_WordSegmenter_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_WordSegmenter_destroy_mv1(WordSegmenter cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_WordSegmenter_destroy_mv1));
 
   /// Construct a [WordSegmenter] with automatically selecting the best available LSTM
   /// or dictionary payload data, using compiled data. This does not assume any content locale.
@@ -217,72 +221,86 @@ final class WordSegmenter implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_WordSegmenter_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_WordSegmenter_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_WordSegmenter_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_WordSegmenter_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_WordSegmenter_create_auto_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_WordSegmenter_create_auto_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_WordSegmenter_create_auto_mv1();
 
-@_DiplomatFfiUse('icu4x_WordSegmenter_create_auto_with_content_locale_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_WordSegmenter_create_auto_with_content_locale_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_WordSegmenter_create_auto_with_content_locale_mv1(ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_WordSegmenter_create_auto_with_content_locale_and_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_WordSegmenter_create_auto_with_content_locale_and_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_WordSegmenter_create_auto_with_content_locale_and_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_WordSegmenter_create_lstm_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_WordSegmenter_create_lstm_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_WordSegmenter_create_lstm_mv1();
 
-@_DiplomatFfiUse('icu4x_WordSegmenter_create_lstm_with_content_locale_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_WordSegmenter_create_lstm_with_content_locale_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_WordSegmenter_create_lstm_with_content_locale_mv1(ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_WordSegmenter_create_lstm_with_content_locale_and_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_WordSegmenter_create_lstm_with_content_locale_and_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_WordSegmenter_create_lstm_with_content_locale_and_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_WordSegmenter_create_dictionary_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_WordSegmenter_create_dictionary_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_WordSegmenter_create_dictionary_mv1();
 
-@_DiplomatFfiUse('icu4x_WordSegmenter_create_dictionary_with_content_locale_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_WordSegmenter_create_dictionary_with_content_locale_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_WordSegmenter_create_dictionary_with_content_locale_mv1(ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_WordSegmenter_create_dictionary_with_content_locale_and_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_WordSegmenter_create_dictionary_with_content_locale_and_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_WordSegmenter_create_dictionary_with_content_locale_and_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_WordSegmenter_create_for_non_complex_scripts_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function()>(isLeaf: true, symbol: 'icu4x_WordSegmenter_create_for_non_complex_scripts_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_WordSegmenter_create_for_non_complex_scripts_mv1();
 
-@_DiplomatFfiUse('icu4x_WordSegmenter_create_for_non_complex_scripts_with_content_locale_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_WordSegmenter_create_for_non_complex_scripts_with_content_locale_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_WordSegmenter_create_for_non_complex_scripts_with_content_locale_mv1(ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_WordSegmenter_create_for_non_complex_scripts_with_content_locale_and_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_WordSegmenter_create_for_non_complex_scripts_with_content_locale_and_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_WordSegmenter_create_for_non_complex_scripts_with_content_locale_and_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale);
 
-@_DiplomatFfiUse('icu4x_WordSegmenter_segment_utf16_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Pointer<ffi.Opaque>, _SliceUtf16)>(isLeaf: true, symbol: 'icu4x_WordSegmenter_segment_utf16_mv1')
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _icu4x_WordSegmenter_segment_utf16_mv1(ffi.Pointer<ffi.Opaque> self, _SliceUtf16 input);

--- a/ffi/dart/lib/src/bindings/ZonedDateFormatter.g.dart
+++ b/ffi/dart/lib/src/bindings/ZonedDateFormatter.g.dart
@@ -17,12 +17,16 @@ final class ZonedDateFormatter implements ffi.Finalizable {
   // maintain borrow validity.
   ZonedDateFormatter._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_ZonedDateFormatter_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_ZonedDateFormatter_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_ZonedDateFormatter_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_ZonedDateFormatter_destroy_mv1(ZonedDateFormatter cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_ZonedDateFormatter_destroy_mv1));
 
   /// Creates a zoned formatter based on a non-zoned formatter.
   ///
@@ -306,97 +310,116 @@ final class ZonedDateFormatter implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_ZonedDateFormatter_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_ZonedDateFormatter_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_ZonedDateFormatter_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_ZonedDateFormatter_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_ZonedDateFormatter_create_specific_long_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateFormatter_create_specific_long_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateFormatter_create_specific_long_mv1(ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateFormatter_create_specific_long_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateFormatter_create_specific_long_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateFormatter_create_specific_long_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateFormatter_create_specific_short_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateFormatter_create_specific_short_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateFormatter_create_specific_short_mv1(ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateFormatter_create_specific_short_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateFormatter_create_specific_short_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateFormatter_create_specific_short_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateFormatter_create_localized_offset_long_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateFormatter_create_localized_offset_long_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateFormatter_create_localized_offset_long_mv1(ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateFormatter_create_localized_offset_long_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateFormatter_create_localized_offset_long_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateFormatter_create_localized_offset_long_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateFormatter_create_localized_offset_short_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateFormatter_create_localized_offset_short_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateFormatter_create_localized_offset_short_mv1(ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateFormatter_create_localized_offset_short_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateFormatter_create_localized_offset_short_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateFormatter_create_localized_offset_short_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateFormatter_create_generic_long_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateFormatter_create_generic_long_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateFormatter_create_generic_long_mv1(ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateFormatter_create_generic_long_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateFormatter_create_generic_long_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateFormatter_create_generic_long_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateFormatter_create_generic_short_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateFormatter_create_generic_short_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateFormatter_create_generic_short_mv1(ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateFormatter_create_generic_short_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateFormatter_create_generic_short_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateFormatter_create_generic_short_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateFormatter_create_location_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateFormatter_create_location_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateFormatter_create_location_mv1(ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateFormatter_create_location_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateFormatter_create_location_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateFormatter_create_location_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateFormatter_create_exemplar_city_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateFormatter_create_exemplar_city_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateFormatter_create_exemplar_city_mv1(ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateFormatter_create_exemplar_city_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateFormatter_create_exemplar_city_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateFormatter_create_exemplar_city_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateFormatter_format_iso_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultVoidInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateFormatter_format_iso_mv1')
 // ignore: non_constant_identifier_names
 external _ResultVoidInt32 _icu4x_ZonedDateFormatter_format_iso_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> isoDate, ffi.Pointer<ffi.Opaque> zone, ffi.Pointer<ffi.Opaque> write);
 
-@_DiplomatFfiUse('icu4x_ZonedDateFormatter_format_same_calendar_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultVoidDateTimeMismatchedCalendarErrorFfi Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateFormatter_format_same_calendar_mv1')
 // ignore: non_constant_identifier_names
 external _ResultVoidDateTimeMismatchedCalendarErrorFfi _icu4x_ZonedDateFormatter_format_same_calendar_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> date, ffi.Pointer<ffi.Opaque> zone, ffi.Pointer<ffi.Opaque> write);

--- a/ffi/dart/lib/src/bindings/ZonedDateFormatterGregorian.g.dart
+++ b/ffi/dart/lib/src/bindings/ZonedDateFormatterGregorian.g.dart
@@ -17,12 +17,16 @@ final class ZonedDateFormatterGregorian implements ffi.Finalizable {
   // maintain borrow validity.
   ZonedDateFormatterGregorian._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_ZonedDateFormatterGregorian_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_ZonedDateFormatterGregorian_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_ZonedDateFormatterGregorian_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_ZonedDateFormatterGregorian_destroy_mv1(ZonedDateFormatterGregorian cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_ZonedDateFormatterGregorian_destroy_mv1));
 
   /// Creates a zoned formatter based on a non-zoned formatter.
   ///
@@ -306,97 +310,116 @@ final class ZonedDateFormatterGregorian implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_ZonedDateFormatterGregorian_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_ZonedDateFormatterGregorian_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_ZonedDateFormatterGregorian_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_ZonedDateFormatterGregorian_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_ZonedDateFormatterGregorian_create_specific_long_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateFormatterGregorian_create_specific_long_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateFormatterGregorian_create_specific_long_mv1(ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateFormatterGregorian_create_specific_long_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateFormatterGregorian_create_specific_long_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateFormatterGregorian_create_specific_long_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateFormatterGregorian_create_specific_short_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateFormatterGregorian_create_specific_short_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateFormatterGregorian_create_specific_short_mv1(ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateFormatterGregorian_create_specific_short_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateFormatterGregorian_create_specific_short_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateFormatterGregorian_create_specific_short_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateFormatterGregorian_create_localized_offset_long_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateFormatterGregorian_create_localized_offset_long_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateFormatterGregorian_create_localized_offset_long_mv1(ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateFormatterGregorian_create_localized_offset_long_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateFormatterGregorian_create_localized_offset_long_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateFormatterGregorian_create_localized_offset_long_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateFormatterGregorian_create_localized_offset_short_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateFormatterGregorian_create_localized_offset_short_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateFormatterGregorian_create_localized_offset_short_mv1(ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateFormatterGregorian_create_localized_offset_short_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateFormatterGregorian_create_localized_offset_short_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateFormatterGregorian_create_localized_offset_short_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateFormatterGregorian_create_generic_long_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateFormatterGregorian_create_generic_long_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateFormatterGregorian_create_generic_long_mv1(ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateFormatterGregorian_create_generic_long_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateFormatterGregorian_create_generic_long_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateFormatterGregorian_create_generic_long_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateFormatterGregorian_create_generic_short_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateFormatterGregorian_create_generic_short_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateFormatterGregorian_create_generic_short_mv1(ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateFormatterGregorian_create_generic_short_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateFormatterGregorian_create_generic_short_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateFormatterGregorian_create_generic_short_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateFormatterGregorian_create_location_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateFormatterGregorian_create_location_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateFormatterGregorian_create_location_mv1(ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateFormatterGregorian_create_location_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateFormatterGregorian_create_location_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateFormatterGregorian_create_location_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateFormatterGregorian_create_exemplar_city_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateFormatterGregorian_create_exemplar_city_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateFormatterGregorian_create_exemplar_city_mv1(ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateFormatterGregorian_create_exemplar_city_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateFormatterGregorian_create_exemplar_city_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateFormatterGregorian_create_exemplar_city_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateFormatterGregorian_format_iso_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultVoidInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateFormatterGregorian_format_iso_mv1')
 // ignore: non_constant_identifier_names
 external _ResultVoidInt32 _icu4x_ZonedDateFormatterGregorian_format_iso_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> isoDate, ffi.Pointer<ffi.Opaque> zone, ffi.Pointer<ffi.Opaque> write);
 
-@_DiplomatFfiUse('icu4x_ZonedDateFormatterGregorian_format_same_calendar_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultVoidDateTimeMismatchedCalendarErrorFfi Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateFormatterGregorian_format_same_calendar_mv1')
 // ignore: non_constant_identifier_names
 external _ResultVoidDateTimeMismatchedCalendarErrorFfi _icu4x_ZonedDateFormatterGregorian_format_same_calendar_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> date, ffi.Pointer<ffi.Opaque> zone, ffi.Pointer<ffi.Opaque> write);

--- a/ffi/dart/lib/src/bindings/ZonedDateTime.g.dart
+++ b/ffi/dart/lib/src/bindings/ZonedDateTime.g.dart
@@ -112,22 +112,26 @@ final class ZonedDateTime {
       ]);
 }
 
-@_DiplomatFfiUse('icu4x_ZonedDateTime_strict_from_string_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultZonedDateTimeFfiInt32 Function(_SliceUtf8, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTime_strict_from_string_mv1')
 // ignore: non_constant_identifier_names
 external _ResultZonedDateTimeFfiInt32 _icu4x_ZonedDateTime_strict_from_string_mv1(_SliceUtf8 v, ffi.Pointer<ffi.Opaque> calendar, ffi.Pointer<ffi.Opaque> ianaParser);
 
-@_DiplomatFfiUse('icu4x_ZonedDateTime_location_only_from_string_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultZonedDateTimeFfiInt32 Function(_SliceUtf8, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTime_location_only_from_string_mv1')
 // ignore: non_constant_identifier_names
 external _ResultZonedDateTimeFfiInt32 _icu4x_ZonedDateTime_location_only_from_string_mv1(_SliceUtf8 v, ffi.Pointer<ffi.Opaque> calendar, ffi.Pointer<ffi.Opaque> ianaParser);
 
-@_DiplomatFfiUse('icu4x_ZonedDateTime_offset_only_from_string_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultZonedDateTimeFfiInt32 Function(_SliceUtf8, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTime_offset_only_from_string_mv1')
 // ignore: non_constant_identifier_names
 external _ResultZonedDateTimeFfiInt32 _icu4x_ZonedDateTime_offset_only_from_string_mv1(_SliceUtf8 v, ffi.Pointer<ffi.Opaque> calendar);
 
-@_DiplomatFfiUse('icu4x_ZonedDateTime_lenient_from_string_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultZonedDateTimeFfiInt32 Function(_SliceUtf8, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTime_lenient_from_string_mv1')
 // ignore: non_constant_identifier_names
 external _ResultZonedDateTimeFfiInt32 _icu4x_ZonedDateTime_lenient_from_string_mv1(_SliceUtf8 v, ffi.Pointer<ffi.Opaque> calendar, ffi.Pointer<ffi.Opaque> ianaParser);

--- a/ffi/dart/lib/src/bindings/ZonedDateTimeFormatter.g.dart
+++ b/ffi/dart/lib/src/bindings/ZonedDateTimeFormatter.g.dart
@@ -17,12 +17,16 @@ final class ZonedDateTimeFormatter implements ffi.Finalizable {
   // maintain borrow validity.
   ZonedDateTimeFormatter._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_ZonedDateTimeFormatter_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_ZonedDateTimeFormatter_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_ZonedDateTimeFormatter_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_ZonedDateTimeFormatter_destroy_mv1(ZonedDateTimeFormatter cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_ZonedDateTimeFormatter_destroy_mv1));
 
   /// Creates a zoned formatter based on a non-zoned formatter.
   ///
@@ -306,97 +310,116 @@ final class ZonedDateTimeFormatter implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_ZonedDateTimeFormatter_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTimeFormatter_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_ZonedDateTimeFormatter_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_ZonedDateTimeFormatter_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_ZonedDateTimeFormatter_create_specific_long_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTimeFormatter_create_specific_long_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateTimeFormatter_create_specific_long_mv1(ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateTimeFormatter_create_specific_long_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTimeFormatter_create_specific_long_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateTimeFormatter_create_specific_long_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateTimeFormatter_create_specific_short_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTimeFormatter_create_specific_short_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateTimeFormatter_create_specific_short_mv1(ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateTimeFormatter_create_specific_short_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTimeFormatter_create_specific_short_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateTimeFormatter_create_specific_short_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateTimeFormatter_create_localized_offset_long_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTimeFormatter_create_localized_offset_long_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateTimeFormatter_create_localized_offset_long_mv1(ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateTimeFormatter_create_localized_offset_long_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTimeFormatter_create_localized_offset_long_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateTimeFormatter_create_localized_offset_long_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateTimeFormatter_create_localized_offset_short_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTimeFormatter_create_localized_offset_short_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateTimeFormatter_create_localized_offset_short_mv1(ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateTimeFormatter_create_localized_offset_short_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTimeFormatter_create_localized_offset_short_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateTimeFormatter_create_localized_offset_short_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateTimeFormatter_create_generic_long_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTimeFormatter_create_generic_long_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateTimeFormatter_create_generic_long_mv1(ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateTimeFormatter_create_generic_long_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTimeFormatter_create_generic_long_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateTimeFormatter_create_generic_long_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateTimeFormatter_create_generic_short_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTimeFormatter_create_generic_short_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateTimeFormatter_create_generic_short_mv1(ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateTimeFormatter_create_generic_short_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTimeFormatter_create_generic_short_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateTimeFormatter_create_generic_short_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateTimeFormatter_create_location_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTimeFormatter_create_location_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateTimeFormatter_create_location_mv1(ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateTimeFormatter_create_location_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTimeFormatter_create_location_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateTimeFormatter_create_location_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateTimeFormatter_create_exemplar_city_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTimeFormatter_create_exemplar_city_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateTimeFormatter_create_exemplar_city_mv1(ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateTimeFormatter_create_exemplar_city_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTimeFormatter_create_exemplar_city_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateTimeFormatter_create_exemplar_city_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateTimeFormatter_format_iso_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultVoidInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTimeFormatter_format_iso_mv1')
 // ignore: non_constant_identifier_names
 external _ResultVoidInt32 _icu4x_ZonedDateTimeFormatter_format_iso_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> isoDate, ffi.Pointer<ffi.Opaque> time, ffi.Pointer<ffi.Opaque> zone, ffi.Pointer<ffi.Opaque> write);
 
-@_DiplomatFfiUse('icu4x_ZonedDateTimeFormatter_format_same_calendar_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultVoidDateTimeMismatchedCalendarErrorFfi Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTimeFormatter_format_same_calendar_mv1')
 // ignore: non_constant_identifier_names
 external _ResultVoidDateTimeMismatchedCalendarErrorFfi _icu4x_ZonedDateTimeFormatter_format_same_calendar_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> date, ffi.Pointer<ffi.Opaque> time, ffi.Pointer<ffi.Opaque> zone, ffi.Pointer<ffi.Opaque> write);

--- a/ffi/dart/lib/src/bindings/ZonedDateTimeFormatterGregorian.g.dart
+++ b/ffi/dart/lib/src/bindings/ZonedDateTimeFormatterGregorian.g.dart
@@ -17,12 +17,16 @@ final class ZonedDateTimeFormatterGregorian implements ffi.Finalizable {
   // maintain borrow validity.
   ZonedDateTimeFormatterGregorian._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_ZonedDateTimeFormatterGregorian_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_ZonedDateTimeFormatterGregorian_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_ZonedDateTimeFormatterGregorian_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_ZonedDateTimeFormatterGregorian_destroy_mv1(ZonedDateTimeFormatterGregorian cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_ZonedDateTimeFormatterGregorian_destroy_mv1));
 
   /// Creates a zoned formatter based on a non-zoned formatter.
   ///
@@ -306,97 +310,116 @@ final class ZonedDateTimeFormatterGregorian implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_ZonedDateTimeFormatterGregorian_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTimeFormatterGregorian_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_ZonedDateTimeFormatterGregorian_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_ZonedDateTimeFormatterGregorian_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_ZonedDateTimeFormatterGregorian_create_specific_long_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTimeFormatterGregorian_create_specific_long_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateTimeFormatterGregorian_create_specific_long_mv1(ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateTimeFormatterGregorian_create_specific_long_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTimeFormatterGregorian_create_specific_long_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateTimeFormatterGregorian_create_specific_long_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateTimeFormatterGregorian_create_specific_short_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTimeFormatterGregorian_create_specific_short_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateTimeFormatterGregorian_create_specific_short_mv1(ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateTimeFormatterGregorian_create_specific_short_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTimeFormatterGregorian_create_specific_short_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateTimeFormatterGregorian_create_specific_short_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateTimeFormatterGregorian_create_localized_offset_long_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTimeFormatterGregorian_create_localized_offset_long_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateTimeFormatterGregorian_create_localized_offset_long_mv1(ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateTimeFormatterGregorian_create_localized_offset_long_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTimeFormatterGregorian_create_localized_offset_long_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateTimeFormatterGregorian_create_localized_offset_long_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateTimeFormatterGregorian_create_localized_offset_short_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTimeFormatterGregorian_create_localized_offset_short_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateTimeFormatterGregorian_create_localized_offset_short_mv1(ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateTimeFormatterGregorian_create_localized_offset_short_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTimeFormatterGregorian_create_localized_offset_short_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateTimeFormatterGregorian_create_localized_offset_short_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateTimeFormatterGregorian_create_generic_long_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTimeFormatterGregorian_create_generic_long_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateTimeFormatterGregorian_create_generic_long_mv1(ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateTimeFormatterGregorian_create_generic_long_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTimeFormatterGregorian_create_generic_long_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateTimeFormatterGregorian_create_generic_long_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateTimeFormatterGregorian_create_generic_short_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTimeFormatterGregorian_create_generic_short_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateTimeFormatterGregorian_create_generic_short_mv1(ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateTimeFormatterGregorian_create_generic_short_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTimeFormatterGregorian_create_generic_short_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateTimeFormatterGregorian_create_generic_short_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateTimeFormatterGregorian_create_location_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTimeFormatterGregorian_create_location_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateTimeFormatterGregorian_create_location_mv1(ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateTimeFormatterGregorian_create_location_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTimeFormatterGregorian_create_location_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateTimeFormatterGregorian_create_location_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateTimeFormatterGregorian_create_exemplar_city_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTimeFormatterGregorian_create_exemplar_city_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateTimeFormatterGregorian_create_exemplar_city_mv1(ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateTimeFormatterGregorian_create_exemplar_city_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTimeFormatterGregorian_create_exemplar_city_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedDateTimeFormatterGregorian_create_exemplar_city_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, ffi.Pointer<ffi.Opaque> formatter);
 
-@_DiplomatFfiUse('icu4x_ZonedDateTimeFormatterGregorian_format_iso_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultVoidInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTimeFormatterGregorian_format_iso_mv1')
 // ignore: non_constant_identifier_names
 external _ResultVoidInt32 _icu4x_ZonedDateTimeFormatterGregorian_format_iso_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> isoDate, ffi.Pointer<ffi.Opaque> time, ffi.Pointer<ffi.Opaque> zone, ffi.Pointer<ffi.Opaque> write);
 
-@_DiplomatFfiUse('icu4x_ZonedDateTimeFormatterGregorian_format_same_calendar_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultVoidDateTimeMismatchedCalendarErrorFfi Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedDateTimeFormatterGregorian_format_same_calendar_mv1')
 // ignore: non_constant_identifier_names
 external _ResultVoidDateTimeMismatchedCalendarErrorFfi _icu4x_ZonedDateTimeFormatterGregorian_format_same_calendar_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> date, ffi.Pointer<ffi.Opaque> time, ffi.Pointer<ffi.Opaque> zone, ffi.Pointer<ffi.Opaque> write);

--- a/ffi/dart/lib/src/bindings/ZonedIsoDateTime.g.dart
+++ b/ffi/dart/lib/src/bindings/ZonedIsoDateTime.g.dart
@@ -80,12 +80,14 @@ final class ZonedIsoDateTime {
       ]);
 }
 
-@_DiplomatFfiUse('icu4x_ZonedIsoDateTime_strict_from_string_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultZonedIsoDateTimeFfiInt32 Function(_SliceUtf8, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedIsoDateTime_strict_from_string_mv1')
 // ignore: non_constant_identifier_names
 external _ResultZonedIsoDateTimeFfiInt32 _icu4x_ZonedIsoDateTime_strict_from_string_mv1(_SliceUtf8 v, ffi.Pointer<ffi.Opaque> ianaParser);
 
-@_DiplomatFfiUse('icu4x_ZonedIsoDateTime_from_epoch_milliseconds_and_utc_offset_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ZonedIsoDateTimeFfi Function(ffi.Int64, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedIsoDateTime_from_epoch_milliseconds_and_utc_offset_mv1')
 // ignore: non_constant_identifier_names
 external _ZonedIsoDateTimeFfi _icu4x_ZonedIsoDateTime_from_epoch_milliseconds_and_utc_offset_mv1(int epochMilliseconds, ffi.Pointer<ffi.Opaque> utcOffset);

--- a/ffi/dart/lib/src/bindings/ZonedTime.g.dart
+++ b/ffi/dart/lib/src/bindings/ZonedTime.g.dart
@@ -105,22 +105,26 @@ final class ZonedTime {
       ]);
 }
 
-@_DiplomatFfiUse('icu4x_ZonedTime_strict_from_string_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultZonedTimeFfiInt32 Function(_SliceUtf8, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedTime_strict_from_string_mv1')
 // ignore: non_constant_identifier_names
 external _ResultZonedTimeFfiInt32 _icu4x_ZonedTime_strict_from_string_mv1(_SliceUtf8 v, ffi.Pointer<ffi.Opaque> ianaParser);
 
-@_DiplomatFfiUse('icu4x_ZonedTime_location_only_from_string_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultZonedTimeFfiInt32 Function(_SliceUtf8, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedTime_location_only_from_string_mv1')
 // ignore: non_constant_identifier_names
 external _ResultZonedTimeFfiInt32 _icu4x_ZonedTime_location_only_from_string_mv1(_SliceUtf8 v, ffi.Pointer<ffi.Opaque> ianaParser);
 
-@_DiplomatFfiUse('icu4x_ZonedTime_offset_only_from_string_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultZonedTimeFfiInt32 Function(_SliceUtf8)>(isLeaf: true, symbol: 'icu4x_ZonedTime_offset_only_from_string_mv1')
 // ignore: non_constant_identifier_names
 external _ResultZonedTimeFfiInt32 _icu4x_ZonedTime_offset_only_from_string_mv1(_SliceUtf8 v);
 
-@_DiplomatFfiUse('icu4x_ZonedTime_lenient_from_string_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultZonedTimeFfiInt32 Function(_SliceUtf8, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedTime_lenient_from_string_mv1')
 // ignore: non_constant_identifier_names
 external _ResultZonedTimeFfiInt32 _icu4x_ZonedTime_lenient_from_string_mv1(_SliceUtf8 v, ffi.Pointer<ffi.Opaque> ianaParser);

--- a/ffi/dart/lib/src/bindings/ZonedTimeFormatter.g.dart
+++ b/ffi/dart/lib/src/bindings/ZonedTimeFormatter.g.dart
@@ -17,12 +17,16 @@ final class ZonedTimeFormatter implements ffi.Finalizable {
   // maintain borrow validity.
   ZonedTimeFormatter._fromFfi(this._ffi, this._selfEdge) {
     if (_selfEdge.isEmpty) {
-      _finalizer.attach(this, _ffi.cast());
+      _icu4x_ZonedTimeFormatter_destroy_mv1(this, _ffi.cast());
     }
   }
 
-  @_DiplomatFfiUse('icu4x_ZonedTimeFormatter_destroy_mv1')
-  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_icu4x_ZonedTimeFormatter_destroy_mv1));
+  // ignore: experimental_member_use
+  @meta.RecordUse()
+  // ignore: non_constant_identifier_names
+  static void _icu4x_ZonedTimeFormatter_destroy_mv1(ZonedTimeFormatter cl, ffi.Pointer<ffi.Void> pointer) => _finalizer.attach(cl, pointer);
+
+  static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_ZonedTimeFormatter_destroy_mv1));
 
   /// Creates a zoned formatter based on a non-zoned formatter.
   ///
@@ -294,92 +298,110 @@ final class ZonedTimeFormatter implements ffi.Finalizable {
 
 }
 
-@_DiplomatFfiUse('icu4x_ZonedTimeFormatter_destroy_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Void>)>(isLeaf: true, symbol: 'icu4x_ZonedTimeFormatter_destroy_mv1')
 // ignore: non_constant_identifier_names
-external void _icu4x_ZonedTimeFormatter_destroy_mv1(ffi.Pointer<ffi.Void> self);
+external void _internal_icu4x_ZonedTimeFormatter_destroy_mv1(ffi.Pointer<ffi.Void> self);
 
-@_DiplomatFfiUse('icu4x_ZonedTimeFormatter_create_specific_long_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_ZonedTimeFormatter_create_specific_long_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedTimeFormatter_create_specific_long_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_ZonedTimeFormatter_create_specific_long_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_ZonedTimeFormatter_create_specific_long_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedTimeFormatter_create_specific_long_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_ZonedTimeFormatter_create_specific_short_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_ZonedTimeFormatter_create_specific_short_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedTimeFormatter_create_specific_short_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_ZonedTimeFormatter_create_specific_short_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_ZonedTimeFormatter_create_specific_short_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedTimeFormatter_create_specific_short_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_ZonedTimeFormatter_create_localized_offset_long_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_ZonedTimeFormatter_create_localized_offset_long_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedTimeFormatter_create_localized_offset_long_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_ZonedTimeFormatter_create_localized_offset_long_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_ZonedTimeFormatter_create_localized_offset_long_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedTimeFormatter_create_localized_offset_long_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_ZonedTimeFormatter_create_localized_offset_short_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_ZonedTimeFormatter_create_localized_offset_short_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedTimeFormatter_create_localized_offset_short_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_ZonedTimeFormatter_create_localized_offset_short_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_ZonedTimeFormatter_create_localized_offset_short_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedTimeFormatter_create_localized_offset_short_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_ZonedTimeFormatter_create_generic_long_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_ZonedTimeFormatter_create_generic_long_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedTimeFormatter_create_generic_long_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_ZonedTimeFormatter_create_generic_long_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_ZonedTimeFormatter_create_generic_long_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedTimeFormatter_create_generic_long_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_ZonedTimeFormatter_create_generic_short_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_ZonedTimeFormatter_create_generic_short_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedTimeFormatter_create_generic_short_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_ZonedTimeFormatter_create_generic_short_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_ZonedTimeFormatter_create_generic_short_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedTimeFormatter_create_generic_short_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_ZonedTimeFormatter_create_location_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_ZonedTimeFormatter_create_location_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedTimeFormatter_create_location_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_ZonedTimeFormatter_create_location_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_ZonedTimeFormatter_create_location_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedTimeFormatter_create_location_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_ZonedTimeFormatter_create_exemplar_city_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_ZonedTimeFormatter_create_exemplar_city_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedTimeFormatter_create_exemplar_city_mv1(ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_ZonedTimeFormatter_create_exemplar_city_with_provider_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultOpaqueInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, _ResultInt32Void, _ResultInt32Void, _ResultInt32Void)>(isLeaf: true, symbol: 'icu4x_ZonedTimeFormatter_create_exemplar_city_with_provider_mv1')
 // ignore: non_constant_identifier_names
 external _ResultOpaqueInt32 _icu4x_ZonedTimeFormatter_create_exemplar_city_with_provider_mv1(ffi.Pointer<ffi.Opaque> provider, ffi.Pointer<ffi.Opaque> locale, _ResultInt32Void length, _ResultInt32Void timePrecision, _ResultInt32Void alignment);
 
-@_DiplomatFfiUse('icu4x_ZonedTimeFormatter_format_mv1')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<_ResultVoidInt32 Function(ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_ZonedTimeFormatter_format_mv1')
 // ignore: non_constant_identifier_names
 external _ResultVoidInt32 _icu4x_ZonedTimeFormatter_format_mv1(ffi.Pointer<ffi.Opaque> self, ffi.Pointer<ffi.Opaque> time, ffi.Pointer<ffi.Opaque> zone, ffi.Pointer<ffi.Opaque> write);

--- a/ffi/dart/lib/src/bindings/lib.g.dart
+++ b/ffi/dart/lib/src/bindings/lib.g.dart
@@ -186,15 +186,6 @@ part 'ZonedIsoDateTime.g.dart';
 part 'ZonedTime.g.dart';
 part 'ZonedTimeFormatter.g.dart';
 
-// ignore: experimental_member_use
-@meta.RecordUse()
-final class _DiplomatFfiUse {
-  final String symbol;
-
-  // ignore: experimental_member_use
-  const _DiplomatFfiUse(@meta.mustBeConst this.symbol);
-}
-
 /// A [Rune] is a Unicode code point, such as `a`, or `💡`.
 ///
 /// The recommended way to obtain a [Rune] is to create it from a
@@ -237,7 +228,8 @@ final class _RustAlloc implements ffi.Allocator {
   }
 }
 
-@_DiplomatFfiUse('diplomat_alloc')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Void> Function(ffi.Size, ffi.Size)>(
   symbol: 'diplomat_alloc',
   isLeaf: true,
@@ -245,7 +237,8 @@ final class _RustAlloc implements ffi.Allocator {
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Void> _diplomat_alloc(int len, int align);
 
-@_DiplomatFfiUse('diplomat_free')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Size Function(ffi.Pointer<ffi.Void>, ffi.Size, ffi.Size)>(
   symbol: 'diplomat_free',
   isLeaf: true,
@@ -1153,22 +1146,26 @@ final class _Write {
   }
 }
 
-@_DiplomatFfiUse('diplomat_buffer_write_create')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Opaque> Function(ffi.Size)>(symbol: 'diplomat_buffer_write_create', isLeaf: true)
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Opaque> _diplomat_buffer_write_create(int len);
 
-@_DiplomatFfiUse('diplomat_buffer_write_len')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Size Function(ffi.Pointer<ffi.Opaque>)>(symbol: 'diplomat_buffer_write_len', isLeaf: true)
 // ignore: non_constant_identifier_names
 external int _diplomat_buffer_write_len(ffi.Pointer<ffi.Opaque> ptr);
 
-@_DiplomatFfiUse('diplomat_buffer_write_get_bytes')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Pointer<ffi.Uint8> Function(ffi.Pointer<ffi.Opaque>)>(symbol: 'diplomat_buffer_write_get_bytes', isLeaf: true)
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ffi.Uint8> _diplomat_buffer_write_get_bytes(ffi.Pointer<ffi.Opaque> ptr);
 
-@_DiplomatFfiUse('diplomat_buffer_write_destroy')
+// ignore: experimental_member_use
+@meta.RecordUse()
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>)>(symbol: 'diplomat_buffer_write_destroy', isLeaf: true)
 // ignore: non_constant_identifier_names
 external void _diplomat_buffer_write_destroy(ffi.Pointer<ffi.Opaque> ptr);

--- a/ffi/dart/pubspec.yaml
+++ b/ffi/dart/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   crypto: ^3.0.7
   ffi: ^2.1.4
   # Pinned as we use unstable APIs
-  hooks: ^2.0.2
+  hooks: 2.0.2
   logging: ^1.3.0
   meta: ^1.17.0
   native_toolchain_c: ^0.19.1

--- a/ffi/dart/pubspec.yaml
+++ b/ffi/dart/pubspec.yaml
@@ -5,7 +5,7 @@
 name: icu4x
 description: > 
   Dart bindings for the Rust `icu` internationalization crate.
-version: 2.2.0-dev.1
+version: 2.2.0-dev.1-wip
 repository: https://github.com/unicode-org/icu4x/tree/main/ffi/dart
 issue_tracker: https://github.com/unicode-org/icu4x/issues?q=is%3Aissue%20is%3Aopen%20label%3AU-flutter
 
@@ -28,11 +28,11 @@ dependencies:
   crypto: ^3.0.7
   ffi: ^2.1.4
   # Pinned as we use unstable APIs
-  hooks: '>=1.0.0 <1.0.1'
+  hooks: ^2.0.2
   logging: ^1.3.0
   meta: ^1.17.0
-  native_toolchain_c: ^0.17.3
-  record_use: ^0.4.2
+  native_toolchain_c: ^0.19.1
+  record_use: ^0.6.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/tools/make/ffi.toml
+++ b/tools/make/ffi.toml
@@ -86,7 +86,7 @@ cd examples/dart
 exec --fail-on-error dart pub get
 exec --fail-on-error dart format --set-exit-if-changed .
 exec --fail-on-error dart analyze
-exec --fail-on-error dart build cli --target bin/example.dart
+exec --fail-on-error dart --enable-experiment=record-use build cli --target bin/example.dart
 bins = glob_array ./build/cli/*/bundle/bin/*
 bin = array_pop ${bins}
 exec --fail-on-error ${bin}

--- a/tools/make/ffi.toml
+++ b/tools/make/ffi.toml
@@ -86,7 +86,7 @@ cd examples/dart
 exec --fail-on-error dart pub get
 exec --fail-on-error dart format --set-exit-if-changed .
 exec --fail-on-error dart analyze
-exec --fail-on-error dart --enable-experiment=record-use build cli bin/example.dart
+exec --fail-on-error dart build cli --target bin/example.dart
 bins = glob_array ./build/cli/*/bundle/bin/*
 bin = array_pop ${bins}
 exec --fail-on-error ${bin}


### PR DESCRIPTION
To not fall too far behind the current implementation.

## Changelog
FFI:
* Update supported Dart toolchain for `record_use` to `3.13.0-215.0.dev`