### PR TITLE
[measure] Clarify TODO(#8269) for unit aliases handling

### DIFF
--- a/components/experimental/src/measure/parser/ids.rs
+++ b/components/experimental/src/measure/parser/ids.rs
@@ -138,7 +138,8 @@ pub(crate) const CLDR_IDS_TRIE: ZeroTrieSimpleAscii<[u8; 1334]> =
         ("pint-metric", 110_usize),
         ("pixel", 111_usize),
         ("point", 112_usize),
-        // TODO(#8269): alias for part
+        // TODO(#8269): `portion` is an alias for `part`. Unit aliases should be handled via a separate
+        // lookup structure (e.g. `UNIT_ALIASES_TRIE`) rather than mapping directly inside `CLDR_IDS_TRIE`.
         ("portion", 113_usize),
         ("pound", 114_usize),
         ("pound-force", 115_usize),


### PR DESCRIPTION
Update TODO comment beside `portion` in `CLDR_IDS_TRIE` to clarify that unit aliases should be handled via a dedicated alias lookup structure (e.g. `UNIT_ALIASES_TRIE`) rather than mapping directly inside `CLDR_IDS_TRIE`.\n\nRef: https://github.com/unicode-org/icu4x/pull/8266#discussion_r3656601524