### PR TITLE
`PluralSubject` trait

### DIFF
--- a/components/decimal/src/abstract_formatter.rs
+++ b/components/decimal/src/abstract_formatter.rs
@@ -3,7 +3,6 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use fixed_decimal::UnsignedDecimal;
-use icu_plurals::PluralOperands;
 use writeable::Writeable;
 
 use crate::{
@@ -23,7 +22,7 @@ pub trait Sealed {}
 /// </div>
 pub trait AbstractFormatter: core::fmt::Debug + Sealed {
     #[doc(hidden)]
-    type FormattedUnsigned<'a>: Writeable
+    type FormattedUnsigned<'a>: Writeable + icu_plurals::PluralSubject
     where
         Self: 'a;
 
@@ -36,9 +35,6 @@ pub trait AbstractFormatter: core::fmt::Debug + Sealed {
         value: W,
         sign: fixed_decimal::Sign,
     ) -> FormattedSign<'a, W>;
-
-    #[doc(hidden)]
-    fn plural_operands(value: &Self::FormattedUnsigned<'_>) -> PluralOperands;
 }
 
 impl Sealed for DecimalFormatter {}
@@ -56,10 +52,6 @@ impl AbstractFormatter for DecimalFormatter {
     ) -> FormattedSign<'a, W> {
         self.format_sign(sign, value)
     }
-
-    fn plural_operands(value: &Self::FormattedUnsigned<'_>) -> PluralOperands {
-        value.plural_operands()
-    }
 }
 
 impl Sealed for CompactDecimalFormatter {}
@@ -76,9 +68,5 @@ impl AbstractFormatter for CompactDecimalFormatter {
         sign: fixed_decimal::Sign,
     ) -> FormattedSign<'a, W> {
         self.decimal_formatter.format_sign(sign, value)
-    }
-
-    fn plural_operands(value: &Self::FormattedUnsigned<'_>) -> PluralOperands {
-        value.plural_operands()
     }
 }

--- a/components/decimal/src/compact_formatter.rs
+++ b/components/decimal/src/compact_formatter.rs
@@ -17,7 +17,7 @@ use crate::{
 use alloc::string::String;
 use fixed_decimal::UnsignedDecimal;
 use icu_pattern::{Pattern, SinglePlaceholder};
-use icu_plurals::{PluralOperands, PluralRules};
+use icu_plurals::{PluralOperands, PluralRules, PluralSubject};
 use icu_provider::DataError;
 use icu_provider::{marker::ErasedMarker, prelude::*};
 use writeable::Writeable;
@@ -624,8 +624,8 @@ impl Writeable for FormattedUnsignedCompactDecimal<'_> {
     }
 }
 
-impl FormattedUnsignedCompactDecimal<'_> {
-    pub(crate) fn plural_operands(&self) -> PluralOperands {
+impl PluralSubject for FormattedUnsignedCompactDecimal<'_> {
+    fn plural_operands(&self) -> PluralOperands {
         PluralOperands::from_significand_and_exponent(&self.significand, self.exponent)
     }
 }

--- a/components/decimal/src/decimal_formatter.rs
+++ b/components/decimal/src/decimal_formatter.rs
@@ -5,7 +5,7 @@
 use super::Cow;
 use core::fmt::Write;
 #[cfg(feature = "unstable")]
-use icu_plurals::PluralOperands;
+use icu_plurals::{PluralOperands, PluralSubject};
 use writeable::Part;
 
 use crate::DecimalFormatterPreferences;
@@ -176,9 +176,9 @@ pub struct FormattedUnsignedDecimal<'l> {
     pub(crate) digits: &'l [char; 10],
 }
 
-impl FormattedUnsignedDecimal<'_> {
-    #[cfg(feature = "unstable")]
-    pub(crate) fn plural_operands(&self) -> PluralOperands {
+#[cfg(feature = "unstable")]
+impl PluralSubject for FormattedUnsignedDecimal<'_> {
+    fn plural_operands(&self) -> PluralOperands {
         PluralOperands::from_significand_and_exponent(&self.value, 0)
     }
 }

--- a/components/experimental/src/dimension/currency/formatter.rs
+++ b/components/experimental/src/dimension/currency/formatter.rs
@@ -8,7 +8,7 @@ use fixed_decimal::Decimal as FixedDecimal;
 use icu_decimal::preferences::CompactDecimalFormatterPreferences;
 use icu_decimal::{AbstractFormatter, DecimalFormatter, DecimalFormatterPreferences};
 use icu_locale_core::preferences::{define_preferences, prefs_convert};
-use icu_plurals::{PluralRules, PluralRulesPreferences};
+use icu_plurals::{PluralRules, PluralRulesPreferences, PluralSubject};
 use icu_provider::prelude::*;
 use writeable::Writeable;
 
@@ -458,7 +458,7 @@ impl<V: AbstractFormatter> CurrencyFormatter<V> {
                 patterns,
                 plural_rules,
             } => {
-                let operands = V::plural_operands(&formatted_value);
+                let operands = formatted_value.plural_operands();
                 let currency_str = extended.get().display_names.get(operands, plural_rules);
                 let pattern = patterns.get().patterns.get(operands, plural_rules);
                 (pattern, currency_str)

--- a/components/experimental/src/dimension/currency/formatter.rs
+++ b/components/experimental/src/dimension/currency/formatter.rs
@@ -21,7 +21,7 @@ use icu_decimal::{
     AbstractFormatter, CompactDecimalFormatter, DecimalFormatter, DecimalFormatterPreferences,
 };
 use icu_locale_core::preferences::{define_preferences, prefs_convert};
-use icu_plurals::{PluralRules, PluralRulesPreferences};
+use icu_plurals::{PluralRules, PluralRulesPreferences, PluralSubject};
 use icu_provider::prelude::*;
 use tinystr::TinyAsciiStr;
 use writeable::Writeable;
@@ -1391,7 +1391,7 @@ impl<V: AbstractFormatter> CurrencyFormatter<V> {
                 patterns,
                 plural_rules,
             } => {
-                let operands = V::plural_operands(&formatted_value);
+                let operands = formatted_value.plural_operands();
                 let currency_str = extended.get().get(operands, plural_rules);
                 let pattern = patterns.get().get(operands, plural_rules);
                 (pattern, currency_str, rounded_value.sign)

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -1178,3 +1178,9 @@ impl<T: PartialEq> PluralElements<T> {
         })
     }
 }
+
+/// A type that can be converted into [`PluralOperands`].
+pub trait PluralSubject {
+    /// Returns this value's [`PluralOperands`].
+    fn plural_operands(&self) -> PluralOperands;
+}


### PR DESCRIPTION
We currently use `Into<PluralOperands>`, which is not great as a trait bound, because it takes owned types, and it's very tricky to write trait bounds where the reference of a type implements a trait.

## Changelog

<!-- Please fill in according to documents/process/changelog.md -->
