### PR TITLE
Remove unused PatternBackend::Error associated type

### DIFF
--- a/components/pattern/src/common.rs
+++ b/components/pattern/src/common.rs
@@ -78,9 +78,6 @@ pub trait PatternBackend: crate::private::Sealed + 'static + core::fmt::Debug {
     #[cfg(feature = "alloc")]
     type PlaceholderKeyCow<'a>;
 
-    /// The type of error that the [`TryWriteable`] for this backend can return.
-    type Error<'a>;
-
     /// The unsized type of the store required for this backend, usually `str` or `[u8]`.
     // Note: it is not good practice to feature-gate trait types, but this trait is sealed
     #[doc(hidden)] // TODO(#4467): Should be internal

--- a/components/pattern/src/double.rs
+++ b/components/pattern/src/double.rs
@@ -309,7 +309,6 @@ impl PatternBackend for DoublePlaceholder {
     type PlaceholderKey<'a> = DoublePlaceholderKey;
     #[cfg(feature = "alloc")]
     type PlaceholderKeyCow<'a> = DoublePlaceholderKey;
-    type Error<'a> = Infallible;
     type Store = str;
     type Iter<'a> = DoublePlaceholderPatternIterator<'a>;
 

--- a/components/pattern/src/frontend/mod.rs
+++ b/components/pattern/src/frontend/mod.rs
@@ -258,9 +258,9 @@ where
     pub fn try_interpolate<'a, P>(
         &'a self,
         value_provider: P,
-    ) -> impl TryWriteable<Error = B::Error<'a>> + fmt::Display + 'a
+    ) -> impl TryWriteable<Error = P::Error> + fmt::Display + 'a
     where
-        P: PlaceholderValueProvider<B::PlaceholderKey<'a>, Error = B::Error<'a>> + 'a,
+        P: PlaceholderValueProvider<B::PlaceholderKey<'a>> + 'a,
     {
         WriteablePattern::<B, P> {
             store: &self.store,
@@ -277,26 +277,23 @@ where
     pub fn try_interpolate_to_string<'a, P>(
         &'a self,
         value_provider: P,
-    ) -> Result<String, (B::Error<'a>, String)>
+    ) -> Result<String, (P::Error, String)>
     where
-        P: PlaceholderValueProvider<B::PlaceholderKey<'a>, Error = B::Error<'a>> + 'a,
+        P: PlaceholderValueProvider<B::PlaceholderKey<'a>> + 'a,
     {
         self.try_interpolate(value_provider)
             .try_write_to_string()
             .map(|s| s.into_owned())
             .map_err(|(e, s)| (e, s.into_owned()))
     }
-}
 
-impl<B> Pattern<B>
-where
-    for<'b> B: PatternBackend<Error<'b> = Infallible>,
-{
     /// Returns a [`Writeable`] that interpolates items from the given replacement provider
     /// into this pattern string.
+    ///
+    /// This is defined only on infallible inputs.
     pub fn interpolate<'a, P>(&'a self, value_provider: P) -> impl Writeable + fmt::Display + 'a
     where
-        P: PlaceholderValueProvider<B::PlaceholderKey<'a>, Error = B::Error<'a>> + 'a,
+        P: PlaceholderValueProvider<B::PlaceholderKey<'a>, Error = Infallible> + 'a,
     {
         TryWriteableInfallibleAsWriteable(WriteablePattern::<B, P> {
             store: &self.store,
@@ -307,10 +304,12 @@ where
     #[cfg(feature = "alloc")]
     /// Interpolates the pattern directly to a string.
     ///
+    /// This is defined only on infallible inputs.
+    ///
     /// ✨ *Enabled with the `alloc` Cargo feature.*
     pub fn interpolate_to_string<'a, P>(&'a self, value_provider: P) -> String
     where
-        P: PlaceholderValueProvider<B::PlaceholderKey<'a>, Error = B::Error<'a>> + 'a,
+        P: PlaceholderValueProvider<B::PlaceholderKey<'a>, Error = Infallible> + 'a,
     {
         self.interpolate(value_provider)
             .write_to_string()
@@ -326,9 +325,9 @@ struct WriteablePattern<'a, B: PatternBackend, P> {
 impl<'a, B, P> TryWriteable for WriteablePattern<'a, B, P>
 where
     B: PatternBackend,
-    P: PlaceholderValueProvider<B::PlaceholderKey<'a>, Error = B::Error<'a>>,
+    P: PlaceholderValueProvider<B::PlaceholderKey<'a>>,
 {
-    type Error = B::Error<'a>;
+    type Error = P::Error;
 
     fn try_write_to_parts<S: PartsWrite + ?Sized>(
         &self,
@@ -374,7 +373,7 @@ where
 impl<'a, B, P> fmt::Display for WriteablePattern<'a, B, P>
 where
     B: PatternBackend,
-    P: PlaceholderValueProvider<B::PlaceholderKey<'a>, Error = B::Error<'a>>,
+    P: PlaceholderValueProvider<B::PlaceholderKey<'a>>,
 {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/components/pattern/src/multi_named.rs
+++ b/components/pattern/src/multi_named.rs
@@ -326,7 +326,6 @@ impl PatternBackend for MultiNamedPlaceholder {
     type PlaceholderKey<'a> = MultiNamedPlaceholderKey<'a>;
     #[cfg(feature = "alloc")]
     type PlaceholderKeyCow<'a> = MultiNamedPlaceholderKeyCow<'a>;
-    type Error<'a> = MissingNamedPlaceholderError<'a>;
     type Store = str;
     type Iter<'a> = MultiNamedPlaceholderPatternIterator<'a>;
 

--- a/components/pattern/src/single.rs
+++ b/components/pattern/src/single.rs
@@ -209,7 +209,6 @@ impl PatternBackend for SinglePlaceholder {
     type PlaceholderKey<'a> = SinglePlaceholderKey;
     #[cfg(feature = "alloc")]
     type PlaceholderKeyCow<'a> = SinglePlaceholderKey;
-    type Error<'a> = Infallible;
     type Store = str;
     type Iter<'a> = SinglePlaceholderPatternIterator<'a>;
 


### PR DESCRIPTION
There were two associated types, one on the pattern, one on the placeholder value provider.

Right now, we only have use cases for an error on the placeholder value provider:

1. A missing placeholder value
2. Bubbling up errors from inner writeables (new)

The associated error on the pattern _might_ come up in the future if a particular pattern type does some sort of lazy validation of the syntax. But, _it wasn't being used in that way_, I would rather add that back in when we actually need it. We don't need it now, so let's simplify the traits.

This is technically semver-breaking. Code such as the following will break:

```rust
let err: DoublePlaceholder::Error = // ...
```

However, I don't know why anyone would write that, at least for Single and Double, since ::Error was set to Infallible. This is most likely to break generic code, of which we have none in ICU4X (since this PR passes CI).

If you want to reduce the semver breakage, I can leave the associated type, mark it deprecated, and not use it anywhere. I'm not actually sure if this makes the PR 100% semver-safe, though, because the bounds are still changing.

## Changelog

icu_pattern: Remove public associated Error type from sealed trait PatternBackend