### PR TITLE
refactor(provider_source/currency): Deduplicate currency pattern datagen helpers

### DIFF
--- a/provider/source/src/currency/essentials.rs
+++ b/provider/source/src/currency/essentials.rs
@@ -10,7 +10,6 @@ use crate::cldr_serde::numbers::NumberPatternItem;
 
 use std::borrow::Cow;
 use std::collections::HashSet;
-use zerovec::VarZeroVec;
 
 use icu_pattern::DoublePlaceholderKey;
 use icu_pattern::DoublePlaceholderPattern;
@@ -47,34 +46,7 @@ impl DataProvider<CurrencyEssentialsV1> for SourceDataProvider {
 
 impl IterableDataProviderCached<CurrencyEssentialsV1> for SourceDataProvider {
     fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
-        let mut ids = HashSet::new();
-        for locale in self.cldr()?.numbers().list_locales()? {
-            let numbers_resource: &cldr_serde::numbers::Resource = self
-                .cldr()?
-                .numbers()
-                .read_and_parse(&locale, "numbers.json")?;
-            let numbers = &numbers_resource.main.value.numbers;
-            let default_numsys = &numbers.default_numbering_system;
-
-            for (nsname, patterns) in &numbers.numsys_data.currency_patterns {
-                if patterns.standard.positive.is_empty() {
-                    continue;
-                }
-                if nsname == default_numsys {
-                    ids.insert(DataIdentifierCow::from_locale(locale));
-                } else {
-                    let attr = DataMarkerAttributes::try_from_str(nsname).map_err(|_| {
-                        DataError::custom("Invalid numbering system name")
-                            .with_display_context(nsname)
-                    })?;
-                    ids.insert(
-                        DataIdentifierBorrowed::for_marker_attributes_and_locale(attr, &locale)
-                            .into_owned(),
-                    );
-                }
-            }
-        }
-        Ok(ids)
+        super::iter_numsys_pattern_ids(self, |patterns| !patterns.standard.positive.is_empty())
     }
 }
 
@@ -144,47 +116,38 @@ fn extract_currency_essentials<'data>(
         }
     }
 
-    let mut unique_patterns = Vec::<Box<DoublePlaceholderPattern>>::new();
-
-    let mut add_pattern = |opt_cow: Option<Cow<'data, DoublePlaceholderPattern>>| -> Option<u8> {
-        opt_cow.map(|cow| {
-            let pat: Box<DoublePlaceholderPattern> = cow.into_owned();
-            if let Some(idx) = unique_patterns.iter().position(|p| p == &pat) {
-                idx as u8
-            } else {
-                let idx = unique_patterns.len() as u8;
-                unique_patterns.push(pat);
-                idx
-            }
-        })
-    };
-
-    let standard_idx = add_pattern(Some(create_positive_pattern(standard)?)).unwrap();
-    let standard_neg_idx = add_pattern(create_negative_pattern(standard)?);
-    let standard_alpha_idx = add_pattern(
-        standard_alpha_next_to_number
-            .map(create_positive_pattern)
-            .transpose()?,
-    )
-    .unwrap_or(standard_idx);
+    let mut tracker = super::UniquePatternsTracker::new();
+    let standard_idx = tracker
+        .add(Some(create_positive_pattern(standard)?))
+        .unwrap();
+    let standard_neg_idx = tracker.add(create_negative_pattern(standard)?);
+    let standard_alpha_idx = tracker
+        .add(
+            standard_alpha_next_to_number
+                .map(create_positive_pattern)
+                .transpose()?,
+        )
+        .unwrap_or(standard_idx);
     let standard_alpha_neg_idx = match standard_alpha_next_to_number {
-        Some(p) => add_pattern(create_negative_pattern(p)?),
+        Some(p) => tracker.add(create_negative_pattern(p)?),
         None => None,
     };
-    let accounting_pos_idx =
-        add_pattern(accounting.map(create_positive_pattern).transpose()?).unwrap_or(standard_idx);
+    let accounting_pos_idx = tracker
+        .add(accounting.map(create_positive_pattern).transpose()?)
+        .unwrap_or(standard_idx);
     let accounting_neg_idx = match accounting {
-        Some(p) => add_pattern(create_negative_pattern(p)?),
+        Some(p) => tracker.add(create_negative_pattern(p)?),
         None => None,
     };
-    let accounting_alpha_pos_idx = add_pattern(
-        accounting_alpha_next_to_number
-            .map(create_positive_pattern)
-            .transpose()?,
-    )
-    .unwrap_or(accounting_pos_idx);
+    let accounting_alpha_pos_idx = tracker
+        .add(
+            accounting_alpha_next_to_number
+                .map(create_positive_pattern)
+                .transpose()?,
+        )
+        .unwrap_or(accounting_pos_idx);
     let accounting_alpha_neg_idx = match accounting_alpha_next_to_number {
-        Some(p) => add_pattern(create_negative_pattern(p)?),
+        Some(p) => tracker.add(create_negative_pattern(p)?),
         None => None,
     };
 
@@ -200,7 +163,7 @@ fn extract_currency_essentials<'data>(
     };
 
     Ok(CurrencyEssentials {
-        patterns: VarZeroVec::from(&unique_patterns),
+        patterns: tracker.into_var_zero_vec(),
         indices,
     })
 }

--- a/provider/source/src/currency/mod.rs
+++ b/provider/source/src/currency/mod.rs
@@ -9,3 +9,79 @@ pub(crate) mod fractions;
 pub(crate) mod no_currency;
 pub(crate) mod patterns;
 pub(crate) mod symbols;
+
+use std::borrow::Cow;
+use std::collections::HashSet;
+
+use icu_pattern::DoublePlaceholderPattern;
+use icu_provider::prelude::*;
+use zerovec::VarZeroVec;
+
+use crate::SourceDataProvider;
+use crate::cldr_serde;
+
+/// Helper to collect and deduplicate `DoublePlaceholderPattern`s into a `VarZeroVec`.
+#[derive(Default)]
+pub(crate) struct UniquePatternsTracker {
+    patterns: Vec<Box<DoublePlaceholderPattern>>,
+}
+
+impl UniquePatternsTracker {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn add(&mut self, opt_cow: Option<Cow<'_, DoublePlaceholderPattern>>) -> Option<u8> {
+        opt_cow.map(|cow| {
+            let pat: Box<DoublePlaceholderPattern> = cow.into_owned();
+            if let Some(idx) = self.patterns.iter().position(|p| p == &pat) {
+                idx as u8
+            } else {
+                let idx = self.patterns.len() as u8;
+                self.patterns.push(pat);
+                idx
+            }
+        })
+    }
+
+    pub fn into_var_zero_vec<'data>(self) -> VarZeroVec<'data, DoublePlaceholderPattern> {
+        VarZeroVec::from(&self.patterns)
+    }
+}
+
+/// Helper to iterate through locales and numbering system patterns in `numbers.json`.
+pub(crate) fn iter_numsys_pattern_ids<F>(
+    provider: &SourceDataProvider,
+    predicate: F,
+) -> Result<HashSet<DataIdentifierCow<'static>>, DataError>
+where
+    F: Fn(&cldr_serde::numbers::CurrencyFormattingPatterns) -> bool,
+{
+    let mut ids = HashSet::new();
+    for locale in provider.cldr()?.numbers().list_locales()? {
+        let numbers_resource: &cldr_serde::numbers::Resource = provider
+            .cldr()?
+            .numbers()
+            .read_and_parse(&locale, "numbers.json")?;
+        let numbers = &numbers_resource.main.value.numbers;
+        let default_numsys = &numbers.default_numbering_system;
+
+        for (nsname, patterns) in &numbers.numsys_data.currency_patterns {
+            if !predicate(patterns) {
+                continue;
+            }
+            if nsname == default_numsys {
+                ids.insert(DataIdentifierCow::from_locale(locale));
+            } else {
+                let attr = DataMarkerAttributes::try_from_str(nsname).map_err(|_| {
+                    DataError::custom("Invalid numbering system name").with_display_context(nsname)
+                })?;
+                ids.insert(
+                    DataIdentifierBorrowed::for_marker_attributes_and_locale(attr, &locale)
+                        .into_owned(),
+                );
+            }
+        }
+    }
+    Ok(ids)
+}

--- a/provider/source/src/currency/no_currency.rs
+++ b/provider/source/src/currency/no_currency.rs
@@ -14,7 +14,6 @@ use std::collections::HashSet;
 use icu_pattern::DoublePlaceholderKey;
 use icu_pattern::DoublePlaceholderPattern;
 use icu_pattern::PatternItemCow;
-use zerovec::VarZeroVec;
 
 use icu::experimental::dimension::provider::currency::no_currency::*;
 use icu_provider::prelude::*;
@@ -58,34 +57,7 @@ fn has_no_currency_pattern(patterns: &cldr_serde::numbers::CurrencyFormattingPat
 
 impl IterableDataProviderCached<CurrencyPatternsNoCurrencyV1> for SourceDataProvider {
     fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
-        let mut ids = HashSet::new();
-        for locale in self.cldr()?.numbers().list_locales()? {
-            let numbers_resource: &cldr_serde::numbers::Resource = self
-                .cldr()?
-                .numbers()
-                .read_and_parse(&locale, "numbers.json")?;
-            let numbers = &numbers_resource.main.value.numbers;
-            let default_numsys = &numbers.default_numbering_system;
-
-            for (nsname, patterns) in &numbers.numsys_data.currency_patterns {
-                if !has_no_currency_pattern(patterns) {
-                    continue;
-                }
-                if nsname == default_numsys {
-                    ids.insert(DataIdentifierCow::from_locale(locale));
-                } else {
-                    let attr = DataMarkerAttributes::try_from_str(nsname).map_err(|_| {
-                        DataError::custom("Invalid numbering system name")
-                            .with_display_context(nsname)
-                    })?;
-                    ids.insert(
-                        DataIdentifierBorrowed::for_marker_attributes_and_locale(attr, &locale)
-                            .into_owned(),
-                    );
-                }
-            }
-        }
-        Ok(ids)
+        super::iter_numsys_pattern_ids(self, has_no_currency_pattern)
     }
 }
 
@@ -192,25 +164,11 @@ fn extract_currency_no_currency<'data>(
             (None, None)
         };
 
-    let mut unique_patterns = Vec::<Box<DoublePlaceholderPattern>>::new();
-
-    let mut add_pattern = |opt_cow: Option<Cow<'data, DoublePlaceholderPattern>>| -> Option<u8> {
-        opt_cow.map(|cow| {
-            let pat: Box<DoublePlaceholderPattern> = cow.into_owned();
-            if let Some(idx) = unique_patterns.iter().position(|p| p == &pat) {
-                idx as u8
-            } else {
-                let idx = unique_patterns.len() as u8;
-                unique_patterns.push(pat);
-                idx
-            }
-        })
-    };
-
-    let standard_idx = add_pattern(Some(standard_pos)).unwrap();
-    let standard_neg_idx = add_pattern(standard_neg);
-    let accounting_pos_idx = add_pattern(accounting_pos).unwrap_or(standard_idx);
-    let accounting_neg_idx = add_pattern(accounting_neg);
+    let mut tracker = super::UniquePatternsTracker::new();
+    let standard_idx = tracker.add(Some(standard_pos)).unwrap();
+    let standard_neg_idx = tracker.add(standard_neg);
+    let accounting_pos_idx = tracker.add(accounting_pos).unwrap_or(standard_idx);
+    let accounting_neg_idx = tracker.add(accounting_neg);
 
     let indices = NoCurrencyPatternIndices {
         standard: standard_idx,
@@ -220,7 +178,7 @@ fn extract_currency_no_currency<'data>(
     };
 
     Ok(CurrencyPatternsNoCurrency {
-        patterns: VarZeroVec::from(&unique_patterns),
+        patterns: tracker.into_var_zero_vec(),
         indices,
     })
 }


### PR DESCRIPTION
## Summary

Follow-up to #8275 addressing review feedback from @robertbastian to deduplicate currency pattern datagen extraction and locale/numsys iteration logic.

> **Note**: Stacked on top of #8275.

1. Added `UniquePatternsTracker` in `provider/source/src/currency/mod.rs` to deduplicate and collect `DoublePlaceholderPattern`s into `VarZeroVec`.
2. Added `iter_numsys_pattern_ids` helper in `provider/source/src/currency/mod.rs` to share the `numbers.json` locale and numbering system pattern iteration logic.
3. Simplified `CurrencyEssentialsV1` (`essentials.rs`) and `CurrencyPatternsNoCurrencyV1` (`no_currency.rs`) to use the shared helpers.

## Changelog

N/A (refactoring only)