### PR TITLE
Use neo grapheme segmenter for neo complex segmentation

### DIFF
--- a/components/segmenter/src/complex/dictionary.rs
+++ b/components/segmenter/src/complex/dictionary.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use crate::grapheme::*;
+use super::AbstractGraphemeClusterSegmenterBorrowed;
 use crate::indices::Utf16Indices;
 use crate::provider::*;
 #[cfg(feature = "unstable")]
@@ -17,11 +17,16 @@ use utf8_iter::Utf8CharIndices;
 /// - `'s` = lifetime of the string being segmented
 ///
 #[derive(Debug)]
-pub(super) struct DictionaryBreakIterator<'data, 's, R: RuleBreakType> {
+pub(super) struct DictionaryBreakIterator<
+    'data,
+    's,
+    G: AbstractGraphemeClusterSegmenterBorrowed<'data>,
+    R: RuleBreakType + 'static,
+> {
     trie: Char16Trie<'data>,
     iter: R::IterAttr<'s>,
     len: usize,
-    grapheme_iter: GraphemeClusterBreakIterator<'data, 's, R>,
+    grapheme_iter: G::Iter<'data, 's, R>,
     // TODO transform value for byte trie
 }
 
@@ -29,7 +34,9 @@ pub(super) struct DictionaryBreakIterator<'data, 's, R: RuleBreakType> {
 /// Please see the [module-level documentation](crate) for its usages.
 ///
 /// [`Iterator`]: core::iter::Iterator
-impl<Y: RuleBreakType> Iterator for DictionaryBreakIterator<'_, '_, Y> {
+impl<'data, 's, G: AbstractGraphemeClusterSegmenterBorrowed<'data>, Y: RuleBreakType> Iterator
+    for DictionaryBreakIterator<'data, 's, G, Y>
+{
     type Item = usize;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -92,16 +99,13 @@ impl<Y: RuleBreakType> Iterator for DictionaryBreakIterator<'_, '_, Y> {
 }
 
 #[derive(Copy, Clone)]
-pub(super) struct DictionarySegmenter<'data> {
+pub(super) struct DictionarySegmenter<'data, G: AbstractGraphemeClusterSegmenterBorrowed<'data>> {
     dict: &'data UCharDictionaryBreakData<'data>,
-    grapheme: GraphemeClusterSegmenterBorrowed<'data>,
+    grapheme: G,
 }
 
-impl<'data> DictionarySegmenter<'data> {
-    pub(super) fn new(
-        dict: &'data UCharDictionaryBreakData<'data>,
-        grapheme: GraphemeClusterSegmenterBorrowed<'data>,
-    ) -> Self {
+impl<'data, G: AbstractGraphemeClusterSegmenterBorrowed<'data>> DictionarySegmenter<'data, G> {
+    pub(super) fn new(dict: &'data UCharDictionaryBreakData<'data>, grapheme: G) -> Self {
         // TODO: no way to verify trie data
         Self { dict, grapheme }
     }
@@ -110,7 +114,7 @@ impl<'data> DictionarySegmenter<'data> {
     pub(super) fn segment_str<'s>(
         self,
         input: &'s str,
-    ) -> DictionaryBreakIterator<'data, 's, Utf8> {
+    ) -> DictionaryBreakIterator<'data, 's, G, Utf8> {
         let grapheme_iter = self.grapheme.segment_str(input);
         DictionaryBreakIterator {
             trie: Char16Trie::new(self.dict.trie_data.clone()),
@@ -125,7 +129,7 @@ impl<'data> DictionarySegmenter<'data> {
     pub(super) fn segment_utf8<'s>(
         self,
         input: &'s [u8],
-    ) -> DictionaryBreakIterator<'data, 's, PotentiallyIllFormedUtf8> {
+    ) -> DictionaryBreakIterator<'data, 's, G, PotentiallyIllFormedUtf8> {
         let grapheme_iter = self.grapheme.segment_utf8(input);
         DictionaryBreakIterator {
             trie: Char16Trie::new(self.dict.trie_data.clone()),
@@ -139,7 +143,7 @@ impl<'data> DictionarySegmenter<'data> {
     pub(super) fn segment_utf16<'s>(
         self,
         input: &'s [u16],
-    ) -> DictionaryBreakIterator<'data, 's, Utf16> {
+    ) -> DictionaryBreakIterator<'data, 's, G, Utf16> {
         let grapheme_iter = self.grapheme.segment_utf16(input);
         DictionaryBreakIterator {
             trie: Char16Trie::new(self.dict.trie_data.clone()),

--- a/components/segmenter/src/complex/lstm/mod.rs
+++ b/components/segmenter/src/complex/lstm/mod.rs
@@ -2,7 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use crate::grapheme::GraphemeClusterSegmenterBorrowed;
+use super::AbstractGraphemeClusterSegmenterBorrowed;
 use crate::indices::Utf16Indices;
 use crate::provider::*;
 #[cfg(feature = "unstable")]
@@ -40,7 +40,7 @@ impl<R: RuleBreakType> Iterator for LstmSegmenterIterator<'_, '_, R> {
 }
 
 #[derive(Clone, Copy)]
-pub(super) struct LstmSegmenter<'data> {
+pub(super) struct LstmSegmenter<'data, G: AbstractGraphemeClusterSegmenterBorrowed<'data>> {
     dic: ZeroMapBorrowed<'data, PotentialUtf8, u16>,
     embedding: MatrixZero<'data, 2>,
     fw_w: MatrixZero<'data, 3>,
@@ -52,15 +52,12 @@ pub(super) struct LstmSegmenter<'data> {
     timew_fw: MatrixZero<'data, 2>,
     timew_bw: MatrixZero<'data, 2>,
     time_b: MatrixZero<'data, 1>,
-    grapheme: Option<GraphemeClusterSegmenterBorrowed<'data>>,
+    grapheme: Option<G>,
 }
 
-impl<'data> LstmSegmenter<'data> {
+impl<'data, G: AbstractGraphemeClusterSegmenterBorrowed<'data>> LstmSegmenter<'data, G> {
     /// Returns `Err` if grapheme data is required but not present
-    pub(super) fn new(
-        lstm: &'data LstmData<'data>,
-        grapheme: GraphemeClusterSegmenterBorrowed<'data>,
-    ) -> Self {
+    pub(super) fn new(lstm: &'data LstmData<'data>, grapheme: G) -> Self {
         let LstmData::Float32(lstm) = lstm;
         let time_w = MatrixZero::from(&lstm.time_w);
         #[expect(clippy::unwrap_used)] // shape (2, 4, hunits)
@@ -239,7 +236,7 @@ struct BiesIterator<'data> {
 impl<'data> BiesIterator<'data> {
     // input_seq is a sequence of id numbers that represents grapheme clusters or code points in the input line. These ids are used later
     // in the embedding layer of the model.
-    fn new(
+    fn new<G: AbstractGraphemeClusterSegmenterBorrowed<'data>>(
         LstmSegmenter {
             embedding,
             fw_w,
@@ -252,7 +249,7 @@ impl<'data> BiesIterator<'data> {
             timew_bw,
             time_b,
             ..
-        }: LstmSegmenter<'data>,
+        }: LstmSegmenter<'data, G>,
         input_seq: Vec<u16>,
     ) -> Self {
         let hunits = fw_u.dim().1;

--- a/components/segmenter/src/complex/mod.rs
+++ b/components/segmenter/src/complex/mod.rs
@@ -6,7 +6,6 @@ use crate::provider::*;
 #[cfg(feature = "unstable")]
 use crate::scaffold::PotentiallyIllFormedUtf8;
 use crate::scaffold::{RuleBreakType, Utf8, Utf16};
-use crate::{GraphemeClusterSegmenter, GraphemeClusterSegmenterBorrowed};
 use alloc::vec::Vec;
 use icu_provider::prelude::*;
 
@@ -20,16 +19,30 @@ mod lstm;
 use lstm::*;
 
 #[derive(Debug)]
-pub struct ComplexIterator<'data, 's, R: RuleBreakType>(ComplexIteratorInner<'data, 's, R>, usize);
+#[doc(hidden)]
+pub struct ComplexIterator<
+    'data,
+    's,
+    G: AbstractGraphemeClusterSegmenterBorrowed<'data>,
+    R: RuleBreakType + 'static,
+>(ComplexIteratorInner<'data, 's, G, R>, usize);
 
 #[derive(Debug)]
-enum ComplexIteratorInner<'data, 's, R: RuleBreakType> {
-    Dictionary(DictionaryBreakIterator<'data, 's, R>),
+#[allow(clippy::large_enum_variant)]
+enum ComplexIteratorInner<
+    'data,
+    's,
+    G: AbstractGraphemeClusterSegmenterBorrowed<'data>,
+    R: RuleBreakType + 'static,
+> {
+    Dictionary(DictionaryBreakIterator<'data, 's, G, R>),
     #[cfg(feature = "lstm")]
     Lstm(LstmSegmenterIterator<'data, 's, R>),
 }
 
-impl<R: RuleBreakType> Iterator for ComplexIterator<'_, '_, R> {
+impl<'data, G: AbstractGraphemeClusterSegmenterBorrowed<'data>, R: RuleBreakType> Iterator
+    for ComplexIterator<'data, '_, G, R>
+{
     type Item = usize;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -58,12 +71,12 @@ pub enum ComplexPayloadBorrowed<'data> {
 }
 
 impl<'data> ComplexPayloadBorrowed<'data> {
-    pub(crate) fn segment_str<'s>(
+    pub(crate) fn segment_str<'s, G: AbstractGraphemeClusterSegmenterBorrowed<'data>>(
         self,
         input: &'s str,
-        grapheme: GraphemeClusterSegmenterBorrowed<'data>,
+        grapheme: G,
         offset: usize,
-    ) -> ComplexIterator<'data, 's, Utf8> {
+    ) -> ComplexIterator<'data, 's, G, Utf8> {
         ComplexIterator(
             match self {
                 Self::Dict(dict) => ComplexIteratorInner::Dictionary(
@@ -79,12 +92,12 @@ impl<'data> ComplexPayloadBorrowed<'data> {
     }
 
     #[cfg(feature = "unstable")]
-    pub(crate) fn segment_utf8<'s>(
+    pub(crate) fn segment_utf8<'s, G: AbstractGraphemeClusterSegmenterBorrowed<'data>>(
         self,
         input: &'s [u8],
-        grapheme: GraphemeClusterSegmenterBorrowed<'data>,
+        grapheme: G,
         offset: usize,
-    ) -> ComplexIterator<'data, 's, PotentiallyIllFormedUtf8> {
+    ) -> ComplexIterator<'data, 's, G, PotentiallyIllFormedUtf8> {
         ComplexIterator(
             match self {
                 Self::Dict(dict) => ComplexIteratorInner::Dictionary(
@@ -99,12 +112,12 @@ impl<'data> ComplexPayloadBorrowed<'data> {
         )
     }
 
-    pub(crate) fn segment_utf16<'s>(
+    pub(crate) fn segment_utf16<'s, G: AbstractGraphemeClusterSegmenterBorrowed<'data>>(
         self,
         input: &'s [u16],
-        grapheme: GraphemeClusterSegmenterBorrowed<'data>,
+        grapheme: G,
         offset: usize,
-    ) -> ComplexIterator<'data, 's, Utf16> {
+    ) -> ComplexIterator<'data, 's, G, Utf16> {
         ComplexIterator(
             match self {
                 Self::Dict(dict) => ComplexIteratorInner::Dictionary(
@@ -144,9 +157,85 @@ impl ComplexPayloadBorrowed<'static> {
     }
 }
 
+pub(crate) trait AbstractGraphemeClusterSegmenter {
+    type Borrowed<'data>: AbstractGraphemeClusterSegmenterBorrowed<'data>
+    where
+        Self: 'data;
+
+    fn as_borrowed<'data>(&'data self) -> Self::Borrowed<'data>;
+}
+
+#[doc(hidden)]
+pub trait AbstractGraphemeClusterSegmenterBorrowed<'data>: core::fmt::Debug + Copy {
+    type Iter<'d, 's, R: RuleBreakType + 'static>: Iterator<Item = usize> + core::fmt::Debug;
+
+    fn segment_str<'s>(self, input: &'s str) -> Self::Iter<'data, 's, Utf8>;
+    #[cfg(feature = "unstable")]
+    fn segment_utf8<'s>(self, input: &'s [u8]) -> Self::Iter<'data, 's, PotentiallyIllFormedUtf8>;
+    fn segment_utf16<'s>(self, input: &'s [u16]) -> Self::Iter<'data, 's, Utf16>;
+}
+
+impl AbstractGraphemeClusterSegmenter for crate::GraphemeClusterSegmenter {
+    type Borrowed<'data> = crate::GraphemeClusterSegmenterBorrowed<'data>;
+
+    fn as_borrowed<'data>(&'data self) -> Self::Borrowed<'data> {
+        self.as_borrowed()
+    }
+}
+
+impl<'data> AbstractGraphemeClusterSegmenterBorrowed<'data>
+    for crate::grapheme::GraphemeClusterSegmenterBorrowed<'data>
+{
+    type Iter<'d, 's, R: RuleBreakType + 'static> =
+        crate::grapheme::GraphemeClusterBreakIterator<'data, 's, R>;
+
+    fn segment_str<'s>(self, input: &'s str) -> Self::Iter<'data, 's, Utf8> {
+        self.segment_str(input)
+    }
+
+    #[cfg(feature = "unstable")]
+    fn segment_utf8<'s>(self, input: &'s [u8]) -> Self::Iter<'data, 's, PotentiallyIllFormedUtf8> {
+        self.segment_utf8(input)
+    }
+
+    fn segment_utf16<'s>(self, input: &'s [u16]) -> Self::Iter<'data, 's, Utf16> {
+        self.segment_utf16(input)
+    }
+}
+
+#[cfg(feature = "unstable")]
+impl AbstractGraphemeClusterSegmenter for crate::neo::GraphemeClusterSegmenter {
+    type Borrowed<'data> = crate::neo::GraphemeClusterSegmenterBorrowed<'data>;
+
+    fn as_borrowed<'data>(&'data self) -> Self::Borrowed<'data> {
+        self.as_borrowed()
+    }
+}
+
+#[cfg(feature = "unstable")]
+impl<'data> AbstractGraphemeClusterSegmenterBorrowed<'data>
+    for crate::neo::GraphemeClusterSegmenterBorrowed<'data>
+{
+    type Iter<'d, 's, R: RuleBreakType + 'static> =
+        crate::neo::GraphemeClusterBreakIterator<'d, 's, R>;
+
+    fn segment_str<'s>(self, input: &'s str) -> Self::Iter<'data, 's, Utf8> {
+        self.segment_str(input)
+    }
+
+    #[cfg(feature = "unstable")]
+    fn segment_utf8<'s>(self, input: &'s [u8]) -> Self::Iter<'data, 's, PotentiallyIllFormedUtf8> {
+        self.segment_utf8(input)
+    }
+
+    fn segment_utf16<'s>(self, input: &'s [u16]) -> Self::Iter<'data, 's, Utf16> {
+        self.segment_utf16(input)
+    }
+}
+
 #[derive(Debug)]
-pub(crate) struct ComplexPayloads {
-    grapheme: GraphemeClusterSegmenter,
+pub(crate) struct ComplexPayloads<G: AbstractGraphemeClusterSegmenter> {
+    grapheme: G,
     my: Option<ComplexPayload>,
     km: Option<ComplexPayload>,
     lo: Option<ComplexPayload>,
@@ -156,8 +245,8 @@ pub(crate) struct ComplexPayloads {
 
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ComplexPayloadsBorrowed<'data> {
-    pub(crate) grapheme: GraphemeClusterSegmenterBorrowed<'data>,
+pub struct ComplexPayloadsBorrowed<'data, G: AbstractGraphemeClusterSegmenterBorrowed<'data>> {
+    pub(crate) grapheme: G,
     my: Option<ComplexPayloadBorrowed<'data>>,
     km: Option<ComplexPayloadBorrowed<'data>>,
     lo: Option<ComplexPayloadBorrowed<'data>>,
@@ -180,7 +269,7 @@ const LO_DICT: &DataMarkerAttributes = DataMarkerAttributes::from_str_or_panic("
 const TH_DICT: &DataMarkerAttributes = DataMarkerAttributes::from_str_or_panic("thaidict");
 const CJ_DICT: &DataMarkerAttributes = DataMarkerAttributes::from_str_or_panic("cjdict");
 
-impl<'data> ComplexPayloadsBorrowed<'data> {
+impl<'data, G: AbstractGraphemeClusterSegmenterBorrowed<'data>> ComplexPayloadsBorrowed<'data, G> {
     pub(crate) fn select(
         &self,
         complex_script: ComplexScript,
@@ -238,7 +327,7 @@ impl<'data> ComplexPayloadsBorrowed<'data> {
     }
 }
 
-impl ComplexPayloadsBorrowed<'static> {
+impl<G: AbstractGraphemeClusterSegmenterBorrowed<'static>> ComplexPayloadsBorrowed<'static, G> {
     #[cfg(feature = "lstm")]
     #[cfg(feature = "compiled_data")]
     pub(crate) fn with_southeast_asian_lstms(&mut self) {
@@ -302,11 +391,13 @@ impl ComplexPayloadsBorrowed<'static> {
                 .map(ComplexPayloadBorrowed::Dict);
         }
     }
+}
 
+impl ComplexPayloadsBorrowed<'static, crate::grapheme::GraphemeClusterSegmenterBorrowed<'static>> {
     #[cfg(feature = "compiled_data")]
     pub(crate) const fn new() -> Self {
         Self {
-            grapheme: GraphemeClusterSegmenter::new(),
+            grapheme: crate::grapheme::GraphemeClusterSegmenter::new(),
             my: None,
             km: None,
             lo: None,
@@ -315,7 +406,9 @@ impl ComplexPayloadsBorrowed<'static> {
         }
     }
 
-    pub(crate) fn static_to_owned(self) -> ComplexPayloads {
+    pub(crate) fn static_to_owned(
+        self,
+    ) -> ComplexPayloads<crate::grapheme::GraphemeClusterSegmenter> {
         ComplexPayloads {
             grapheme: self.grapheme.static_to_owned(),
             my: self.my.map(ComplexPayloadBorrowed::static_to_owned),
@@ -327,8 +420,34 @@ impl ComplexPayloadsBorrowed<'static> {
     }
 }
 
-impl ComplexPayloads {
-    pub(crate) fn as_borrowed(&self) -> ComplexPayloadsBorrowed<'_> {
+#[cfg(feature = "unstable")]
+impl ComplexPayloadsBorrowed<'static, crate::neo::GraphemeClusterSegmenterBorrowed<'static>> {
+    #[cfg(feature = "compiled_data")]
+    pub(crate) const fn new() -> Self {
+        Self {
+            grapheme: crate::neo::GraphemeClusterSegmenter::new(),
+            my: None,
+            km: None,
+            lo: None,
+            th: None,
+            ja: None,
+        }
+    }
+
+    pub(crate) fn static_to_owned(self) -> ComplexPayloads<crate::neo::GraphemeClusterSegmenter> {
+        ComplexPayloads {
+            grapheme: self.grapheme.static_to_owned(),
+            my: self.my.map(ComplexPayloadBorrowed::static_to_owned),
+            km: self.km.map(ComplexPayloadBorrowed::static_to_owned),
+            lo: self.lo.map(ComplexPayloadBorrowed::static_to_owned),
+            th: self.th.map(ComplexPayloadBorrowed::static_to_owned),
+            ja: self.ja.map(ComplexPayloadBorrowed::static_to_owned),
+        }
+    }
+}
+
+impl<G: AbstractGraphemeClusterSegmenter> ComplexPayloads<G> {
+    pub(crate) fn as_borrowed(&self) -> ComplexPayloadsBorrowed<'_, G::Borrowed<'_>> {
         ComplexPayloadsBorrowed {
             grapheme: self.grapheme.as_borrowed(),
             my: self.my.as_ref().map(ComplexPayload::as_borrowed),
@@ -406,13 +525,32 @@ impl ComplexPayloads {
         }
         Ok(())
     }
+}
 
+impl ComplexPayloads<crate::grapheme::GraphemeClusterSegmenter> {
     pub(crate) fn try_new<D>(provider: &D) -> Result<Self, DataError>
     where
         D: DataProvider<SegmenterBreakGraphemeClusterV1> + ?Sized,
     {
         Ok(Self {
-            grapheme: GraphemeClusterSegmenter::try_new_unstable(provider)?,
+            grapheme: crate::grapheme::GraphemeClusterSegmenter::try_new_unstable(provider)?,
+            my: None,
+            km: None,
+            lo: None,
+            th: None,
+            ja: None,
+        })
+    }
+}
+
+#[cfg(feature = "unstable")]
+impl ComplexPayloads<crate::neo::GraphemeClusterSegmenter> {
+    pub(crate) fn try_new<D>(provider: &D) -> Result<Self, DataError>
+    where
+        D: DataProvider<SegmenterBreakGraphemeClusterV2> + ?Sized,
+    {
+        Ok(Self {
+            grapheme: crate::neo::GraphemeClusterSegmenter::try_new_unstable(provider)?,
             my: None,
             km: None,
             lo: None,
@@ -465,7 +603,11 @@ mod tests {
     use super::*;
 
     #[track_caller]
-    fn check_complex(s: &str, expected: &[&str], segmenter: ComplexPayloadsBorrowed<'_>) {
+    fn check_complex<'data, G: AbstractGraphemeClusterSegmenterBorrowed<'data>>(
+        s: &str,
+        expected: &[&str],
+        segmenter: ComplexPayloadsBorrowed<'data, G>,
+    ) {
         use itertools::Itertools;
 
         let segments = [0]
@@ -500,9 +642,22 @@ mod tests {
 
     #[test]
     fn thai() {
-        let mut lstm = ComplexPayloadsBorrowed::new();
+        let mut lstm = ComplexPayloadsBorrowed::<crate::GraphemeClusterSegmenterBorrowed>::new();
         lstm.with_southeast_asian_lstms();
-        let mut dict = ComplexPayloadsBorrowed::new();
+        let mut dict = ComplexPayloadsBorrowed::<crate::GraphemeClusterSegmenterBorrowed>::new();
+        dict.with_southeast_asian_dictionaries();
+
+        check_complex("ภาษาไทยภาษาไทย", &["ภาษา", "ไทย", "ภาษา", "ไทย"], lstm);
+        check_complex("ภาษาไทยภาษาไทย", &["ภาษา", "ไทย", "ภาษา", "ไทย"], dict);
+    }
+
+    #[test]
+    fn thai_neo() {
+        let mut lstm =
+            ComplexPayloadsBorrowed::<crate::neo::GraphemeClusterSegmenterBorrowed>::new();
+        lstm.with_southeast_asian_lstms();
+        let mut dict =
+            ComplexPayloadsBorrowed::<crate::neo::GraphemeClusterSegmenterBorrowed>::new();
         dict.with_southeast_asian_dictionaries();
 
         check_complex("ภาษาไทยภาษาไทย", &["ภาษา", "ไทย", "ภาษา", "ไทย"], lstm);
@@ -511,11 +666,38 @@ mod tests {
 
     #[test]
     fn mixed() {
-        let mut lstm = ComplexPayloadsBorrowed::new();
+        let mut lstm = ComplexPayloadsBorrowed::<crate::GraphemeClusterSegmenterBorrowed>::new();
         lstm.with_southeast_asian_lstms();
         lstm.with_japanese_dictionary();
 
-        let mut dict = ComplexPayloadsBorrowed::new();
+        let mut dict = ComplexPayloadsBorrowed::<crate::GraphemeClusterSegmenterBorrowed>::new();
+        dict.with_southeast_asian_dictionaries();
+        dict.with_japanese_dictionary();
+
+        check_complex("ภาษาไทย龟山岛", &["ภาษา", "ไทย", "龟山岛"], lstm);
+        check_complex("ภาษาไทย龟山岛", &["ภาษา", "ไทย", "龟山岛"], dict);
+
+        check_complex(
+            "こんにちは世界ภาษาไทย",
+            &["こんにちは", "世界", "ภาษา", "ไทย"],
+            lstm,
+        );
+        check_complex(
+            "こんにちは世界ภาษาไทย",
+            &["こんにちは", "世界", "ภาษา", "ไทย"],
+            dict,
+        );
+    }
+
+    #[test]
+    fn mixed_neo() {
+        let mut lstm =
+            ComplexPayloadsBorrowed::<crate::neo::GraphemeClusterSegmenterBorrowed>::new();
+        lstm.with_southeast_asian_lstms();
+        lstm.with_japanese_dictionary();
+
+        let mut dict =
+            ComplexPayloadsBorrowed::<crate::neo::GraphemeClusterSegmenterBorrowed>::new();
         dict.with_southeast_asian_dictionaries();
         dict.with_japanese_dictionary();
 

--- a/components/segmenter/src/line.rs
+++ b/components/segmenter/src/line.rs
@@ -2,7 +2,6 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use crate::complex::*;
 use crate::indices::*;
 use crate::provider::*;
 use crate::rule_segmenter::*;

--- a/components/segmenter/src/neo/line.rs
+++ b/components/segmenter/src/neo/line.rs
@@ -3,7 +3,6 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use super::*;
-use crate::complex::{ComplexPayloads, ComplexPayloadsBorrowed};
 use crate::indices::{Latin1Indices, Utf16Indices};
 use crate::iterator_helpers::derive_usize_iterator_with_type;
 use crate::line::{LineBreakOptions, LineBreakStrictness, LineBreakWordOption};
@@ -216,7 +215,6 @@ impl LineSegmenter {
         D: DataProvider<SegmenterBreakLineV2>
             + DataProvider<SegmenterBreakLineOverrideV2>
             + DataProvider<SegmenterLstmAutoV1>
-            + DataProvider<SegmenterBreakGraphemeClusterV1>
             + DataProvider<SegmenterBreakGraphemeClusterV2>
             + ?Sized,
     {
@@ -263,7 +261,6 @@ impl LineSegmenter {
         D: DataProvider<SegmenterBreakLineV2>
             + DataProvider<SegmenterBreakLineOverrideV2>
             + DataProvider<SegmenterLstmAutoV1>
-            + DataProvider<SegmenterBreakGraphemeClusterV1>
             + DataProvider<SegmenterBreakGraphemeClusterV2>
             + ?Sized,
     {
@@ -307,7 +304,6 @@ impl LineSegmenter {
         D: DataProvider<SegmenterBreakLineV2>
             + DataProvider<SegmenterDictionaryExtendedV1>
             + DataProvider<SegmenterBreakLineOverrideV2>
-            + DataProvider<SegmenterBreakGraphemeClusterV1>
             + DataProvider<SegmenterBreakGraphemeClusterV2>
             + ?Sized,
     {
@@ -383,7 +379,6 @@ impl LineSegmenter {
     ) -> Result<Self, DataError>
     where
         D: DataProvider<SegmenterBreakLineV2>
-            + DataProvider<SegmenterBreakGraphemeClusterV1>
             + DataProvider<SegmenterBreakGraphemeClusterV2>
             + DataProvider<SegmenterBreakLineOverrideV2>
             + ?Sized,

--- a/components/segmenter/src/neo/mod.rs
+++ b/components/segmenter/src/neo/mod.rs
@@ -4,7 +4,6 @@
 
 //! Experimental reimplementations
 
-use crate::complex::ComplexIterator;
 use crate::provider::{
     Acceptance, ComplexScript, SegmenterStateMachine, SegmenterStateMachineOverride, Symbol,
 };
@@ -19,6 +18,12 @@ mod sentence;
 pub use sentence::*;
 mod word;
 pub use word::*;
+
+pub(crate) type ComplexIterator<'data, 's, R> =
+    crate::complex::ComplexIterator<'data, 's, GraphemeClusterSegmenterBorrowed<'data>, R>;
+type ComplexPayloads = crate::complex::ComplexPayloads<GraphemeClusterSegmenter>;
+pub(crate) type ComplexPayloadsBorrowed<'data> =
+    crate::complex::ComplexPayloadsBorrowed<'data, GraphemeClusterSegmenterBorrowed<'data>>;
 
 pub(crate) trait ComplexHandler<Y: RuleBreakType> {
     const BREAK_STATUS: u8;

--- a/components/segmenter/src/neo/word.rs
+++ b/components/segmenter/src/neo/word.rs
@@ -2,12 +2,11 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use super::{ComplexHandler, RuleBreakIterator, RuleBreakType};
-use crate::complex::*;
+use super::*;
 use crate::indices::{Latin1Indices, Utf16Indices};
 use crate::iterator_helpers::derive_usize_iterator_with_type;
 use crate::provider::*;
-use crate::rule_segmenter::*;
+use crate::scaffold::{Latin1, PotentiallyIllFormedUtf8, RuleBreakType, Utf8, Utf16};
 #[cfg(feature = "compiled_data")]
 use crate::word::WordBreakInvariantOptions;
 use crate::word::WordBreakOptions;
@@ -242,7 +241,7 @@ impl WordSegmenter {
         D: DataProvider<SegmenterBreakWordV2>
             + DataProvider<SegmenterDictionaryAutoV1>
             + DataProvider<SegmenterLstmAutoV1>
-            + DataProvider<SegmenterBreakGraphemeClusterV1>
+            + DataProvider<SegmenterBreakGraphemeClusterV2>
             + ?Sized,
     {
         let mut complex = ComplexPayloads::try_new(provider)?;
@@ -316,7 +315,7 @@ impl WordSegmenter {
     where
         D: DataProvider<SegmenterBreakWordV2>
             + DataProvider<SegmenterLstmAutoV1>
-            + DataProvider<SegmenterBreakGraphemeClusterV1>
+            + DataProvider<SegmenterBreakGraphemeClusterV2>
             + ?Sized,
     {
         let mut s = Self::try_new_for_non_complex_scripts_unstable(provider, options)?;
@@ -379,7 +378,7 @@ impl WordSegmenter {
         D: DataProvider<SegmenterBreakWordV2>
             + DataProvider<SegmenterDictionaryAutoV1>
             + DataProvider<SegmenterDictionaryExtendedV1>
-            + DataProvider<SegmenterBreakGraphemeClusterV1>
+            + DataProvider<SegmenterBreakGraphemeClusterV2>
             + ?Sized,
     {
         let mut s = Self::try_new_for_non_complex_scripts_unstable(provider, options)?;
@@ -420,7 +419,7 @@ impl WordSegmenter {
     ) -> Result<Self, DataError>
     where
         D: DataProvider<SegmenterBreakWordV2>
-            + DataProvider<SegmenterBreakGraphemeClusterV1>
+            + DataProvider<SegmenterBreakGraphemeClusterV2>
             + ?Sized,
     {
         Ok(Self {

--- a/components/segmenter/src/rule_segmenter.rs
+++ b/components/segmenter/src/rule_segmenter.rs
@@ -2,16 +2,15 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-#[cfg(feature = "unstable")]
-use crate::GraphemeClusterSegmenterBorrowed;
-use crate::complex::ComplexPayloadsBorrowed;
-#[cfg(feature = "unstable")]
-use crate::complex::{ComplexIterator, ComplexPayloadBorrowed};
 use crate::indices::{Latin1Indices, Utf16Indices};
 use crate::provider::*;
 use alloc::vec::Vec;
 use core::str::CharIndices;
 use utf8_iter::Utf8CharIndices;
+
+pub(crate) type ComplexPayloads = crate::complex::ComplexPayloads<crate::GraphemeClusterSegmenter>;
+pub(crate) type ComplexPayloadsBorrowed<'data> =
+    crate::complex::ComplexPayloadsBorrowed<'data, crate::GraphemeClusterSegmenterBorrowed<'data>>;
 
 /// A trait allowing for `RuleBreakIterator` to be generalized to multiple string
 /// encoding methods and granularity such as grapheme cluster, word, etc.
@@ -20,7 +19,7 @@ use utf8_iter::Utf8CharIndices;
 /// 🚫 This trait is sealed; it cannot be implemented by user code. If an API requests an item that implements this
 /// trait, please consider using a type from the implementors listed below.
 /// </div>
-pub trait RuleBreakType: crate::private::Sealed + Sized {
+pub trait RuleBreakType: crate::private::Sealed + Sized + core::fmt::Debug + 'static {
     /// The iterator over characters.
     type IterAttr<'s>: Iterator<Item = (usize, Self::CharType)> + Clone + core::fmt::Debug;
 
@@ -53,7 +52,7 @@ pub trait RuleBreakType: crate::private::Sealed + Sized {
         data: &Self::ComplexPayload<'data>,
         complex: &Self::IterAttr<'s>,
         past_complex: &Self::IterAttr<'s>,
-    ) -> ComplexIterator<'data, 's, Self>;
+    ) -> crate::neo::ComplexIterator<'data, 's, Self>;
 
     #[doc(hidden)]
     #[cfg(feature = "unstable")]
@@ -309,11 +308,11 @@ impl RuleBreakType for Utf8 {
     const CAN_CONTAIN_SA: bool = true;
 
     #[cfg(feature = "unstable")]
-    type ComplexPayloads<'data> = ComplexPayloadsBorrowed<'data>;
+    type ComplexPayloads<'data> = crate::neo::ComplexPayloadsBorrowed<'data>;
     #[cfg(feature = "unstable")]
     type ComplexPayload<'data> = (
-        ComplexPayloadBorrowed<'data>,
-        GraphemeClusterSegmenterBorrowed<'data>,
+        crate::complex::ComplexPayloadBorrowed<'data>,
+        crate::neo::GraphemeClusterSegmenterBorrowed<'data>,
     );
 
     #[cfg(feature = "unstable")]
@@ -329,7 +328,7 @@ impl RuleBreakType for Utf8 {
         &(lang, grapheme): &Self::ComplexPayload<'data>,
         complex: &Self::IterAttr<'s>,
         past_complex: &Self::IterAttr<'s>,
-    ) -> ComplexIterator<'data, 's, Self> {
+    ) -> crate::neo::ComplexIterator<'data, 's, Self> {
         let complex_offset = complex.offset();
         #[allow(clippy::indexing_slicing)] // valid offset
         let complex = &complex.as_str()[..(past_complex.offset() - complex_offset)];
@@ -365,11 +364,11 @@ impl RuleBreakType for PotentiallyIllFormedUtf8 {
     const CAN_CONTAIN_SA: bool = true;
 
     #[cfg(feature = "unstable")]
-    type ComplexPayloads<'data> = ComplexPayloadsBorrowed<'data>;
+    type ComplexPayloads<'data> = crate::neo::ComplexPayloadsBorrowed<'data>;
     #[cfg(feature = "unstable")]
     type ComplexPayload<'data> = (
-        ComplexPayloadBorrowed<'data>,
-        GraphemeClusterSegmenterBorrowed<'data>,
+        crate::complex::ComplexPayloadBorrowed<'data>,
+        crate::neo::GraphemeClusterSegmenterBorrowed<'data>,
     );
 
     #[cfg(feature = "unstable")]
@@ -385,7 +384,7 @@ impl RuleBreakType for PotentiallyIllFormedUtf8 {
         &(lang, grapheme): &Self::ComplexPayload<'data>,
         complex: &Self::IterAttr<'s>,
         past_complex: &Self::IterAttr<'s>,
-    ) -> ComplexIterator<'data, 's, Self> {
+    ) -> crate::neo::ComplexIterator<'data, 's, Self> {
         let offset = complex.offset();
         #[allow(clippy::indexing_slicing)] // valid offset
         let complex = &complex.as_slice()[..(past_complex.offset() - offset)];
@@ -438,7 +437,7 @@ impl RuleBreakType for Latin1 {
         &complex_payload: &Self::ComplexPayloads<'data>,
         _: &Self::IterAttr<'s>,
         _: &Self::IterAttr<'s>,
-    ) -> ComplexIterator<'data, 's, Self> {
+    ) -> crate::neo::ComplexIterator<'data, 's, Self> {
         match complex_payload {}
     }
 
@@ -471,11 +470,11 @@ impl RuleBreakType for Utf16 {
     const CAN_CONTAIN_SA: bool = true;
 
     #[cfg(feature = "unstable")]
-    type ComplexPayloads<'data> = ComplexPayloadsBorrowed<'data>;
+    type ComplexPayloads<'data> = crate::neo::ComplexPayloadsBorrowed<'data>;
     #[cfg(feature = "unstable")]
     type ComplexPayload<'data> = (
-        ComplexPayloadBorrowed<'data>,
-        GraphemeClusterSegmenterBorrowed<'data>,
+        crate::complex::ComplexPayloadBorrowed<'data>,
+        crate::neo::GraphemeClusterSegmenterBorrowed<'data>,
     );
 
     #[cfg(feature = "unstable")]
@@ -491,7 +490,7 @@ impl RuleBreakType for Utf16 {
         &(lang, grapheme): &Self::ComplexPayload<'data>,
         complex: &Self::IterAttr<'s>,
         past_complex: &Self::IterAttr<'s>,
-    ) -> ComplexIterator<'data, 's, Utf16> {
+    ) -> crate::neo::ComplexIterator<'data, 's, Self> {
         let complex_offset = complex.offset();
         #[allow(clippy::indexing_slicing)] // valid offset
         let complex = &complex.as_slice()[..(past_complex.offset() - complex_offset)];

--- a/components/segmenter/src/word.rs
+++ b/components/segmenter/src/word.rs
@@ -2,7 +2,6 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use crate::complex::*;
 use crate::indices::{Latin1Indices, Utf16Indices};
 use crate::iterator_helpers::derive_usize_iterator_with_type;
 use crate::provider::*;
@@ -13,6 +12,10 @@ use alloc::vec::Vec;
 use icu_locale_core::LanguageIdentifier;
 use icu_provider::prelude::*;
 use utf8_iter::Utf8CharIndices;
+
+type ComplexPayloads = crate::complex::ComplexPayloads<crate::GraphemeClusterSegmenter>;
+type ComplexPayloadsBorrowed<'data> =
+    crate::complex::ComplexPayloadsBorrowed<'data, crate::GraphemeClusterSegmenterBorrowed<'data>>;
 
 /// Options to tailor word breaking behavior.
 #[non_exhaustive]


### PR DESCRIPTION
So far, the neo segmenters have used the existing complex segmentation code, which uses a (non-neo) `GraphemeClusterBreakSegmenter` internally. This PR makes the whole complex code path generic in a GCBS, so that neo can use neo.

#7962 

## Changelog

N/A