### PR TITLE
Add `libm` for android

### DIFF
--- a/ffi/dart/hook/link.dart
+++ b/ffi/dart/hook/link.dart
@@ -58,13 +58,16 @@ Future<void> main(List<String> args) async {
       packageName: input.packageName,
       assetName: 'src/bindings/lib.g.dart',
       sources: [staticLib.file!.toFilePath()],
-      libraries:
-          // On Windows, icu4x.lib is lacking /DEFAULTLIB directives to advise
-          // the linker on what libraries to link against. To make up for that,
-          // the libraries used have to be provided to the linker explicitly.
-          input.config.code.targetOS == OS.windows
-          ? const ['MSVCRT', 'ws2_32', 'userenv', 'ntdll']
-          : const [],
+      libraries: switch (input.config.code.targetOS) {
+        // On Windows, icu4x.lib is lacking /DEFAULTLIB directives to advise
+        // the linker on what libraries to link against. To make up for that,
+        // the libraries used have to be provided to the linker explicitly.
+        OS.windows => const ['MSVCRT', 'ws2_32', 'userenv', 'ntdll'],
+        // On Android, libm (math library) is not linked by default, but math
+        // functions like `expf` referenced in Rust libicu4x require libm.
+        OS.android => const ['m'],
+        _ => const [],
+      },
       linkerOptions: LinkerOptions.treeshake(symbolsToKeep: usedSymbols),
     ).run(
       input: input,


### PR DESCRIPTION
We should probably have some CI testing for Android. Not sure how to set it up though, or if it's even possible.

## Changelog

FFI:
- Add `libm` as a library input in the Dart linking script for Android.