### PR TITLE
feat: add SLSA build provenance and SBOM attestations for FFI release binaries

### DIFF
--- a/.github/workflows/artifacts-build.yml
+++ b/.github/workflows/artifacts-build.yml
@@ -32,6 +32,7 @@ permissions:
   contents: write
   pages: write
   id-token: write
+  attestations: write
 
 env:
   GCP_PROJECT_ID: "dev-infra-273822"
@@ -768,6 +769,15 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref_type == 'tag' && github.repository == 'unicode-org/icu4x'
     steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Generate SPDX SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          path: ./
+          format: spdx-json
+          output-file: icu4x-sbom.spdx.json
+
       - name: Download binaries
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
@@ -775,6 +785,17 @@ jobs:
 
       - name: Display structure of downloaded files
         run: ls -R
+
+      - name: Generate build provenance attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: 'ffi-*-libs/*'
+
+      - name: Generate SBOM attestation
+        uses: actions/attest@v4
+        with:
+          subject-path: 'ffi-*-libs/*'
+          sbom-path: icu4x-sbom.spdx.json
 
       - name: Release
         uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8

--- a/ffi/dart/hook/build.dart
+++ b/ffi/dart/hook/build.dart
@@ -151,6 +151,17 @@ final class FetchMode extends BuildMode {
       input.outputDirectory.resolve(input.config.filename('icu4x')),
     );
     await library.writeAsBytes(bytes);
+    if (input.userDefines['verifyAttestation'] == true) {
+      await runProcess('gh', [
+        'attestation',
+        'verify',
+        library.path,
+        '--owner',
+        'unicode-org',
+        '--repo',
+        'icu4x',
+      ]);
+    }
     return library.uri;
   }
 

--- a/ffi/dart/tool/regenerate_hashes.dart
+++ b/ffi/dart/tool/regenerate_hashes.dart
@@ -53,6 +53,31 @@ Future<void> main(List<String> args) async {
         continue;
       }
       final bytes = await response.fold<List<int>>([], (a, b) => a..addAll(b));
+
+      final tempFile = File(
+        '${Directory.systemTemp.path}/icu4x_verify_$rustTarget-$libraryType',
+      );
+      await tempFile.writeAsBytes(bytes);
+
+      print(
+        'Verifying GitHub artifact attestation for $rustTarget-$libraryType...',
+      );
+      final verifyResult = await Process.run('gh', [
+        'attestation',
+        'verify',
+        tempFile.path,
+        '--owner',
+        'unicode-org',
+        '--repo',
+        'icu4x',
+      ]);
+      if (verifyResult.exitCode != 0) {
+        throw Exception(
+          'SECURITY ERROR: Artifact attestation verification failed for '
+          '$rustTarget-$libraryType at $uri:\n${verifyResult.stderr}',
+        );
+      }
+
       final fileHash = sha256.convert(bytes).toString();
       fileHashes[(rustTarget, libraryType)] = fileHash;
       print('Hash is $fileHash');


### PR DESCRIPTION
### Summary
- Configures `attestations: write` permissions in `.github/workflows/artifacts-build.yml`.
- Generates SPDX SBOM from `Cargo.lock` using `anchore/sbom-action@v0` in the `release-ffi-libs` release job.
- Generates SLSA v1.0 build provenance (`actions/attest-build-provenance@v2`) and SBOM attestations (`actions/attest@v4`) for all released FFI binaries (`ffi-*-libs/*`).
- Updates `ffi/dart/tool/regenerate_hashes.dart` to verify GitHub artifact attestations before recording SHA-256 hashes in `hashes.dart`.
- Adds optional runtime artifact attestation verification in `FetchMode` (`ffi/dart/hook/build.dart`) when `verifyAttestation: true` is configured in user defines.

## Changelog

N/A