### PR TITLE
Use range dep for diplomat-runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -223,9 +223,12 @@ icu_benchmark_macros = { path = "tools/benchmark/macros" }
 # The version here can either be a `version = ".."` spec or `git = "https://github.com/rust-diplomat/diplomat", rev = ".."`
 # Diplomat must be published preceding a new ICU4X release but may use git versions in between
 diplomat = { version = "0.16.0", default-features = false }
-diplomat-runtime = { version = "0.16.0", default-features = false }
 diplomat_core = { version = "0.16.0", default-features = false }
 diplomat-tool = { version = "0.16.0" }
+# Range dep for better compatability. We will not have this problem
+# after diplomat-runtime 1.0.0
+# <https://github.com/rust-diplomat/diplomat/issues/958>
+diplomat-runtime = { version = ">= 0.15.2, < 0.17.0", default-features = false }
 
 # EXTERNAL DEPENDENCIES
 #


### PR DESCRIPTION
In preparation for https://github.com/rust-diplomat/diplomat/issues/958, we're going to try to have expansive range deps until we get diplomat-runtime 1.0.0.

This also avoids problems in Chromium which has two Diplomat projects in it now.

## Changelog: N/A
