### PR TITLE
refactor: Adapt most crates to unconditionally use `#![no_std]`

### DIFF
--- a/components/calendar/src/lib.rs
+++ b/components/calendar/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, doc)), no_std)]
+#![no_std]
 #![cfg_attr(
     not(test),
     deny(
@@ -91,6 +91,9 @@
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
+
+#[cfg(test)]
+extern crate std;
 
 // Make sure inherent docs go first
 mod date;

--- a/components/casemap/src/lib.rs
+++ b/components/casemap/src/lib.rs
@@ -28,7 +28,7 @@
 //! [`ICU4X`]: ../icu/index.html
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, doc)), no_std)]
+#![no_std]
 #![cfg_attr(
     not(test),
     deny(
@@ -43,6 +43,9 @@
 #![allow(confusable_idents, uncommon_codepoints)]
 
 extern crate alloc;
+
+#[cfg(test)]
+extern crate std;
 
 mod casemapper;
 mod closer;

--- a/components/collator/src/lib.rs
+++ b/components/collator/src/lib.rs
@@ -7,7 +7,7 @@
 // described in LICENSE.
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, doc)), no_std)]
+#![no_std]
 #![cfg_attr(
     not(test),
     deny(
@@ -342,6 +342,9 @@
 //! [`CollatorOptions`]: options::CollatorOptions
 
 extern crate alloc;
+
+#[cfg(test)]
+extern crate std;
 
 mod comparison;
 #[cfg(doc)]

--- a/components/collections/codepointtrie_builder/src/lib.rs
+++ b/components/collections/codepointtrie_builder/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-// #![cfg_attr(not(any(test, doc)), no_std)]
+// #![no_std]
 // #![cfg_attr(
 //     not(test),
 //     deny(

--- a/components/collections/src/lib.rs
+++ b/components/collections/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, doc)), no_std)]
+#![no_std]
 #![cfg_attr(
     not(test),
     deny(
@@ -35,6 +35,9 @@
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
+
+#[cfg(test)]
+extern crate std;
 
 pub mod char16trie;
 pub mod codepointinvlist;

--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, doc)), no_std)]
+#![no_std]
 #![cfg_attr(
     not(test),
     deny(
@@ -120,6 +120,9 @@
 //! For field sets that don't contain dates, this can also be achieved using [`NoCalendarFormatter`].
 
 extern crate alloc;
+
+#[cfg(test)]
+extern crate std;
 
 #[cfg(feature = "unstable_chrono_0_4")]
 mod chrono;

--- a/components/decimal/src/lib.rs
+++ b/components/decimal/src/lib.rs
@@ -74,7 +74,7 @@
 //! [`DecimalFormatter`]: DecimalFormatter
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, doc)), no_std)]
+#![no_std]
 #![cfg_attr(
     not(test),
     deny(
@@ -88,6 +88,9 @@
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
+
+#[cfg(test)]
+extern crate std;
 
 #[cfg(feature = "alloc")]
 #[doc(hidden)] // TODO(#3647): should be private

--- a/components/experimental/src/dimension/currency/compact_formatter.rs
+++ b/components/experimental/src/dimension/currency/compact_formatter.rs
@@ -2,6 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+extern crate alloc;
+
 use core::fmt::Display;
 
 use crate::dimension::provider::{
@@ -17,8 +19,6 @@ use writeable::Writeable;
 
 use super::{CurrencyCode, options::CurrencyFormatterOptions};
 use icu_pattern::DoublePlaceholderPattern;
-
-extern crate alloc;
 
 define_preferences!(
     /// The preferences for currency formatting.

--- a/components/experimental/src/dimension/currency/formatter.rs
+++ b/components/experimental/src/dimension/currency/formatter.rs
@@ -2,6 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+extern crate alloc;
+
 use core::fmt::Display;
 
 use fixed_decimal::Decimal;
@@ -17,8 +19,6 @@ use super::super::provider::currency::essentials::CurrencyEssentialsV1;
 use super::CurrencyCode;
 use super::options::CurrencyFormatterOptions;
 use icu_pattern::DoublePlaceholderPattern;
-
-extern crate alloc;
 
 define_preferences!(
     /// The preferences for currency formatting.

--- a/components/experimental/src/dimension/currency/long_compact_formatter.rs
+++ b/components/experimental/src/dimension/currency/long_compact_formatter.rs
@@ -2,6 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+extern crate alloc;
+
 use core::fmt::Display;
 
 use fixed_decimal::Decimal;
@@ -16,8 +18,6 @@ use crate::dimension::provider::currency::{
 };
 
 use super::CurrencyCode;
-
-extern crate alloc;
 
 /// A formatter for monetary values.
 ///

--- a/components/experimental/src/dimension/currency/long_formatter.rs
+++ b/components/experimental/src/dimension/currency/long_formatter.rs
@@ -2,6 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+extern crate alloc;
+
 use core::fmt::Display;
 
 use fixed_decimal::Decimal;
@@ -15,8 +17,6 @@ use crate::dimension::provider::currency::{
 };
 
 use super::{CurrencyCode, formatter::CurrencyFormatterPreferences};
-
-extern crate alloc;
 
 /// A formatter for monetary values.
 ///

--- a/components/experimental/src/dimension/percent/formatter.rs
+++ b/components/experimental/src/dimension/percent/formatter.rs
@@ -2,6 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+extern crate alloc;
+
 use fixed_decimal::Decimal;
 use icu_decimal::options::DecimalFormatterOptions;
 use icu_decimal::{DecimalFormatter, DecimalFormatterPreferences};
@@ -12,8 +14,6 @@ use icu_provider::prelude::*;
 use super::super::provider::percent::PercentEssentialsV1;
 use super::format::FormattedPercent;
 use super::options::PercentFormatterOptions;
-
-extern crate alloc;
 
 define_preferences!(
     /// The preferences for percent formatting.

--- a/components/experimental/src/dimension/units/formatter.rs
+++ b/components/experimental/src/dimension/units/formatter.rs
@@ -2,6 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+extern crate alloc;
+
 use fixed_decimal::Decimal;
 use icu_decimal::options::DecimalFormatterOptions;
 use icu_decimal::{DecimalFormatter, DecimalFormatterPreferences};
@@ -14,8 +16,6 @@ use super::options::{UnitsFormatterOptions, Width};
 use crate::dimension::provider::units::display_names::UnitsDisplayNamesV1;
 use icu_provider::prelude::*;
 use smallvec::SmallVec;
-
-extern crate alloc;
 
 define_preferences!(
     /// The preferences for units formatting.

--- a/components/experimental/src/lib.rs
+++ b/components/experimental/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, doc)), no_std)]
+#![no_std]
 #![cfg_attr(
     not(test),
     deny(
@@ -26,6 +26,9 @@
 #![allow(clippy::module_inception)]
 
 extern crate alloc;
+
+#[cfg(test)]
+extern crate std;
 
 pub mod dimension;
 pub mod displaynames;

--- a/components/icu/src/lib.rs
+++ b/components/icu/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, doc)), no_std)]
+#![no_std]
 #![cfg_attr(
     not(test),
     deny(
@@ -14,6 +14,9 @@
     )
 )]
 #![warn(missing_docs)]
+
+#[cfg(test)]
+extern crate std;
 
 //! `icu` is the main meta-crate of the `ICU4X` project.
 //!

--- a/components/list/src/lib.rs
+++ b/components/list/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, doc)), no_std)]
+#![no_std]
 #![cfg_attr(
     not(test),
     deny(
@@ -90,6 +90,9 @@
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
+
+#[cfg(test)]
+extern crate std;
 
 mod lazy_automaton;
 mod list_formatter;

--- a/components/locale/src/lib.rs
+++ b/components/locale/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, doc)), no_std)]
+#![no_std]
 #![cfg_attr(
     not(test),
     deny(
@@ -82,6 +82,9 @@
 //! [`UTS #35: Unicode LDML 3. LocaleId Canonicalization`]: https://unicode.org/reports/tr35/#LocaleId_Canonicalization,
 
 extern crate alloc;
+
+#[cfg(test)]
+extern crate std;
 
 mod canonicalizer;
 mod directionality;

--- a/components/locale_core/src/lib.rs
+++ b/components/locale_core/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, doc)), no_std)]
+#![no_std]
 #![cfg_attr(
     not(test),
     deny(
@@ -63,6 +63,9 @@
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
+
+#[cfg(test)]
+extern crate std;
 
 #[macro_use]
 mod helpers;

--- a/components/normalizer/src/lib.rs
+++ b/components/normalizer/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, doc)), no_std)]
+#![no_std]
 #![cfg_attr(
     not(test),
     deny(
@@ -57,6 +57,9 @@
 //! ```
 
 extern crate alloc;
+
+#[cfg(test)]
+extern crate std;
 
 // TODO: The plan is to replace
 // `#[cfg(not(icu4x_unstable_fast_trie_only))]`

--- a/components/pattern/src/lib.rs
+++ b/components/pattern/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, doc)), no_std)]
+#![no_std]
 #![cfg_attr(
     not(test),
     deny(
@@ -45,6 +45,9 @@
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
+
+#[cfg(test)]
+extern crate std;
 
 #[cfg(feature = "alloc")]
 mod builder;

--- a/components/pattern/tests/derive_test.rs
+++ b/components/pattern/tests/derive_test.rs
@@ -27,7 +27,6 @@ struct DeriveTest_SinglePlaceholderPattern_Cow<'data> {
 #[cfg(all(feature = "databake", feature = "alloc"))]
 fn bake_SinglePlaceholderPattern_Cow() {
     use databake::*;
-    extern crate std;
     test_bake!(
         DeriveTest_SinglePlaceholderPattern_Cow<'static>,
         crate::DeriveTest_SinglePlaceholderPattern_Cow {

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, doc)), no_std)]
+#![no_std]
 #![cfg_attr(
     not(test),
     deny(
@@ -71,6 +71,9 @@
 //! [Language Plural Rules]: https://unicode.org/reports/tr35/tr35-numbers.html#Language_Plural_Rules
 
 extern crate alloc;
+
+#[cfg(test)]
+extern crate std;
 
 mod operands;
 mod options;

--- a/components/properties/src/lib.rs
+++ b/components/properties/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, doc)), no_std)]
+#![no_std]
 #![cfg_attr(
     not(test),
     deny(
@@ -72,6 +72,9 @@
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
+
+#[cfg(test)]
+extern crate std;
 
 mod code_point_set;
 pub use code_point_set::{CodePointSetData, CodePointSetDataBorrowed};

--- a/components/segmenter/src/lib.rs
+++ b/components/segmenter/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, doc)), no_std)]
+#![no_std]
 #![cfg_attr(
     not(test),
     deny(
@@ -117,6 +117,9 @@
 //! See [`SentenceSegmenter`] for more examples.
 
 extern crate alloc;
+
+#[cfg(test)]
+extern crate std;
 
 mod complex;
 mod indices;

--- a/components/time/src/lib.rs
+++ b/components/time/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, doc)), no_std)]
+#![no_std]
 #![cfg_attr(
     not(test),
     deny(
@@ -22,6 +22,9 @@
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
+
+#[cfg(test)]
+extern crate std;
 
 pub mod provider;
 pub mod scaffold;

--- a/documents/process/boilerplate.md
+++ b/documents/process/boilerplate.md
@@ -4,40 +4,54 @@ This file contains explanations of ICU4X-specific conventions on boilerplate (ex
 
 ## Library annotations
 
-In order to assert that library crates conform to the ICU4X style guide, the following annotation should be present in every *lib.rs* file. The annotations do the following:
+To ensure the ICU4X library crates conform to the project's style guide, every `lib.rs` file must include the standard boilerplate annotations.
 
-1. Set the crate to be `no_std`
-2. Enforce no unannotated panicky behavior, except in test mode
-3. Require every exported method to be documented, implement `Debug`, and be `non_exhaustive` or annotated as exhaustive
+These annotations enforce the following rules:
 
-If the crate has no `std` feature:
+1. Configure the crate as `no_std`.
+2. Enforce annotating any panicking behavior, except during tests.
+3. Require every exported item to be documented, implement `Debug`, and where appropriate marked as `non_exhaustive` (_unless annotated to permit as exhaustive_).
 
-    // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-    #![cfg_attr(not(any(test, doc)), no_std)]
-    #![cfg_attr(
-        not(test),
-        deny(
-            clippy::indexing_slicing,
-            clippy::unwrap_used,
-            clippy::expect_used,
-            clippy::panic,
-        )
-    )]
-    #![warn(missing_docs)]
+> [!NOTE]
+> While the majority of lints are configured globally via the workspace `Cargo.toml`, some [boilerplate-level overrides remain necessary][gh-issues::boilerplate-lints] due to upstream tooling limitations.
 
-Not all crates are yet able to be annotated in this way. Annotations may be omitted and added when able.
+Include the following at the top of each `lib.rs` file:
 
-If the crate has an `std` feature, specify this in the first line:
+```rust
+// https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
+#![no_std]
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::indexing_slicing,
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+    )
+)]
+#![warn(missing_docs)]
 
-    // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-    #![cfg_attr(not(any(test, doc)), no_std)]
-    #![cfg_attr(
-        not(test),
-        deny(
-            clippy::indexing_slicing,
-            clippy::unwrap_used,
-            clippy::expect_used,
-            clippy::panic,
-        )
-    )]
-    #![warn(missing_docs)]
+#[cfg(test)]
+extern crate std;
+```
+
+By convention, `extern crate std;` should be placed immediately following the crate-level attributes. If the file also requires `extern crate alloc;`, place `extern crate std;` after the `alloc` declaration.
+
+Not all crates are compatible with the full boilerplate. Incompatible annotations should be included but commented out (_if that is `#![no_std]`, the associated `extern crate std` lines should be excluded from the file_).
+
+Mandating `#![no_std]` ensures that the [`core` prelude is always used instead][prelude-nostd] of the [`std` prelude][prelude-std]. This provides a consistent prelude across environments, ensuring that `std` is only explicitly referenced where required.
+
+> [!NOTE]
+> When a crate optionally supports `std`, it should be gated via a `std` feature and additionally enabled when generating documentation:
+> 
+> ```rust
+> #[cfg(any(test, doc, feature = "std"))]
+> extern crate std;
+> ```
+> 
+> - Some crates may **only support `std`**, in which case `extern crate std;` is enforced without any conditional constraints.
+> - Any crate missing this extern presently relies upon an implicit `std` prelude, but it's boilerplate should have `#![no_std]` commented out, until that crate has been migrated to explicitly import from `std`.
+
+[gh-issues::boilerplate-lints]: https://github.com/unicode-org/icu4x/issues/5974#issuecomment-3775926163
+[prelude-nostd]: https://doc.rust-lang.org/reference/names/preludes.html#the-no_std-attribute
+[prelude-std]: https://doc.rust-lang.org/std/prelude/index.html

--- a/ffi/capi/src/lib.rs
+++ b/ffi/capi/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, feature = "std")), no_std)]
+#![no_std]
 #![cfg_attr(
     not(test),
     deny(
@@ -50,9 +50,8 @@
 //! semver version, as are the bindings in the <code>bindings</code> folder.
 //! </div>
 
-// Renamed so you can't accidentally use it
-#[cfg(target_arch = "wasm32")]
-extern crate std as rust_std;
+#[cfg(any(test, doc, feature = "std"))]
+extern crate std;
 
 #[cfg(all(not(feature = "std"), feature = "looping_panic_handler"))]
 #[panic_handler]

--- a/ffi/capi/src/lib.rs
+++ b/ffi/capi/src/lib.rs
@@ -50,18 +50,19 @@
 //! semver version, as are the bindings in the <code>bindings</code> folder.
 //! </div>
 
+extern crate alloc;
+
 #[cfg(any(test, doc, feature = "std"))]
 extern crate std;
+
+#[cfg(all(not(feature = "std"), feature = "libc_alloc"))]
+extern crate libc_alloc;
 
 #[cfg(all(not(feature = "std"), feature = "looping_panic_handler"))]
 #[panic_handler]
 fn panic(_info: &core::panic::PanicInfo) -> ! {
     loop {}
 }
-
-extern crate alloc;
-#[cfg(all(not(feature = "std"), feature = "libc_alloc"))]
-extern crate libc_alloc;
 
 #[cfg(feature = "datetime")]
 pub(crate) mod datetime_helpers;

--- a/ffi/ecma402/src/lib.rs
+++ b/ffi/ecma402/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-// #![cfg_attr(not(any(test, doc)), no_std)]
+// #![no_std]
 #![cfg_attr(
     not(test),
     deny(

--- a/ffi/freertos/src/lib.rs
+++ b/ffi/freertos/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, doc)), no_std)]
+#![no_std]
 #![cfg_attr(
     not(test),
     deny(
@@ -32,6 +32,9 @@
     feature(alloc_error_handler)
 )]
 
+#[cfg(test)]
+extern crate std;
+
 // Necessary to for symbols to be linked in
 extern crate icu_capi;
 
@@ -59,9 +62,3 @@ mod stuff {
         loop {}
     }
 }
-
-// Needed for rust runtime stuff
-//
-// renamed so you can't accidentally use it
-#[cfg(not(target_os = "none"))]
-extern crate std as rust_std;

--- a/provider/adapters/src/lib.rs
+++ b/provider/adapters/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, doc)), no_std)]
+#![no_std]
 #![cfg_attr(
     not(test),
     deny(
@@ -23,6 +23,9 @@
 //! - Use the [`fallback`] module to automatically resolve arbitrary locales for data loading.
 
 extern crate alloc;
+
+#[cfg(test)]
+extern crate std;
 
 pub mod either;
 pub mod empty;

--- a/provider/baked/src/lib.rs
+++ b/provider/baked/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-// #![cfg_attr(not(any(test, doc)), no_std)]
+// #![no_std]
 // #![cfg_attr(
 //     not(test),
 //     deny(

--- a/provider/blob/src/lib.rs
+++ b/provider/blob/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, doc, feature = "export")), no_std)]
+#![no_std]
 #![cfg_attr(
     not(test),
     deny(
@@ -30,6 +30,9 @@
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
+
+#[cfg(any(test, doc, feature = "export"))]
+extern crate std;
 
 mod blob_data_provider;
 mod blob_schema;

--- a/provider/blob/tests/test_versions.rs
+++ b/provider/blob/tests/test_versions.rs
@@ -2,6 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+extern crate alloc;
+
 use icu_locale::subtags::{Language, region, script};
 use icu_locale_core::LanguageIdentifier;
 use icu_provider::dynutil::UpcastDataPayload;
@@ -209,5 +211,4 @@ impl IterableDataProvider<HelloWorldV1> for ManyLocalesProvider {
     }
 }
 
-extern crate alloc;
 icu_provider::export::make_exportable_provider!(ManyLocalesProvider, [HelloWorldV1,]);

--- a/provider/core/src/lib.rs
+++ b/provider/core/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, doc, feature = "std")), no_std)]
+#![no_std]
 #![cfg_attr(
     not(test),
     deny(
@@ -92,6 +92,9 @@
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
+
+#[cfg(any(test, doc, feature = "std"))]
+extern crate std;
 
 #[cfg(feature = "baked")]
 pub mod baked;
@@ -192,10 +195,10 @@ pub use log;
 #[doc(hidden)] // internal
 #[cfg(all(
     not(feature = "logging"),
-    all(debug_assertions, feature = "alloc", not(target_os = "none"))
+    debug_assertions,
+    feature = "std",
 ))]
 pub mod log {
-    extern crate std;
     pub use std::eprintln as error;
     pub use std::eprintln as warn;
     pub use std::eprintln as info;
@@ -203,11 +206,12 @@ pub mod log {
     pub use std::eprintln as trace;
 }
 
+#[doc(hidden)] // internal
 #[cfg(all(
     not(feature = "logging"),
-    not(all(debug_assertions, feature = "alloc", not(target_os = "none"),))
+    not(debug_assertions),
+    not(feature = "std"),
 ))]
-#[doc(hidden)] // internal
 pub mod log {
     #[macro_export]
     macro_rules! _internal_noop_log {

--- a/provider/export/src/export_impl.rs
+++ b/provider/export/src/export_impl.rs
@@ -482,6 +482,8 @@ impl fmt::Display for DisplayDuration {
 
 #[test]
 fn test_collation_filtering() {
+    extern crate alloc;
+
     use crate::DataLocaleFamily;
     use icu::locale::locale;
     use std::collections::BTreeSet;
@@ -526,7 +528,6 @@ fn test_collation_filtering() {
         }
     }
 
-    extern crate alloc;
     icu_provider::export::make_exportable_provider!(
         Provider,
         [icu::collator::provider::CollationTailoringV1,]

--- a/provider/export/src/lib.rs
+++ b/provider/export/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-// #![cfg_attr(not(any(test, doc)), no_std)]
+// #![no_std]
 // #![cfg_attr(
 //     not(test),
 //     deny(
@@ -14,6 +14,7 @@
 //     )
 // )]
 #![warn(missing_docs)]
+
 #![allow(clippy::needless_doctest_main)]
 //! `icu_provider_export` is a library to generate data files that can be used in ICU4X data providers.
 //!

--- a/provider/export/tests/test-options.rs
+++ b/provider/export/tests/test-options.rs
@@ -2,6 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+extern crate alloc;
+
 #[path = "testutil.rs"]
 mod testutil;
 
@@ -88,7 +90,6 @@ impl IterableDataProvider<HelloWorldV1> for TestingProvider {
     }
 }
 
-extern crate alloc;
 make_exportable_provider!(TestingProvider, [HelloWorldV1,]);
 
 fn families(

--- a/provider/fs/src/lib.rs
+++ b/provider/fs/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-// #![cfg_attr(not(any(test, doc)), no_std)]
+// #![no_std]
 #![cfg_attr(
     not(test),
     deny(

--- a/provider/icu4x-datagen/src/main.rs
+++ b/provider/icu4x-datagen/src/main.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-// #![cfg_attr(not(any(test, doc)), no_std)]
+// #![no_std]
 // #![cfg_attr(
 //     not(test),
 //     deny(

--- a/provider/registry/src/lib.rs
+++ b/provider/registry/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, doc)), no_std)]
+#![no_std]
 #![cfg_attr(
     not(test),
     deny(
@@ -14,6 +14,9 @@
     )
 )]
 #![warn(missing_docs)]
+
+#[cfg(test)]
+extern crate std;
 
 //! Exposes the list of all known `DataMarker`s.
 //!

--- a/provider/source/src/lib.rs
+++ b/provider/source/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-// #![cfg_attr(not(any(test, doc)), no_std)]
+// #![no_std]
 // #![cfg_attr(
 //     not(test),
 //     deny(

--- a/tutorials/data-provider-runtime.md
+++ b/tutorials/data-provider-runtime.md
@@ -265,6 +265,8 @@ Forking providers can be implemented using `DataPayload::dynamic_cast`. For an e
 To add custom data markers to your baked data or postcard file, create a forking exportable provider:
 
 ```rust
+extern crate alloc;
+
 use icu::locale::locale;
 use icu::plurals::provider::PluralsCardinalV1;
 use icu_provider::prelude::*;
@@ -309,7 +311,6 @@ impl IterableDataProvider<CustomV1> for CustomProvider {
     }
 }
 
-extern crate alloc;
 icu_provider::export::make_exportable_provider!(CustomProvider, [CustomV1,]);
 
 let icu4x_source_provider = SourceDataProvider::new();

--- a/utils/bies/src/lib.rs
+++ b/utils/bies/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-// #![cfg_attr(not(any(test, doc)), no_std)]
+// #![no_std]
 // #![cfg_attr(
 //     not(test),
 //     deny(

--- a/utils/calendrical_calculations/src/lib.rs
+++ b/utils/calendrical_calculations/src/lib.rs
@@ -8,7 +8,7 @@
 // package root or at http://www.apache.org/licenses/LICENSE-2.0.
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, doc)), no_std)]
+#![no_std]
 #![cfg_attr(
     not(test),
     deny(
@@ -19,6 +19,9 @@
     )
 )]
 #![warn(missing_docs)]
+
+#[cfg(test)]
+extern crate std;
 
 //! Calendrical calculations
 //!

--- a/utils/crlify/src/lib.rs
+++ b/utils/crlify/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-// #![cfg_attr(not(any(test, doc)), no_std)]
+// #![no_std]
 #![cfg_attr(
     not(test),
     deny(

--- a/utils/databake/derive/src/lib.rs
+++ b/utils/databake/derive/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-// #![cfg_attr(not(any(test, doc)), no_std)]
+// #![no_std]
 // #![cfg_attr(
 //     not(test),
 //     deny(

--- a/utils/databake/src/lib.rs
+++ b/utils/databake/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-// #![cfg_attr(not(any(test, doc)), no_std)]
+// #![no_std]
 #![cfg_attr(
     not(test),
     deny(

--- a/utils/fixed_decimal/src/lib.rs
+++ b/utils/fixed_decimal/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, doc)), no_std)]
+#![no_std]
 #![cfg_attr(
     not(test),
     deny(
@@ -14,6 +14,9 @@
     )
 )]
 #![warn(missing_docs)]
+
+#[cfg(test)]
+extern crate std;
 
 //! `fixed_decimal` is a utility crate of the [`ICU4X`] project.
 //!

--- a/utils/ixdtf/src/lib.rs
+++ b/utils/ixdtf/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, doc)), no_std)]
+#![no_std]
 #![cfg_attr(
     not(test),
     deny(
@@ -14,6 +14,9 @@
     )
 )]
 // #![warn(missing_docs)]
+
+#[cfg(test)]
+extern crate std;
 
 //! Parsers for extended date time string and Duration parsing.
 //!

--- a/utils/litemap/src/lib.rs
+++ b/utils/litemap/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, doc)), no_std)]
+#![no_std]
 #![cfg_attr(
     not(test),
     deny(
@@ -58,7 +58,7 @@
 //! [`Vec`]: alloc::vec::Vec
 
 // for intra doc links
-#[cfg(doc)]
+#[cfg(any(test, doc))]
 extern crate std;
 
 #[cfg(feature = "alloc")]

--- a/utils/potential_utf/src/lib.rs
+++ b/utils/potential_utf/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, doc)), no_std)]
+#![no_std]
 #![cfg_attr(
     not(test),
     deny(
@@ -19,6 +19,9 @@
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
+
+#[cfg(test)]
+extern crate std;
 
 mod uchar;
 mod ustr;

--- a/utils/resb/src/binary/deserializer.rs
+++ b/utils/resb/src/binary/deserializer.rs
@@ -2,6 +2,9 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+extern crate alloc;
+use alloc::string::String;
+
 use core::fmt;
 
 use crate::MASK_28_BIT;
@@ -10,9 +13,6 @@ use super::{
     get_subslice, header::BinHeader, read_u16, BinIndex, BinaryDeserializerError, CharsetFamily,
     FormatVersion, ResDescriptor, ResourceReprType,
 };
-
-extern crate alloc;
-use alloc::string::String;
 
 use serde_core::{de, forward_to_deserialize_any, Deserialize};
 

--- a/utils/resb/src/lib.rs
+++ b/utils/resb/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, doc, feature = "std")), no_std)]
+#![no_std]
 #![cfg_attr(
     not(test),
     deny(
@@ -25,6 +25,9 @@
 //! [`ICU4X`]: ../icu/index.html
 
 extern crate alloc;
+
+#[cfg(any(test, doc, feature = "std"))]
+extern crate std;
 
 pub mod binary;
 

--- a/utils/tinystr/src/lib.rs
+++ b/utils/tinystr/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, doc)), no_std)]
+#![no_std]
 #![cfg_attr(
     not(test),
     deny(
@@ -83,6 +83,9 @@ mod ule;
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
+
+#[cfg(test)]
+extern crate std;
 
 pub use ascii::TinyAsciiStr;
 pub use error::ParseError;

--- a/utils/tzif/src/lib.rs
+++ b/utils/tzif/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-// #![cfg_attr(not(any(test, doc)), no_std)]
+// #![no_std]
 #![cfg_attr(
     not(test),
     deny(

--- a/utils/writeable/src/lib.rs
+++ b/utils/writeable/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, doc)), no_std)]
+#![no_std]
 #![cfg_attr(
     not(test),
     deny(
@@ -75,6 +75,9 @@
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
+
+#[cfg(test)]
+extern crate std;
 
 mod cmp;
 mod concat;

--- a/utils/yoke/derive/src/lib.rs
+++ b/utils/yoke/derive/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-// #![cfg_attr(not(any(test, doc)), no_std)]
+// #![no_std]
 #![cfg_attr(
     not(test),
     deny(

--- a/utils/yoke/src/lib.rs
+++ b/utils/yoke/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, doc)), no_std)]
+#![no_std]
 #![cfg_attr(
     not(test),
     deny(
@@ -43,6 +43,9 @@
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
+
+#[cfg(test)]
+extern crate std;
 
 pub mod cartable_ptr;
 pub mod either;

--- a/utils/zerofrom/derive/src/lib.rs
+++ b/utils/zerofrom/derive/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-// #![cfg_attr(not(any(test, doc)), no_std)]
+// #![no_std]
 #![cfg_attr(
     not(test),
     deny(

--- a/utils/zerofrom/src/lib.rs
+++ b/utils/zerofrom/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, doc)), no_std)]
+#![no_std]
 #![cfg_attr(
     not(test),
     deny(
@@ -25,6 +25,9 @@
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
+
+#[cfg(test)]
+extern crate std;
 
 mod macro_impls;
 mod zero_from;

--- a/utils/zerotrie/src/byte_phf/builder.rs
+++ b/utils/zerotrie/src/byte_phf/builder.rs
@@ -146,7 +146,6 @@ impl PerfectByteHashMap<Vec<u8>> {
 mod tests {
     use super::*;
 
-    extern crate std;
     use std::print;
     use std::println;
 

--- a/utils/zerotrie/src/byte_phf/mod.rs
+++ b/utils/zerotrie/src/byte_phf/mod.rs
@@ -285,7 +285,6 @@ where
 mod tests {
     use super::*;
     use alloc::vec::Vec;
-    extern crate std;
 
     fn random_alphanums(seed: u64, len: usize) -> Vec<u8> {
         use rand::seq::SliceRandom;

--- a/utils/zerotrie/src/lib.rs
+++ b/utils/zerotrie/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, doc)), no_std)]
+#![no_std]
 #![cfg_attr(
     not(test),
     deny(
@@ -62,6 +62,9 @@
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
+
+#[cfg(test)]
+extern crate std;
 
 mod builder;
 mod byte_phf;

--- a/utils/zerotrie/tests/derive_test.rs
+++ b/utils/zerotrie/tests/derive_test.rs
@@ -25,7 +25,6 @@ struct DeriveTest_ZeroTrie_ZeroVec<'data> {
 #[cfg(all(feature = "databake", feature = "alloc"))]
 fn bake_ZeroTrie_ZeroVec() {
     use databake::*;
-    extern crate std;
     test_bake!(
         DeriveTest_ZeroTrie_ZeroVec<'static>,
         crate::DeriveTest_ZeroTrie_ZeroVec {
@@ -51,7 +50,6 @@ struct DeriveTest_ZeroTrieSimpleAscii_ZeroVec<'data> {
 #[cfg(all(feature = "databake", feature = "alloc"))]
 fn bake_ZeroTrieSimpleAscii_ZeroVec() {
     use databake::*;
-    extern crate std;
     test_bake!(
         DeriveTest_ZeroTrieSimpleAscii_ZeroVec<'static>,
         crate::DeriveTest_ZeroTrieSimpleAscii_ZeroVec {
@@ -76,7 +74,6 @@ struct DeriveTest_ZeroAsciiIgnoreCaseTrie_ZeroVec<'data> {
 #[cfg(all(feature = "databake", feature = "alloc"))]
 fn bake_ZeroAsciiIgnoreCaseTrie_ZeroVec() {
     use databake::*;
-    extern crate std;
     test_bake!(
         DeriveTest_ZeroAsciiIgnoreCaseTrie_ZeroVec<'static>,
         crate::DeriveTest_ZeroAsciiIgnoreCaseTrie_ZeroVec {
@@ -101,7 +98,6 @@ struct DeriveTest_ZeroTriePerfectHash_ZeroVec<'data> {
 #[cfg(all(feature = "databake", feature = "alloc"))]
 fn bake_ZeroTriePerfectHash_ZeroVec() {
     use databake::*;
-    extern crate std;
     test_bake!(
         DeriveTest_ZeroTriePerfectHash_ZeroVec<'static>,
         crate::DeriveTest_ZeroTriePerfectHash_ZeroVec {
@@ -126,7 +122,6 @@ struct DeriveTest_ZeroTrieExtendedCapacity_ZeroVec<'data> {
 #[cfg(all(feature = "databake", feature = "alloc"))]
 fn bake_ZeroTrieExtendedCapacity_ZeroVec() {
     use databake::*;
-    extern crate std;
     test_bake!(
         DeriveTest_ZeroTrieExtendedCapacity_ZeroVec<'static>,
         crate::DeriveTest_ZeroTrieExtendedCapacity_ZeroVec {

--- a/utils/zerovec/derive/src/lib.rs
+++ b/utils/zerovec/derive/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-// #![cfg_attr(not(any(test, doc)), no_std)]
+// #![no_std]
 // #![cfg_attr(
 //     not(test),
 //     deny(

--- a/utils/zerovec/src/lib.rs
+++ b/utils/zerovec/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, doc)), no_std)]
+#![no_std]
 #![cfg_attr(
     not(test),
     deny(
@@ -212,6 +212,9 @@
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
+
+#[cfg(test)]
+extern crate std;
 
 mod cow;
 #[cfg(feature = "hashmap")]

--- a/utils/zoneinfo64/src/lib.rs
+++ b/utils/zoneinfo64/src/lib.rs
@@ -3,7 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 // https://github.com/unicode-org/icu4x/blob/main/documents/process/boilerplate.md#library-annotations
-#![cfg_attr(not(any(test, doc)), no_std)]
+#![no_std]
 #![cfg_attr(
     not(test),
     deny(
@@ -51,6 +51,9 @@
 //! ```
 
 extern crate alloc;
+
+#[cfg(test)]
+extern crate std;
 
 use alloc::boxed::Box;
 use alloc::string::String;


### PR DESCRIPTION
This minor refactor across crates is [at the request](https://github.com/unicode-org/icu4x/issues/8035#issuecomment-4799490007) of @robertbastian to PR the relevant changes.

I've tried to make it a bit easier to review by scoping related changes across commits.

I've additionally revised the boilerplate docs, and shuffled some extern imports around. There were some minor changes I made that I'm assuming are valid but as I'm not an actual user of any of these crates I'm deferring that to test coverage 😅 (_I'll highlight these via review comments_)

Any crate with boilerplate for `no_std` commented out has been left that way as I assume there is implicit reliance upon the `std` prelude and I lack time to pursue updating those crates. I have documented that discrepancy at the end of the boilerplate docs, should anyone wish to tackle that going forward 💪

I did all these changes manually (_well where possible with the editor search find/replace functionality_), but did consult Gemini to assist as peer review when revising my wording in the boilerplate docs.

**NOTE:** I've not been able to follow the [contributor checklist](https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md#checklist). As I'm pressed for time and my current system is at 77/88GB of committed memory, I've pieced this PR together via the `github.dev` web editor (_now rebranded as `vscode.dev`_). It may not be perfect but at least outlines the scope of change.

## Changelog (N/A)

