### PR TITLE
Add Miri CI job for zerovec and yoke

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -156,6 +156,36 @@ jobs:
       run: cargo make ci-job-test-gigo
 
 
+  # ci-job-miri
+  miri:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+    # Cargo-make boilerplate
+    - name: Install cargo-make
+      uses: taiki-e/install-action@64e4e2f995104968c78bd697b253d55bf557af66 # v2.41.11
+      with:
+        tool: cargo-make@0.37.13
+
+    # Toolchain boilerplate
+    - name: Potentially override rust version with nightly
+      run: cargo make set-ci-toolchain
+    - name: Show the selected Rust toolchain
+      run: rustup show
+
+    # Job-specific dependencies
+    - name: Install Miri
+      run: |
+        rustup toolchain install "${PINNED_CI_NIGHTLY}"
+        rustup component add miri --toolchain "${PINNED_CI_NIGHTLY}"
+
+    # Actual job
+    - name: Run `cargo make ci-job-miri`
+      run: cargo make ci-job-miri
+
+
   # ci-job-test-cargo
   test-cargo:
     runs-on: ubuntu-latest

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -306,6 +306,7 @@ if not ${event_name}
 end
 
 ci_toolchain = set "pinned-stable"
+selected_pinned_nightly = set "${PINNED_CI_NIGHTLY}"
 
 echo "set-ci-toolchain: GITHUB_EVENT_NAME is ${event_name}"
 
@@ -338,14 +339,19 @@ if  ${is_workflow} or ${is_schedule}
 end
 
 
+if starts_with "${ci_toolchain}" "nightly"
+    selected_pinned_nightly = set "${ci_toolchain}"
+end
+
+appendfile ${env_file} "PINNED_CI_NIGHTLY=${selected_pinned_nightly}\n"
+appendfile ${env_file} "LLVM_COMPATIBLE_NIGHTLY=${LLVM_COMPATIBLE_NIGHTLY}\n"
+
 if not eq ${ci_toolchain} "pinned-stable"
     echo "Setting up CI environment for forced-${ci_toolchain} Rust build"
     appendfile ${env_file} "CI_TOOLCHAIN=${ci_toolchain}\n"
     exec rustup override set ${ci_toolchain}
 
     if starts_with "${ci_toolchain}" "nightly"
-        # This affects tasks that can only be built on nightly
-        appendfile ${env_file} "PINNED_CI_NIGHTLY=${ci_toolchain}\n"
         appendfile ${env_file} "RUSTFLAGS=--cfg=icu4x_nightly_tests\n"
     end
 else

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -99,6 +99,15 @@ dependencies = [
     "test-docs",
 ]
 
+[tasks.ci-job-miri]
+description = "Run Miri tests for unsafe crates (currently allowed to fail)"
+category = "CI"
+env = { ICU4X_DATA_DIR = "../stubdata" }
+script_runner = "@duckscript"
+script = '''
+exec --fail-on-error cargo +${PINNED_CI_NIGHTLY} miri test -p zerovec --features serde -p yoke
+'''
+
 [tasks.ci-job-full-datagen]
 description = "Run full data generation on latest CLDR and ICU"
 category = "CI"
@@ -257,6 +266,7 @@ dependencies = [
     # Get a coffee
     "ci-job-test",
     "ci-job-test-docs",
+    "ci-job-miri",
     "ci-job-test-cargo",
     "ci-job-testdata",
     "ci-job-features",


### PR DESCRIPTION
## Summary

Adds a non-blocking Miri CI job for the unsafe crates `zerovec` and `yoke`.

This change:

- Adds a new `ci-job-miri` task to `Makefile.toml`
- Includes the task in the local `ci-all` aggregate
- Adds a dedicated `miri` GitHub Actions job in `build-test.yml`
- Uses ICU4X's pinned nightly toolchain
- Runs Miri for `zerovec` (with the required `serde` feature) and `yoke`
- Configures the job with `continue-on-error: true` while existing Miri issues are being tracked

This follows the discussion in #1259, where it was suggested to add the CI job as an allowed failure until the existing Miri failures tracked in #6723 are resolved.

Closes #1259

## Testing

Verified locally:

```bash
cargo make ci-job-miri
```

This executes:

```bash
cargo +nightly-2026-06-01 miri test -p zerovec --features serde -p yoke
```

Additionally verified:

- The new `ci-job-miri` task is included in `ci-all`
- The workflow is configured as a non-blocking (`continue-on-error`) job
- Only `Makefile.toml` and `.github/workflows/build-test.yml` are modified

## Changelog

- [x] No user-facing changelog entry required (internal CI/test infrastructure change)