### PR TITLE
Fix grapheme iterator desync when dictionary segmenter rewinds (#7888)

### DIFF
--- a/components/segmenter/src/complex/dictionary.rs
+++ b/components/segmenter/src/complex/dictionary.rs
@@ -60,13 +60,14 @@ impl<Y: RuleBreakType> Iterator for DictionaryBreakIterator<'_, '_, Y> {
                     }
 
                     intermediate_length = next.0 + Y::char_len(next.1);
-                    previous_match = Some(self.iter.clone());
+                    previous_match = Some((self.iter.clone(), self.grapheme_iter.clone_internal()));
                 }
                 TrieResult::NoMatch => {
                     if intermediate_length > 0 {
-                        if let Some(previous_match) = previous_match {
+                        if let Some((prev_iter, prev_grapheme_iter)) = previous_match {
                             // Rewind previous match point
-                            self.iter = previous_match;
+                            self.iter = prev_iter;
+                            self.grapheme_iter = prev_grapheme_iter;
                         }
                         return Some(intermediate_length);
                     }
@@ -239,5 +240,35 @@ mod tests {
         let s_utf16: Vec<u16> = s.encode_utf16().collect();
         let r: Vec<usize> = segmenter.segment_utf16(&s_utf16).collect();
         assert_eq!(r, vec![0, 4, 7, 11, 14, 18, 21]);
+    }
+
+    #[test]
+    fn test_dictionary_grapheme_rewind() {
+        let response: DataResponse<SegmenterDictionaryAutoV1> = Baked
+            .load(DataRequest {
+                id: DataIdentifierBorrowed::for_marker_attributes(
+                    DataMarkerAttributes::from_str_or_panic("cjdict"),
+                ),
+                ..Default::default()
+            })
+            .unwrap();
+        let dict_segmenter =
+            DictionarySegmenter::new(response.payload.get(), GraphemeClusterSegmenter::new());
+
+        // Test that grapheme_iter is correctly rewound when trie traversal backtracks.
+        // In "エディターエディター":
+        // 1. "エディター" (15 bytes) is matched as an Intermediate dictionary word at byte 15.
+        // 2. Trie traversal continues exploring whether the compound prefix "エディターエディ..."
+        //    forms a longer dictionary word, advancing grapheme_iter past byte 15 in the process.
+        // 3. When trie traversal eventually hits NoMatch, self.iter rewinds to the last match
+        //    at byte 15.
+        // 4. Without rewinding grapheme_iter alongside self.iter, on the next call to next()
+        //    (starting from byte 15), grapheme_iter is already positioned ahead of byte 15.
+        //    When the second word's prefix "エディ" hits an Intermediate match at byte 24,
+        //    the grapheme boundary check fails because grapheme_iter skips past 24, causing
+        //    incorrect segmentation.
+        let s = "エディターエディター";
+        let result: Vec<usize> = dict_segmenter.segment_str(s).collect();
+        assert_eq!(result, vec![15, 30]);
     }
 }

--- a/components/segmenter/src/grapheme.rs
+++ b/components/segmenter/src/grapheme.rs
@@ -35,6 +35,23 @@ pub(crate) enum GraphemeClusterBreakIteratorInner<'data, 's, Y: RuleBreakType> {
     Neo(crate::neo::RuleBreakIterator<'data, 's, Y, crate::neo::NoComplexHandler>),
 }
 
+impl<'data, 's, Y: RuleBreakType> Clone for GraphemeClusterBreakIteratorInner<'data, 's, Y> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Legacy(iter) => Self::Legacy(iter.clone()),
+            #[cfg(feature = "unstable")]
+            Self::Neo(iter) => Self::Neo(iter.clone()),
+        }
+    }
+}
+
+impl<'data, 's, Y: RuleBreakType> GraphemeClusterBreakIterator<'data, 's, Y> {
+    /// TODO(#8196): do we want to expose clone on this?
+    pub(crate) fn clone_internal(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
 impl<Y: RuleBreakType> Iterator for GraphemeClusterBreakIterator<'_, '_, Y> {
     type Item = usize;
     #[inline]

--- a/components/segmenter/src/grapheme.rs
+++ b/components/segmenter/src/grapheme.rs
@@ -35,20 +35,37 @@ pub(crate) enum GraphemeClusterBreakIteratorInner<'data, 's, Y: RuleBreakType> {
     Neo(crate::neo::RuleBreakIterator<'data, 's, Y, crate::neo::NoComplexHandler>),
 }
 
-impl<'data, 's, Y: RuleBreakType> Clone for GraphemeClusterBreakIteratorInner<'data, 's, Y> {
-    fn clone(&self) -> Self {
-        match self {
-            Self::Legacy(iter) => Self::Legacy(iter.clone()),
-            #[cfg(feature = "unstable")]
-            Self::Neo(iter) => Self::Neo(iter.clone()),
-        }
-    }
-}
-
 impl<'data, 's, Y: RuleBreakType> GraphemeClusterBreakIterator<'data, 's, Y> {
     /// TODO(#8196): do we want to expose clone on this?
     pub(crate) fn clone_internal(&self) -> Self {
-        Self(self.0.clone())
+        let inner = match &self.0 {
+            GraphemeClusterBreakIteratorInner::Legacy(iter) => {
+                GraphemeClusterBreakIteratorInner::Legacy(RuleBreakIterator {
+                    iter: iter.iter.clone(),
+                    len: iter.len,
+                    current_pos_data: iter.current_pos_data,
+                    result_cache: iter.result_cache.clone(),
+                    data: iter.data,
+                    complex: iter.complex,
+                    boundary_property: iter.boundary_property,
+                    locale_override: iter.locale_override,
+                    handle_complex: iter.handle_complex,
+                })
+            }
+            #[cfg(feature = "unstable")]
+            GraphemeClusterBreakIteratorInner::Neo(iter) => {
+                GraphemeClusterBreakIteratorInner::Neo(crate::neo::RuleBreakIterator {
+                    data: iter.data,
+                    pseudo_symbol_map: iter.pseudo_symbol_map,
+                    cache: iter.cache.clone(),
+                    lookahead_positions: iter.lookahead_positions.clone(),
+                    remaining_input: iter.remaining_input.clone(),
+                    last_accepting_status: iter.last_accepting_status,
+                    complex: iter.complex,
+                })
+            }
+        };
+        Self(inner)
     }
 }
 

--- a/components/segmenter/src/neo/mod.rs
+++ b/components/segmenter/src/neo/mod.rs
@@ -15,8 +15,8 @@ use smallvec::SmallVec;
 pub(crate) trait ComplexHandler<Y: RuleBreakType> {
     const BREAK_STATUS: u8;
     const BREAK_AT_BOUNDARIES: bool;
-    type Cache: smallvec::Array<Item = usize>;
-    type ComplexPayloads<'s>: core::fmt::Debug;
+    type Cache: smallvec::Array<Item = usize> + Clone;
+    type ComplexPayloads<'s>: core::fmt::Debug + Clone;
     type ComplexPayload<'s>: core::fmt::Debug;
 
     fn select<'data>(
@@ -132,6 +132,22 @@ pub(crate) struct RuleBreakIterator<'data, 's, Y: RuleBreakType, C: ComplexHandl
     remaining_input: Y::IterAttr<'s>,
     last_accepting_status: u8,
     complex: Option<C::ComplexPayloads<'data>>,
+}
+
+impl<'data, 's, Y: RuleBreakType, C: ComplexHandler<Y>> Clone
+    for RuleBreakIterator<'data, 's, Y, C>
+{
+    fn clone(&self) -> Self {
+        Self {
+            data: self.data,
+            pseudo_symbol_map: self.pseudo_symbol_map,
+            cache: self.cache.clone(),
+            lookahead_positions: self.lookahead_positions.clone(),
+            remaining_input: self.remaining_input.clone(),
+            last_accepting_status: self.last_accepting_status,
+            complex: self.complex.clone(),
+        }
+    }
 }
 
 #[test]

--- a/components/segmenter/src/neo/mod.rs
+++ b/components/segmenter/src/neo/mod.rs
@@ -15,8 +15,8 @@ use smallvec::SmallVec;
 pub(crate) trait ComplexHandler<Y: RuleBreakType> {
     const BREAK_STATUS: u8;
     const BREAK_AT_BOUNDARIES: bool;
-    type Cache: smallvec::Array<Item = usize> + Clone;
-    type ComplexPayloads<'s>: core::fmt::Debug + Clone;
+    type Cache: smallvec::Array<Item = usize>;
+    type ComplexPayloads<'s>: core::fmt::Debug;
     type ComplexPayload<'s>: core::fmt::Debug;
 
     fn select<'data>(
@@ -124,30 +124,14 @@ impl<Y: RuleBreakType> ComplexHandler<Y> for ComplexWord<Y> {
 /// For examples of use, see [`LineSegmenter`].
 #[derive(Debug)]
 pub(crate) struct RuleBreakIterator<'data, 's, Y: RuleBreakType, C: ComplexHandler<Y> + ?Sized> {
-    data: &'data SegmenterStateMachine<'data>,
-    pseudo_symbol_map: &'data zerovec::ZeroVec<'data, (Symbol, ComplexScript)>,
+    pub(crate) data: &'data SegmenterStateMachine<'data>,
+    pub(crate) pseudo_symbol_map: &'data zerovec::ZeroVec<'data, (Symbol, ComplexScript)>,
     // We use `IntoIter` so that we can pop from the front in O(1) time.
-    cache: smallvec::IntoIter<C::Cache>,
-    lookahead_positions: SmallVec<[Option<Y::IterAttr<'s>>; 1]>,
-    remaining_input: Y::IterAttr<'s>,
-    last_accepting_status: u8,
-    complex: Option<C::ComplexPayloads<'data>>,
-}
-
-impl<'data, 's, Y: RuleBreakType, C: ComplexHandler<Y>> Clone
-    for RuleBreakIterator<'data, 's, Y, C>
-{
-    fn clone(&self) -> Self {
-        Self {
-            data: self.data,
-            pseudo_symbol_map: self.pseudo_symbol_map,
-            cache: self.cache.clone(),
-            lookahead_positions: self.lookahead_positions.clone(),
-            remaining_input: self.remaining_input.clone(),
-            last_accepting_status: self.last_accepting_status,
-            complex: self.complex.clone(),
-        }
-    }
+    pub(crate) cache: smallvec::IntoIter<C::Cache>,
+    pub(crate) lookahead_positions: SmallVec<[Option<Y::IterAttr<'s>>; 1]>,
+    pub(crate) remaining_input: Y::IterAttr<'s>,
+    pub(crate) last_accepting_status: u8,
+    pub(crate) complex: Option<C::ComplexPayloads<'data>>,
 }
 
 #[test]

--- a/components/segmenter/src/rule_segmenter.rs
+++ b/components/segmenter/src/rule_segmenter.rs
@@ -35,7 +35,7 @@ pub trait RuleBreakType: crate::private::Sealed + Sized {
 
     #[doc(hidden)]
     #[cfg(feature = "unstable")]
-    type ComplexPayloads<'data>: core::fmt::Debug;
+    type ComplexPayloads<'data>: core::fmt::Debug + Clone;
     #[doc(hidden)]
     #[cfg(feature = "unstable")]
     type ComplexPayload<'data>: core::fmt::Debug;
@@ -91,6 +91,22 @@ pub struct RuleBreakIterator<'data, 's, Y: RuleBreakType> {
     // Should return None if there is no complex script handling
     pub(crate) handle_complex:
         fn(&mut RuleBreakIterator<'data, 's, Y>, Y::CharType) -> Option<usize>,
+}
+
+impl<'data, 's, Y: RuleBreakType> Clone for RuleBreakIterator<'data, 's, Y> {
+    fn clone(&self) -> Self {
+        Self {
+            iter: self.iter.clone(),
+            len: self.len,
+            current_pos_data: self.current_pos_data,
+            result_cache: self.result_cache.clone(),
+            data: self.data,
+            complex: self.complex,
+            boundary_property: self.boundary_property,
+            locale_override: self.locale_override,
+            handle_complex: self.handle_complex,
+        }
+    }
 }
 
 pub(crate) fn empty_handle_complex<Y: RuleBreakType>(

--- a/components/segmenter/src/rule_segmenter.rs
+++ b/components/segmenter/src/rule_segmenter.rs
@@ -35,7 +35,7 @@ pub trait RuleBreakType: crate::private::Sealed + Sized {
 
     #[doc(hidden)]
     #[cfg(feature = "unstable")]
-    type ComplexPayloads<'data>: core::fmt::Debug + Clone;
+    type ComplexPayloads<'data>: core::fmt::Debug + Clone + Copy;
     #[doc(hidden)]
     #[cfg(feature = "unstable")]
     type ComplexPayload<'data>: core::fmt::Debug;
@@ -91,22 +91,6 @@ pub struct RuleBreakIterator<'data, 's, Y: RuleBreakType> {
     // Should return None if there is no complex script handling
     pub(crate) handle_complex:
         fn(&mut RuleBreakIterator<'data, 's, Y>, Y::CharType) -> Option<usize>,
-}
-
-impl<'data, 's, Y: RuleBreakType> Clone for RuleBreakIterator<'data, 's, Y> {
-    fn clone(&self) -> Self {
-        Self {
-            iter: self.iter.clone(),
-            len: self.len,
-            current_pos_data: self.current_pos_data,
-            result_cache: self.result_cache.clone(),
-            data: self.data,
-            complex: self.complex,
-            boundary_property: self.boundary_property,
-            locale_override: self.locale_override,
-            handle_complex: self.handle_complex,
-        }
-    }
 }
 
 pub(crate) fn empty_handle_complex<Y: RuleBreakType>(


### PR DESCRIPTION

Sometimes `DictionaryBreakIterator::next()` does a speculative iterator advance, and then "rewinds" when it fails. The current code rewinds the contained iterator but not the contained grapheme iterator. Seems incorrect to me.


This was incidentally discovered by an LLM while I was trying to analyze this code for #7888.



<details><summary>LLM analysis</summary>
When exploring dictionary matches in `DictionaryBreakIterator::next()`, hitting an Intermediate match advances the `grapheme_iter` to check if the match aligns with a grapheme boundary. If subsequent trie traversal fails with NoMatch, self.iter is rewound to the previous match point, but previously `self.grapheme_iter` and `last_grapheme_offset` were not rewound.

This caused grapheme_iter to be out of sync with iter on subsequent next() calls, potentially rejecting valid grapheme boundaries after a backtrack. We implement Clone manually for RuleBreakIterator and GraphemeClusterBreakIterator (avoiding unnecessary Y: Clone bounds) and save/restore the grapheme iterator state alongside iter on backtrack.

Investigation of #7888 confirms there is no `O(n*m)` quadratic behavior between dictionary trie traversal and grapheme boundary checks: grapheme_iter moves monotonically across iterations and trie backtrack distance is bounded by maximum dictionary word length.

</details>

## Changelog

icu_segmenter:
 - Fix rewinding behavior in dictionary segmenter
