### PR TITLE
Use self.as_str() instead of &self.0 in impl Writeable for subtags

### DIFF
--- a/components/locale_core/src/helpers.rs
+++ b/components/locale_core/src/helpers.rs
@@ -146,7 +146,7 @@ macro_rules! impl_tinystr_subtag {
             }
         }
 
-        writeable::impl_writeable_delegate!($name, |&self| &self.0, #[cfg(feature = "alloc")]);
+        writeable::impl_writeable_delegate!($name, |&self| self.as_str(), #[cfg(feature = "alloc")]);
         writeable::impl_display_with_writeable!($name, #[cfg(feature = "alloc")]);
 
         #[doc = concat!("A macro allowing for compile-time construction of valid [`", stringify!($name), "`] subtags.")]


### PR DESCRIPTION
Address feedback from PR #8139:
- Delegate `Writeable` to `as_str()` instead of `&self.0` (which is `TinyAsciiStr`) for locale subtags in `helpers.rs`.

The macro syntax changes suggested in #8139 are being discussed in #8165.

## Changelog

N/A