### PR TITLE
Add writeable delegate macros and support where clauses

### DIFF
--- a/components/decimal/src/decimal_formatter.rs
+++ b/components/decimal/src/decimal_formatter.rs
@@ -238,38 +238,10 @@ impl Writeable for FormattedUnsignedDecimal<'_> {
     }
 }
 
-impl Writeable for FormattedDecimal<'_> {
-    fn write_to_parts<W>(&self, sink: &mut W) -> Result<(), core::fmt::Error>
-    where
-        W: PartsWrite + ?Sized,
-    {
-        self.0.write_to_parts(sink)
-    }
-}
-
+writeable::impl_writeable_delegate!(FormattedDecimal<'_>, |&self| &self.0, #[cfg(feature = "alloc")]);
 writeable::impl_display_with_writeable!(FormattedDecimal<'_>, #[cfg(feature = "alloc")]);
 writeable::impl_display_with_writeable!(FormattedUnsignedDecimal<'_>, #[cfg(feature = "alloc")]);
-
-/// This trait is implemented for compatibility with [`fmt!`](core::fmt)
-/// To create a string, [`Writeable::write_to_string`] is usually more efficient
-impl<T: Writeable> core::fmt::Display for FormattedSign<'_, T> {
-    #[inline]
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        Writeable::write_to(&self, f)
-    }
-}
-#[cfg(feature = "alloc")]
-impl<T: Writeable> FormattedSign<'_, T> {
-    /// Converts the given value to a `String`.
-    ///
-    /// Under the hood, this uses an efficient [`Writeable`] implementation.
-    /// However, in order to avoid allocating a string, it is more efficient
-    /// to use [`Writeable`] directly.
-    #[allow(clippy::inherent_to_string_shadow_display)]
-    pub fn to_string(&self) -> String {
-        Writeable::write_to_string(self).into_owned()
-    }
-}
+writeable::impl_display_with_writeable!(FormattedSign<'_, T>, #[cfg(feature = "alloc")], where T: Writeable);
 
 #[test]
 fn test_numbering_resolution_fallback() {

--- a/components/locale_core/src/helpers.rs
+++ b/components/locale_core/src/helpers.rs
@@ -146,20 +146,7 @@ macro_rules! impl_tinystr_subtag {
             }
         }
 
-        impl writeable::Writeable for $name {
-            #[inline]
-            fn write_to<W: core::fmt::Write + ?Sized>(&self, sink: &mut W) -> core::fmt::Result {
-                sink.write_str(self.as_str())
-            }
-            #[inline]
-            fn writeable_length_hint(&self) -> writeable::LengthHint {
-                writeable::LengthHint::exact(self.0.len())
-            }
-            fn writeable_borrow(&self) -> Option<&str> {
-                Some(self.0.as_str())
-            }
-        }
-
+        writeable::impl_writeable_delegate!($name, |&self| &self.0, #[cfg(feature = "alloc")]);
         writeable::impl_display_with_writeable!($name, #[cfg(feature = "alloc")]);
 
         #[doc = concat!("A macro allowing for compile-time construction of valid [`", stringify!($name), "`] subtags.")]

--- a/ffi/capi/tests/missing_apis.txt
+++ b/ffi/capi/tests/missing_apis.txt
@@ -23,3 +23,4 @@ icu::collator::CollatorBorrowed::new_root#FnInStruct
 icu::collator::CollatorBorrowed::write_sort_key_to#FnInStruct
 icu::collator::CollatorBorrowed::write_sort_key_utf16_to#FnInStruct
 icu::collator::CollatorBorrowed::write_sort_key_utf8_to#FnInStruct
+icu::decimal::FormattedDecimal::write_to#FnInStruct

--- a/provider/core/src/hello_world.rs
+++ b/provider/core/src/hello_world.rs
@@ -367,20 +367,7 @@ impl HelloWorldFormatter {
     }
 }
 
-impl Writeable for FormattedHelloWorld<'_> {
-    fn write_to<W: core::fmt::Write + ?Sized>(&self, sink: &mut W) -> core::fmt::Result {
-        self.data.message.write_to(sink)
-    }
-
-    fn writeable_borrow(&self) -> Option<&str> {
-        self.data.message.writeable_borrow()
-    }
-
-    fn writeable_length_hint(&self) -> writeable::LengthHint {
-        self.data.message.writeable_length_hint()
-    }
-}
-
+writeable::impl_writeable_delegate!(FormattedHelloWorld<'_>, |&self| &self.data.message);
 writeable::impl_display_with_writeable!(FormattedHelloWorld<'_>);
 
 #[cfg(feature = "export")]

--- a/utils/fixed_decimal/src/integer.rs
+++ b/utils/fixed_decimal/src/integer.rs
@@ -3,7 +3,6 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use core::convert::TryFrom;
-use core::fmt;
 
 use core::str::FromStr;
 
@@ -68,11 +67,7 @@ impl_fixed_integer_from_integer_type!(u32);
 impl_fixed_integer_from_integer_type!(u16);
 impl_fixed_integer_from_integer_type!(u8);
 
-impl writeable::Writeable for FixedInteger {
-    fn write_to<W: fmt::Write + ?Sized>(&self, sink: &mut W) -> fmt::Result {
-        self.0.write_to(sink)
-    }
-}
+writeable::impl_writeable_delegate!(FixedInteger, |&self| &self.0);
 
 impl TryFrom<Decimal> for FixedInteger {
     type Error = LimitError;

--- a/utils/writeable/src/impls.rs
+++ b/utils/writeable/src/impls.rs
@@ -113,22 +113,7 @@ impl Writeable for str {
 }
 
 #[cfg(feature = "alloc")]
-impl Writeable for String {
-    #[inline]
-    fn write_to<W: fmt::Write + ?Sized>(&self, sink: &mut W) -> fmt::Result {
-        sink.write_str(self)
-    }
-
-    #[inline]
-    fn writeable_length_hint(&self) -> LengthHint {
-        LengthHint::exact(self.len())
-    }
-
-    #[inline]
-    fn writeable_borrow(&self) -> Option<&str> {
-        Some(self)
-    }
-}
+crate::impl_writeable_delegate!(String, |&self| self.as_str());
 
 impl Writeable for char {
     #[inline]
@@ -150,33 +135,7 @@ impl Writeable for char {
     }
 }
 
-impl<T: Writeable + ?Sized> Writeable for &T {
-    #[inline]
-    fn write_to<W: fmt::Write + ?Sized>(&self, sink: &mut W) -> fmt::Result {
-        (*self).write_to(sink)
-    }
-
-    #[inline]
-    fn write_to_parts<W: PartsWrite + ?Sized>(&self, sink: &mut W) -> fmt::Result {
-        (*self).write_to_parts(sink)
-    }
-
-    #[inline]
-    fn writeable_length_hint(&self) -> LengthHint {
-        (*self).writeable_length_hint()
-    }
-
-    #[inline]
-    fn writeable_borrow(&self) -> Option<&str> {
-        (*self).writeable_borrow()
-    }
-
-    #[inline]
-    #[cfg(feature = "alloc")]
-    fn write_to_string(&self) -> Cow<'_, str> {
-        (*self).write_to_string()
-    }
-}
+crate::impl_writeable_delegate!(&T, |&self| *self, #[cfg(feature = "alloc")], where T: Writeable + ?Sized);
 
 #[cfg(feature = "alloc")]
 macro_rules! impl_write_smart_pointer {

--- a/utils/writeable/src/lib.rs
+++ b/utils/writeable/src/lib.rs
@@ -383,7 +383,7 @@ pub trait Writeable {
 /// );
 /// ```
 ///
-/// With a cfg on fn write_to_string:
+/// With a cfg on fn `write_to_string`:
 ///
 /// ```
 /// struct MyStruct(String);

--- a/utils/writeable/src/lib.rs
+++ b/utils/writeable/src/lib.rs
@@ -144,6 +144,8 @@ pub mod _internal {
     #[cfg(feature = "alloc")]
     pub use super::testing::writeable_to_parts_for_test;
     #[cfg(feature = "alloc")]
+    pub use alloc::borrow::Cow;
+    #[cfg(feature = "alloc")]
     pub use alloc::string::String;
 }
 
@@ -364,6 +366,79 @@ pub trait Writeable {
     }
 }
 
+/// Macro to implement [`Writeable`] by delegating to another `Writeable`.
+///
+/// Useful for wrapper types.
+///
+/// # Examples
+///
+/// ```
+/// struct MyStruct(String);
+/// writeable::impl_writeable_delegate!(MyStruct, |&self| &self.0);
+/// writeable::impl_display_with_writeable!(MyStruct);
+///
+/// writeable::assert_writeable_eq!(
+///     MyStruct("hello".to_string()),
+///     "hello"
+/// );
+/// ```
+///
+/// With a cfg on fn write_to_string:
+///
+/// ```
+/// struct MyStruct(String);
+/// writeable::impl_writeable_delegate!(MyStruct, |&self| &self.0, #[cfg(feature = "alloc")]);
+/// writeable::impl_display_with_writeable!(MyStruct);
+///
+/// writeable::assert_writeable_eq!(
+///     MyStruct("hello".to_string()),
+///     "hello"
+/// );
+/// ```
+///
+/// With generics:
+///
+/// ```
+/// use writeable::Writeable;
+///
+/// struct MyStruct<T>(T);
+/// writeable::impl_writeable_delegate!(MyStruct<T>, |&self| &self.0, where T: Writeable);
+/// writeable::impl_display_with_writeable!(MyStruct<T>, where T: Writeable);
+///
+/// writeable::assert_writeable_eq!(
+///     MyStruct("hello"),
+///     "hello"
+/// );
+/// ```
+#[macro_export]
+macro_rules! impl_writeable_delegate {
+    ($ty:ty, |&$self:ident| $delegate:expr $(, #[$alloc_feature:meta])? $(, where $($generics:tt)*)?) => {
+        impl $(<$($generics)*>)? $crate::Writeable for $ty {
+            #[inline]
+            fn write_to<W: core::fmt::Write + ?Sized>(&$self, sink: &mut W) -> core::fmt::Result {
+                ($delegate).write_to(sink)
+            }
+            #[inline]
+            fn write_to_parts<S: $crate::PartsWrite + ?Sized>(&$self, sink: &mut S) -> core::fmt::Result {
+                ($delegate).write_to_parts(sink)
+            }
+            #[inline]
+            fn writeable_length_hint(&$self) -> $crate::LengthHint {
+                ($delegate).writeable_length_hint()
+            }
+            #[inline]
+            fn writeable_borrow(&$self) -> Option<&str> {
+                ($delegate).writeable_borrow()
+            }
+            #[inline]
+            $(#[$alloc_feature])?
+            fn write_to_string(&$self) -> $crate::_internal::Cow<'_, str> {
+                ($delegate).write_to_string()
+            }
+        }
+    };
+}
+
 /// Implements [`Display`](core::fmt::Display) for types that implement [`Writeable`].
 ///
 /// It's recommended to do this for every [`Writeable`] type, as it will add
@@ -373,22 +448,45 @@ pub trait Writeable {
 /// This macro also adds a concrete `to_string` function. This function will shadow the
 /// standard library `ToString`, using the more efficient writeable-based code path.
 /// To add only `Display`, use the `@display` macro variant.
+///
+/// If your type has generics, list them in a `where` clause in the macro invocation.
+///
+/// # Examples
+///
+/// ```
+/// use writeable::Writeable;
+/// use std::fmt;
+///
+/// struct Message<T>(T);
+///
+/// impl<T> Writeable for Message<T> where T: Writeable {
+///     fn write_to<W: fmt::Write + ?Sized>(&self, sink: &mut W) -> fmt::Result {
+///         sink.write_str("Message: ")?;
+///         self.0.write_to(sink)
+///     }
+///     // ...
+/// }
+///
+/// writeable::impl_display_with_writeable!(Message<T>, where T: Writeable);
+///
+/// writeable::assert_writeable_eq!(Message("hello"), "Message: hello");
+/// ```
 #[macro_export]
 macro_rules! impl_display_with_writeable {
-    (@display, $type:ty) => {
+    (@display, $type:ty $(, where $($generics:tt)*)?) => {
         /// This trait is implemented for compatibility with [`fmt!`](core::fmt).
         /// To create a string, [`Writeable::write_to_string`] is usually more efficient.
-        impl core::fmt::Display for $type {
+        impl $(<$($generics)*>)? core::fmt::Display for $type {
             #[inline]
             fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
                 $crate::Writeable::write_to(&self, f)
             }
         }
     };
-    ($type:ty $(, #[$alloc_feature:meta])? ) => {
-        $crate::impl_display_with_writeable!(@display, $type);
+    ($type:ty $(, #[$alloc_feature:meta])? $(, where $($generics:tt)*)?) => {
+        $crate::impl_display_with_writeable!(@display, $type $(, where $($generics)*)?);
         $(#[$alloc_feature])?
-        impl $type {
+        impl $(<$($generics)*>)? $type {
             /// Converts the given value to a `String`.
             ///
             /// Under the hood, this uses an efficient [`Writeable`] implementation.

--- a/utils/writeable/src/lib.rs
+++ b/utils/writeable/src/lib.rs
@@ -388,7 +388,7 @@ pub trait Writeable {
 /// ```
 /// struct MyStruct(String);
 /// writeable::impl_writeable_delegate!(MyStruct, |&self| &self.0, #[cfg(feature = "alloc")]);
-/// writeable::impl_display_with_writeable!(MyStruct);
+/// writeable::impl_display_with_writeable!(MyStruct, #[cfg(feature = "alloc")]);
 ///
 /// writeable::assert_writeable_eq!(
 ///     MyStruct("hello".to_string()),

--- a/utils/writeable/src/parts_write_adapter.rs
+++ b/utils/writeable/src/parts_write_adapter.rs
@@ -114,9 +114,4 @@ impl<T: Writeable + ?Sized> Writeable for WithPart<T> {
     }
 }
 
-impl<T: Writeable + ?Sized> fmt::Display for WithPart<T> {
-    #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        Writeable::write_to(&self, f)
-    }
-}
+crate::impl_display_with_writeable!(WithPart<T>, where T: Writeable + ?Sized);

--- a/utils/writeable/src/parts_write_adapter.rs
+++ b/utils/writeable/src/parts_write_adapter.rs
@@ -114,4 +114,4 @@ impl<T: Writeable + ?Sized> Writeable for WithPart<T> {
     }
 }
 
-crate::impl_display_with_writeable!(WithPart<T>, where T: Writeable + ?Sized);
+crate::impl_display_with_writeable!(@display, WithPart<T>, where T: Writeable + ?Sized);

--- a/utils/writeable/src/try_writeable.rs
+++ b/utils/writeable/src/try_writeable.rs
@@ -370,7 +370,7 @@ where
 /// );
 /// ```
 ///
-/// With a cfg on fn write_to_string:
+/// With a cfg on fn `write_to_string`:
 ///
 /// ```
 /// struct MyStruct(Result<String, String>);

--- a/utils/writeable/src/try_writeable.rs
+++ b/utils/writeable/src/try_writeable.rs
@@ -395,6 +395,28 @@ where
 ///     "hello"
 /// );
 /// ```
+///
+/// Implement both `Writeable` and `TryWriteable`:
+///
+/// ```
+/// use writeable::adapters::LossyWrap;
+///
+/// // The LossyWrap needs to be a field of MyStruct since it can be borrowed from.
+/// struct MyStruct(LossyWrap<Result<String, String>>);
+/// writeable::impl_try_writeable_delegate!(MyStruct, |&self| &self.0.0, Error = String);
+/// writeable::impl_writeable_delegate!(MyStruct, |&self| &self.0);
+/// writeable::impl_display_with_writeable!(MyStruct);
+///
+/// writeable::assert_try_writeable_eq!(
+///     MyStruct(LossyWrap(Ok("hello".to_string()))),
+///     "hello"
+/// );
+///
+/// writeable::assert_writeable_eq!(
+///     MyStruct(LossyWrap(Ok("hello".to_string()))),
+///     "hello"
+/// );
+/// ```
 #[macro_export]
 macro_rules! impl_try_writeable_delegate {
     ($ty:ty, |&$self:ident| $delegate:expr, Error = $error:ty $(, #[$alloc_feature:meta])? $(, where $($generics:tt)*)?) => {

--- a/utils/writeable/src/try_writeable.rs
+++ b/utils/writeable/src/try_writeable.rs
@@ -354,36 +354,91 @@ where
     }
 }
 
-impl<T: TryWriteable + ?Sized> TryWriteable for &T {
-    type Error = T::Error;
-
-    #[inline]
-    fn try_write_to<W: fmt::Write + ?Sized>(
-        &self,
-        sink: &mut W,
-    ) -> Result<Result<(), Self::Error>, fmt::Error> {
-        (*self).try_write_to(sink)
-    }
-
-    #[inline]
-    fn try_write_to_parts<S: PartsWrite + ?Sized>(
-        &self,
-        sink: &mut S,
-    ) -> Result<Result<(), Self::Error>, fmt::Error> {
-        (*self).try_write_to_parts(sink)
-    }
-
-    #[inline]
-    fn writeable_length_hint(&self) -> LengthHint {
-        (*self).writeable_length_hint()
-    }
-
-    #[inline]
-    #[cfg(feature = "alloc")]
-    fn try_write_to_string(&self) -> Result<Cow<'_, str>, (Self::Error, Cow<'_, str>)> {
-        (*self).try_write_to_string()
-    }
+/// Macro to implement [`TryWriteable`] by delegating to another `TryWriteable`.
+///
+/// Useful for wrapper types.
+///
+/// # Examples
+///
+/// ```
+/// struct MyStruct(Result<String, String>);
+/// writeable::impl_try_writeable_delegate!(MyStruct, |&self| &self.0, Error = String);
+///
+/// writeable::assert_try_writeable_eq!(
+///     MyStruct(Ok("hello".to_string())),
+///     "hello"
+/// );
+/// ```
+///
+/// With a cfg on fn write_to_string:
+///
+/// ```
+/// struct MyStruct(Result<String, String>);
+/// writeable::impl_try_writeable_delegate!(MyStruct, |&self| &self.0, Error = String, #[cfg(feature = "alloc")]);
+///
+/// writeable::assert_try_writeable_eq!(
+///     MyStruct(Ok("hello".to_string())),
+///     "hello"
+/// );
+/// ```
+///
+/// With generics:
+///
+/// ```
+/// use writeable::Writeable;
+///
+/// struct MyStruct<T>(Result<T, T>);
+/// writeable::impl_try_writeable_delegate!(MyStruct<T>, |&self| &self.0, Error = T, where T: Writeable + Clone);
+///
+/// writeable::assert_try_writeable_eq!(
+///     MyStruct(Ok("hello".to_string())),
+///     "hello"
+/// );
+/// ```
+#[macro_export]
+macro_rules! impl_try_writeable_delegate {
+    ($ty:ty, |&$self:ident| $delegate:expr, Error = $error:ty $(, #[$alloc_feature:meta])? $(, where $($generics:tt)*)?) => {
+        impl$(<$($generics)*>)? $crate::TryWriteable for $ty {
+            type Error = $error;
+            #[inline]
+            fn try_write_to<W: core::fmt::Write + ?Sized>(
+                &$self,
+                sink: &mut W,
+            ) -> core::result::Result<core::result::Result<(), Self::Error>, core::fmt::Error> {
+                ($delegate).try_write_to(sink)
+            }
+            #[inline]
+            fn try_write_to_parts<S: $crate::PartsWrite + ?Sized>(
+                &$self,
+                sink: &mut S,
+            ) -> core::result::Result<core::result::Result<(), Self::Error>, core::fmt::Error> {
+                ($delegate).try_write_to_parts(sink)
+            }
+            #[inline]
+            fn writeable_length_hint(&$self) -> $crate::LengthHint {
+                ($delegate).writeable_length_hint()
+            }
+            #[inline]
+            $(#[$alloc_feature])?
+            fn try_write_to_string(
+                &$self,
+            ) -> core::result::Result<
+                $crate::_internal::Cow<'_, str>,
+                (Self::Error, $crate::_internal::Cow<'_, str>),
+            > {
+                ($delegate).try_write_to_string()
+            }
+        }
+    };
 }
+
+impl_try_writeable_delegate!(
+    &T,
+    |&self| *self,
+    Error = T::Error,
+    #[cfg(feature = "alloc")],
+    where T: TryWriteable + ?Sized
+);
 
 /// Testing macros for types implementing [`TryWriteable`].
 ///
@@ -472,4 +527,18 @@ fn test_result_try_writeable() {
     result = Err(44);
     assert_try_writeable_eq!(result, "44", Err(44));
     assert_try_writeable_parts_eq!(result, "44", Err(44), [(0, 2, Part::ERROR)])
+}
+
+#[cfg(test)]
+struct DelegatedTryMessage<'s>(Result<&'s str, usize>);
+
+#[cfg(test)]
+impl_try_writeable_delegate!(DelegatedTryMessage<'_>, |&self| &self.0, Error = usize);
+
+#[test]
+fn test_delegated_try_writeable() {
+    let mut message = DelegatedTryMessage(Ok("success"));
+    assert_try_writeable_eq!(message, "success");
+    message = DelegatedTryMessage(Err(44));
+    assert_try_writeable_eq!(message, "44", Err(44));
 }

--- a/utils/writeable/tests/writeable.rs
+++ b/utils/writeable/tests/writeable.rs
@@ -32,3 +32,17 @@ fn test_basic() {
     };
     assert_writeable_eq!(&message, input_string);
 }
+
+struct DelegatedMessage<'s>(WriteableMessage<'s>);
+
+writeable::impl_writeable_delegate!(DelegatedMessage<'_>, |&self| &self.0);
+writeable::impl_display_with_writeable!(DelegatedMessage<'_>);
+
+#[test]
+fn test_delegated() {
+    let input_string = "hello world 2";
+    let message = DelegatedMessage(WriteableMessage {
+        message: input_string,
+    });
+    assert_writeable_eq!(&message, input_string);
+}


### PR DESCRIPTION
This PR is 80% human, 20% Gemini.

I added `writeable::impl_writeable_delegate!` and `writeable::impl_try_writeable_delegate!`, using them throughout the codebase.

They support generics via a `where` clause at the end of the macro invocation. I experimented with several ways to get the generics into `macro_rules!`, and I settled on this approach as the cleanest. If you have another suggestion that works, feel free to offer it.

I also went ahead and modified the existing `writeable::impl_display_with_writeable` to support the same `where` clause syntax.

This PR fixes several call sites, both inside the writeable crate and outside the writeable crate, by delegating all of the trait functions, not just one or two. There is never a case with a pure delegation Writeable impl where all the functions should not be delegated in their entirety.

Although displaynames is what gave me the motivation to work on this PR, the PR is not motivated solely because of displaynames. I did not touch any of the code in displaynames because I didn't want to introduce merge conflicts, but I will migrate them soon.

## Changelog

writeable:
    - New `impl_writeable_delegate!` macro to delegate `Writeable` implementations
    - New `impl_try_writeable_delegate!` macro to delegate `TryWriteable` implementations
    - Support for `where` clause in `impl_display_with_writeable!`
