### PR TITLE
Introduce dedicated LanguageIdentifierDisplayNameOptions struct

### DIFF
--- a/components/experimental/src/displaynames/mod.rs
+++ b/components/experimental/src/displaynames/mod.rs
@@ -66,4 +66,5 @@ pub use displaynames::DisplayNamesPreferences;
 pub use options::DisplayNamesOptions;
 pub use options::Fallback;
 pub use options::LanguageDisplay;
+pub use options::LanguageIdentifierDisplayNameOptions;
 pub use options::Style;

--- a/components/experimental/src/displaynames/options.rs
+++ b/components/experimental/src/displaynames/options.rs
@@ -35,6 +35,14 @@ pub struct DisplayNamesOptions {
     pub language_display: LanguageDisplay,
 }
 
+/// A bag of options defining how a language identifier display name will be formatted.
+#[derive(Copy, Debug, Eq, PartialEq, Clone, Default)]
+#[non_exhaustive]
+pub struct LanguageIdentifierDisplayNameOptions {
+    /// The language display kind, defaults to "dialect".
+    pub language_display: Option<LanguageDisplay>,
+}
+
 /// An enum for formatting style.
 #[allow(missing_docs)] // The variants are self explanatory.
 #[non_exhaustive]

--- a/components/experimental/src/displaynames/single/README.md
+++ b/components/experimental/src/displaynames/single/README.md
@@ -19,7 +19,7 @@ classDiagram
 
     class LanguageIdentifierDisplayNameOwned~M~ {
         -lid: LanguageIdentifier
-        -options: DisplayNamesOptions
+        -options: LanguageIdentifierDisplayNameOptions
         +try_new(prefs, options, lid) Self  // Medium
         +try_new_short(prefs, options, lid) Self
         +try_new_long(prefs, options, lid) Self
@@ -157,7 +157,7 @@ We implement this trait for two marker models:
 *   **`models::Menu`**: Used for Menu display style. The `LanguagePayload` is `DataPayload<LocaleNamesLanguageMenuMediumV1>`.
 
 #### 2. The Generic Owned Struct
-`LanguageIdentifierDisplayNameOwned<M>` holds the `LanguageIdentifier`, `DisplayNamesOptions`, the generic `language_payload` (determined by `M`), optional `script_payload` and `region_payload` (both using `DataPayloadOr` with `ErasedDisplayNameMarker`), a vector of `variant_payloads` (using `ErasedDisplayNameMarker`), and the `pattern_payload` (using `LocaleNamesEssentialsV1`).
+`LanguageIdentifierDisplayNameOwned<M>` holds the `LanguageIdentifier`, `LanguageIdentifierDisplayNameOptions`, the generic `language_payload` (determined by `M`), optional `script_payload` and `region_payload` (both using `DataPayloadOr` with `ErasedDisplayNameMarker`), a vector of `variant_payloads` (using `ErasedDisplayNameMarker`), and the `pattern_payload` (using `LocaleNamesEssentialsV1`).
 
 > [!NOTE]
 > **Allocation Papercut**: Storing `variant_payloads` in a `Vec` requires heap allocation, which prevents this struct from being strictly allocation-free in `no_std` environments without an allocator. 
@@ -229,5 +229,8 @@ The following features defined in UTS #35 are currently not supported and are pl
 3.  **Fallback Behavior in Single Formatters**:
     Currently, single formatters (`Script`, `Region`, `Variant`, `Language`) fail-fast in the constructor (`try_new` returns `Err(DataError)`) if the specific subtag data is missing from the provider (e.g., `xx` or an untranslated language).
     *   *Resolution*: We will redesign the single formatters to support falling back to the code instead of failing with `DataError`. This has been deferred to a follow-up issue: [#8100](https://github.com/unicode-org/icu4x/issues/8100).
+4.  **Dialect Names Data Marker**:
+    Should dialect names (currently loaded using the same `LocaleNamesLanguageMediumV1` marker but with language+script+region attributes) be moved to a separate data marker to avoid overloading the language name marker and to allow applications to opt-out of dialect data to save binary size?
+
 
 

--- a/components/experimental/src/displaynames/single/language.rs
+++ b/components/experimental/src/displaynames/single/language.rs
@@ -6,7 +6,9 @@ use crate::displaynames::provider::*;
 use crate::displaynames::single::{
     RegionDisplayNameOwned, ScriptDisplayNameOwned, VariantDisplayNameOwned,
 };
-use crate::displaynames::{DisplayNamesOptions, DisplayNamesPreferences, LanguageDisplay};
+use crate::displaynames::{
+    DisplayNamesPreferences, LanguageDisplay, LanguageIdentifierDisplayNameOptions,
+};
 use alloc::vec::Vec;
 use icu_pattern::DoublePlaceholderPattern;
 use icu_provider::DataPayloadOr;
@@ -19,13 +21,13 @@ use tinystr::TinyAsciiStr;
 ///
 /// ```
 /// use icu::experimental::displaynames::{
-///     DisplayNamesPreferences, DisplayNamesOptions, single::LanguageIdentifierDisplayNameOwned,
+///     DisplayNamesPreferences, LanguageIdentifierDisplayNameOptions, single::LanguageIdentifierDisplayNameOwned,
 /// };
 /// use icu::locale::{locale, langid};
 /// use writeable::assert_writeable_eq;
 ///
 /// let prefs = DisplayNamesPreferences::from(locale!("en"));
-/// let options = DisplayNamesOptions::default();
+/// let options = LanguageIdentifierDisplayNameOptions::default();
 /// let display_name = LanguageIdentifierDisplayNameOwned::try_new(
 ///     prefs,
 ///     langid!("fr-CA"),
@@ -39,7 +41,7 @@ use tinystr::TinyAsciiStr;
 #[derive(Debug)]
 pub struct LanguageIdentifierDisplayNameOwned {
     formatting_locale: DataLocale,
-    options: DisplayNamesOptions,
+    options: LanguageIdentifierDisplayNameOptions,
     language_payload: DataPayload<LocaleNamesLanguageMediumV1>,
     script_payload: DataPayloadOr<LocaleNamesScriptMediumV1, ()>,
     region_payload: DataPayloadOr<LocaleNamesRegionMediumV1, ()>,
@@ -50,7 +52,7 @@ pub struct LanguageIdentifierDisplayNameOwned {
 
 impl LanguageIdentifierDisplayNameOwned {
     icu_provider::gen_buffer_data_constructors!(
-        (prefs: DisplayNamesPreferences, subject: icu_locale::LanguageIdentifier, options: DisplayNamesOptions) -> result: Result<Self, DataError>,
+        (prefs: DisplayNamesPreferences, subject: icu_locale::LanguageIdentifier, options: LanguageIdentifierDisplayNameOptions) -> result: Result<Self, DataError>,
         /// Loads the language display name for a given language identifier and locale using compiled data.
         functions: [
             try_new,
@@ -65,7 +67,7 @@ impl LanguageIdentifierDisplayNameOwned {
         provider: &D,
         prefs: DisplayNamesPreferences,
         mut subject: icu_locale::LanguageIdentifier,
-        options: DisplayNamesOptions,
+        options: LanguageIdentifierDisplayNameOptions,
     ) -> Result<Self, DataError>
     where
         D: DataProvider<LocaleNamesLanguageMediumV1>
@@ -91,7 +93,7 @@ impl LanguageIdentifierDisplayNameOwned {
         let mut language_payload = None;
 
         // Only try dialect if requested (which is the default)
-        if options.language_display == LanguageDisplay::Dialect {
+        if options.language_display.unwrap_or_default() == LanguageDisplay::Dialect {
             for (language, script, region) in [
                 (subject.language, Some(subject.script), Some(subject.region)),
                 (subject.language, Some(subject.script), None),

--- a/components/experimental/tests/displaynames/tests.rs
+++ b/components/experimental/tests/displaynames/tests.rs
@@ -2,7 +2,9 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use icu_experimental::displaynames::{DisplayNamesOptions, multi::LocaleDisplayNamesFormatter};
+use icu_experimental::displaynames::{
+    DisplayNamesOptions, LanguageIdentifierDisplayNameOptions, multi::LocaleDisplayNamesFormatter,
+};
 use icu_locale_core::Locale;
 use icu_locale_core::locale;
 use std::borrow::Cow;
@@ -174,8 +176,12 @@ fn test_concatenate() {
         // Test the newer LanguageIdentifierDisplayName
         use icu_experimental::displaynames::single::LanguageIdentifierDisplayNameOwned;
         let lang_id = cas.input_1.id.clone();
-        let result =
-            LanguageIdentifierDisplayNameOwned::try_new(locale.clone().into(), lang_id, options);
+        let single_options = LanguageIdentifierDisplayNameOptions::default();
+        let result = LanguageIdentifierDisplayNameOwned::try_new(
+            locale.clone().into(),
+            lang_id,
+            single_options,
+        );
         match result {
             Ok(single_display_name) => {
                 assert_eq!(cas.single_should_err, false, "{cas:?}");


### PR DESCRIPTION
This pull request is part of the implementation for the main locale display names tracking issue: #7825.

This pull request introduces a dedicated options bag `LanguageIdentifierDisplayNameOptions` specifically for the single formatter `LanguageIdentifierDisplayNameOwned` (and its borrowed version).

Previously, the single formatter reused the general `DisplayNamesOptions` bag, which contains options like `style` that are only supported by the multi-formatters (since single formatters are currently hardcoded to the `Medium` width data markers).

By introducing a dedicated options bag, we:
1. Cleanly separate the options supported by the single formatter (currently only `language_display` / dialect resolution).
2. Prevent confusion regarding unsupported options like `style`.
3. Lay the foundation for adding fallback options specifically to the single formatter in a subsequent step.

All docstring examples, constructors, and integration tests have been updated to use the new options bag.

🤖 This pull request was created by an AI agent working with @sffc.

## Changelog

icu_experimental/displaynames: Introduce dedicated `LanguageIdentifierDisplayNameOptions` struct
  * New types: `LanguageIdentifierDisplayNameOptions`
