### PR TITLE
Release Dart version `2.2.0.dev.3` to include bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Several crates have had patch releases in the 2.2 stream:
         - Fix an issue in JS bindings where enums in objects were not parsed correctly
     - (2.2.0.dev.2) `icu4x` Dart package
         - Update `package:hooks` dependency and change required toolchain to `3.13.0-215.0.dev`
+    - (2.2.0.dev.3) `icu4x` Dart package
+        - Add `libm` as a library input in the Dart linking script for Android.
 
 ## icu4x 2.2
 

--- a/ffi/dart/hook/link.dart
+++ b/ffi/dart/hook/link.dart
@@ -58,13 +58,16 @@ Future<void> main(List<String> args) async {
       packageName: input.packageName,
       assetName: 'src/bindings/lib.g.dart',
       sources: [staticLib.file!.toFilePath()],
-      libraries:
-          // On Windows, icu4x.lib is lacking /DEFAULTLIB directives to advise
-          // the linker on what libraries to link against. To make up for that,
-          // the libraries used have to be provided to the linker explicitly.
-          input.config.code.targetOS == OS.windows
-          ? const ['MSVCRT', 'ws2_32', 'userenv', 'ntdll']
-          : const [],
+      libraries: switch (input.config.code.targetOS) {
+        // On Windows, icu4x.lib is lacking /DEFAULTLIB directives to advise
+        // the linker on what libraries to link against. To make up for that,
+        // the libraries used have to be provided to the linker explicitly.
+        OS.windows => const ['MSVCRT', 'ws2_32', 'userenv', 'ntdll'],
+        // On Android, libm (math library) is not linked by default, but math
+        // functions like `expf` referenced in Rust libicu4x require libm.
+        OS.android => const ['m'],
+        _ => const [],
+      },
       linkerOptions: LinkerOptions.treeshake(symbolsToKeep: usedSymbols),
     ).run(
       input: input,

--- a/ffi/dart/pubspec.yaml
+++ b/ffi/dart/pubspec.yaml
@@ -5,7 +5,7 @@
 name: icu4x
 description: > 
   Dart bindings for the Rust `icu` internationalization crate.
-version: 2.2.0-dev.2
+version: 2.2.0-dev.3
 repository: https://github.com/unicode-org/icu4x/tree/main/ffi/dart
 issue_tracker: https://github.com/unicode-org/icu4x/issues?q=is%3Aissue%20is%3Aopen%20label%3AU-flutter
 


### PR DESCRIPTION
To get the change to intl4x.

## Changelog

Release Dart version `2.2.0.dev.3`
