### PR TITLE
Don't use Ord with enumerated properties

### DIFF
--- a/components/properties/src/script.rs
+++ b/components/properties/src/script.rs
@@ -13,6 +13,7 @@ use core::iter::FromIterator;
 use core::ops::RangeInclusive;
 #[cfg(feature = "alloc")]
 use icu_collections::codepointinvlist::CodePointInversionList;
+use icu_collections::codepointtrie::TrieValue;
 use icu_provider::prelude::*;
 use zerovec::{ZeroSlice, ule::AsULE};
 
@@ -211,7 +212,7 @@ impl<'a> ScriptExtensionsSet<'a> {
     ///     .contains(&Script::Grantha));
     /// ```
     pub fn contains(&self, x: &Script) -> bool {
-        ZeroSlice::binary_search(self.values, x).is_ok()
+        ZeroSlice::binary_search_by(self.values, |y| y.to_u32().cmp(&x.to_u32())).is_ok()
     }
 
     /// Gets an iterator over the elements.

--- a/provider/source/src/properties/enum_codepointtrie.rs
+++ b/provider/source/src/properties/enum_codepointtrie.rs
@@ -13,8 +13,7 @@ use icu::collections::codepointtrie::{CodePointTrie, TrieValue};
 use icu::properties::props::EnumeratedProperty;
 use icu::properties::provider::{names::*, *};
 use icu_provider::prelude::*;
-use std::collections::BTreeMap;
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::Debug;
 use zerotrie::ZeroTrieSimpleAscii;
 use zerovec::ule::NichedOption;
@@ -23,7 +22,7 @@ impl SourceDataProvider {
     #[cfg(any(feature = "use_wasm", feature = "use_icu4c"))]
     pub(super) fn build_enumerated_prop<T: EnumeratedProperty + Debug>(
         &self,
-        short_name_to_t: BTreeMap<&'static str, T>,
+        short_name_to_t: HashMap<&'static str, T>,
     ) -> Result<CodePointTrie<'static, T>, DataError> {
         let name = core::str::from_utf8(T::NAME).unwrap();
         let short_name = core::str::from_utf8(T::SHORT_NAME).unwrap();
@@ -140,8 +139,8 @@ impl SourceDataProvider {
         &'a self,
         name: &str,
         short_name: &str,
-    ) -> Result<(BTreeMap<&'a str, (&'a str, NameType)>, Option<&'a str>), DataError> {
-        let mut names = BTreeMap::new();
+    ) -> Result<(HashMap<&'a str, (&'a str, NameType)>, Option<&'a str>), DataError> {
+        let mut names = HashMap::new();
         let mut default = None;
 
         for line in self.parse_ucd_lines("ucd/PropertyValueAliases.txt")? {
@@ -201,38 +200,27 @@ enum NameType {
     Alias,
 }
 
-fn validate_dense<T: TrieValue + Ord + Debug>(map: &BTreeMap<T, &str>) -> Result<(), DataError> {
-    if let Some((&first, _)) = map.first_key_value() {
-        if first.to_u32() > 0 {
-            return Err(DataError::custom(
-                "Property has nonzero starting discriminant, perhaps consider \
-                 storing its names as a sparse map or by specializing this error",
-            )
-            .with_debug_context(&first));
-        }
-    } else {
-        return Err(DataError::custom("Property has no values!"));
+fn validate_dense<T: TrieValue + Debug, V: Debug + Copy>(
+    map: &HashMap<T, V>,
+) -> Result<Vec<V>, DataError> {
+    let map = map
+        .iter()
+        .map(|(k, &v)| (k.to_u32() as usize, v))
+        .collect::<BTreeMap<_, _>>();
+
+    if !map.keys().copied().eq(0..map.len()) {
+        return Err(DataError::custom(
+            "Property has more than 0 gaps and cannot be stored in a dense map",
+        )
+        .with_debug_context(&map));
     };
-    if let Some((&last, _)) = map.last_key_value() {
-        let range = last.to_u32() as usize + 1;
-        let count = map.len();
-        let gaps = range - count;
-        if gaps > 0 {
-            return Err(DataError::custom(
-                "Property has more than 0 gaps, \
-                perhaps consider storing its names in a sparse map or by specializing this error",
-            )
-            .with_display_context(&gaps));
-        }
-    } else {
-        return Err(DataError::custom("Property has no values!"));
-    };
-    Ok(())
+
+    Ok(map.into_values().collect())
 }
 
 #[allow(clippy::unnecessary_wraps)] // signature required by macro
-fn convert_sparse<T: TrieValue + Ord>(
-    map: BTreeMap<T, &str>,
+fn convert_sparse<T: TrieValue>(
+    map: HashMap<T, &str>,
 ) -> Result<PropertyEnumToValueNameSparseMap<'static>, DataError> {
     Ok(PropertyEnumToValueNameSparseMap {
         map: map
@@ -242,24 +230,24 @@ fn convert_sparse<T: TrieValue + Ord>(
     })
 }
 
-fn convert_linear<T: TrieValue + Ord + Debug>(
-    map: BTreeMap<T, &str>,
+fn convert_linear<T: TrieValue + Debug>(
+    map: HashMap<T, &str>,
 ) -> Result<PropertyEnumToValueNameLinearMap<'static>, DataError> {
-    validate_dense(&map)?;
+    let dense = validate_dense(&map)?;
 
     Ok(PropertyEnumToValueNameLinearMap {
-        map: (&map.into_values().collect::<Vec<_>>()).into(),
+        map: (&dense).into(),
     })
 }
 
 fn convert_script(
-    map: BTreeMap<icu::properties::props::Script, &str>,
+    map: HashMap<icu::properties::props::Script, &str>,
 ) -> Result<PropertyScriptToIcuScriptMap<'static>, DataError> {
-    validate_dense(&map)?;
+    let dense = validate_dense(&map)?;
 
     Ok(PropertyScriptToIcuScriptMap {
-        map: map
-            .into_values()
+        map: dense
+            .into_iter()
             .map(|s| {
                 if s.is_empty() {
                     Ok(NichedOption(None))
@@ -322,7 +310,7 @@ macro_rules! expand {
                 fn load(&self, req: DataRequest) -> Result<DataResponse<$parse_marker>, DataError> {
                     self.check_req::<$parse_marker>(req)?;
 
-                    let short_name_to_t = <$prop>::names().collect::<BTreeMap<_, _>>();
+                    let short_name_to_t = <$prop>::names().collect::<HashMap<_, _>>();
 
                     let names = self.enumerated_prop_names(core::str::from_utf8(<$prop as EnumeratedProperty>::NAME).unwrap(), core::str::from_utf8(<$prop as EnumeratedProperty>::SHORT_NAME).unwrap())?.0;
 
@@ -341,7 +329,7 @@ macro_rules! expand {
                         // Add short names that are only defined in ICU4X, not in Unicode (Scripts)
                         .chain(short_name_to_t.clone().into_iter())
                         .map(|(n, v)| (n, v.to_u32() as usize))
-                        .collect::<BTreeMap<_, _>>()
+                        .collect::<HashMap<_, _>>()
                         .into_iter()
                         .collect::<ZeroTrieSimpleAscii<_>>()
                         .convert_store();
@@ -371,7 +359,7 @@ macro_rules! expand {
             {
                 fn load(&self, req: DataRequest) -> Result<DataResponse<$long_marker>, DataError> {
                     self.check_req::<$long_marker>(req)?;
-                    let short_name_to_t = <$prop>::names().collect::<BTreeMap<_, _>>();
+                    let short_name_to_t = <$prop>::names().collect::<HashMap<_, _>>();
 
                     let names = self.enumerated_prop_names(core::str::from_utf8(<$prop as EnumeratedProperty>::NAME).unwrap(), core::str::from_utf8(<$prop as EnumeratedProperty>::SHORT_NAME).unwrap())?.0;
 
@@ -443,7 +431,7 @@ impl DataProvider<PropertyNameParseGeneralCategoryMaskV1> for SourceDataProvider
 
         self.check_req::<PropertyNameParseGeneralCategoryMaskV1>(req)?;
 
-        let short_name_to_t = GeneralCategoryGroup::names().collect::<BTreeMap<_, _>>();
+        let short_name_to_t = GeneralCategoryGroup::names().collect::<HashMap<_, _>>();
 
         let trie = self
             .enumerated_prop_names("General_Category", "gc")?

--- a/provider/source/src/properties/script.rs
+++ b/provider/source/src/properties/script.rs
@@ -8,13 +8,14 @@
 )]
 
 use crate::SourceDataProvider;
+use icu::collections::codepointtrie::TrieValue;
 use icu::properties::props::EnumeratedProperty;
 use icu::properties::props::Script;
 use icu::properties::provider::{PropertyScriptWithExtensionsV1, ScriptWithExtensionsProperty};
 use icu::properties::script::ScriptWithExt;
 use icu::properties::{CodePointMapData, PropertyParser};
 use icu_provider::prelude::*;
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{HashMap, HashSet};
 use zerovec::{VarZeroVec, ZeroSlice, ZeroVec};
 
 // implement data provider
@@ -50,7 +51,7 @@ impl DataProvider<PropertyScriptWithExtensionsV1> for SourceDataProvider {
                 let script = CodePointMapData::try_new_unstable(self)?;
 
                 let mut script_sets = vec![];
-                let mut script_sets_lookup = BTreeMap::new();
+                let mut script_sets_lookup = HashMap::new();
 
                 let mut char_with_extensions = HashMap::new();
 
@@ -65,8 +66,8 @@ impl DataProvider<PropertyScriptWithExtensionsV1> for SourceDataProvider {
                         .split_ascii_whitespace()
                         .filter_map(|s| script_parser.as_borrowed().get_strict(s))
                         .collect::<Vec<_>>();
-                    // Sort in discriminant order
-                    value.sort();
+                    // Sort in stable order
+                    value.sort_by_key(|s| s.to_u32());
 
                     let cp_range = super::ucd_helpers::parse_range(cp_range);
 


### PR DESCRIPTION
See https://github.com/unicode-org/icu4x/issues/6067#issuecomment-4925539102

Dategen should use public API, and I don't think `Ord` should be public API.

## Changelog

N/A