### PR TITLE
Remove arrayvec and arraystring dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,15 +129,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arraystring"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d517c467117e1d8ca795bc8cc90857ff7f79790cca0e26f6e9462694ece0185"
-dependencies = [
- "typenum",
-]
-
-[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1497,7 +1488,6 @@ dependencies = [
 name = "icu_collator"
 version = "2.2.0"
 dependencies = [
- "arraystring",
  "atoi",
  "criterion",
  "databake",
@@ -1753,8 +1743,6 @@ version = "2.2.0"
 name = "icu_normalizer"
 version = "2.2.0"
 dependencies = [
- "arraystring",
- "arrayvec",
  "atoi",
  "criterion",
  "databake",
@@ -3584,12 +3572,6 @@ name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
-
-[[package]]
-name = "typenum"
-version = "1.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "tzif"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -244,7 +244,6 @@ diplomat-tool = { git = "https://github.com/rust-diplomat/diplomat", rev = "e827
 # EXTRA_CAPI_DEPS
 # EXTRA_BLOB_DEPS
 # EXTRA_FS_DEPS
-arrayvec = { version = "0.7.2", default-features = false }
 chrono = { version = "0.4", default-features = false }
 chrono-tz = { version = "0.10", default-features = false }
 core_maths = { version = "0.1.0", default-features = false }
@@ -282,7 +281,6 @@ serde-aux = { version = "4.0.0", default-features = false }
 toml = { version = "0.8.0", default-features = false, features = ["parse"] }
 
 ## External Deps Group 3: Dev and Datagen deps. Include default features.
-arraystring = "0.3.0"
 askama = "0.15"
 atoi = "2.0.0"
 bincode = "1.3.1" # Can be updated to 2.0 after MSRV 1.85

--- a/components/collator/Cargo.toml
+++ b/components/collator/Cargo.toml
@@ -41,7 +41,6 @@ icu_collator_data = { workspace = true, optional = true }
 icu_locale = { workspace = true, optional = true }
 
 [dev-dependencies]
-arraystring = { workspace = true }
 atoi = { workspace = true }
 icu = { path = "../../components/icu", default-features = false }
 icu_locale_core = { path = "../../components/locale_core" }

--- a/components/collator/tests/tests.rs
+++ b/components/collator/tests/tests.rs
@@ -39,8 +39,6 @@ const _: () = {
     icu_normalizer_data::impl_normalizer_uts46_data_v1!(TestingProvider);
 };
 
-type StackString = arraystring::ArrayString<arraystring::typenum::U32>;
-
 fn assert_all_comparisons(
     collator: &CollatorBorrowed,
     left: &str,
@@ -73,12 +71,12 @@ fn assert_all_comparisons(
 }
 
 /// Parse a string of space-separated hexadecimal code points (ending in end of input or semicolon)
-fn parse_hex(mut hexes: &[u8]) -> Option<StackString> {
-    let mut buf = StackString::new();
+fn parse_hex(mut hexes: &[u8]) -> Option<String> {
+    let mut buf = String::new();
     loop {
         let (scalar, mut offset) = u32::from_radix_16(hexes);
         if let Some(c) = core::char::from_u32(scalar) {
-            buf.try_push(c).unwrap();
+            buf.push(c);
         } else {
             return None;
         }

--- a/components/normalizer/Cargo.toml
+++ b/components/normalizer/Cargo.toml
@@ -40,8 +40,6 @@ serde = { workspace = true, features = ["derive", "alloc"], optional = true }
 icu_normalizer_data = { workspace = true, optional = true }
 
 [dev-dependencies]
-arraystring = { workspace = true }
-arrayvec = { workspace = true }
 atoi = { workspace = true }
 detone = { workspace = true }
 icu = { path = "../../components/icu", default-features = false }

--- a/components/normalizer/tests/tests.rs
+++ b/components/normalizer/tests/tests.rs
@@ -454,13 +454,11 @@ fn test_uts46_normalize_validate() {
     );
 }
 
-type StackString = arraystring::ArrayString<arraystring::typenum::U48>;
-
 #[test]
 fn test_nfd_str_to() {
     let normalizer = DecomposingNormalizerBorrowed::new_nfd();
 
-    let mut buf = StackString::new();
+    let mut buf = String::new();
     assert!(normalizer.normalize_to("ä", &mut buf).is_ok());
     assert_eq!(&buf, "a\u{0308}");
 
@@ -473,7 +471,7 @@ fn test_nfd_str_to() {
 fn test_nfd_utf8_to() {
     let normalizer = DecomposingNormalizerBorrowed::new_nfd();
 
-    let mut buf = StackString::new();
+    let mut buf = String::new();
     assert!(
         normalizer
             .normalize_utf8_to("ä".as_bytes(), &mut buf)
@@ -490,13 +488,11 @@ fn test_nfd_utf8_to() {
     assert_eq!(&buf, "e\u{0323}\u{0302}");
 }
 
-type StackVec = arrayvec::ArrayVec<u16, 32>;
-
 #[test]
 fn test_nfd_utf16_to() {
     let normalizer = DecomposingNormalizerBorrowed::new_nfd();
 
-    let mut buf = StackVec::new();
+    let mut buf = Vec::new();
     assert!(
         normalizer
             .normalize_utf16_to([0x00E4u16].as_slice(), &mut buf)
@@ -517,7 +513,7 @@ fn test_nfd_utf16_to() {
 fn test_nfc_str_to() {
     let normalizer = ComposingNormalizerBorrowed::new_nfc();
 
-    let mut buf = StackString::new();
+    let mut buf = String::new();
     assert!(normalizer.normalize_to("a\u{0308}", &mut buf).is_ok());
     assert_eq!(&buf, "ä");
 
@@ -534,7 +530,7 @@ fn test_nfc_str_to() {
 fn test_nfc_utf8_to() {
     let normalizer = ComposingNormalizerBorrowed::new_nfc();
 
-    let mut buf = StackString::new();
+    let mut buf = String::new();
     assert!(
         normalizer
             .normalize_utf8_to("a\u{0308}".as_bytes(), &mut buf)
@@ -555,7 +551,7 @@ fn test_nfc_utf8_to() {
 fn test_nfc_utf16_to() {
     let normalizer = ComposingNormalizerBorrowed::new_nfc();
 
-    let mut buf = StackVec::new();
+    let mut buf = Vec::new();
     assert!(
         normalizer
             .normalize_utf16_to([0x0061u16, 0x0308u16].as_slice(), &mut buf)
@@ -576,7 +572,7 @@ fn test_nfc_utf16_to() {
 fn test_nfc_utf8_to_errors() {
     let normalizer = ComposingNormalizerBorrowed::new_nfc();
 
-    let mut buf = StackString::new();
+    let mut buf = String::new();
     assert!(
         normalizer
             .normalize_utf8_to(b"\xFFa\xCC\x88\xFF", &mut buf)
@@ -613,7 +609,7 @@ fn test_nfc_utf8_to_errors() {
 fn test_nfd_utf8_to_errors() {
     let normalizer = DecomposingNormalizerBorrowed::new_nfd();
 
-    let mut buf = StackString::new();
+    let mut buf = String::new();
     assert!(
         normalizer
             .normalize_utf8_to(b"\xFF\xC3\xA4\xFF", &mut buf)
@@ -650,7 +646,7 @@ fn test_nfd_utf8_to_errors() {
 fn test_nfc_utf16_to_errors() {
     let normalizer = ComposingNormalizerBorrowed::new_nfc();
 
-    let mut buf = StackVec::new();
+    let mut buf = Vec::new();
     assert!(
         normalizer
             .normalize_utf16_to([0xD800u16, 0x0061u16, 0x0308u16].as_slice(), &mut buf)
@@ -777,7 +773,7 @@ fn test_nfc_utf16_to_errors() {
 fn test_nfd_utf16_to_errors() {
     let normalizer = DecomposingNormalizerBorrowed::new_nfd();
 
-    let mut buf = StackVec::new();
+    let mut buf = Vec::new();
     assert!(
         normalizer
             .normalize_utf16_to([0xD800u16, 0x00E4u16].as_slice(), &mut buf)
@@ -904,19 +900,19 @@ use atoi::FromRadix16;
 use icu_properties::props::CanonicalCombiningClass;
 
 /// Parse five semicolon-terminated strings consisting of space-separated hexadecimal scalar values
-fn parse_hex(mut hexes: &[u8]) -> [StackString; 5] {
+fn parse_hex(mut hexes: &[u8]) -> [String; 5] {
     let mut strings = [
-        StackString::new(),
-        StackString::new(),
-        StackString::new(),
-        StackString::new(),
-        StackString::new(),
+        String::new(),
+        String::new(),
+        String::new(),
+        String::new(),
+        String::new(),
     ];
     let mut current = 0;
     loop {
         let (scalar, mut offset) = u32::from_radix_16(hexes);
         let c = core::char::from_u32(scalar).unwrap();
-        strings[current].try_push(c).unwrap();
+        strings[current].push(c);
         match hexes[offset] {
             b';' => {
                 current += 1;
@@ -1132,30 +1128,24 @@ fn test_conformance() {
 //     }
 // }
 
-fn str_to_utf16(s: &str, sink: &mut StackVec) {
+fn str_to_utf16(s: &str, sink: &mut Vec<u16>) {
     sink.clear();
-    let mut buf = [0u16; 2];
-    for c in s.chars() {
-        sink.try_extend_from_slice(c.encode_utf16(&mut buf))
-            .unwrap();
-    }
+    sink.extend(s.encode_utf16());
 }
 
-fn char_to_utf16(c: char, sink: &mut StackVec) {
+fn char_to_utf16(c: char, sink: &mut Vec<u16>) {
     sink.clear();
-    let mut buf = [0u16; 2];
-    sink.try_extend_from_slice(c.encode_utf16(&mut buf))
-        .unwrap();
+    sink.extend(c.encode_utf16(&mut [0; 2]).iter());
 }
 
-fn str_to_str(s: &str, sink: &mut StackString) {
+fn str_to_str(s: &str, sink: &mut String) {
     sink.clear();
-    sink.try_push_str(s).unwrap();
+    sink.push_str(s);
 }
 
-fn char_to_str(c: char, sink: &mut StackString) {
+fn char_to_str(c: char, sink: &mut String) {
     sink.clear();
-    sink.try_push(c).unwrap();
+    sink.push(c);
 }
 
 #[test]
@@ -1165,9 +1155,9 @@ fn test_conformance_utf16() {
     let nfc = ComposingNormalizerBorrowed::new_nfc();
     let nfkc = ComposingNormalizerBorrowed::new_nfkc();
 
-    let mut input = StackVec::new();
-    let mut normalized = StackVec::new();
-    let mut expected = StackVec::new();
+    let mut input = Vec::new();
+    let mut normalized = Vec::new();
+    let mut expected = Vec::new();
 
     let mut prev = 0u32;
     let mut part = 0u8;
@@ -1378,9 +1368,9 @@ fn test_conformance_utf8() {
     let nfc = ComposingNormalizerBorrowed::new_nfc();
     let nfkc = ComposingNormalizerBorrowed::new_nfkc();
 
-    let mut input = StackString::new();
-    let mut normalized = StackString::new();
-    let mut expected = StackString::new();
+    let mut input = String::new();
+    let mut normalized = String::new();
+    let mut expected = String::new();
 
     let mut prev = 0u32;
     let mut part = 0u8;


### PR DESCRIPTION
There's no point using them over `Vec` and `String` in those two tests and pulling in dependencies for that.

## Changelog

N/A