### PR TITLE
Add Writeable Replace adapter

### DIFF
--- a/utils/writeable/src/lib.rs
+++ b/utils/writeable/src/lib.rs
@@ -83,6 +83,7 @@ mod either;
 mod impls;
 mod ops;
 mod parts_write_adapter;
+mod replace;
 #[cfg(feature = "alloc")]
 mod testing;
 #[cfg(feature = "alloc")]
@@ -109,6 +110,7 @@ pub mod adapters {
     pub use concat::Concat;
     pub use parts_write_adapter::CoreWriteAsPartsWrite;
     pub use parts_write_adapter::WithPart;
+    pub use replace::Replace;
     pub use try_writeable::TryWriteableInfallibleAsWriteable;
     pub use try_writeable::WriteableAsTryWriteableInfallible;
 

--- a/utils/writeable/src/replace.rs
+++ b/utils/writeable/src/replace.rs
@@ -140,7 +140,7 @@ where
         // KMP State Transition:
         // While we have a mismatch and we are not at the start of the needle,
         // backtrack using the prefix function.
-        while matched > 0 && self.remaining_needle.chars().next() != Some(c) {
+        while matched > 0 && !self.remaining_needle.starts_with(c) {
             let old_j = matched;
             matched = get_pi_bytes(self.needle, old_j);
             // Since we backtracked, the prefix of length `old_j - j` is no longer
@@ -152,7 +152,7 @@ where
         }
 
         // If the character matches the next character in the needle, advance the match state.
-        if self.remaining_needle.chars().next() == Some(c) {
+        if self.remaining_needle.starts_with(c) {
             // Advance remaining_needle by the matched character.
             self.remaining_needle = self
                 .remaining_needle
@@ -172,7 +172,7 @@ where
     }
 }
 
-impl<'a, A, C> Writeable for Replace<A, &'a str, C>
+impl<A, C> Writeable for Replace<A, &str, C>
 where
     A: Writeable,
     C: Writeable,

--- a/utils/writeable/src/replace.rs
+++ b/utils/writeable/src/replace.rs
@@ -29,7 +29,7 @@ use core::fmt;
 /// assert_writeable_eq!(replace, "I 💖 Rust and Rust loves me!");
 /// ```
 #[derive(Debug)]
-#[allow(clippy::exhaustive_structs)] // designed for nesting
+#[allow(clippy::exhaustive_structs)] // well-defined 3-tuple
 pub struct Replace<A, B, C> {
     /// The source writeable.
     pub source: A,

--- a/utils/writeable/src/replace.rs
+++ b/utils/writeable/src/replace.rs
@@ -4,14 +4,11 @@
 
 use crate::{impl_display_with_writeable, LengthHint, Writeable};
 use core::fmt;
-use core::ops::Range;
 
 /// A [`Writeable`] adapter that replaces occurrences of a needle with a replacement.
 ///
 /// This adapter performs the replacement in a streaming fashion during `write_to`,
 /// requiring zero allocations.
-///
-/// All occurrences of the needle are replaced.
 ///
 /// # Examples
 ///
@@ -40,13 +37,13 @@ pub struct Replace<A, B, C> {
     pub replacement: C,
 }
 
-/// Computes the Knuth-Morris-Pratt (KMP) prefix function (failure function) value
-/// for the character prefix ending at byte index `matched_bytes` in `needle`.
-///
-/// Returns the byte length of the longest proper prefix of `needle[0..matched_bytes]`
-/// that is also a suffix of `needle[0..matched_bytes]`.
-///
-/// This is computed on the fly without allocation by iterating over char boundaries.
+// Computes the Knuth-Morris-Pratt (KMP) prefix function (failure function) value
+// for the character prefix ending at byte index `matched_bytes` in `needle`.
+//
+// Returns the byte length of the longest proper prefix of `needle[0..matched_bytes]`
+// that is also a suffix of `needle[0..matched_bytes]`.
+//
+// This is computed on the fly without allocation by iterating over char boundaries.
 fn get_pi_bytes(needle: &str, matched_bytes: usize) -> usize {
     let s = match needle.get(0..matched_bytes) {
         Some(s) => s,
@@ -74,146 +71,154 @@ fn get_pi_bytes(needle: &str, matched_bytes: usize) -> usize {
 
 // A writer wrapper that performs streaming replacement.
 // It intercepts characters written to it, matches them against `needle` using KMP
-// (tracking progress by byte offsets), and writes `replacement` when a full match
-// is found, or the original characters otherwise.
-struct ReplaceWriter<'a, W: ?Sized, B, C> {
+// (tracking progress by storing the remaining unmatched suffix of the needle),
+// and writes `replacement` when a full match is found, or the original characters otherwise.
+struct ReplaceWriter<'a, W: ?Sized, C> {
     // The underlying sink to write to.
     sink: &'a mut W,
     // The needle we are searching for.
-    needle: &'a B,
+    needle: &'a str,
     // The replacement to write when the needle is matched.
     replacement: &'a C,
-    // The number of bytes of `needle` matched so far.
-    // This is always aligned to a character boundary.
-    matched_bytes: usize,
+    // The remaining unmatched suffix of the needle.
+    // This is always a suffix of `needle` starting at a character boundary.
+    remaining_needle: &'a str,
 }
 
-impl<'a, W, B, C> ReplaceWriter<'a, W, B, C>
+impl<'a, W, C> ReplaceWriter<'a, W, C>
 where
     W: fmt::Write + ?Sized,
-    B: AsRef<str>,
     C: Writeable,
 {
-    fn new(sink: &'a mut W, needle: &'a B, replacement: &'a C) -> Self {
+    fn new(sink: &'a mut W, needle: &'a str, replacement: &'a C) -> Self {
         Self {
             sink,
             needle,
             replacement,
-            matched_bytes: 0,
+            remaining_needle: needle,
         }
     }
 
-    fn needle_slice(&self, range: Range<usize>) -> Option<&'a str> {
-        self.needle.as_ref().get(range)
+    // Helper to get the length of the prefix matched so far.
+    fn matched_len(&self) -> usize {
+        self.needle.len() - self.remaining_needle.len()
     }
 
-    fn needle_char_at(&self, index: usize) -> Option<char> {
-        self.needle
-            .as_ref()
-            .get(index..)
-            .and_then(|s| s.chars().next())
+    // Finalizes the writer, flushing any partially matched prefix to the sink.
+    fn finalize(&mut self) -> fmt::Result {
+        let matched = self.matched_len();
+        if matched > 0 {
+            let slice = self.needle.get(0..matched).ok_or(fmt::Error)?;
+            self.sink.write_str(slice)?;
+            self.remaining_needle = self.needle;
+        }
+        Ok(())
+    }
+}
+
+impl<'a, W, C> fmt::Write for ReplaceWriter<'a, W, C>
+where
+    W: fmt::Write + ?Sized,
+    C: Writeable,
+{
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        for c in s.chars() {
+            self.write_char(c)?;
+        }
+        Ok(())
     }
 
-    // Processes a single character from the source stream.
-    fn write_char_buffered(&mut self, c: char) -> fmt::Result {
-        let needle_str = self.needle.as_ref();
-        let needle_len_bytes = needle_str.len();
+    fn write_char(&mut self, c: char) -> fmt::Result {
+        let needle_len_bytes = self.needle.len();
 
         // If the needle is empty, we just pass through the characters.
         if needle_len_bytes == 0 {
             return self.sink.write_char(c);
         }
 
-        let mut j = self.matched_bytes;
-        debug_assert!(j < needle_str.len());
+        let mut matched = self.matched_len();
         // KMP State Transition:
         // While we have a mismatch and we are not at the start of the needle,
         // backtrack using the prefix function.
-        while j > 0 && self.needle_char_at(j) != Some(c) {
-            let old_j = j;
-            j = get_pi_bytes(needle_str, j);
+        while matched > 0 && self.remaining_needle.chars().next() != Some(c) {
+            let old_j = matched;
+            matched = get_pi_bytes(self.needle, old_j);
             // Since we backtracked, the prefix of length `old_j - j` is no longer
             // part of the potential match. We write it to the sink as a single slice.
-            let slice = self.needle_slice(0..(old_j - j)).ok_or(fmt::Error)?;
+            let slice = self.needle.get(0..(old_j - matched)).ok_or(fmt::Error)?;
             self.sink.write_str(slice)?;
+            // Update remaining_needle to reflect the new matched length.
+            self.remaining_needle = self.needle.get(matched..).ok_or(fmt::Error)?;
         }
 
         // If the character matches the next character in the needle, advance the match state.
-        if self.needle_char_at(j) == Some(c) {
-            j += c.len_utf8();
-            // Check if we found a full match.
-            if j == needle_len_bytes {
+        if self.remaining_needle.chars().next() == Some(c) {
+            // Advance remaining_needle by the matched character.
+            self.remaining_needle = self
+                .remaining_needle
+                .get(c.len_utf8()..)
+                .ok_or(fmt::Error)?;
+            if self.remaining_needle.is_empty() {
                 // Full match found! Write the replacement instead of the needle.
                 self.replacement.write_to(self.sink)?;
-                // Reset match state to start searching for the next occurrence.
-                j = 0;
+                // Reset match state.
+                self.remaining_needle = self.needle;
             }
         } else {
             // Mismatch at the very beginning of the needle. Write the character as is.
             self.sink.write_char(c)?;
         }
-        self.matched_bytes = j;
-        Ok(())
-    }
-
-    // Flushes any partially matched prefix at the end of the stream.
-    fn flush(&mut self) -> fmt::Result {
-        let slice = self.needle_slice(0..self.matched_bytes).ok_or(fmt::Error)?;
-        self.sink.write_str(slice)?;
-        self.matched_bytes = 0;
         Ok(())
     }
 }
 
-impl<'a, W, B, C> fmt::Write for ReplaceWriter<'a, W, B, C>
-where
-    W: fmt::Write + ?Sized,
-    B: AsRef<str>,
-    C: Writeable,
-{
-    fn write_str(&mut self, s: &str) -> fmt::Result {
-        for c in s.chars() {
-            self.write_char_buffered(c)?;
-        }
-        Ok(())
-    }
-
-    fn write_char(&mut self, c: char) -> fmt::Result {
-        self.write_char_buffered(c)
-    }
-}
-
-impl<A, B, C> Writeable for Replace<A, B, C>
+impl<'a, A, C> Writeable for Replace<A, &'a str, C>
 where
     A: Writeable,
-    B: AsRef<str>,
     C: Writeable,
 {
+    // We do not implement writeable_borrow because it is meant to be a constant-time O(1)
+    // operation, but determining if a replacement occurred would require O(N) scanning.
     fn write_to<W: fmt::Write + ?Sized>(&self, sink: &mut W) -> fmt::Result {
-        let mut writer = ReplaceWriter::new(sink, &self.needle, &self.replacement);
+        let mut writer = ReplaceWriter::new(sink, self.needle, &self.replacement);
         self.source.write_to(&mut writer)?;
-        writer.flush()
+        writer.finalize()
     }
 
     fn writeable_length_hint(&self) -> LengthHint {
         let source_hint = self.source.writeable_length_hint();
-        let needle_len = self.needle.as_ref().len();
+        let needle_len = self.needle.len();
         let replacement_hint = self.replacement.writeable_length_hint();
 
-        if let Some(replacement_len) = replacement_hint.1 {
-            if replacement_hint.0 == replacement_len && needle_len == replacement_len {
+        // If needle and replacement have same exact length, length is unchanged.
+        if let Some(r_upper) = replacement_hint.1 {
+            if replacement_hint.0 == r_upper && needle_len == r_upper {
                 return source_hint;
             }
         }
 
-        LengthHint::undefined()
-    }
+        let mut lower = 0;
+        let mut upper = None;
 
-    // TODO: how should we implement write_to_parts? What if the needle spans a part?
-    // TODO: should we implement writeable_borrow, if a replacement doesn't occur? It is O(N)
+        // If replacement is always larger than or equal to needle:
+        // New length is at least the source length.
+        if replacement_hint.0 >= needle_len {
+            lower = source_hint.0;
+        }
+
+        // If replacement is always smaller than or equal to needle:
+        // New length is at most the source length.
+        if let Some(r_upper) = replacement_hint.1 {
+            if r_upper <= needle_len {
+                upper = source_hint.1;
+            }
+        }
+
+        LengthHint(lower, upper)
+    }
 }
 
-impl_display_with_writeable!(Replace<A, B, C>, #[cfg(feature = "alloc")], where A: Writeable, B: AsRef<str>, C: Writeable);
+impl_display_with_writeable!(Replace<A, &'a str, C>, #[cfg(feature = "alloc")], where 'a, A: Writeable, C: Writeable);
 
 #[test]
 fn test_replace() {

--- a/utils/writeable/src/replace.rs
+++ b/utils/writeable/src/replace.rs
@@ -4,6 +4,7 @@
 
 use crate::{impl_display_with_writeable, LengthHint, Writeable};
 use core::fmt;
+use core::ops::Range;
 
 /// A [`Writeable`] adapter that replaces occurrences of a needle with a replacement.
 ///
@@ -29,7 +30,7 @@ use core::fmt;
 /// assert_writeable_eq!(replace, "I 💖 Rust and Rust loves me!");
 /// ```
 #[derive(Debug)]
-#[allow(clippy::exhaustive_structs)] // well-defined 3-tuple
+#[allow(clippy::exhaustive_structs)] // designed for nesting
 pub struct Replace<A, B, C> {
     /// The source writeable.
     pub source: A,
@@ -39,34 +40,42 @@ pub struct Replace<A, B, C> {
     pub replacement: C,
 }
 
-// Helper function to get the character at a specific index in a string slice.
-// Since Rust strings are UTF-8, this is an O(N) operation, but it is acceptable
-// because we assume the needle is small.
-fn get_char(s: &str, index: usize) -> Option<char> {
-    s.chars().nth(index)
-}
-
-// Computes the Knuth-Morris-Pratt (KMP) prefix function (failure function) value
-// for the character at index `i` in `needle`.
-//
-// The prefix function value `pi[i]` is the length of the longest proper prefix
-// of `needle[0..=i]` that is also a suffix of `needle[0..=i]`.
-//
-// This is computed on the fly without allocation.
-fn get_pi_char(needle: &str, i: usize) -> usize {
-    for k in (1..=i).rev() {
-        let prefix = needle.chars().take(k);
-        let suffix = needle.chars().take(i + 1).skip(i + 1 - k);
-        if prefix.eq(suffix) {
-            return k;
+/// Computes the Knuth-Morris-Pratt (KMP) prefix function (failure function) value
+/// for the character prefix ending at byte index `matched_bytes` in `needle`.
+///
+/// Returns the byte length of the longest proper prefix of `needle[0..matched_bytes]`
+/// that is also a suffix of `needle[0..matched_bytes]`.
+///
+/// This is computed on the fly without allocation by iterating over char boundaries.
+fn get_pi_bytes(needle: &str, matched_bytes: usize) -> usize {
+    let s = match needle.get(0..matched_bytes) {
+        Some(s) => s,
+        None => return 0,
+    };
+    // char_indices() gives us the byte offsets of character starts.
+    // These offsets correspond to the byte lengths of all possible prefixes.
+    // We want to iterate them in reverse order, excluding the first one (0)
+    // because we want proper prefixes.
+    for k in s
+        .char_indices()
+        .map(|(idx, _)| idx)
+        .rev()
+        .filter(|&idx| idx > 0)
+    {
+        // Compare the prefix of length `k` with the suffix of length `k`.
+        if let Some(suffix) = s.as_bytes().get(s.len() - k..) {
+            if s.as_bytes().starts_with(suffix) {
+                return k;
+            }
         }
     }
     0
 }
 
 // A writer wrapper that performs streaming replacement.
-// It intercepts characters written to it, matches them against `needle` using KMP,
-// and writes `replacement` when a full match is found, or the original characters otherwise.
+// It intercepts characters written to it, matches them against `needle` using KMP
+// (tracking progress by byte offsets), and writes `replacement` when a full match
+// is found, or the original characters otherwise.
 struct ReplaceWriter<'a, W: ?Sized, B, C> {
     // The underlying sink to write to.
     sink: &'a mut W,
@@ -74,8 +83,9 @@ struct ReplaceWriter<'a, W: ?Sized, B, C> {
     needle: &'a B,
     // The replacement to write when the needle is matched.
     replacement: &'a C,
-    // The number of characters of `needle` matched so far.
-    matched_chars: usize,
+    // The number of bytes of `needle` matched so far.
+    // This is always aligned to a character boundary.
+    matched_bytes: usize,
 }
 
 impl<'a, W, B, C> ReplaceWriter<'a, W, B, C>
@@ -89,40 +99,50 @@ where
             sink,
             needle,
             replacement,
-            matched_chars: 0,
+            matched_bytes: 0,
         }
+    }
+
+    fn needle_slice(&self, range: Range<usize>) -> Option<&'a str> {
+        self.needle.as_ref().get(range)
+    }
+
+    fn needle_char_at(&self, index: usize) -> Option<char> {
+        self.needle
+            .as_ref()
+            .get(index..)
+            .and_then(|s| s.chars().next())
     }
 
     // Processes a single character from the source stream.
     fn write_char_buffered(&mut self, c: char) -> fmt::Result {
         let needle_str = self.needle.as_ref();
-        let needle_len = needle_str.chars().count();
+        let needle_len_bytes = needle_str.len();
 
         // If the needle is empty, we just pass through the characters.
-        if needle_len == 0 {
+        if needle_len_bytes == 0 {
             return self.sink.write_char(c);
         }
 
-        let mut j = self.matched_chars;
+        let mut j = self.matched_bytes;
+        debug_assert!(j < needle_str.len());
         // KMP State Transition:
         // While we have a mismatch and we are not at the start of the needle,
         // backtrack using the prefix function.
-        while j > 0 && get_char(needle_str, j) != Some(c) {
+        while j > 0 && self.needle_char_at(j) != Some(c) {
             let old_j = j;
-            j = get_pi_char(needle_str, j - 1);
-            // Since we backtracked, the characters in `needle[j..old_j]` are no longer
-            // part of the potential match. We must write them to the sink.
-            // Note: We only write the prefix of the needle that is no longer matched.
-            for ch in needle_str.chars().take(old_j - j) {
-                self.sink.write_char(ch)?;
-            }
+            j = get_pi_bytes(needle_str, j);
+            // Since we backtracked, the prefix of length `old_j - j` is no longer
+            // part of the potential match. We write it to the sink as a single slice.
+            let slice = self.needle_slice(0..(old_j - j)).ok_or(fmt::Error)?;
+            self.sink.write_str(slice)?;
         }
 
         // If the character matches the next character in the needle, advance the match state.
-        if get_char(needle_str, j) == Some(c) {
-            j += 1;
+        if self.needle_char_at(j) == Some(c) {
+            j += c.len_utf8();
             // Check if we found a full match.
-            if j == needle_len {
+            if j == needle_len_bytes {
                 // Full match found! Write the replacement instead of the needle.
                 self.replacement.write_to(self.sink)?;
                 // Reset match state to start searching for the next occurrence.
@@ -132,18 +152,15 @@ where
             // Mismatch at the very beginning of the needle. Write the character as is.
             self.sink.write_char(c)?;
         }
-        self.matched_chars = j;
+        self.matched_bytes = j;
         Ok(())
     }
 
     // Flushes any partially matched prefix at the end of the stream.
-    // If the stream ends and we have a partial match, those characters must be written.
     fn flush(&mut self) -> fmt::Result {
-        let needle_str = self.needle.as_ref();
-        for ch in needle_str.chars().take(self.matched_chars) {
-            self.sink.write_char(ch)?;
-        }
-        self.matched_chars = 0;
+        let slice = self.needle_slice(0..self.matched_bytes).ok_or(fmt::Error)?;
+        self.sink.write_str(slice)?;
+        self.matched_bytes = 0;
         Ok(())
     }
 }
@@ -282,4 +299,20 @@ fn test_replace() {
         replacement: "星",
     };
     assert_writeable_eq!(replace10, "🚀🚁");
+
+    // Multi-byte UTF-8 with backtracking (no match)
+    let replace11 = Replace {
+        source: "🚀🚀🚁",
+        needle: "🚀🚀🛸",
+        replacement: "星",
+    };
+    assert_writeable_eq!(replace11, "🚀🚀🚁");
+
+    // Multi-byte UTF-8 with backtracking (match)
+    let replace12 = Replace {
+        source: "🚀🚀🚀🛸",
+        needle: "🚀🚀🛸",
+        replacement: "星",
+    };
+    assert_writeable_eq!(replace12, "🚀星");
 }

--- a/utils/writeable/src/replace.rs
+++ b/utils/writeable/src/replace.rs
@@ -12,7 +12,7 @@ pub struct Replace<A, B, C> {
     pub replacement: C,
 }
 
-impl<A, B, C> Writeable for Replace<A, B, C> where A: Writeable, B: Writeable, C: Writeable {
+impl<A, B, C> Writeable for Replace<A, B, C> where A: Writeable, B: AsRef<str>, C: Writeable {
     fn write_to<W: core::fmt::Write + ?Sized>(&self, sink: &mut W) -> core::fmt::Result {
         todo!()
     }
@@ -26,12 +26,12 @@ impl<A, B, C> Writeable for Replace<A, B, C> where A: Writeable, B: Writeable, C
     }
 }
 
-impl_display_with_writeable!(Replace<A, B, C>, #[cfg(feature = "alloc")], where A: Writeable, B: Writeable, C: Writeable);
+impl_display_with_writeable!(Replace<A, B, C>, #[cfg(feature = "alloc")], where A: Writeable, B: AsRef<str>, C: Writeable);
 
 #[test]
 fn test_replace() {
     let source = Concat("Hello", " 10 22 1101 33");
-    let needle = Concat("1", "0");
+    let needle = "10";
     let replacement = Concat("4", "4");
 
     let replace = Replace { source, needle, replacement };

--- a/utils/writeable/src/replace.rs
+++ b/utils/writeable/src/replace.rs
@@ -1,0 +1,40 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use crate::{Writeable, assert_writeable_eq, concat::Concat, impl_display_with_writeable};
+
+#[derive(Debug)]
+#[allow(clippy::exhaustive_structs)] // designed for nesting
+pub struct Replace<A, B, C> {
+    pub source: A,
+    pub needle: B,
+    pub replacement: C,
+}
+
+impl<A, B, C> Writeable for Replace<A, B, C> where A: Writeable, B: Writeable, C: Writeable {
+    fn write_to<W: core::fmt::Write + ?Sized>(&self, sink: &mut W) -> core::fmt::Result {
+        todo!()
+    }
+
+    fn write_to_parts<S: crate::PartsWrite + ?Sized>(&self, sink: &mut S) -> core::fmt::Result {
+        todo!()
+    }
+
+    fn writeable_length_hint(&self) -> crate::LengthHint {
+        todo!() // is this even possible to do efficiently?
+    }
+}
+
+impl_display_with_writeable!(Replace<A, B, C>, #[cfg(feature = "alloc")], where A: Writeable, B: Writeable, C: Writeable);
+
+#[test]
+fn test_replace() {
+    let source = Concat("Hello", " 10 22 1101 33");
+    let needle = Concat("1", "0");
+    let replacement = Concat("4", "4");
+
+    let replace = Replace { source, needle, replacement };
+
+    assert_writeable_eq!(replace, "Hello 44 22 1441 33");
+}

--- a/utils/writeable/src/replace.rs
+++ b/utils/writeable/src/replace.rs
@@ -2,27 +2,176 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use crate::{Writeable, assert_writeable_eq, concat::Concat, impl_display_with_writeable};
+use crate::{impl_display_with_writeable, LengthHint, PartsWrite, Writeable};
+use core::fmt;
 
+/// A [`Writeable`] adapter that replaces occurrences of a needle with a replacement.
 #[derive(Debug)]
 #[allow(clippy::exhaustive_structs)] // designed for nesting
 pub struct Replace<A, B, C> {
+    /// The source writeable.
     pub source: A,
+    /// The needle to search for.
     pub needle: B,
+    /// The replacement writeable.
     pub replacement: C,
 }
 
-impl<A, B, C> Writeable for Replace<A, B, C> where A: Writeable, B: AsRef<str>, C: Writeable {
-    fn write_to<W: core::fmt::Write + ?Sized>(&self, sink: &mut W) -> core::fmt::Result {
-        todo!()
+// Helper function to get the character at a specific index in a string slice.
+// Since Rust strings are UTF-8, this is an O(N) operation, but it is acceptable
+// because we assume the needle is small.
+fn get_char(s: &str, index: usize) -> Option<char> {
+    s.chars().nth(index)
+}
+
+// Computes the Knuth-Morris-Pratt (KMP) prefix function (failure function) value
+// for the character at index `i` in `needle`.
+//
+// The prefix function value `pi[i]` is the length of the longest proper prefix
+// of `needle[0..=i]` that is also a suffix of `needle[0..=i]`.
+//
+// This is computed on the fly without allocation.
+fn get_pi_char(needle: &str, i: usize) -> usize {
+    for k in (1..=i).rev() {
+        let prefix = needle.chars().take(k);
+        let suffix = needle.chars().take(i + 1).skip(i + 1 - k);
+        if prefix.eq(suffix) {
+            return k;
+        }
+    }
+    0
+}
+
+// A writer wrapper that performs streaming replacement.
+// It intercepts characters written to it, matches them against `needle` using KMP,
+// and writes `replacement` when a full match is found, or the original characters otherwise.
+struct ReplaceWriter<'a, W: ?Sized, B, C> {
+    // The underlying sink to write to.
+    sink: &'a mut W,
+    // The needle we are searching for.
+    needle: &'a B,
+    // The replacement to write when the needle is matched.
+    replacement: &'a C,
+    // The number of characters of `needle` matched so far.
+    matched_chars: usize,
+}
+
+impl<'a, W, B, C> ReplaceWriter<'a, W, B, C>
+where
+    W: fmt::Write + ?Sized,
+    B: AsRef<str>,
+    C: Writeable,
+{
+    fn new(sink: &'a mut W, needle: &'a B, replacement: &'a C) -> Self {
+        Self {
+            sink,
+            needle,
+            replacement,
+            matched_chars: 0,
+        }
     }
 
-    fn write_to_parts<S: crate::PartsWrite + ?Sized>(&self, sink: &mut S) -> core::fmt::Result {
-        todo!()
+    // Processes a single character from the source stream.
+    fn write_char_buffered(&mut self, c: char) -> fmt::Result {
+        let needle_str = self.needle.as_ref();
+        let needle_len = needle_str.chars().count();
+
+        // If the needle is empty, we just pass through the characters.
+        if needle_len == 0 {
+            return self.sink.write_char(c);
+        }
+
+        let mut j = self.matched_chars;
+        // KMP State Transition:
+        // While we have a mismatch and we are not at the start of the needle,
+        // backtrack using the prefix function.
+        while j > 0 && get_char(needle_str, j) != Some(c) {
+            let old_j = j;
+            j = get_pi_char(needle_str, j - 1);
+            // Since we backtracked, the characters in `needle[j..old_j]` are no longer
+            // part of the potential match. We must write them to the sink.
+            // Note: We only write the prefix of the needle that is no longer matched.
+            for ch in needle_str.chars().take(old_j - j) {
+                self.sink.write_char(ch)?;
+            }
+        }
+
+        // If the character matches the next character in the needle, advance the match state.
+        if get_char(needle_str, j) == Some(c) {
+            j += 1;
+            // Check if we found a full match.
+            if j == needle_len {
+                // Full match found! Write the replacement instead of the needle.
+                self.replacement.write_to(self.sink)?;
+                // Reset match state to start searching for the next occurrence.
+                j = 0;
+            }
+        } else {
+            // Mismatch at the very beginning of the needle. Write the character as is.
+            self.sink.write_char(c)?;
+        }
+        self.matched_chars = j;
+        Ok(())
     }
 
-    fn writeable_length_hint(&self) -> crate::LengthHint {
-        todo!() // is this even possible to do efficiently?
+    // Flushes any partially matched prefix at the end of the stream.
+    // If the stream ends and we have a partial match, those characters must be written.
+    fn flush(&mut self) -> fmt::Result {
+        let needle_str = self.needle.as_ref();
+        for ch in needle_str.chars().take(self.matched_chars) {
+            self.sink.write_char(ch)?;
+        }
+        self.matched_chars = 0;
+        Ok(())
+    }
+}
+
+impl<'a, W, B, C> fmt::Write for ReplaceWriter<'a, W, B, C>
+where
+    W: fmt::Write + ?Sized,
+    B: AsRef<str>,
+    C: Writeable,
+{
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        for c in s.chars() {
+            self.write_char_buffered(c)?;
+        }
+        Ok(())
+    }
+
+    fn write_char(&mut self, c: char) -> fmt::Result {
+        self.write_char_buffered(c)
+    }
+}
+
+impl<A, B, C> Writeable for Replace<A, B, C>
+where
+    A: Writeable,
+    B: AsRef<str>,
+    C: Writeable,
+{
+    fn write_to<W: fmt::Write + ?Sized>(&self, sink: &mut W) -> fmt::Result {
+        let mut writer = ReplaceWriter::new(sink, &self.needle, &self.replacement);
+        self.source.write_to(&mut writer)?;
+        writer.flush()
+    }
+
+    fn write_to_parts<S: PartsWrite + ?Sized>(&self, sink: &mut S) -> fmt::Result {
+        self.write_to(sink)
+    }
+
+    fn writeable_length_hint(&self) -> LengthHint {
+        let source_hint = self.source.writeable_length_hint();
+        let needle_len = self.needle.as_ref().len();
+        let replacement_hint = self.replacement.writeable_length_hint();
+
+        if let Some(replacement_len) = replacement_hint.1 {
+            if replacement_hint.0 == replacement_len && needle_len == replacement_len {
+                return source_hint;
+            }
+        }
+
+        LengthHint::undefined()
     }
 }
 
@@ -30,11 +179,86 @@ impl_display_with_writeable!(Replace<A, B, C>, #[cfg(feature = "alloc")], where 
 
 #[test]
 fn test_replace() {
-    let source = Concat("Hello", " 10 22 1101 33");
-    let needle = "10";
-    let replacement = Concat("4", "4");
+    use crate::assert_writeable_eq;
+    use crate::concat::Concat;
 
-    let replace = Replace { source, needle, replacement };
+    // Basic replacement
+    let replace1 = Replace {
+        source: Concat("Hello", " 10 22 1101 33"),
+        needle: "10",
+        replacement: Concat("4", "4"),
+    };
+    assert_writeable_eq!(replace1, "Hello 44 22 1441 33");
 
-    assert_writeable_eq!(replace, "Hello 44 22 1441 33");
+    // Empty needle (should just write source)
+    let replace2 = Replace {
+        source: "Hello World",
+        needle: "",
+        replacement: "X",
+    };
+    assert_writeable_eq!(replace2, "Hello World");
+
+    // Empty replacement
+    let replace3 = Replace {
+        source: "Hello 10 World 10",
+        needle: "10",
+        replacement: "",
+    };
+    assert_writeable_eq!(replace3, "Hello  World ");
+
+    // Needle not found
+    let replace4 = Replace {
+        source: "Hello World",
+        needle: "10",
+        replacement: "X",
+    };
+    assert_writeable_eq!(replace4, "Hello World");
+
+    // Needle at the beginning
+    let replace5 = Replace {
+        source: "10 Hello World",
+        needle: "10",
+        replacement: "X",
+    };
+    assert_writeable_eq!(replace5, "X Hello World");
+
+    // Needle at the end
+    let replace6 = Replace {
+        source: "Hello World 10",
+        needle: "10",
+        replacement: "X",
+    };
+    assert_writeable_eq!(replace6, "Hello World X");
+
+    // Overlapping needles (should consume and not match again)
+    let replace7 = Replace {
+        source: "ababa",
+        needle: "aba",
+        replacement: "X",
+    };
+    assert_writeable_eq!(replace7, "Xba");
+
+    // Self-overlap but no match
+    let replace8 = Replace {
+        source: "aab",
+        needle: "aac",
+        replacement: "X",
+    };
+    assert_writeable_eq!(replace8, "aab");
+
+    // Multi-byte UTF-8
+    let replace9 = Replace {
+        source: "🚀 🛸 🚀🚀 🚁",
+        needle: "🚀",
+        replacement: "星",
+    };
+    assert_writeable_eq!(replace9, "星 🛸 星星 🚁");
+
+    // Multi-byte UTF-8 with partial match
+    let replace10 = Replace {
+        source: "🚀🚁",
+        needle: "🚀🛸",
+        replacement: "星",
+    };
+    assert_writeable_eq!(replace10, "🚀🚁");
 }

--- a/utils/writeable/src/replace.rs
+++ b/utils/writeable/src/replace.rs
@@ -2,10 +2,32 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
-use crate::{impl_display_with_writeable, LengthHint, PartsWrite, Writeable};
+use crate::{impl_display_with_writeable, LengthHint, Writeable};
 use core::fmt;
 
 /// A [`Writeable`] adapter that replaces occurrences of a needle with a replacement.
+///
+/// This adapter performs the replacement in a streaming fashion during `write_to`,
+/// requiring zero allocations.
+///
+/// All occurrences of the needle are replaced.
+///
+/// # Examples
+///
+/// ```
+/// use writeable::adapters::Replace;
+/// use writeable::concat_writeable;
+/// use writeable::assert_writeable_eq;
+///
+/// let source = concat_writeable!("I 💖 🦀", " and 🦀 loves me!");
+/// let replace = Replace {
+///     source,
+///     needle: "🦀",
+///     replacement: "Rust",
+/// };
+///
+/// assert_writeable_eq!(replace, "I 💖 Rust and Rust loves me!");
+/// ```
 #[derive(Debug)]
 #[allow(clippy::exhaustive_structs)] // designed for nesting
 pub struct Replace<A, B, C> {
@@ -156,10 +178,6 @@ where
         writer.flush()
     }
 
-    fn write_to_parts<S: PartsWrite + ?Sized>(&self, sink: &mut S) -> fmt::Result {
-        self.write_to(sink)
-    }
-
     fn writeable_length_hint(&self) -> LengthHint {
         let source_hint = self.source.writeable_length_hint();
         let needle_len = self.needle.as_ref().len();
@@ -173,6 +191,9 @@ where
 
         LengthHint::undefined()
     }
+
+    // TODO: how should we implement write_to_parts? What if the needle spans a part?
+    // TODO: should we implement writeable_borrow, if a replacement doesn't occur? It is O(N)
 }
 
 impl_display_with_writeable!(Replace<A, B, C>, #[cfg(feature = "alloc")], where A: Writeable, B: AsRef<str>, C: Writeable);


### PR DESCRIPTION
This is a zero-allocation string replacement adapter for Writeables.

I wrote the architecture and let an AI write the implementation. It used Knuth-Morris-Pratt. You can see which commits are human and which commits are AI.

Note: the needle needs to be `impl AsRef<str>` instead of `impl Writeable` in order to implement this in a no-allocation fashion, since it is sometimes necessary to backtrack. However, both the source and the replacement can be `impl Writeable`.

For now I'm only adding an adapter struct. In the future we could add an extension trait to allow things like

```rust
my_writeable.replace("a", "b")
```

## Changelog

writeable: new struct `writeable::adapters::Replace`