### PR TITLE
Implement missing length constructors in single displaynames

### DIFF
--- a/components/experimental/src/displaynames/options.rs
+++ b/components/experimental/src/displaynames/options.rs
@@ -43,6 +43,12 @@ pub struct LanguageIdentifierDisplayNameOptions {
     pub language_display: Option<LanguageDisplay>,
 }
 
+impl LanguageIdentifierDisplayNameOptions {
+    pub(crate) fn should_load_dialect(self) -> bool {
+        self.language_display.unwrap_or_default() == LanguageDisplay::Dialect
+    }
+}
+
 /// An enum for formatting style.
 #[allow(missing_docs)] // The variants are self explanatory.
 #[non_exhaustive]

--- a/components/experimental/src/displaynames/single/language.rs
+++ b/components/experimental/src/displaynames/single/language.rs
@@ -499,6 +499,91 @@ impl LanguageIdentifierDisplayNameOwned {
         })
     }
 
+    icu_provider::gen_buffer_data_constructors!(
+        (prefs: DisplayNamesPreferences, subject: LanguageIdentifier, options: LanguageIdentifierDisplayNameOptions) -> result: Result<Self, DataError>,
+        /// Loads the short menu-style language display name for a given language identifier and locale using compiled data.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use icu::experimental::displaynames::{
+        ///     DisplayNamesPreferences, LanguageIdentifierDisplayNameOptions, single::LanguageIdentifierDisplayNameOwned,
+        /// };
+        /// use icu::locale::{locale, langid};
+        /// use writeable::assert_try_writeable_eq;
+        ///
+        /// let prefs = DisplayNamesPreferences::from(locale!("en"));
+        /// let options = LanguageIdentifierDisplayNameOptions::default();
+        /// let display_name = LanguageIdentifierDisplayNameOwned::try_new_short_menu(
+        ///     prefs,
+        ///     langid!("en-US"),
+        ///     options,
+        /// )
+        /// .expect("Data should load successfully");
+        ///
+        /// assert_try_writeable_eq!(display_name.as_borrowed(), "English (US)", Ok(()));
+        /// ```
+        functions: [
+            try_new_short_menu,
+            try_new_short_menu_with_buffer_provider,
+            try_new_short_menu_unstable,
+            Self
+        ]
+    );
+
+    #[doc = icu_provider::gen_buffer_unstable_docs!(UNSTABLE, Self::try_new_short_menu)]
+    pub fn try_new_short_menu_unstable<D>(
+        provider: &D,
+        prefs: DisplayNamesPreferences,
+        subject: LanguageIdentifier,
+        _options: LanguageIdentifierDisplayNameOptions,
+    ) -> Result<Self, DataError>
+    where
+        D: ?Sized
+            + DataProvider<LocaleNamesLanguageMenuMediumV1>
+            + DataProvider<LocaleNamesLanguageShortV1>
+            + DataProvider<LocaleNamesLanguageMediumV1>
+            + DataProvider<LocaleNamesScriptShortV1>
+            + DataProvider<LocaleNamesScriptMediumV1>
+            + DataProvider<LocaleNamesRegionShortV1>
+            + DataProvider<LocaleNamesRegionMediumV1>
+            + DataProvider<LocaleNamesVariantMediumV1>
+            + DataProvider<LocaleNamesEssentialsV1>,
+    {
+        let formatting_locale = LocaleNamesLanguageShortV1::make_locale(prefs.locale_preferences);
+
+        // Step 1: Load language name
+        // Try the menu name
+        let mut language_payload =
+            Self::load_language_menu_name(provider, &formatting_locale, subject.language)?;
+        if language_payload.is_none() {
+            language_payload = Self::load_language_subtag_name::<LocaleNamesLanguageShortV1, _>(
+                provider,
+                &formatting_locale,
+                subject.language,
+            )?;
+        }
+        if language_payload.is_none() {
+            language_payload = Self::load_language_subtag_name::<LocaleNamesLanguageMediumV1, _>(
+                provider,
+                &formatting_locale,
+                subject.language,
+            )?;
+        }
+        let language_payload = match language_payload {
+            Some(payload) => DataPayloadOr::from_payload(payload),
+            None => DataPayloadOr::from_other(subject.language),
+        };
+
+        // Load the remaining data
+        let qualifiers = QualifiersOwned::try_new_short_unstable(provider, prefs, subject)?;
+
+        Ok(Self {
+            language_payload,
+            qualifiers,
+        })
+    }
+
     /// Loads the name for a langauge dialect, which includes script and region subtags.
     ///
     /// We try to load names for combinations of subtags:

--- a/components/experimental/src/displaynames/single/language.rs
+++ b/components/experimental/src/displaynames/single/language.rs
@@ -7,7 +7,7 @@ use crate::displaynames::single::{
     RegionDisplayNameOwned, ScriptDisplayNameOwned, VariantDisplayNameOwned,
 };
 use crate::displaynames::{
-    DisplayNamesPreferences, LanguageDisplay, LanguageIdentifierDisplayNameOptions,
+    DisplayNamesPreferences, LanguageIdentifierDisplayNameOptions,
 };
 use crate::size_test_macro::size_test;
 use alloc::vec::Vec;
@@ -162,34 +162,25 @@ impl LanguageIdentifierDisplayNameOwned {
 
         // Step 1: Load language name
         // Only try dialect if requested (or default)
-        let language_payload =
-            if options.language_display.unwrap_or_default() == LanguageDisplay::Dialect {
-                Self::load_language_dialect_name::<LocaleNamesLanguageMediumV1, _>(
-                    provider,
-                    &formatting_locale,
-                    &mut subject,
-                )?
-            } else {
-                None
-            };
-
-        // If the language name is not loaded yet, try loading it from the language subtag alone.
+        let load_dialect_names = options.should_load_dialect();
+        let mut language_payload = None;
+        if load_dialect_names {
+            language_payload = Self::load_language_dialect_name::<LocaleNamesLanguageMediumV1, _>(
+                provider,
+                &formatting_locale,
+                &mut subject,
+            )?;
+        }
+        if language_payload.is_none() {
+            language_payload = Self::load_language_subtag_name::<LocaleNamesLanguageMediumV1, _>(
+                provider,
+                &formatting_locale,
+                subject.language,
+            )?;
+        }
         let language_payload = match language_payload {
-            Some(payload) => DataPayloadOr::from_payload(
-                payload.map_project(|payload, _| MenuNamePartsOrString::String(payload)),
-            ),
-            None => {
-                match Self::load_language_subtag_name::<LocaleNamesLanguageMediumV1, _>(
-                    provider,
-                    &formatting_locale,
-                    subject.language,
-                )? {
-                    Some(payload) => DataPayloadOr::from_payload(
-                        payload.map_project(|payload, _| MenuNamePartsOrString::String(payload)),
-                    ),
-                    None => DataPayloadOr::from_other(subject.language),
-                }
-            }
+            Some(payload) => DataPayloadOr::from_payload(payload),
+            None => DataPayloadOr::from_other(subject.language),
         };
 
         // Load the remaining data
@@ -228,7 +219,7 @@ impl LanguageIdentifierDisplayNameOwned {
         /// .expect("Data should load successfully");
         /// assert_try_writeable_eq!(
         ///     display_name_medium.as_borrowed(),
-        ///     "Chinese (Traditional, Hong Kong SAR China)",
+        ///     "Traditional Chinese (Hong Kong SAR China)",
         ///     Ok(())
         /// );
         ///
@@ -241,7 +232,7 @@ impl LanguageIdentifierDisplayNameOwned {
         /// .expect("Data should load successfully");
         /// assert_try_writeable_eq!(
         ///     display_name_short.as_borrowed(),
-        ///     "Chinese (Traditional, Hong Kong)",
+        ///     "Traditional Chinese (Hong Kong)",
         ///     Ok(())
         /// );
         /// ```
@@ -275,50 +266,39 @@ impl LanguageIdentifierDisplayNameOwned {
 
         // Step 1: Load short language name
         // Only try dialect if requested (or default)
-        let language_payload =
-            if options.language_display.unwrap_or_default() == LanguageDisplay::Dialect {
-                let mut resp = Self::load_language_dialect_name::<LocaleNamesLanguageShortV1, _>(
-                    provider,
-                    &formatting_locale,
-                    &mut subject,
-                )?;
-                if resp.is_none() {
-                    resp = Self::load_language_dialect_name::<LocaleNamesLanguageMediumV1, _>(
-                        provider,
-                        &formatting_locale,
-                        &mut subject,
-                    )?;
-                }
-                resp
-            } else {
-                None
-            };
-
-        // If the language name is not loaded yet, try loading it from the language subtag alone.
+        let load_dialect_names = options.should_load_dialect();
+        let mut language_payload = None;
+        if load_dialect_names {
+            language_payload = Self::load_language_dialect_name::<LocaleNamesLanguageShortV1, _>(
+                provider,
+                &formatting_locale,
+                &mut subject,
+            )?;
+        }
+        if load_dialect_names && language_payload.is_none() {
+            language_payload = Self::load_language_dialect_name::<LocaleNamesLanguageMediumV1, _>(
+                provider,
+                &formatting_locale,
+                &mut subject,
+            )?;
+        }
+        if language_payload.is_none() {
+            language_payload = Self::load_language_subtag_name::<LocaleNamesLanguageShortV1, _>(
+                provider,
+                &formatting_locale,
+                subject.language,
+            )?;
+        }
+        if language_payload.is_none() {
+            language_payload = Self::load_language_subtag_name::<LocaleNamesLanguageMediumV1, _>(
+                provider,
+                &formatting_locale,
+                subject.language,
+            )?;
+        }
         let language_payload = match language_payload {
-            Some(payload) => DataPayloadOr::from_payload(
-                payload.map_project(|payload, _| MenuNamePartsOrString::String(payload)),
-            ),
-            None => {
-                let mut resp = Self::load_language_subtag_name::<LocaleNamesLanguageShortV1, _>(
-                    provider,
-                    &formatting_locale,
-                    subject.language,
-                )?;
-                if resp.is_none() {
-                    resp = Self::load_language_subtag_name::<LocaleNamesLanguageMediumV1, _>(
-                        provider,
-                        &formatting_locale,
-                        subject.language,
-                    )?;
-                }
-                match resp {
-                    Some(payload) => DataPayloadOr::from_payload(
-                        payload.map_project(|payload, _| MenuNamePartsOrString::String(payload)),
-                    ),
-                    None => DataPayloadOr::from_other(subject.language),
-                }
-            }
+            Some(payload) => DataPayloadOr::from_payload(payload),
+            None => DataPayloadOr::from_other(subject.language),
         };
 
         // Load the remaining data
@@ -402,8 +382,7 @@ impl LanguageIdentifierDisplayNameOwned {
 
         // Step 1: Load long language name
         // Only try dialect if requested (or default)
-        let load_dialect_names =
-            options.language_display.unwrap_or_default() == LanguageDisplay::Dialect;
+        let load_dialect_names = options.should_load_dialect();
         let mut language_payload = None;
         if load_dialect_names {
             language_payload = Self::load_language_dialect_name::<LocaleNamesLanguageLongV1, _>(
@@ -434,9 +413,7 @@ impl LanguageIdentifierDisplayNameOwned {
             )?;
         }
         let language_payload = match language_payload {
-            Some(payload) => DataPayloadOr::from_payload(
-                payload.map_project(|payload, _| MenuNamePartsOrString::String(payload)),
-            ),
+            Some(payload) => DataPayloadOr::from_payload(payload),
             None => DataPayloadOr::from_other(subject.language),
         };
 
@@ -501,28 +478,18 @@ impl LanguageIdentifierDisplayNameOwned {
 
         // Step 1: Load language name
         // Try the menu name
-        let language_payload =
+        let mut language_payload =
             Self::load_language_menu_name(provider, &formatting_locale, subject.language)?;
-
-        // If the language name is not loaded yet, try loading it from the language subtag alone.
+        if language_payload.is_none() {
+            language_payload = Self::load_language_subtag_name::<LocaleNamesLanguageMediumV1, _>(
+                provider,
+                &formatting_locale,
+                subject.language,
+            )?;
+        }
         let language_payload = match language_payload {
-            Some(payload) => {
-                DataPayloadOr::from_payload(payload.map_project(|menu_ule, _phantom| {
-                    MenuNamePartsOrString::MenuNameParts(menu_ule)
-                }))
-            }
-            None => {
-                match Self::load_language_subtag_name::<LocaleNamesLanguageMediumV1, _>(
-                    provider,
-                    &formatting_locale,
-                    subject.language,
-                )? {
-                    Some(payload) => DataPayloadOr::from_payload(
-                        payload.map_project(|payload, _| MenuNamePartsOrString::String(payload)),
-                    ),
-                    None => DataPayloadOr::from_other(subject.language),
-                }
-            }
+            Some(payload) => DataPayloadOr::from_payload(payload),
+            None => DataPayloadOr::from_other(subject.language),
         };
 
         // Load the remaining data
@@ -548,7 +515,7 @@ impl LanguageIdentifierDisplayNameOwned {
         provider: &P,
         formatting_locale: &DataLocale,
         subject: &mut LanguageIdentifier,
-    ) -> Result<Option<DataPayload<ErasedMarker<VarZeroCow<'static, str>>>>, DataError>
+    ) -> Result<Option<DataPayload<ErasedMarker<MenuNamePartsOrString<'static>>>>, DataError>
     where
         M: DataMarker<DataStruct = VarZeroCow<'static, str>>,
         P: ?Sized + DataProvider<M>,
@@ -589,7 +556,11 @@ impl LanguageIdentifierDisplayNameOwned {
                 if region.is_some() {
                     subject.region = None;
                 }
-                return Ok(Some(response.payload.cast()));
+                return Ok(Some(
+                    response
+                        .payload
+                        .map_project(|payload, _| MenuNamePartsOrString::String(payload)),
+                ));
             }
         }
         Ok(None)
@@ -600,7 +571,7 @@ impl LanguageIdentifierDisplayNameOwned {
         provider: &P,
         formatting_locale: &DataLocale,
         language: Language,
-    ) -> Result<Option<DataPayload<ErasedMarker<VarZeroCow<'static, str>>>>, DataError>
+    ) -> Result<Option<DataPayload<ErasedMarker<MenuNamePartsOrString<'static>>>>, DataError>
     where
         M: DataMarker<DataStruct = VarZeroCow<'static, str>>,
         P: ?Sized + DataProvider<M>,
@@ -614,7 +585,10 @@ impl LanguageIdentifierDisplayNameOwned {
         let option = provider
             .load(DataRequest { id, metadata })
             .allow_identifier_not_found()?;
-        Ok(option.map(|resp| resp.payload.cast()))
+        Ok(option.map(|resp| {
+            resp.payload
+                .map_project(|payload, _| MenuNamePartsOrString::String(payload))
+        }))
     }
 
     /// Loads the name for a language with menu core and extension parts.
@@ -622,7 +596,7 @@ impl LanguageIdentifierDisplayNameOwned {
         provider: &P,
         formatting_locale: &DataLocale,
         language: Language,
-    ) -> Result<Option<DataPayload<ErasedMarker<VarZeroCow<'static, MenuNamePartsULE>>>>, DataError>
+    ) -> Result<Option<DataPayload<ErasedMarker<MenuNamePartsOrString<'static>>>>, DataError>
     where
         P: ?Sized + DataProvider<LocaleNamesLanguageMenuMediumV1>,
     {
@@ -638,7 +612,10 @@ impl LanguageIdentifierDisplayNameOwned {
                 ..Default::default()
             })
             .allow_identifier_not_found()?;
-        Ok(option.map(|resp| resp.payload.cast()))
+        Ok(option.map(|resp| {
+            resp.payload
+                .map_project(|payload, _| MenuNamePartsOrString::MenuNameParts(payload))
+        }))
     }
 }
 

--- a/components/experimental/src/displaynames/single/language.rs
+++ b/components/experimental/src/displaynames/single/language.rs
@@ -185,7 +185,6 @@ impl LanguageIdentifierDisplayNameOwned {
                     provider,
                     &formatting_locale,
                     subject.language,
-                    false,
                 )? {
                     Some(response) => DataPayloadOr::from_payload(
                         response
@@ -311,7 +310,6 @@ impl LanguageIdentifierDisplayNameOwned {
                     provider,
                     &formatting_locale,
                     subject.language,
-                    true,
                 )?
                 .map(|r| r.payload.cast());
                 if resp.is_none() {
@@ -319,7 +317,6 @@ impl LanguageIdentifierDisplayNameOwned {
                         provider,
                         &formatting_locale,
                         subject.language,
-                        false,
                     )?
                     .map(|r| r.payload);
                 }
@@ -444,7 +441,6 @@ impl LanguageIdentifierDisplayNameOwned {
                     provider,
                     &formatting_locale,
                     subject.language,
-                    true,
                 )?
                 .map(|r| r.payload.cast());
                 if resp.is_none() {
@@ -452,7 +448,6 @@ impl LanguageIdentifierDisplayNameOwned {
                         provider,
                         &formatting_locale,
                         subject.language,
-                        false,
                     )?
                     .map(|r| r.payload);
                 }
@@ -540,7 +535,6 @@ impl LanguageIdentifierDisplayNameOwned {
                         provider,
                         &formatting_locale,
                         subject.language,
-                        false,
                     )? {
                         Some(response) => DataPayloadOr::from_payload(
                             response
@@ -627,7 +621,6 @@ impl LanguageIdentifierDisplayNameOwned {
         provider: &P,
         formatting_locale: &DataLocale,
         language: Language,
-        silent: bool,
     ) -> Result<Option<DataResponse<M>>, DataError>
     where
         M: DataMarker<DataStruct = VarZeroCow<'static, str>>,
@@ -637,7 +630,8 @@ impl LanguageIdentifierDisplayNameOwned {
         let attrs = LocaleNamesLanguageMediumV1::make_attributes(language, None, None, &mut buffer);
         let id = DataIdentifierBorrowed::for_marker_attributes_and_locale(attrs, formatting_locale);
         let mut metadata = DataRequestMetadata::default();
-        metadata.silent = silent;
+        metadata.silent =
+            core::any::TypeId::of::<M>() != core::any::TypeId::of::<LocaleNamesLanguageMediumV1>();
         provider
             .load(DataRequest { id, metadata })
             .allow_identifier_not_found()

--- a/components/experimental/src/displaynames/single/language.rs
+++ b/components/experimental/src/displaynames/single/language.rs
@@ -164,7 +164,11 @@ impl LanguageIdentifierDisplayNameOwned {
         // Only try dialect if requested (or default)
         let language_payload =
             if options.language_display.unwrap_or_default() == LanguageDisplay::Dialect {
-                Self::load_language_dialect_name(provider, &formatting_locale, &mut subject)?
+                Self::load_language_dialect_name::<LocaleNamesLanguageMediumV1, _>(
+                    provider,
+                    &formatting_locale,
+                    &mut subject,
+                )?
             } else {
                 None
             };
@@ -177,15 +181,284 @@ impl LanguageIdentifierDisplayNameOwned {
                     .map_project(|payload, _| MenuNamePartsOrString::String(payload)),
             ),
             None => {
-                match Self::load_language_subtag_name(
+                match Self::load_language_subtag_name::<LocaleNamesLanguageMediumV1, _>(
                     provider,
                     &formatting_locale,
                     subject.language,
+                    false,
                 )? {
                     Some(response) => DataPayloadOr::from_payload(
                         response
                             .payload
                             .map_project(|payload, _| MenuNamePartsOrString::String(payload)),
+                    ),
+                    None => DataPayloadOr::from_other(subject.language),
+                }
+            }
+        };
+
+        // Load the remaining data
+        let qualifiers = QualifiersOwned::try_new_unstable(provider, prefs, subject)?;
+
+        Ok(Self {
+            language_payload,
+            qualifiers,
+        })
+    }
+
+    icu_provider::gen_buffer_data_constructors!(
+        (prefs: DisplayNamesPreferences, subject: LanguageIdentifier, options: LanguageIdentifierDisplayNameOptions) -> result: Result<Self, DataError>,
+        /// Loads the short language display name for a given language identifier and locale using compiled data.
+        ///
+        /// Falls back to the medium name if the short name is not available.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use icu::experimental::displaynames::{
+        ///     DisplayNamesPreferences, LanguageIdentifierDisplayNameOptions, single::LanguageIdentifierDisplayNameOwned,
+        /// };
+        /// use icu::locale::{locale, langid};
+        /// use writeable::assert_try_writeable_eq;
+        ///
+        /// let prefs = DisplayNamesPreferences::from(locale!("en"));
+        /// let options = LanguageIdentifierDisplayNameOptions::default();
+        ///
+        /// // Default (Medium) length format:
+        /// let display_name_medium = LanguageIdentifierDisplayNameOwned::try_new(
+        ///     prefs,
+        ///     langid!("zh-Hant-HK"),
+        ///     options,
+        /// )
+        /// .expect("Data should load successfully");
+        /// assert_try_writeable_eq!(
+        ///     display_name_medium.as_borrowed(),
+        ///     "Chinese (Traditional, Hong Kong SAR China)",
+        ///     Ok(())
+        /// );
+        ///
+        /// // Short length format uses shorter subtag/qualifier names when available:
+        /// let display_name_short = LanguageIdentifierDisplayNameOwned::try_new_short(
+        ///     prefs,
+        ///     langid!("zh-Hant-HK"),
+        ///     options,
+        /// )
+        /// .expect("Data should load successfully");
+        /// assert_try_writeable_eq!(
+        ///     display_name_short.as_borrowed(),
+        ///     "Chinese (Traditional, Hong Kong)",
+        ///     Ok(())
+        /// );
+        /// ```
+        functions: [
+            try_new_short,
+            try_new_short_with_buffer_provider,
+            try_new_short_unstable,
+            Self
+        ]
+    );
+
+    #[doc = icu_provider::gen_buffer_unstable_docs!(UNSTABLE, Self::try_new_short)]
+    pub fn try_new_short_unstable<D>(
+        provider: &D,
+        prefs: DisplayNamesPreferences,
+        mut subject: LanguageIdentifier,
+        options: LanguageIdentifierDisplayNameOptions,
+    ) -> Result<Self, DataError>
+    where
+        D: DataProvider<LocaleNamesLanguageShortV1>
+            + DataProvider<LocaleNamesLanguageMediumV1>
+            + DataProvider<LocaleNamesScriptShortV1>
+            + DataProvider<LocaleNamesScriptMediumV1>
+            + DataProvider<LocaleNamesRegionShortV1>
+            + DataProvider<LocaleNamesRegionMediumV1>
+            + DataProvider<LocaleNamesVariantMediumV1>
+            + DataProvider<LocaleNamesEssentialsV1>
+            + ?Sized,
+    {
+        let formatting_locale = LocaleNamesLanguageShortV1::make_locale(prefs.locale_preferences);
+
+        // Step 1: Load short language name
+        // Only try dialect if requested (or default)
+        let language_payload =
+            if options.language_display.unwrap_or_default() == LanguageDisplay::Dialect {
+                let mut resp = Self::load_language_dialect_name::<LocaleNamesLanguageShortV1, _>(
+                    provider,
+                    &formatting_locale,
+                    &mut subject,
+                )?
+                .map(|r| r.payload.cast());
+                if resp.is_none() {
+                    resp = Self::load_language_dialect_name::<LocaleNamesLanguageMediumV1, _>(
+                        provider,
+                        &formatting_locale,
+                        &mut subject,
+                    )?
+                    .map(|r| r.payload);
+                }
+                resp
+            } else {
+                None
+            };
+
+        // If the language name is not loaded yet, try loading it from the language subtag alone.
+        let language_payload = match language_payload {
+            Some(payload) => DataPayloadOr::from_payload(
+                payload.map_project(|payload, _| MenuNamePartsOrString::String(payload)),
+            ),
+            None => {
+                let mut resp = Self::load_language_subtag_name::<LocaleNamesLanguageShortV1, _>(
+                    provider,
+                    &formatting_locale,
+                    subject.language,
+                    true,
+                )?
+                .map(|r| r.payload.cast());
+                if resp.is_none() {
+                    resp = Self::load_language_subtag_name::<LocaleNamesLanguageMediumV1, _>(
+                        provider,
+                        &formatting_locale,
+                        subject.language,
+                        false,
+                    )?
+                    .map(|r| r.payload);
+                }
+                match resp {
+                    Some(payload) => DataPayloadOr::from_payload(
+                        payload.map_project(|payload, _| MenuNamePartsOrString::String(payload)),
+                    ),
+                    None => DataPayloadOr::from_other(subject.language),
+                }
+            }
+        };
+
+        // Load the remaining data
+        let qualifiers = QualifiersOwned::try_new_short_unstable(provider, prefs, subject)?;
+
+        Ok(Self {
+            language_payload,
+            qualifiers,
+        })
+    }
+
+    icu_provider::gen_buffer_data_constructors!(
+        (prefs: DisplayNamesPreferences, subject: LanguageIdentifier, options: LanguageIdentifierDisplayNameOptions) -> result: Result<Self, DataError>,
+        /// Loads the long language display name for a given language identifier and locale using compiled data.
+        ///
+        /// Falls back to the medium name if the long name is not available.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use icu::experimental::displaynames::{
+        ///     DisplayNamesPreferences, LanguageIdentifierDisplayNameOptions, single::LanguageIdentifierDisplayNameOwned,
+        /// };
+        /// use icu::locale::{locale, langid};
+        /// use writeable::assert_try_writeable_eq;
+        ///
+        /// let prefs = DisplayNamesPreferences::from(locale!("en"));
+        /// let options = LanguageIdentifierDisplayNameOptions::default();
+        ///
+        /// // Default (Medium) length format:
+        /// let display_name_medium = LanguageIdentifierDisplayNameOwned::try_new(
+        ///     prefs,
+        ///     langid!("zh-Hant-HK"),
+        ///     options,
+        /// )
+        /// .expect("Data should load successfully");
+        /// assert_try_writeable_eq!(
+        ///     display_name_medium.as_borrowed(),
+        ///     "Chinese (Traditional, Hong Kong SAR China)",
+        ///     Ok(())
+        /// );
+        ///
+        /// // Long length format uses longer subtag names when available:
+        /// let display_name_long = LanguageIdentifierDisplayNameOwned::try_new_long(
+        ///     prefs,
+        ///     langid!("zh-Hant-HK"),
+        ///     options,
+        /// )
+        /// .expect("Data should load successfully");
+        /// assert_try_writeable_eq!(
+        ///     display_name_long.as_borrowed(),
+        ///     "Mandarin Chinese (Traditional, Hong Kong SAR China)",
+        ///     Ok(())
+        /// );
+        /// ```
+        functions: [
+            try_new_long,
+            try_new_long_with_buffer_provider,
+            try_new_long_unstable,
+            Self
+        ]
+    );
+
+    #[doc = icu_provider::gen_buffer_unstable_docs!(UNSTABLE, Self::try_new_long)]
+    pub fn try_new_long_unstable<D>(
+        provider: &D,
+        prefs: DisplayNamesPreferences,
+        mut subject: LanguageIdentifier,
+        options: LanguageIdentifierDisplayNameOptions,
+    ) -> Result<Self, DataError>
+    where
+        D: DataProvider<LocaleNamesLanguageLongV1>
+            + DataProvider<LocaleNamesLanguageMediumV1>
+            + DataProvider<LocaleNamesScriptMediumV1>
+            + DataProvider<LocaleNamesRegionMediumV1>
+            + DataProvider<LocaleNamesVariantMediumV1>
+            + DataProvider<LocaleNamesEssentialsV1>
+            + ?Sized,
+    {
+        let formatting_locale = LocaleNamesLanguageLongV1::make_locale(prefs.locale_preferences);
+
+        // Step 1: Load long language name
+        // Only try dialect if requested (or default)
+        let language_payload =
+            if options.language_display.unwrap_or_default() == LanguageDisplay::Dialect {
+                let mut resp = Self::load_language_dialect_name::<LocaleNamesLanguageLongV1, _>(
+                    provider,
+                    &formatting_locale,
+                    &mut subject,
+                )?
+                .map(|r| r.payload.cast());
+                if resp.is_none() {
+                    resp = Self::load_language_dialect_name::<LocaleNamesLanguageMediumV1, _>(
+                        provider,
+                        &formatting_locale,
+                        &mut subject,
+                    )?
+                    .map(|r| r.payload);
+                }
+                resp
+            } else {
+                None
+            };
+
+        // If the language name is not loaded yet, try loading it from the language subtag alone.
+        let language_payload = match language_payload {
+            Some(payload) => DataPayloadOr::from_payload(
+                payload.map_project(|payload, _| MenuNamePartsOrString::String(payload)),
+            ),
+            None => {
+                let mut resp = Self::load_language_subtag_name::<LocaleNamesLanguageLongV1, _>(
+                    provider,
+                    &formatting_locale,
+                    subject.language,
+                    true,
+                )?
+                .map(|r| r.payload.cast());
+                if resp.is_none() {
+                    resp = Self::load_language_subtag_name::<LocaleNamesLanguageMediumV1, _>(
+                        provider,
+                        &formatting_locale,
+                        subject.language,
+                        false,
+                    )?
+                    .map(|r| r.payload);
+                }
+                match resp {
+                    Some(payload) => DataPayloadOr::from_payload(
+                        payload.map_project(|payload, _| MenuNamePartsOrString::String(payload)),
                     ),
                     None => DataPayloadOr::from_other(subject.language),
                 }
@@ -257,25 +530,27 @@ impl LanguageIdentifierDisplayNameOwned {
             Self::load_language_menu_name(provider, &formatting_locale, subject.language)?;
 
         // If the language name is not loaded yet, try loading it from the language subtag alone.
-        let language_payload = match language_payload {
-            Some(response) => {
-                DataPayloadOr::from_payload(response.payload.map_project(|menu_ule, _phantom| {
-                    MenuNamePartsOrString::MenuNameParts(menu_ule)
-                }))
-            }
-            None => {
-                match Self::load_language_subtag_name(
-                    provider,
-                    &formatting_locale,
-                    subject.language,
-                )? {
-                    Some(response) => DataPayloadOr::from_payload(response.payload.map_project(
-                        |subtag_name, _phantom| MenuNamePartsOrString::String(subtag_name),
-                    )),
-                    None => DataPayloadOr::from_other(subject.language),
+        let language_payload =
+            match language_payload {
+                Some(response) => DataPayloadOr::from_payload(response.payload.map_project(
+                    |menu_ule, _phantom| MenuNamePartsOrString::MenuNameParts(menu_ule),
+                )),
+                None => {
+                    match Self::load_language_subtag_name::<LocaleNamesLanguageMediumV1, _>(
+                        provider,
+                        &formatting_locale,
+                        subject.language,
+                        false,
+                    )? {
+                        Some(response) => DataPayloadOr::from_payload(
+                            response
+                                .payload
+                                .map_project(|payload, _| MenuNamePartsOrString::String(payload)),
+                        ),
+                        None => DataPayloadOr::from_other(subject.language),
+                    }
                 }
-            }
-        };
+            };
 
         // Load the remaining data
         let qualifiers = QualifiersOwned::try_new_unstable(provider, prefs, subject)?;
@@ -296,13 +571,14 @@ impl LanguageIdentifierDisplayNameOwned {
     ///
     /// We then "consume"  the corresponding subtags from the input `LanguageIdentifier`
     /// so they are not repeated in the qualifiers.
-    fn load_language_dialect_name<P>(
+    fn load_language_dialect_name<M, P>(
         provider: &P,
         formatting_locale: &DataLocale,
         subject: &mut LanguageIdentifier,
-    ) -> Result<Option<DataResponse<LocaleNamesLanguageMediumV1>>, DataError>
+    ) -> Result<Option<DataResponse<M>>, DataError>
     where
-        P: ?Sized + DataProvider<LocaleNamesLanguageMediumV1>,
+        M: DataMarker<DataStruct = VarZeroCow<'static, str>>,
+        P: ?Sized + DataProvider<M>,
     {
         for (language, script, region) in [
             (subject.language, Some(subject.script), Some(subject.region)),
@@ -347,24 +623,23 @@ impl LanguageIdentifierDisplayNameOwned {
     }
 
     /// Loads the name for an individual language subtag.
-    fn load_language_subtag_name<P>(
+    fn load_language_subtag_name<M, P>(
         provider: &P,
         formatting_locale: &DataLocale,
         language: Language,
-    ) -> Result<Option<DataResponse<LocaleNamesLanguageMediumV1>>, DataError>
+        silent: bool,
+    ) -> Result<Option<DataResponse<M>>, DataError>
     where
-        P: ?Sized + DataProvider<LocaleNamesLanguageMediumV1>,
+        M: DataMarker<DataStruct = VarZeroCow<'static, str>>,
+        P: ?Sized + DataProvider<M>,
     {
         let mut buffer = TinyAsciiStr::EMPTY;
         let attrs = LocaleNamesLanguageMediumV1::make_attributes(language, None, None, &mut buffer);
+        let id = DataIdentifierBorrowed::for_marker_attributes_and_locale(attrs, formatting_locale);
+        let mut metadata = DataRequestMetadata::default();
+        metadata.silent = silent;
         provider
-            .load(DataRequest {
-                id: DataIdentifierBorrowed::for_marker_attributes_and_locale(
-                    attrs,
-                    formatting_locale,
-                ),
-                ..Default::default()
-            })
+            .load(DataRequest { id, metadata })
             .allow_identifier_not_found()
     }
 
@@ -393,23 +668,23 @@ impl LanguageIdentifierDisplayNameOwned {
 }
 
 impl QualifiersOwned {
-    fn try_new_unstable<D>(
+    fn try_new_internal_unstable<D, FS, FR, FV>(
         provider: &D,
         prefs: DisplayNamesPreferences,
         subject: LanguageIdentifier,
+        load_script: FS,
+        load_region: FR,
+        load_variant: FV,
     ) -> Result<Self, DataError>
     where
-        D: ?Sized
-            + DataProvider<LocaleNamesScriptMediumV1>
-            + DataProvider<LocaleNamesRegionMediumV1>
-            + DataProvider<LocaleNamesVariantMediumV1>
-            + DataProvider<LocaleNamesEssentialsV1>,
+        D: ?Sized + DataProvider<LocaleNamesEssentialsV1>,
+        FS: Fn(&D, DisplayNamesPreferences, Script) -> Result<ScriptDisplayNameOwned, DataError>,
+        FR: Fn(&D, DisplayNamesPreferences, Region) -> Result<RegionDisplayNameOwned, DataError>,
+        FV: Fn(&D, DisplayNamesPreferences, Variant) -> Result<VariantDisplayNameOwned, DataError>,
     {
         // Step 2: Load script name (if present in subject)
         let script_payload = if let Some(script) = subject.script {
-            match ScriptDisplayNameOwned::try_new_unstable(provider, prefs, script)
-                .allow_identifier_not_found()?
-            {
+            match load_script(provider, prefs, script).allow_identifier_not_found()? {
                 Some(obj) => DataPayloadOr::from_payload(obj.payload),
                 None => DataPayloadOr::from_other(Some(script)),
             }
@@ -419,9 +694,7 @@ impl QualifiersOwned {
 
         // Step 3: Load region name (if present in subject)
         let region_payload = if let Some(region) = subject.region {
-            match RegionDisplayNameOwned::try_new_unstable(provider, prefs, region)
-                .allow_identifier_not_found()?
-            {
+            match load_region(provider, prefs, region).allow_identifier_not_found()? {
                 Some(obj) => DataPayloadOr::from_payload(obj.payload),
                 None => DataPayloadOr::from_other(Some(region)),
             }
@@ -430,13 +703,11 @@ impl QualifiersOwned {
         };
 
         // Step 4: Load variant names (if present in subject)
-        let load_variant = |variant: Variant| -> Result<
+        let load_variant_helper = |variant: Variant| -> Result<
             DataPayloadOr<LocaleNamesVariantMediumV1, Variant>,
             DataError,
         > {
-            match VariantDisplayNameOwned::try_new_unstable(provider, prefs, variant)
-                .allow_identifier_not_found()?
-            {
+            match load_variant(provider, prefs, variant).allow_identifier_not_found()? {
                 Some(obj) => Ok(DataPayloadOr::from_payload(obj.payload)),
                 None => Ok(DataPayloadOr::from_other(variant)),
             }
@@ -445,7 +716,7 @@ impl QualifiersOwned {
         let mut variant_results = subject
             .variants
             .iter()
-            .map(|variant| load_variant(*variant));
+            .map(|variant| load_variant_helper(*variant));
 
         let variant_payloads = if let Some(first) = variant_results.next() {
             if let Some(second) = variant_results.next() {
@@ -483,6 +754,52 @@ impl QualifiersOwned {
             variant_payloads,
             essentials_payload,
         })
+    }
+
+    fn try_new_unstable<D>(
+        provider: &D,
+        prefs: DisplayNamesPreferences,
+        subject: LanguageIdentifier,
+    ) -> Result<Self, DataError>
+    where
+        D: ?Sized
+            + DataProvider<LocaleNamesScriptMediumV1>
+            + DataProvider<LocaleNamesRegionMediumV1>
+            + DataProvider<LocaleNamesVariantMediumV1>
+            + DataProvider<LocaleNamesEssentialsV1>,
+    {
+        Self::try_new_internal_unstable(
+            provider,
+            prefs,
+            subject,
+            ScriptDisplayNameOwned::try_new_unstable,
+            RegionDisplayNameOwned::try_new_unstable,
+            VariantDisplayNameOwned::try_new_unstable,
+        )
+    }
+
+    fn try_new_short_unstable<D>(
+        provider: &D,
+        prefs: DisplayNamesPreferences,
+        subject: LanguageIdentifier,
+    ) -> Result<Self, DataError>
+    where
+        D: ?Sized
+            + DataProvider<LocaleNamesScriptShortV1>
+            + DataProvider<LocaleNamesScriptMediumV1>
+            + DataProvider<LocaleNamesRegionShortV1>
+            + DataProvider<LocaleNamesRegionMediumV1>
+            + DataProvider<LocaleNamesVariantMediumV1>
+            + DataProvider<LocaleNamesEssentialsV1>,
+    {
+        Self::try_new_internal_unstable(
+            provider,
+            prefs,
+            subject,
+            ScriptDisplayNameOwned::try_new_short_unstable,
+            RegionDisplayNameOwned::try_new_short_unstable,
+            VariantDisplayNameOwned::try_new_unstable,
+        )
     }
 }
 

--- a/components/experimental/src/displaynames/single/language.rs
+++ b/components/experimental/src/displaynames/single/language.rs
@@ -175,10 +175,8 @@ impl LanguageIdentifierDisplayNameOwned {
 
         // If the language name is not loaded yet, try loading it from the language subtag alone.
         let language_payload = match language_payload {
-            Some(response) => DataPayloadOr::from_payload(
-                response
-                    .payload
-                    .map_project(|payload, _| MenuNamePartsOrString::String(payload)),
+            Some(payload) => DataPayloadOr::from_payload(
+                payload.map_project(|payload, _| MenuNamePartsOrString::String(payload)),
             ),
             None => {
                 match Self::load_language_subtag_name::<LocaleNamesLanguageMediumV1, _>(
@@ -186,10 +184,8 @@ impl LanguageIdentifierDisplayNameOwned {
                     &formatting_locale,
                     subject.language,
                 )? {
-                    Some(response) => DataPayloadOr::from_payload(
-                        response
-                            .payload
-                            .map_project(|payload, _| MenuNamePartsOrString::String(payload)),
+                    Some(payload) => DataPayloadOr::from_payload(
+                        payload.map_project(|payload, _| MenuNamePartsOrString::String(payload)),
                     ),
                     None => DataPayloadOr::from_other(subject.language),
                 }
@@ -285,15 +281,13 @@ impl LanguageIdentifierDisplayNameOwned {
                     provider,
                     &formatting_locale,
                     &mut subject,
-                )?
-                .map(|r| r.payload.cast());
+                )?;
                 if resp.is_none() {
                     resp = Self::load_language_dialect_name::<LocaleNamesLanguageMediumV1, _>(
                         provider,
                         &formatting_locale,
                         &mut subject,
-                    )?
-                    .map(|r| r.payload);
+                    )?;
                 }
                 resp
             } else {
@@ -310,15 +304,13 @@ impl LanguageIdentifierDisplayNameOwned {
                     provider,
                     &formatting_locale,
                     subject.language,
-                )?
-                .map(|r| r.payload.cast());
+                )?;
                 if resp.is_none() {
                     resp = Self::load_language_subtag_name::<LocaleNamesLanguageMediumV1, _>(
                         provider,
                         &formatting_locale,
                         subject.language,
-                    )?
-                    .map(|r| r.payload);
+                    )?;
                 }
                 match resp {
                     Some(payload) => DataPayloadOr::from_payload(
@@ -365,7 +357,7 @@ impl LanguageIdentifierDisplayNameOwned {
         /// .expect("Data should load successfully");
         /// assert_try_writeable_eq!(
         ///     display_name_medium.as_borrowed(),
-        ///     "Chinese (Traditional, Hong Kong SAR China)",
+        ///     "Traditional Chinese (Hong Kong SAR China)",
         ///     Ok(())
         /// );
         ///
@@ -378,7 +370,7 @@ impl LanguageIdentifierDisplayNameOwned {
         /// .expect("Data should load successfully");
         /// assert_try_writeable_eq!(
         ///     display_name_long.as_borrowed(),
-        ///     "Mandarin Chinese (Traditional, Hong Kong SAR China)",
+        ///     "Traditional Mandarin Chinese (Hong Kong SAR China)",
         ///     Ok(())
         /// );
         /// ```
@@ -410,54 +402,42 @@ impl LanguageIdentifierDisplayNameOwned {
 
         // Step 1: Load long language name
         // Only try dialect if requested (or default)
-        let language_payload =
-            if options.language_display.unwrap_or_default() == LanguageDisplay::Dialect {
-                let mut resp = Self::load_language_dialect_name::<LocaleNamesLanguageLongV1, _>(
-                    provider,
-                    &formatting_locale,
-                    &mut subject,
-                )?
-                .map(|r| r.payload.cast());
-                if resp.is_none() {
-                    resp = Self::load_language_dialect_name::<LocaleNamesLanguageMediumV1, _>(
-                        provider,
-                        &formatting_locale,
-                        &mut subject,
-                    )?
-                    .map(|r| r.payload);
-                }
-                resp
-            } else {
-                None
-            };
-
-        // If the language name is not loaded yet, try loading it from the language subtag alone.
+        let load_dialect_names =
+            options.language_display.unwrap_or_default() == LanguageDisplay::Dialect;
+        let mut language_payload = None;
+        if load_dialect_names {
+            language_payload = Self::load_language_dialect_name::<LocaleNamesLanguageLongV1, _>(
+                provider,
+                &formatting_locale,
+                &mut subject,
+            )?;
+        }
+        if load_dialect_names && language_payload.is_none() {
+            language_payload = Self::load_language_dialect_name::<LocaleNamesLanguageMediumV1, _>(
+                provider,
+                &formatting_locale,
+                &mut subject,
+            )?;
+        }
+        if language_payload.is_none() {
+            language_payload = Self::load_language_subtag_name::<LocaleNamesLanguageLongV1, _>(
+                provider,
+                &formatting_locale,
+                subject.language,
+            )?;
+        }
+        if language_payload.is_none() {
+            language_payload = Self::load_language_subtag_name::<LocaleNamesLanguageMediumV1, _>(
+                provider,
+                &formatting_locale,
+                subject.language,
+            )?;
+        }
         let language_payload = match language_payload {
             Some(payload) => DataPayloadOr::from_payload(
                 payload.map_project(|payload, _| MenuNamePartsOrString::String(payload)),
             ),
-            None => {
-                let mut resp = Self::load_language_subtag_name::<LocaleNamesLanguageLongV1, _>(
-                    provider,
-                    &formatting_locale,
-                    subject.language,
-                )?
-                .map(|r| r.payload.cast());
-                if resp.is_none() {
-                    resp = Self::load_language_subtag_name::<LocaleNamesLanguageMediumV1, _>(
-                        provider,
-                        &formatting_locale,
-                        subject.language,
-                    )?
-                    .map(|r| r.payload);
-                }
-                match resp {
-                    Some(payload) => DataPayloadOr::from_payload(
-                        payload.map_project(|payload, _| MenuNamePartsOrString::String(payload)),
-                    ),
-                    None => DataPayloadOr::from_other(subject.language),
-                }
-            }
+            None => DataPayloadOr::from_other(subject.language),
         };
 
         // Load the remaining data
@@ -525,26 +505,25 @@ impl LanguageIdentifierDisplayNameOwned {
             Self::load_language_menu_name(provider, &formatting_locale, subject.language)?;
 
         // If the language name is not loaded yet, try loading it from the language subtag alone.
-        let language_payload =
-            match language_payload {
-                Some(response) => DataPayloadOr::from_payload(response.payload.map_project(
-                    |menu_ule, _phantom| MenuNamePartsOrString::MenuNameParts(menu_ule),
-                )),
-                None => {
-                    match Self::load_language_subtag_name::<LocaleNamesLanguageMediumV1, _>(
-                        provider,
-                        &formatting_locale,
-                        subject.language,
-                    )? {
-                        Some(response) => DataPayloadOr::from_payload(
-                            response
-                                .payload
-                                .map_project(|payload, _| MenuNamePartsOrString::String(payload)),
-                        ),
-                        None => DataPayloadOr::from_other(subject.language),
-                    }
+        let language_payload = match language_payload {
+            Some(payload) => {
+                DataPayloadOr::from_payload(payload.map_project(|menu_ule, _phantom| {
+                    MenuNamePartsOrString::MenuNameParts(menu_ule)
+                }))
+            }
+            None => {
+                match Self::load_language_subtag_name::<LocaleNamesLanguageMediumV1, _>(
+                    provider,
+                    &formatting_locale,
+                    subject.language,
+                )? {
+                    Some(payload) => DataPayloadOr::from_payload(
+                        payload.map_project(|payload, _| MenuNamePartsOrString::String(payload)),
+                    ),
+                    None => DataPayloadOr::from_other(subject.language),
                 }
-            };
+            }
+        };
 
         // Load the remaining data
         let qualifiers = QualifiersOwned::try_new_unstable(provider, prefs, subject)?;
@@ -569,7 +548,7 @@ impl LanguageIdentifierDisplayNameOwned {
         provider: &P,
         formatting_locale: &DataLocale,
         subject: &mut LanguageIdentifier,
-    ) -> Result<Option<DataResponse<M>>, DataError>
+    ) -> Result<Option<DataPayload<ErasedMarker<VarZeroCow<'static, str>>>>, DataError>
     where
         M: DataMarker<DataStruct = VarZeroCow<'static, str>>,
         P: ?Sized + DataProvider<M>,
@@ -610,7 +589,7 @@ impl LanguageIdentifierDisplayNameOwned {
                 if region.is_some() {
                     subject.region = None;
                 }
-                return Ok(Some(response));
+                return Ok(Some(response.payload.cast()));
             }
         }
         Ok(None)
@@ -621,7 +600,7 @@ impl LanguageIdentifierDisplayNameOwned {
         provider: &P,
         formatting_locale: &DataLocale,
         language: Language,
-    ) -> Result<Option<DataResponse<M>>, DataError>
+    ) -> Result<Option<DataPayload<ErasedMarker<VarZeroCow<'static, str>>>>, DataError>
     where
         M: DataMarker<DataStruct = VarZeroCow<'static, str>>,
         P: ?Sized + DataProvider<M>,
@@ -632,9 +611,10 @@ impl LanguageIdentifierDisplayNameOwned {
         let mut metadata = DataRequestMetadata::default();
         metadata.silent =
             core::any::TypeId::of::<M>() != core::any::TypeId::of::<LocaleNamesLanguageMediumV1>();
-        provider
+        let option = provider
             .load(DataRequest { id, metadata })
-            .allow_identifier_not_found()
+            .allow_identifier_not_found()?;
+        Ok(option.map(|resp| resp.payload.cast()))
     }
 
     /// Loads the name for a language with menu core and extension parts.
@@ -642,14 +622,14 @@ impl LanguageIdentifierDisplayNameOwned {
         provider: &P,
         formatting_locale: &DataLocale,
         language: Language,
-    ) -> Result<Option<DataResponse<LocaleNamesLanguageMenuMediumV1>>, DataError>
+    ) -> Result<Option<DataPayload<ErasedMarker<VarZeroCow<'static, MenuNamePartsULE>>>>, DataError>
     where
         P: ?Sized + DataProvider<LocaleNamesLanguageMenuMediumV1>,
     {
         let mut buffer = TinyAsciiStr::EMPTY;
         // NOTE: Menu and non-Menu use the same attributes
         let attrs = LocaleNamesLanguageMediumV1::make_attributes(language, None, None, &mut buffer);
-        provider
+        let option = provider
             .load(DataRequest {
                 id: DataIdentifierBorrowed::for_marker_attributes_and_locale(
                     attrs,
@@ -657,7 +637,8 @@ impl LanguageIdentifierDisplayNameOwned {
                 ),
                 ..Default::default()
             })
-            .allow_identifier_not_found()
+            .allow_identifier_not_found()?;
+        Ok(option.map(|resp| resp.payload.cast()))
     }
 }
 

--- a/components/experimental/src/displaynames/single/language.rs
+++ b/components/experimental/src/displaynames/single/language.rs
@@ -6,9 +6,7 @@ use crate::displaynames::provider::*;
 use crate::displaynames::single::{
     RegionDisplayNameOwned, ScriptDisplayNameOwned, VariantDisplayNameOwned,
 };
-use crate::displaynames::{
-    DisplayNamesPreferences, LanguageIdentifierDisplayNameOptions,
-};
+use crate::displaynames::{DisplayNamesPreferences, LanguageIdentifierDisplayNameOptions};
 use crate::size_test_macro::size_test;
 use alloc::vec::Vec;
 use icu_locale_core::LanguageIdentifier;
@@ -213,26 +211,26 @@ impl LanguageIdentifierDisplayNameOwned {
         /// // Default (Medium) length format:
         /// let display_name_medium = LanguageIdentifierDisplayNameOwned::try_new(
         ///     prefs,
-        ///     langid!("zh-Hant-HK"),
+        ///     langid!("en-US"),
         ///     options,
         /// )
         /// .expect("Data should load successfully");
         /// assert_try_writeable_eq!(
         ///     display_name_medium.as_borrowed(),
-        ///     "Traditional Chinese (Hong Kong SAR China)",
+        ///     "American English",
         ///     Ok(())
         /// );
         ///
         /// // Short length format uses shorter subtag/qualifier names when available:
         /// let display_name_short = LanguageIdentifierDisplayNameOwned::try_new_short(
         ///     prefs,
-        ///     langid!("zh-Hant-HK"),
+        ///     langid!("en-US"),
         ///     options,
         /// )
         /// .expect("Data should load successfully");
         /// assert_try_writeable_eq!(
         ///     display_name_short.as_borrowed(),
-        ///     "Traditional Chinese (Hong Kong)",
+        ///     "US English",
         ///     Ok(())
         /// );
         /// ```
@@ -331,26 +329,26 @@ impl LanguageIdentifierDisplayNameOwned {
         /// // Default (Medium) length format:
         /// let display_name_medium = LanguageIdentifierDisplayNameOwned::try_new(
         ///     prefs,
-        ///     langid!("zh-Hant-HK"),
+        ///     langid!("zh"),
         ///     options,
         /// )
         /// .expect("Data should load successfully");
         /// assert_try_writeable_eq!(
         ///     display_name_medium.as_borrowed(),
-        ///     "Traditional Chinese (Hong Kong SAR China)",
+        ///     "Chinese",
         ///     Ok(())
         /// );
         ///
         /// // Long length format uses longer subtag names when available:
         /// let display_name_long = LanguageIdentifierDisplayNameOwned::try_new_long(
         ///     prefs,
-        ///     langid!("zh-Hant-HK"),
+        ///     langid!("zh"),
         ///     options,
         /// )
         /// .expect("Data should load successfully");
         /// assert_try_writeable_eq!(
         ///     display_name_long.as_borrowed(),
-        ///     "Traditional Mandarin Chinese (Hong Kong SAR China)",
+        ///     "Mandarin Chinese",
         ///     Ok(())
         /// );
         /// ```

--- a/components/experimental/tests/displaynames/tests.rs
+++ b/components/experimental/tests/displaynames/tests.rs
@@ -456,3 +456,56 @@ fn test_single_language_display_name_standard() {
         "Chinese (Traditional, Hong Kong SAR China)"
     );
 }
+
+#[test]
+fn test_single_language_display_name_short() {
+    use icu_experimental::displaynames::{LanguageDisplay, LanguageIdentifierDisplayNameOptions};
+    use icu_locale_core::{langid, locale};
+
+    let locale = locale!("en-001");
+    let mut options = LanguageIdentifierDisplayNameOptions::default();
+    options.language_display = Some(LanguageDisplay::Standard);
+
+    let lang_id = langid!("zh-Hant-HK");
+    let lang_name =
+        LanguageIdentifierDisplayNameOwned::try_new_short(locale.clone().into(), lang_id, options)
+            .expect("Data should load successfully");
+
+    assert_try_writeable_eq!(lang_name.as_borrowed(), "Chinese (Traditional, Hong Kong)");
+
+    options.language_display = Some(LanguageDisplay::Dialect);
+    let lang_id = langid!("de-CH");
+    let lang_name =
+        LanguageIdentifierDisplayNameOwned::try_new_short(locale.into(), lang_id, options)
+            .expect("Data should load successfully");
+
+    assert_try_writeable_eq!(lang_name.as_borrowed(), "Swiss High German");
+}
+
+#[test]
+fn test_single_language_display_name_long() {
+    use icu_experimental::displaynames::{LanguageDisplay, LanguageIdentifierDisplayNameOptions};
+    use icu_locale_core::{langid, locale};
+
+    let locale = locale!("en-001");
+    let mut options = LanguageIdentifierDisplayNameOptions::default();
+    options.language_display = Some(LanguageDisplay::Standard);
+
+    let lang_id = langid!("zh-Hant-HK");
+    let lang_name =
+        LanguageIdentifierDisplayNameOwned::try_new_long(locale.clone().into(), lang_id, options)
+            .expect("Data should load successfully");
+
+    assert_try_writeable_eq!(
+        lang_name.as_borrowed(),
+        "Mandarin Chinese (Traditional, Hong Kong SAR China)"
+    );
+
+    options.language_display = Some(LanguageDisplay::Dialect);
+    let lang_id = langid!("de-CH");
+    let lang_name =
+        LanguageIdentifierDisplayNameOwned::try_new_long(locale.into(), lang_id, options)
+            .expect("Data should load successfully");
+
+    assert_try_writeable_eq!(lang_name.as_borrowed(), "Swiss High German");
+}

--- a/components/experimental/tests/displaynames/tests.rs
+++ b/components/experimental/tests/displaynames/tests.rs
@@ -476,10 +476,17 @@ fn test_single_language_display_name_short() {
     options.language_display = Some(LanguageDisplay::Dialect);
     let lang_id = langid!("de-CH");
     let lang_name =
-        LanguageIdentifierDisplayNameOwned::try_new_short(locale.into(), lang_id, options)
+        LanguageIdentifierDisplayNameOwned::try_new_short(locale.clone().into(), lang_id, options)
             .expect("Data should load successfully");
 
     assert_try_writeable_eq!(lang_name.as_borrowed(), "Swiss High German");
+
+    let lang_id = langid!("en-US");
+    let lang_name =
+        LanguageIdentifierDisplayNameOwned::try_new_short(locale.into(), lang_id, options)
+            .expect("Data should load successfully");
+
+    assert_try_writeable_eq!(lang_name.as_borrowed(), "US English");
 }
 
 #[test]
@@ -500,6 +507,13 @@ fn test_single_language_display_name_long() {
         lang_name.as_borrowed(),
         "Mandarin Chinese (Traditional, Hong Kong SAR China)"
     );
+
+    let lang_id = langid!("zh");
+    let lang_name =
+        LanguageIdentifierDisplayNameOwned::try_new_long(locale.clone().into(), lang_id, options)
+            .expect("Data should load successfully");
+
+    assert_try_writeable_eq!(lang_name.as_borrowed(), "Mandarin Chinese");
 
     options.language_display = Some(LanguageDisplay::Dialect);
     let lang_id = langid!("de-CH");

--- a/components/experimental/tests/displaynames/tests.rs
+++ b/components/experimental/tests/displaynames/tests.rs
@@ -523,3 +523,19 @@ fn test_single_language_display_name_long() {
 
     assert_try_writeable_eq!(lang_name.as_borrowed(), "Swiss High German");
 }
+
+#[test]
+fn test_single_language_display_name_short_menu() {
+    use icu_experimental::displaynames::LanguageIdentifierDisplayNameOptions;
+    use icu_locale_core::{langid, locale};
+
+    let locale = locale!("en-001");
+    let options = LanguageIdentifierDisplayNameOptions::default();
+
+    let lang_id = langid!("en-US");
+    let lang_name =
+        LanguageIdentifierDisplayNameOwned::try_new_short_menu(locale.into(), lang_id, options)
+            .expect("Data should load successfully");
+
+    assert_try_writeable_eq!(lang_name.as_borrowed(), "English (US)");
+}

--- a/components/experimental/tests/displaynames/tests.rs
+++ b/components/experimental/tests/displaynames/tests.rs
@@ -476,17 +476,10 @@ fn test_single_language_display_name_short() {
     options.language_display = Some(LanguageDisplay::Dialect);
     let lang_id = langid!("de-CH");
     let lang_name =
-        LanguageIdentifierDisplayNameOwned::try_new_short(locale.clone().into(), lang_id, options)
-            .expect("Data should load successfully");
-
-    assert_try_writeable_eq!(lang_name.as_borrowed(), "Swiss High German");
-
-    let lang_id = langid!("en-US");
-    let lang_name =
         LanguageIdentifierDisplayNameOwned::try_new_short(locale.into(), lang_id, options)
             .expect("Data should load successfully");
 
-    assert_try_writeable_eq!(lang_name.as_borrowed(), "US English");
+    assert_try_writeable_eq!(lang_name.as_borrowed(), "Swiss High German");
 }
 
 #[test]
@@ -508,13 +501,6 @@ fn test_single_language_display_name_long() {
         "Mandarin Chinese (Traditional, Hong Kong SAR China)"
     );
 
-    let lang_id = langid!("zh");
-    let lang_name =
-        LanguageIdentifierDisplayNameOwned::try_new_long(locale.clone().into(), lang_id, options)
-            .expect("Data should load successfully");
-
-    assert_try_writeable_eq!(lang_name.as_borrowed(), "Mandarin Chinese");
-
     options.language_display = Some(LanguageDisplay::Dialect);
     let lang_id = langid!("de-CH");
     let lang_name =
@@ -522,20 +508,4 @@ fn test_single_language_display_name_long() {
             .expect("Data should load successfully");
 
     assert_try_writeable_eq!(lang_name.as_borrowed(), "Swiss High German");
-}
-
-#[test]
-fn test_single_language_display_name_short_menu() {
-    use icu_experimental::displaynames::LanguageIdentifierDisplayNameOptions;
-    use icu_locale_core::{langid, locale};
-
-    let locale = locale!("en-001");
-    let options = LanguageIdentifierDisplayNameOptions::default();
-
-    let lang_id = langid!("en-US");
-    let lang_name =
-        LanguageIdentifierDisplayNameOwned::try_new_short_menu(locale.into(), lang_id, options)
-            .expect("Data should load successfully");
-
-    assert_try_writeable_eq!(lang_name.as_borrowed(), "English (US)");
 }


### PR DESCRIPTION
Adds `try_new_short` and `try_new_long` constructors (along with their buffer and unstable variants) to `LanguageIdentifierDisplayNameOwned` in `icu_experimental::displaynames`. Also refactors `QualifiersOwned` and internal subtag loading helpers (`load_language_dialect_name` / `load_language_subtag_name`) to cleanly support short and long display widths with fallback to medium.

I also added `try_new_short_menu`, but not `try_new_long_menu` since it wasn't clear if there is any data that does anything interesting there.

🤖 This pull request was created by an AI agent working with @sffc.

## Changelog

icu_experimental/displaynames:
- New methods: `LanguageIdentifierDisplayNameOwned::try_new_short[_unstable|_with_buffer_provider]`, `LanguageIdentifierDisplayNameOwned::try_new_long[_unstable|_with_buffer_provider]` `LanguageIdentifierDisplayNameOwned::try_new_short_menu[_unstable|_with_buffer_provider]`