### PR TITLE
Skip building if code assets are disabled

### DIFF
--- a/ffi/dart/hook/build.dart
+++ b/ffi/dart/hook/build.dart
@@ -11,6 +11,10 @@ import 'package:icu4x/src/hook_helpers/hashes.dart' show fileHashes, version;
 
 void main(List<String> args) async {
   await build(args, (input, output) async {
+    if (!input.config.buildCodeAssets) {
+      print('Building code assets is disabled in this run, skipping build.');
+      return;
+    }
     BuildOptions buildOptions;
     try {
       buildOptions = BuildOptions.fromDefines(input.userDefines);
@@ -94,6 +98,11 @@ class BuildOptions {
       localPath: defines.path('localPath'),
       checkoutPath: defines.path('checkoutPath'),
     );
+  }
+
+  @override
+  String toString() {
+    return 'BuildOptions(buildMode: $buildMode, localPath: $localPath, checkoutPath: $checkoutPath)';
   }
 }
 


### PR DESCRIPTION
As Flutter will re-run the build hooks multiple times, once with data, once with code assets, etc.

We only need to act on code assets.

## Changelog

FFI: 
  * Dart: in the build hook, skip building if code assets are disabled.