### PR TITLE
refactor(currency): make PASS_THROUGH private on CurrencyPatternsNoCurrency

### DIFF
--- a/components/experimental/src/dimension/provider/currency/no_currency.rs
+++ b/components/experimental/src/dimension/provider/currency/no_currency.rs
@@ -64,7 +64,7 @@ impl<'a> CurrencyPatternsNoCurrency<'a> {
     ///
     /// This is used as a safe fallback if an index in [`NoCurrencyPatternIndices`] is out of bounds
     /// due to corrupt or malformed provider data.
-    pub const PASS_THROUGH: &'static DoublePlaceholderPattern =
+    const PASS_THROUGH: &'static DoublePlaceholderPattern =
         DoublePlaceholderPattern::from_ref_store_unchecked("\u{2}\u{1}");
 
     /// Gets the standard positive no-currency pattern.


### PR DESCRIPTION
## Overview

Addresses review comment [#8275 (discussion_r3690432204)](https://github.com/unicode-org/icu4x/pull/8275#discussion_r3690432204) by removing `pub` visibility from `CurrencyPatternsNoCurrency::PASS_THROUGH`.

- The `PASS_THROUGH` constant is an internal fallback pattern used when data indices are corrupt or out of bounds.
- It does not need to be exposed as part of the public API of `CurrencyPatternsNoCurrency`.

## Changes

- [components/experimental/src/dimension/provider/currency/no_currency.rs]: Changed `pub const PASS_THROUGH` to `const PASS_THROUGH`.

## Changelog

N/A (internal visibility refinement)