### PR TITLE
Fix IXDTF trailing input validation after annotations

### DIFF
--- a/utils/ixdtf/src/parsers/datetime.rs
+++ b/utils/ixdtf/src/parsers/datetime.rs
@@ -144,6 +144,7 @@ pub(crate) fn parse_annotated_year_month<'a, T: EncodingType>(
     }
 
     let annotation_set = annotations::parse_annotation_set(cursor, handler)?;
+    cursor.close()?;
 
     Ok(IxdtfParseRecord {
         date: Some(year_month),
@@ -190,6 +191,7 @@ pub(crate) fn parse_annotated_month_day<'a, T: EncodingType>(
     }
 
     let annotation_set = annotations::parse_annotation_set(cursor, handler)?;
+    cursor.close()?;
 
     Ok(IxdtfParseRecord {
         date: Some(date),

--- a/utils/ixdtf/src/parsers/tests.rs
+++ b/utils/ixdtf/src/parsers/tests.rs
@@ -429,6 +429,10 @@ fn invalid_year_month() {
     let bad_value = "-00202011Z[Europe/Berlin]";
     let err = IxdtfParser::from_str(bad_value).parse_year_month();
     assert_eq!(err, Err(ParseError::InvalidEnd));
+
+    let bad_value = "2020-11[u-ca=iso8601]junk";
+    let err = IxdtfParser::from_str(bad_value).parse_year_month();
+    assert_eq!(err, Err(ParseError::InvalidEnd));
 }
 
 #[test]
@@ -449,7 +453,11 @@ fn temporal_month_day() {
 fn invalid_month_day() {
     let bad_value = "-11-07";
     let err = IxdtfParser::from_str(bad_value).parse_month_day();
-    assert_eq!(err, Err(ParseError::MonthDayHyphen))
+    assert_eq!(err, Err(ParseError::MonthDayHyphen));
+
+    let bad_value = "11-07[+04:00]junk";
+    let err = IxdtfParser::from_str(bad_value).parse_month_day();
+    assert_eq!(err, Err(ParseError::InvalidEnd));
 }
 
 #[test]


### PR DESCRIPTION
Annotated `YearMonth` and `MonthDay` parsers checked for trailing input when no annotations were present, but returned without closing the cursor after parsing an annotation set. This allowed inputs such as `2020-11[u-ca=iso8601]junk` to be accepted.

Close the cursor after annotated parses and add regressions covering calendar and time-zone annotations.

## Validation

- `cargo test --all-features` (44 unit tests and 23 doctests)
- `cargo clippy --all-targets --all-features`
- `rustfmt --check` on the changed Rust files

## Changelog

ixdtf:
 - Reject trailing input after annotations in `YearMonth` and `MonthDay` parsing
