### PR TITLE
Install `cargo-rdme` from GitHub

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -500,6 +500,12 @@ jobs:
     - name: Show the selected Rust toolchain
       run: rustup show
 
+    # Job-specific dependencies
+    - name: Install cargo-rdme
+      uses: taiki-e/install-action@64e4e2f995104968c78bd697b253d55bf557af66 # v2.41.11
+      with:
+        tool: cargo-rdme@1.5.1
+
     # Actual job
     - name: Tidy
       run: cargo make ci-job-tidy


### PR DESCRIPTION
Because it doesn't build.

## Changelog

N/A