### PR TITLE
Make cargo check-all-features work for tests in icu_provider_source

### DIFF
--- a/provider/source/src/properties/bin_cp_set.rs
+++ b/provider/source/src/properties/bin_cp_set.rs
@@ -448,9 +448,9 @@ macro_rules! impl_posix_property {
                 ) -> Result<DataResponse<$marker>, DataError> {
                     self.check_req::<$marker>(req)?;
 
-                    #[cfg(not(feature = "unstable"))]
+                    #[cfg(not(any(test, feature = "unstable")))]
                     use icu::properties::unstable_unicodeset_parse::parse_unstable;
-                    #[cfg(feature = "unstable")]
+                    #[cfg(any(test, feature = "unstable"))]
                     use icu::properties::unicodeset_parse::parse_unstable;
 
                     let set = parse_unstable($set_string, self)

--- a/provider/source/src/segmenter/mod.rs
+++ b/provider/source/src/segmenter/mod.rs
@@ -9,8 +9,6 @@ use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use crate::cldr_cache::CldrCache;
 #[cfg(feature = "unstable")]
-use crate::source::AbstractFs;
-#[cfg(feature = "unstable")]
 use crate::source::Cache;
 use crate::source::{RscdCache, include_files};
 #[cfg(feature = "unstable")]
@@ -867,7 +865,7 @@ implement_override!(SegmenterBreakSentenceOverrideV1, "sentence.toml", ["el"]);
 
 #[cfg(feature = "unstable")]
 #[cfg(any(feature = "use_wasm", feature = "use_icu4c"))]
-fn neo_sources() -> AbstractFs {
+fn neo_sources() -> crate::source::AbstractFs {
     include_files!(
         "../../data/segmenter/neo/";
         "GraphemeClusterBreakStates.txt",
@@ -903,7 +901,8 @@ fn neo_cldr_json() -> &'static CldrCache {
 
 #[test]
 #[ignore]
-#[cfg(feature = "networking")]
+#[cfg(all(feature = "unstable", feature = "networking"))]
+#[cfg(any(feature = "use_wasm", feature = "use_icu4c"))]
 fn download() {
     use std::fs::File;
     use std::io::Write;
@@ -915,7 +914,7 @@ fn download() {
         std::fs::create_dir_all(target.parent().unwrap()).unwrap();
         crlify::BufWriterWithLineEndingFix::new(File::create(&target).unwrap())
             .write_all(
-                &AbstractFs::new_from_url(format!(
+                &crate::source::AbstractFs::new_from_url(format!(
                     "https://unicode.org/review/pri555/{}",
                     SourceDataProvider::TESTED_UNICODE_TAG
                 ))
@@ -1002,7 +1001,7 @@ impl SourceDataProvider {
 
     fn build_segmenter(
         &self,
-        sources: &AbstractFs,
+        sources: &crate::source::AbstractFs,
         prefix: &str,
         status_lookup: fn(&str) -> u8,
     ) -> Result<TailoredSegmenter, DataError> {


### PR DESCRIPTION
I was wanting to debug issues involving tests with different feature combinations but they weren't building in icu_provider_source. This PR fixes it.

Split from #8233

## Changelog

N/A