### PR TITLE
feat(currency): Introduce try_new_code constructors and IsoName fallback

### DIFF
--- a/components/experimental/src/dimension/currency/compact_formatter.rs
+++ b/components/experimental/src/dimension/currency/compact_formatter.rs
@@ -33,6 +33,16 @@ impl CurrencyFormatter<CompactDecimalFormatter> {
     icu_provider::gen_buffer_data_constructors!(
         (prefs: CurrencyFormatterPreferences, currency_code: &CurrencyCode) -> error: DataError,
         functions: [
+            try_new_compact_code: skip,
+            try_new_compact_code_with_buffer_provider,
+            try_new_compact_code_unstable,
+            Self
+        ]
+    );
+
+    icu_provider::gen_buffer_data_constructors!(
+        (prefs: CurrencyFormatterPreferences, currency_code: &CurrencyCode) -> error: DataError,
+        functions: [
             try_new_compact_name: skip,
             try_new_compact_name_with_buffer_provider,
             try_new_compact_name_unstable,
@@ -56,6 +66,16 @@ impl CurrencyFormatter<CompactDecimalFormatter> {
             try_new_compact_long_symbol_narrow: skip,
             try_new_compact_long_symbol_narrow_with_buffer_provider,
             try_new_compact_long_symbol_narrow_unstable,
+            Self
+        ]
+    );
+
+    icu_provider::gen_buffer_data_constructors!(
+        (prefs: CurrencyFormatterPreferences, currency_code: &CurrencyCode) -> error: DataError,
+        functions: [
+            try_new_compact_long_code: skip,
+            try_new_compact_long_code_with_buffer_provider,
+            try_new_compact_long_code_unstable,
             Self
         ]
     );
@@ -103,6 +123,23 @@ impl CurrencyFormatter<CompactDecimalFormatter> {
             prefs,
             *currency_code,
             CurrencySymbolsV1::NARROW,
+        )
+    }
+
+    /// Creates a new [`CurrencyFormatter`] for compact short number formatting using the 3-letter ISO currency code from compiled locale data.
+    ///
+    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
+    ///
+    /// [📚 Help choosing a constructor](icu_provider::constructors)
+    #[cfg(feature = "compiled_data")]
+    pub fn try_new_compact_code(
+        prefs: CurrencyFormatterPreferences,
+        currency_code: &CurrencyCode,
+    ) -> Result<Self, DataError> {
+        Self::try_new_code_internal(
+            CompactDecimalFormatter::try_new_short((&prefs).into(), Default::default())?,
+            prefs,
+            *currency_code,
         )
     }
 
@@ -156,6 +193,23 @@ impl CurrencyFormatter<CompactDecimalFormatter> {
             prefs,
             *currency_code,
             CurrencySymbolsV1::NARROW,
+        )
+    }
+
+    /// Creates a new [`CurrencyFormatter`] for compact long number formatting using the 3-letter ISO currency code from compiled locale data.
+    ///
+    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
+    ///
+    /// [📚 Help choosing a constructor](icu_provider::constructors)
+    #[cfg(feature = "compiled_data")]
+    pub fn try_new_compact_long_code(
+        prefs: CurrencyFormatterPreferences,
+        currency_code: &CurrencyCode,
+    ) -> Result<Self, DataError> {
+        Self::try_new_code_internal(
+            CompactDecimalFormatter::try_new_long((&prefs).into(), Default::default())?,
+            prefs,
+            *currency_code,
         )
     }
 
@@ -331,6 +385,58 @@ impl CurrencyFormatter<CompactDecimalFormatter> {
             + DataProvider<icu_decimal::provider::DecimalCompactLongV1>,
     {
         Self::try_new_name_internal_unstable(
+            provider,
+            CompactDecimalFormatter::try_new_long_unstable(
+                provider,
+                (&prefs).into(),
+                Default::default(),
+            )?,
+            prefs,
+            *currency_code,
+        )
+    }
+
+    #[doc = icu_provider::gen_buffer_unstable_docs!(UNSTABLE, Self::try_new_compact_code)]
+    pub fn try_new_compact_code_unstable<D>(
+        provider: &D,
+        prefs: CurrencyFormatterPreferences,
+        currency_code: &CurrencyCode,
+    ) -> Result<Self, DataError>
+    where
+        D: ?Sized
+            + DataProvider<CurrencyEssentialsV1>
+            + DataProvider<icu_decimal::provider::DecimalCompactShortV1>
+            + DataProvider<icu_decimal::provider::DecimalSymbolsV1>
+            + DataProvider<icu_decimal::provider::DecimalDigitsV1>
+            + DataProvider<icu_plurals::provider::PluralsCardinalV1>,
+    {
+        Self::try_new_code_internal_unstable(
+            provider,
+            CompactDecimalFormatter::try_new_short_unstable(
+                provider,
+                (&prefs).into(),
+                Default::default(),
+            )?,
+            prefs,
+            *currency_code,
+        )
+    }
+
+    #[doc = icu_provider::gen_buffer_unstable_docs!(UNSTABLE, Self::try_new_compact_long_code)]
+    pub fn try_new_compact_long_code_unstable<D>(
+        provider: &D,
+        prefs: CurrencyFormatterPreferences,
+        currency_code: &CurrencyCode,
+    ) -> Result<Self, DataError>
+    where
+        D: ?Sized
+            + DataProvider<CurrencyEssentialsV1>
+            + DataProvider<icu_decimal::provider::DecimalCompactLongV1>
+            + DataProvider<icu_decimal::provider::DecimalSymbolsV1>
+            + DataProvider<icu_decimal::provider::DecimalDigitsV1>
+            + DataProvider<icu_plurals::provider::PluralsCardinalV1>,
+    {
+        Self::try_new_code_internal_unstable(
             provider,
             CompactDecimalFormatter::try_new_long_unstable(
                 provider,

--- a/components/experimental/src/dimension/currency/format.rs
+++ b/components/experimental/src/dimension/currency/format.rs
@@ -262,4 +262,36 @@ mod tests {
             CurrencyFormatter::try_new_symbol_narrow(prefs, &currency_code).unwrap();
         assert_writeable_eq!(fmt_symbol_narrow.format_fixed_decimal(&value), "$12,345.67");
     }
+
+    #[test]
+    pub fn test_code() {
+        let prefs_en = locale!("en-US").into();
+        let currency_usd = CurrencyCode(tinystr!(3, "USD"));
+        let value = "12345.67".parse().unwrap();
+
+        let fmt_code_en = CurrencyFormatter::try_new_code(prefs_en, &currency_usd).unwrap();
+        assert_writeable_eq!(
+            fmt_code_en.format_fixed_decimal(&value),
+            "USD\u{a0}12,345.67"
+        );
+
+        let prefs_fr = locale!("fr-FR").into();
+        let currency_eur = CurrencyCode(tinystr!(3, "EUR"));
+        let fmt_code_fr = CurrencyFormatter::try_new_code(prefs_fr, &currency_eur).unwrap();
+        assert_writeable_eq!(
+            fmt_code_fr.format_fixed_decimal(&value),
+            "12\u{202f}345,67\u{a0}EUR"
+        );
+    }
+
+    #[test]
+    pub fn test_name_fallback_to_iso_extended() {
+        let prefs_en = locale!("en-US").into();
+        // Unknown currency code should gracefully fall back to IsoExtended instead of DataError(IdentifierNotFound)
+        let currency_xyz = CurrencyCode(tinystr!(3, "XYZ"));
+        let value = "12345.67".parse().unwrap();
+
+        let fmt_name = CurrencyFormatter::try_new_name(prefs_en, &currency_xyz).unwrap();
+        assert_writeable_eq!(fmt_name.format_fixed_decimal(&value), "12,345.67 XYZ");
+    }
 }

--- a/components/experimental/src/dimension/currency/format.rs
+++ b/components/experimental/src/dimension/currency/format.rs
@@ -285,9 +285,9 @@ mod tests {
     }
 
     #[test]
-    pub fn test_name_fallback_to_iso_extended() {
+    pub fn test_name_fallback_to_iso_name() {
         let prefs_en = locale!("en-US").into();
-        // Unknown currency code should gracefully fall back to IsoExtended instead of DataError(IdentifierNotFound)
+        // Unknown currency code should gracefully fall back to IsoName instead of DataError(IdentifierNotFound)
         let currency_xyz = CurrencyCode(tinystr!(3, "XYZ"));
         let value = "12345.67".parse().unwrap();
 

--- a/components/experimental/src/dimension/currency/formatter.rs
+++ b/components/experimental/src/dimension/currency/formatter.rs
@@ -51,7 +51,6 @@ pub(crate) enum CurrencyFormatterData {
     },
     IsoName {
         patterns: DataPayload<CurrencyPatternsDataV1>,
-        plural_rules: PluralRules,
         currency: CurrencyCode,
     },
     Symbol {
@@ -245,19 +244,16 @@ impl<V: AbstractFormatter> CurrencyFormatter<V> {
 
         let patterns = crate::provider::Baked.load(Default::default())?.payload;
 
-        let plural_rules = PluralRules::try_new_cardinal((&prefs).into())?;
-
         let currency_data = match extended_opt {
-            Some(extended) => CurrencyFormatterData::Name {
-                extended,
-                patterns,
-                plural_rules,
-            },
-            None => CurrencyFormatterData::IsoName {
-                patterns,
-                plural_rules,
-                currency,
-            },
+            Some(extended) => {
+                let plural_rules = PluralRules::try_new_cardinal((&prefs).into())?;
+                CurrencyFormatterData::Name {
+                    extended,
+                    patterns,
+                    plural_rules,
+                }
+            }
+            None => CurrencyFormatterData::IsoName { patterns, currency },
         };
 
         Ok(Self {
@@ -298,19 +294,17 @@ impl<V: AbstractFormatter> CurrencyFormatter<V> {
 
         let patterns = provider.load(Default::default())?.payload;
 
-        let plural_rules = PluralRules::try_new_cardinal_unstable(provider, (&prefs).into())?;
-
         let currency_data = match extended_opt {
-            Some(extended) => CurrencyFormatterData::Name {
-                extended,
-                patterns,
-                plural_rules,
-            },
-            None => CurrencyFormatterData::IsoName {
-                patterns,
-                plural_rules,
-                currency,
-            },
+            Some(extended) => {
+                let plural_rules =
+                    PluralRules::try_new_cardinal_unstable(provider, (&prefs).into())?;
+                CurrencyFormatterData::Name {
+                    extended,
+                    patterns,
+                    plural_rules,
+                }
+            }
+            None => CurrencyFormatterData::IsoName { patterns, currency },
         };
 
         Ok(Self {
@@ -617,14 +611,9 @@ impl<V: AbstractFormatter> CurrencyFormatter<V> {
                 let pattern = essential.get().get_positive(true, true);
                 (pattern, currency.0.as_str())
             }
-            CurrencyFormatterData::IsoName {
-                patterns,
-                plural_rules,
-                currency,
-            } => {
-                let operands = V::plural_operands(&formatted_value);
+            CurrencyFormatterData::IsoName { patterns, currency } => {
                 let currency_str = currency.0.as_str();
-                let pattern = patterns.get().get(operands, plural_rules);
+                let pattern = patterns.get().elements.get_default().1;
                 (pattern, currency_str)
             }
             CurrencyFormatterData::Symbol { essential, symbol } => {

--- a/components/experimental/src/dimension/currency/formatter.rs
+++ b/components/experimental/src/dimension/currency/formatter.rs
@@ -49,7 +49,7 @@ pub(crate) enum CurrencyFormatterData {
         essential: DataPayload<CurrencyEssentialsV1>,
         currency: CurrencyCode,
     },
-    IsoExtended {
+    IsoName {
         patterns: DataPayload<CurrencyPatternsDataV1>,
         plural_rules: PluralRules,
         currency: CurrencyCode,
@@ -253,7 +253,7 @@ impl<V: AbstractFormatter> CurrencyFormatter<V> {
                 patterns,
                 plural_rules,
             },
-            None => CurrencyFormatterData::IsoExtended {
+            None => CurrencyFormatterData::IsoName {
                 patterns,
                 plural_rules,
                 currency,
@@ -306,7 +306,7 @@ impl<V: AbstractFormatter> CurrencyFormatter<V> {
                 patterns,
                 plural_rules,
             },
-            None => CurrencyFormatterData::IsoExtended {
+            None => CurrencyFormatterData::IsoName {
                 patterns,
                 plural_rules,
                 currency,
@@ -617,7 +617,7 @@ impl<V: AbstractFormatter> CurrencyFormatter<V> {
                 let pattern = essential.get().get_positive(true, true);
                 (pattern, currency.0.as_str())
             }
-            CurrencyFormatterData::IsoExtended {
+            CurrencyFormatterData::IsoName {
                 patterns,
                 plural_rules,
                 currency,

--- a/components/experimental/src/dimension/currency/formatter.rs
+++ b/components/experimental/src/dimension/currency/formatter.rs
@@ -49,6 +49,11 @@ pub(crate) enum CurrencyFormatterData {
         essential: DataPayload<CurrencyEssentialsV1>,
         currency: CurrencyCode,
     },
+    IsoExtended {
+        patterns: DataPayload<CurrencyPatternsDataV1>,
+        plural_rules: PluralRules,
+        currency: CurrencyCode,
+    },
     Symbol {
         essential: DataPayload<CurrencyEssentialsV1>,
         symbol: DataPayload<CurrencySymbolsV1>,
@@ -164,6 +169,57 @@ impl<V: AbstractFormatter> CurrencyFormatter<V> {
     }
 
     #[cfg(feature = "compiled_data")]
+    pub(crate) fn try_new_code_internal(
+        value_formatter: V,
+        prefs: CurrencyFormatterPreferences,
+        currency: CurrencyCode,
+    ) -> Result<Self, DataError> {
+        let locale = CurrencyEssentialsV1::make_locale(prefs.locale_preferences);
+        let decimal_prefs = DecimalFormatterPreferences::from(&prefs);
+
+        let req_id = decimal_prefs.nu_id(&locale);
+        let default_id = DataIdentifierBorrowed::for_locale(&locale);
+        let ids = req_id.into_iter().chain(core::iter::once(default_id));
+        let essential =
+            load_with_fallback::<CurrencyEssentialsV1>(&crate::provider::Baked, ids.clone())?
+                .payload;
+
+        Ok(Self {
+            value_formatter,
+            currency_data: CurrencyFormatterData::Iso {
+                essential,
+                currency,
+            },
+        })
+    }
+
+    pub(crate) fn try_new_code_internal_unstable<D>(
+        provider: &D,
+        value_formatter: V,
+        prefs: CurrencyFormatterPreferences,
+        currency: CurrencyCode,
+    ) -> Result<Self, DataError>
+    where
+        D: ?Sized + DataProvider<CurrencyEssentialsV1>,
+    {
+        let locale = CurrencyEssentialsV1::make_locale(prefs.locale_preferences);
+        let decimal_prefs = DecimalFormatterPreferences::from(&prefs);
+
+        let req_id = decimal_prefs.nu_id(&locale);
+        let default_id = DataIdentifierBorrowed::for_locale(&locale);
+        let ids = req_id.into_iter().chain(core::iter::once(default_id));
+        let essential = load_with_fallback::<CurrencyEssentialsV1>(provider, ids.clone())?.payload;
+
+        Ok(Self {
+            value_formatter,
+            currency_data: CurrencyFormatterData::Iso {
+                essential,
+                currency,
+            },
+        })
+    }
+
+    #[cfg(feature = "compiled_data")]
     pub(crate) fn try_new_name_internal(
         value_formatter: V,
         prefs: CurrencyFormatterPreferences,
@@ -176,27 +232,37 @@ impl<V: AbstractFormatter> CurrencyFormatter<V> {
                     .into_error()
                     .with_debug_context("failed to get data marker attribute from a `CurrencyCode`")
             })?;
-        let extended = crate::provider::Baked
+        let extended_opt = crate::provider::Baked
             .load(DataRequest {
                 id: DataIdentifierBorrowed::for_marker_attributes_and_locale(
                     marker_attributes,
                     &locale,
                 ),
                 ..Default::default()
-            })?
-            .payload;
+            })
+            .allow_identifier_not_found()?
+            .map(|res| res.payload);
 
         let patterns = crate::provider::Baked.load(Default::default())?.payload;
 
         let plural_rules = PluralRules::try_new_cardinal((&prefs).into())?;
 
-        Ok(Self {
-            value_formatter,
-            currency_data: CurrencyFormatterData::Name {
+        let currency_data = match extended_opt {
+            Some(extended) => CurrencyFormatterData::Name {
                 extended,
                 patterns,
                 plural_rules,
             },
+            None => CurrencyFormatterData::IsoExtended {
+                patterns,
+                plural_rules,
+                currency,
+            },
+        };
+
+        Ok(Self {
+            value_formatter,
+            currency_data,
         })
     }
 
@@ -219,27 +285,37 @@ impl<V: AbstractFormatter> CurrencyFormatter<V> {
                     .into_error()
                     .with_debug_context("failed to get data marker attribute from a `CurrencyCode`")
             })?;
-        let extended = provider
+        let extended_opt = provider
             .load(DataRequest {
                 id: DataIdentifierBorrowed::for_marker_attributes_and_locale(
                     marker_attributes,
                     &locale,
                 ),
                 ..Default::default()
-            })?
-            .payload;
+            })
+            .allow_identifier_not_found()?
+            .map(|res| res.payload);
 
         let patterns = provider.load(Default::default())?.payload;
 
         let plural_rules = PluralRules::try_new_cardinal_unstable(provider, (&prefs).into())?;
 
-        Ok(Self {
-            value_formatter,
-            currency_data: CurrencyFormatterData::Name {
+        let currency_data = match extended_opt {
+            Some(extended) => CurrencyFormatterData::Name {
                 extended,
                 patterns,
                 plural_rules,
             },
+            None => CurrencyFormatterData::IsoExtended {
+                patterns,
+                plural_rules,
+                currency,
+            },
+        };
+
+        Ok(Self {
+            value_formatter,
+            currency_data,
         })
     }
 }
@@ -347,6 +423,68 @@ impl CurrencyFormatter<DecimalFormatter> {
             prefs,
             *currency_code,
             CurrencySymbolsV1::NARROW,
+        )
+    }
+
+    icu_provider::gen_buffer_data_constructors!(
+        (prefs: CurrencyFormatterPreferences, currency_code: &CurrencyCode) -> error: DataError,
+        functions: [
+            try_new_code: skip,
+            try_new_code_with_buffer_provider,
+            try_new_code_unstable,
+            Self
+        ]
+    );
+
+    /// Creates a new [`CurrencyFormatter`] for formatting using the 3-letter ISO currency code from compiled locale data.
+    ///
+    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
+    ///
+    /// [📚 Help choosing a constructor](icu_provider::constructors)
+    ///
+    /// # Examples
+    /// ```
+    /// use icu::experimental::dimension::currency::formatter::CurrencyFormatter;
+    /// use icu::experimental::dimension::currency::CurrencyCode;
+    /// use icu::locale::locale;
+    /// use tinystr::*;
+    /// use writeable::assert_writeable_eq;
+    ///
+    /// let currency_preferences = locale!("en-US").into();
+    /// let currency_code = CurrencyCode(tinystr!(3, "USD"));
+    /// let fmt = CurrencyFormatter::try_new_code(currency_preferences, &currency_code).unwrap();
+    /// let value = "12345.67".parse().unwrap();
+    /// assert_writeable_eq!(fmt.format_fixed_decimal(&value), "USD\u{a0}12,345.67");
+    /// ```
+    #[cfg(feature = "compiled_data")]
+    pub fn try_new_code(
+        prefs: CurrencyFormatterPreferences,
+        currency_code: &CurrencyCode,
+    ) -> Result<Self, DataError> {
+        Self::try_new_code_internal(
+            DecimalFormatter::try_new((&prefs).into(), Default::default())?,
+            prefs,
+            *currency_code,
+        )
+    }
+
+    #[doc = icu_provider::gen_buffer_unstable_docs!(UNSTABLE, Self::try_new_code)]
+    pub fn try_new_code_unstable<D>(
+        provider: &D,
+        prefs: CurrencyFormatterPreferences,
+        currency_code: &CurrencyCode,
+    ) -> Result<Self, DataError>
+    where
+        D: ?Sized
+            + DataProvider<CurrencyEssentialsV1>
+            + DataProvider<icu_decimal::provider::DecimalSymbolsV1>
+            + DataProvider<icu_decimal::provider::DecimalDigitsV1>,
+    {
+        Self::try_new_code_internal_unstable(
+            provider,
+            DecimalFormatter::try_new_unstable(provider, (&prefs).into(), Default::default())?,
+            prefs,
+            *currency_code,
         )
     }
 
@@ -478,6 +616,16 @@ impl<V: AbstractFormatter> CurrencyFormatter<V> {
             } => {
                 let pattern = essential.get().get_positive(true, true);
                 (pattern, currency.0.as_str())
+            }
+            CurrencyFormatterData::IsoExtended {
+                patterns,
+                plural_rules,
+                currency,
+            } => {
+                let operands = V::plural_operands(&formatted_value);
+                let currency_str = currency.0.as_str();
+                let pattern = patterns.get().get(operands, plural_rules);
+                (pattern, currency_str)
             }
             CurrencyFormatterData::Symbol { essential, symbol } => {
                 let symbol = symbol.get();


### PR DESCRIPTION
Introduce `try_new_code` constructor family for formatting with 3-letter ISO currency codes (e.g. `USD`, `EUR`) without requiring symbol data payloads, completing the 12-constructor matrix across standard and compact formatting.

## Key Changes
- **Complete Constructor Matrix (`try_new_code`)**: Implement `try_new_code`, `try_new_compact_code`, and `try_new_compact_long_code` (and their compiled/buffer/unstable variants). These explicitly construct `CurrencyFormatterData::Iso`, adapting standard symbol fallback layout without requiring `CurrencySymbolsV1` data payloads.
- **Remove Optional Payloads (`IsoName` Fallback)**: Add `CurrencyFormatterData::IsoName` to eliminate `Option<DataPayload>` in full display name formatters (`Name`). When `try_new_name` encounters missing localized display names, it cleanly falls back to `IsoName`, bypassing unnecessary `PluralRules` instantiation and styling with default unit patterns.
- **Tests**: Add unit tests in `format.rs` (`test_code` and `test_name_fallback_to_iso_name`) verifying ISO code formatting and graceful fallback behavior.

TAG=agy
CONV=f93d26e4-1f87-41f6-88d1-9069dadd73ee

## Changelog

icu_experimental/currency:

- Introduce `try_new_code` constructors for explicit ISO code formatting across decimal and compact currency formatters.
- Introduce `IsoName` fallback variant in `try_new_name` to remove optional payload overhead when long currency display names are absent.