### PR TITLE
Support TryWriteable inputs in Single and Double placeholder patterns

### DIFF
--- a/components/pattern/src/double.rs
+++ b/components/pattern/src/double.rs
@@ -7,8 +7,8 @@
 use core::convert::Infallible;
 use core::{cmp::Ordering, str::FromStr};
 use either::Either;
-use writeable::Writeable;
 use writeable::adapters::WriteableAsTryWriteableInfallible;
+use writeable::{TryWriteable, Writeable};
 
 use crate::Error;
 use crate::common::*;
@@ -124,6 +124,60 @@ where
             DoublePlaceholderKey::Place1 => item1,
         };
         WriteableAsTryWriteableInfallible(writeable)
+    }
+    #[inline]
+    fn map_literal<'a, 'l>(&'a self, literal: &'l str) -> Self::L<'a, 'l> {
+        literal
+    }
+}
+
+/// A pair of values for [`DoublePlaceholder`] that may bubble up errors.
+///
+/// # Examples
+///
+/// Format a pattern with two placeholders, where the second value is an error:
+///
+/// ```
+/// use either::Either;
+/// use icu_pattern::DoublePlaceholderPattern;
+/// use icu_pattern::DoublePlaceholderValueProviderTry;
+/// use writeable::assert_try_writeable_eq;
+///
+/// let pattern = DoublePlaceholderPattern::try_from_str("{0}-{1}", Default::default()).unwrap();
+/// assert_try_writeable_eq!(
+///     pattern.try_interpolate(DoublePlaceholderValueProviderTry(Ok::<&str, &str>("xxx"), Err::<&str, &str>("yyy"))),
+///     "xxx-yyy",
+///     Err(Either::Right("yyy"))
+/// );
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(clippy::exhaustive_structs)] // holds two placeholder values
+pub struct DoublePlaceholderValueProviderTry<W0, W1>(pub W0, pub W1);
+
+impl<W0, W1> PlaceholderValueProvider<DoublePlaceholderKey>
+    for DoublePlaceholderValueProviderTry<W0, W1>
+where
+    W0: TryWriteable,
+    W1: TryWriteable,
+{
+    type Error = Either<W0::Error, W1::Error>;
+
+    type W<'a>
+        = Either<&'a W0, &'a W1>
+    where
+        Self: 'a;
+
+    type L<'a, 'l>
+        = &'l str
+    where
+        Self: 'a;
+
+    #[inline]
+    fn value_for(&self, key: DoublePlaceholderKey) -> Self::W<'_> {
+        match key {
+            DoublePlaceholderKey::Place0 => Either::Left(&self.0),
+            DoublePlaceholderKey::Place1 => Either::Right(&self.1),
+        }
     }
     #[inline]
     fn map_literal<'a, 'l>(&'a self, literal: &'l str) -> Self::L<'a, 'l> {

--- a/components/pattern/src/lib.rs
+++ b/components/pattern/src/lib.rs
@@ -66,6 +66,7 @@ pub use common::PatternItemCow;
 pub use common::PlaceholderValueProvider;
 pub use double::DoublePlaceholder;
 pub use double::DoublePlaceholderKey;
+pub use double::DoublePlaceholderValueProviderTry;
 pub use error::PatternError;
 pub use frontend::Pattern;
 #[cfg(feature = "serde")]
@@ -85,6 +86,7 @@ pub use parser::ParserOptions;
 pub use parser::QuoteMode;
 pub use single::SinglePlaceholder;
 pub use single::SinglePlaceholderKey;
+pub use single::SinglePlaceholderValueProviderTry;
 
 mod private {
     pub trait Sealed {}

--- a/components/pattern/src/single.rs
+++ b/components/pattern/src/single.rs
@@ -6,8 +6,8 @@
 
 use core::convert::Infallible;
 use core::{cmp::Ordering, str::FromStr};
-use writeable::Writeable;
 use writeable::adapters::WriteableAsTryWriteableInfallible;
+use writeable::{TryWriteable, Writeable};
 
 use crate::Error;
 use crate::common::*;
@@ -104,6 +104,55 @@ where
     fn value_for(&self, _key: SinglePlaceholderKey) -> Self::W<'_> {
         let [value] = self;
         WriteableAsTryWriteableInfallible(value)
+    }
+    #[inline]
+    fn map_literal<'a, 'l>(&'a self, literal: &'l str) -> Self::L<'a, 'l> {
+        literal
+    }
+}
+
+/// A value for [`SinglePlaceholder`] that may bubble up errors.
+///
+/// # Examples
+///
+/// Format a pattern with one placeholder, which holds an error:
+///
+/// ```
+/// use either::Either;
+/// use icu_pattern::SinglePlaceholderPattern;
+/// use icu_pattern::SinglePlaceholderValueProviderTry;
+/// use writeable::assert_try_writeable_eq;
+///
+/// let pattern = SinglePlaceholderPattern::try_from_str("Hello {0}", Default::default()).unwrap();
+/// assert_try_writeable_eq!(
+///     pattern.try_interpolate(SinglePlaceholderValueProviderTry(Err::<&str, &str>("Errory"))),
+///     "Hello Errory",
+///     Err("Errory")
+/// );
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(clippy::exhaustive_structs)] // holds a single placeholder value
+pub struct SinglePlaceholderValueProviderTry<W>(pub W);
+
+impl<W> PlaceholderValueProvider<SinglePlaceholderKey> for SinglePlaceholderValueProviderTry<W>
+where
+    W: TryWriteable,
+{
+    type Error = W::Error;
+
+    type W<'a>
+        = &'a W
+    where
+        Self: 'a;
+
+    type L<'a, 'l>
+        = &'l str
+    where
+        Self: 'a;
+
+    #[inline]
+    fn value_for(&self, _key: SinglePlaceholderKey) -> Self::W<'_> {
+        &self.0
     }
     #[inline]
     fn map_literal<'a, 'l>(&'a self, literal: &'l str) -> Self::L<'a, 'l> {


### PR DESCRIPTION
Depends on #8122

There are multiple ways to do this. With this PR, the user needs to wrap the TryWriteables in a named tuple struct, since it needs a different implementation of PlaceholderValueProvider than the plain tuple. I tried another approach where `interpolate` and `try_interpolate` accept _different traits_, which means that you can pass a plain tuple into both. You can see that approach [here](https://github.com/sffc/omnicu/tree/pattern-try). I am not sure which approach I prefer. I put up this PR because it doesn't involve semver breakage, although the diffbase PR #8122 is technically a semver breakage.

## Changelog

icu_pattern: new input structs DoublePlaceholderValueProviderTry, SinglePlaceholderValueProviderTry