### PR TITLE
fix(utils): enable some missing Cargo features

### DIFF
--- a/utils/yoke/derive/Cargo.toml
+++ b/utils/yoke/derive/Cargo.toml
@@ -29,7 +29,7 @@ synstructure = { workspace = true }
 
 [dev-dependencies]
 yoke = { path = "..", features = ["derive"] }
-zerovec = { path = "../../../utils/zerovec", features = ["yoke", "alloc"] }
+zerovec = { path = "../../../utils/zerovec", features = ["alloc", "yoke"] }
 
 [lints]
 workspace = true

--- a/utils/yoke/derive/Cargo.toml
+++ b/utils/yoke/derive/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/lib.rs"
 [dependencies]
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
-syn = { workspace = true, features = ["fold"] }
+syn = { workspace = true, features = ["fold", "visit"] }
 synstructure = { workspace = true }
 
 [dev-dependencies]

--- a/utils/zerofrom/derive/Cargo.toml
+++ b/utils/zerofrom/derive/Cargo.toml
@@ -30,7 +30,7 @@ synstructure = { workspace = true }
 
 [dev-dependencies]
 zerofrom = { path = "..", features = ["derive"]}
-zerovec = { path = "../../../utils/zerovec", features = ["yoke"] }
+zerovec = { path = "../../../utils/zerovec", features = ["alloc", "yoke"] }
 
 [lints]
 workspace = true

--- a/utils/zerofrom/derive/Cargo.toml
+++ b/utils/zerofrom/derive/Cargo.toml
@@ -25,7 +25,7 @@ path = "src/lib.rs"
 [dependencies]
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
-syn = { workspace = true, features = ["fold"] }
+syn = { workspace = true, features = ["fold", "visit"] }
 synstructure = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->
This enables the `visit` Cargo feature on `syn` in `yoke-derive` and `zerofrom-derive` and `alloc` on `zerovec` in `zerofrom`, which were missing, likely because their need was hidden due to feature unification in the workspace.

I've found this by bumping `syn` to v3 (for which I plan to open a PR soon, but needs an [update of `synstructure`](https://github.com/mystor/synstructure/pull/75) first) in `yoke-derive` and `zerofrom-derive` individually.

## Changelog (N/A)

<!-- Please fill in according to documents/process/changelog.md -->
