### PR TITLE
refactor(currency): Take CurrencyCode by value and rename Iso variant to IsoSymbol

### DIFF
--- a/components/experimental/src/dimension/currency/compact_format.rs
+++ b/components/experimental/src/dimension/currency/compact_format.rs
@@ -14,7 +14,7 @@ mod tests {
     pub fn test_en_us() {
         let prefs = locale!("en-US").into();
         let currency_code = CurrencyCode(tinystr!(3, "USD"));
-        let fmt = CurrencyFormatter::try_new_compact_symbol(prefs, &currency_code).unwrap();
+        let fmt = CurrencyFormatter::try_new_compact_symbol(prefs, currency_code).unwrap();
 
         // Positive case
         let positive_value = "12345.67".parse().unwrap();
@@ -31,7 +31,7 @@ mod tests {
     pub fn test_fr_fr() {
         let prefs = locale!("fr-FR").into();
         let currency_code = CurrencyCode(tinystr!(3, "EUR"));
-        let fmt = CurrencyFormatter::try_new_compact_symbol(prefs, &currency_code).unwrap();
+        let fmt = CurrencyFormatter::try_new_compact_symbol(prefs, currency_code).unwrap();
 
         // Positive case
         let positive_value = "12345.67".parse().unwrap();
@@ -48,7 +48,7 @@ mod tests {
     pub fn test_zh_cn() {
         let prefs = locale!("zh-CN").into();
         let currency_code = CurrencyCode(tinystr!(3, "CNY"));
-        let fmt = CurrencyFormatter::try_new_compact_symbol(prefs, &currency_code).unwrap();
+        let fmt = CurrencyFormatter::try_new_compact_symbol(prefs, currency_code).unwrap();
 
         // Positive case
         let positive_value = "12345.67".parse().unwrap();
@@ -65,7 +65,7 @@ mod tests {
     pub fn test_ar_eg() {
         let prefs = locale!("ar-EG").into();
         let currency_code = CurrencyCode(tinystr!(3, "EGP"));
-        let fmt = CurrencyFormatter::try_new_compact_symbol(prefs, &currency_code).unwrap();
+        let fmt = CurrencyFormatter::try_new_compact_symbol(prefs, currency_code).unwrap();
 
         // Positive case
         let positive_value = "12345.67".parse().unwrap();
@@ -87,7 +87,7 @@ mod tests {
         let prefs = locale!("en-US").into();
 
         let currency_code = CurrencyCode(tinystr!(3, "USD"));
-        let fmt = CurrencyFormatter::try_new_compact_long_name(prefs, &currency_code).unwrap();
+        let fmt = CurrencyFormatter::try_new_compact_long_name(prefs, currency_code).unwrap();
 
         // Positive case
         let positive_value = "12345.67".parse().unwrap();
@@ -105,7 +105,7 @@ mod tests {
         let prefs = locale!("en-US").into();
 
         let currency_code = CurrencyCode(tinystr!(3, "USD"));
-        let fmt = CurrencyFormatter::try_new_compact_long_name(prefs, &currency_code).unwrap();
+        let fmt = CurrencyFormatter::try_new_compact_long_name(prefs, currency_code).unwrap();
 
         // Positive case
         let positive_value = "12345000.67".parse().unwrap();
@@ -123,7 +123,7 @@ mod tests {
         let prefs = locale!("fr-FR").into();
 
         let currency_code = CurrencyCode(tinystr!(3, "USD"));
-        let fmt = CurrencyFormatter::try_new_compact_long_name(prefs, &currency_code).unwrap();
+        let fmt = CurrencyFormatter::try_new_compact_long_name(prefs, currency_code).unwrap();
 
         // Positive case
         let positive_value = "12345.67".parse().unwrap();
@@ -141,7 +141,7 @@ mod tests {
         let prefs = locale!("fr-FR").into();
 
         let currency_code = CurrencyCode(tinystr!(3, "USD"));
-        let fmt = CurrencyFormatter::try_new_compact_long_name(prefs, &currency_code).unwrap();
+        let fmt = CurrencyFormatter::try_new_compact_long_name(prefs, currency_code).unwrap();
 
         // Positive case
         let positive_value = "12345000.67".parse().unwrap();
@@ -160,8 +160,8 @@ mod tests {
         let usd = CurrencyCode(tinystr!(3, "USD"));
         let sek = CurrencyCode(tinystr!(3, "SEK"));
 
-        let fmt_usd = CurrencyFormatter::try_new_compact_symbol(prefs, &usd).unwrap();
-        let fmt_sek = CurrencyFormatter::try_new_compact_symbol(prefs, &sek).unwrap();
+        let fmt_usd = CurrencyFormatter::try_new_compact_symbol(prefs, usd).unwrap();
+        let fmt_sek = CurrencyFormatter::try_new_compact_symbol(prefs, sek).unwrap();
 
         // Small number (magnitude < 3, no compact suffix): should fall back cleanly
         let small_value = "123".parse().unwrap();
@@ -178,9 +178,9 @@ mod tests {
         let prefs = locale!("en-US").into();
         let usd = CurrencyCode(tinystr!(3, "USD"));
 
-        let fmt_compact_name = CurrencyFormatter::try_new_compact_name(prefs, &usd).unwrap();
+        let fmt_compact_name = CurrencyFormatter::try_new_compact_name(prefs, usd).unwrap();
         let fmt_compact_long_symbol =
-            CurrencyFormatter::try_new_compact_long_symbol(prefs, &usd).unwrap();
+            CurrencyFormatter::try_new_compact_long_symbol(prefs, usd).unwrap();
 
         let val = "12345.67".parse().unwrap();
         assert_writeable_eq!(
@@ -190,6 +190,27 @@ mod tests {
         assert_writeable_eq!(
             fmt_compact_long_symbol.format_fixed_decimal(&val),
             "$12 thousand"
+        );
+    }
+
+    #[test]
+    pub fn test_compact_code() {
+        let prefs_en = locale!("en-US").into();
+        let currency_usd = CurrencyCode(tinystr!(3, "USD"));
+        let value = "12345.67".parse().unwrap();
+
+        let fmt_compact_code =
+            CurrencyFormatter::try_new_compact_code(prefs_en, currency_usd).unwrap();
+        let fmt_compact_long_code =
+            CurrencyFormatter::try_new_compact_long_code(prefs_en, currency_usd).unwrap();
+
+        assert_writeable_eq!(
+            fmt_compact_code.format_fixed_decimal(&value),
+            "USD\u{a0}12K"
+        );
+        assert_writeable_eq!(
+            fmt_compact_long_code.format_fixed_decimal(&value),
+            "USD\u{a0}12 thousand"
         );
     }
 }

--- a/components/experimental/src/dimension/currency/compact_formatter.rs
+++ b/components/experimental/src/dimension/currency/compact_formatter.rs
@@ -11,7 +11,7 @@ use super::formatter::{CurrencyFormatter, CurrencyFormatterPreferences};
 
 impl CurrencyFormatter<CompactDecimalFormatter> {
     icu_provider::gen_buffer_data_constructors!(
-        (prefs: CurrencyFormatterPreferences, currency_code: &CurrencyCode) -> error: DataError,
+        (prefs: CurrencyFormatterPreferences, currency_code: CurrencyCode) -> error: DataError,
         functions: [
             try_new_compact_symbol: skip,
             try_new_compact_symbol_with_buffer_provider,
@@ -21,7 +21,7 @@ impl CurrencyFormatter<CompactDecimalFormatter> {
     );
 
     icu_provider::gen_buffer_data_constructors!(
-        (prefs: CurrencyFormatterPreferences, currency_code: &CurrencyCode) -> error: DataError,
+        (prefs: CurrencyFormatterPreferences, currency_code: CurrencyCode) -> error: DataError,
         functions: [
             try_new_compact_symbol_narrow: skip,
             try_new_compact_symbol_narrow_with_buffer_provider,
@@ -31,7 +31,7 @@ impl CurrencyFormatter<CompactDecimalFormatter> {
     );
 
     icu_provider::gen_buffer_data_constructors!(
-        (prefs: CurrencyFormatterPreferences, currency_code: &CurrencyCode) -> error: DataError,
+        (prefs: CurrencyFormatterPreferences, currency_code: CurrencyCode) -> error: DataError,
         functions: [
             try_new_compact_code: skip,
             try_new_compact_code_with_buffer_provider,
@@ -41,7 +41,7 @@ impl CurrencyFormatter<CompactDecimalFormatter> {
     );
 
     icu_provider::gen_buffer_data_constructors!(
-        (prefs: CurrencyFormatterPreferences, currency_code: &CurrencyCode) -> error: DataError,
+        (prefs: CurrencyFormatterPreferences, currency_code: CurrencyCode) -> error: DataError,
         functions: [
             try_new_compact_name: skip,
             try_new_compact_name_with_buffer_provider,
@@ -51,7 +51,7 @@ impl CurrencyFormatter<CompactDecimalFormatter> {
     );
 
     icu_provider::gen_buffer_data_constructors!(
-        (prefs: CurrencyFormatterPreferences, currency_code: &CurrencyCode) -> error: DataError,
+        (prefs: CurrencyFormatterPreferences, currency_code: CurrencyCode) -> error: DataError,
         functions: [
             try_new_compact_long_symbol: skip,
             try_new_compact_long_symbol_with_buffer_provider,
@@ -61,7 +61,7 @@ impl CurrencyFormatter<CompactDecimalFormatter> {
     );
 
     icu_provider::gen_buffer_data_constructors!(
-        (prefs: CurrencyFormatterPreferences, currency_code: &CurrencyCode) -> error: DataError,
+        (prefs: CurrencyFormatterPreferences, currency_code: CurrencyCode) -> error: DataError,
         functions: [
             try_new_compact_long_symbol_narrow: skip,
             try_new_compact_long_symbol_narrow_with_buffer_provider,
@@ -71,7 +71,7 @@ impl CurrencyFormatter<CompactDecimalFormatter> {
     );
 
     icu_provider::gen_buffer_data_constructors!(
-        (prefs: CurrencyFormatterPreferences, currency_code: &CurrencyCode) -> error: DataError,
+        (prefs: CurrencyFormatterPreferences, currency_code: CurrencyCode) -> error: DataError,
         functions: [
             try_new_compact_long_code: skip,
             try_new_compact_long_code_with_buffer_provider,
@@ -81,7 +81,7 @@ impl CurrencyFormatter<CompactDecimalFormatter> {
     );
 
     icu_provider::gen_buffer_data_constructors!(
-        (prefs: CurrencyFormatterPreferences, currency_code: &CurrencyCode) -> error: DataError,
+        (prefs: CurrencyFormatterPreferences, currency_code: CurrencyCode) -> error: DataError,
         functions: [
             try_new_compact_long_name: skip,
             try_new_compact_long_name_with_buffer_provider,
@@ -98,12 +98,12 @@ impl CurrencyFormatter<CompactDecimalFormatter> {
     #[cfg(feature = "compiled_data")]
     pub fn try_new_compact_symbol(
         prefs: CurrencyFormatterPreferences,
-        currency_code: &CurrencyCode,
+        currency_code: CurrencyCode,
     ) -> Result<Self, DataError> {
         Self::try_new_essential(
             CompactDecimalFormatter::try_new_short((&prefs).into(), Default::default())?,
             prefs,
-            *currency_code,
+            currency_code,
             CurrencySymbolsV1::SHORT,
         )
     }
@@ -116,12 +116,12 @@ impl CurrencyFormatter<CompactDecimalFormatter> {
     #[cfg(feature = "compiled_data")]
     pub fn try_new_compact_symbol_narrow(
         prefs: CurrencyFormatterPreferences,
-        currency_code: &CurrencyCode,
+        currency_code: CurrencyCode,
     ) -> Result<Self, DataError> {
         Self::try_new_essential(
             CompactDecimalFormatter::try_new_short((&prefs).into(), Default::default())?,
             prefs,
-            *currency_code,
+            currency_code,
             CurrencySymbolsV1::NARROW,
         )
     }
@@ -134,12 +134,12 @@ impl CurrencyFormatter<CompactDecimalFormatter> {
     #[cfg(feature = "compiled_data")]
     pub fn try_new_compact_code(
         prefs: CurrencyFormatterPreferences,
-        currency_code: &CurrencyCode,
+        currency_code: CurrencyCode,
     ) -> Result<Self, DataError> {
         Self::try_new_code_internal(
             CompactDecimalFormatter::try_new_short((&prefs).into(), Default::default())?,
             prefs,
-            *currency_code,
+            currency_code,
         )
     }
 
@@ -151,12 +151,12 @@ impl CurrencyFormatter<CompactDecimalFormatter> {
     #[cfg(feature = "compiled_data")]
     pub fn try_new_compact_name(
         prefs: CurrencyFormatterPreferences,
-        currency_code: &CurrencyCode,
+        currency_code: CurrencyCode,
     ) -> Result<Self, DataError> {
         Self::try_new_name_internal(
             CompactDecimalFormatter::try_new_short((&prefs).into(), Default::default())?,
             prefs,
-            *currency_code,
+            currency_code,
         )
     }
 
@@ -168,12 +168,12 @@ impl CurrencyFormatter<CompactDecimalFormatter> {
     #[cfg(feature = "compiled_data")]
     pub fn try_new_compact_long_symbol(
         prefs: CurrencyFormatterPreferences,
-        currency_code: &CurrencyCode,
+        currency_code: CurrencyCode,
     ) -> Result<Self, DataError> {
         Self::try_new_essential(
             CompactDecimalFormatter::try_new_long((&prefs).into(), Default::default())?,
             prefs,
-            *currency_code,
+            currency_code,
             CurrencySymbolsV1::SHORT,
         )
     }
@@ -186,12 +186,12 @@ impl CurrencyFormatter<CompactDecimalFormatter> {
     #[cfg(feature = "compiled_data")]
     pub fn try_new_compact_long_symbol_narrow(
         prefs: CurrencyFormatterPreferences,
-        currency_code: &CurrencyCode,
+        currency_code: CurrencyCode,
     ) -> Result<Self, DataError> {
         Self::try_new_essential(
             CompactDecimalFormatter::try_new_long((&prefs).into(), Default::default())?,
             prefs,
-            *currency_code,
+            currency_code,
             CurrencySymbolsV1::NARROW,
         )
     }
@@ -204,12 +204,12 @@ impl CurrencyFormatter<CompactDecimalFormatter> {
     #[cfg(feature = "compiled_data")]
     pub fn try_new_compact_long_code(
         prefs: CurrencyFormatterPreferences,
-        currency_code: &CurrencyCode,
+        currency_code: CurrencyCode,
     ) -> Result<Self, DataError> {
         Self::try_new_code_internal(
             CompactDecimalFormatter::try_new_long((&prefs).into(), Default::default())?,
             prefs,
-            *currency_code,
+            currency_code,
         )
     }
 
@@ -221,12 +221,12 @@ impl CurrencyFormatter<CompactDecimalFormatter> {
     #[cfg(feature = "compiled_data")]
     pub fn try_new_compact_long_name(
         prefs: CurrencyFormatterPreferences,
-        currency_code: &CurrencyCode,
+        currency_code: CurrencyCode,
     ) -> Result<Self, DataError> {
         Self::try_new_name_internal(
             CompactDecimalFormatter::try_new_long((&prefs).into(), Default::default())?,
             prefs,
-            *currency_code,
+            currency_code,
         )
     }
 
@@ -234,7 +234,7 @@ impl CurrencyFormatter<CompactDecimalFormatter> {
     pub fn try_new_compact_symbol_unstable<D>(
         provider: &D,
         prefs: CurrencyFormatterPreferences,
-        currency_code: &CurrencyCode,
+        currency_code: CurrencyCode,
     ) -> Result<Self, DataError>
     where
         D: ?Sized
@@ -253,7 +253,7 @@ impl CurrencyFormatter<CompactDecimalFormatter> {
                 Default::default(),
             )?,
             prefs,
-            *currency_code,
+            currency_code,
             CurrencySymbolsV1::SHORT,
         )
     }
@@ -262,7 +262,7 @@ impl CurrencyFormatter<CompactDecimalFormatter> {
     pub fn try_new_compact_symbol_narrow_unstable<D>(
         provider: &D,
         prefs: CurrencyFormatterPreferences,
-        currency_code: &CurrencyCode,
+        currency_code: CurrencyCode,
     ) -> Result<Self, DataError>
     where
         D: ?Sized
@@ -281,7 +281,7 @@ impl CurrencyFormatter<CompactDecimalFormatter> {
                 Default::default(),
             )?,
             prefs,
-            *currency_code,
+            currency_code,
             CurrencySymbolsV1::NARROW,
         )
     }
@@ -290,7 +290,7 @@ impl CurrencyFormatter<CompactDecimalFormatter> {
     pub fn try_new_compact_name_unstable<D>(
         provider: &D,
         prefs: CurrencyFormatterPreferences,
-        currency_code: &CurrencyCode,
+        currency_code: CurrencyCode,
     ) -> Result<Self, DataError>
     where
         D: ?Sized
@@ -309,7 +309,7 @@ impl CurrencyFormatter<CompactDecimalFormatter> {
                 Default::default(),
             )?,
             prefs,
-            *currency_code,
+            currency_code,
         )
     }
 
@@ -317,7 +317,7 @@ impl CurrencyFormatter<CompactDecimalFormatter> {
     pub fn try_new_compact_long_symbol_unstable<D>(
         provider: &D,
         prefs: CurrencyFormatterPreferences,
-        currency_code: &CurrencyCode,
+        currency_code: CurrencyCode,
     ) -> Result<Self, DataError>
     where
         D: ?Sized
@@ -336,7 +336,7 @@ impl CurrencyFormatter<CompactDecimalFormatter> {
                 Default::default(),
             )?,
             prefs,
-            *currency_code,
+            currency_code,
             CurrencySymbolsV1::SHORT,
         )
     }
@@ -345,7 +345,7 @@ impl CurrencyFormatter<CompactDecimalFormatter> {
     pub fn try_new_compact_long_symbol_narrow_unstable<D>(
         provider: &D,
         prefs: CurrencyFormatterPreferences,
-        currency_code: &CurrencyCode,
+        currency_code: CurrencyCode,
     ) -> Result<Self, DataError>
     where
         D: ?Sized
@@ -364,7 +364,7 @@ impl CurrencyFormatter<CompactDecimalFormatter> {
                 Default::default(),
             )?,
             prefs,
-            *currency_code,
+            currency_code,
             CurrencySymbolsV1::NARROW,
         )
     }
@@ -373,7 +373,7 @@ impl CurrencyFormatter<CompactDecimalFormatter> {
     pub fn try_new_compact_long_name_unstable<D>(
         provider: &D,
         prefs: CurrencyFormatterPreferences,
-        currency_code: &CurrencyCode,
+        currency_code: CurrencyCode,
     ) -> Result<Self, DataError>
     where
         D: ?Sized
@@ -392,7 +392,7 @@ impl CurrencyFormatter<CompactDecimalFormatter> {
                 Default::default(),
             )?,
             prefs,
-            *currency_code,
+            currency_code,
         )
     }
 
@@ -400,7 +400,7 @@ impl CurrencyFormatter<CompactDecimalFormatter> {
     pub fn try_new_compact_code_unstable<D>(
         provider: &D,
         prefs: CurrencyFormatterPreferences,
-        currency_code: &CurrencyCode,
+        currency_code: CurrencyCode,
     ) -> Result<Self, DataError>
     where
         D: ?Sized
@@ -418,7 +418,7 @@ impl CurrencyFormatter<CompactDecimalFormatter> {
                 Default::default(),
             )?,
             prefs,
-            *currency_code,
+            currency_code,
         )
     }
 
@@ -426,7 +426,7 @@ impl CurrencyFormatter<CompactDecimalFormatter> {
     pub fn try_new_compact_long_code_unstable<D>(
         provider: &D,
         prefs: CurrencyFormatterPreferences,
-        currency_code: &CurrencyCode,
+        currency_code: CurrencyCode,
     ) -> Result<Self, DataError>
     where
         D: ?Sized
@@ -444,7 +444,7 @@ impl CurrencyFormatter<CompactDecimalFormatter> {
                 Default::default(),
             )?,
             prefs,
-            *currency_code,
+            currency_code,
         )
     }
 }

--- a/components/experimental/src/dimension/currency/format.rs
+++ b/components/experimental/src/dimension/currency/format.rs
@@ -17,7 +17,7 @@ mod tests {
         let currency_code = CurrencyCode(tinystr!(3, "USD"));
 
         // Short / Symbol
-        let fmt_symbol = CurrencyFormatter::try_new_symbol(prefs, &currency_code).unwrap();
+        let fmt_symbol = CurrencyFormatter::try_new_symbol(prefs, currency_code).unwrap();
         let positive_value = "12345.67".parse().unwrap();
         assert_writeable_eq!(
             fmt_symbol.format_fixed_decimal(&positive_value),
@@ -41,7 +41,7 @@ mod tests {
 
         // Narrow / Symbol Narrow
         let fmt_symbol_narrow =
-            CurrencyFormatter::try_new_symbol_narrow(prefs, &currency_code).unwrap();
+            CurrencyFormatter::try_new_symbol_narrow(prefs, currency_code).unwrap();
         assert_writeable_eq!(
             fmt_symbol_narrow.format_fixed_decimal(&positive_value),
             "$12,345.67"
@@ -62,7 +62,7 @@ mod tests {
         );
 
         // Long / Name
-        let fmt_name = CurrencyFormatter::try_new_name(prefs, &currency_code).unwrap();
+        let fmt_name = CurrencyFormatter::try_new_name(prefs, currency_code).unwrap();
         assert_writeable_eq!(
             fmt_name.format_fixed_decimal(&positive_value),
             "12,345.67 US dollars"
@@ -89,7 +89,7 @@ mod tests {
         let currency_code = CurrencyCode(tinystr!(3, "EUR"));
 
         // Short / Symbol
-        let fmt_symbol = CurrencyFormatter::try_new_symbol(prefs, &currency_code).unwrap();
+        let fmt_symbol = CurrencyFormatter::try_new_symbol(prefs, currency_code).unwrap();
         let positive_value = "12345.67".parse().unwrap();
         assert_writeable_eq!(
             fmt_symbol.format_fixed_decimal(&positive_value),
@@ -103,7 +103,7 @@ mod tests {
 
         // Narrow / Symbol Narrow
         let fmt_symbol_narrow =
-            CurrencyFormatter::try_new_symbol_narrow(prefs, &currency_code).unwrap();
+            CurrencyFormatter::try_new_symbol_narrow(prefs, currency_code).unwrap();
         assert_writeable_eq!(
             fmt_symbol_narrow.format_fixed_decimal(&positive_value),
             "12\u{202f}345,67\u{a0}€"
@@ -114,7 +114,7 @@ mod tests {
         );
 
         // Long / Name
-        let fmt_name = CurrencyFormatter::try_new_name(prefs, &currency_code).unwrap();
+        let fmt_name = CurrencyFormatter::try_new_name(prefs, currency_code).unwrap();
         assert_writeable_eq!(
             fmt_name.format_fixed_decimal(&positive_value),
             "12\u{202f}345,67 euros"
@@ -131,7 +131,7 @@ mod tests {
         let currency_code = CurrencyCode(tinystr!(3, "EGP"));
 
         // Short / Symbol
-        let fmt_symbol = CurrencyFormatter::try_new_symbol(prefs, &currency_code).unwrap();
+        let fmt_symbol = CurrencyFormatter::try_new_symbol(prefs, currency_code).unwrap();
         let positive_value = "12345.67".parse().unwrap();
         // TODO(#6064)
         assert_writeable_eq!(
@@ -147,7 +147,7 @@ mod tests {
 
         // Narrow / Symbol Narrow
         let fmt_symbol_narrow =
-            CurrencyFormatter::try_new_symbol_narrow(prefs, &currency_code).unwrap();
+            CurrencyFormatter::try_new_symbol_narrow(prefs, currency_code).unwrap();
         // TODO(#6064)
         assert_writeable_eq!(
             fmt_symbol_narrow.format_fixed_decimal(&positive_value),
@@ -160,7 +160,7 @@ mod tests {
         );
 
         // Long / Name
-        let fmt_name = CurrencyFormatter::try_new_name(prefs, &currency_code).unwrap();
+        let fmt_name = CurrencyFormatter::try_new_name(prefs, currency_code).unwrap();
         assert_writeable_eq!(
             fmt_name.format_fixed_decimal(&positive_value),
             "١٢٬٣٤٥٫٦٧ جنيه مصري"
@@ -178,7 +178,7 @@ mod tests {
         let value = "12345.67".parse().unwrap();
 
         // Short / Symbol USD in fr-FR should be US$ or $US
-        let fmt_symbol = CurrencyFormatter::try_new_symbol(prefs, &currency_code).unwrap();
+        let fmt_symbol = CurrencyFormatter::try_new_symbol(prefs, currency_code).unwrap();
         assert_writeable_eq!(
             fmt_symbol.format_fixed_decimal(&value),
             "12\u{202f}345,67\u{a0}$US"
@@ -186,7 +186,7 @@ mod tests {
 
         // Narrow / Symbol Narrow USD in fr-FR should be $
         let fmt_symbol_narrow =
-            CurrencyFormatter::try_new_symbol_narrow(prefs, &currency_code).unwrap();
+            CurrencyFormatter::try_new_symbol_narrow(prefs, currency_code).unwrap();
         assert_writeable_eq!(
             fmt_symbol_narrow.format_fixed_decimal(&value),
             "12\u{202f}345,67\u{a0}$"
@@ -201,16 +201,14 @@ mod tests {
         let value = "12345.67".parse().unwrap();
 
         // 1. Default numbering system (arab) - Symbol
-        let fmt_arab_symbol =
-            CurrencyFormatter::try_new_symbol(prefs_arab, &currency_code).unwrap();
+        let fmt_arab_symbol = CurrencyFormatter::try_new_symbol(prefs_arab, currency_code).unwrap();
         assert_writeable_eq!(
             fmt_arab_symbol.format_fixed_decimal(&value),
             "\u{200f}١٢٬٣٤٥٫٦٧\u{a0}ج.م.\u{200f}"
         );
 
         // 2. Locale extension override (latn) - Symbol
-        let fmt_latn_symbol =
-            CurrencyFormatter::try_new_symbol(prefs_latn, &currency_code).unwrap();
+        let fmt_latn_symbol = CurrencyFormatter::try_new_symbol(prefs_latn, currency_code).unwrap();
         assert_writeable_eq!(
             fmt_latn_symbol.format_fixed_decimal(&value),
             "\u{200f}12,345.67\u{a0}ج.م.\u{200f}"
@@ -218,7 +216,7 @@ mod tests {
 
         // 3. Default numbering system (arab) - Symbol Narrow
         let fmt_arab_symbol_narrow =
-            CurrencyFormatter::try_new_symbol_narrow(prefs_arab, &currency_code).unwrap();
+            CurrencyFormatter::try_new_symbol_narrow(prefs_arab, currency_code).unwrap();
         assert_writeable_eq!(
             fmt_arab_symbol_narrow.format_fixed_decimal(&value),
             "\u{200f}١٢٬٣٤٥٫٦٧\u{a0}E£"
@@ -226,21 +224,21 @@ mod tests {
 
         // 4. Locale extension override (latn) - Symbol Narrow
         let fmt_latn_symbol_narrow =
-            CurrencyFormatter::try_new_symbol_narrow(prefs_latn, &currency_code).unwrap();
+            CurrencyFormatter::try_new_symbol_narrow(prefs_latn, currency_code).unwrap();
         assert_writeable_eq!(
             fmt_latn_symbol_narrow.format_fixed_decimal(&value),
             "\u{200f}12,345.67\u{a0}E£"
         );
 
         // 5. Default numbering system (arab) - Name
-        let fmt_arab_name = CurrencyFormatter::try_new_name(prefs_arab, &currency_code).unwrap();
+        let fmt_arab_name = CurrencyFormatter::try_new_name(prefs_arab, currency_code).unwrap();
         assert_writeable_eq!(
             fmt_arab_name.format_fixed_decimal(&value),
             "١٢٬٣٤٥٫٦٧ جنيه مصري"
         );
 
         // 6. Locale extension override (latn) - Name
-        let fmt_latn_name = CurrencyFormatter::try_new_name(prefs_latn, &currency_code).unwrap();
+        let fmt_latn_name = CurrencyFormatter::try_new_name(prefs_latn, currency_code).unwrap();
         assert_writeable_eq!(
             fmt_latn_name.format_fixed_decimal(&value),
             "12,345.67 جنيه مصري"
@@ -254,12 +252,12 @@ mod tests {
         let value = "12345.67".parse().unwrap();
 
         // Short / Symbol
-        let fmt_symbol = CurrencyFormatter::try_new_symbol(prefs, &currency_code).unwrap();
+        let fmt_symbol = CurrencyFormatter::try_new_symbol(prefs, currency_code).unwrap();
         assert_writeable_eq!(fmt_symbol.format_fixed_decimal(&value), "CA$12,345.67");
 
         // Narrow / Symbol Narrow
         let fmt_symbol_narrow =
-            CurrencyFormatter::try_new_symbol_narrow(prefs, &currency_code).unwrap();
+            CurrencyFormatter::try_new_symbol_narrow(prefs, currency_code).unwrap();
         assert_writeable_eq!(fmt_symbol_narrow.format_fixed_decimal(&value), "$12,345.67");
     }
 
@@ -269,7 +267,7 @@ mod tests {
         let currency_usd = CurrencyCode(tinystr!(3, "USD"));
         let value = "12345.67".parse().unwrap();
 
-        let fmt_code_en = CurrencyFormatter::try_new_code(prefs_en, &currency_usd).unwrap();
+        let fmt_code_en = CurrencyFormatter::try_new_code(prefs_en, currency_usd).unwrap();
         assert_writeable_eq!(
             fmt_code_en.format_fixed_decimal(&value),
             "USD\u{a0}12,345.67"
@@ -277,7 +275,7 @@ mod tests {
 
         let prefs_fr = locale!("fr-FR").into();
         let currency_eur = CurrencyCode(tinystr!(3, "EUR"));
-        let fmt_code_fr = CurrencyFormatter::try_new_code(prefs_fr, &currency_eur).unwrap();
+        let fmt_code_fr = CurrencyFormatter::try_new_code(prefs_fr, currency_eur).unwrap();
         assert_writeable_eq!(
             fmt_code_fr.format_fixed_decimal(&value),
             "12\u{202f}345,67\u{a0}EUR"
@@ -291,7 +289,7 @@ mod tests {
         let currency_xyz = CurrencyCode(tinystr!(3, "XYZ"));
         let value = "12345.67".parse().unwrap();
 
-        let fmt_name = CurrencyFormatter::try_new_name(prefs_en, &currency_xyz).unwrap();
+        let fmt_name = CurrencyFormatter::try_new_name(prefs_en, currency_xyz).unwrap();
         assert_writeable_eq!(fmt_name.format_fixed_decimal(&value), "12,345.67 XYZ");
     }
 }

--- a/components/experimental/src/dimension/currency/formatter.rs
+++ b/components/experimental/src/dimension/currency/formatter.rs
@@ -45,7 +45,7 @@ prefs_convert!(
 
 #[derive(Debug)]
 pub(crate) enum CurrencyFormatterData {
-    Iso {
+    IsoSymbol {
         essential: DataPayload<CurrencyEssentialsV1>,
         currency: CurrencyCode,
     },
@@ -111,7 +111,7 @@ impl<V: AbstractFormatter> CurrencyFormatter<V> {
                 essential,
                 symbol: res.payload,
             },
-            None => CurrencyFormatterData::Iso {
+            None => CurrencyFormatterData::IsoSymbol {
                 essential,
                 currency,
             },
@@ -155,7 +155,7 @@ impl<V: AbstractFormatter> CurrencyFormatter<V> {
                 essential,
                 symbol: res.payload,
             },
-            None => CurrencyFormatterData::Iso {
+            None => CurrencyFormatterData::IsoSymbol {
                 essential,
                 currency,
             },
@@ -185,7 +185,7 @@ impl<V: AbstractFormatter> CurrencyFormatter<V> {
 
         Ok(Self {
             value_formatter,
-            currency_data: CurrencyFormatterData::Iso {
+            currency_data: CurrencyFormatterData::IsoSymbol {
                 essential,
                 currency,
             },
@@ -211,7 +211,7 @@ impl<V: AbstractFormatter> CurrencyFormatter<V> {
 
         Ok(Self {
             value_formatter,
-            currency_data: CurrencyFormatterData::Iso {
+            currency_data: CurrencyFormatterData::IsoSymbol {
                 essential,
                 currency,
             },
@@ -316,7 +316,7 @@ impl<V: AbstractFormatter> CurrencyFormatter<V> {
 
 impl CurrencyFormatter<DecimalFormatter> {
     icu_provider::gen_buffer_data_constructors!(
-        (prefs: CurrencyFormatterPreferences, currency_code: &CurrencyCode) -> error: DataError,
+        (prefs: CurrencyFormatterPreferences, currency_code: CurrencyCode) -> error: DataError,
         functions: [
             try_new_symbol: skip,
             try_new_symbol_with_buffer_provider,
@@ -326,7 +326,7 @@ impl CurrencyFormatter<DecimalFormatter> {
     );
 
     icu_provider::gen_buffer_data_constructors!(
-        (prefs: CurrencyFormatterPreferences, currency_code: &CurrencyCode) -> error: DataError,
+        (prefs: CurrencyFormatterPreferences, currency_code: CurrencyCode) -> error: DataError,
         functions: [
             try_new_symbol_narrow: skip,
             try_new_symbol_narrow_with_buffer_provider,
@@ -348,12 +348,12 @@ impl CurrencyFormatter<DecimalFormatter> {
     #[cfg(feature = "compiled_data")]
     pub fn try_new_symbol(
         prefs: CurrencyFormatterPreferences,
-        currency_code: &CurrencyCode,
+        currency_code: CurrencyCode,
     ) -> Result<Self, DataError> {
         Self::try_new_essential(
             DecimalFormatter::try_new((&prefs).into(), Default::default())?,
             prefs,
-            *currency_code,
+            currency_code,
             CurrencySymbolsV1::SHORT,
         )
     }
@@ -366,12 +366,12 @@ impl CurrencyFormatter<DecimalFormatter> {
     #[cfg(feature = "compiled_data")]
     pub fn try_new_symbol_narrow(
         prefs: CurrencyFormatterPreferences,
-        currency_code: &CurrencyCode,
+        currency_code: CurrencyCode,
     ) -> Result<Self, DataError> {
         Self::try_new_essential(
             DecimalFormatter::try_new((&prefs).into(), Default::default())?,
             prefs,
-            *currency_code,
+            currency_code,
             CurrencySymbolsV1::NARROW,
         )
     }
@@ -380,7 +380,7 @@ impl CurrencyFormatter<DecimalFormatter> {
     pub fn try_new_symbol_unstable<D>(
         provider: &D,
         prefs: CurrencyFormatterPreferences,
-        currency_code: &CurrencyCode,
+        currency_code: CurrencyCode,
     ) -> Result<Self, DataError>
     where
         D: ?Sized
@@ -393,7 +393,7 @@ impl CurrencyFormatter<DecimalFormatter> {
             provider,
             DecimalFormatter::try_new_unstable(provider, (&prefs).into(), Default::default())?,
             prefs,
-            *currency_code,
+            currency_code,
             CurrencySymbolsV1::SHORT,
         )
     }
@@ -402,7 +402,7 @@ impl CurrencyFormatter<DecimalFormatter> {
     pub fn try_new_symbol_narrow_unstable<D>(
         provider: &D,
         prefs: CurrencyFormatterPreferences,
-        currency_code: &CurrencyCode,
+        currency_code: CurrencyCode,
     ) -> Result<Self, DataError>
     where
         D: ?Sized
@@ -415,13 +415,13 @@ impl CurrencyFormatter<DecimalFormatter> {
             provider,
             DecimalFormatter::try_new_unstable(provider, (&prefs).into(), Default::default())?,
             prefs,
-            *currency_code,
+            currency_code,
             CurrencySymbolsV1::NARROW,
         )
     }
 
     icu_provider::gen_buffer_data_constructors!(
-        (prefs: CurrencyFormatterPreferences, currency_code: &CurrencyCode) -> error: DataError,
+        (prefs: CurrencyFormatterPreferences, currency_code: CurrencyCode) -> error: DataError,
         functions: [
             try_new_code: skip,
             try_new_code_with_buffer_provider,
@@ -446,19 +446,19 @@ impl CurrencyFormatter<DecimalFormatter> {
     ///
     /// let currency_preferences = locale!("en-US").into();
     /// let currency_code = CurrencyCode(tinystr!(3, "USD"));
-    /// let fmt = CurrencyFormatter::try_new_code(currency_preferences, &currency_code).unwrap();
+    /// let fmt = CurrencyFormatter::try_new_code(currency_preferences, currency_code).unwrap();
     /// let value = "12345.67".parse().unwrap();
     /// assert_writeable_eq!(fmt.format_fixed_decimal(&value), "USD\u{a0}12,345.67");
     /// ```
     #[cfg(feature = "compiled_data")]
     pub fn try_new_code(
         prefs: CurrencyFormatterPreferences,
-        currency_code: &CurrencyCode,
+        currency_code: CurrencyCode,
     ) -> Result<Self, DataError> {
         Self::try_new_code_internal(
             DecimalFormatter::try_new((&prefs).into(), Default::default())?,
             prefs,
-            *currency_code,
+            currency_code,
         )
     }
 
@@ -466,7 +466,7 @@ impl CurrencyFormatter<DecimalFormatter> {
     pub fn try_new_code_unstable<D>(
         provider: &D,
         prefs: CurrencyFormatterPreferences,
-        currency_code: &CurrencyCode,
+        currency_code: CurrencyCode,
     ) -> Result<Self, DataError>
     where
         D: ?Sized
@@ -478,12 +478,12 @@ impl CurrencyFormatter<DecimalFormatter> {
             provider,
             DecimalFormatter::try_new_unstable(provider, (&prefs).into(), Default::default())?,
             prefs,
-            *currency_code,
+            currency_code,
         )
     }
 
     icu_provider::gen_buffer_data_constructors!(
-        (prefs: CurrencyFormatterPreferences, currency_code: &CurrencyCode) -> error: DataError,
+        (prefs: CurrencyFormatterPreferences, currency_code: CurrencyCode) -> error: DataError,
         functions: [
             try_new_name: skip,
             try_new_name_with_buffer_provider,
@@ -508,19 +508,19 @@ impl CurrencyFormatter<DecimalFormatter> {
     ///
     /// let currency_preferences = locale!("en-US").into();
     /// let currency_code = CurrencyCode(tinystr!(3, "USD"));
-    /// let fmt = CurrencyFormatter::try_new_name(currency_preferences, &currency_code).unwrap();
+    /// let fmt = CurrencyFormatter::try_new_name(currency_preferences, currency_code).unwrap();
     /// let value = "12345.67".parse().unwrap();
     /// assert_writeable_eq!(fmt.format_fixed_decimal(&value), "12,345.67 US dollars");
     /// ```
     #[cfg(feature = "compiled_data")]
     pub fn try_new_name(
         prefs: CurrencyFormatterPreferences,
-        currency_code: &CurrencyCode,
+        currency_code: CurrencyCode,
     ) -> Result<Self, DataError> {
         Self::try_new_name_internal(
             DecimalFormatter::try_new((&prefs).into(), Default::default())?,
             prefs,
-            *currency_code,
+            currency_code,
         )
     }
 
@@ -528,7 +528,7 @@ impl CurrencyFormatter<DecimalFormatter> {
     pub fn try_new_name_unstable<D>(
         provider: &D,
         prefs: CurrencyFormatterPreferences,
-        currency_code: &CurrencyCode,
+        currency_code: CurrencyCode,
     ) -> Result<Self, DataError>
     where
         D: ?Sized
@@ -542,7 +542,7 @@ impl CurrencyFormatter<DecimalFormatter> {
             provider,
             DecimalFormatter::try_new_unstable(provider, (&prefs).into(), Default::default())?,
             prefs,
-            *currency_code,
+            currency_code,
         )
     }
 }
@@ -560,7 +560,7 @@ impl<V: AbstractFormatter> CurrencyFormatter<V> {
     ///
     /// let locale = locale!("en-US").into();
     /// let currency_code = CurrencyCode(tinystr!(3, "USD"));
-    /// let fmt = CurrencyFormatter::try_new_symbol(locale, &currency_code).unwrap();
+    /// let fmt = CurrencyFormatter::try_new_symbol(locale, currency_code).unwrap();
     /// let value = "12345.67".parse().unwrap();
     /// assert_writeable_eq!(
     ///     fmt.format_fixed_decimal(&value),
@@ -577,7 +577,7 @@ impl<V: AbstractFormatter> CurrencyFormatter<V> {
     ///
     /// let locale = locale!("en-US").into();
     /// let currency_code = CurrencyCode(tinystr!(3, "USD"));
-    /// let fmt = CurrencyFormatter::try_new_compact_symbol(locale, &currency_code).unwrap();
+    /// let fmt = CurrencyFormatter::try_new_compact_symbol(locale, currency_code).unwrap();
     /// let value = "12345.67".parse().unwrap();
     /// assert_writeable_eq!(fmt.format_fixed_decimal(&value), "$12K");
     /// ```
@@ -591,7 +591,7 @@ impl<V: AbstractFormatter> CurrencyFormatter<V> {
     ///
     /// let currency_prefs = locale!("en-US").into();
     /// let currency_code = CurrencyCode(tinystr!(3, "USD"));
-    /// let fmt = CurrencyFormatter::try_new_compact_long_symbol(currency_prefs, &currency_code).unwrap();
+    /// let fmt = CurrencyFormatter::try_new_compact_long_symbol(currency_prefs, currency_code).unwrap();
     /// let value = "12345.67".parse().unwrap();
     /// assert_writeable_eq!(fmt.format_fixed_decimal(&value), "$12 thousand");
     /// ```
@@ -604,7 +604,7 @@ impl<V: AbstractFormatter> CurrencyFormatter<V> {
         // TODO(#8146): Evaluate if FixedDecimal is the correct input type or if we should use
         // an exact decimal/money representation.
         let (pattern, currency_str) = match &self.currency_data {
-            CurrencyFormatterData::Iso {
+            CurrencyFormatterData::IsoSymbol {
                 essential,
                 currency,
             } => {


### PR DESCRIPTION
Address review feedback left on #8229 from @robertbastian:
- Change all `try_new_*` constructor signatures in `CurrencyFormatter` to take `CurrencyCode` by value instead of by reference (`CurrencyCode` is a small `Copy` struct).
- Rename `CurrencyFormatterData::Iso` enum variant to `IsoSymbol` for clarity and symmetry with `IsoName`.
- Add unit test coverage (`test_compact_code`) for both short and long compact ISO currency code formatting.

## Changelog 

N/A