### PR TITLE
Add get_with_writeable to zerotrie

### DIFF
--- a/utils/writeable/src/concat.rs
+++ b/utils/writeable/src/concat.rs
@@ -118,6 +118,17 @@ where
     }
 }
 
+impl<'a, A, B, T> Into<fn(&'a mut T, &'a Concat<A, B>) -> fmt::Result> for &'a Concat<A, B>
+where
+    T: fmt::Write,
+    A: Writeable,
+    B: Writeable,
+{
+    fn into(self) -> fn(&mut T, &Concat<A, B>) -> fmt::Result {
+        |write, context| context.write_to(write)
+    }
+}
+
 /// Returns a [`Writeable`] concatenating any number of [`Writeable`]s.
 ///
 /// The macro resolves to a nested [`Concat`].

--- a/utils/writeable/src/concat.rs
+++ b/utils/writeable/src/concat.rs
@@ -118,17 +118,6 @@ where
     }
 }
 
-impl<'a, A, B, T> Into<fn(&'a mut T, &'a Concat<A, B>) -> fmt::Result> for &'a Concat<A, B>
-where
-    T: fmt::Write,
-    A: Writeable,
-    B: Writeable,
-{
-    fn into(self) -> fn(&mut T, &Concat<A, B>) -> fmt::Result {
-        |write, context| context.write_to(write)
-    }
-}
-
 /// Returns a [`Writeable`] concatenating any number of [`Writeable`]s.
 ///
 /// The macro resolves to a nested [`Concat`].

--- a/utils/zerotrie/Cargo.toml
+++ b/utils/zerotrie/Cargo.toml
@@ -31,6 +31,7 @@ serde_core = { workspace = true, optional = true }
 yoke = { workspace = true, features = ["derive"], optional = true }
 zerofrom = { workspace = true, optional = true }
 zerovec = { workspace = true, optional = true }
+writeable = { workspace = true, optional = true }
 
 [dev-dependencies]
 bincode = { workspace = true }
@@ -63,6 +64,7 @@ serde = ["dep:serde_core", "dep:litemap", "alloc", "litemap/serde", "zerovec?/se
 yoke = ["dep:yoke"]
 zerofrom = ["dep:zerofrom"]
 zerovec = ["dep:zerovec"]
+writeable = ["dep:writeable"]
 
 [[bench]]
 name = "overview"

--- a/utils/zerotrie/src/cursor.rs
+++ b/utils/zerotrie/src/cursor.rs
@@ -166,6 +166,32 @@ where
         let _infallible = writeable.write_to(&mut cursor);
         cursor.take_value()
     }
+
+    /// # Examples
+    ///
+    /// ```
+    /// use zerotrie::ZeroAsciiIgnoreCaseTrie;
+    /// use writeable::adapters::Concat;
+    ///
+    /// // A trie with two values: "aBc" and "aBcdEf"
+    /// let trie = ZeroAsciiIgnoreCaseTrie::from_bytes(b"aBc\x80dEf\x81");
+    ///
+    /// // Get out the value for "abc"
+    /// assert_eq!(trie.get_with_write(Concat("a", "bc")), Some(0));
+    /// ```
+    pub fn get_with_write<T>(
+        &self,
+        value: T,
+    ) -> Option<usize>
+    where
+    for<'a, 'b> &'a T: Into<fn(&'a mut ZeroAsciiIgnoreCaseTrieCursor<'b>, &'a T) -> fmt::Result>
+    {
+        // where F: FnOnce(&mut ZeroAsciiIgnoreCaseTrieCursor) -> fmt::Result
+        let mut cursor = self.cursor();
+        let callback = (&value).into();
+        callback(&mut cursor, &value).ok()?;
+        cursor.take_value()
+    }
 }
 
 impl<'a> ZeroTrieSimpleAscii<&'a [u8]> {

--- a/utils/zerotrie/src/cursor.rs
+++ b/utils/zerotrie/src/cursor.rs
@@ -7,6 +7,9 @@
 //! For examples, see the `.cursor()` functions
 //! and the `Cursor` types in this module.
 
+#[cfg(feature = "writeable")]
+use writeable::Writeable;
+
 use crate::reader;
 use crate::ZeroAsciiIgnoreCaseTrie;
 use crate::ZeroTrieSimpleAscii;
@@ -74,6 +77,32 @@ where
             trie: self.as_borrowed_slice(),
         }
     }
+
+    /// Queries the trie using a [`Writeable`].
+    ///
+    /// This is a special case of [`Self::cursor()`].
+    ///
+    /// ✨ *Enabled with the `writeable` Cargo feature.*
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zerotrie::ZeroTrieSimpleAscii;
+    /// use writeable::adapters::Concat;
+    ///
+    /// // A trie with two values: "abc" and "abcdef"
+    /// let trie = ZeroTrieSimpleAscii::from_bytes(b"abc\x80def\x81");
+    ///
+    /// // Get out the value for "abc"
+    /// assert_eq!(trie.get_with_writeable(Concat("a", "bc")), Some(0));
+    /// ```
+    #[cfg(feature = "writeable")]
+    #[inline]
+    pub fn get_with_writeable(&self, writeable: impl Writeable) -> Option<usize> {
+        let mut cursor = self.cursor();
+        let _infallible = writeable.write_to(&mut cursor);
+        cursor.take_value()
+    }
 }
 
 impl<Store> ZeroAsciiIgnoreCaseTrie<Store>
@@ -110,6 +139,32 @@ where
         ZeroAsciiIgnoreCaseTrieCursor {
             trie: self.as_borrowed_slice(),
         }
+    }
+
+    /// Queries the trie using a [`Writeable`].
+    ///
+    /// This is a special case of [`Self::cursor()`].
+    ///
+    /// ✨ *Enabled with the `writeable` Cargo feature.*
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zerotrie::ZeroAsciiIgnoreCaseTrie;
+    /// use writeable::adapters::Concat;
+    ///
+    /// // A trie with two values: "aBc" and "aBcdEf"
+    /// let trie = ZeroAsciiIgnoreCaseTrie::from_bytes(b"aBc\x80dEf\x81");
+    ///
+    /// // Get out the value for "abc"
+    /// assert_eq!(trie.get_with_writeable(Concat("a", "bc")), Some(0));
+    /// ```
+    #[cfg(feature = "writeable")]
+    #[inline]
+    pub fn get_with_writeable(&self, writeable: impl Writeable) -> Option<usize> {
+        let mut cursor = self.cursor();
+        let _infallible = writeable.write_to(&mut cursor);
+        cursor.take_value()
     }
 }
 

--- a/utils/zerotrie/src/cursor.rs
+++ b/utils/zerotrie/src/cursor.rs
@@ -166,32 +166,6 @@ where
         let _infallible = writeable.write_to(&mut cursor);
         cursor.take_value()
     }
-
-    /// # Examples
-    ///
-    /// ```
-    /// use zerotrie::ZeroAsciiIgnoreCaseTrie;
-    /// use writeable::adapters::Concat;
-    ///
-    /// // A trie with two values: "aBc" and "aBcdEf"
-    /// let trie = ZeroAsciiIgnoreCaseTrie::from_bytes(b"aBc\x80dEf\x81");
-    ///
-    /// // Get out the value for "abc"
-    /// assert_eq!(trie.get_with_write(Concat("a", "bc")), Some(0));
-    /// ```
-    pub fn get_with_write<T>(
-        &self,
-        value: T,
-    ) -> Option<usize>
-    where
-    for<'a, 'b> &'a T: Into<fn(&'a mut ZeroAsciiIgnoreCaseTrieCursor<'b>, &'a T) -> fmt::Result>
-    {
-        // where F: FnOnce(&mut ZeroAsciiIgnoreCaseTrieCursor) -> fmt::Result
-        let mut cursor = self.cursor();
-        let callback = (&value).into();
-        callback(&mut cursor, &value).ok()?;
-        cursor.take_value()
-    }
 }
 
 impl<'a> ZeroTrieSimpleAscii<&'a [u8]> {


### PR DESCRIPTION
Just a convenience wrapper around existing functionality.

## Changelog

zerotrie:

- New function: `ZeroTrieSimpleAscii::get_with_writeable`
- New function: `ZeroAsciiIgnoreCaseTrie::get_with_writeable`