### PR TITLE
Restrict Greek case logic to certain Unicode blocks

### DIFF
--- a/components/casemap/tests/gen_greek_to_me.rs
+++ b/components/casemap/tests/gen_greek_to_me.rs
@@ -6,7 +6,6 @@ use icu_casemap::CaseMapper;
 use icu_casemap::greek_to_me::{
     self, GreekDiacritics, GreekPrecomposedLetterData, GreekVowel, PackedGreekPrecomposedLetterData,
 };
-use icu_locale_core::LanguageIdentifier;
 use icu_normalizer::DecomposingNormalizerBorrowed;
 use icu_properties::{
     CodePointMapData,
@@ -15,154 +14,111 @@ use icu_properties::{
 use std::collections::BTreeMap;
 use std::fmt::Write;
 
+include!("../src/greek_to_me/data.rs");
+
 fn main() {
-    let decomposer = DecomposingNormalizerBorrowed::new_nfd();
-    let script = CodePointMapData::<Script>::new();
-    let gc = CodePointMapData::<GeneralCategory>::new();
-    let cm = CaseMapper::new();
+    fn greek_precomposed_letter_data(ch: char) -> u8 {
+        let decomposer = DecomposingNormalizerBorrowed::new_nfd();
+        let sc = CodePointMapData::<Script>::new();
+        let gc = CodePointMapData::<GeneralCategory>::new();
+        let cm = CaseMapper::new();
 
-    let mut vec_370 = vec![0; 0x400 - 0x370];
-    let mut vec_1f00 = vec![0; 0x100];
-    let mut extras = BTreeMap::new();
+        if sc.get(ch) != Script::Greek || !GeneralCategoryGroup::Letter.contains(gc.get(ch)) {
+            return 0;
+        }
 
-    // Loop over all codepoints
-    for range in script.iter_ranges_for_value(Script::Greek) {
-        for ch in range {
-            if let Ok(ch) = char::try_from(ch) {
-                if !GeneralCategoryGroup::Letter.contains(gc.get(ch))
-                    || !matches!(ch,
-                        // Greek_And_Coptic
-                        '\u{0370}'..='\u{03FF}' |
-                        // Greek_Extended
-                        '\u{1F00}'..='\u{1FFF}' |
-                        // Letterlike_Symbols
-                        '\u{2100}'..='\u{214F}'
-                    )
-                {
-                    continue;
-                }
-                let mut buf = [0u8; 4];
-                let nfd = decomposer.normalize_utf8(ch.encode_utf8(&mut buf).as_bytes());
-                let mut data: Option<GreekPrecomposedLetterData> = None;
+        let mut nfd = decomposer.normalize_iter([ch].into_iter());
 
-                for nfd_ch in nfd.chars() {
-                    match nfd_ch {
-                        // accented: [:toNFD=/[\u0300\u0301\u0342\u0302\u0303\u0311]/:]&[:Grek:]&[:L:] (from the JSPs: toNFD is an extension).
-                        greek_to_me::diacritics!(ACCENTS) => {
-                            if let Some(GreekPrecomposedLetterData::Vowel(_, ref mut diacritics)) =
-                                data
-                            {
-                                diacritics.accented = true;
-                            } else {
-                                panic!(
-                                    "Found character {ch} that has diacritics but is not a Greek vowel"
-                                );
-                            }
-                        }
-                        // dialytika: [:toNFD=/[\u0308]/:]&[:Grek:]&[:L:] (from the JSPs: toNFD is an extension).
-                        greek_to_me::diacritics!(DIALYTIKA) => {
-                            if let Some(GreekPrecomposedLetterData::Vowel(_, ref mut diacritics)) =
-                                data
-                            {
-                                diacritics.dialytika = true;
-                            } else {
-                                panic!(
-                                    "Found character {ch} that has diacritics but is not a Greek vowel"
-                                );
-                            }
-                        }
-                        // precomposed_ypogegrammeni [:toNFD=/[\u0345]/:]&[:Grek:]&[:L:] (from the JSPs: toNFD is an extension).
-                        greek_to_me::diacritics!(YPOGEGRAMMENI) => {
-                            if let Some(GreekPrecomposedLetterData::Vowel(_, ref mut diacritics)) =
-                                data
-                            {
-                                diacritics.ypogegrammeni = true;
-                            } else {
-                                panic!(
-                                    "Found character {ch} that has diacritics but is not a Greek vowel"
-                                );
-                            }
-                        }
-                        greek_to_me::diacritics!(BREATHING_AND_LENGTH)
-                        | greek_to_me::diacritics!(ACCENTS) => {
-                            // Rho takes breathing marks but other consonants should not
-                            if let Some(GreekPrecomposedLetterData::Consonant(false)) = data {
-                                panic!(
-                                    "Found character {ch} that has diacritics but is not a Greek vowel"
-                                );
-                            }
-                        }
-                        // caps: [[:Grek:]&[:L:]] . NFD, remove non-letters, uppercase
-                        letter if GeneralCategoryGroup::Letter.contains(gc.get(letter)) => {
-                            let uppercased = cm
-                                .uppercase_to_string(
-                                    letter.encode_utf8(&mut [0; 4]),
-                                    &LanguageIdentifier::UNKNOWN,
-                                )
-                                .into_owned();
-                            let mut iter = uppercased.chars();
-                            let uppercased = iter.next().unwrap();
-                            assert!(
-                                iter.next().is_none(),
-                                "{letter} Should uppercase to a single letter char, instead uppercased to {uppercased:?}"
-                            );
+        let letter = nfd.next().unwrap();
+        assert!(GeneralCategoryGroup::Letter.contains(gc.get(letter)));
+        let letter = cm.simple_uppercase(letter);
 
-                            if let Ok(vowel) = GreekVowel::try_from(uppercased) {
-                                data = Some(GreekPrecomposedLetterData::Vowel(
-                                    vowel,
-                                    GreekDiacritics::default(),
-                                ))
-                            } else {
-                                let is_rho = uppercased == greek_to_me::CAPITAL_RHO;
-                                data = Some(GreekPrecomposedLetterData::Consonant(is_rho))
-                            };
-                        }
-                        _ => (),
-                    }
-                }
-
-                if let Some(data) = data {
-                    let packed = PackedGreekPrecomposedLetterData::from(data);
-                    assert_eq!(
-                        Ok(data),
-                        packed.try_into(),
-                        "packed data for {ch} ({packed:?}) must roundtrip!"
-                    );
-                    let ch_i = ch as usize;
-                    if (0x370..=0x3FF).contains(&ch_i) {
-                        vec_370[ch_i - 0x370] = packed.0;
-                    } else if (0x1f00..0x1fff).contains(&ch_i) {
-                        vec_1f00[ch_i - 0x1f00] = packed.0;
-                    } else {
-                        extras.insert(ch, packed.0);
-                    }
+        let data = if let Ok(vowel) = GreekVowel::try_from(letter) {
+            let mut diacritics = GreekDiacritics::default();
+            for diacritic in nfd {
+                match diacritic {
+                    greek_to_me::diacritics!(ACCENTS) => diacritics.accented = true,
+                    greek_to_me::diacritics!(DIALYTIKA) => diacritics.dialytika = true,
+                    greek_to_me::diacritics!(YPOGEGRAMMENI) => diacritics.ypogegrammeni = true,
+                    greek_to_me::diacritics!(BREATHING_AND_LENGTH) => {}
+                    _ => panic!("Unhandled vowel diacritic {diacritic:?}"),
                 }
             }
+            GreekPrecomposedLetterData::Vowel(vowel, diacritics)
+        } else {
+            let is_rho = letter == greek_to_me::CAPITAL_RHO;
+            for diacritic in nfd {
+                match diacritic {
+                    // Rho takes breathing marks but other consonants should not
+                    greek_to_me::diacritics!(BREATHING_AND_LENGTH) if is_rho => {}
+                    _ => panic!("Unhandled consonant diacritic {diacritic:?}"),
+                }
+            }
+            GreekPrecomposedLetterData::Consonant(is_rho)
+        };
+
+        let packed = PackedGreekPrecomposedLetterData::from(data);
+        assert_eq!(
+            Ok(data),
+            packed.try_into(),
+            "packed data for {ch} ({packed:?}) must roundtrip!"
+        );
+        packed.0
+    }
+
+    // Greek_And_Coptic block (U+0370..U+03FF)
+    let vec_370 = ('\u{0370}'..='\u{03FF}')
+        .map(greek_precomposed_letter_data)
+        .collect::<Vec<_>>();
+
+    // Greek_Extended block (U+1F00..U+1FFF)
+    let vec_1f00 = ('\u{1F00}'..='\u{1FFF}')
+        .map(greek_precomposed_letter_data)
+        .collect::<Vec<_>>();
+
+    // All characters that canonically decompose to a single Greek letter but are not in the Greek blocks.
+    let mut extras = BTreeMap::new();
+    for ch in (0..=char::MAX as u32).filter_map(char::from_u32) {
+        if matches!(ch, '\u{0370}'..='\u{03FF}' | '\u{1F00}'..='\u{1FFF}') {
+            continue;
+        }
+
+        let mut nfd = DecomposingNormalizerBorrowed::new_nfd().normalize_iter([ch].into_iter());
+
+        if let (Some(c @ ('\u{0370}'..='\u{03FF}' | '\u{1F00}'..='\u{1FFF}')), None) =
+            (nfd.next(), nfd.next())
+        {
+            let c_i = c as usize;
+
+            extras.insert(
+                ch,
+                if c_i <= 0x3FF {
+                    vec_370[c_i - 0x370]
+                } else {
+                    vec_1f00[c_i - 0x1f00]
+                },
+            );
         }
     }
 
-    vec_370.truncate(
-        vec_370
-            .iter()
-            .rposition(|x| *x != 0)
-            .expect("must have some greek data")
-            + 1,
-    );
-    vec_1f00.truncate(
-        vec_1f00
-            .iter()
-            .rposition(|x| *x != 0)
-            .expect("must have some greek data")
-            + 1,
-    );
+    let vec_370 = &vec_370[..vec_370.iter().rposition(|&x| x != 0).unwrap() + 1];
+    let vec_1f00 = &vec_1f00[..vec_1f00.iter().rposition(|&x| x != 0).unwrap() + 1];
 
-    let mut others = String::new();
-    for (ch, data) in extras {
-        writeln!(&mut others, "        {ch:?} => {data},").unwrap();
-    }
+    let matches = DATA_370 == vec_370
+        && DATA_1F00 == vec_1f00
+        && (0..=char::MAX as u32)
+            .filter_map(char::from_u32)
+            .all(|ch| match_extras(ch) == extras.get(&ch).copied());
 
-    let output = format!(
-        r#"// This file is part of ICU4X. For terms of use, please see the file
+    if !matches {
+        let mut others = String::new();
+        for (&ch, &data) in &extras {
+            writeln!(&mut others, "        {ch:?} => {data},").unwrap();
+        }
+        println!(
+            r#"Please copy the following file to src/greek_to_me/data.rs:
+========================================================
+// This file is part of ICU4X. For terms of use, please see the file
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
@@ -184,32 +140,9 @@ pub(crate) fn match_extras(ch: char) -> Option<u8> {{
         _ => return None
     }})
 }}
-"#,
-        vec_370.len(),
-        vec_1f00.len(),
-    );
-
-    let local = include_str!("../src/greek_to_me/data.rs");
-
-    // We cannot just check if the two are unequal because on Windows core.autocrlf
-    // may have messed with the line endings on the file, or it may have not (either
-    // due to a changed setting, or due to the code being in a cargo cache/vendor. We also
-    // cannot fix this by passing `--config newline_style=unix` to rustfmt. We must
-    // perform a `\r`-agnostic comparison.
-    //
-    // (technically this should only catch `\r\n` and not just `\r` but for a golden
-    // test on rustfmt output it does not matter)
-    if local
-        .trim()
-        .chars()
-        .filter(|&x| x != '\r')
-        .ne(output.trim().chars().filter(|&x| x != '\r'))
-    {
-        println!(
-            r#"Please copy the following file to src/greek_to_me/data.rs:
-========================================================
-{output}
-========================================================"#
+========================================================"#,
+            vec_370.len(),
+            vec_1f00.len(),
         );
 
         panic!(

--- a/components/casemap/tests/gen_greek_to_me.rs
+++ b/components/casemap/tests/gen_greek_to_me.rs
@@ -29,7 +29,16 @@ fn main() {
     for range in script.iter_ranges_for_value(Script::Greek) {
         for ch in range {
             if let Ok(ch) = char::try_from(ch) {
-                if !GeneralCategoryGroup::Letter.contains(gc.get(ch)) {
+                if !GeneralCategoryGroup::Letter.contains(gc.get(ch))
+                    || !matches!(ch,
+                        // Greek_And_Coptic
+                        '\u{0370}'..='\u{03FF}' |
+                        // Greek_Extended
+                        '\u{1F00}'..='\u{1FFF}' |
+                        // Letterlike_Symbols
+                        '\u{2100}'..='\u{214F}'
+                    )
+                {
                     continue;
                 }
                 let mut buf = [0u8; 4];
@@ -83,9 +92,7 @@ fn main() {
                                 );
                             }
                         }
-                        // Ignore all small letters
-                        '\u{1D00}'..='\u{1DBF}' | '\u{AB65}' => (),
-                        // caps: [[:Grek:]&[:L:]-[\u1D00-\u1DBF\uAB65]] . NFD, remove non-letters, uppercase
+                        // caps: [[:Grek:]&[:L:]] . NFD, remove non-letters, uppercase
                         letter if GeneralCategoryGroup::Letter.contains(gc.get(letter)) => {
                             let uppercased = cm
                                 .uppercase_to_string(
@@ -151,7 +158,7 @@ fn main() {
 
     let mut others = String::new();
     for (ch, data) in extras {
-        writeln!(&mut others, "        '{ch}' => {data},").unwrap();
+        writeln!(&mut others, "        {ch:?} => {data},").unwrap();
     }
 
     let output = format!(


### PR DESCRIPTION
This replaces the hardcoded exclusion ranges `'\u{1D00}'..='\u{1DBF}' | '\u{AB65}'` by more future-proof inclusions by block. This is needed for Unicode 18.

## Changelog

N/A