### PR TITLE
Make ComplexPayloads private, not hidden

### DIFF
--- a/components/segmenter/src/complex/mod.rs
+++ b/components/segmenter/src/complex/mod.rs
@@ -19,8 +19,7 @@ mod lstm;
 use lstm::*;
 
 #[derive(Debug)]
-#[doc(hidden)]
-pub struct ComplexIterator<
+pub(crate) struct ComplexIterator<
     'data,
     's,
     G: AbstractGraphemeClusterSegmenterBorrowed<'data>,
@@ -165,8 +164,7 @@ pub(crate) trait AbstractGraphemeClusterSegmenter {
     fn as_borrowed<'data>(&'data self) -> Self::Borrowed<'data>;
 }
 
-#[doc(hidden)]
-pub trait AbstractGraphemeClusterSegmenterBorrowed<'data>: core::fmt::Debug + Copy {
+pub(crate) trait AbstractGraphemeClusterSegmenterBorrowed<'data>: core::fmt::Debug + Copy {
     type Iter<'d, 's, R: RuleBreakType + 'static>: Iterator<Item = usize> + core::fmt::Debug;
 
     fn segment_str<'s>(self, input: &'s str) -> Self::Iter<'data, 's, Utf8>;
@@ -244,8 +242,7 @@ pub(crate) struct ComplexPayloads<G: AbstractGraphemeClusterSegmenter> {
 }
 
 #[derive(Debug, Clone, Copy)]
-#[doc(hidden)]
-pub struct ComplexPayloadsBorrowed<'data, G: AbstractGraphemeClusterSegmenterBorrowed<'data>> {
+pub(crate) struct ComplexPayloadsBorrowed<'data, G: AbstractGraphemeClusterSegmenterBorrowed<'data>> {
     pub(crate) grapheme: G,
     my: Option<ComplexPayloadBorrowed<'data>>,
     km: Option<ComplexPayloadBorrowed<'data>>,

--- a/components/segmenter/src/line.rs
+++ b/components/segmenter/src/line.rs
@@ -14,7 +14,7 @@ use icu_locale_core::subtags::{Language, language};
 use icu_provider::prelude::*;
 use utf8_iter::Utf8CharIndices;
 
-#[doc(hidden)]
+#[doc(hidden)] // datagen
 impl RuleBreakData<'_> {
     pub const LINE_PROPERTY_AI: u8 = 1;
     pub const LINE_PROPERTY_AL: u8 = 3;
@@ -44,7 +44,7 @@ impl RuleBreakData<'_> {
 }
 
 #[cfg_attr(not(test), allow(dead_code))]
-#[doc(hidden)]
+#[doc(hidden)] // datagen
 impl RuleBreakData<'_> {
     pub const LINE_PROPERTY_AK: u8 = 2;
     pub const LINE_PROPERTY_AL_DOTTED_CIRCLE: u8 = 4;


### PR DESCRIPTION
Noticed in https://github.com/unicode-org/icu4x/pull/8152

ComplexPayloads is public-hidden because it's used in a public-hidden associated type. But we don't need it to be: the associated type can be public-hidden and this type can be private and it should work just fine.


## Changelog: N/A

