### PR TITLE
Implement Menu display names feature

### DIFF
--- a/components/experimental/src/displaynames/single/README.md
+++ b/components/experimental/src/displaynames/single/README.md
@@ -20,10 +20,10 @@ classDiagram
     class LanguageIdentifierDisplayNameOwned~M~ {
         -lid: LanguageIdentifier
         -options: LanguageIdentifierDisplayNameOptions
-        +try_new(prefs, options, lid) Self  // Medium
-        +try_new_short(prefs, options, lid) Self
-        +try_new_long(prefs, options, lid) Self
-        +try_new_menu(prefs, options, lid) Self // Only for M = Menu
+        +try_new(prefs, lid, options) Self  // Medium
+        +try_new_short(prefs, lid, options) Self
+        +try_new_long(prefs, lid, options) Self
+        +try_new_menu(prefs, lid, options) Self // Only for M = Menu
         +as_borrowed(&self) LanguageIdentifierDisplayName
     }
     class LanguageIdentifierDisplayName {
@@ -85,10 +85,9 @@ To reflect this, each formatter provides explicit constructors for each supporte
 All owned constructors take their target subtag or `LanguageIdentifier` **by value** because the owned struct needs to store the identifier for fallback purposes, and copying/moving these identifiers is highly efficient in ICU4X (using `TinyStr` under the hood).
 
 *   **`LanguageIdentifierDisplayName` / `LanguageIdentifierDisplayNameOwned<M>`**: Formats a full `LanguageIdentifier` (language, script, region, and variants) into a localized string. It is generic over the display model (Standard/Dialect vs. Menu).
-    *   `LanguageIdentifierDisplayNameOwned::try_new(prefs, options, lid)`: Constructor for **Medium** width (Standard/Dialect).
-    *   `LanguageIdentifierDisplayNameOwned::try_new_short(prefs, options, lid)`: Constructor for **Short** width (Standard/Dialect).
-    *   `LanguageIdentifierDisplayNameOwned::try_new_long(prefs, options, lid)`: Constructor for **Long** width (Standard/Dialect).
-    *   `LanguageIdentifierDisplayNameOwned::try_new_menu(prefs, options, lid)`: Constructor for **Menu** style (Medium width).
+    *   `LanguageIdentifierDisplayNameOwned::try_new(prefs, lid, options)`: Constructor for **Medium** width (Standard/Dialect).
+    *   `LanguageIdentifierDisplayNameOwned::try_new_menu(prefs, lid, options)`: Constructor for **Menu** style (Medium width).
+    *   *(Note: Short and Long constructors for full language identifiers are currently not implemented; see Limitations & Future Work).*
 *   **`RegionDisplayName` / `RegionDisplayNameOwned`**: Formats a single `Region` subtag (e.g., `US` -> "United States").
     *   `RegionDisplayNameOwned::try_new(prefs, subtag)`: Constructor for **Medium** width.
     *   `RegionDisplayNameOwned::try_new_short(prefs, subtag)`: Constructor for **Short** width.
@@ -166,8 +165,8 @@ To support both standard formatting and the specialized Menu style (which requir
 We define a `LanguageIdentifierDisplayNameModel` trait with an associated type `LanguagePayload`. 
 
 We implement this trait for two marker models:
-*   **`models::Standard`**: Used for Standard and Dialect display styles. The `LanguagePayload` is `DataPayloadOr<ErasedDisplayNameMarker, ()>`.
-*   **`models::Menu`**: Used for Menu display style. The `LanguagePayload` is `DataPayload<LocaleNamesLanguageMenuMediumV1>`.
+*   **`models::Standard`**: Used for Standard and Dialect display styles. The `LanguagePayload` is `DataPayloadOr<LocaleNamesLanguageMediumV1, Language>`.
+*   **`models::Menu`**: Used for Menu display style. The `LanguagePayload` is `MenuLanguagePayload`, an enum wrapping either `DataPayload<LocaleNamesLanguageMenuMediumV1>` or a fallback `DataPayloadOr<LocaleNamesLanguageMediumV1, Language>`.
 
 #### 2. The Generic Owned Struct
 `LanguageIdentifierDisplayNameOwned<M>` holds the `LanguageIdentifier`, `LanguageIdentifierDisplayNameOptions`, the generic `language_payload` (determined by `M`), optional `script_payload` and `region_payload` (both using `DataPayloadOr` with `ErasedDisplayNameMarker`), a vector of `variant_payloads` (using `ErasedDisplayNameMarker`), and the `pattern_payload` (using `LocaleNamesEssentialsV1`).
@@ -190,7 +189,7 @@ This struct holds only cheap, borrowed references:
 #### 4. Resolution in `as_borrowed()`
 The differences are resolved in the model-specific implementations of `as_borrowed()`:
 *   For the **`Standard`** model: `base_name` is resolved from `language_payload` (falling back to the raw BCP-47 language subtag if missing), and `menu_extension` is `None`.
-*   For the **`Menu`** model: `base_name` is resolved from `language_payload.get().core`, and `menu_extension` is `Some(language_payload.get().extension)`.
+*   For the **`Menu`** model: if a menu name is present, `base_name` is resolved from `core` and `menu_extension` is `Some(extension)` (if non-empty). If the language has no menu entry in CLDR, it falls back at runtime to loading the Medium width display name, where `menu_extension` is `None`.
 
 #### 5. Zero-Allocation Formatting Pipeline
 In `Writeable::write_to` for `LanguageIdentifierDisplayName<'a>`, we treat `menu_extension` (if present), `script_name`, `region_name`, and the resolved variant names as qualifiers. A stack-allocated `QualifiersWriteable` helper joins them using `locale_separator` directly into the sink, and `icu_pattern::Pattern::interpolate` combines `base_name` and the qualifiers into `locale_pattern` directly into the output sink without any heap allocation.
@@ -228,6 +227,7 @@ As per [CLDR-19336](https://unicode-org.atlassian.net/browse/CLDR-19336), some l
 The following features defined in UTS #35 are currently not supported and are planned for future releases:
 
 1.  **Locale Extension Keywords (UTS #35 §3.2)**: Formatting Unicode extension keys and types (e.g., `-u-ca-gregory` -> "Calendar: Gregorian") using `localeKeyTypePattern`.
+2.  **Short and Long Language Widths**: While Region and Script display names support `try_new_short`, `LanguageIdentifierDisplayNameOwned` currently only implements `try_new` (Medium width) and `try_new_menu`. Support for explicit Short and Long language display widths (`try_new_short` and `try_new_long`) is planned for future releases.
 
 ---
 

--- a/components/experimental/src/displaynames/single/language.rs
+++ b/components/experimental/src/displaynames/single/language.rs
@@ -31,6 +31,93 @@ size_test!(
     184
 );
 
+/// A trait defining the data model for a language display name (Standard vs. Menu).
+pub trait LanguageIdentifierDisplayNameModel {
+    /// The payload storage type for this model.
+    type LanguagePayload: 'static + core::fmt::Debug;
+    /// Extracts the borrowed base name and optional menu extension from the payload.
+    fn as_borrowed<'a>(
+        payload: &'a Self::LanguagePayload,
+    ) -> (NameOrFallback<'a>, Option<NameOrFallback<'a>>);
+}
+
+/// Marker models for language display names.
+pub mod models {
+    /// Model for standard and dialect language display names.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    #[allow(clippy::exhaustive_structs)]
+    pub struct Standard;
+
+    /// Model for menu style language display names.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    #[allow(clippy::exhaustive_structs)]
+    pub struct Menu;
+}
+
+size_test!(
+    LanguageIdentifierDisplayNameOwned<models::Menu>,
+    language_identifier_display_name_owned_menu_size,
+    192
+);
+
+impl LanguageIdentifierDisplayNameModel for models::Standard {
+    type LanguagePayload = DataPayloadOr<LocaleNamesLanguageMediumV1, Language>;
+
+    fn as_borrowed<'a>(
+        payload: &'a Self::LanguagePayload,
+    ) -> (NameOrFallback<'a>, Option<NameOrFallback<'a>>) {
+        (NameOrFallback::from(payload), None)
+    }
+}
+
+/// The payload for menu style language display names, supporting runtime fallback to Medium width.
+pub enum MenuLanguagePayload {
+    /// Loaded menu style display name.
+    Menu(DataPayload<LocaleNamesLanguageMenuMediumV1>),
+    /// Fallback to standard medium display name.
+    Medium(DataPayload<LocaleNamesLanguageMediumV1>),
+    /// Fallback to raw BCP-47 subtag code.
+    Subtag(Language),
+}
+
+impl core::fmt::Debug for MenuLanguagePayload {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Menu(p) => {
+                let parts = p.get();
+                f.debug_struct("Menu")
+                    .field("core", &parts.core())
+                    .field("extension", &parts.extension())
+                    .finish()
+            }
+            Self::Medium(p) => f.debug_tuple("Medium").field(p).finish(),
+            Self::Subtag(subtag) => f.debug_tuple("Subtag").field(subtag).finish(),
+        }
+    }
+}
+
+impl LanguageIdentifierDisplayNameModel for models::Menu {
+    type LanguagePayload = MenuLanguagePayload;
+
+    fn as_borrowed<'a>(
+        payload: &'a Self::LanguagePayload,
+    ) -> (NameOrFallback<'a>, Option<NameOrFallback<'a>>) {
+        match payload {
+            MenuLanguagePayload::Menu(p) => {
+                let parts = p.get();
+                let ext = if parts.extension().is_empty() {
+                    None
+                } else {
+                    Some(NameOrFallback(Ok(parts.extension())))
+                };
+                (NameOrFallback(Ok(parts.core())), ext)
+            }
+            MenuLanguagePayload::Medium(p) => (NameOrFallback(Ok(p.get().as_ref())), None),
+            MenuLanguagePayload::Subtag(subtag) => (NameOrFallback(Err(subtag.as_str())), None),
+        }
+    }
+}
+
 /// A localized display name for a language identifier, owned version.
 ///
 /// The formatter falls back to the BCP-47 subtag when localized display names are missing
@@ -94,11 +181,38 @@ size_test!(
 /// use writeable::assert_writeable_eq;
 /// assert_writeable_eq!(borrowed, "Italian (Qabc, Europe)");
 /// ```
+///
+/// Menu style display names can be loaded using [`LanguageIdentifierDisplayNameOwned::try_new_menu`]:
+///
+/// ```
+/// use icu::experimental::displaynames::{
+///     DisplayNamesPreferences, LanguageIdentifierDisplayNameOptions,
+///     single::{LanguageIdentifierDisplayNameOwned, models},
+/// };
+/// use icu::locale::{locale, langid};
+/// use writeable::assert_try_writeable_eq;
+///
+/// let prefs = DisplayNamesPreferences::from(locale!("en"));
+/// let options = LanguageIdentifierDisplayNameOptions::default();
+/// let display_name: LanguageIdentifierDisplayNameOwned<models::Menu> =
+///     LanguageIdentifierDisplayNameOwned::try_new_menu(
+///         prefs,
+///         langid!("ku"),
+///         options,
+///     )
+///     .expect("Data should load successfully");
+///
+/// assert_try_writeable_eq!(display_name.as_borrowed(), "Kurdish (Kurmanji)", Ok(()));
+/// assert_eq!(display_name.as_borrowed().menu_extension(), Some("Kurmanji"));
+/// ```
 #[doc = language_identifier_display_name_owned_size!()]
 #[derive(Debug)]
-pub struct LanguageIdentifierDisplayNameOwned {
+pub struct LanguageIdentifierDisplayNameOwned<M = models::Standard>
+where
+    M: LanguageIdentifierDisplayNameModel,
+{
     /// Either the language display name or the subtag as fallback
-    language_payload: DataPayloadOr<LocaleNamesLanguageMediumV1, Language>,
+    language_payload: M::LanguagePayload,
     /// Either the script display name, the subtag as fallback, or None if absent
     script_payload: DataPayloadOr<LocaleNamesScriptMediumV1, Option<Script>>,
     /// Either the region display name, the subtag as fallback, or None if absent
@@ -113,7 +227,108 @@ pub struct LanguageIdentifierDisplayNameOwned {
     essentials_payload: DataPayload<LocaleNamesEssentialsV1>,
 }
 
-impl LanguageIdentifierDisplayNameOwned {
+type QualifiersAndEssentials = (
+    DataPayloadOr<LocaleNamesScriptMediumV1, Option<Script>>,
+    DataPayloadOr<LocaleNamesRegionMediumV1, Option<Region>>,
+    DataPayloadOr<
+        LocaleNamesVariantMediumV1,
+        Result<Vec<DataPayloadOr<LocaleNamesVariantMediumV1, Variant>>, Variant>,
+    >,
+    DataPayload<LocaleNamesEssentialsV1>,
+);
+
+fn load_qualifiers_and_essentials<D>(
+    provider: &D,
+    prefs: DisplayNamesPreferences,
+    subject: &LanguageIdentifier,
+    formatting_locale: &DataLocale,
+) -> Result<QualifiersAndEssentials, DataError>
+where
+    D: DataProvider<LocaleNamesScriptMediumV1>
+        + DataProvider<LocaleNamesRegionMediumV1>
+        + DataProvider<LocaleNamesVariantMediumV1>
+        + DataProvider<LocaleNamesEssentialsV1>
+        + ?Sized,
+{
+    // Step 2: Load script name (if present in subject)
+    let script_payload = if let Some(script) = subject.script {
+        match ScriptDisplayNameOwned::try_new_unstable(provider, prefs, script)
+            .allow_identifier_not_found()?
+        {
+            Some(obj) => DataPayloadOr::from_payload(obj.payload),
+            None => DataPayloadOr::from_other(Some(script)),
+        }
+    } else {
+        DataPayloadOr::from_other(None)
+    };
+
+    // Step 3: Load region name (if present in subject)
+    let region_payload = if let Some(region) = subject.region {
+        match RegionDisplayNameOwned::try_new_unstable(provider, prefs, region)
+            .allow_identifier_not_found()?
+        {
+            Some(obj) => DataPayloadOr::from_payload(obj.payload),
+            None => DataPayloadOr::from_other(Some(region)),
+        }
+    } else {
+        DataPayloadOr::from_other(None)
+    };
+
+    // Step 4: Load variant names (if present in subject)
+    let load_variant = |variant: Variant| -> Result<
+        DataPayloadOr<LocaleNamesVariantMediumV1, Variant>,
+        DataError,
+    > {
+        match VariantDisplayNameOwned::try_new_unstable(provider, prefs, variant)
+            .allow_identifier_not_found()?
+        {
+            Some(obj) => Ok(DataPayloadOr::from_payload(obj.payload)),
+            None => Ok(DataPayloadOr::from_other(variant)),
+        }
+    };
+
+    let mut variant_results = subject
+        .variants
+        .iter()
+        .map(|variant| load_variant(*variant));
+
+    let variant_payloads = if let Some(first) = variant_results.next() {
+        if let Some(second) = variant_results.next() {
+            // 2 or more variants
+            let payload_vec = [first, second]
+                .into_iter()
+                .chain(variant_results)
+                .collect::<Result<Vec<_>, _>>()?;
+            DataPayloadOr::from_other(Ok(payload_vec))
+        } else {
+            // 1 variant
+            match first?.into_inner() {
+                Ok(payload) => DataPayloadOr::from_payload(payload),
+                Err(fallback_code) => DataPayloadOr::from_other(Err(fallback_code)),
+            }
+        }
+    } else {
+        // 0 variants
+        DataPayloadOr::from_other(Ok(Vec::new()))
+    };
+
+    // Step 5: Load essentials
+    let essentials_payload = provider
+        .load(DataRequest {
+            id: DataIdentifierBorrowed::for_locale(formatting_locale),
+            ..Default::default()
+        })?
+        .payload;
+
+    Ok((
+        script_payload,
+        region_payload,
+        variant_payloads,
+        essentials_payload,
+    ))
+}
+
+impl LanguageIdentifierDisplayNameOwned<models::Standard> {
     icu_provider::gen_buffer_data_constructors!(
         (prefs: DisplayNamesPreferences, subject: LanguageIdentifier, options: LanguageIdentifierDisplayNameOptions) -> result: Result<Self, DataError>,
         /// Loads the language display name for a given language identifier and locale using compiled data.
@@ -231,75 +446,8 @@ impl LanguageIdentifierDisplayNameOwned {
             }
         };
 
-        // Step 2: Load script name (if present in subject)
-        let script_payload = if let Some(script) = subject.script {
-            match ScriptDisplayNameOwned::try_new_unstable(provider, prefs, script)
-                .allow_identifier_not_found()?
-            {
-                Some(obj) => DataPayloadOr::from_payload(obj.payload),
-                None => DataPayloadOr::from_other(Some(script)),
-            }
-        } else {
-            DataPayloadOr::from_other(None)
-        };
-
-        // Step 3: Load region name (if present in subject)
-        let region_payload = if let Some(region) = subject.region {
-            match RegionDisplayNameOwned::try_new_unstable(provider, prefs, region)
-                .allow_identifier_not_found()?
-            {
-                Some(obj) => DataPayloadOr::from_payload(obj.payload),
-                None => DataPayloadOr::from_other(Some(region)),
-            }
-        } else {
-            DataPayloadOr::from_other(None)
-        };
-
-        // Step 4: Load variant names (if present in subject)
-        let load_variant = |variant: Variant| -> Result<
-            DataPayloadOr<LocaleNamesVariantMediumV1, Variant>,
-            DataError,
-        > {
-            match VariantDisplayNameOwned::try_new_unstable(provider, prefs, variant)
-                .allow_identifier_not_found()?
-            {
-                Some(obj) => Ok(DataPayloadOr::from_payload(obj.payload)),
-                None => Ok(DataPayloadOr::from_other(variant)),
-            }
-        };
-
-        let mut variant_results = subject
-            .variants
-            .iter()
-            .map(|variant| load_variant(*variant));
-
-        let variant_payloads = if let Some(first) = variant_results.next() {
-            if let Some(second) = variant_results.next() {
-                // 2 or more variants
-                let payload_vec = [first, second]
-                    .into_iter()
-                    .chain(variant_results)
-                    .collect::<Result<Vec<_>, _>>()?;
-                DataPayloadOr::from_other(Ok(payload_vec))
-            } else {
-                // 1 variant
-                match first?.into_inner() {
-                    Ok(payload) => DataPayloadOr::from_payload(payload),
-                    Err(fallback_code) => DataPayloadOr::from_other(Err(fallback_code)),
-                }
-            }
-        } else {
-            // 0 variants
-            DataPayloadOr::from_other(Ok(Vec::new()))
-        };
-
-        // Step 5: Load essentials
-        let essentials_payload = provider
-            .load(DataRequest {
-                id: DataIdentifierBorrowed::for_locale(&formatting_locale),
-                ..Default::default()
-            })?
-            .payload;
+        let (script_payload, region_payload, variant_payloads, essentials_payload) =
+            load_qualifiers_and_essentials(provider, prefs, &subject, &formatting_locale)?;
 
         Ok(Self {
             language_payload,
@@ -309,14 +457,152 @@ impl LanguageIdentifierDisplayNameOwned {
             essentials_payload,
         })
     }
+}
 
+impl LanguageIdentifierDisplayNameOwned<models::Menu> {
+    icu_provider::gen_buffer_data_constructors!(
+        (prefs: DisplayNamesPreferences, subject: LanguageIdentifier, options: LanguageIdentifierDisplayNameOptions) -> result: Result<Self, DataError>,
+        /// Loads the menu language display name for a given language identifier and locale using compiled data.
+        functions: [
+            try_new_menu,
+            try_new_menu_with_buffer_provider,
+            try_new_menu_unstable,
+            Self
+        ]
+    );
+
+    #[doc = icu_provider::gen_buffer_unstable_docs!(UNSTABLE, Self::try_new_menu)]
+    #[doc = language_identifier_display_name_owned_menu_size!()]
+    pub fn try_new_menu_unstable<D>(
+        provider: &D,
+        prefs: DisplayNamesPreferences,
+        mut subject: LanguageIdentifier,
+        options: LanguageIdentifierDisplayNameOptions,
+    ) -> Result<Self, DataError>
+    where
+        D: DataProvider<LocaleNamesLanguageMenuMediumV1>
+            + DataProvider<LocaleNamesLanguageMediumV1>
+            + DataProvider<LocaleNamesScriptMediumV1>
+            + DataProvider<LocaleNamesRegionMediumV1>
+            + DataProvider<LocaleNamesVariantMediumV1>
+            + DataProvider<LocaleNamesEssentialsV1>
+            + ?Sized,
+    {
+        let formatting_locale = LocaleNamesLanguageMediumV1::make_locale(prefs.locale_preferences);
+        let mut language_payload = None;
+
+        if options.language_display.unwrap_or_default() == LanguageDisplay::Dialect {
+            for (language, script, region) in [
+                (subject.language, Some(subject.script), Some(subject.region)),
+                (subject.language, Some(subject.script), None),
+                (subject.language, None, Some(subject.region)),
+            ] {
+                let script = match script {
+                    Some(Some(script)) => Some(script),
+                    Some(None) => continue,
+                    None => None,
+                };
+                let region = match region {
+                    Some(Some(region)) => Some(region),
+                    Some(None) => continue,
+                    None => None,
+                };
+                let mut buffer = TinyAsciiStr::EMPTY;
+                let attrs = LocaleNamesLanguageMediumV1::make_attributes(
+                    language,
+                    script,
+                    region,
+                    &mut buffer,
+                );
+                let id = DataIdentifierBorrowed::for_marker_attributes_and_locale(
+                    attrs,
+                    &formatting_locale,
+                );
+                let mut metadata = DataRequestMetadata::default();
+                metadata.silent = true;
+                if let Some(response) = provider
+                    .load(DataRequest { id, metadata })
+                    .allow_identifier_not_found()?
+                {
+                    language_payload = Some(MenuLanguagePayload::Menu(response.payload));
+                    if script.is_some() {
+                        subject.script = None;
+                    }
+                    if region.is_some() {
+                        subject.region = None;
+                    }
+                    break;
+                }
+                if let Some(response) = provider
+                    .load(DataRequest { id, metadata })
+                    .allow_identifier_not_found()?
+                {
+                    language_payload = Some(MenuLanguagePayload::Medium(response.payload));
+                    if script.is_some() {
+                        subject.script = None;
+                    }
+                    if region.is_some() {
+                        subject.region = None;
+                    }
+                    break;
+                }
+            }
+        }
+
+        let language_payload = match language_payload {
+            Some(payload) => payload,
+            None => {
+                let mut buffer = TinyAsciiStr::EMPTY;
+                let attrs = LocaleNamesLanguageMediumV1::make_attributes(
+                    subject.language,
+                    None,
+                    None,
+                    &mut buffer,
+                );
+                let id = DataIdentifierBorrowed::for_marker_attributes_and_locale(
+                    attrs,
+                    &formatting_locale,
+                );
+                let mut metadata = DataRequestMetadata::default();
+                metadata.silent = true;
+                if let Some(response) = provider
+                    .load(DataRequest { id, metadata })
+                    .allow_identifier_not_found()?
+                {
+                    MenuLanguagePayload::Menu(response.payload)
+                } else {
+                    let response = provider
+                        .load(DataRequest {
+                            id,
+                            ..Default::default()
+                        })
+                        .allow_identifier_not_found()?;
+                    match response {
+                        Some(obj) => MenuLanguagePayload::Medium(obj.payload),
+                        None => MenuLanguagePayload::Subtag(subject.language),
+                    }
+                }
+            }
+        };
+
+        let (script_payload, region_payload, variant_payloads, essentials_payload) =
+            load_qualifiers_and_essentials(provider, prefs, &subject, &formatting_locale)?;
+
+        Ok(Self {
+            language_payload,
+            script_payload,
+            region_payload,
+            variant_payloads,
+            essentials_payload,
+        })
+    }
+}
+
+impl<M: LanguageIdentifierDisplayNameModel> LanguageIdentifierDisplayNameOwned<M> {
     /// Returns a borrowed version of this display name
     /// suitable for writing out to a string.
     pub fn as_borrowed(&self) -> LanguageIdentifierDisplayName<'_> {
-        let base_name = match self.language_payload.get() {
-            Ok(p) => NameOrFallback(Ok(p.as_ref())),
-            Err(lang) => NameOrFallback(Err(lang.as_str())),
-        };
+        let (base_name, menu_extension) = M::as_borrowed(&self.language_payload);
 
         let script_name = match self.script_payload.get() {
             Ok(p) => Some(NameOrFallback(Ok(p.as_ref()))),
@@ -338,6 +624,7 @@ impl LanguageIdentifierDisplayNameOwned {
 
         LanguageIdentifierDisplayName(LossyWrap(LanguageIdentifierDisplayNameInner {
             base_name,
+            menu_extension,
             script_name,
             region_name,
             variants,
@@ -372,9 +659,39 @@ pub struct LanguageIdentifierDisplayName<'a>(
     pub(crate) LossyWrap<LanguageIdentifierDisplayNameInner<'a>>,
 );
 
+impl<'a> LanguageIdentifierDisplayName<'a> {
+    /// Returns the menu extension part of the display name, if present.
+    ///
+    /// For example, for "Kurdish (Kurmanji)", this returns `Some("Kurmanji")`.
+    pub fn menu_extension(&self) -> Option<&'a str> {
+        self.0.0.menu_extension.and_then(|nf| nf.0.ok())
+    }
+}
+
 /// A struct implementing [`TryWriteable`] that returns a [`LanguageIdentifierNameFallbackError`]
 #[derive(Debug, Clone, Copy)]
-struct NameOrFallback<'a>(Result<&'a str, &'a str>);
+pub struct NameOrFallback<'a>(pub(crate) Result<&'a str, &'a str>);
+
+impl<'a> From<&'a DataPayloadOr<LocaleNamesLanguageMediumV1, Language>> for NameOrFallback<'a> {
+    fn from(payload: &'a DataPayloadOr<LocaleNamesLanguageMediumV1, Language>) -> Self {
+        match payload.get() {
+            Ok(p) => NameOrFallback(Ok(p.as_ref())),
+            Err(lang) => NameOrFallback(Err(lang.as_str())),
+        }
+    }
+}
+
+impl<'a> From<&'a str> for NameOrFallback<'a> {
+    fn from(s: &'a str) -> Self {
+        NameOrFallback(Ok(s))
+    }
+}
+
+impl<'a> From<Result<&'a str, &'a str>> for NameOrFallback<'a> {
+    fn from(res: Result<&'a str, &'a str>) -> Self {
+        NameOrFallback(res)
+    }
+}
 
 writeable::impl_try_writeable_delegate!(
     NameOrFallback<'a>,
@@ -387,6 +704,7 @@ writeable::impl_try_writeable_delegate!(
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct LanguageIdentifierDisplayNameInner<'a> {
     base_name: NameOrFallback<'a>,
+    menu_extension: Option<NameOrFallback<'a>>,
     script_name: Option<NameOrFallback<'a>>,
     region_name: Option<NameOrFallback<'a>>,
     variants: BorrowedVariants<'a>,
@@ -405,6 +723,7 @@ writeable::impl_writeable_delegate!(LanguageIdentifierDisplayName<'_>, |&self| &
 writeable::impl_display_with_writeable!(LanguageIdentifierDisplayName<'_>);
 
 struct QualifiersWriteable<'a> {
+    menu_extension: Option<NameOrFallback<'a>>,
     script: Option<NameOrFallback<'a>>,
     region: Option<NameOrFallback<'a>>,
     variants: BorrowedVariants<'a>,
@@ -449,6 +768,9 @@ impl<'a> TryWriteable for QualifiersWriteable<'a> {
         };
 
         let mut result = Ok(());
+        if let Some(menu_ext) = self.menu_extension {
+            result = result.and(write_item(sink, menu_ext)?);
+        }
         if let Some(script) = self.script {
             result = result.and(write_item(sink, script)?);
         }
@@ -475,7 +797,11 @@ impl<'a> TryWriteable for QualifiersWriteable<'a> {
 
     fn writeable_length_hint(&self) -> LengthHint {
         let mut length_hint = LengthHint::exact(0);
-        let mut num_items = 0;
+        let mut num_items = 0usize;
+        if let Some(menu_ext) = self.menu_extension {
+            length_hint += menu_ext.writeable_length_hint();
+            num_items += 1;
+        }
         if let Some(script) = self.script {
             length_hint += script.writeable_length_hint();
             num_items += 1;
@@ -499,14 +825,17 @@ impl<'a> TryWriteable for QualifiersWriteable<'a> {
                 }
             }
         }
-        length_hint += LengthHint::exact(self.separator_str().len() * (num_items - 1));
+        length_hint += LengthHint::exact(self.separator_str().len() * num_items.saturating_sub(1));
         length_hint
     }
 }
 
 impl LanguageIdentifierDisplayNameInner<'_> {
     fn has_qualifiers(&self) -> bool {
-        self.script_name.is_some() || self.region_name.is_some() || !self.variants.is_empty()
+        self.menu_extension.is_some()
+            || self.script_name.is_some()
+            || self.region_name.is_some()
+            || !self.variants.is_empty()
     }
 }
 
@@ -525,6 +854,7 @@ impl<'a> TryWriteable for LanguageIdentifierDisplayNameInner<'a> {
                 .try_interpolate(DoublePlaceholderValueProviderTry(
                     self.base_name,
                     QualifiersWriteable {
+                        menu_extension: self.menu_extension,
                         script: self.script_name,
                         region: self.region_name,
                         variants: self.variants,
@@ -544,6 +874,7 @@ impl<'a> TryWriteable for LanguageIdentifierDisplayNameInner<'a> {
                 .try_interpolate(DoublePlaceholderValueProviderTry(
                     self.base_name,
                     QualifiersWriteable {
+                        menu_extension: self.menu_extension,
                         script: self.script_name,
                         region: self.region_name,
                         variants: self.variants,

--- a/components/experimental/src/displaynames/single/mod.rs
+++ b/components/experimental/src/displaynames/single/mod.rs
@@ -9,9 +9,8 @@
 //!
 //! ### Status
 //!
-//! Currently, this module has limited support. It supports regions, scripts,
-//! and variants, but support for languages and locales is currently missing.
-//! More features are on their way.
+//! Currently, this module supports languages, regions, scripts, and variants.
+//! Support for full locale display names (with extension keywords) is planned for future releases.
 //!
 //! If you have any feedback, please let us know at
 //! <https://github.com/unicode-org/icu4x/issues/7825>.
@@ -25,8 +24,8 @@ mod variant;
 
 // Re-export from submodules
 pub use language::{
-    LanguageIdentifierDisplayName, LanguageIdentifierDisplayNameOwned,
-    LanguageIdentifierNameFallbackError,
+    LanguageIdentifierDisplayName, LanguageIdentifierDisplayNameModel,
+    LanguageIdentifierDisplayNameOwned, LanguageIdentifierNameFallbackError, models,
 };
 pub use region::{RegionDisplayName, RegionDisplayNameOwned};
 pub use script::{ScriptDisplayName, ScriptDisplayNameOwned};

--- a/components/experimental/tests/displaynames/tests.rs
+++ b/components/experimental/tests/displaynames/tests.rs
@@ -243,3 +243,112 @@ fn test_single_language_display_name_standard() {
         "Chinese (Traditional, Hong Kong SAR China)"
     );
 }
+
+#[test]
+fn test_single_language_display_name_menu() {
+    use icu_experimental::displaynames::{
+        LanguageDisplay, LanguageIdentifierDisplayNameOptions,
+        single::{LanguageIdentifierDisplayNameOwned, LanguageIdentifierNameFallbackError, models},
+    };
+    use icu_locale_core::{langid, locale};
+    use writeable::{Part, assert_try_writeable_parts_eq};
+
+    let locale = locale!("en-001");
+    let options = LanguageIdentifierDisplayNameOptions::default();
+
+    // Case 1: Split menu name (ku -> "Kurdish (Kurmanji)")
+    let display_name: LanguageIdentifierDisplayNameOwned<models::Menu> =
+        LanguageIdentifierDisplayNameOwned::try_new_menu(
+            locale.clone().into(),
+            langid!("ku"),
+            options,
+        )
+        .expect("Data should load successfully");
+    let borrowed = display_name.as_borrowed();
+    assert_try_writeable_eq!(borrowed, "Kurdish (Kurmanji)");
+    assert_eq!(borrowed.menu_extension(), Some("Kurmanji"));
+
+    // Case 2: Split menu name with additional qualifiers (ku-TR -> "Kurdish (Kurmanji, Türkiye)")
+    let display_name = LanguageIdentifierDisplayNameOwned::try_new_menu(
+        locale.clone().into(),
+        langid!("ku-TR"),
+        options,
+    )
+    .expect("Data should load successfully");
+    let borrowed = display_name.as_borrowed();
+    assert_try_writeable_eq!(borrowed, "Kurdish (Kurmanji, Türkiye)");
+    assert_eq!(borrowed.menu_extension(), Some("Kurmanji"));
+
+    // Case 3: Menu name with empty extension (zh -> "Chinese, Mandarin")
+    let display_name = LanguageIdentifierDisplayNameOwned::try_new_menu(
+        locale.clone().into(),
+        langid!("zh"),
+        options,
+    )
+    .expect("Data should load successfully");
+    let borrowed = display_name.as_borrowed();
+    assert_try_writeable_eq!(borrowed, "Chinese, Mandarin");
+    assert_eq!(borrowed.menu_extension(), None);
+
+    // Case 4: Runtime fallback to Medium width when menu entry is missing (nl -> "Dutch")
+    let display_name = LanguageIdentifierDisplayNameOwned::try_new_menu(
+        locale.clone().into(),
+        langid!("nl"),
+        options,
+    )
+    .expect("Data should load successfully");
+    let borrowed = display_name.as_borrowed();
+    assert_try_writeable_eq!(borrowed, "Dutch");
+    assert_eq!(borrowed.menu_extension(), None);
+
+    // Case 5: Runtime fallback to Medium width dialect when menu entry is missing (nl-BE -> "Flemish")
+    let display_name = LanguageIdentifierDisplayNameOwned::try_new_menu(
+        locale.clone().into(),
+        langid!("nl-BE"),
+        options,
+    )
+    .expect("Data should load successfully");
+    let borrowed = display_name.as_borrowed();
+    assert_try_writeable_eq!(borrowed, "Flemish");
+    assert_eq!(borrowed.menu_extension(), None);
+
+    // Case 6: Runtime fallback to Medium width for French (fr -> "French")
+    let display_name = LanguageIdentifierDisplayNameOwned::try_new_menu(
+        locale.clone().into(),
+        langid!("fr"),
+        options,
+    )
+    .expect("Data should load successfully");
+    let borrowed = display_name.as_borrowed();
+    assert_try_writeable_eq!(borrowed, "French");
+    assert_eq!(borrowed.menu_extension(), None);
+
+    // Case 7: Unknown subtag in Menu mode (it-Qabc-150 -> "Italian (Qabc, Europe)" with Part::ERROR span)
+    let display_name = LanguageIdentifierDisplayNameOwned::try_new_menu(
+        locale.clone().into(),
+        langid!("it-Qabc-150"),
+        options,
+    )
+    .expect("Data should load successfully");
+    let borrowed = display_name.as_borrowed();
+    assert_try_writeable_parts_eq!(
+        borrowed,
+        "Italian (Qabc, Europe)",
+        Err(LanguageIdentifierNameFallbackError),
+        [(9, 13, Part::ERROR)]
+    );
+    assert_eq!(borrowed.menu_extension(), None);
+
+    // Case 8: Standard display option in Menu mode (nl-BE -> "Dutch (Belgium)" instead of "Flemish")
+    let mut std_options = LanguageIdentifierDisplayNameOptions::default();
+    std_options.language_display = Some(LanguageDisplay::Standard);
+    let display_name = LanguageIdentifierDisplayNameOwned::try_new_menu(
+        locale.clone().into(),
+        langid!("nl-BE"),
+        std_options,
+    )
+    .expect("Data should load successfully");
+    let borrowed = display_name.as_borrowed();
+    assert_try_writeable_eq!(borrowed, "Dutch (Belgium)");
+    assert_eq!(borrowed.menu_extension(), None);
+}


### PR DESCRIPTION
Implement support for Menu style display names (`LocaleNamesLanguageMenuMediumV1`) in `LanguageIdentifierDisplayNameOwned` by adopting the generic model architecture documented in `single/README.md`.

In UI language dropdowns and selectors, languages often require specialized menu formatting (e.g., displaying "Kurdish (Kurmanji)" with a base name and menu extension, or "Chinese, Mandarin"). This change introduces the `LanguageIdentifierDisplayNameModel` trait and parameterizes `LanguageIdentifierDisplayNameOwned<M = models::Standard>` over `models::Standard` vs `models::Menu`. Calling `try_new_menu` loads split menu data and gracefully falls back at runtime to standard Medium width display names when menu entries are absent in CLDR. During formatting, any present menu extension is emitted as the primary qualifier in parentheses before script, region, and variants.

🤖 This pull request was created by an AI agent working with @sffc.

## Changelog

icu_experimental: Add Menu display names feature for language identifiers
  * New trait: `LanguageIdentifierDisplayNameModel`
  * New module: `single::models` (with types `Standard` and `Menu`)
  * New methods: `LanguageIdentifierDisplayNameOwned::try_new_menu()`, `try_new_menu_with_buffer_provider()`, `try_new_menu_unstable()`, and `LanguageIdentifierDisplayName::menu_extension()`
  * New type: `NameOrFallback`
  * New type parameter: `LanguageIdentifierDisplayNameOwned<M = models::Standard>`