### PR TITLE
Inline Char16Trie traversal methods

### DIFF
--- a/components/collections/src/char16trie/trie.rs
+++ b/components/collections/src/char16trie/trie.rs
@@ -197,6 +197,7 @@ impl<'a> Char16TrieIterator<'a> {
     /// let res = iter.next('c');
     /// assert_eq!(res, TrieResult::NoMatch);
     /// ```
+    #[inline]
     pub fn next(&mut self, c: char) -> TrieResult {
         if (c as u32) <= 0xffff {
             self.next16(c as u16)
@@ -230,6 +231,7 @@ impl<'a> Char16TrieIterator<'a> {
     /// let res = iter.next('c');
     /// assert_eq!(res, TrieResult::NoMatch);
     /// ```
+    #[inline]
     pub fn next32(&mut self, c: u32) -> TrieResult {
         if c <= 0xffff {
             self.next16(c as u16)
@@ -263,6 +265,7 @@ impl<'a> Char16TrieIterator<'a> {
     /// let res = iter.next16('c' as u16);
     /// assert_eq!(res, TrieResult::NoMatch);
     /// ```
+    #[inline]
     pub fn next16(&mut self, c: u16) -> TrieResult {
         let mut pos = match self.pos {
             Some(p) => p,
@@ -291,6 +294,7 @@ impl<'a> Char16TrieIterator<'a> {
         }
     }
 
+    #[inline]
     fn branch_next(&mut self, pos: usize, length: usize, in_unit: u16) -> TrieResult {
         let mut pos = pos;
         let mut length = length;
@@ -365,6 +369,7 @@ impl<'a> Char16TrieIterator<'a> {
         }
     }
 
+    #[inline]
     fn next_impl(&mut self, pos: usize, in_unit: u16) -> TrieResult {
         let mut node = trie_unwrap!(self.trie.get(pos));
         let mut pos = pos + 1;
@@ -404,6 +409,7 @@ impl<'a> Char16TrieIterator<'a> {
         TrieResult::NoMatch
     }
 
+    #[inline]
     fn stop(&mut self) {
         self.pos = None;
     }
@@ -445,6 +451,7 @@ impl<'a> Char16TrieIterator<'a> {
         Some(v)
     }
 
+    #[inline]
     fn value_result(&self, pos: usize) -> TrieResult {
         match self.get_value(pos) {
             Some(result) => result,


### PR DESCRIPTION
This PR isolates the `Char16TrieIterator` traversal inline annotations from #8113.

The change is intentionally small: it only adds `#[inline]` to the hot traversal entry points and helper paths in `components/collections/src/char16trie/trie.rs`. It does not change public APIs or include ResultCache, zero-copy complex segmentation, or benchmark implementation changes.

This is separate because `Char16TrieIterator` is shared by both the published segmenter and the in-progress `neo` segmenter, and cross-crate inline behavior is independent from the other segmenter optimizations.

## Benchmark

The comparison benchmark from #8141 is now merged into `main`, so no benchmark patch is present in this PR.

- Baseline: `origin/main` at `9f1a2f700876d4166202f18850ecf05e4e3fb912`
- PR head: `8b2ca38d9ac2a2b3f2d4b472554f778783e36dac`
- Benchmark: #8141 final head `73727ace45cb6102eb5d21340194a9fda0214f73`, merged as `c0846c9000467f1292e6d6a0e98db6798cf6a417`
- Full matrix: `cargo bench -p icu_segmenter --bench bench --features unstable -- dictionary --sample-size 50 --measurement-time 3 --warm-up-time 1 --noplot`
- Targeted confirmation: the same command with an exact case filter, `--sample-size 100 --measurement-time 8 --warm-up-time 2 --noplot`

Both revisions were precompiled with separate `CARGO_TARGET_DIR` values. The full 28-case dictionary matrix was run twice in opposite revision order. Representative complex-script cases were then run as adjacent baseline/PR pairs twice, reversing both revision and case order. Values below are the geometric mean of the two Criterion median point estimates; lower is better.

| Workload | `main` | PR | Delta |
| --- | ---: | ---: | ---: |
| Line UTF-8, Thai, published dictionary | 2.994 us | 2.986 us | -0.2% |
| Line UTF-8, Thai, `neo` dictionary | 2.989 us | 2.848 us | -4.7% |
| Word UTF-8, Japanese, published dictionary | 1.741 us | 1.712 us | -1.7% |
| Word UTF-8, Japanese, `neo` dictionary | 1.035 us | 1.009 us | -2.6% |
| Line UTF-8, mixed text, published dictionary | 14.642 us | 14.497 us | -1.0% |
| Line UTF-8, mixed text, `neo` dictionary | 12.897 us | 12.411 us | -3.8% |
| Word UTF-8, mixed text, published dictionary | 20.749 us | 20.578 us | -0.8% |
| Word UTF-8, mixed text, `neo` dictionary | 14.974 us | 14.739 us | -1.6% |

The repeatable value is concentrated in complex-script dictionary traversal: targeted `neo` cases improve by 1.6% to 4.7%, while published cases are neutral to about 1.7% faster. In the full UTF-8/UTF-16 matrix, all eight `neo` Thai/Japanese/Mixed dictionary cases improved in both rounds. The workstation was not isolated, so sub-1% changes and non-complex English controls are treated as noise rather than attributed to this PR.

<details>
<summary>Complete 28-case dictionary matrix</summary>

The two round columns are independently paired PR-versus-`main` median deltas. The final column is their geometric mean.

| Criterion case | Round 1 | Round 2 | Paired delta |
| --- | ---: | ---: | ---: |
| `Line Break/UTF16/En CSS/dictionary` | -0.0% | -0.4% | -0.2% |
| `Line Break/UTF16/En CSS/neo/dictionary` | +5.3% | +6.3% | +5.8% |
| `Line Break/UTF16/En/dictionary` | +2.5% | +0.0% | +1.2% |
| `Line Break/UTF16/En/neo/dictionary` | +5.5% | -7.0% | -0.9% |
| `Line Break/UTF16/Mixed/dictionary` | -1.6% | -2.0% | -1.8% |
| `Line Break/UTF16/Mixed/neo/dictionary` | -1.7% | -0.8% | -1.2% |
| `Line Break/UTF16/Th/dictionary` | -3.4% | +1.4% | -1.0% |
| `Line Break/UTF16/Th/neo/dictionary` | -3.0% | -3.1% | -3.1% |
| `Line Break/UTF8/En CSS/dictionary` | +2.0% | +2.0% | +2.0% |
| `Line Break/UTF8/En CSS/neo/dictionary` | +2.2% | +2.7% | +2.5% |
| `Line Break/UTF8/En/dictionary` | +0.7% | +1.0% | +0.9% |
| `Line Break/UTF8/En/neo/dictionary` | +7.5% | +1.0% | +4.2% |
| `Line Break/UTF8/Mixed/dictionary` | -0.4% | -0.3% | -0.3% |
| `Line Break/UTF8/Mixed/neo/dictionary` | -2.2% | -1.8% | -2.0% |
| `Line Break/UTF8/Th/dictionary` | +1.3% | +14.1% | +7.5% |
| `Line Break/UTF8/Th/neo/dictionary` | -5.3% | -4.7% | -5.0% |
| `Word Break/UTF16/En/dictionary` | -0.3% | +5.2% | +2.4% |
| `Word Break/UTF16/En/neo/dictionary` | -0.2% | -3.8% | -2.0% |
| `Word Break/UTF16/Ja/dictionary` | -2.9% | -14.2% | -8.7% |
| `Word Break/UTF16/Ja/neo/dictionary` | -5.6% | -9.7% | -7.7% |
| `Word Break/UTF16/Mixed/dictionary` | -1.8% | -3.4% | -2.6% |
| `Word Break/UTF16/Mixed/neo/dictionary` | -3.8% | -2.5% | -3.1% |
| `Word Break/UTF8/En/dictionary` | +3.4% | -0.7% | +1.3% |
| `Word Break/UTF8/En/neo/dictionary` | +20.4% | -1.2% | +9.1% |
| `Word Break/UTF8/Ja/dictionary` | +12.2% | -3.7% | +3.9% |
| `Word Break/UTF8/Ja/neo/dictionary` | -4.1% | -2.4% | -3.2% |
| `Word Break/UTF8/Mixed/dictionary` | -1.1% | -1.5% | -1.3% |
| `Word Break/UTF8/Mixed/neo/dictionary` | -1.4% | -2.4% | -1.9% |

</details>

## Changelog

icu_collections: Improve Char16Trie traversal performance with inline annotations.
