### PR TITLE
Rename single display name types to follow new convention

### DIFF
--- a/components/experimental/src/displaynames/mod.rs
+++ b/components/experimental/src/displaynames/mod.rs
@@ -22,7 +22,7 @@
 //!
 //! ```
 //! use icu::experimental::displaynames::multi::RegionDisplayNames;
-//! use icu::experimental::displaynames::single::RegionDisplayNameOwned;
+//! use icu::experimental::displaynames::single::RegionDisplayName;
 //! use icu::experimental::displaynames::DisplayNamesOptions;
 //! use icu::locale::{locale, subtags::region};
 //! use writeable::assert_writeable_eq;
@@ -35,8 +35,8 @@
 //! assert_writeable_eq!(multi.of(region!("GB")).unwrap(), "United Kingdom");
 //!
 //! // Single: Load only the region(s) we need.
-//! let us = RegionDisplayNameOwned::try_new_light(locale, region!("US")).unwrap();
-//! let gb = RegionDisplayNameOwned::try_new_light(locale, region!("GB")).unwrap();
+//! let us = RegionDisplayName::try_new_light(locale, region!("US")).unwrap();
+//! let gb = RegionDisplayName::try_new_light(locale, region!("GB")).unwrap();
 //! assert_writeable_eq!(us, "United States");
 //! assert_writeable_eq!(gb, "United Kingdom");
 //! ```

--- a/components/experimental/src/displaynames/single/README.md
+++ b/components/experimental/src/displaynames/single/README.md
@@ -17,55 +17,55 @@ classDiagram
         +write_to(&self, sink)
     }
 
-    class LanguageIdentifierDisplayNameOwned~M~ {
+    class LanguageIdentifierDisplayName~M~ {
         -lid: LanguageIdentifier
-        -options: LanguageIdentifierDisplayNameOptions
+        -options: LanguageIdentifierDisplayNameBorrowedOptions
         +try_new_light(prefs, options, lid) Self  // Medium
         +try_new_short_light(prefs, options, lid) Self
         +try_new_long_light(prefs, options, lid) Self
         +try_new_menu_light(prefs, options, lid) Self // Only for M = Menu
-        +as_borrowed(&self) LanguageIdentifierDisplayName
+        +as_borrowed(&self) LanguageIdentifierDisplayNameBorrowed
     }
-    class LanguageIdentifierDisplayName {
+    class LanguageIdentifierDisplayNameBorrowed {
         +write_to(&self, sink)
     }
-    LanguageIdentifierDisplayNameOwned ..> LanguageIdentifierDisplayName : borrows to
-    LanguageIdentifierDisplayName ..|> Writeable : implements
+    LanguageIdentifierDisplayName ..> LanguageIdentifierDisplayNameBorrowed : borrows to
+    LanguageIdentifierDisplayNameBorrowed ..|> Writeable : implements
 
-    class RegionDisplayNameOwned {
-        -payload: DataPayload~ErasedDisplayNameMarker~
-        +try_new_light(prefs, subtag) Self // Medium
-        +try_new_short_light(prefs, subtag) Self
-        +as_borrowed(&self) RegionDisplayName
-    }
     class RegionDisplayName {
-        +write_to(&self, sink)
-    }
-    RegionDisplayNameOwned ..> RegionDisplayName : borrows to
-    RegionDisplayName ..|> Writeable : implements
-
-    class ScriptDisplayNameOwned {
         -payload: DataPayload~ErasedDisplayNameMarker~
         +try_new_light(prefs, subtag) Self // Medium
         +try_new_short_light(prefs, subtag) Self
-        +as_borrowed(&self) ScriptDisplayName
+        +as_borrowed(&self) RegionDisplayNameBorrowed
     }
-    class ScriptDisplayName {
+    class RegionDisplayNameBorrowed {
         +write_to(&self, sink)
     }
-    ScriptDisplayNameOwned ..> ScriptDisplayName : borrows to
-    ScriptDisplayName ..|> Writeable : implements
+    RegionDisplayName ..> RegionDisplayNameBorrowed : borrows to
+    RegionDisplayNameBorrowed ..|> Writeable : implements
 
-    class VariantDisplayNameOwned {
+    class ScriptDisplayName {
+        -payload: DataPayload~ErasedDisplayNameMarker~
+        +try_new_light(prefs, subtag) Self // Medium
+        +try_new_short_light(prefs, subtag) Self
+        +as_borrowed(&self) ScriptDisplayNameBorrowed
+    }
+    class ScriptDisplayNameBorrowed {
+        +write_to(&self, sink)
+    }
+    ScriptDisplayName ..> ScriptDisplayNameBorrowed : borrows to
+    ScriptDisplayNameBorrowed ..|> Writeable : implements
+
+    class VariantDisplayName {
         -payload: DataPayload~ErasedDisplayNameMarker~
         +try_new_heavy(prefs, subtag) Self // Medium
-        +as_borrowed(&self) VariantDisplayName
+        +as_borrowed(&self) VariantDisplayNameBorrowed
     }
-    class VariantDisplayName {
+    class VariantDisplayNameBorrowed {
         +write_to(&self, sink)
     }
-    VariantDisplayNameOwned ..> VariantDisplayName : borrows to
-    VariantDisplayName ..|> Writeable : implements
+    VariantDisplayName ..> VariantDisplayNameBorrowed : borrows to
+    VariantDisplayNameBorrowed ..|> Writeable : implements
 ```
 
 ## Formatters & Constructors
@@ -84,29 +84,29 @@ To reflect this, each formatter provides explicit constructors for each supporte
 ### Value-Passing
 All owned constructors take their target subtag or `LanguageIdentifier` **by value** because the owned struct needs to store the identifier for fallback purposes, and copying/moving these identifiers is highly efficient in ICU4X (using `TinyStr` under the hood).
 
-*   **`LanguageIdentifierDisplayName` / `LanguageIdentifierDisplayNameOwned<M>`**: Formats a full `LanguageIdentifier` (language, script, region, and variants) into a localized string. It is generic over the display model (Standard/Dialect vs. Menu).
-    *   `LanguageIdentifierDisplayNameOwned::try_new_light(prefs, options, lid)`: Constructor for **Medium** width (Standard/Dialect).
-    *   `LanguageIdentifierDisplayNameOwned::try_new_short_light(prefs, options, lid)`: Constructor for **Short** width (Standard/Dialect).
-    *   `LanguageIdentifierDisplayNameOwned::try_new_long_light(prefs, options, lid)`: Constructor for **Long** width (Standard/Dialect).
-    *   `LanguageIdentifierDisplayNameOwned::try_new_menu_light(prefs, options, lid)`: Constructor for **Menu** style (Medium width).
-*   **`RegionDisplayName` / `RegionDisplayNameOwned`**: Formats a single `Region` subtag (e.g., `US` -> "United States").
-    *   `RegionDisplayNameOwned::try_new_light(prefs, subtag)`: Constructor for **Medium** width.
-    *   `RegionDisplayNameOwned::try_new_short_light(prefs, subtag)`: Constructor for **Short** width.
-*   **`ScriptDisplayName` / `ScriptDisplayNameOwned`**: Formats a single `Script` subtag (e.g., `Latn` -> "Latin").
-    *   `ScriptDisplayNameOwned::try_new_light(prefs, subtag)`: Constructor for **Medium** width.
-    *   `ScriptDisplayNameOwned::try_new_short_light(prefs, subtag)`: Constructor for **Short** width.
-*   **`VariantDisplayName` / `VariantDisplayNameOwned`**: Formats a single `Variant` subtag (e.g., `valencia` -> "Valencian").
-    *   `VariantDisplayNameOwned::try_new_heavy(prefs, subtag)`: Constructor for **Medium** width.
+*   **`LanguageIdentifierDisplayNameBorrowed` / `LanguageIdentifierDisplayName<M>`**: Formats a full `LanguageIdentifier` (language, script, region, and variants) into a localized string. It is generic over the display model (Standard/Dialect vs. Menu).
+    *   `LanguageIdentifierDisplayName::try_new_light(prefs, options, lid)`: Constructor for **Medium** width (Standard/Dialect).
+    *   `LanguageIdentifierDisplayName::try_new_short_light(prefs, options, lid)`: Constructor for **Short** width (Standard/Dialect).
+    *   `LanguageIdentifierDisplayName::try_new_long_light(prefs, options, lid)`: Constructor for **Long** width (Standard/Dialect).
+    *   `LanguageIdentifierDisplayName::try_new_menu_light(prefs, options, lid)`: Constructor for **Menu** style (Medium width).
+*   **`RegionDisplayNameBorrowed` / `RegionDisplayName`**: Formats a single `Region` subtag (e.g., `US` -> "United States").
+    *   `RegionDisplayName::try_new_light(prefs, subtag)`: Constructor for **Medium** width.
+    *   `RegionDisplayName::try_new_short_light(prefs, subtag)`: Constructor for **Short** width.
+*   **`ScriptDisplayNameBorrowed` / `ScriptDisplayName`**: Formats a single `Script` subtag (e.g., `Latn` -> "Latin").
+    *   `ScriptDisplayName::try_new_light(prefs, subtag)`: Constructor for **Medium** width.
+    *   `ScriptDisplayName::try_new_short_light(prefs, subtag)`: Constructor for **Short** width.
+*   **`VariantDisplayNameBorrowed` / `VariantDisplayName`**: Formats a single `Variant` subtag (e.g., `valencia` -> "Valencian").
+    *   `VariantDisplayName::try_new_heavy(prefs, subtag)`: Constructor for **Medium** width.
 
 ---
 
 ## Fallback & `TryWriteable`
 
-The `LanguageIdentifierDisplayName` formatter supports BCP-47 subtag fallback when localized display names are missing from the data provider. It implements the fallback using `TryWriteable`.
+The `LanguageIdentifierDisplayNameBorrowed` formatter supports BCP-47 subtag fallback when localized display names are missing from the data provider. It implements the fallback using `TryWriteable`.
 
 ### Detecting Fallback with `TryWriteable`
 
-To allow applications to detect whether a fallback occurred (and which parts of the output are fallbacks), `LanguageIdentifierDisplayName` implements the **`TryWriteable`** trait.
+To allow applications to detect whether a fallback occurred (and which parts of the output are fallbacks), `LanguageIdentifierDisplayNameBorrowed` implements the **`TryWriteable`** trait.
 *   **Lossy Mode (Default)**: If you format the display name using the standard `Writeable` or `Display` trait, it runs in "lossy mode", automatically writing the fallback codes and discarding any errors.
 *   **Strict/Detection Mode**: You can borrow the formatter via `.as_borrowed()` and call `try_write_to` or `try_write_to_parts` to capture the `LanguageIdentifierNameFallbackError` if a fallback occurred. In `try_write_to_parts`, a `Part::ERROR` will annotate the fallback strings.
 
@@ -155,22 +155,22 @@ The `single` module adheres to general ICU4X design principles to support `no_st
 *   **Stack Optimization**: We leverage standard ICU4X patterns like `DataPayloadOr` to store optional payloads (e.g., optional script/region) without the stack size overhead of `Option<DataPayload>`.
 *   **Payload Erasing**: We use `ErasedMarker` to allow fields to hold different width variants of the payloads polymorphically at runtime, sharing the same underlying `VarZeroCow<'static, str>` data struct.
     *   *Type Alias*: `pub(crate) type ErasedDisplayNameMarker = icu_provider::marker::ErasedMarker<VarZeroCow<'static, str>>;`
-    *   *Benefit*: This allows the same owned struct (e.g., `LanguageIdentifierDisplayNameOwned`) to store data loaded from different width markers (Short, Medium, or Long) depending on which constructor was called, keeping the struct type width-agnostic.
+    *   *Benefit*: This allows the same owned struct (e.g., `LanguageIdentifierDisplayName`) to store data loaded from different width markers (Short, Medium, or Long) depending on which constructor was called, keeping the struct type width-agnostic.
 *   **Zero-Allocation Interpolation**: We use the `icu_pattern` crate to interpolate the base language and qualifiers (joined by `localeSeparator`) directly into the output sink.
 
 ### Generic Owned Type with Shared Borrowed Type
 
-To support both standard formatting and the specialized Menu style (which requires `LocaleNamesLanguageMenuMediumV1` wrapping `MenuNameParts` instead of `str`), we use a single generic owned type `LanguageIdentifierDisplayNameOwned<M>` that delegates its language payload type to a model trait, inspired by the `Model` generic in `TimeZoneInfo`.
+To support both standard formatting and the specialized Menu style (which requires `LocaleNamesLanguageMenuMediumV1` wrapping `MenuNameParts` instead of `str`), we use a single generic owned type `LanguageIdentifierDisplayName<M>` that delegates its language payload type to a model trait, inspired by the `Model` generic in `TimeZoneInfo`.
 
 #### 1. The Model Trait and Implementations
-We define a `LanguageIdentifierDisplayNameModel` trait with an associated type `LanguagePayload`. 
+We define a `LanguageIdentifierDisplayNameBorrowedModel` trait with an associated type `LanguagePayload`. 
 
 We implement this trait for two marker models:
 *   **`models::Standard`**: Used for Standard and Dialect display styles. The `LanguagePayload` is `DataPayloadOr<ErasedDisplayNameMarker, ()>`.
 *   **`models::Menu`**: Used for Menu display style. The `LanguagePayload` is `DataPayload<LocaleNamesLanguageMenuMediumV1>`.
 
 #### 2. The Generic Owned Struct
-`LanguageIdentifierDisplayNameOwned<M>` holds the `LanguageIdentifier`, `LanguageIdentifierDisplayNameOptions`, the generic `language_payload` (determined by `M`), optional `script_payload` and `region_payload` (both using `DataPayloadOr` with `ErasedDisplayNameMarker`), a vector of `variant_payloads` (using `ErasedDisplayNameMarker`), and the `pattern_payload` (using `LocaleNamesEssentialsV1`).
+`LanguageIdentifierDisplayName<M>` holds the `LanguageIdentifier`, `LanguageIdentifierDisplayNameBorrowedOptions`, the generic `language_payload` (determined by `M`), optional `script_payload` and `region_payload` (both using `DataPayloadOr` with `ErasedDisplayNameMarker`), a vector of `variant_payloads` (using `ErasedDisplayNameMarker`), and the `pattern_payload` (using `LocaleNamesEssentialsV1`).
 
 > [!NOTE]
 > **Allocation Papercut**: Storing `variant_payloads` in a `Vec` requires heap allocation, which prevents this struct from being strictly allocation-free in `no_std` environments without an allocator. 
@@ -178,7 +178,7 @@ We implement this trait for two marker models:
 > *Follow-up (TODO #7825)*: We should explore using a stack-allocated collection like `SmallVec` (e.g., `SmallVec<[DataPayload<ErasedDisplayNameMarker>; 1]>`) to eliminate heap allocation for the vast majority of locales that have zero or one variant.
 
 #### 3. The Shared Borrowed Struct
-Both models resolve their payload differences and borrow to a single, non-generic **`LanguageIdentifierDisplayName<'a>`** struct. 
+Both models resolve their payload differences and borrow to a single, non-generic **`LanguageIdentifierDisplayNameBorrowed<'a>`** struct. 
 
 This struct holds only cheap, borrowed references:
 *   `base_name`: The resolved base language name (or "core" part for menu style) as a `&'a str`.
@@ -193,7 +193,7 @@ The differences are resolved in the model-specific implementations of `as_borrow
 *   For the **`Menu`** model: `base_name` is resolved from `language_payload.get().core`, and `menu_extension` is `Some(language_payload.get().extension)`.
 
 #### 5. Zero-Allocation Formatting Pipeline
-In `Writeable::write_to` for `LanguageIdentifierDisplayName<'a>`, we treat `menu_extension` (if present), `script_name`, `region_name`, and the resolved variant names as qualifiers. A stack-allocated `QualifiersWriteable` helper joins them using `locale_separator` directly into the sink, and `icu_pattern::Pattern::interpolate` combines `base_name` and the qualifiers into `locale_pattern` directly into the output sink without any heap allocation.
+In `Writeable::write_to` for `LanguageIdentifierDisplayNameBorrowed<'a>`, we treat `menu_extension` (if present), `script_name`, `region_name`, and the resolved variant names as qualifiers. A stack-allocated `QualifiersWriteable` helper joins them using `locale_separator` directly into the sink, and `icu_pattern::Pattern::interpolate` combines `base_name` and the qualifiers into `locale_pattern` directly into the output sink without any heap allocation.
 
 ---
 
@@ -234,10 +234,10 @@ The following features defined in UTS #35 are currently not supported and are pl
 ## Open Questions
 
 1.  **Writeable on Owned Types**:
-    Owned types like `ScriptDisplayNameOwned`, `RegionDisplayNameOwned`, `VariantDisplayNameOwned`, and `LanguageIdentifierDisplayNameOwned` implement `Writeable` (by forwarding to their borrowed counterparts via `.as_borrowed()`).
+    Owned types like `ScriptDisplayName`, `RegionDisplayName`, `VariantDisplayName`, and `LanguageIdentifierDisplayName` implement `Writeable` (by forwarding to their borrowed counterparts via `.as_borrowed()`).
     *   *Resolution*: We decided to keep implementing `Writeable` directly on owned types for convenience, as there is no harm in having multiple `Writeable` implementations.
 2.  **Constructor Argument Order**:
-    In `LanguageIdentifierDisplayNameOwned::try_new_light(prefs, locale_id, options)`, we have placed `options` last.
+    In `LanguageIdentifierDisplayName::try_new_light(prefs, locale_id, options)`, we have placed `options` last.
     *   *Resolution*: This aligns with the standard ICU4X API style, as `options` behaves like a trailing optional bag.
 3.  **Dialect Names Data Marker**:
     Should dialect names (currently loaded using the same `LocaleNamesLanguageMediumV1` marker but with language+script+region attributes) be moved to a separate data marker to avoid overloading the language name marker and to allow applications to opt-out of dialect data to save binary size?

--- a/components/experimental/src/displaynames/single/language.rs
+++ b/components/experimental/src/displaynames/single/language.rs
@@ -13,7 +13,7 @@ use crate::displaynames::provider::{
     LocaleNamesVariantMediumHeavyV1, MenuNamePartsULE,
 };
 use crate::displaynames::single::{
-    RegionDisplayNameOwned, ScriptDisplayNameOwned, VariantDisplayNameOwned, load_one,
+    RegionDisplayName, ScriptDisplayName, VariantDisplayName, load_one,
 };
 use crate::displaynames::{DisplayNamesPreferences, LanguageIdentifierDisplayNameOptions};
 use crate::size_test_macro::size_test;
@@ -49,7 +49,7 @@ type MenuNamePartsMarker = ErasedMarker<VarZeroCow<'static, MenuNamePartsULE>>;
 type StringMarker = ErasedMarker<VarZeroCow<'static, str>>;
 
 size_test!(
-    LanguageIdentifierDisplayNameOwned,
+    LanguageIdentifierDisplayName,
     language_identifier_display_name_owned_size,
     192
 );
@@ -120,14 +120,14 @@ macro_rules! table_row {
 ///
 /// ```
 /// use icu::experimental::displaynames::{
-///     DisplayNamesPreferences, LanguageIdentifierDisplayNameOptions, single::LanguageIdentifierDisplayNameOwned,
+///     DisplayNamesPreferences, LanguageIdentifierDisplayNameOptions, single::LanguageIdentifierDisplayName,
 /// };
 /// use icu::locale::{locale, langid};
 /// use writeable::assert_try_writeable_eq;
 ///
 /// let prefs = DisplayNamesPreferences::from(locale!("en"));
 /// let options = LanguageIdentifierDisplayNameOptions::default();
-/// let display_name = LanguageIdentifierDisplayNameOwned::try_new_light(
+/// let display_name = LanguageIdentifierDisplayName::try_new_light(
 ///     prefs,
 ///     langid!("fr-CA"),
 ///     options,
@@ -142,7 +142,7 @@ macro_rules! table_row {
 /// ```
 /// use icu::experimental::displaynames::{
 ///     DisplayNamesPreferences, LanguageIdentifierDisplayNameOptions,
-///     single::LanguageIdentifierDisplayNameOwned, single::LanguageIdentifierNameFallbackError,
+///     single::LanguageIdentifierDisplayName, single::LanguageIdentifierNameFallbackError,
 /// };
 /// use icu::locale::{locale, langid};
 /// use writeable::{Part, TryWriteable, assert_try_writeable_parts_eq};
@@ -153,7 +153,7 @@ macro_rules! table_row {
 /// // "it-Qabc-150" has known language "it" ("Italian") and known region "150" ("Europe"),
 /// // but unknown script "Qabc".
 /// let lang_id = langid!("it-Qabc-150");
-/// let display_name = LanguageIdentifierDisplayNameOwned::try_new_light(
+/// let display_name = LanguageIdentifierDisplayName::try_new_light(
 ///     prefs,
 ///     lang_id,
 ///     options,
@@ -176,7 +176,7 @@ macro_rules! table_row {
 /// ```
 #[doc = language_identifier_display_name_owned_size!()]
 #[derive(Debug)]
-pub struct LanguageIdentifierDisplayNameOwned {
+pub struct LanguageIdentifierDisplayName {
     /// Either the language display name or the subtag as fallback
     language_payload: DataPayloadOr<ErasedMarker<MenuNamePartsOrString<'static>>, Language>,
     /// All other fields (shared between Standard and Menu)
@@ -304,7 +304,7 @@ macro_rules! try_load_dialect_name {
     }};
 }
 
-impl LanguageIdentifierDisplayNameOwned {
+impl LanguageIdentifierDisplayName {
     icu_provider::gen_buffer_data_constructors!(
         (prefs: DisplayNamesPreferences, subject: LanguageIdentifier, options: LanguageIdentifierDisplayNameOptions) -> result: Result<Self, DataError>,
         /// Loads the language display name for a given language identifier and locale using compiled data.
@@ -386,13 +386,13 @@ impl LanguageIdentifierDisplayNameOwned {
         /// # Examples
         ///
         /// ```
-        /// use icu::experimental::displaynames::single::LanguageIdentifierDisplayNameOwned;
+        /// use icu::experimental::displaynames::single::LanguageIdentifierDisplayName;
         /// use icu::experimental::displaynames::single::LanguageIdentifierNameFallbackError;
         /// use icu::locale::{langid, locale};
         /// use writeable::assert_try_writeable_eq;
         ///
         /// // French contains its own translation in French...
-        /// let fr_fr = LanguageIdentifierDisplayNameOwned::try_new_tiny(
+        /// let fr_fr = LanguageIdentifierDisplayName::try_new_tiny(
         ///     locale!("fr").into(),
         ///     langid!("fr"),
         ///     Default::default()
@@ -404,7 +404,7 @@ impl LanguageIdentifierDisplayNameOwned {
         /// );
         ///
         /// // ...but not a translation for German.
-        /// let fr_de = LanguageIdentifierDisplayNameOwned::try_new_tiny(
+        /// let fr_de = LanguageIdentifierDisplayName::try_new_tiny(
         ///     locale!("fr").into(),
         ///     langid!("de"),
         ///     Default::default()
@@ -484,7 +484,7 @@ impl LanguageIdentifierDisplayNameOwned {
         ///
         /// ```
         /// use icu::experimental::displaynames::{
-        ///     DisplayNamesPreferences, LanguageIdentifierDisplayNameOptions, single::LanguageIdentifierDisplayNameOwned,
+        ///     DisplayNamesPreferences, LanguageIdentifierDisplayNameOptions, single::LanguageIdentifierDisplayName,
         /// };
         /// use icu::locale::{locale, langid};
         /// use writeable::assert_try_writeable_eq;
@@ -493,7 +493,7 @@ impl LanguageIdentifierDisplayNameOwned {
         /// let options = LanguageIdentifierDisplayNameOptions::default();
         ///
         /// // Default (Medium) length format:
-        /// let display_name_medium = LanguageIdentifierDisplayNameOwned::try_new_light(
+        /// let display_name_medium = LanguageIdentifierDisplayName::try_new_light(
         ///     prefs,
         ///     langid!("en-US"),
         ///     options,
@@ -506,7 +506,7 @@ impl LanguageIdentifierDisplayNameOwned {
         /// );
         ///
         /// // Short length format uses shorter subtag/qualifier names when available:
-        /// let display_name_short = LanguageIdentifierDisplayNameOwned::try_new_short_light(
+        /// let display_name_short = LanguageIdentifierDisplayName::try_new_short_light(
         ///     prefs,
         ///     langid!("en-US"),
         ///     options,
@@ -608,7 +608,7 @@ impl LanguageIdentifierDisplayNameOwned {
         ///
         /// ```
         /// use icu::experimental::displaynames::{
-        ///     DisplayNamesPreferences, LanguageIdentifierDisplayNameOptions, single::LanguageIdentifierDisplayNameOwned,
+        ///     DisplayNamesPreferences, LanguageIdentifierDisplayNameOptions, single::LanguageIdentifierDisplayName,
         /// };
         /// use icu::locale::{locale, langid};
         /// use writeable::assert_try_writeable_eq;
@@ -617,7 +617,7 @@ impl LanguageIdentifierDisplayNameOwned {
         /// let options = LanguageIdentifierDisplayNameOptions::default();
         ///
         /// // Default (Medium) length format:
-        /// let display_name_medium = LanguageIdentifierDisplayNameOwned::try_new_light(
+        /// let display_name_medium = LanguageIdentifierDisplayName::try_new_light(
         ///     prefs,
         ///     langid!("zh"),
         ///     options,
@@ -630,7 +630,7 @@ impl LanguageIdentifierDisplayNameOwned {
         /// );
         ///
         /// // Long length format uses longer subtag names when available:
-        /// let display_name_long = LanguageIdentifierDisplayNameOwned::try_new_long_heavy(
+        /// let display_name_long = LanguageIdentifierDisplayName::try_new_long_heavy(
         ///     prefs,
         ///     langid!("zh"),
         ///     options,
@@ -728,14 +728,14 @@ impl LanguageIdentifierDisplayNameOwned {
         ///
         /// ```
         /// use icu::experimental::displaynames::{
-        ///     DisplayNamesPreferences, LanguageIdentifierDisplayNameOptions, single::LanguageIdentifierDisplayNameOwned,
+        ///     DisplayNamesPreferences, LanguageIdentifierDisplayNameOptions, single::LanguageIdentifierDisplayName,
         /// };
         /// use icu::locale::{locale, langid};
         /// use writeable::assert_try_writeable_eq;
         ///
         /// let prefs = DisplayNamesPreferences::from(locale!("en"));
         /// let options = LanguageIdentifierDisplayNameOptions::default();
-        /// let display_name = LanguageIdentifierDisplayNameOwned::try_new_menu_light(
+        /// let display_name = LanguageIdentifierDisplayName::try_new_menu_light(
         ///     prefs,
         ///     langid!("fr-CA"),
         ///     options,
@@ -817,14 +817,14 @@ impl LanguageIdentifierDisplayNameOwned {
         ///
         /// ```
         /// use icu::experimental::displaynames::{
-        ///     DisplayNamesPreferences, LanguageIdentifierDisplayNameOptions, single::LanguageIdentifierDisplayNameOwned,
+        ///     DisplayNamesPreferences, LanguageIdentifierDisplayNameOptions, single::LanguageIdentifierDisplayName,
         /// };
         /// use icu::locale::{locale, langid};
         /// use writeable::assert_try_writeable_eq;
         ///
         /// let prefs = DisplayNamesPreferences::from(locale!("en"));
         /// let options = LanguageIdentifierDisplayNameOptions::default();
-        /// let display_name = LanguageIdentifierDisplayNameOwned::try_new_short_menu_light(
+        /// let display_name = LanguageIdentifierDisplayName::try_new_short_menu_light(
         ///     prefs,
         ///     langid!("en-US"),
         ///     options,
@@ -1222,14 +1222,14 @@ impl LanguageIdentifierDisplayNameOwned {
         ///
         /// ```
         /// use icu::experimental::displaynames::{
-        ///     DisplayNamesPreferences, LanguageIdentifierDisplayNameOptions, single::LanguageIdentifierDisplayNameOwned,
+        ///     DisplayNamesPreferences, LanguageIdentifierDisplayNameOptions, single::LanguageIdentifierDisplayName,
         /// };
         /// use icu::locale::{locale, langid};
         /// use writeable::assert_try_writeable_eq;
         ///
         /// let prefs = DisplayNamesPreferences::from(locale!("en"));
         /// let options = LanguageIdentifierDisplayNameOptions::default();
-        /// let display_name = LanguageIdentifierDisplayNameOwned::try_new_menu_heavy(
+        /// let display_name = LanguageIdentifierDisplayName::try_new_menu_heavy(
         ///     prefs,
         ///     langid!("en-US"),
         ///     options,
@@ -1331,14 +1331,14 @@ impl LanguageIdentifierDisplayNameOwned {
         ///
         /// ```
         /// use icu::experimental::displaynames::{
-        ///     DisplayNamesPreferences, LanguageIdentifierDisplayNameOptions, single::LanguageIdentifierDisplayNameOwned,
+        ///     DisplayNamesPreferences, LanguageIdentifierDisplayNameOptions, single::LanguageIdentifierDisplayName,
         /// };
         /// use icu::locale::{locale, langid};
         /// use writeable::assert_try_writeable_eq;
         ///
         /// let prefs = DisplayNamesPreferences::from(locale!("en"));
         /// let options = LanguageIdentifierDisplayNameOptions::default();
-        /// let display_name = LanguageIdentifierDisplayNameOwned::try_new_short_menu_heavy(
+        /// let display_name = LanguageIdentifierDisplayName::try_new_short_menu_heavy(
         ///     prefs,
         ///     langid!("en-US"),
         ///     options,
@@ -1461,9 +1461,9 @@ impl QualifiersOwned {
     ) -> Result<Self, DataError>
     where
         D: ?Sized + DataProvider<LocaleNamesEssentialsV1>,
-        FS: Fn(&D, DisplayNamesPreferences, Script) -> Result<ScriptDisplayNameOwned, DataError>,
-        FR: Fn(&D, DisplayNamesPreferences, Region) -> Result<RegionDisplayNameOwned, DataError>,
-        FV: Fn(&D, DisplayNamesPreferences, Variant) -> Result<VariantDisplayNameOwned, DataError>,
+        FS: Fn(&D, DisplayNamesPreferences, Script) -> Result<ScriptDisplayName, DataError>,
+        FR: Fn(&D, DisplayNamesPreferences, Region) -> Result<RegionDisplayName, DataError>,
+        FV: Fn(&D, DisplayNamesPreferences, Variant) -> Result<VariantDisplayName, DataError>,
     {
         // Step 2: Load script name (if present in subject)
         let script_payload = if let Some(script) = subject.script {
@@ -1557,9 +1557,9 @@ impl QualifiersOwned {
             provider,
             prefs,
             subject,
-            ScriptDisplayNameOwned::try_new_light_unstable,
-            RegionDisplayNameOwned::try_new_light_unstable,
-            VariantDisplayNameOwned::try_new_heavy_unstable,
+            ScriptDisplayName::try_new_light_unstable,
+            RegionDisplayName::try_new_light_unstable,
+            VariantDisplayName::try_new_heavy_unstable,
         )
     }
 
@@ -1579,9 +1579,9 @@ impl QualifiersOwned {
             provider,
             prefs,
             subject,
-            ScriptDisplayNameOwned::try_new_tiny_unstable,
-            RegionDisplayNameOwned::try_new_tiny_unstable,
-            VariantDisplayNameOwned::try_new_heavy_unstable,
+            ScriptDisplayName::try_new_tiny_unstable,
+            RegionDisplayName::try_new_tiny_unstable,
+            VariantDisplayName::try_new_heavy_unstable,
         )
     }
 
@@ -1605,9 +1605,9 @@ impl QualifiersOwned {
             provider,
             prefs,
             subject,
-            ScriptDisplayNameOwned::try_new_light_unstable,
-            RegionDisplayNameOwned::try_new_short_light_unstable,
-            VariantDisplayNameOwned::try_new_heavy_unstable,
+            ScriptDisplayName::try_new_light_unstable,
+            RegionDisplayName::try_new_short_light_unstable,
+            VariantDisplayName::try_new_heavy_unstable,
         )
     }
 
@@ -1630,9 +1630,9 @@ impl QualifiersOwned {
             provider,
             prefs,
             subject,
-            ScriptDisplayNameOwned::try_new_heavy_unstable,
-            RegionDisplayNameOwned::try_new_light_unstable,
-            VariantDisplayNameOwned::try_new_heavy_unstable,
+            ScriptDisplayName::try_new_heavy_unstable,
+            RegionDisplayName::try_new_light_unstable,
+            VariantDisplayName::try_new_heavy_unstable,
         )
     }
 
@@ -1658,17 +1658,17 @@ impl QualifiersOwned {
             provider,
             prefs,
             subject,
-            ScriptDisplayNameOwned::try_new_short_heavy_unstable,
-            RegionDisplayNameOwned::try_new_short_light_unstable,
-            VariantDisplayNameOwned::try_new_heavy_unstable,
+            ScriptDisplayName::try_new_short_heavy_unstable,
+            RegionDisplayName::try_new_short_light_unstable,
+            VariantDisplayName::try_new_heavy_unstable,
         )
     }
 }
 
-impl LanguageIdentifierDisplayNameOwned {
+impl LanguageIdentifierDisplayName {
     /// Returns a borrowed version of this display name
     /// suitable for writing out to a string.
-    pub fn as_borrowed(&self) -> LanguageIdentifierDisplayName<'_> {
+    pub fn as_borrowed(&self) -> LanguageIdentifierDisplayNameBorrowed<'_> {
         let mut qualifiers = self.qualifiers.as_borrowed();
         let base_name = match self.language_payload.get() {
             Ok(MenuNamePartsOrString::String(string)) => NameOrFallback(Ok(string.as_ref())),
@@ -1681,7 +1681,7 @@ impl LanguageIdentifierDisplayNameOwned {
             Err(lang) => NameOrFallback(Err(lang.as_str())),
         };
 
-        LanguageIdentifierDisplayName(LossyWrap(LanguageIdentifierDisplayNameInner {
+        LanguageIdentifierDisplayNameBorrowed(LossyWrap(LanguageIdentifierDisplayNameInner {
             base_name,
             qualifiers,
         }))
@@ -1738,9 +1738,9 @@ impl BorrowedVariants<'_> {
 
 /// A localized display name for a language identifier.
 ///
-/// See [`LanguageIdentifierDisplayNameOwned`].
+/// See [`LanguageIdentifierDisplayName`].
 #[derive(Debug, Clone, Copy)]
-pub struct LanguageIdentifierDisplayName<'a>(
+pub struct LanguageIdentifierDisplayNameBorrowed<'a>(
     pub(crate) LossyWrap<LanguageIdentifierDisplayNameInner<'a>>,
 );
 
@@ -1763,14 +1763,14 @@ pub(crate) struct LanguageIdentifierDisplayNameInner<'a> {
 }
 
 writeable::impl_try_writeable_delegate!(
-    LanguageIdentifierDisplayName<'_>,
+    LanguageIdentifierDisplayNameBorrowed<'_>,
     |&self| &self.0.0,
     Error = LanguageIdentifierNameFallbackError
 );
 
-writeable::impl_writeable_delegate!(LanguageIdentifierDisplayName<'_>, |&self| &self.0);
+writeable::impl_writeable_delegate!(LanguageIdentifierDisplayNameBorrowed<'_>, |&self| &self.0);
 
-writeable::impl_display_with_writeable!(LanguageIdentifierDisplayName<'_>);
+writeable::impl_display_with_writeable!(LanguageIdentifierDisplayNameBorrowed<'_>);
 
 #[derive(Debug, Copy, Clone)]
 struct QualifiersBorrowed<'a> {
@@ -1950,14 +1950,15 @@ mod tests {
         macro_rules! check_row {
             ($constructor:ident) => {
                 let items = inputs.iter().map(|id| {
-                    LanguageIdentifierDisplayNameOwned::$constructor(prefs_en, id.clone(), options)
-                        .map(|display_name| {
+                    LanguageIdentifierDisplayName::$constructor(prefs_en, id.clone(), options).map(
+                        |display_name| {
                             display_name
                                 .as_borrowed()
                                 .try_write_to_string()
                                 .map(|s| s.into_owned())
                                 .map_err(|e| e.0)
-                        })
+                        },
+                    )
                 });
                 assert_eq!(
                     super::super::format_table_row(stringify!($constructor), items),

--- a/components/experimental/src/displaynames/single/mod.rs
+++ b/components/experimental/src/displaynames/single/mod.rs
@@ -25,12 +25,12 @@ mod variant;
 
 // Re-export from submodules
 pub use language::{
-    LanguageIdentifierDisplayName, LanguageIdentifierDisplayNameOwned,
+    LanguageIdentifierDisplayName, LanguageIdentifierDisplayNameBorrowed,
     LanguageIdentifierNameFallbackError,
 };
-pub use region::{RegionDisplayName, RegionDisplayNameOwned};
-pub use script::{ScriptDisplayName, ScriptDisplayNameOwned};
-pub use variant::{VariantDisplayName, VariantDisplayNameOwned};
+pub use region::{RegionDisplayName, RegionDisplayNameBorrowed};
+pub use script::{ScriptDisplayName, ScriptDisplayNameBorrowed};
+pub use variant::{VariantDisplayName, VariantDisplayNameBorrowed};
 
 use icu_provider::prelude::*;
 

--- a/components/experimental/src/displaynames/single/region.rs
+++ b/components/experimental/src/displaynames/single/region.rs
@@ -61,21 +61,21 @@ macro_rules! table_row {
 /// # Example
 ///
 /// ```
-/// use icu::experimental::displaynames::single::RegionDisplayNameOwned;
+/// use icu::experimental::displaynames::single::RegionDisplayName;
 /// use icu::locale::{locale, subtags::region};
 /// use writeable::assert_writeable_eq;
 ///
-/// let display_name = RegionDisplayNameOwned::try_new_light(locale!("en").into(), region!("US"))
+/// let display_name = RegionDisplayName::try_new_light(locale!("en").into(), region!("US"))
 ///     .expect("Data should load successfully");
 ///
 /// assert_writeable_eq!(display_name, "United States");
 /// ```
 #[derive(Debug)]
-pub struct RegionDisplayNameOwned {
+pub struct RegionDisplayName {
     pub(crate) payload: DataPayload<LocaleNamesRegionMediumLightV1>,
 }
 
-impl RegionDisplayNameOwned {
+impl RegionDisplayName {
     icu_provider::gen_buffer_data_constructors!(
         (prefs: DisplayNamesPreferences, region: Region) -> result: Result<Self, DataError>,
         /// Loads the region display name for a given region and locale using compiled data.
@@ -119,11 +119,11 @@ impl RegionDisplayNameOwned {
         /// # Examples
         ///
         /// ```
-        /// use icu::experimental::displaynames::single::RegionDisplayNameOwned;
+        /// use icu::experimental::displaynames::single::RegionDisplayName;
         /// use icu::locale::{locale, subtags::region};
         /// use writeable::assert_writeable_eq;
         ///
-        /// let display_name = RegionDisplayNameOwned::try_new_tiny(locale!("en").into(), region!("US"))
+        /// let display_name = RegionDisplayName::try_new_tiny(locale!("en").into(), region!("US"))
         ///     .expect("Data should load successfully");
         ///
         /// assert_writeable_eq!(display_name, "United States");
@@ -200,7 +200,7 @@ impl RegionDisplayNameOwned {
         ///
         /// ```
         /// use icu::experimental::displaynames::{
-        ///     DisplayNamesPreferences, single::RegionDisplayNameOwned,
+        ///     DisplayNamesPreferences, single::RegionDisplayName,
         /// };
         /// use icu::locale::{locale, subtags::region};
         /// use writeable::assert_writeable_eq;
@@ -208,12 +208,12 @@ impl RegionDisplayNameOwned {
         /// let prefs: DisplayNamesPreferences = locale!("en-US").into();
         ///
         /// // "US" has a short display name in en-US
-        /// let display_name_short = RegionDisplayNameOwned::try_new_short_light(prefs, region!("US"))
+        /// let display_name_short = RegionDisplayName::try_new_short_light(prefs, region!("US"))
         ///     .expect("Data should load successfully");
         /// assert_writeable_eq!(display_name_short, "US");
         ///
         /// // "AD" does not have a short display name, so it falls back to the long display name
-        /// let display_name_long = RegionDisplayNameOwned::try_new_short_light(prefs, region!("AD"))
+        /// let display_name_long = RegionDisplayName::try_new_short_light(prefs, region!("AD"))
         ///     .expect("Data should load successfully");
         /// assert_writeable_eq!(display_name_long, "Andorra");
         /// ```
@@ -258,22 +258,22 @@ impl RegionDisplayNameOwned {
     }
 
     /// Returns a borrowed version of this display name.
-    pub fn as_borrowed(&self) -> RegionDisplayName<'_> {
-        RegionDisplayName {
+    pub fn as_borrowed(&self) -> RegionDisplayNameBorrowed<'_> {
+        RegionDisplayNameBorrowed {
             value: self.payload.get(),
         }
     }
 }
 
-impl_writeable_for_single_display_name_owned!(RegionDisplayNameOwned);
+impl_writeable_for_single_display_name_owned!(RegionDisplayName);
 
 /// A localized display name for a single region.
 #[derive(Debug, Clone, Copy)]
-pub struct RegionDisplayName<'a> {
+pub struct RegionDisplayNameBorrowed<'a> {
     value: &'a str,
 }
 
-impl_writeable_for_single_display_name_borrowed!(RegionDisplayName);
+impl_writeable_for_single_display_name_borrowed!(RegionDisplayNameBorrowed);
 
 #[cfg(test)]
 mod tests {
@@ -288,7 +288,7 @@ mod tests {
         macro_rules! check_row {
             ($constructor:ident) => {
                 let items = inputs.iter().map(|id| {
-                    RegionDisplayNameOwned::$constructor(prefs_en, *id)
+                    RegionDisplayName::$constructor(prefs_en, *id)
                         .map(|name| Ok::<_, ()>(name.to_string()))
                 });
                 assert_eq!(

--- a/components/experimental/src/displaynames/single/script.rs
+++ b/components/experimental/src/displaynames/single/script.rs
@@ -61,21 +61,21 @@ macro_rules! table_row {
 /// # Example
 ///
 /// ```
-/// use icu::experimental::displaynames::single::ScriptDisplayNameOwned;
+/// use icu::experimental::displaynames::single::ScriptDisplayName;
 /// use icu::locale::{locale, subtags::script};
 /// use writeable::assert_writeable_eq;
 ///
-/// let display_name = ScriptDisplayNameOwned::try_new_light(locale!("en").into(), script!("Latn"))
+/// let display_name = ScriptDisplayName::try_new_light(locale!("en").into(), script!("Latn"))
 ///     .expect("Data should load successfully");
 ///
 /// assert_writeable_eq!(display_name, "Latin");
 /// ```
 #[derive(Debug)]
-pub struct ScriptDisplayNameOwned {
+pub struct ScriptDisplayName {
     pub(crate) payload: DataPayload<LocaleNamesScriptMediumLightV1>,
 }
 
-impl ScriptDisplayNameOwned {
+impl ScriptDisplayName {
     icu_provider::gen_buffer_data_constructors!(
         (prefs: DisplayNamesPreferences, script: Script) -> result: Result<Self, DataError>,
         /// Loads the script display name for a given script and locale using compiled data.
@@ -119,12 +119,12 @@ impl ScriptDisplayNameOwned {
         /// # Examples
         ///
         /// ```
-        /// use icu::experimental::displaynames::single::ScriptDisplayNameOwned;
+        /// use icu::experimental::displaynames::single::ScriptDisplayName;
         /// use icu::locale::{locale, subtags::script};
         /// use writeable::assert_writeable_eq;
         ///
         /// // Minimal script names contain Latn for en
-        /// let display_name = ScriptDisplayNameOwned::try_new_tiny(locale!("en").into(), script!("Latn")).unwrap();
+        /// let display_name = ScriptDisplayName::try_new_tiny(locale!("en").into(), script!("Latn")).unwrap();
         /// assert_writeable_eq!(display_name, "Latin");
         /// ```
         functions: [
@@ -160,11 +160,11 @@ impl ScriptDisplayNameOwned {
         /// # Examples
         ///
         /// ```
-        /// use icu::experimental::displaynames::single::ScriptDisplayNameOwned;
+        /// use icu::experimental::displaynames::single::ScriptDisplayName;
         /// use icu::locale::{locale, subtags::script};
         /// use writeable::assert_writeable_eq;
         ///
-        /// let display_name = ScriptDisplayNameOwned::try_new_heavy(locale!("en").into(), script!("Latn"))
+        /// let display_name = ScriptDisplayName::try_new_heavy(locale!("en").into(), script!("Latn"))
         ///     .expect("Data should load successfully");
         ///
         /// assert_writeable_eq!(display_name, "Latin");
@@ -215,11 +215,11 @@ impl ScriptDisplayNameOwned {
         /// # Examples
         ///
         /// ```
-        /// use icu::experimental::displaynames::single::ScriptDisplayNameOwned;
+        /// use icu::experimental::displaynames::single::ScriptDisplayName;
         /// use icu::locale::{locale, subtags::script};
         /// use writeable::assert_writeable_eq;
         ///
-        /// let display_name = ScriptDisplayNameOwned::try_new_short_heavy(locale!("en").into(), script!("Xsux"))
+        /// let display_name = ScriptDisplayName::try_new_short_heavy(locale!("en").into(), script!("Xsux"))
         ///     .expect("Data should load successfully");
         ///
         /// assert_writeable_eq!(display_name, "S-A Cuneiform");
@@ -265,22 +265,22 @@ impl ScriptDisplayNameOwned {
     }
 
     /// Returns a borrowed version of this display name.
-    pub fn as_borrowed(&self) -> ScriptDisplayName<'_> {
-        ScriptDisplayName {
+    pub fn as_borrowed(&self) -> ScriptDisplayNameBorrowed<'_> {
+        ScriptDisplayNameBorrowed {
             value: self.payload.get(),
         }
     }
 }
 
-impl_writeable_for_single_display_name_owned!(ScriptDisplayNameOwned);
+impl_writeable_for_single_display_name_owned!(ScriptDisplayName);
 
 /// A localized display name for a single script.
 #[derive(Debug, Clone, Copy)]
-pub struct ScriptDisplayName<'a> {
+pub struct ScriptDisplayNameBorrowed<'a> {
     value: &'a str,
 }
 
-impl_writeable_for_single_display_name_borrowed!(ScriptDisplayName);
+impl_writeable_for_single_display_name_borrowed!(ScriptDisplayNameBorrowed);
 
 #[cfg(test)]
 mod tests {
@@ -295,7 +295,7 @@ mod tests {
         macro_rules! check_row {
             ($constructor:ident) => {
                 let items = inputs.iter().map(|id| {
-                    ScriptDisplayNameOwned::$constructor(prefs_en, *id)
+                    ScriptDisplayName::$constructor(prefs_en, *id)
                         .map(|name| Ok::<_, ()>(name.to_string()))
                 });
                 assert_eq!(

--- a/components/experimental/src/displaynames/single/variant.rs
+++ b/components/experimental/src/displaynames/single/variant.rs
@@ -44,21 +44,21 @@ macro_rules! table_row {
 /// # Example
 ///
 /// ```
-/// use icu::experimental::displaynames::single::VariantDisplayNameOwned;
+/// use icu::experimental::displaynames::single::VariantDisplayName;
 /// use icu::locale::{locale, subtags::variant};
 /// use writeable::assert_writeable_eq;
 ///
-/// let display_name = VariantDisplayNameOwned::try_new_heavy(locale!("en").into(), variant!("fonipa"))
+/// let display_name = VariantDisplayName::try_new_heavy(locale!("en").into(), variant!("fonipa"))
 ///     .expect("Data should load successfully");
 ///
 /// assert_writeable_eq!(display_name, "IPA Phonetics");
 /// ```
 #[derive(Debug)]
-pub struct VariantDisplayNameOwned {
+pub struct VariantDisplayName {
     pub(crate) payload: DataPayload<LocaleNamesVariantMediumHeavyV1>,
 }
 
-impl VariantDisplayNameOwned {
+impl VariantDisplayName {
     icu_provider::gen_buffer_data_constructors!(
         (prefs: DisplayNamesPreferences, variant: Variant) -> result: Result<Self, DataError>,
         /// Loads the display name for a given variant in a given locale using compiled data.
@@ -66,11 +66,11 @@ impl VariantDisplayNameOwned {
         /// # Examples
         ///
         /// ```
-        /// use icu::experimental::displaynames::single::VariantDisplayNameOwned;
+        /// use icu::experimental::displaynames::single::VariantDisplayName;
         /// use icu::locale::{locale, subtags::variant};
         /// use writeable::assert_writeable_eq;
         ///
-        /// let display_name = VariantDisplayNameOwned::try_new_heavy(locale!("en").into(), variant!("fonipa"))
+        /// let display_name = VariantDisplayName::try_new_heavy(locale!("en").into(), variant!("fonipa"))
         ///     .expect("Data should load successfully");
         ///
         /// assert_writeable_eq!(display_name, "IPA Phonetics");
@@ -100,22 +100,22 @@ impl VariantDisplayNameOwned {
     }
 
     /// Returns a borrowed version of this display name.
-    pub fn as_borrowed(&self) -> VariantDisplayName<'_> {
-        VariantDisplayName {
+    pub fn as_borrowed(&self) -> VariantDisplayNameBorrowed<'_> {
+        VariantDisplayNameBorrowed {
             value: self.payload.get(),
         }
     }
 }
 
-impl_writeable_for_single_display_name_owned!(VariantDisplayNameOwned);
+impl_writeable_for_single_display_name_owned!(VariantDisplayName);
 
 /// A localized display name for a single variant.
 #[derive(Debug, Clone, Copy)]
-pub struct VariantDisplayName<'a> {
+pub struct VariantDisplayNameBorrowed<'a> {
     value: &'a str,
 }
 
-impl_writeable_for_single_display_name_borrowed!(VariantDisplayName);
+impl_writeable_for_single_display_name_borrowed!(VariantDisplayNameBorrowed);
 
 #[cfg(test)]
 mod tests {
@@ -130,7 +130,7 @@ mod tests {
         macro_rules! check_row {
             ($constructor:ident) => {
                 let items = inputs.iter().map(|id| {
-                    VariantDisplayNameOwned::$constructor(prefs_en, *id)
+                    VariantDisplayName::$constructor(prefs_en, *id)
                         .map(|name| Ok::<_, ()>(name.to_string()))
                 });
                 assert_eq!(

--- a/components/experimental/tests/displaynames/tests.rs
+++ b/components/experimental/tests/displaynames/tests.rs
@@ -4,8 +4,8 @@
 
 use icu_experimental::displaynames::DisplayNamesPreferences;
 use icu_experimental::displaynames::single::{
-    LanguageIdentifierDisplayName, LanguageIdentifierDisplayNameOwned,
-    LanguageIdentifierNameFallbackError, RegionDisplayNameOwned,
+    LanguageIdentifierDisplayName, LanguageIdentifierDisplayNameBorrowed,
+    LanguageIdentifierNameFallbackError, RegionDisplayName,
 };
 use icu_experimental::displaynames::{
     DisplayNamesOptions, LanguageIdentifierDisplayNameOptions, multi::LocaleDisplayNamesFormatter,
@@ -366,12 +366,12 @@ fn test_concatenate() {
             check_locale_name_formatter(&formatter, &cas);
         }
 
-        // Test the newer LanguageIdentifierDisplayName
+        // Test the newer LanguageIdentifierDisplayNameBorrowed
         let lang_id = cas.input_1.id.clone();
         let single_options = LanguageIdentifierDisplayNameOptions::default();
 
         fn check_language_name_borrowed(
-            borrowed: LanguageIdentifierDisplayName<'_>,
+            borrowed: LanguageIdentifierDisplayNameBorrowed<'_>,
             cas: &TestCase<'_>,
         ) {
             assert_writeable_eq!(borrowed, cas.expected, "{cas:?}");
@@ -386,7 +386,7 @@ fn test_concatenate() {
             }
         }
         if matches!(cas.display_type, DisplayType::Any | DisplayType::Dialect) {
-            let dname_standard_owned = LanguageIdentifierDisplayNameOwned::try_new_heavy(
+            let dname_standard_owned = LanguageIdentifierDisplayName::try_new_heavy(
                 locale.clone().into(),
                 lang_id.clone(),
                 single_options,
@@ -396,7 +396,7 @@ fn test_concatenate() {
             check_language_name_borrowed(borrowed, cas);
         }
         if matches!(cas.display_type, DisplayType::Any | DisplayType::Menu) {
-            let dname_menu_owned = LanguageIdentifierDisplayNameOwned::try_new_menu_heavy(
+            let dname_menu_owned = LanguageIdentifierDisplayName::try_new_menu_heavy(
                 locale.clone().into(),
                 lang_id,
                 single_options,
@@ -421,7 +421,7 @@ fn test_fallback_parts() {
 
     // xx-YY has both language and region missing in CLDR en data.
     // It should fall back to "xx (YY)" and annotate "xx" and "YY" with Part::ERROR.
-    let display_name = LanguageIdentifierDisplayNameOwned::try_new_light(
+    let display_name = LanguageIdentifierDisplayName::try_new_light(
         locale.into(),
         "xx-Latn-YY".parse().unwrap(),
         options,
@@ -448,9 +448,8 @@ fn test_single_language_display_name_standard() {
     // This should format "zh-Hant-HK" to "Chinese (Traditional, Hong Kong SAR China)"
     // in "en-001" using LanguageDisplay::Standard
     let lang_id = langid!("zh-Hant-HK");
-    let lang_name =
-        LanguageIdentifierDisplayNameOwned::try_new_light(locale.into(), lang_id, options)
-            .expect("Data should load successfully");
+    let lang_name = LanguageIdentifierDisplayName::try_new_light(locale.into(), lang_id, options)
+        .expect("Data should load successfully");
 
     assert_try_writeable_eq!(
         lang_name.as_borrowed(),
@@ -468,19 +467,16 @@ fn test_single_language_display_name_short() {
     options.language_display = Some(LanguageDisplay::Standard);
 
     let lang_id = langid!("zh-Hant-HK");
-    let lang_name = LanguageIdentifierDisplayNameOwned::try_new_short_light(
-        locale.clone().into(),
-        lang_id,
-        options,
-    )
-    .expect("Data should load successfully");
+    let lang_name =
+        LanguageIdentifierDisplayName::try_new_short_light(locale.clone().into(), lang_id, options)
+            .expect("Data should load successfully");
 
     assert_try_writeable_eq!(lang_name.as_borrowed(), "Chinese (Traditional, Hong Kong)");
 
     options.language_display = Some(LanguageDisplay::Dialect);
     let lang_id = langid!("de-CH");
     let lang_name =
-        LanguageIdentifierDisplayNameOwned::try_new_short_light(locale.into(), lang_id, options)
+        LanguageIdentifierDisplayName::try_new_short_light(locale.into(), lang_id, options)
             .expect("Data should load successfully");
 
     assert_try_writeable_eq!(lang_name.as_borrowed(), "Swiss High German");
@@ -496,12 +492,9 @@ fn test_single_language_display_name_long() {
     options.language_display = Some(LanguageDisplay::Standard);
 
     let lang_id = langid!("zh-Hant-HK");
-    let lang_name = LanguageIdentifierDisplayNameOwned::try_new_long_heavy(
-        locale.clone().into(),
-        lang_id,
-        options,
-    )
-    .expect("Data should load successfully");
+    let lang_name =
+        LanguageIdentifierDisplayName::try_new_long_heavy(locale.clone().into(), lang_id, options)
+            .expect("Data should load successfully");
 
     assert_try_writeable_eq!(
         lang_name.as_borrowed(),
@@ -511,7 +504,7 @@ fn test_single_language_display_name_long() {
     options.language_display = Some(LanguageDisplay::Dialect);
     let lang_id = langid!("de-CH");
     let lang_name =
-        LanguageIdentifierDisplayNameOwned::try_new_long_light(locale.into(), lang_id, options)
+        LanguageIdentifierDisplayName::try_new_long_light(locale.into(), lang_id, options)
             .expect("Data should load successfully");
 
     assert_try_writeable_eq!(lang_name.as_borrowed(), "Swiss High German");
@@ -533,7 +526,7 @@ fn test_us_and_uk_english_display_names() {
     standard_options.language_display = Some(LanguageDisplay::Standard);
 
     // 1. try_new_light (Dialect: "American English" / "British English")
-    let name_us = LanguageIdentifierDisplayNameOwned::try_new_light(
+    let name_us = LanguageIdentifierDisplayName::try_new_light(
         locale.clone().into(),
         lang_us.clone(),
         default_options,
@@ -541,7 +534,7 @@ fn test_us_and_uk_english_display_names() {
     .unwrap();
     assert_try_writeable_eq!(name_us.as_borrowed(), "American English");
 
-    let name_gb = LanguageIdentifierDisplayNameOwned::try_new_light(
+    let name_gb = LanguageIdentifierDisplayName::try_new_light(
         locale.clone().into(),
         lang_gb.clone(),
         default_options,
@@ -550,7 +543,7 @@ fn test_us_and_uk_english_display_names() {
     assert_try_writeable_eq!(name_gb.as_borrowed(), "British English");
 
     // 1b. try_new_light with LanguageDisplay::Standard ("English (United States)" / "English (United Kingdom)")
-    let name_us_std = LanguageIdentifierDisplayNameOwned::try_new_light(
+    let name_us_std = LanguageIdentifierDisplayName::try_new_light(
         locale.clone().into(),
         lang_us.clone(),
         standard_options,
@@ -558,7 +551,7 @@ fn test_us_and_uk_english_display_names() {
     .unwrap();
     assert_try_writeable_eq!(name_us_std.as_borrowed(), "English (United States)");
 
-    let name_gb_std = LanguageIdentifierDisplayNameOwned::try_new_light(
+    let name_gb_std = LanguageIdentifierDisplayName::try_new_light(
         locale.clone().into(),
         lang_gb.clone(),
         standard_options,
@@ -567,7 +560,7 @@ fn test_us_and_uk_english_display_names() {
     assert_try_writeable_eq!(name_gb_std.as_borrowed(), "English (United Kingdom)");
 
     // 2. try_new_short_light ("US English" / "UK English")
-    let name_us_short = LanguageIdentifierDisplayNameOwned::try_new_short_light(
+    let name_us_short = LanguageIdentifierDisplayName::try_new_short_light(
         locale.clone().into(),
         lang_us.clone(),
         default_options,
@@ -575,7 +568,7 @@ fn test_us_and_uk_english_display_names() {
     .unwrap();
     assert_try_writeable_eq!(name_us_short.as_borrowed(), "US English");
 
-    let name_gb_short = LanguageIdentifierDisplayNameOwned::try_new_short_light(
+    let name_gb_short = LanguageIdentifierDisplayName::try_new_short_light(
         locale.clone().into(),
         lang_gb.clone(),
         default_options,
@@ -584,7 +577,7 @@ fn test_us_and_uk_english_display_names() {
     assert_try_writeable_eq!(name_gb_short.as_borrowed(), "UK English");
 
     // 3. try_new_long_light ("American English" / "British English")
-    let name_us_long = LanguageIdentifierDisplayNameOwned::try_new_long_light(
+    let name_us_long = LanguageIdentifierDisplayName::try_new_long_light(
         locale.clone().into(),
         lang_us.clone(),
         default_options,
@@ -592,7 +585,7 @@ fn test_us_and_uk_english_display_names() {
     .unwrap();
     assert_try_writeable_eq!(name_us_long.as_borrowed(), "American English");
 
-    let name_gb_long = LanguageIdentifierDisplayNameOwned::try_new_long_light(
+    let name_gb_long = LanguageIdentifierDisplayName::try_new_long_light(
         locale.clone().into(),
         lang_gb.clone(),
         default_options,
@@ -601,7 +594,7 @@ fn test_us_and_uk_english_display_names() {
     assert_try_writeable_eq!(name_gb_long.as_borrowed(), "British English");
 
     // 4. try_new_menu_light ("English (United States)" / "English (United Kingdom)")
-    let name_us_menu = LanguageIdentifierDisplayNameOwned::try_new_menu_light(
+    let name_us_menu = LanguageIdentifierDisplayName::try_new_menu_light(
         locale.clone().into(),
         lang_us.clone(),
         default_options,
@@ -609,7 +602,7 @@ fn test_us_and_uk_english_display_names() {
     .unwrap();
     assert_try_writeable_eq!(name_us_menu.as_borrowed(), "English (United States)");
 
-    let name_gb_menu = LanguageIdentifierDisplayNameOwned::try_new_menu_light(
+    let name_gb_menu = LanguageIdentifierDisplayName::try_new_menu_light(
         locale.clone().into(),
         lang_gb.clone(),
         default_options,
@@ -618,7 +611,7 @@ fn test_us_and_uk_english_display_names() {
     assert_try_writeable_eq!(name_gb_menu.as_borrowed(), "English (United Kingdom)");
 
     // 5. try_new_short_menu_light ("English (US)" / "English (UK)")
-    let name_us_short_menu = LanguageIdentifierDisplayNameOwned::try_new_short_menu_light(
+    let name_us_short_menu = LanguageIdentifierDisplayName::try_new_short_menu_light(
         locale.clone().into(),
         lang_us.clone(),
         default_options,
@@ -626,7 +619,7 @@ fn test_us_and_uk_english_display_names() {
     .unwrap();
     assert_try_writeable_eq!(name_us_short_menu.as_borrowed(), "English (US)");
 
-    let name_gb_short_menu = LanguageIdentifierDisplayNameOwned::try_new_short_menu_light(
+    let name_gb_short_menu = LanguageIdentifierDisplayName::try_new_short_menu_light(
         locale.clone().into(),
         lang_gb.clone(),
         default_options,
@@ -635,7 +628,7 @@ fn test_us_and_uk_english_display_names() {
     assert_try_writeable_eq!(name_gb_short_menu.as_borrowed(), "English (UK)");
 
     // 6. try_new_tiny: in "en" locale, both "en-US" and "en-GB" are present in minimal data
-    let name_us_minimal = LanguageIdentifierDisplayNameOwned::try_new_tiny(
+    let name_us_minimal = LanguageIdentifierDisplayName::try_new_tiny(
         locale.clone().into(),
         lang_us.clone(),
         default_options,
@@ -643,7 +636,7 @@ fn test_us_and_uk_english_display_names() {
     .unwrap();
     assert_try_writeable_eq!(name_us_minimal.as_borrowed(), "English (United States)");
 
-    let name_gb_minimal = LanguageIdentifierDisplayNameOwned::try_new_tiny(
+    let name_gb_minimal = LanguageIdentifierDisplayName::try_new_tiny(
         locale.clone().into(),
         lang_gb.clone(),
         default_options,
@@ -652,7 +645,7 @@ fn test_us_and_uk_english_display_names() {
     assert_try_writeable_eq!(name_gb_minimal.as_borrowed(), "English (United Kingdom)");
 
     // Non-minimal dialect like "fr-CA" in "en" locale minimal slice falls back
-    let name_fr_ca_minimal = LanguageIdentifierDisplayNameOwned::try_new_tiny(
+    let name_fr_ca_minimal = LanguageIdentifierDisplayName::try_new_tiny(
         locale.into(),
         langid!("fr-CA"),
         default_options,
@@ -666,7 +659,7 @@ fn test_us_and_uk_english_display_names() {
 
     // 7. Verify behavior across regional English locales (en-US, en-GB, en-001)
     for regional_locale in [locale!("en-US"), locale!("en-GB"), locale!("en-001")] {
-        let us_name = LanguageIdentifierDisplayNameOwned::try_new_light(
+        let us_name = LanguageIdentifierDisplayName::try_new_light(
             regional_locale.clone().into(),
             lang_us.clone(),
             default_options,
@@ -674,7 +667,7 @@ fn test_us_and_uk_english_display_names() {
         .unwrap();
         assert_try_writeable_eq!(us_name.as_borrowed(), "American English");
 
-        let gb_name = LanguageIdentifierDisplayNameOwned::try_new_light(
+        let gb_name = LanguageIdentifierDisplayName::try_new_light(
             regional_locale.clone().into(),
             lang_gb.clone(),
             default_options,
@@ -682,7 +675,7 @@ fn test_us_and_uk_english_display_names() {
         .unwrap();
         assert_try_writeable_eq!(gb_name.as_borrowed(), "British English");
 
-        let gb_name = LanguageIdentifierDisplayNameOwned::try_new_light(
+        let gb_name = LanguageIdentifierDisplayName::try_new_light(
             regional_locale.into(),
             langid!("en-001"),
             default_options,
@@ -697,32 +690,32 @@ fn test_region_display_name_overrides() {
     let prefs_ko = DisplayNamesPreferences::from(locale!("ko"));
 
     assert_writeable_eq!(
-        RegionDisplayNameOwned::try_new_light(prefs_ko, region!("KR")).unwrap(),
+        RegionDisplayName::try_new_light(prefs_ko, region!("KR")).unwrap(),
         "대한민국"
     );
     assert_writeable_eq!(
-        RegionDisplayNameOwned::try_new_short_light(prefs_ko, region!("KR")).unwrap(),
+        RegionDisplayName::try_new_short_light(prefs_ko, region!("KR")).unwrap(),
         "한국"
     );
     assert_writeable_eq!(
-        RegionDisplayNameOwned::try_new_tiny(prefs_ko, region!("KR")).unwrap(),
+        RegionDisplayName::try_new_tiny(prefs_ko, region!("KR")).unwrap(),
         "대한민국"
     );
     assert_writeable_eq!(
-        RegionDisplayNameOwned::try_new_short_tiny(prefs_ko, region!("KR")).unwrap(),
+        RegionDisplayName::try_new_short_tiny(prefs_ko, region!("KR")).unwrap(),
         "한국"
     );
 
     let prefs_fa = DisplayNamesPreferences::from(locale!("fa"));
 
     assert_writeable_eq!(
-        RegionDisplayNameOwned::try_new_light(prefs_fa, region!("SA")).unwrap(),
+        RegionDisplayName::try_new_light(prefs_fa, region!("SA")).unwrap(),
         "عربستان سعودی"
     );
     assert_writeable_eq!(
-        RegionDisplayNameOwned::try_new_short_light(prefs_fa, region!("SA")).unwrap(),
+        RegionDisplayName::try_new_short_light(prefs_fa, region!("SA")).unwrap(),
         "عربستان"
     );
-    assert!(RegionDisplayNameOwned::try_new_tiny(prefs_fa, region!("SA")).is_err());
-    assert!(RegionDisplayNameOwned::try_new_short_tiny(prefs_fa, region!("SA")).is_err());
+    assert!(RegionDisplayName::try_new_tiny(prefs_fa, region!("SA")).is_err());
+    assert!(RegionDisplayName::try_new_short_tiny(prefs_fa, region!("SA")).is_err());
 }


### PR DESCRIPTION
#8180

Rename XDisplayName to XDisplayNameBorrowed and XDisplayNameOwned to XDisplayName in experimental displaynames single (where X is LanguageIdentifier, Region, Script, Variant).

This aligns the naming convention with other borrowed/owned pairs in ICU4X.

🤖 This pull request was created by an AI agent working with @sffc.

## Changelog

icu_experimental/displaynames: Rename single display name types to follow new convention
  * New types: `LanguageIdentifierDisplayNameBorrowed`, `RegionDisplayNameBorrowed`, `ScriptDisplayNameBorrowed`, `VariantDisplayNameBorrowed` (borrowed versions of display names)
  * Renamed types: `LanguageIdentifierDisplayNameOwned` -> `LanguageIdentifierDisplayName`, `RegionDisplayNameOwned` -> `RegionDisplayName`, `ScriptDisplayNameOwned` -> `ScriptDisplayName`, `VariantDisplayNameOwned` -> `VariantDisplayName` (owned versions of display names, formerly had `Owned` suffix)
