### PR TITLE
Implement menu names for language identifiers

### DIFF
--- a/components/experimental/src/displaynames/provider.rs
+++ b/components/experimental/src/displaynames/provider.rs
@@ -160,6 +160,7 @@ pub struct VariantDisplayNames<'data> {
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_experimental::displaynames::provider))]
 #[zerovec::make_varule(MenuNamePartsULE)]
+#[zerovec::derive(Debug)]
 #[zerovec::skip_derive(Ord)]
 #[cfg_attr(feature = "serde", zerovec::derive(Deserialize))]
 #[cfg_attr(feature = "datagen", zerovec::derive(Serialize))]
@@ -281,6 +282,25 @@ icu_provider::data_marker!(
     LocaleNamesEssentials<'static>
 );
 
+/// A data struct that is either [`MenuNameParts`] or a string
+#[derive(Debug, PartialEq, Clone, yoke::Yokeable, zerofrom::ZeroFrom)]
+#[allow(clippy::exhaustive_enums)] // provider-unstable
+pub enum MenuNamePartsOrString<'a> {
+    /// A data struct that is [`MenuNameParts`]
+    MenuNameParts(VarZeroCow<'a, MenuNamePartsULE>),
+    /// A data struct that is a string
+    String(VarZeroCow<'a, str>),
+}
+
+/// A marker for [`MenuNamePartsOrString`]
+#[derive(Debug)]
+#[allow(clippy::exhaustive_structs)] // marker
+pub struct MenuNamePartsOrStringErased;
+
+impl DynamicDataMarker for MenuNamePartsOrStringErased {
+    type DataStruct = MenuNamePartsOrString<'static>;
+}
+
 impl LocaleNamesLanguageMediumV1 {
     /// Helper to construct infallible attributes from subtags.
     #[inline]
@@ -318,8 +338,21 @@ impl LocaleNamesLanguageMediumV1 {
     }
 }
 
+impl LocaleNamesLanguageMenuMediumV1 {
+    /// Helper to create data marker attributes from subtags.
+    #[inline]
+    pub(crate) fn make_attributes(
+        language: Language,
+        script: Option<Script>,
+        region: Option<Region>,
+        buffer: &mut tinystr::TinyAsciiStr<16>,
+    ) -> &DataMarkerAttributes {
+        LocaleNamesLanguageMediumV1::make_attributes(language, script, region, buffer)
+    }
+}
+
 impl LocaleNamesRegionMediumV1 {
-    /// Helper to create data marker attributes from a region.
+    /// Helper to construct infallible attributes from subtags.
     #[inline]
     pub(crate) fn make_attributes(region: &Region) -> &DataMarkerAttributes {
         // This is infallible (will not panic) because a validated `Region` is guaranteed to

--- a/components/experimental/src/displaynames/single/language.rs
+++ b/components/experimental/src/displaynames/single/language.rs
@@ -40,7 +40,9 @@ pub mod models {
     /// </div>
     pub trait LanguageIdentifierDisplayNameModel: private::Sealed {
         /// The payload storage type for this model.
-        type LanguagePayloadUnstable: 'static + core::fmt::Debug;
+        type LanguageMarkerUnstable: DynamicDataMarker<
+            DataStruct: for<'a> yoke::Yokeable<'a, Output: core::fmt::Debug>,
+        >;
     }
 
     /// Model for standard and dialect language display names.
@@ -50,7 +52,7 @@ pub mod models {
 
     impl private::Sealed for Standard {}
     impl LanguageIdentifierDisplayNameModel for Standard {
-        type LanguagePayloadUnstable = DataPayloadOr<LocaleNamesLanguageMediumV1, Language>;
+        type LanguageMarkerUnstable = LocaleNamesLanguageMediumV1;
     }
 
     /// Model for menu style language display names.
@@ -60,7 +62,7 @@ pub mod models {
 
     impl private::Sealed for Menu {}
     impl LanguageIdentifierDisplayNameModel for Menu {
-        type LanguagePayloadUnstable = DataPayloadOr<LocaleNamesLanguageMediumV1, Language>;
+        type LanguageMarkerUnstable = MenuNamePartsOrStringErased;
     }
 }
 
@@ -75,7 +77,7 @@ size_test!(
 /// The formatter falls back to the BCP-47 subtag when localized display names are missing
 /// from the data provider. Fallback can be detected using [`TryWriteable`].
 ///
-/// # Example
+/// # Examples
 ///
 /// ```
 /// use icu::experimental::displaynames::{
@@ -137,7 +139,7 @@ size_test!(
 #[derive(Debug)]
 pub struct LanguageIdentifierDisplayNameOwned<M: models::LanguageIdentifierDisplayNameModel> {
     /// Either the language display name or the subtag as fallback
-    language_payload: M::LanguagePayloadUnstable,
+    language_payload: DataPayloadOr<M::LanguageMarkerUnstable, Language>,
     /// All other fields (shared between Standard and Menu)
     qualifiers: QualifiersOwned,
 }
@@ -206,6 +208,93 @@ impl LanguageIdentifierDisplayNameOwned<models::Standard> {
                     subject.language,
                 )? {
                     Some(response) => DataPayloadOr::from_payload(response.payload),
+                    None => DataPayloadOr::from_other(subject.language),
+                }
+            }
+        };
+
+        // Load the remaining data
+        let qualifiers = QualifiersOwned::try_new_unstable(provider, prefs, subject)?;
+
+        Ok(Self {
+            language_payload,
+            qualifiers,
+        })
+    }
+}
+
+impl LanguageIdentifierDisplayNameOwned<models::Menu> {
+    icu_provider::gen_buffer_data_constructors!(
+        (prefs: DisplayNamesPreferences, subject: LanguageIdentifier, options: LanguageIdentifierDisplayNameOptions) -> result: Result<Self, DataError>,
+        /// Loads the menu-style language display name for a given language identifier and locale using compiled data.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use icu::experimental::displaynames::{
+        ///     DisplayNamesPreferences, LanguageIdentifierDisplayNameOptions, single::LanguageIdentifierDisplayNameOwned,
+        /// };
+        /// use icu::locale::{locale, langid};
+        /// use writeable::assert_try_writeable_eq;
+        ///
+        /// let prefs = DisplayNamesPreferences::from(locale!("en"));
+        /// let options = LanguageIdentifierDisplayNameOptions::default();
+        /// let display_name = LanguageIdentifierDisplayNameOwned::try_new_menu(
+        ///     prefs,
+        ///     langid!("fr-CA"),
+        ///     options,
+        /// )
+        /// .expect("Data should load successfully");
+        ///
+        /// assert_try_writeable_eq!(display_name.as_borrowed(), "French (Canada)", Ok(()));
+        /// ```
+        functions: [
+            try_new_menu,
+            try_new_menu_with_buffer_provider,
+            try_new_menu_unstable,
+            Self
+        ]
+    );
+
+    #[doc = icu_provider::gen_buffer_unstable_docs!(UNSTABLE, Self::try_new_menu)]
+    pub fn try_new_menu_unstable<D>(
+        provider: &D,
+        prefs: DisplayNamesPreferences,
+        subject: LanguageIdentifier,
+        _options: LanguageIdentifierDisplayNameOptions,
+    ) -> Result<Self, DataError>
+    where
+        D: ?Sized
+            + DataProvider<LocaleNamesLanguageMenuMediumV1>
+            + DataProvider<LocaleNamesLanguageMediumV1>
+            + DataProvider<LocaleNamesScriptMediumV1>
+            + DataProvider<LocaleNamesRegionMediumV1>
+            + DataProvider<LocaleNamesVariantMediumV1>
+            + DataProvider<LocaleNamesEssentialsV1>,
+    {
+        let formatting_locale = LocaleNamesLanguageMediumV1::make_locale(prefs.locale_preferences);
+
+        // Step 1: Load language name
+        // Try the menu name
+        let language_payload =
+            Self::load_language_menu_name(provider, &formatting_locale, subject.language)?;
+
+        // If the language name is not loaded yet, try loading it from the language subtag alone.
+        let language_payload = match language_payload {
+            Some(response) => {
+                DataPayloadOr::from_payload(response.payload.map_project(|menu_ule, _phantom| {
+                    MenuNamePartsOrString::MenuNameParts(menu_ule)
+                }))
+            }
+            None => {
+                match Self::load_language_subtag_name(
+                    provider,
+                    &formatting_locale,
+                    subject.language,
+                )? {
+                    Some(response) => DataPayloadOr::from_payload(response.payload.map_project(
+                        |subtag_name, _phantom| MenuNamePartsOrString::String(subtag_name),
+                    )),
                     None => DataPayloadOr::from_other(subject.language),
                 }
             }
@@ -293,6 +382,29 @@ impl<M: models::LanguageIdentifierDisplayNameModel> LanguageIdentifierDisplayNam
     {
         let mut buffer = TinyAsciiStr::EMPTY;
         let attrs = LocaleNamesLanguageMediumV1::make_attributes(language, None, None, &mut buffer);
+        provider
+            .load(DataRequest {
+                id: DataIdentifierBorrowed::for_marker_attributes_and_locale(
+                    attrs,
+                    formatting_locale,
+                ),
+                ..Default::default()
+            })
+            .allow_identifier_not_found()
+    }
+
+    /// Loads the name for a language with menu core and extension parts.
+    fn load_language_menu_name<P>(
+        provider: &P,
+        formatting_locale: &DataLocale,
+        language: Language,
+    ) -> Result<Option<DataResponse<LocaleNamesLanguageMenuMediumV1>>, DataError>
+    where
+        P: ?Sized + DataProvider<LocaleNamesLanguageMenuMediumV1>,
+    {
+        let mut buffer = TinyAsciiStr::EMPTY;
+        let attrs =
+            LocaleNamesLanguageMenuMediumV1::make_attributes(language, None, None, &mut buffer);
         provider
             .load(DataRequest {
                 id: DataIdentifierBorrowed::for_marker_attributes_and_locale(
@@ -415,6 +527,27 @@ impl LanguageIdentifierDisplayNameOwned<models::Standard> {
     }
 }
 
+impl LanguageIdentifierDisplayNameOwned<models::Menu> {
+    /// Returns a borrowed version of this display name
+    /// suitable for writing out to a string.
+    pub fn as_borrowed(&self) -> LanguageIdentifierDisplayName<'_> {
+        let mut qualifiers = self.qualifiers.as_borrowed();
+        let base_name = match self.language_payload.get() {
+            Ok(MenuNamePartsOrString::MenuNameParts(parts)) => {
+                qualifiers.menu_extension = Some(parts.extension());
+                NameOrFallback(Ok(parts.core()))
+            }
+            Ok(MenuNamePartsOrString::String(string)) => NameOrFallback(Ok(string.as_ref())),
+            Err(lang) => NameOrFallback(Err(lang.as_str())),
+        };
+
+        LanguageIdentifierDisplayName(LossyWrap(LanguageIdentifierDisplayNameInner {
+            base_name,
+            qualifiers,
+        }))
+    }
+}
+
 impl QualifiersOwned {
     pub fn as_borrowed(&self) -> QualifiersBorrowed<'_> {
         let script = match self.script_payload.get() {
@@ -436,6 +569,7 @@ impl QualifiersOwned {
         };
 
         QualifiersBorrowed {
+            menu_extension: None,
             script,
             region,
             variants,
@@ -500,6 +634,7 @@ writeable::impl_display_with_writeable!(LanguageIdentifierDisplayName<'_>);
 
 #[derive(Debug, Copy, Clone)]
 struct QualifiersBorrowed<'a> {
+    menu_extension: Option<&'a str>,
     script: Option<NameOrFallback<'a>>,
     region: Option<NameOrFallback<'a>>,
     variants: BorrowedVariants<'a>,
@@ -520,7 +655,10 @@ impl<'a> QualifiersBorrowed<'a> {
     }
 
     fn is_empty(&self) -> bool {
-        self.script.is_none() && self.region.is_none() && self.variants.is_empty()
+        self.menu_extension.is_none()
+            && self.script.is_none()
+            && self.region.is_none()
+            && self.variants.is_empty()
     }
 }
 
@@ -534,6 +672,11 @@ impl<'a> TryWriteable for QualifiersBorrowed<'a> {
         // TODO: See whether we can share this code with the list component.
         let mut first = true;
         let separator_str = self.separator_str();
+
+        if let Some(menu_extension) = self.menu_extension {
+            sink.write_str(menu_extension)?;
+            first = false;
+        }
 
         let mut write_item = |sink: &mut S,
                               res: NameOrFallback|
@@ -576,6 +719,10 @@ impl<'a> TryWriteable for QualifiersBorrowed<'a> {
     fn writeable_length_hint(&self) -> LengthHint {
         let mut length_hint = LengthHint::exact(0);
         let mut num_items = 0;
+        if let Some(menu_extension) = self.menu_extension {
+            length_hint += writeable::Writeable::writeable_length_hint(&menu_extension);
+            num_items += 1;
+        }
         if let Some(script) = self.script {
             length_hint += script.writeable_length_hint();
             num_items += 1;

--- a/components/experimental/src/displaynames/single/language.rs
+++ b/components/experimental/src/displaynames/single/language.rs
@@ -534,7 +534,9 @@ impl LanguageIdentifierDisplayNameOwned<models::Menu> {
         let mut qualifiers = self.qualifiers.as_borrowed();
         let base_name = match self.language_payload.get() {
             Ok(MenuNamePartsOrString::MenuNameParts(parts)) => {
-                qualifiers.menu_extension = Some(parts.extension());
+                if !parts.extension().is_empty() {
+                    qualifiers.menu_extension = Some(parts.extension());
+                }
                 NameOrFallback(Ok(parts.core()))
             }
             Ok(MenuNamePartsOrString::String(string)) => NameOrFallback(Ok(string.as_ref())),

--- a/components/experimental/src/displaynames/single/language.rs
+++ b/components/experimental/src/displaynames/single/language.rs
@@ -99,6 +99,12 @@ size_test!(
 pub struct LanguageIdentifierDisplayNameOwned {
     /// Either the language display name or the subtag as fallback
     language_payload: DataPayloadOr<LocaleNamesLanguageMediumV1, Language>,
+    /// All other fields (shared between Standard and Menu)
+    qualifiers: QualifiersOwned,
+}
+
+#[derive(Debug)]
+struct QualifiersOwned {
     /// Either the script display name, the subtag as fallback, or None if absent
     script_payload: DataPayloadOr<LocaleNamesScriptMediumV1, Option<Script>>,
     /// Either the region display name, the subtag as fallback, or None if absent
@@ -143,94 +149,134 @@ impl LanguageIdentifierDisplayNameOwned {
         let formatting_locale = LocaleNamesLanguageMediumV1::make_locale(prefs.locale_preferences);
 
         // Step 1: Load language name
-        // We want to find the best display name for the given subject.
-        // In Dialect mode (default), we try to load names for combinations of subtags:
-        // - Language + Script + Region (e.g., "zh-Hant-HK")
-        // - Language + Script (e.g., "zh-Hant")
-        // - Language + Region (e.g., "en-GB")
-        // If any of these are found in the CLDR language names, we use it as the base name,
-        // and we "consume" the corresponding subtags so they are not repeated in the qualifiers.
-        // If none are found, we fall back to the base language name (e.g., "zh") and all
-        // present subtags (script, region, variants) will be formatted as qualifiers.
-        let mut language_payload = None;
-
-        // Only try dialect if requested (which is the default)
-        if options.language_display.unwrap_or_default() == LanguageDisplay::Dialect {
-            for (language, script, region) in [
-                (subject.language, Some(subject.script), Some(subject.region)),
-                (subject.language, Some(subject.script), None),
-                (subject.language, None, Some(subject.region)),
-            ] {
-                // For Script and Region:
-                // - Some in the first position means "this should be present"
-                // - None in the first position means "skip this field"
-                // We skip Some(None) because that case will be handled in a subsequent iteration
-                let script = match script {
-                    Some(Some(script)) => Some(script),
-                    Some(None) => continue,
-                    None => None,
-                };
-                let region = match region {
-                    Some(Some(region)) => Some(region),
-                    Some(None) => continue,
-                    None => None,
-                };
-                let mut buffer = TinyAsciiStr::EMPTY;
-                let attrs = LocaleNamesLanguageMediumV1::make_attributes(
-                    language,
-                    script,
-                    region,
-                    &mut buffer,
-                );
-                let id = DataIdentifierBorrowed::for_marker_attributes_and_locale(
-                    attrs,
-                    &formatting_locale,
-                );
-                let mut metadata = DataRequestMetadata::default();
-                metadata.silent = true;
-                if let Some(response) = provider
-                    .load(DataRequest { id, metadata })
-                    .allow_identifier_not_found()?
-                {
-                    language_payload = Some(DataPayloadOr::from_payload(response.payload));
-                    if script.is_some() {
-                        subject.script = None;
-                    }
-                    if region.is_some() {
-                        subject.region = None;
-                    }
-                    break;
-                }
-            }
-        }
+        // Only try dialect if requested (or default)
+        let language_payload =
+            if options.language_display.unwrap_or_default() == LanguageDisplay::Dialect {
+                Self::load_language_dialect_name(provider, &formatting_locale, &mut subject)?
+            } else {
+                None
+            };
 
         // If the language name is not loaded yet, try loading it from the language subtag alone.
         let language_payload = match language_payload {
-            Some(payload) => payload,
+            Some(response) => DataPayloadOr::from_payload(response.payload),
             None => {
-                let mut buffer = TinyAsciiStr::EMPTY;
-                let attrs = LocaleNamesLanguageMediumV1::make_attributes(
+                match Self::load_language_subtag_name(
+                    provider,
+                    &formatting_locale,
                     subject.language,
-                    None,
-                    None,
-                    &mut buffer,
-                );
-                let response = provider
-                    .load(DataRequest {
-                        id: DataIdentifierBorrowed::for_marker_attributes_and_locale(
-                            attrs,
-                            &formatting_locale,
-                        ),
-                        ..Default::default()
-                    })
-                    .allow_identifier_not_found()?;
-                match response {
-                    Some(obj) => DataPayloadOr::from_payload(obj.payload),
+                )? {
+                    Some(response) => DataPayloadOr::from_payload(response.payload),
                     None => DataPayloadOr::from_other(subject.language),
                 }
             }
         };
 
+        // Load the remaining data
+        let qualifiers = QualifiersOwned::try_new_unstable(provider, prefs, subject)?;
+
+        Ok(Self {
+            language_payload,
+            qualifiers,
+        })
+    }
+
+    /// Loads the name for a langauge dialect, which includes script and region subtags.
+    ///
+    /// We try to load names for combinations of subtags:
+    ///
+    /// - Language + Script + Region (e.g., "zh-Hant-HK")
+    /// - Language + Script (e.g., "zh-Hant")
+    /// - Language + Region (e.g., "en-GB")
+    ///
+    /// We then "consume"  the corresponding subtags from the input LanguageIdentifier
+    /// so they are not repeated in the qualifiers.
+    fn load_language_dialect_name<P>(
+        provider: &P,
+        formatting_locale: &DataLocale,
+        subject: &mut LanguageIdentifier,
+    ) -> Result<Option<DataResponse<LocaleNamesLanguageMediumV1>>, DataError>
+    where
+        P: ?Sized + DataProvider<LocaleNamesLanguageMediumV1>,
+    {
+        for (language, script, region) in [
+            (subject.language, Some(subject.script), Some(subject.region)),
+            (subject.language, Some(subject.script), None),
+            (subject.language, None, Some(subject.region)),
+        ] {
+            // For Script and Region:
+            // - Some in the first position means "this should be present"
+            // - None in the first position means "skip this field"
+            // We skip Some(None) because that case will be handled in a subsequent iteration
+            let script = match script {
+                Some(Some(script)) => Some(script),
+                Some(None) => continue,
+                None => None,
+            };
+            let region = match region {
+                Some(Some(region)) => Some(region),
+                Some(None) => continue,
+                None => None,
+            };
+            let mut buffer = TinyAsciiStr::EMPTY;
+            let attrs =
+                LocaleNamesLanguageMediumV1::make_attributes(language, script, region, &mut buffer);
+            let id =
+                DataIdentifierBorrowed::for_marker_attributes_and_locale(attrs, &formatting_locale);
+            let mut metadata = DataRequestMetadata::default();
+            metadata.silent = true;
+            if let Some(response) = provider
+                .load(DataRequest { id, metadata })
+                .allow_identifier_not_found()?
+            {
+                if script.is_some() {
+                    subject.script = None;
+                }
+                if region.is_some() {
+                    subject.region = None;
+                }
+                return Ok(Some(response));
+            }
+        }
+        Ok(None)
+    }
+
+    /// Loads the name for an individual language subtag.
+    fn load_language_subtag_name<P>(
+        provider: &P,
+        formatting_locale: &DataLocale,
+        language: Language,
+    ) -> Result<Option<DataResponse<LocaleNamesLanguageMediumV1>>, DataError>
+    where
+        P: ?Sized + DataProvider<LocaleNamesLanguageMediumV1>,
+    {
+        let mut buffer = TinyAsciiStr::EMPTY;
+        let attrs = LocaleNamesLanguageMediumV1::make_attributes(language, None, None, &mut buffer);
+        provider
+            .load(DataRequest {
+                id: DataIdentifierBorrowed::for_marker_attributes_and_locale(
+                    attrs,
+                    formatting_locale,
+                ),
+                ..Default::default()
+            })
+            .allow_identifier_not_found()
+    }
+}
+
+impl QualifiersOwned {
+    fn try_new_unstable<D>(
+        provider: &D,
+        prefs: DisplayNamesPreferences,
+        subject: LanguageIdentifier,
+    ) -> Result<Self, DataError>
+    where
+        D: ?Sized
+            + DataProvider<LocaleNamesScriptMediumV1>
+            + DataProvider<LocaleNamesRegionMediumV1>
+            + DataProvider<LocaleNamesVariantMediumV1>
+            + DataProvider<LocaleNamesEssentialsV1>,
+    {
         // Step 2: Load script name (if present in subject)
         let script_payload = if let Some(script) = subject.script {
             match ScriptDisplayNameOwned::try_new_unstable(provider, prefs, script)
@@ -296,20 +342,23 @@ impl LanguageIdentifierDisplayNameOwned {
         // Step 5: Load essentials
         let essentials_payload = provider
             .load(DataRequest {
-                id: DataIdentifierBorrowed::for_locale(&formatting_locale),
+                id: DataIdentifierBorrowed::for_locale(&LocaleNamesEssentialsV1::make_locale(
+                    prefs.locale_preferences,
+                )),
                 ..Default::default()
             })?
             .payload;
 
         Ok(Self {
-            language_payload,
             script_payload,
             region_payload,
             variant_payloads,
             essentials_payload,
         })
     }
+}
 
+impl LanguageIdentifierDisplayNameOwned {
     /// Returns a borrowed version of this display name
     /// suitable for writing out to a string.
     pub fn as_borrowed(&self) -> LanguageIdentifierDisplayName<'_> {
@@ -318,13 +367,22 @@ impl LanguageIdentifierDisplayNameOwned {
             Err(lang) => NameOrFallback(Err(lang.as_str())),
         };
 
-        let script_name = match self.script_payload.get() {
+        LanguageIdentifierDisplayName(LossyWrap(LanguageIdentifierDisplayNameInner {
+            base_name,
+            qualifiers: self.qualifiers.as_borrowed(),
+        }))
+    }
+}
+
+impl QualifiersOwned {
+    pub fn as_borrowed(&self) -> QualifiersBorrowed<'_> {
+        let script = match self.script_payload.get() {
             Ok(p) => Some(NameOrFallback(Ok(p.as_ref()))),
             Err(Some(script)) => Some(NameOrFallback(Err(script.as_str()))),
             Err(None) => None,
         };
 
-        let region_name = match self.region_payload.get() {
+        let region = match self.region_payload.get() {
             Ok(p) => Some(NameOrFallback(Ok(p.as_ref()))),
             Err(Some(region)) => Some(NameOrFallback(Err(region.as_str()))),
             Err(None) => None,
@@ -336,14 +394,13 @@ impl LanguageIdentifierDisplayNameOwned {
             Err(Err(variant)) => BorrowedVariants::One(NameOrFallback(Err(variant.as_str()))),
         };
 
-        LanguageIdentifierDisplayName(LossyWrap(LanguageIdentifierDisplayNameInner {
-            base_name,
-            script_name,
-            region_name,
+        QualifiersBorrowed {
+            script,
+            region,
             variants,
-            locale_pattern: &self.essentials_payload.get().locale_pattern,
-            locale_separator: &self.essentials_payload.get().locale_separator,
-        }))
+            glue: &self.essentials_payload.get().locale_pattern,
+            separator: &self.essentials_payload.get().locale_separator,
+        }
     }
 }
 
@@ -387,11 +444,7 @@ writeable::impl_try_writeable_delegate!(
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct LanguageIdentifierDisplayNameInner<'a> {
     base_name: NameOrFallback<'a>,
-    script_name: Option<NameOrFallback<'a>>,
-    region_name: Option<NameOrFallback<'a>>,
-    variants: BorrowedVariants<'a>,
-    locale_pattern: &'a DoublePlaceholderPattern,
-    locale_separator: &'a DoublePlaceholderPattern,
+    qualifiers: QualifiersBorrowed<'a>,
 }
 
 writeable::impl_try_writeable_delegate!(
@@ -404,14 +457,16 @@ writeable::impl_writeable_delegate!(LanguageIdentifierDisplayName<'_>, |&self| &
 
 writeable::impl_display_with_writeable!(LanguageIdentifierDisplayName<'_>);
 
-struct QualifiersWriteable<'a> {
+#[derive(Debug, Copy, Clone)]
+struct QualifiersBorrowed<'a> {
     script: Option<NameOrFallback<'a>>,
     region: Option<NameOrFallback<'a>>,
     variants: BorrowedVariants<'a>,
+    glue: &'a DoublePlaceholderPattern,
     separator: &'a DoublePlaceholderPattern,
 }
 
-impl<'a> QualifiersWriteable<'a> {
+impl<'a> QualifiersBorrowed<'a> {
     fn separator_str(&self) -> &'a str {
         let mut separator_str = ", ";
         for item in self.separator.iter() {
@@ -422,9 +477,13 @@ impl<'a> QualifiersWriteable<'a> {
         }
         separator_str
     }
+
+    fn is_empty(&self) -> bool {
+        self.script.is_none() && self.region.is_none() && self.variants.is_empty()
+    }
 }
 
-impl<'a> TryWriteable for QualifiersWriteable<'a> {
+impl<'a> TryWriteable for QualifiersBorrowed<'a> {
     type Error = LanguageIdentifierNameFallbackError;
 
     fn try_write_to_parts<S: PartsWrite + ?Sized>(
@@ -504,12 +563,6 @@ impl<'a> TryWriteable for QualifiersWriteable<'a> {
     }
 }
 
-impl LanguageIdentifierDisplayNameInner<'_> {
-    fn has_qualifiers(&self) -> bool {
-        self.script_name.is_some() || self.region_name.is_some() || !self.variants.is_empty()
-    }
-}
-
 impl<'a> TryWriteable for LanguageIdentifierDisplayNameInner<'a> {
     type Error = LanguageIdentifierNameFallbackError;
 
@@ -517,19 +570,15 @@ impl<'a> TryWriteable for LanguageIdentifierDisplayNameInner<'a> {
         &self,
         sink: &mut S,
     ) -> Result<Result<(), Self::Error>, core::fmt::Error> {
-        if !self.has_qualifiers() {
+        if self.qualifiers.is_empty() {
             self.base_name.try_write_to_parts(sink)
         } else {
             let result = self
-                .locale_pattern
+                .qualifiers
+                .glue
                 .try_interpolate(DoublePlaceholderValueProviderTry(
                     self.base_name,
-                    QualifiersWriteable {
-                        script: self.script_name,
-                        region: self.region_name,
-                        variants: self.variants,
-                        separator: self.locale_separator,
-                    },
+                    self.qualifiers,
                 ))
                 .try_write_to_parts(sink)?;
             Ok(result.map_err(either::Either::into_inner))
@@ -537,25 +586,21 @@ impl<'a> TryWriteable for LanguageIdentifierDisplayNameInner<'a> {
     }
 
     fn writeable_length_hint(&self) -> LengthHint {
-        if !self.has_qualifiers() {
+        if self.qualifiers.is_empty() {
             self.base_name.writeable_length_hint()
         } else {
-            self.locale_pattern
+            self.qualifiers
+                .glue
                 .try_interpolate(DoublePlaceholderValueProviderTry(
                     self.base_name,
-                    QualifiersWriteable {
-                        script: self.script_name,
-                        region: self.region_name,
-                        variants: self.variants,
-                        separator: self.locale_separator,
-                    },
+                    self.qualifiers,
                 ))
                 .writeable_length_hint()
         }
     }
 
     fn try_writeable_borrow(&self) -> Option<Result<&str, (Self::Error, &str)>> {
-        if !self.has_qualifiers() {
+        if self.qualifiers.is_empty() {
             self.base_name.try_writeable_borrow()
         } else {
             None

--- a/components/experimental/src/displaynames/single/language.rs
+++ b/components/experimental/src/displaynames/single/language.rs
@@ -319,7 +319,7 @@ impl<M: models::LanguageIdentifierDisplayNameModel> LanguageIdentifierDisplayNam
     /// - Language + Script (e.g., "zh-Hant")
     /// - Language + Region (e.g., "en-GB")
     ///
-    /// We then "consume"  the corresponding subtags from the input LanguageIdentifier
+    /// We then "consume"  the corresponding subtags from the input `LanguageIdentifier`
     /// so they are not repeated in the qualifiers.
     fn load_language_dialect_name<P>(
         provider: &P,
@@ -352,7 +352,7 @@ impl<M: models::LanguageIdentifierDisplayNameModel> LanguageIdentifierDisplayNam
             let attrs =
                 LocaleNamesLanguageMediumV1::make_attributes(language, script, region, &mut buffer);
             let id =
-                DataIdentifierBorrowed::for_marker_attributes_and_locale(attrs, &formatting_locale);
+                DataIdentifierBorrowed::for_marker_attributes_and_locale(attrs, formatting_locale);
             let mut metadata = DataRequestMetadata::default();
             metadata.silent = true;
             if let Some(response) = provider

--- a/components/experimental/src/displaynames/single/language.rs
+++ b/components/experimental/src/displaynames/single/language.rs
@@ -25,8 +25,47 @@ use writeable::{PartsWrite, TryWriteable, adapters::LossyWrap};
 #[allow(clippy::exhaustive_structs)]
 pub struct LanguageIdentifierNameFallbackError;
 
+/// Marker models for language display names.
+pub mod models {
+    use super::*;
+    mod private {
+        pub trait Sealed {}
+    }
+
+    /// A trait defining the data model for a language display name (Standard vs. Menu).
+    ///
+    /// <div class="stab unstable">
+    /// 🚫 This trait is sealed; it cannot be implemented by user code. If an API requests an item that implements this
+    /// trait, please consider using a type from the implementors listed below.
+    /// </div>
+    pub trait LanguageIdentifierDisplayNameModel: private::Sealed {
+        /// The payload storage type for this model.
+        type LanguagePayloadUnstable: 'static + core::fmt::Debug;
+    }
+
+    /// Model for standard and dialect language display names.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    #[allow(clippy::exhaustive_structs)]
+    pub struct Standard;
+
+    impl private::Sealed for Standard {}
+    impl LanguageIdentifierDisplayNameModel for Standard {
+        type LanguagePayloadUnstable = DataPayloadOr<LocaleNamesLanguageMediumV1, Language>;
+    }
+
+    /// Model for menu style language display names.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    #[allow(clippy::exhaustive_structs)]
+    pub struct Menu;
+
+    impl private::Sealed for Menu {}
+    impl LanguageIdentifierDisplayNameModel for Menu {
+        type LanguagePayloadUnstable = DataPayloadOr<LocaleNamesLanguageMediumV1, Language>;
+    }
+}
+
 size_test!(
-    LanguageIdentifierDisplayNameOwned,
+    LanguageIdentifierDisplayNameOwned<models::Standard>,
     language_identifier_display_name_owned_size,
     184
 );
@@ -96,9 +135,9 @@ size_test!(
 /// ```
 #[doc = language_identifier_display_name_owned_size!()]
 #[derive(Debug)]
-pub struct LanguageIdentifierDisplayNameOwned {
+pub struct LanguageIdentifierDisplayNameOwned<M: models::LanguageIdentifierDisplayNameModel> {
     /// Either the language display name or the subtag as fallback
-    language_payload: DataPayloadOr<LocaleNamesLanguageMediumV1, Language>,
+    language_payload: M::LanguagePayloadUnstable,
     /// All other fields (shared between Standard and Menu)
     qualifiers: QualifiersOwned,
 }
@@ -119,7 +158,7 @@ struct QualifiersOwned {
     essentials_payload: DataPayload<LocaleNamesEssentialsV1>,
 }
 
-impl LanguageIdentifierDisplayNameOwned {
+impl LanguageIdentifierDisplayNameOwned<models::Standard> {
     icu_provider::gen_buffer_data_constructors!(
         (prefs: DisplayNamesPreferences, subject: LanguageIdentifier, options: LanguageIdentifierDisplayNameOptions) -> result: Result<Self, DataError>,
         /// Loads the language display name for a given language identifier and locale using compiled data.
@@ -180,7 +219,9 @@ impl LanguageIdentifierDisplayNameOwned {
             qualifiers,
         })
     }
+}
 
+impl<M: models::LanguageIdentifierDisplayNameModel> LanguageIdentifierDisplayNameOwned<M> {
     /// Loads the name for a langauge dialect, which includes script and region subtags.
     ///
     /// We try to load names for combinations of subtags:
@@ -358,7 +399,7 @@ impl QualifiersOwned {
     }
 }
 
-impl LanguageIdentifierDisplayNameOwned {
+impl LanguageIdentifierDisplayNameOwned<models::Standard> {
     /// Returns a borrowed version of this display name
     /// suitable for writing out to a string.
     pub fn as_borrowed(&self) -> LanguageIdentifierDisplayName<'_> {

--- a/components/experimental/tests/displaynames/tests.rs
+++ b/components/experimental/tests/displaynames/tests.rs
@@ -51,19 +51,34 @@ fn test_concatenate() {
             single_result: Ok(()),
         },
         TestCase {
+            input_1: &locale!("zh"),
+            display_type: DisplayType::Dialect,
+            expected: "Chinese",
+            should_borrow: true,
+            single_result: Ok(()),
+        },
+        TestCase {
+            input_1: &locale!("zh"),
+            display_type: DisplayType::Menu,
+            expected: "Chinese, Mandarin",
+            should_borrow: true,
+            single_result: Ok(()),
+        },
+        TestCase {
             input_1: &locale!("zh-Hans"),
             display_type: DisplayType::Dialect,
             expected: "Simplified Chinese",
             should_borrow: true,
             single_result: Ok(()),
         },
-        // TestCase {
-        //     input_1: &locale!("zh-Hans"),
-        //     display_type: DisplayType::Menu,
-        //     expected: "Chinese (Simplified)",
-        //     should_borrow: true,
-        //     single_result: Ok(()),
-        // },
+        TestCase {
+            input_1: &locale!("zh-Hans"),
+            display_type: DisplayType::Menu,
+            // Note: this behavior might change in CLDR 49
+            expected: "Chinese, Mandarin (Simplified)",
+            should_borrow: false,
+            single_result: Ok(()),
+        },
         TestCase {
             input_1: &locale!("es-419"),
             display_type: DisplayType::Dialect,
@@ -127,13 +142,14 @@ fn test_concatenate() {
             should_borrow: false,
             single_result: Ok(()),
         },
-        // TestCase {
-        //     input_1: &locale!("zh-Hans-CN"),
-        //     display_type: DisplayType::Menu,
-        //     expected: "Chinese (Simplified, China)",
-        //     should_borrow: false,
-        //     single_result: Ok(()),
-        // },
+        TestCase {
+            input_1: &locale!("zh-Hans-CN"),
+            display_type: DisplayType::Menu,
+            // Note: this behavior might change in CLDR 49
+            expected: "Chinese, Mandarin (Simplified, China)",
+            should_borrow: false,
+            single_result: Ok(()),
+        },
         TestCase {
             input_1: &locale!("es-419-fonipa"),
             display_type: DisplayType::Dialect,
@@ -257,13 +273,14 @@ fn test_concatenate() {
             should_borrow: false,
             single_result: Ok(()),
         },
-        // TestCase {
-        //     input_1: &locale!("zh-Hant-HK"),
-        //     display_type: DisplayType::Menu,
-        //     expected: "Chinese (Traditional, Hong Kong SAR China)",
-        //     should_borrow: false,
-        //     single_result: Ok(()),
-        // },
+        TestCase {
+            input_1: &locale!("zh-Hant-HK"),
+            display_type: DisplayType::Menu,
+            // Note: this behavior might change in CLDR 49
+            expected: "Chinese, Mandarin (Traditional, Hong Kong SAR China)",
+            should_borrow: false,
+            single_result: Ok(()),
+        },
         TestCase {
             // Multiple variants
             input_1: &Locale::try_from_str("es-fonipa-posix-valencia").unwrap(),

--- a/components/experimental/tests/displaynames/tests.rs
+++ b/components/experimental/tests/displaynames/tests.rs
@@ -321,16 +321,14 @@ fn test_concatenate() {
     for cas in &cases {
         // TODO: Add tests for different data locales.
         let locale = locale!("en-001");
-        let options: DisplayNamesOptions = Default::default();
 
         // Test the older LocaleDisplayNamesFormatter
-        if matches!(cas.display_type, DisplayType::Any | DisplayType::Dialect) {
-            let display_name = LocaleDisplayNamesFormatter::try_new(locale.clone().into(), options)
-                .expect("Data should load successfully");
-
-            let result = display_name.of(cas.input_1);
+        fn check_locale_name_formatter(
+            formatter: &LocaleDisplayNamesFormatter,
+            cas: &TestCase<'_>,
+        ) {
+            let result = formatter.of(cas.input_1);
             assert_eq!(result, cas.expected, "{cas:?}");
-
             if cas.should_borrow {
                 assert!(matches!(result, Cow::Borrowed(_)), "{cas:?}");
             } else {
@@ -339,22 +337,38 @@ fn test_concatenate() {
                 assert_eq!(result.capacity(), result.len(), "{cas:?}");
             }
         }
+        if matches!(cas.display_type, DisplayType::Any | DisplayType::Dialect) {
+            let options: DisplayNamesOptions = Default::default();
+            let formatter = LocaleDisplayNamesFormatter::try_new(locale.clone().into(), options)
+                .expect("Data should load successfully");
+            check_locale_name_formatter(&formatter, cas);
+        }
+        if matches!(cas.display_type, DisplayType::Any | DisplayType::Menu) {
+            let mut options: DisplayNamesOptions = Default::default();
+            options.language_display = icu_experimental::displaynames::LanguageDisplay::Standard;
+            options.style = Some(icu_experimental::displaynames::Style::Menu);
+            // "Hindi (Latin)" is a literal string in data,
+            // but it gets reconstructed from patterns for Menu names
+            let mut cas = cas.clone();
+            if cas.expected == "Hindi (Latin)" {
+                cas.should_borrow = false;
+            }
+            // "Kurmanji" Kurdish is not supported in the old code
+            if cas.expected == "Kurdish (Kurmanji)" {
+                cas.expected = "Kurdish";
+                cas.should_borrow = true;
+            }
+            if cas.expected == "Kurdish (Kurmanji, Iraq)" {
+                cas.expected = "Kurdish (Iraq)";
+            }
+            let formatter = LocaleDisplayNamesFormatter::try_new(locale.clone().into(), options)
+                .expect("Data should load successfully");
+            check_locale_name_formatter(&formatter, &cas);
+        }
 
         // Test the newer LanguageIdentifierDisplayName
         let lang_id = cas.input_1.id.clone();
         let single_options = LanguageIdentifierDisplayNameOptions::default();
-        let dname_standard_owned = LanguageIdentifierDisplayNameOwned::try_new(
-            locale.clone().into(),
-            lang_id.clone(),
-            single_options,
-        )
-        .unwrap();
-        let dname_menu_owned = LanguageIdentifierDisplayNameOwned::try_new_menu(
-            locale.clone().into(),
-            lang_id,
-            single_options,
-        )
-        .unwrap();
 
         fn check_language_name_borrowed(
             borrowed: LanguageIdentifierDisplayName<'_>,
@@ -372,10 +386,22 @@ fn test_concatenate() {
             }
         }
         if matches!(cas.display_type, DisplayType::Any | DisplayType::Dialect) {
+            let dname_standard_owned = LanguageIdentifierDisplayNameOwned::try_new(
+                locale.clone().into(),
+                lang_id.clone(),
+                single_options,
+            )
+            .unwrap();
             let borrowed = dname_standard_owned.as_borrowed();
             check_language_name_borrowed(borrowed, cas);
         }
         if matches!(cas.display_type, DisplayType::Any | DisplayType::Menu) {
+            let dname_menu_owned = LanguageIdentifierDisplayNameOwned::try_new_menu(
+                locale.clone().into(),
+                lang_id,
+                single_options,
+            )
+            .unwrap();
             let borrowed = dname_menu_owned.as_borrowed();
             // "Hindi (Latin)" is a literal string in data,
             // but it gets reconstructed from patterns for Menu names

--- a/components/experimental/tests/displaynames/tests.rs
+++ b/components/experimental/tests/displaynames/tests.rs
@@ -3,7 +3,8 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use icu_experimental::displaynames::single::{
-    LanguageIdentifierDisplayNameOwned, LanguageIdentifierNameFallbackError,
+    LanguageIdentifierDisplayName, LanguageIdentifierDisplayNameOwned,
+    LanguageIdentifierNameFallbackError,
 };
 use icu_experimental::displaynames::{
     DisplayNamesOptions, LanguageIdentifierDisplayNameOptions, multi::LocaleDisplayNamesFormatter,
@@ -17,9 +18,19 @@ use writeable::{
 
 #[test]
 fn test_concatenate() {
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
+    enum DisplayType {
+        /// The string is valid for both dialect and menu
+        Any,
+        /// The string is valid for dialect only
+        Dialect,
+        /// The string is valid for menu only
+        Menu,
+    }
+    #[derive(Debug, Clone)]
     struct TestCase<'a> {
         pub input_1: &'a Locale,
+        pub display_type: DisplayType,
         pub expected: &'a str,
         pub should_borrow: bool,
         pub single_result: Result<(), LanguageIdentifierNameFallbackError>,
@@ -27,67 +38,141 @@ fn test_concatenate() {
     let cases = [
         TestCase {
             input_1: &locale!("de-CH"),
+            display_type: DisplayType::Dialect,
             expected: "Swiss High German",
             should_borrow: true,
             single_result: Ok(()),
         },
         TestCase {
+            input_1: &locale!("de-CH"),
+            display_type: DisplayType::Menu,
+            expected: "German (Switzerland)",
+            should_borrow: false,
+            single_result: Ok(()),
+        },
+        TestCase {
             input_1: &locale!("zh-Hans"),
+            display_type: DisplayType::Dialect,
             expected: "Simplified Chinese",
             should_borrow: true,
             single_result: Ok(()),
         },
+        // TestCase {
+        //     input_1: &locale!("zh-Hans"),
+        //     display_type: DisplayType::Menu,
+        //     expected: "Chinese (Simplified)",
+        //     should_borrow: true,
+        //     single_result: Ok(()),
+        // },
         TestCase {
             input_1: &locale!("es-419"),
+            display_type: DisplayType::Dialect,
             expected: "Latin American Spanish",
             should_borrow: true,
             single_result: Ok(()),
         },
         TestCase {
+            input_1: &locale!("es-419"),
+            display_type: DisplayType::Menu,
+            expected: "Spanish (Latin America)",
+            should_borrow: false,
+            single_result: Ok(()),
+        },
+        TestCase {
             input_1: &locale!("es-Cyrl-MX"),
+            display_type: DisplayType::Dialect,
             expected: "Mexican Spanish (Cyrillic)",
             should_borrow: false,
             single_result: Ok(()),
         },
         TestCase {
+            input_1: &locale!("es-Cyrl-MX"),
+            display_type: DisplayType::Menu,
+            expected: "Spanish (Cyrillic, Mexico)",
+            should_borrow: false,
+            single_result: Ok(()),
+        },
+        TestCase {
             input_1: &"en-Latn-GB-fonipa-scouse".parse().unwrap(),
+            display_type: DisplayType::Dialect,
             expected: "British English (Latin, IPA Phonetics, Scouse)",
             should_borrow: false,
             single_result: Ok(()),
         },
         TestCase {
+            input_1: &"en-Latn-GB-fonipa-scouse".parse().unwrap(),
+            display_type: DisplayType::Menu,
+            expected: "English (Latin, United Kingdom, IPA Phonetics, Scouse)",
+            should_borrow: false,
+            single_result: Ok(()),
+        },
+        TestCase {
             input_1: &locale!("de-Latn-CH"),
+            display_type: DisplayType::Dialect,
             expected: "Swiss High German (Latin)",
             should_borrow: false,
             single_result: Ok(()),
         },
         TestCase {
-            input_1: &locale!("zh-Hans-CN"),
-            expected: "Simplified Chinese (China)",
+            input_1: &locale!("de-Latn-CH"),
+            display_type: DisplayType::Menu,
+            expected: "German (Latin, Switzerland)",
             should_borrow: false,
             single_result: Ok(()),
         },
         TestCase {
+            input_1: &locale!("zh-Hans-CN"),
+            display_type: DisplayType::Dialect,
+            expected: "Simplified Chinese (China)",
+            should_borrow: false,
+            single_result: Ok(()),
+        },
+        // TestCase {
+        //     input_1: &locale!("zh-Hans-CN"),
+        //     display_type: DisplayType::Menu,
+        //     expected: "Chinese (Simplified, China)",
+        //     should_borrow: false,
+        //     single_result: Ok(()),
+        // },
+        TestCase {
             input_1: &locale!("es-419-fonipa"),
+            display_type: DisplayType::Dialect,
             expected: "Latin American Spanish (IPA Phonetics)",
             should_borrow: false,
             single_result: Ok(()),
         },
         TestCase {
+            input_1: &locale!("es-419-fonipa"),
+            display_type: DisplayType::Menu,
+            expected: "Spanish (Latin America, IPA Phonetics)",
+            should_borrow: false,
+            single_result: Ok(()),
+        },
+        TestCase {
             input_1: &locale!("es-Latn-419"),
+            display_type: DisplayType::Dialect,
             expected: "Latin American Spanish (Latin)",
+            should_borrow: false,
+            single_result: Ok(()),
+        },
+        TestCase {
+            input_1: &locale!("es-Latn-419"),
+            display_type: DisplayType::Menu,
+            expected: "Spanish (Latin, Latin America)",
             should_borrow: false,
             single_result: Ok(()),
         },
         TestCase {
             // Language not found
             input_1: &locale!("xx"),
+            display_type: DisplayType::Any,
             expected: "xx",
             should_borrow: true,
             single_result: Err(LanguageIdentifierNameFallbackError),
         },
         TestCase {
             input_1: &locale!("xx-YY"),
+            display_type: DisplayType::Any,
             expected: "xx (YY)",
             should_borrow: false,
             single_result: Err(LanguageIdentifierNameFallbackError),
@@ -95,6 +180,7 @@ fn test_concatenate() {
         TestCase {
             // Script not found
             input_1: &locale!("en-Qzzz"),
+            display_type: DisplayType::Any,
             expected: "English (Qzzz)",
             should_borrow: false,
             single_result: Err(LanguageIdentifierNameFallbackError),
@@ -102,6 +188,7 @@ fn test_concatenate() {
         TestCase {
             // Region not found
             input_1: &locale!("en-QZ"),
+            display_type: DisplayType::Any,
             expected: "English (QZ)",
             should_borrow: false,
             single_result: Err(LanguageIdentifierNameFallbackError),
@@ -109,50 +196,93 @@ fn test_concatenate() {
         TestCase {
             // Variant not found
             input_1: &locale!("en-qzzzz"),
+            display_type: DisplayType::Any,
             expected: "English (qzzzz)",
             should_borrow: false,
             single_result: Err(LanguageIdentifierNameFallbackError),
         },
         TestCase {
             input_1: &"aa-Brai-CC-fonipa-posix".parse().unwrap(),
+            display_type: DisplayType::Any,
             expected: "Afar (Braille, Cocos (Keeling) Islands, IPA Phonetics, Computer)",
             should_borrow: false,
             single_result: Ok(()),
         },
         TestCase {
             input_1: &locale!("nl-BE"),
+            display_type: DisplayType::Dialect,
             expected: "Flemish",
             should_borrow: true,
             single_result: Ok(()),
         },
         TestCase {
+            input_1: &locale!("nl-BE"),
+            display_type: DisplayType::Menu,
+            expected: "Dutch (Belgium)",
+            should_borrow: false,
+            single_result: Ok(()),
+        },
+        TestCase {
             input_1: &locale!("nl-Latn-BE"),
+            display_type: DisplayType::Dialect,
             expected: "Flemish (Latin)",
             should_borrow: false,
             single_result: Ok(()),
         },
         TestCase {
+            input_1: &locale!("nl-Latn-BE"),
+            display_type: DisplayType::Menu,
+            expected: "Dutch (Latin, Belgium)",
+            should_borrow: false,
+            single_result: Ok(()),
+        },
+        TestCase {
             input_1: &"zh-Hans-fonipa".parse().unwrap(),
+            display_type: DisplayType::Dialect,
             expected: "Simplified Chinese (IPA Phonetics)",
             should_borrow: false,
             single_result: Ok(()),
         },
         TestCase {
             input_1: &locale!("hi-Latn"),
+            display_type: DisplayType::Any,
             expected: "Hindi (Latin)",
             should_borrow: true,
             single_result: Ok(()),
         },
         TestCase {
             input_1: &locale!("zh-Hant-HK"),
+            display_type: DisplayType::Dialect,
             expected: "Traditional Chinese (Hong Kong SAR China)",
             should_borrow: false,
             single_result: Ok(()),
         },
+        // TestCase {
+        //     input_1: &locale!("zh-Hant-HK"),
+        //     display_type: DisplayType::Menu,
+        //     expected: "Chinese (Traditional, Hong Kong SAR China)",
+        //     should_borrow: false,
+        //     single_result: Ok(()),
+        // },
         TestCase {
             // Multiple variants
             input_1: &Locale::try_from_str("es-fonipa-posix-valencia").unwrap(),
+            display_type: DisplayType::Any,
             expected: "Spanish (IPA Phonetics, Computer, Valencian)",
+            should_borrow: false,
+            single_result: Ok(()),
+        },
+        TestCase {
+            input_1: &locale!("ku"),
+            display_type: DisplayType::Dialect,
+            expected: "Kurdish",
+            should_borrow: true,
+            single_result: Ok(()),
+        },
+        TestCase {
+            input_1: &locale!("ku"),
+            display_type: DisplayType::Menu,
+            expected: "Kurdish (Kurmanji)",
             should_borrow: false,
             single_result: Ok(()),
         },
@@ -163,40 +293,66 @@ fn test_concatenate() {
         let options: DisplayNamesOptions = Default::default();
 
         // Test the older LocaleDisplayNamesFormatter
-        let display_name = LocaleDisplayNamesFormatter::try_new(locale.clone().into(), options)
-            .expect("Data should load successfully");
+        if matches!(cas.display_type, DisplayType::Any | DisplayType::Dialect) {
+            let display_name = LocaleDisplayNamesFormatter::try_new(locale.clone().into(), options)
+                .expect("Data should load successfully");
 
-        let result = display_name.of(cas.input_1);
-        assert_eq!(result, cas.expected);
+            let result = display_name.of(cas.input_1);
+            assert_eq!(result, cas.expected, "{cas:?}");
 
-        if cas.should_borrow {
-            assert!(matches!(result, Cow::Borrowed(_)));
-        } else {
-            assert!(matches!(result, Cow::Owned(_)));
-            let result = result.into_owned();
-            assert_eq!(result.capacity(), result.len());
+            if cas.should_borrow {
+                assert!(matches!(result, Cow::Borrowed(_)), "{cas:?}");
+            } else {
+                assert!(matches!(result, Cow::Owned(_)), "{cas:?}");
+                let result = result.into_owned();
+                assert_eq!(result.capacity(), result.len(), "{cas:?}");
+            }
         }
 
         // Test the newer LanguageIdentifierDisplayName
         let lang_id = cas.input_1.id.clone();
         let single_options = LanguageIdentifierDisplayNameOptions::default();
-        let single_display_name = LanguageIdentifierDisplayNameOwned::try_new(
+        let dname_standard_owned = LanguageIdentifierDisplayNameOwned::try_new(
+            locale.clone().into(),
+            lang_id.clone(),
+            single_options,
+        )
+        .unwrap();
+        let dname_menu_owned = LanguageIdentifierDisplayNameOwned::try_new_menu(
             locale.clone().into(),
             lang_id,
             single_options,
         )
         .unwrap();
-        let borrowed = single_display_name.as_borrowed();
-        assert_writeable_eq!(borrowed, cas.expected, "{cas:?}");
-        assert_try_writeable_eq!(borrowed, cas.expected, cas.single_result, "{cas:?}");
 
-        let cow = borrowed.write_to_string();
-        if cas.should_borrow {
-            assert!(matches!(cow, Cow::Borrowed(_)), "{cas:?}");
-        } else {
-            assert!(matches!(cow, Cow::Owned(_)), "{cas:?}");
-            let result = cow.into_owned();
-            assert_eq!(result.capacity(), result.len(), "{cas:?}");
+        fn check_language_name_borrowed(
+            borrowed: LanguageIdentifierDisplayName<'_>,
+            cas: &TestCase<'_>,
+        ) {
+            assert_writeable_eq!(borrowed, cas.expected, "{cas:?}");
+            assert_try_writeable_eq!(borrowed, cas.expected, cas.single_result, "{cas:?}");
+            let cow = borrowed.write_to_string();
+            if cas.should_borrow {
+                assert!(matches!(cow, Cow::Borrowed(_)), "{cas:?}");
+            } else {
+                assert!(matches!(cow, Cow::Owned(_)), "{cas:?}");
+                let result = cow.into_owned();
+                assert_eq!(result.capacity(), result.len(), "{cas:?}");
+            }
+        }
+        if matches!(cas.display_type, DisplayType::Any | DisplayType::Dialect) {
+            let borrowed = dname_standard_owned.as_borrowed();
+            check_language_name_borrowed(borrowed, cas);
+        }
+        if matches!(cas.display_type, DisplayType::Any | DisplayType::Menu) {
+            let borrowed = dname_menu_owned.as_borrowed();
+            // "Hindi (Latin)" is a literal string in data,\
+            // but it doesn't get borrowed for Menu names
+            let mut cas = cas.clone();
+            if cas.expected == "Hindi (Latin)" {
+                cas.should_borrow = false;
+            }
+            check_language_name_borrowed(borrowed, &cas);
         }
     }
 }

--- a/components/experimental/tests/displaynames/tests.rs
+++ b/components/experimental/tests/displaynames/tests.rs
@@ -303,6 +303,20 @@ fn test_concatenate() {
             should_borrow: false,
             single_result: Ok(()),
         },
+        TestCase {
+            input_1: &locale!("ku-IQ"),
+            display_type: DisplayType::Dialect,
+            expected: "Kurdish (Iraq)",
+            should_borrow: false,
+            single_result: Ok(()),
+        },
+        TestCase {
+            input_1: &locale!("ku-IQ"),
+            display_type: DisplayType::Menu,
+            expected: "Kurdish (Kurmanji, Iraq)",
+            should_borrow: false,
+            single_result: Ok(()),
+        },
     ];
     for cas in &cases {
         // TODO: Add tests for different data locales.
@@ -363,8 +377,8 @@ fn test_concatenate() {
         }
         if matches!(cas.display_type, DisplayType::Any | DisplayType::Menu) {
             let borrowed = dname_menu_owned.as_borrowed();
-            // "Hindi (Latin)" is a literal string in data,\
-            // but it doesn't get borrowed for Menu names
+            // "Hindi (Latin)" is a literal string in data,
+            // but it gets reconstructed from patterns for Menu names
             let mut cas = cas.clone();
             if cas.expected == "Hindi (Latin)" {
                 cas.should_borrow = false;


### PR DESCRIPTION
#7825 

I attempted this with an LLM, #8204, but was unhappy with the result so I redid it without the LLM.

This is reviewable commit-by-commit.

## Changelog

icu_experimental::displaynames:

- New scaffolding trait `single::models::LanguageIdentifierDisplayNameModel`
- New marker type `single::models::Standard`
- New marker type `single::models::Menu`
- New constructors `LanguageIdentifierDisplayNameOwned::try_new_menu[_unstable|_with_buffer_provider]`