### PR TITLE
Scaffolding traits for range formatting

### DIFF
--- a/components/datetime/src/dynamic.rs
+++ b/components/datetime/src/dynamic.rs
@@ -548,3 +548,34 @@ impl DateAndTimeFieldSet {
         }
     }
 }
+
+impl CompositeFieldSet {
+    pub(crate) fn to_raw_options(self) -> RawOptions {
+        match self {
+            CompositeFieldSet::Date(field_set) => field_set.to_raw_options(),
+            CompositeFieldSet::CalendarPeriod(field_set) => field_set.to_raw_options(),
+            CompositeFieldSet::Time(field_set) => field_set.to_raw_options(),
+            CompositeFieldSet::DateTime(field_set) => field_set.to_raw_options(),
+            CompositeFieldSet::DateZone(combo) => combo.dt().to_raw_options(),
+            CompositeFieldSet::TimeZone(combo) => combo.dt().to_raw_options(),
+            CompositeFieldSet::DateTimeZone(combo) => combo.dt().to_raw_options(),
+            CompositeFieldSet::Zone(_) => RawOptions {
+                length: None,
+                date_fields: None,
+                year_style: None,
+                alignment: None,
+                time_precision: None,
+            },
+        }
+    }
+
+    pub(crate) fn to_zone(self) -> Option<ZoneFieldSet> {
+        match self {
+            CompositeFieldSet::Zone(field_set) => Some(field_set),
+            CompositeFieldSet::DateZone(combo) => Some(combo.z()),
+            CompositeFieldSet::TimeZone(combo) => Some(combo.z()),
+            CompositeFieldSet::DateTimeZone(combo) => Some(combo.z()),
+            _ => None,
+        }
+    }
+}

--- a/components/datetime/src/fieldsets.rs
+++ b/components/datetime/src/fieldsets.rs
@@ -59,7 +59,10 @@ pub use crate::combo::Combo;
 use crate::{
     options::*,
     provider::semantic_skeletons::{DatetimePatternsGlueV1, GluePattern},
-    provider::{fields, names::*, semantic_skeletons::*, time_zones::tz},
+    provider::{
+        fields, names::*, range_patterns::DatetimePatternsRangeTimeV1, semantic_skeletons::*,
+        time_zones::tz,
+    },
     raw::neo::RawOptions,
     scaffold::*,
 };
@@ -537,14 +540,16 @@ macro_rules! impl_date_or_calendar_period_marker {
         }
         impl<C: CldrCalendar> TypedDateDataMarkers<C> for $type {
             type DateSkeletonPatternsV1 = datetime_marker_helper!(@dates/typed, yes);
-            type YearNamesV1 = datetime_marker_helper!(@years/typed, $($years_yes)?);
-            type MonthNamesV1 = datetime_marker_helper!(@months/typed, $($months_yes)?);
+            type DateRangeSkeletonPatternsV1 = datetime_marker_helper!(@dates/range/typed, yes);
+            type YearNamesV1 = datetime_marker_helper!(@years/typed, $($year_yes)?);
+            type MonthNamesV1 = datetime_marker_helper!(@months/typed, $($month_yes)?);
             type WeekdayNamesV1 = datetime_marker_helper!(@weekdays, $($weekdays_yes)?);
         }
         impl DateDataMarkers for $type {
             type Skel = datetime_marker_helper!(@calmarkers, yes);
-            type Year = datetime_marker_helper!(@calmarkers, $($years_yes)?);
-            type Month = datetime_marker_helper!(@calmarkers, $($months_yes)?);
+            type RangeSkel = datetime_marker_helper!(@calmarkers, yes);
+            type Year = datetime_marker_helper!(@calmarkers, $($year_yes)?);
+            type Month = datetime_marker_helper!(@calmarkers, $($month_yes)?);
             type WeekdayNamesV1 = datetime_marker_helper!(@weekdays, $($weekdays_yes)?);
         }
         impl DateTimeMarkers for $type {
@@ -701,12 +706,14 @@ macro_rules! impl_date_marker {
         }
         impl<C: CldrCalendar> TypedDateDataMarkers<C> for $type_time {
             type DateSkeletonPatternsV1 = datetime_marker_helper!(@dates/typed, yes);
+            type DateRangeSkeletonPatternsV1 = datetime_marker_helper!(@dates/range/typed, yes);
             type YearNamesV1 = datetime_marker_helper!(@years/typed, $($years_yes)?);
             type MonthNamesV1 = datetime_marker_helper!(@months/typed, $($months_yes)?);
             type WeekdayNamesV1 = datetime_marker_helper!(@weekdays, $($weekdays_yes)?);
         }
         impl DateDataMarkers for $type_time {
             type Skel = datetime_marker_helper!(@calmarkers, yes);
+            type RangeSkel = datetime_marker_helper!(@calmarkers, yes);
             type Year = datetime_marker_helper!(@calmarkers, $($years_yes)?);
             type Month = datetime_marker_helper!(@calmarkers, $($months_yes)?);
             type WeekdayNamesV1 = datetime_marker_helper!(@weekdays, $($weekdays_yes)?);
@@ -715,6 +722,7 @@ macro_rules! impl_date_marker {
             // TODO(#6497): Consider making dayperiods optional
             type DayPeriodNamesV1 = datetime_marker_helper!(@dayperiods, yes);
             type TimeSkeletonPatternsV1 = datetime_marker_helper!(@times, yes);
+            type TimeRangeSkeletonPatternsV1 = datetime_marker_helper!(@times/range, yes);
             type HourInput = datetime_marker_helper!(@input/hour, yes);
             type MinuteInput = datetime_marker_helper!(@input/minute, yes);
             type SecondInput = datetime_marker_helper!(@input/second, yes);
@@ -868,6 +876,7 @@ macro_rules! impl_time_marker {
         impl TimeMarkers for $type {
             type DayPeriodNamesV1 = datetime_marker_helper!(@dayperiods, $($dayperiods_yes)?);
             type TimeSkeletonPatternsV1 = datetime_marker_helper!(@times, yes);
+            type TimeRangeSkeletonPatternsV1 = datetime_marker_helper!(@times/range, yes);
             type HourInput = datetime_marker_helper!(@input/hour, $($hour_yes)?);
             type MinuteInput = datetime_marker_helper!(@input/minute, $($minute_yes)?);
             type SecondInput = datetime_marker_helper!(@input/second, $($second_yes)?);

--- a/components/datetime/src/fieldsets.rs
+++ b/components/datetime/src/fieldsets.rs
@@ -541,15 +541,15 @@ macro_rules! impl_date_or_calendar_period_marker {
         impl<C: CldrCalendar> TypedDateDataMarkers<C> for $type {
             type DateSkeletonPatternsV1 = datetime_marker_helper!(@dates/typed, yes);
             type DateRangeSkeletonPatternsV1 = datetime_marker_helper!(@dates/range/typed, yes);
-            type YearNamesV1 = datetime_marker_helper!(@years/typed, $($year_yes)?);
-            type MonthNamesV1 = datetime_marker_helper!(@months/typed, $($month_yes)?);
+            type YearNamesV1 = datetime_marker_helper!(@years/typed, $($years_yes)?);
+            type MonthNamesV1 = datetime_marker_helper!(@months/typed, $($months_yes)?);
             type WeekdayNamesV1 = datetime_marker_helper!(@weekdays, $($weekdays_yes)?);
         }
         impl DateDataMarkers for $type {
             type Skel = datetime_marker_helper!(@calmarkers, yes);
             type RangeSkel = datetime_marker_helper!(@calmarkers, yes);
-            type Year = datetime_marker_helper!(@calmarkers, $($year_yes)?);
-            type Month = datetime_marker_helper!(@calmarkers, $($month_yes)?);
+            type Year = datetime_marker_helper!(@calmarkers, $($years_yes)?);
+            type Month = datetime_marker_helper!(@calmarkers, $($months_yes)?);
             type WeekdayNamesV1 = datetime_marker_helper!(@weekdays, $($weekdays_yes)?);
         }
         impl DateTimeMarkers for $type {

--- a/components/datetime/src/provider/range_patterns.rs
+++ b/components/datetime/src/provider/range_patterns.rs
@@ -459,6 +459,9 @@ icu_provider::data_struct!(
     #[cfg(feature = "datagen")]
 );
 
+pub(crate) type ErasedPackedRangePatterns =
+    icu_provider::marker::ErasedMarker<PackedRangePatterns<'static>>;
+
 icu_provider::data_marker!(
     /// `DatetimePatternsRangeGlueV1`
     DatetimePatternsRangeGlueV1,

--- a/components/datetime/src/raw/neo.rs
+++ b/components/datetime/src/raw/neo.rs
@@ -529,6 +529,51 @@ impl<'a> ZonePatternDataBorrowed<'a> {
     }
 }
 
+/// Helper function to map a [`CompositeFieldSet`] to loaded date and time pattern selection data.
+///
+/// This function decomposes a composite field set into its date and time components,
+/// applying the provided loader closures `load_date` and `load_time` respectively to load
+/// the specific pattern selection data payloads.
+///
+/// If a component (date or time) is not present in the composite field set, `None` is returned
+/// for that component.
+#[inline]
+fn map_composite_skeleton<DateRes, TimeRes, E>(
+    skeleton: CompositeFieldSet,
+    mut load_date: impl FnMut(&DataMarkerAttributes) -> Result<DateRes, E>,
+    mut load_time: impl FnMut(TimeFieldSet) -> Result<TimeRes, E>,
+) -> Result<(Option<DateRes>, Option<TimeRes>), E> {
+    let mut date = None;
+    let mut time = None;
+    match skeleton {
+        CompositeFieldSet::Date(field_set) => {
+            date = Some(load_date(field_set.id_str())?);
+        }
+        CompositeFieldSet::CalendarPeriod(field_set) => {
+            date = Some(load_date(field_set.id_str())?);
+        }
+        CompositeFieldSet::Time(field_set) => {
+            time = Some(load_time(field_set)?);
+        }
+        CompositeFieldSet::DateTime(field_set) => {
+            date = Some(load_date(field_set.to_date_field_set().id_str())?);
+            time = Some(load_time(field_set.to_time_field_set())?);
+        }
+        CompositeFieldSet::DateZone(combo) => {
+            date = Some(load_date(combo.dt().id_str())?);
+        }
+        CompositeFieldSet::DateTimeZone(combo) => {
+            date = Some(load_date(combo.dt().to_date_field_set().id_str())?);
+            time = Some(load_time(combo.dt().to_time_field_set())?);
+        }
+        CompositeFieldSet::TimeZone(combo) => {
+            time = Some(load_time(combo.dt())?);
+        }
+        CompositeFieldSet::Zone(_) => {}
+    }
+    Ok((date, time))
+}
+
 impl DateTimeZonePatternSelectionData {
     pub(crate) fn try_new_with_skeleton(
         date_provider: &(impl BoundDataProvider<ErasedPackedPatterns> + ?Sized),
@@ -537,182 +582,77 @@ impl DateTimeZonePatternSelectionData {
         prefs: DateTimeFormatterPreferences,
         skeleton: CompositeFieldSet,
     ) -> Result<Self, DataError> {
-        match skeleton {
-            CompositeFieldSet::Date(field_set) => {
-                let options = field_set.to_raw_options();
-                let selection = DatePatternSelectionData::try_new_with_skeleton(
+        // Handle overlap early return.
+        if let CompositeFieldSet::DateTime(field_set) = skeleton {
+            let options = field_set.to_raw_options();
+            if let (Some(attributes), None) = (field_set.id_str(), prefs.hour_cycle)
+                && let Some(overlap) = TimePatternSelectionData::try_new_overlap_with_skeleton(
                     date_provider,
                     prefs,
-                    field_set.id_str(),
-                )?;
-                Ok(Self {
+                    attributes,
                     options,
-                    prefs: Default::default(), // not used: no time
-                    date: selection,
-                    time: TimePatternSelectionData::none(),
-                    zone: None,
-                    glue: None,
-                })
-            }
-            CompositeFieldSet::CalendarPeriod(field_set) => {
-                let options = field_set.to_raw_options();
-                let selection = DatePatternSelectionData::try_new_with_skeleton(
-                    date_provider,
-                    prefs,
-                    field_set.id_str(),
-                )?;
-                Ok(Self {
-                    options,
-                    prefs: Default::default(), // not used: no time
-                    date: selection,
-                    time: TimePatternSelectionData::none(),
-                    zone: None,
-                    glue: None,
-                })
-            }
-            CompositeFieldSet::Time(field_set) => {
-                let options = field_set.to_raw_options();
-                let selection = TimePatternSelectionData::try_new_with_skeleton(
-                    time_provider,
-                    prefs,
-                    field_set,
-                )?;
+                )
+                .allow_identifier_not_found()?
+            {
                 let prefs = RawPreferences::from_prefs(prefs);
-                Ok(Self {
+                return Ok(Self {
                     options,
                     prefs,
                     date: DatePatternSelectionData::none(),
-                    time: selection,
+                    time: overlap,
                     zone: None,
                     glue: None,
-                })
-            }
-            CompositeFieldSet::Zone(field_set) => {
-                let selection = ZonePatternSelectionData::new_with_skeleton(field_set);
-                Ok(Self {
-                    options: RawOptions {
-                        length: None,
-                        date_fields: None,
-                        year_style: None,
-                        alignment: None,
-                        time_precision: None,
-                    },
-                    prefs: Default::default(), // not used: no time
-                    date: DatePatternSelectionData::none(),
-                    time: TimePatternSelectionData::none(),
-                    zone: Some(selection),
-                    glue: None,
-                })
-            }
-            CompositeFieldSet::DateTime(field_set) => {
-                let options = field_set.to_raw_options();
-                // TODO(#5387): load the patterns for custom hour cycles here
-                if let (Some(attributes), None) = (field_set.id_str(), prefs.hour_cycle) {
-                    // Try loading an overlap pattern.
-                    // Note: Overlap patterns are loaded from the date skeleton pattern provider
-                    // and then stored as a TimePatternSelectionData.
-                    if let Some(overlap) = TimePatternSelectionData::try_new_overlap_with_skeleton(
-                        date_provider,
-                        prefs,
-                        attributes,
-                        options,
-                    )
-                    .allow_identifier_not_found()?
-                    {
-                        let prefs = RawPreferences::from_prefs(prefs);
-                        return Ok(Self {
-                            options,
-                            prefs,
-                            date: DatePatternSelectionData::none(),
-                            time: overlap,
-                            zone: None,
-                            glue: None,
-                        });
-                    }
-                }
-                let date = DatePatternSelectionData::try_new_with_skeleton(
-                    date_provider,
-                    prefs,
-                    field_set.to_date_field_set().id_str(),
-                )?;
-                let time = TimePatternSelectionData::try_new_with_skeleton(
-                    time_provider,
-                    prefs,
-                    field_set.to_time_field_set(),
-                )?;
-                let glue = Self::load_glue(glue_provider, prefs, options, GlueType::DateTime)?;
-                let prefs = RawPreferences::from_prefs(prefs);
-                Ok(Self {
-                    options,
-                    prefs,
-                    date,
-                    time,
-                    zone: None,
-                    glue: Some(glue),
-                })
-            }
-            CompositeFieldSet::DateZone(combo) => {
-                let options = combo.dt().to_raw_options();
-                let date = DatePatternSelectionData::try_new_with_skeleton(
-                    date_provider,
-                    prefs,
-                    combo.dt().id_str(),
-                )?;
-                let zone = ZonePatternSelectionData::new_with_skeleton(combo.z());
-                let glue = Self::load_glue(glue_provider, prefs, options, GlueType::DateZone)?;
-                Ok(Self {
-                    options,
-                    prefs: Default::default(), // not used: no time
-                    date,
-                    time: TimePatternSelectionData::none(),
-                    zone: Some(zone),
-                    glue: Some(glue),
-                })
-            }
-            CompositeFieldSet::TimeZone(combo) => {
-                let options = combo.dt().to_raw_options();
-                let time = TimePatternSelectionData::try_new_with_skeleton(
-                    time_provider,
-                    prefs,
-                    combo.dt(),
-                )?;
-                let zone = ZonePatternSelectionData::new_with_skeleton(combo.z());
-                let glue = Self::load_glue(glue_provider, prefs, options, GlueType::TimeZone)?;
-                let prefs = RawPreferences::from_prefs(prefs);
-                Ok(Self {
-                    options,
-                    prefs,
-                    date: DatePatternSelectionData::none(),
-                    time,
-                    zone: Some(zone),
-                    glue: Some(glue),
-                })
-            }
-            CompositeFieldSet::DateTimeZone(combo) => {
-                let options = combo.dt().to_raw_options();
-                let date = DatePatternSelectionData::try_new_with_skeleton(
-                    date_provider,
-                    prefs,
-                    combo.dt().to_date_field_set().id_str(),
-                )?;
-                let time = TimePatternSelectionData::try_new_with_skeleton(
-                    time_provider,
-                    prefs,
-                    combo.dt().to_time_field_set(),
-                )?;
-                let zone = ZonePatternSelectionData::new_with_skeleton(combo.z());
-                let glue = Self::load_glue(glue_provider, prefs, options, GlueType::DateTimeZone)?;
-                let prefs = RawPreferences::from_prefs(prefs);
-                Ok(Self {
-                    options,
-                    prefs,
-                    date,
-                    time,
-                    zone: Some(zone),
-                    glue: Some(glue),
-                })
+                });
             }
         }
+
+        let options = skeleton.to_raw_options();
+        let zone = skeleton
+            .to_zone()
+            .map(ZonePatternSelectionData::new_with_skeleton);
+
+        let glue_type = match skeleton {
+            CompositeFieldSet::DateTime(_) => Some(GlueType::DateTime),
+            CompositeFieldSet::DateZone(_) => Some(GlueType::DateZone),
+            CompositeFieldSet::TimeZone(_) => Some(GlueType::TimeZone),
+            CompositeFieldSet::DateTimeZone(_) => Some(GlueType::DateTimeZone),
+            _ => None,
+        };
+
+        let glue = if let Some(gt) = glue_type {
+            Some(Self::load_glue(glue_provider, prefs, options, gt)?)
+        } else {
+            None
+        };
+
+        let (date_opt, time_opt) = map_composite_skeleton(
+            skeleton,
+            |d_attrs| {
+                DatePatternSelectionData::try_new_with_skeleton(date_provider, prefs, d_attrs)
+            },
+            |t_field_set| {
+                TimePatternSelectionData::try_new_with_skeleton(time_provider, prefs, t_field_set)
+            },
+        )?;
+
+        let has_time = time_opt.is_some();
+        let date = date_opt.unwrap_or_else(DatePatternSelectionData::none);
+        let time = time_opt.unwrap_or_else(TimePatternSelectionData::none);
+
+        let prefs = if has_time {
+            RawPreferences::from_prefs(prefs)
+        } else {
+            Default::default()
+        };
+
+        Ok(Self {
+            options,
+            prefs,
+            date,
+            time,
+            zone,
+            glue,
+        })
     }
 
     fn load_glue(
@@ -837,71 +777,26 @@ impl DateTimeZoneRangePatternSelectionData {
             })?
             .payload;
 
-        let mut date_range = DateRangePatternSelectionData::none();
-        let mut time_range = TimeRangePatternSelectionData::none();
+        let (date_opt, time_opt) = map_composite_skeleton(
+            skeleton,
+            |d_attrs| {
+                DateRangePatternSelectionData::try_new_with_skeleton(
+                    date_range_provider,
+                    prefs,
+                    d_attrs,
+                )
+            },
+            |t_field_set| {
+                TimeRangePatternSelectionData::try_new_with_skeleton(
+                    time_range_provider,
+                    prefs,
+                    t_field_set,
+                )
+            },
+        )?;
 
-        match skeleton {
-            CompositeFieldSet::Date(field_set) => {
-                date_range = DateRangePatternSelectionData::try_new_with_skeleton(
-                    date_range_provider,
-                    prefs,
-                    field_set.id_str(),
-                )?;
-            }
-            CompositeFieldSet::CalendarPeriod(field_set) => {
-                date_range = DateRangePatternSelectionData::try_new_with_skeleton(
-                    date_range_provider,
-                    prefs,
-                    field_set.id_str(),
-                )?;
-            }
-            CompositeFieldSet::Time(field_set) => {
-                time_range = TimeRangePatternSelectionData::try_new_with_skeleton(
-                    time_range_provider,
-                    prefs,
-                    field_set,
-                )?;
-            }
-            CompositeFieldSet::DateTime(field_set) => {
-                date_range = DateRangePatternSelectionData::try_new_with_skeleton(
-                    date_range_provider,
-                    prefs,
-                    field_set.to_date_field_set().id_str(),
-                )?;
-                time_range = TimeRangePatternSelectionData::try_new_with_skeleton(
-                    time_range_provider,
-                    prefs,
-                    field_set.to_time_field_set(),
-                )?;
-            }
-            CompositeFieldSet::DateZone(combo) => {
-                date_range = DateRangePatternSelectionData::try_new_with_skeleton(
-                    date_range_provider,
-                    prefs,
-                    combo.dt().id_str(),
-                )?;
-            }
-            CompositeFieldSet::DateTimeZone(combo) => {
-                date_range = DateRangePatternSelectionData::try_new_with_skeleton(
-                    date_range_provider,
-                    prefs,
-                    combo.dt().to_date_field_set().id_str(),
-                )?;
-                time_range = TimeRangePatternSelectionData::try_new_with_skeleton(
-                    time_range_provider,
-                    prefs,
-                    combo.dt().to_time_field_set(),
-                )?;
-            }
-            CompositeFieldSet::TimeZone(combo) => {
-                time_range = TimeRangePatternSelectionData::try_new_with_skeleton(
-                    time_range_provider,
-                    prefs,
-                    combo.dt(),
-                )?;
-            }
-            CompositeFieldSet::Zone(_) => {}
-        }
+        let date_range = date_opt.unwrap_or_else(DateRangePatternSelectionData::none);
+        let time_range = time_opt.unwrap_or_else(TimeRangePatternSelectionData::none);
 
         Ok(Self {
             date_range,

--- a/components/datetime/src/raw/neo.rs
+++ b/components/datetime/src/raw/neo.rs
@@ -13,6 +13,12 @@ use crate::provider::pattern::{
     GenericPatternItem, PatternItem,
     runtime::{self, PatternMetadata},
 };
+#[cfg(feature = "unstable")]
+#[allow(unused_imports)]
+use crate::provider::range_patterns::{
+    DateGreatestDifferenceField, DatetimePatternsRangeGlueV1, ErasedPackedRangePatterns,
+    RangePatternInfoBorrowed, TimeGreatestDifferenceField,
+};
 use crate::provider::{
     packed_pattern::{ErasedPackedPatterns, PackedSkeletonVariant},
     semantic_skeletons::{DatetimePatternsGlueV1, GluePattern, marker_attrs},
@@ -228,6 +234,46 @@ impl DatePatternSelectionData {
     }
 }
 
+/// Data required for selecting date range patterns.
+///
+/// This struct holds the patterns used to format the date portion of a range.
+#[derive(Debug, Clone)]
+#[cfg(feature = "unstable")]
+#[allow(dead_code)]
+pub(crate) struct DateRangePatternSelectionData {
+    /// The loaded date range patterns, or `None` if date range formatting is not supported.
+    payload: DataPayloadOr<ErasedPackedRangePatterns, ()>,
+}
+
+#[cfg(feature = "unstable")]
+#[allow(dead_code)]
+impl DateRangePatternSelectionData {
+    pub(crate) fn none() -> Self {
+        Self {
+            payload: DataPayloadOr::none(),
+        }
+    }
+
+    pub(crate) fn try_new_with_skeleton(
+        provider: &(impl BoundDataProvider<ErasedPackedRangePatterns> + ?Sized),
+        prefs: DateTimeFormatterPreferences,
+        attributes: &DataMarkerAttributes,
+    ) -> Result<Self, DataError> {
+        let locale = provider
+            .bound_marker()
+            .make_locale(prefs.locale_preferences);
+        let payload = provider
+            .load_bound(DataRequest {
+                id: DataIdentifierBorrowed::for_marker_attributes_and_locale(attributes, &locale),
+                ..Default::default()
+            })?
+            .payload;
+        Ok(Self {
+            payload: DataPayloadOr::from_payload(payload),
+        })
+    }
+}
+
 impl DateTimeInputUnchecked {
     fn resolve_time_precision(
         &self,
@@ -381,6 +427,70 @@ impl<'a> TimePatternDataBorrowed<'a> {
             hour_cycle,
             subsecond_digits,
         }
+    }
+}
+
+/// Data required for selecting time range patterns.
+///
+/// This struct holds the patterns used to format the time portion of a range.
+#[derive(Debug, Clone)]
+#[cfg(feature = "unstable")]
+#[allow(dead_code)]
+pub(crate) struct TimeRangePatternSelectionData {
+    /// The loaded time range patterns, or `None` if time range formatting is not supported.
+    payload: DataPayloadOr<ErasedPackedRangePatterns, ()>,
+}
+
+#[cfg(feature = "unstable")]
+#[allow(dead_code)]
+impl TimeRangePatternSelectionData {
+    pub(crate) fn none() -> Self {
+        Self {
+            payload: DataPayloadOr::none(),
+        }
+    }
+
+    pub(crate) fn try_new_with_skeleton(
+        provider: &(impl BoundDataProvider<ErasedPackedRangePatterns> + ?Sized),
+        prefs: DateTimeFormatterPreferences,
+        components: TimeFieldSet,
+    ) -> Result<Self, DataError> {
+        let locale = provider
+            .bound_marker()
+            .make_locale(prefs.locale_preferences);
+        let prefs = RawPreferences::from_prefs(prefs);
+        // First try to load with the explicit hour cycle. If there is no explicit hour cycle,
+        // or if loading the explicit hour cycle fails, then load with the default hour cycle.
+        let mut maybe_payload = None;
+        if let Some(hour_cycle) = prefs.hour_cycle {
+            maybe_payload = provider
+                .load_bound(DataRequest {
+                    id: DataIdentifierBorrowed::for_marker_attributes_and_locale(
+                        components.id_str_for_hour_cycle(Some(hour_cycle)),
+                        &locale,
+                    ),
+                    ..Default::default()
+                })
+                .allow_identifier_not_found()?
+                .map(|r| r.payload);
+        }
+        let payload = match maybe_payload {
+            Some(payload) => payload,
+            None => {
+                provider
+                    .load_bound(DataRequest {
+                        id: DataIdentifierBorrowed::for_marker_attributes_and_locale(
+                            components.id_str_for_hour_cycle(None),
+                            &locale,
+                        ),
+                        ..Default::default()
+                    })?
+                    .payload
+            }
+        };
+        Ok(Self {
+            payload: DataPayloadOr::from_payload(payload),
+        })
     }
 }
 
@@ -684,6 +794,120 @@ impl DateTimeZonePatternSelectionData {
             alignment: self.options.alignment,
             year_style: self.options.year_style,
         }
+    }
+}
+
+/// Data required for selecting date, time, and zone range patterns.
+///
+/// This struct consolidates the date and time range patterns, as well as the
+/// fallback range glue used when no specific greatest-difference pattern is available.
+#[derive(Debug, Clone)]
+#[cfg(feature = "unstable")]
+#[allow(dead_code)]
+pub(crate) struct DateTimeZoneRangePatternSelectionData {
+    /// Data for selecting date range patterns.
+    pub(crate) date_range: DateRangePatternSelectionData,
+    /// Data for selecting time range patterns.
+    pub(crate) time_range: TimeRangePatternSelectionData,
+    /// Fallback range glue patterns.
+    pub(crate) range_glue: DataPayload<DatetimePatternsRangeGlueV1>,
+}
+
+#[cfg(feature = "unstable")]
+#[allow(dead_code)]
+impl DateTimeZoneRangePatternSelectionData {
+    pub(crate) fn try_new_with_skeleton(
+        date_range_provider: &(impl BoundDataProvider<ErasedPackedRangePatterns> + ?Sized),
+        time_range_provider: &(impl BoundDataProvider<ErasedPackedRangePatterns> + ?Sized),
+        range_glue_provider: &(impl BoundDataProvider<DatetimePatternsRangeGlueV1> + ?Sized),
+        prefs: DateTimeFormatterPreferences,
+        skeleton: CompositeFieldSet,
+    ) -> Result<Self, DataError> {
+        let locale = range_glue_provider
+            .bound_marker()
+            .make_locale(prefs.locale_preferences);
+
+        let range_glue = range_glue_provider
+            .load_bound(DataRequest {
+                id: DataIdentifierBorrowed::for_marker_attributes_and_locale(
+                    DataMarkerAttributes::empty(),
+                    &locale,
+                ),
+                ..Default::default()
+            })?
+            .payload;
+
+        let mut date_range = DateRangePatternSelectionData::none();
+        let mut time_range = TimeRangePatternSelectionData::none();
+
+        match skeleton {
+            CompositeFieldSet::Date(field_set) => {
+                date_range = DateRangePatternSelectionData::try_new_with_skeleton(
+                    date_range_provider,
+                    prefs,
+                    field_set.id_str(),
+                )?;
+            }
+            CompositeFieldSet::CalendarPeriod(field_set) => {
+                date_range = DateRangePatternSelectionData::try_new_with_skeleton(
+                    date_range_provider,
+                    prefs,
+                    field_set.id_str(),
+                )?;
+            }
+            CompositeFieldSet::Time(field_set) => {
+                time_range = TimeRangePatternSelectionData::try_new_with_skeleton(
+                    time_range_provider,
+                    prefs,
+                    field_set,
+                )?;
+            }
+            CompositeFieldSet::DateTime(field_set) => {
+                date_range = DateRangePatternSelectionData::try_new_with_skeleton(
+                    date_range_provider,
+                    prefs,
+                    field_set.to_date_field_set().id_str(),
+                )?;
+                time_range = TimeRangePatternSelectionData::try_new_with_skeleton(
+                    time_range_provider,
+                    prefs,
+                    field_set.to_time_field_set(),
+                )?;
+            }
+            CompositeFieldSet::DateZone(combo) => {
+                date_range = DateRangePatternSelectionData::try_new_with_skeleton(
+                    date_range_provider,
+                    prefs,
+                    combo.dt().id_str(),
+                )?;
+            }
+            CompositeFieldSet::DateTimeZone(combo) => {
+                date_range = DateRangePatternSelectionData::try_new_with_skeleton(
+                    date_range_provider,
+                    prefs,
+                    combo.dt().to_date_field_set().id_str(),
+                )?;
+                time_range = TimeRangePatternSelectionData::try_new_with_skeleton(
+                    time_range_provider,
+                    prefs,
+                    combo.dt().to_time_field_set(),
+                )?;
+            }
+            CompositeFieldSet::TimeZone(combo) => {
+                time_range = TimeRangePatternSelectionData::try_new_with_skeleton(
+                    time_range_provider,
+                    prefs,
+                    combo.dt(),
+                )?;
+            }
+            CompositeFieldSet::Zone(_) => {}
+        }
+
+        Ok(Self {
+            date_range,
+            time_range,
+            range_glue,
+        })
     }
 }
 

--- a/components/datetime/src/raw/neo.rs
+++ b/components/datetime/src/raw/neo.rs
@@ -585,7 +585,11 @@ impl DateTimeZonePatternSelectionData {
         // Handle overlap early return.
         if let CompositeFieldSet::DateTime(field_set) = skeleton {
             let options = field_set.to_raw_options();
+            // TODO(#5387): load the patterns for custom hour cycles here
             if let (Some(attributes), None) = (field_set.id_str(), prefs.hour_cycle)
+                // Try loading an overlap pattern.
+                // Note: Overlap patterns are loaded from the date skeleton pattern provider
+                // and then stored as a TimePatternSelectionData.
                 && let Some(overlap) = TimePatternSelectionData::try_new_overlap_with_skeleton(
                     date_provider,
                     prefs,

--- a/components/datetime/src/scaffold/calendar.rs
+++ b/components/datetime/src/scaffold/calendar.rs
@@ -5,7 +5,7 @@
 //! Scaffolding traits and impls for calendars.
 
 use crate::MismatchedCalendarError;
-use crate::provider::{names::*, packed_pattern::*, semantic_skeletons::*};
+use crate::provider::{names::*, packed_pattern::*, range_patterns::*, semantic_skeletons::*};
 use crate::scaffold::UnstableSealed;
 use core::marker::PhantomData;
 use icu_calendar::cal;
@@ -40,60 +40,72 @@ pub trait CldrCalendar: UnstableSealed {
 
     /// The data marker for loading skeleton patterns for this calendar.
     type SkeletaV1: DataMarker<DataStruct = PackedPatterns<'static>>;
+
+    /// The data marker for loading range skeleton patterns for this calendar.
+    type RangeSkeletaV1: DataMarker<DataStruct = PackedRangePatterns<'static>>;
 }
 
 impl CldrCalendar for () {
     type YearNamesV1 = NeverMarker<YearNames<'static>>;
     type MonthNamesV1 = NeverMarker<MonthNames<'static>>;
     type SkeletaV1 = NeverMarker<PackedPatterns<'static>>;
+    type RangeSkeletaV1 = NeverMarker<PackedRangePatterns<'static>>;
 }
 
 impl CldrCalendar for cal::Buddhist {
     type YearNamesV1 = DatetimeNamesYearBuddhistV1;
     type MonthNamesV1 = DatetimeNamesMonthBuddhistV1;
     type SkeletaV1 = DatetimePatternsDateBuddhistV1;
+    type RangeSkeletaV1 = DatetimePatternsRangeDateBuddhistV1;
 }
 
 impl CldrCalendar for cal::ChineseTraditional {
     type YearNamesV1 = DatetimeNamesYearChineseV1;
     type MonthNamesV1 = DatetimeNamesMonthChineseV1;
     type SkeletaV1 = DatetimePatternsDateChineseV1;
+    type RangeSkeletaV1 = DatetimePatternsRangeDateChineseV1;
 }
 
 impl CldrCalendar for cal::Coptic {
     type YearNamesV1 = DatetimeNamesYearCopticV1;
     type MonthNamesV1 = DatetimeNamesMonthCopticV1;
     type SkeletaV1 = DatetimePatternsDateCopticV1;
+    type RangeSkeletaV1 = DatetimePatternsRangeDateCopticV1;
 }
 
 impl CldrCalendar for cal::KoreanTraditional {
     type YearNamesV1 = DatetimeNamesYearDangiV1;
     type MonthNamesV1 = DatetimeNamesMonthDangiV1;
     type SkeletaV1 = DatetimePatternsDateDangiV1;
+    type RangeSkeletaV1 = DatetimePatternsRangeDateDangiV1;
 }
 
 impl CldrCalendar for cal::Ethiopian {
     type YearNamesV1 = DatetimeNamesYearEthiopianV1;
     type MonthNamesV1 = DatetimeNamesMonthEthiopianV1;
     type SkeletaV1 = DatetimePatternsDateEthiopianV1;
+    type RangeSkeletaV1 = DatetimePatternsRangeDateEthiopianV1;
 }
 
 impl CldrCalendar for cal::Gregorian {
     type YearNamesV1 = DatetimeNamesYearGregorianV1;
     type MonthNamesV1 = DatetimeNamesMonthGregorianV1;
     type SkeletaV1 = DatetimePatternsDateGregorianV1;
+    type RangeSkeletaV1 = DatetimePatternsRangeDateGregorianV1;
 }
 
 impl CldrCalendar for cal::Hebrew {
     type YearNamesV1 = DatetimeNamesYearHebrewV1;
     type MonthNamesV1 = DatetimeNamesMonthHebrewV1;
     type SkeletaV1 = DatetimePatternsDateHebrewV1;
+    type RangeSkeletaV1 = DatetimePatternsRangeDateHebrewV1;
 }
 
 impl CldrCalendar for cal::Indian {
     type YearNamesV1 = DatetimeNamesYearIndianV1;
     type MonthNamesV1 = DatetimeNamesMonthIndianV1;
     type SkeletaV1 = DatetimePatternsDateIndianV1;
+    type RangeSkeletaV1 = DatetimePatternsRangeDateIndianV1;
 }
 
 /// [`hijri::Rules`](cal::hijri::unstable_internal::Rules)-specific formatting options.
@@ -140,6 +152,9 @@ pub trait FormattableHijriRules: cal::hijri::unstable_internal::Rules + Unstable
 
     /// The data marker for loading skeleton patterns for this calendar.
     type SkeletaV1: DataMarker<DataStruct = PackedPatterns<'static>>;
+
+    /// The data marker for loading range skeleton patterns for this calendar.
+    type RangeSkeletaV1: DataMarker<DataStruct = PackedRangePatterns<'static>>;
 }
 
 impl UnstableSealed for cal::hijri::TabularAlgorithm {}
@@ -147,6 +162,7 @@ impl FormattableHijriRules for cal::hijri::TabularAlgorithm {
     type YearNamesV1 = DatetimeNamesYearHijriV1;
     type MonthNamesV1 = DatetimeNamesMonthHijriV1;
     type SkeletaV1 = DatetimePatternsDateHijriV1;
+    type RangeSkeletaV1 = DatetimePatternsRangeDateHijriV1;
 }
 
 impl UnstableSealed for cal::hijri::UmmAlQura {}
@@ -154,6 +170,7 @@ impl FormattableHijriRules for cal::hijri::UmmAlQura {
     type YearNamesV1 = DatetimeNamesYearHijriV1;
     type MonthNamesV1 = DatetimeNamesMonthHijriV1;
     type SkeletaV1 = DatetimePatternsDateHijriV1;
+    type RangeSkeletaV1 = DatetimePatternsRangeDateHijriV1;
 }
 
 #[allow(deprecated)]
@@ -163,30 +180,35 @@ impl FormattableHijriRules for cal::hijri::AstronomicalSimulation {
     type YearNamesV1 = DatetimeNamesYearHijriV1;
     type MonthNamesV1 = DatetimeNamesMonthHijriV1;
     type SkeletaV1 = DatetimePatternsDateHijriV1;
+    type RangeSkeletaV1 = DatetimePatternsRangeDateHijriV1;
 }
 
 impl<R: FormattableHijriRules> CldrCalendar for cal::Hijri<R> {
     type YearNamesV1 = R::YearNamesV1;
     type MonthNamesV1 = R::MonthNamesV1;
     type SkeletaV1 = R::SkeletaV1;
+    type RangeSkeletaV1 = R::RangeSkeletaV1;
 }
 
 impl CldrCalendar for cal::Japanese {
     type YearNamesV1 = DatetimeNamesYearJapaneseV1;
     type MonthNamesV1 = DatetimeNamesMonthJapaneseV1;
     type SkeletaV1 = DatetimePatternsDateJapaneseV1;
+    type RangeSkeletaV1 = DatetimePatternsRangeDateJapaneseV1;
 }
 
 impl CldrCalendar for cal::Persian {
     type YearNamesV1 = DatetimeNamesYearPersianV1;
     type MonthNamesV1 = DatetimeNamesMonthPersianV1;
     type SkeletaV1 = DatetimePatternsDatePersianV1;
+    type RangeSkeletaV1 = DatetimePatternsRangeDatePersianV1;
 }
 
 impl CldrCalendar for cal::Roc {
     type YearNamesV1 = DatetimeNamesYearRocV1;
     type MonthNamesV1 = DatetimeNamesMonthRocV1;
     type SkeletaV1 = DatetimePatternsDateRocV1;
+    type RangeSkeletaV1 = DatetimePatternsRangeDateRocV1;
 }
 
 impl UnstableSealed for () {}
@@ -644,6 +666,21 @@ impl CalMarkers<ErasedPackedPatterns> for FullDataCalMarkers {
     type Japanese = <cal::Japanese as CldrCalendar>::SkeletaV1;
     type Persian = <cal::Persian as CldrCalendar>::SkeletaV1;
     type Roc = <cal::Roc as CldrCalendar>::SkeletaV1;
+}
+
+impl CalMarkers<ErasedPackedRangePatterns> for FullDataCalMarkers {
+    type Buddhist = <cal::Buddhist as CldrCalendar>::RangeSkeletaV1;
+    type Chinese = <cal::ChineseTraditional as CldrCalendar>::RangeSkeletaV1;
+    type Coptic = <cal::Coptic as CldrCalendar>::RangeSkeletaV1;
+    type Dangi = <cal::KoreanTraditional as CldrCalendar>::RangeSkeletaV1;
+    type Ethiopian = <cal::Ethiopian as CldrCalendar>::RangeSkeletaV1;
+    type Gregorian = <cal::Gregorian as CldrCalendar>::RangeSkeletaV1;
+    type Hebrew = <cal::Hebrew as CldrCalendar>::RangeSkeletaV1;
+    type Indian = <cal::Indian as CldrCalendar>::RangeSkeletaV1;
+    type Hijri = <cal::Hijri<cal::hijri::UmmAlQura> as CldrCalendar>::RangeSkeletaV1;
+    type Japanese = <cal::Japanese as CldrCalendar>::RangeSkeletaV1;
+    type Persian = <cal::Persian as CldrCalendar>::RangeSkeletaV1;
+    type Roc = <cal::Roc as CldrCalendar>::RangeSkeletaV1;
 }
 
 /// A type that can be converted into a specific calendar system.

--- a/components/datetime/src/scaffold/calendar.rs
+++ b/components/datetime/src/scaffold/calendar.rs
@@ -140,6 +140,7 @@ impl CldrCalendar for cal::Indian {
 ///     type MonthNamesV1 =
 ///         <hijri::UmmAlQura as FormattableHijriRules>::MonthNamesV1;
 ///     type SkeletaV1 = <hijri::UmmAlQura as FormattableHijriRules>::SkeletaV1;
+///     type RangeSkeletaV1 = <hijri::UmmAlQura as FormattableHijriRules>::RangeSkeletaV1;
 /// }
 /// ```
 // TODO: default associated types would be nice (https://github.com/rust-lang/rust/issues/29661)

--- a/components/datetime/src/scaffold/dynamic_impls.rs
+++ b/components/datetime/src/scaffold/dynamic_impls.rs
@@ -5,7 +5,9 @@
 use super::*;
 use crate::fieldsets::enums::*;
 use crate::provider::semantic_skeletons::{DatetimePatternsGlueV1, GluePattern};
-use crate::provider::{names::*, semantic_skeletons::*, time_zones::tz};
+use crate::provider::{
+    names::*, range_patterns::DatetimePatternsRangeTimeV1, semantic_skeletons::*, time_zones::tz,
+};
 use icu_calendar::types::{DayOfMonth, DayOfYear, MonthInfo, RataDie, Weekday, YearInfo};
 use icu_provider::marker::NeverMarker;
 use icu_time::{
@@ -44,6 +46,7 @@ impl DateInputMarkers for DateFieldSet {
 
 impl<C: CldrCalendar> TypedDateDataMarkers<C> for DateFieldSet {
     type DateSkeletonPatternsV1 = datetime_marker_helper!(@dates/typed, yes);
+    type DateRangeSkeletonPatternsV1 = datetime_marker_helper!(@dates/range/typed, yes);
     type YearNamesV1 = datetime_marker_helper!(@years/typed, yes);
     type MonthNamesV1 = datetime_marker_helper!(@months/typed, yes);
     type WeekdayNamesV1 = datetime_marker_helper!(@weekdays, yes);
@@ -51,6 +54,7 @@ impl<C: CldrCalendar> TypedDateDataMarkers<C> for DateFieldSet {
 
 impl DateDataMarkers for DateFieldSet {
     type Skel = datetime_marker_helper!(@calmarkers, yes);
+    type RangeSkel = datetime_marker_helper!(@calmarkers, yes);
     type Year = datetime_marker_helper!(@calmarkers, yes);
     type Month = datetime_marker_helper!(@calmarkers, yes);
     type WeekdayNamesV1 = datetime_marker_helper!(@weekdays, yes);
@@ -94,6 +98,7 @@ impl DateInputMarkers for CalendarPeriodFieldSet {
 
 impl<C: CldrCalendar> TypedDateDataMarkers<C> for CalendarPeriodFieldSet {
     type DateSkeletonPatternsV1 = datetime_marker_helper!(@dates/typed, yes);
+    type DateRangeSkeletonPatternsV1 = datetime_marker_helper!(@dates/range/typed, yes);
     type YearNamesV1 = datetime_marker_helper!(@years/typed, yes);
     type MonthNamesV1 = datetime_marker_helper!(@months/typed, yes);
     type WeekdayNamesV1 = datetime_marker_helper!(@weekdays,);
@@ -101,6 +106,7 @@ impl<C: CldrCalendar> TypedDateDataMarkers<C> for CalendarPeriodFieldSet {
 
 impl DateDataMarkers for CalendarPeriodFieldSet {
     type Skel = datetime_marker_helper!(@calmarkers, yes);
+    type RangeSkel = datetime_marker_helper!(@calmarkers, yes);
     type Year = datetime_marker_helper!(@calmarkers, yes);
     type Month = datetime_marker_helper!(@calmarkers, yes);
     type WeekdayNamesV1 = datetime_marker_helper!(@weekdays,);
@@ -136,6 +142,7 @@ impl DateTimeNamesMarker for TimeFieldSet {
 impl TimeMarkers for TimeFieldSet {
     type DayPeriodNamesV1 = datetime_marker_helper!(@dayperiods, yes);
     type TimeSkeletonPatternsV1 = datetime_marker_helper!(@times, yes);
+    type TimeRangeSkeletonPatternsV1 = datetime_marker_helper!(@times/range, yes);
     type HourInput = datetime_marker_helper!(@input/hour, yes);
     type MinuteInput = datetime_marker_helper!(@input/minute, yes);
     type SecondInput = datetime_marker_helper!(@input/second, yes);

--- a/components/datetime/src/scaffold/fieldset_traits.rs
+++ b/components/datetime/src/scaffold/fieldset_traits.rs
@@ -3,12 +3,8 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::{
-    provider::names::*,
-    provider::packed_pattern::*,
-    provider::range_patterns::*,
-    provider::semantic_skeletons::GluePattern,
-    provider::time_zones::tz,
-    scaffold::*,
+    provider::names::*, provider::packed_pattern::*, provider::range_patterns::*,
+    provider::semantic_skeletons::GluePattern, provider::time_zones::tz, scaffold::*,
 };
 use icu_calendar::{
     provider::{CalendarJapaneseModernV1, CalendarPreferredV1},
@@ -279,6 +275,7 @@ where
 /// Trait to consolidate data provider markers defined by this crate
 /// for datetime range skeleton patterns with a fixed calendar.
 #[rustfmt::skip]
+#[allow(dead_code)]
 pub trait AllFixedCalendarRangePatternDataMarkers<C: CldrCalendar, FSet: DateTimeMarkers>:
     DataProvider<<FSet::D as TypedDateDataMarkers<C>>::DateRangeSkeletonPatternsV1>
     + DataProvider<<FSet::T as TimeMarkers>::TimeRangeSkeletonPatternsV1>
@@ -403,26 +400,38 @@ where
     FSet::T: TimeMarkers,
     FSet::Z: ZoneMarkers,
     T: ?Sized
-        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Buddhist>
-        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Chinese>
-        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Coptic>
-        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Dangi>
-        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Ethiopian>
-        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Gregorian>
-        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Hebrew>
-        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Indian>
-        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Hijri>
-        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Japanese>
-        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Persian>
-        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Roc>
+        + DataProvider<
+            <<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Buddhist,
+        > + DataProvider<
+            <<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Chinese,
+        > + DataProvider<
+            <<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Coptic,
+        > + DataProvider<
+            <<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Dangi,
+        > + DataProvider<
+            <<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Ethiopian,
+        > + DataProvider<
+            <<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Gregorian,
+        > + DataProvider<
+            <<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Hebrew,
+        > + DataProvider<
+            <<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Indian,
+        > + DataProvider<
+            <<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Hijri,
+        > + DataProvider<
+            <<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Japanese,
+        > + DataProvider<
+            <<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Persian,
+        > + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Roc>
         + DataProvider<<FSet::T as TimeMarkers>::TimeSkeletonPatternsV1>
-        + DataProvider<FSet::GluePatternV1>
+        + DataProvider<FSet::GluePatternV1>,
 {
 }
 
 /// Trait to consolidate data provider markers defined by this crate
 /// for datetime range skeleton patterns with any calendar.
 #[rustfmt::skip]
+#[allow(dead_code)]
 pub trait AllAnyCalendarRangePatternDataMarkers<FSet: DateTimeMarkers>:
     DataProvider<<<FSet::D as DateDataMarkers>::RangeSkel as CalMarkers<ErasedPackedRangePatterns>>::Buddhist>
     + DataProvider<<<FSet::D as DateDataMarkers>::RangeSkel as CalMarkers<ErasedPackedRangePatterns>>::Chinese>

--- a/components/datetime/src/scaffold/fieldset_traits.rs
+++ b/components/datetime/src/scaffold/fieldset_traits.rs
@@ -3,8 +3,11 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::{
+    provider::names::*,
+    provider::packed_pattern::*,
+    provider::range_patterns::*,
     provider::semantic_skeletons::GluePattern,
-    provider::{names::*, packed_pattern::*, time_zones::tz},
+    provider::time_zones::tz,
     scaffold::*,
 };
 use icu_calendar::{
@@ -54,6 +57,8 @@ pub trait DateInputMarkers: UnstableSealed {
 pub trait TypedDateDataMarkers<C>: UnstableSealed {
     /// Marker for loading date skeleton patterns.
     type DateSkeletonPatternsV1: DataMarker<DataStruct = PackedPatterns<'static>>;
+    /// Marker for loading date range skeleton patterns.
+    type DateRangeSkeletonPatternsV1: DataMarker<DataStruct = PackedRangePatterns<'static>>;
     /// Marker for loading year names.
     type YearNamesV1: DataMarker<DataStruct = YearNames<'static>>;
     /// Marker for loading month names.
@@ -74,6 +79,8 @@ pub trait TypedDateDataMarkers<C>: UnstableSealed {
 pub trait DateDataMarkers: UnstableSealed {
     /// Cross-calendar data markers for date skeleta.
     type Skel: CalMarkers<ErasedPackedPatterns>;
+    /// Cross-calendar data markers for date range skeleta.
+    type RangeSkel: CalMarkers<ErasedPackedRangePatterns>;
     /// Cross-calendar data markers for year names.
     type Year: CalMarkers<YearNamesV1>;
     /// Cross-calendar data markers for month names.
@@ -102,6 +109,8 @@ pub trait TimeMarkers: UnstableSealed {
     type NanosecondInput: IntoOption<Nanosecond>;
     /// Marker for loading time skeleton patterns.
     type TimeSkeletonPatternsV1: DataMarker<DataStruct = PackedPatterns<'static>>;
+    /// Marker for loading time range skeleton patterns.
+    type TimeRangeSkeletonPatternsV1: DataMarker<DataStruct = PackedRangePatterns<'static>>;
     /// Marker for loading day period names.
     type DayPeriodNamesV1: DataMarker<DataStruct = DayPeriodNames<'static>>;
 }
@@ -268,6 +277,35 @@ where
 }
 
 /// Trait to consolidate data provider markers defined by this crate
+/// for datetime range skeleton patterns with a fixed calendar.
+#[rustfmt::skip]
+pub trait AllFixedCalendarRangePatternDataMarkers<C: CldrCalendar, FSet: DateTimeMarkers>:
+    DataProvider<<FSet::D as TypedDateDataMarkers<C>>::DateRangeSkeletonPatternsV1>
+    + DataProvider<<FSet::T as TimeMarkers>::TimeRangeSkeletonPatternsV1>
+    + DataProvider<DatetimePatternsRangeGlueV1>
+where
+    FSet::D: TypedDateDataMarkers<C>,
+    FSet::T: TimeMarkers,
+    FSet::Z: ZoneMarkers,
+{
+}
+
+#[rustfmt::skip]
+impl<T, C, FSet> AllFixedCalendarRangePatternDataMarkers<C, FSet> for T
+where
+    C: CldrCalendar,
+    FSet: DateTimeMarkers,
+    FSet::D: TypedDateDataMarkers<C>,
+    FSet::T: TimeMarkers,
+    FSet::Z: ZoneMarkers,
+    T: ?Sized
+        + DataProvider<<FSet::D as TypedDateDataMarkers<C>>::DateRangeSkeletonPatternsV1>
+        + DataProvider<<FSet::T as TimeMarkers>::TimeRangeSkeletonPatternsV1>
+        + DataProvider<DatetimePatternsRangeGlueV1>,
+{
+}
+
+/// Trait to consolidate data provider markers defined by this crate
 /// for datetime formatting with a fixed calendar.
 ///
 /// This trait is implemented on all providers that support datetime formatting,
@@ -358,7 +396,6 @@ where
 {
 }
 
-#[rustfmt::skip]
 impl<T, FSet> AllAnyCalendarPatternDataMarkers<FSet> for T
 where
     FSet: DateTimeMarkers,
@@ -380,6 +417,56 @@ where
         + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Roc>
         + DataProvider<<FSet::T as TimeMarkers>::TimeSkeletonPatternsV1>
         + DataProvider<FSet::GluePatternV1>
+{
+}
+
+/// Trait to consolidate data provider markers defined by this crate
+/// for datetime range skeleton patterns with any calendar.
+#[rustfmt::skip]
+pub trait AllAnyCalendarRangePatternDataMarkers<FSet: DateTimeMarkers>:
+    DataProvider<<<FSet::D as DateDataMarkers>::RangeSkel as CalMarkers<ErasedPackedRangePatterns>>::Buddhist>
+    + DataProvider<<<FSet::D as DateDataMarkers>::RangeSkel as CalMarkers<ErasedPackedRangePatterns>>::Chinese>
+    + DataProvider<<<FSet::D as DateDataMarkers>::RangeSkel as CalMarkers<ErasedPackedRangePatterns>>::Coptic>
+    + DataProvider<<<FSet::D as DateDataMarkers>::RangeSkel as CalMarkers<ErasedPackedRangePatterns>>::Dangi>
+    + DataProvider<<<FSet::D as DateDataMarkers>::RangeSkel as CalMarkers<ErasedPackedRangePatterns>>::Ethiopian>
+    + DataProvider<<<FSet::D as DateDataMarkers>::RangeSkel as CalMarkers<ErasedPackedRangePatterns>>::Gregorian>
+    + DataProvider<<<FSet::D as DateDataMarkers>::RangeSkel as CalMarkers<ErasedPackedRangePatterns>>::Hebrew>
+    + DataProvider<<<FSet::D as DateDataMarkers>::RangeSkel as CalMarkers<ErasedPackedRangePatterns>>::Indian>
+    + DataProvider<<<FSet::D as DateDataMarkers>::RangeSkel as CalMarkers<ErasedPackedRangePatterns>>::Hijri>
+    + DataProvider<<<FSet::D as DateDataMarkers>::RangeSkel as CalMarkers<ErasedPackedRangePatterns>>::Japanese>
+    + DataProvider<<<FSet::D as DateDataMarkers>::RangeSkel as CalMarkers<ErasedPackedRangePatterns>>::Persian>
+    + DataProvider<<<FSet::D as DateDataMarkers>::RangeSkel as CalMarkers<ErasedPackedRangePatterns>>::Roc>
+    + DataProvider<<FSet::T as TimeMarkers>::TimeRangeSkeletonPatternsV1>
+    + DataProvider<DatetimePatternsRangeGlueV1>
+where
+    FSet::D: DateDataMarkers,
+    FSet::T: TimeMarkers,
+    FSet::Z: ZoneMarkers,
+{
+}
+
+#[rustfmt::skip]
+impl<T, FSet> AllAnyCalendarRangePatternDataMarkers<FSet> for T
+where
+    FSet: DateTimeMarkers,
+    FSet::D: DateDataMarkers,
+    FSet::T: TimeMarkers,
+    FSet::Z: ZoneMarkers,
+    T: ?Sized
+        + DataProvider<<<FSet::D as DateDataMarkers>::RangeSkel as CalMarkers<ErasedPackedRangePatterns>>::Buddhist>
+        + DataProvider<<<FSet::D as DateDataMarkers>::RangeSkel as CalMarkers<ErasedPackedRangePatterns>>::Chinese>
+        + DataProvider<<<FSet::D as DateDataMarkers>::RangeSkel as CalMarkers<ErasedPackedRangePatterns>>::Coptic>
+        + DataProvider<<<FSet::D as DateDataMarkers>::RangeSkel as CalMarkers<ErasedPackedRangePatterns>>::Dangi>
+        + DataProvider<<<FSet::D as DateDataMarkers>::RangeSkel as CalMarkers<ErasedPackedRangePatterns>>::Ethiopian>
+        + DataProvider<<<FSet::D as DateDataMarkers>::RangeSkel as CalMarkers<ErasedPackedRangePatterns>>::Gregorian>
+        + DataProvider<<<FSet::D as DateDataMarkers>::RangeSkel as CalMarkers<ErasedPackedRangePatterns>>::Hebrew>
+        + DataProvider<<<FSet::D as DateDataMarkers>::RangeSkel as CalMarkers<ErasedPackedRangePatterns>>::Indian>
+        + DataProvider<<<FSet::D as DateDataMarkers>::RangeSkel as CalMarkers<ErasedPackedRangePatterns>>::Hijri>
+        + DataProvider<<<FSet::D as DateDataMarkers>::RangeSkel as CalMarkers<ErasedPackedRangePatterns>>::Japanese>
+        + DataProvider<<<FSet::D as DateDataMarkers>::RangeSkel as CalMarkers<ErasedPackedRangePatterns>>::Persian>
+        + DataProvider<<<FSet::D as DateDataMarkers>::RangeSkel as CalMarkers<ErasedPackedRangePatterns>>::Roc>
+        + DataProvider<<FSet::T as TimeMarkers>::TimeRangeSkeletonPatternsV1>
+        + DataProvider<DatetimePatternsRangeGlueV1>,
 {
 }
 
@@ -529,6 +616,7 @@ impl DateInputMarkers for () {
 
 impl<C> TypedDateDataMarkers<C> for () {
     type DateSkeletonPatternsV1 = NeverMarker<PackedPatterns<'static>>;
+    type DateRangeSkeletonPatternsV1 = NeverMarker<PackedRangePatterns<'static>>;
     type YearNamesV1 = NeverMarker<YearNames<'static>>;
     type MonthNamesV1 = NeverMarker<MonthNames<'static>>;
     type WeekdayNamesV1 = NeverMarker<WeekdayNames<'static>>;
@@ -536,6 +624,7 @@ impl<C> TypedDateDataMarkers<C> for () {
 
 impl DateDataMarkers for () {
     type Skel = NoDataCalMarkers;
+    type RangeSkel = NoDataCalMarkers;
     type Year = NoDataCalMarkers;
     type Month = NoDataCalMarkers;
     type WeekdayNamesV1 = NeverMarker<WeekdayNames<'static>>;
@@ -547,6 +636,7 @@ impl TimeMarkers for () {
     type SecondInput = ();
     type NanosecondInput = ();
     type TimeSkeletonPatternsV1 = NeverMarker<PackedPatterns<'static>>;
+    type TimeRangeSkeletonPatternsV1 = NeverMarker<PackedRangePatterns<'static>>;
     type DayPeriodNamesV1 = NeverMarker<DayPeriodNames<'static>>;
 }
 
@@ -567,6 +657,7 @@ impl ZoneMarkers for () {
     type MetazonePeriodV1 = NeverMarker<tz::MzPeriod<'static>>;
 }
 
+#[allow(unused_macro_rules)]
 macro_rules! datetime_marker_helper {
     (@years/typed, yes) => {
         C::YearNamesV1
@@ -582,6 +673,12 @@ macro_rules! datetime_marker_helper {
     };
     (@dates/typed, yes) => {
         C::SkeletaV1
+    };
+    (@dates/range/typed, yes) => {
+        C::RangeSkeletaV1
+    };
+    (@dates/range/typed,) => {
+        NeverMarker<PackedRangePatterns<'static>>
     };
     (@calmarkers, yes) => {
         FullDataCalMarkers
@@ -600,6 +697,12 @@ macro_rules! datetime_marker_helper {
     };
     (@times, yes) => {
         DatetimePatternsTimeV1
+    };
+    (@times/range, yes) => {
+        DatetimePatternsRangeTimeV1
+    };
+    (@times/range,) => {
+        NeverMarker<PackedRangePatterns<'static>>
     };
     (@glue, yes) => {
         DatetimePatternsGlueV1

--- a/components/datetime/src/scaffold/fieldset_traits.rs
+++ b/components/datetime/src/scaffold/fieldset_traits.rs
@@ -393,6 +393,7 @@ where
 {
 }
 
+#[rustfmt::skip]
 impl<T, FSet> AllAnyCalendarPatternDataMarkers<FSet> for T
 where
     FSet: DateTimeMarkers,
@@ -400,31 +401,20 @@ where
     FSet::T: TimeMarkers,
     FSet::Z: ZoneMarkers,
     T: ?Sized
-        + DataProvider<
-            <<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Buddhist,
-        > + DataProvider<
-            <<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Chinese,
-        > + DataProvider<
-            <<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Coptic,
-        > + DataProvider<
-            <<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Dangi,
-        > + DataProvider<
-            <<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Ethiopian,
-        > + DataProvider<
-            <<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Gregorian,
-        > + DataProvider<
-            <<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Hebrew,
-        > + DataProvider<
-            <<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Indian,
-        > + DataProvider<
-            <<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Hijri,
-        > + DataProvider<
-            <<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Japanese,
-        > + DataProvider<
-            <<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Persian,
-        > + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Roc>
+        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Buddhist>
+        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Chinese>
+        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Coptic>
+        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Dangi>
+        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Ethiopian>
+        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Gregorian>
+        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Hebrew>
+        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Indian>
+        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Hijri>
+        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Japanese>
+        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Persian>
+        + DataProvider<<<FSet::D as DateDataMarkers>::Skel as CalMarkers<ErasedPackedPatterns>>::Roc>
         + DataProvider<<FSet::T as TimeMarkers>::TimeSkeletonPatternsV1>
-        + DataProvider<FSet::GluePatternV1>,
+        + DataProvider<FSet::GluePatternV1>
 {
 }
 

--- a/components/datetime/src/scaffold/fieldset_traits.rs
+++ b/components/datetime/src/scaffold/fieldset_traits.rs
@@ -656,7 +656,6 @@ impl ZoneMarkers for () {
     type MetazonePeriodV1 = NeverMarker<tz::MzPeriod<'static>>;
 }
 
-#[allow(unused_macro_rules)]
 macro_rules! datetime_marker_helper {
     (@years/typed, yes) => {
         C::YearNamesV1
@@ -675,9 +674,6 @@ macro_rules! datetime_marker_helper {
     };
     (@dates/range/typed, yes) => {
         C::RangeSkeletaV1
-    };
-    (@dates/range/typed,) => {
-        NeverMarker<PackedRangePatterns<'static>>
     };
     (@calmarkers, yes) => {
         FullDataCalMarkers
@@ -699,9 +695,6 @@ macro_rules! datetime_marker_helper {
     };
     (@times/range, yes) => {
         DatetimePatternsRangeTimeV1
-    };
-    (@times/range,) => {
-        NeverMarker<PackedRangePatterns<'static>>
     };
     (@glue, yes) => {
         DatetimePatternsGlueV1

--- a/components/datetime/tests/hijri_iran.rs
+++ b/components/datetime/tests/hijri_iran.rs
@@ -108,6 +108,8 @@ impl icu_datetime::scaffold::FormattableHijriRules for IranSighting {
         <hijri::TabularAlgorithm as icu_datetime::scaffold::FormattableHijriRules>::YearNamesV1;
     type SkeletaV1 =
         <hijri::TabularAlgorithm as icu_datetime::scaffold::FormattableHijriRules>::SkeletaV1;
+    type RangeSkeletaV1 =
+        <hijri::TabularAlgorithm as icu_datetime::scaffold::FormattableHijriRules>::RangeSkeletaV1;
 }
 
 #[test]


### PR DESCRIPTION
Part of #5448

Split out of #8149

This hooks up the scaffolding and pattern selection data loading framework for range formatting.

You can see #8149 to understand how this is used: I'm trying to keep this work in smaller PRs as much as possible and at this point more of it is "land APIs that will be useful later" which is harder to holistically review but overall the code here is still pretty straightforward so it should be fine.

## Changelog

icu_datetime: Add scaffolding for range formatting
  - New associated type: `TypedDateDataMarkers::RangeSkel`