### PR TITLE
fix(currency): evaluate plural rules against formatted amount

### DIFF
--- a/components/decimal/src/abstract_formatter.rs
+++ b/components/decimal/src/abstract_formatter.rs
@@ -3,6 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use fixed_decimal::UnsignedDecimal;
+use icu_plurals::PluralOperands;
 use writeable::Writeable;
 
 use crate::{
@@ -15,6 +16,11 @@ pub trait Sealed {}
 /// A trait representing an abstract number formatter.
 ///
 /// This is a building block for more complicated formatters, like currency or units.
+///
+/// <div class="stab unstable">
+/// 🚫 This trait is sealed; it cannot be implemented by user code. If an API requests an item that implements this
+/// trait, please consider using a type from the implementors listed below.
+/// </div>
 pub trait AbstractFormatter: core::fmt::Debug + Sealed {
     #[doc(hidden)]
     type FormattedUnsigned<'a>: Writeable
@@ -30,6 +36,9 @@ pub trait AbstractFormatter: core::fmt::Debug + Sealed {
         value: W,
         sign: fixed_decimal::Sign,
     ) -> FormattedSign<'a, W>;
+
+    #[doc(hidden)]
+    fn plural_operands(value: &Self::FormattedUnsigned<'_>) -> PluralOperands;
 }
 
 impl Sealed for DecimalFormatter {}
@@ -47,6 +56,10 @@ impl AbstractFormatter for DecimalFormatter {
     ) -> FormattedSign<'a, W> {
         self.format_sign(sign, value)
     }
+
+    fn plural_operands(value: &Self::FormattedUnsigned<'_>) -> PluralOperands {
+        value.plural_operands()
+    }
 }
 
 impl Sealed for CompactDecimalFormatter {}
@@ -63,5 +76,9 @@ impl AbstractFormatter for CompactDecimalFormatter {
         sign: fixed_decimal::Sign,
     ) -> FormattedSign<'a, W> {
         self.decimal_formatter.format_sign(sign, value)
+    }
+
+    fn plural_operands(value: &Self::FormattedUnsigned<'_>) -> PluralOperands {
+        value.plural_operands()
     }
 }

--- a/components/decimal/src/compact_formatter.rs
+++ b/components/decimal/src/compact_formatter.rs
@@ -17,7 +17,7 @@ use crate::{
 use alloc::string::String;
 use fixed_decimal::UnsignedDecimal;
 use icu_pattern::{Pattern, SinglePlaceholder};
-use icu_plurals::PluralRules;
+use icu_plurals::{PluralOperands, PluralRules};
 use icu_provider::DataError;
 use icu_provider::{marker::ErasedMarker, prelude::*};
 use writeable::Writeable;
@@ -396,6 +396,7 @@ impl CompactDecimalFormatter {
                     pattern: Some(t.variable.get(1.into(), &self.plural_rules).1),
                     significand: UnsignedDecimal::ONE,
                     decimal_formatter: &self.decimal_formatter,
+                    exponent: next_exponent,
                 };
             }
         }
@@ -420,6 +421,7 @@ impl CompactDecimalFormatter {
                 .multiplied_pow10(-i16::from(exponent))
                 .trimmed_end(),
             decimal_formatter: &self.decimal_formatter,
+            exponent,
         }
     }
 
@@ -608,6 +610,7 @@ pub struct FormattedUnsignedCompactDecimal<'l> {
     pattern: Option<&'l Pattern<SinglePlaceholder>>,
     significand: UnsignedDecimal,
     decimal_formatter: &'l DecimalFormatter,
+    exponent: u8,
 }
 
 impl Writeable for FormattedUnsignedCompactDecimal<'_> {
@@ -618,6 +621,12 @@ impl Writeable for FormattedUnsignedCompactDecimal<'_> {
                 .decimal_formatter
                 .format_unsigned(Cow::Borrowed(&self.significand))])
             .write_to(sink)
+    }
+}
+
+impl FormattedUnsignedCompactDecimal<'_> {
+    pub(crate) fn plural_operands(&self) -> PluralOperands {
+        PluralOperands::from_significand_and_exponent(&self.significand, self.exponent)
     }
 }
 

--- a/components/decimal/src/compact_formatter.rs
+++ b/components/decimal/src/compact_formatter.rs
@@ -636,6 +636,7 @@ mod tests {
     use super::*;
     use crate::options::GroupingStrategy;
     use icu_locale_core::locale;
+    use icu_plurals::PluralElements;
     use writeable::assert_writeable_eq;
 
     #[allow(non_snake_case)]
@@ -699,6 +700,37 @@ mod tests {
             let result10T = formatter.format(&10_000_000_000_000_000i64.into());
             assert_writeable_eq!(result10T, case.expected10T, "{:?}", case);
         }
+    }
+
+    #[test]
+    fn plural() {
+        let decimal = DecimalFormatter::try_new(locale!("fr").into(), Default::default()).unwrap();
+        let decimal = decimal.format_unsigned(Cow::Owned(999_999u64.into()));
+
+        let compact =
+            CompactDecimalFormatter::try_new_short(locale!("fr").into(), Default::default())
+                .unwrap();
+        let compact = compact.format_unsigned(&999_999u64.into());
+
+        let dollars = PluralElements::new("dollars US")
+            .with_one_value(Some("dollar US"))
+            .with_many_value(Some("de dollars US"));
+
+        assert_eq!(
+            *dollars.get(
+                decimal.plural_operands(),
+                &PluralRules::try_new(locale!("fr").into(), Default::default()).unwrap()
+            ),
+            "dollars US"
+        );
+
+        assert_eq!(
+            *dollars.get(
+                compact.plural_operands(),
+                &PluralRules::try_new(locale!("fr").into(), Default::default()).unwrap()
+            ),
+            "de dollars US"
+        );
     }
 
     #[test]

--- a/components/decimal/src/decimal_formatter.rs
+++ b/components/decimal/src/decimal_formatter.rs
@@ -4,6 +4,8 @@
 
 use super::Cow;
 use core::fmt::Write;
+#[cfg(feature = "unstable")]
+use icu_plurals::PluralOperands;
 use writeable::Part;
 
 use crate::DecimalFormatterPreferences;
@@ -172,6 +174,13 @@ pub struct FormattedUnsignedDecimal<'l> {
     pub(crate) options: &'l DecimalFormatterOptions,
     pub(crate) symbols: &'l DecimalSymbols<'l>,
     pub(crate) digits: &'l [char; 10],
+}
+
+impl FormattedUnsignedDecimal<'_> {
+    #[cfg(feature = "unstable")]
+    pub(crate) fn plural_operands(&self) -> PluralOperands {
+        PluralOperands::from_significand_and_exponent(&self.value, 0)
+    }
 }
 
 #[doc(hidden)] // TODO(#3647): should be private

--- a/components/experimental/src/dimension/currency/formatter.rs
+++ b/components/experimental/src/dimension/currency/formatter.rs
@@ -458,7 +458,7 @@ impl<V: AbstractFormatter> CurrencyFormatter<V> {
                 patterns,
                 plural_rules,
             } => {
-                let operands = value.into();
+                let operands = V::plural_operands(&formatted_value);
                 let currency_str = extended.get().display_names.get(operands, plural_rules);
                 let pattern = patterns.get().patterns.get(operands, plural_rules);
                 (pattern, currency_str)

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -1080,6 +1080,20 @@ impl<T> PluralElements<T> {
     }
 
     /// Returns the value for the given [`PluralOperands`] and [`PluralRules`].
+    ///
+    /// # Example
+    /// ```
+    /// use icu::locale::locale;
+    /// use icu::plurals::{PluralCategory, PluralRules, PluralElements};
+    ///
+    /// let rules = PluralRules::try_new_cardinal(locale!("fr").into()).unwrap();
+    ///
+    /// let elements = PluralElements::new("chats").with_one_value(Some("chat"));
+    ///
+    /// assert_eq!(*elements.get(0_usize.into(), &rules), "chat");
+    /// assert_eq!(*elements.get(1_usize.into(), &rules), "chat");
+    /// assert_eq!(*elements.get(12_usize.into(), &rules), "chats");
+    /// ```
     pub fn get<'a>(&'a self, op: PluralOperands, rules: &PluralRules) -> &'a T {
         let category = rules.category_for(op);
 

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -1078,6 +1078,32 @@ impl<T> PluralElements<T> {
     pub fn as_ref(&self) -> PluralElements<&T> {
         PluralElements(self.0.as_ref())
     }
+
+    /// Returns the value for the given [`PluralOperands`] and [`PluralRules`].
+    pub fn get<'a>(&'a self, op: PluralOperands, rules: &PluralRules) -> &'a T {
+        let category = rules.category_for(op);
+
+        if op.is_exactly_zero()
+            && let Some(value) = self.0.explicit_zero.as_ref()
+        {
+            return value;
+        }
+
+        if op.is_exactly_one()
+            && let Some(value) = self.0.explicit_one.as_ref()
+        {
+            return value;
+        }
+
+        match category {
+            PluralCategory::Zero => self.zero(),
+            PluralCategory::One => self.one(),
+            PluralCategory::Two => self.two(),
+            PluralCategory::Few => self.few(),
+            PluralCategory::Many => self.many(),
+            PluralCategory::Other => self.other(),
+        }
+    }
 }
 
 impl<T: PartialEq> PluralElements<T> {

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -1110,13 +1110,14 @@ impl<T> PluralElements<T> {
         }
 
         match category {
-            PluralCategory::Zero => self.zero(),
-            PluralCategory::One => self.one(),
-            PluralCategory::Two => self.two(),
-            PluralCategory::Few => self.few(),
-            PluralCategory::Many => self.many(),
-            PluralCategory::Other => self.other(),
+            PluralCategory::Zero => self.0.zero.as_ref(),
+            PluralCategory::One => self.0.one.as_ref(),
+            PluralCategory::Two => self.0.two.as_ref(),
+            PluralCategory::Few => self.0.few.as_ref(),
+            PluralCategory::Many => self.0.many.as_ref(),
+            PluralCategory::Other => return &self.0.other,
         }
+        .unwrap_or(&self.0.other)
     }
 }
 

--- a/components/plurals/src/operands.rs
+++ b/components/plurals/src/operands.rs
@@ -258,6 +258,7 @@ impl From<u128> for PluralOperands {
 }
 
 impl PluralOperands {
+    #[doc(hidden)] // todo: figure out whether to expose this
     /// Creates a [`PluralOperands`] from a significand and power of ten.
     pub fn from_significand_and_exponent(dec: &UnsignedDecimal, exp: u8) -> PluralOperands {
         let exp_i16 = i16::from(exp);

--- a/components/plurals/src/operands.rs
+++ b/components/plurals/src/operands.rs
@@ -258,7 +258,8 @@ impl From<u128> for PluralOperands {
 }
 
 impl PluralOperands {
-    fn from_significand_and_exponent(dec: &UnsignedDecimal, exp: u8) -> PluralOperands {
+    /// Creates a [`PluralOperands`] from a significand and power of ten.
+    pub fn from_significand_and_exponent(dec: &UnsignedDecimal, exp: u8) -> PluralOperands {
         let exp_i16 = i16::from(exp);
 
         let mag_range = dec.magnitude_range();

--- a/ffi/capi/tests/missing_apis.txt
+++ b/ffi/capi/tests/missing_apis.txt
@@ -24,7 +24,6 @@ icu::collator::CollatorBorrowed::write_sort_key_to#FnInStruct
 icu::collator::CollatorBorrowed::write_sort_key_utf16_to#FnInStruct
 icu::collator::CollatorBorrowed::write_sort_key_utf8_to#FnInStruct
 icu::decimal::FormattedDecimal::write_to#FnInStruct
-icu::plurals::PluralOperands::from_significand_and_exponent#FnInStruct
 icu::segmenter::GraphemeClusterSegmenter::new_neo#FnInStruct
 icu::segmenter::LineSegmenter::new_neo_auto#FnInStruct
 icu::segmenter::LineSegmenter::new_neo_dictionary#FnInStruct

--- a/ffi/capi/tests/missing_apis.txt
+++ b/ffi/capi/tests/missing_apis.txt
@@ -24,6 +24,7 @@ icu::collator::CollatorBorrowed::write_sort_key_to#FnInStruct
 icu::collator::CollatorBorrowed::write_sort_key_utf16_to#FnInStruct
 icu::collator::CollatorBorrowed::write_sort_key_utf8_to#FnInStruct
 icu::decimal::FormattedDecimal::write_to#FnInStruct
+icu::plurals::PluralOperands::from_significand_and_exponent#FnInStruct
 icu::segmenter::GraphemeClusterSegmenter::new_neo#FnInStruct
 icu::segmenter::LineSegmenter::new_neo_auto#FnInStruct
 icu::segmenter::LineSegmenter::new_neo_dictionary#FnInStruct


### PR DESCRIPTION
Currently the currency formatter uses the input `Decimal` to determine the plural category. This is wrong, it needs to use the formatted `FormattedUnsignedDecimal`/`FormattedUnsignedCompactDecimal`. This is because these types might have a different plural category than the `Decimal` they're representing. For example in `fr`, `999_999` has category `other` ("dollars US"), but "1.0 million" has category `many` ("de dollars US").

## Changelog

`icu_plurals`:
* add `PluralElements::get`
