### PR TITLE
Graduate DataPayloadOr

### DIFF
--- a/provider/core/src/lib.rs
+++ b/provider/core/src/lib.rs
@@ -123,7 +123,6 @@ mod request;
 pub use request::{DataLocale, DataMarkerAttributes, DataRequest, DataRequestMetadata, *};
 
 mod response;
-#[doc(hidden)] // TODO(#4467): establish this as an internal API
 pub use response::DataPayloadOr;
 pub use response::{Cart, DataPayload, DataResponse, DataResponseMetadata};
 

--- a/provider/core/src/response.rs
+++ b/provider/core/src/response.rs
@@ -92,7 +92,7 @@ pub struct DataPayload<M: DynamicDataMarker>(pub(crate) DataPayloadInner<M>);
 ///
 /// The type parameter `O` is stored as part of the interior enum, leading to
 /// better stack size optimization. `O` can be as large as the [`DataPayload`]
-/// minus two words without impacting stack size.
+/// minus two usizes without impacting stack size.
 ///
 /// # Examples
 ///
@@ -132,19 +132,19 @@ pub struct DataPayload<M: DynamicDataMarker>(pub(crate) DataPayloadInner<M>);
 ///
 /// const W: usize = size_of::<usize>();
 ///
-/// // Data struct is 3 words:
+/// // Data struct is 3 usizes:
 /// icu_provider::data_marker!(SampleV1, [usize; 3]);
 ///
-/// // DataPayload adds a word for a total of 4 words:
+/// // DataPayload adds a usize for a total of 4 usizes:
 /// assert_eq!(W * 4, size_of::<DataPayload<SampleV1>>());
 ///
-/// // Option<DataPayload> balloons to 5 words:
+/// // Option<DataPayload> balloons to 5 usizes:
 /// assert_eq!(W * 5, size_of::<Option<DataPayload<SampleV1>>>());
 ///
 /// // But, using DataPayloadOr is the same size as DataPayload:
 /// assert_eq!(W * 4, size_of::<DataPayloadOr<SampleV1, ()>>());
 ///
-/// // The largest optimized Other type is two words smaller than the DataPayload:
+/// // The largest optimized Other type is two usizes smaller than the DataPayload:
 /// assert_eq!(W * 4, size_of::<DataPayloadOr<SampleV1, [usize; 1]>>());
 /// assert_eq!(W * 4, size_of::<DataPayloadOr<SampleV1, [usize; 2]>>());
 /// assert_eq!(W * 5, size_of::<DataPayloadOr<SampleV1, [usize; 3]>>());


### PR DESCRIPTION
We already use it in icu_datetime, and I want to use it in icu_locale_names. The design is good enough; I would like to graduate this. It's hard for us to change it anyway because it isn't behind an unstable feature.

The only real downside is that it's not obvious when to use this type instead of `Option<DataPayload>`. It exists to reduce stack sizes, full stop. It deviates from Rust style, but has convenient constructors and methods that make it feel like an `Option<DataPayload>`.

## Changelog

icu_provider: Stabilize type DataPayloadOr, added as draft in 1.5