### PR TITLE
fix(data): Use icu_locale_fallback in baked CurrencyPatternsNoCurrencyV1

### DIFF
--- a/provider/data/experimental/data/currency_patterns_no_currency_v1.rs.data
+++ b/provider/data/experimental/data/currency_patterns_no_currency_v1.rs.data
@@ -35,7 +35,7 @@ macro_rules! __impl_currency_patterns_no_currency_v1 {
                 let payload = if let Some(payload) = icu_provider::baked::DataStore::get(&Self::DATA_CURRENCY_PATTERNS_NO_CURRENCY_V1, req.id, req.metadata.attributes_prefix_match) {
                     payload
                 } else {
-                    const FALLBACKER: icu::locale::fallback::LocaleFallbackerWithConfig<'static> = icu::locale::fallback::LocaleFallbacker::new().for_config(<icu::experimental::dimension::provider::currency::no_currency::CurrencyPatternsNoCurrencyV1 as icu_provider::DataMarker>::INFO.fallback_config);
+                    const FALLBACKER: icu_locale_fallback::LocaleFallbackerWithConfig<'static> = icu_locale_fallback::LocaleFallbacker::new().for_config(<icu::experimental::dimension::provider::currency::no_currency::CurrencyPatternsNoCurrencyV1 as icu_provider::DataMarker>::INFO.fallback_config);
                     let mut fallback_iterator = FALLBACKER.fallback_for(req.id.locale.clone());
                     loop {
                         if let Some(payload) = icu_provider::baked::DataStore::get(&Self::DATA_CURRENCY_PATTERNS_NO_CURRENCY_V1, icu_provider::DataIdentifierBorrowed::for_marker_attributes_and_locale(req.id.marker_attributes, fallback_iterator.get()), req.metadata.attributes_prefix_match) {


### PR DESCRIPTION
## Overview

Following the split of `icu_locale_fallback` out of `icu_locale` in #8245 (#3931), `CurrencyPatternsNoCurrencyV1` in `provider/data/experimental` still referenced `icu::locale::fallback::LocaleFallbackerWithConfig`, breaking compilation of `icu_experimental` and the CI semver check.

This PR updates the macro to use `icu_locale_fallback::LocaleFallbackerWithConfig`.

## Changelog
* [icu_experimental_data] Use `icu_locale_fallback` in baked `CurrencyPatternsNoCurrencyV1`.