### PR TITLE
Format changelog as nested bullet points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## icu 2.2.x
+## icu4x 2.2.x
 
 Several crates have had patch releases in the 2.2 stream:
 
@@ -321,7 +321,7 @@ Several crates have had patch releases in the 2.2 stream:
         - Mark `Offset`, `Transition`, and `PossibleOffset` as `#[non_exhaustive]`
         - Internal cleanups
 
-## icu 2.1.x
+## icu4x 2.1.x
 
 Several crates have had patch releases in the 2.1 stream:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,6 +416,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 name = "changelog"
 version = "2.2.0"
 dependencies = [
+ "cargo_metadata",
  "clap",
  "indexmap",
  "regex",

--- a/tools/changelog/Cargo.toml
+++ b/tools/changelog/Cargo.toml
@@ -17,6 +17,7 @@ include.workspace = true
 publish = false
 
 [dependencies]
+cargo_metadata = "0.19.2"
 clap = { workspace = true, features = ["derive"]}
 indexmap = { workspace = true, features = ["serde"] }
 regex.workspace = true

--- a/tools/changelog/src/changelog.rs
+++ b/tools/changelog/src/changelog.rs
@@ -4,14 +4,16 @@
 
 use crate::args::MakeChangelog;
 use crate::github::{GithubState, PrData};
+use cargo_metadata::MetadataCommand;
 use regex::Regex;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt::Write;
 use std::sync::LazyLock;
 
 pub(crate) fn run(args: MakeChangelog) {
     let state = GithubState::load(&args.json);
-    let mut organized = OrganizedChangelog::default();
+    let crate_categories = load_crate_categories();
+    let mut organized = OrganizedChangelog::new(crate_categories);
     for data in state.revs.values() {
         organized.add(data);
     }
@@ -19,10 +21,69 @@ pub(crate) fn run(args: MakeChangelog) {
     organized.render();
 }
 
-#[derive(Debug, Default)]
+fn load_crate_categories() -> HashMap<String, Category> {
+    let metadata = MetadataCommand::new()
+        .exec()
+        .expect("Failed to run cargo metadata");
+
+    let mut map = HashMap::new();
+    for package in metadata.workspace_packages() {
+        let category = if package
+            .manifest_path
+            .components()
+            .any(|c| c.as_str() == "components")
+        {
+            Category::Components
+        } else if package
+            .manifest_path
+            .components()
+            .any(|c| c.as_str() == "provider")
+        {
+            Category::Data
+        } else if package
+            .manifest_path
+            .components()
+            .any(|c| c.as_str() == "ffi")
+        {
+            Category::Ffi
+        } else if package
+            .manifest_path
+            .components()
+            .any(|c| c.as_str() == "utils" || c.as_str() == "tools")
+        {
+            Category::Utils
+        } else {
+            Category::Components
+        };
+        map.insert(package.name.clone(), category);
+    }
+    map
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+enum Category {
+    Components,
+    Data,
+    Ffi,
+    Utils,
+}
+
+impl std::fmt::Display for Category {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Category::Components => write!(f, "Components"),
+            Category::Data => write!(f, "Data model and providers"),
+            Category::Ffi => write!(f, "FFI"),
+            Category::Utils => write!(f, "Utils"),
+        }
+    }
+}
+
+#[derive(Debug)]
 struct OrganizedChangelog {
-    /// Different crate sections
-    sections: BTreeMap<String, Vec<ChangelogEntry>>,
+    crate_categories: HashMap<String, Category>,
+    /// Category -> Option<Crate> -> Entries
+    sections: BTreeMap<Category, BTreeMap<Option<String>, Vec<ChangelogEntry>>>,
     /// Additional data that was not included in the crate sections.
     additional: Vec<(PrData, String)>,
     /// N/A PRs
@@ -44,15 +105,76 @@ static CHANGELOG_HEADER: LazyLock<Regex> =
 static SECTION: LazyLock<Regex> =
     LazyLock::new(|| Regex::new("^(?<crate>`?\\S+`?:|`\\S+`)(?<entry>.*)$").unwrap());
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 struct SectionState {
-    krate: String,
+    category: Category,
+    krate: Option<String>,
     entry: String,
     bullets: Vec<(usize, String)>,
     indent_stack: Vec<usize>,
 }
 
 impl OrganizedChangelog {
+    fn new(crate_categories: HashMap<String, Category>) -> Self {
+        Self {
+            crate_categories,
+            sections: BTreeMap::new(),
+            additional: Vec::new(),
+            n_a: Vec::new(),
+            no_changelog_found: Vec::new(),
+            misformatted: Vec::new(),
+        }
+    }
+
+    fn get_category<'a>(&self, krate: &'a str) -> (Category, Option<&'a str>) {
+        if krate == "General" || krate == "Components" || krate == "components" {
+            return (Category::Components, None);
+        }
+        if krate == "Data" || krate == "data" || krate == "Data model and providers" {
+            return (Category::Data, None);
+        }
+        if krate == "FFI" || krate == "ffi" {
+            return (Category::Ffi, None);
+        }
+        if krate == "Utils" || krate == "utils" {
+            return (Category::Utils, None);
+        }
+
+        if let Some(&cat) = self.crate_categories.get(krate) {
+            return (cat, Some(krate));
+        }
+
+        if krate.contains('/') {
+            let part_before = krate.split('/').next().unwrap();
+            let (cat, _) = self.get_category(part_before);
+            return (cat, Some(krate));
+        }
+
+        let mut sorted_crates: Vec<&String> = self.crate_categories.keys().collect();
+        sorted_crates.sort_by_key(|b| std::cmp::Reverse(b.len()));
+
+        for &c in &sorted_crates {
+            if krate.starts_with(c) {
+                return (self.crate_categories[c], Some(krate));
+            }
+        }
+
+        if krate.contains("provider")
+            || krate.contains("datagen")
+            || krate.contains("source")
+            || krate.contains("registry")
+            || krate.contains("metadata")
+        {
+            return (Category::Data, Some(krate));
+        }
+
+        if krate.contains("capi") || krate.contains("harfbuzz") || krate.contains("diplomat") {
+            return (Category::Ffi, Some(krate));
+        }
+
+        (Category::Components, Some(krate))
+    }
+
     fn add(&mut self, data: &PrData) {
         if data.is_dependabot() {
             return;
@@ -81,15 +203,19 @@ impl OrganizedChangelog {
             if let Some(header) = SECTION.captures(line) {
                 self.flush(data, &mut current_section);
                 let entry = header.name("entry").unwrap().as_str().trim().to_owned();
+                let krate_str = header
+                    .name("crate")
+                    .unwrap()
+                    .as_str()
+                    .trim_matches(':')
+                    .trim_matches('`')
+                    .to_owned();
+
+                let (category, krate) = self.get_category(&krate_str);
 
                 current_section = Some(SectionState {
-                    krate: header
-                        .name("crate")
-                        .unwrap()
-                        .as_str()
-                        .trim_matches(':')
-                        .trim_matches('`')
-                        .to_owned(),
+                    category,
+                    krate: krate.map(String::from),
                     entry,
                     bullets: Vec::new(),
                     indent_stack: Vec::new(),
@@ -121,6 +247,7 @@ impl OrganizedChangelog {
                         Err(idx) => {
                             // If there are indents beyond this, skip them
                             current_section.indent_stack.truncate(idx);
+                            current_section.indent_stack.push(bullet_index);
                             idx
                         }
                     };
@@ -160,20 +287,34 @@ impl OrganizedChangelog {
             entry: section.entry,
             bullets: section.bullets,
         };
-        self.sections.entry(section.krate).or_default().push(entry)
+        self.sections
+            .entry(section.category)
+            .or_default()
+            .entry(section.krate)
+            .or_default()
+            .push(entry)
     }
 
     fn render(&self) {
         println!("\n\n# Crates\n=====================\n");
-        // This is a silly but convenient way of doing indentation in format strings
-        static INDENTATION: &str = "                                               ";
 
-        for (header, entries) in &self.sections {
-            println!("\n## {header}\n");
-            for entry in entries {
-                println!("- {} (unicode-org#{})", entry.entry, entry.number);
-                for bullet in &entry.bullets {
-                    println!(" {}- {}", &INDENTATION[..bullet.0], bullet.1);
+        for (category, krates) in &self.sections {
+            println!("- {category}");
+            for (krate, entries) in krates {
+                match krate {
+                    Some(krate) => {
+                        println!("  - `{krate}`");
+                    }
+                    None => {
+                        println!("  - General");
+                    }
+                }
+                for entry in entries {
+                    println!("    - {} (unicode-org#{})", entry.entry, entry.number);
+                    for bullet in &entry.bullets {
+                        let indent = 6 + bullet.0 * 2;
+                        println!("{:indent$}- {}", "", bullet.1, indent = indent);
+                    }
                 }
             }
         }

--- a/tools/changelog/tests/test_changelog_golden.md
+++ b/tools/changelog/tests/test_changelog_golden.md
@@ -3,66 +3,47 @@
 # Crates
 =====================
 
-
-## FFI
-
-- Fix an issue in JS bindings where enums in objects were not parsed correctly (unicode-org#7885)
-
-## General
-
-- Updated data to TZDB 2026c (unicode-org#8200)
-
-## icu_calendar
-
-- Add `AnyCalendarKind::try_new` and deprecate  `AnyCalendarKind::new`. The new version uses locale data to infer calendars from locales. (unicode-org#8102)
-- Deprecate `CalendarPreferences::resolve_calendar`. This method did not perform likely-subtags expansion. (unicode-org#8102)
-- Fix bug in leap year calculation for Julian calendar (unicode-org#9003)
-
-## icu_casemapping
-
-- Fix `TrailingCase::Unchanged` handling for Dutch (unicode-org#7863)
-
-## icu_datetime
-
-- Use the correct calendar even if the region is only implied by the language (i.e. `fa`) (unicode-org#8102)
-- Improved performance of datetime formatting (unicode-org#9002)
- - Optimized cache lookup
- - Reduced allocations in helper functions
- - Avoided cloning locale in hot path
-
-## icu_experimental/currency
-
-- Add formatting support for negative currency subpatterns (unicode-org#9001)
-
-## icu_experimental/personnames
-
-- Add initial implementation of person names formatter (unicode-org#9006)
-- Add support for titles and honorifics in person names (unicode-org#9007)
-
-## icu_list
-
-- Add support for custom list styles (unicode-org#9004)
- - Allowed users to pass custom templates
- - Added validation for templates
- - Checked for matching placeholders
- - Verified order of placeholders
-
-## icu_locale_core
-
-- `preferences` types now implement `databake` (feature-gated) (unicode-org#8102)
-
-## icu_properties
-
-- Update properties data for Unicode 16.0 (unicode-org#9005)
- - Loaded new property files
- - Updated script definitions
- - Added new scripts
- - Updated aliases for existing scripts
-
-## writeable
-
-- impl TryWriteable on references (unicode-org#8109)
-- impl TryWriteable on Either (unicode-org#8109)
+- Components
+  - General
+    - Updated data to TZDB 2026c (unicode-org#8200)
+  - `icu_calendar`
+    - Add `AnyCalendarKind::try_new` and deprecate  `AnyCalendarKind::new`. The new version uses locale data to infer calendars from locales. (unicode-org#8102)
+    - Deprecate `CalendarPreferences::resolve_calendar`. This method did not perform likely-subtags expansion. (unicode-org#8102)
+    - Fix bug in leap year calculation for Julian calendar (unicode-org#9003)
+  - `icu_casemapping`
+    - Fix `TrailingCase::Unchanged` handling for Dutch (unicode-org#7863)
+  - `icu_datetime`
+    - Use the correct calendar even if the region is only implied by the language (i.e. `fa`) (unicode-org#8102)
+    - Improved performance of datetime formatting (unicode-org#9002)
+      - Optimized cache lookup
+      - Reduced allocations in helper functions
+        - Avoided cloning locale in hot path
+  - `icu_experimental/currency`
+    - Add formatting support for negative currency subpatterns (unicode-org#9001)
+  - `icu_experimental/personnames`
+    - Add initial implementation of person names formatter (unicode-org#9006)
+    - Add support for titles and honorifics in person names (unicode-org#9007)
+  - `icu_list`
+    - Add support for custom list styles (unicode-org#9004)
+      - Allowed users to pass custom templates
+      - Added validation for templates
+        - Checked for matching placeholders
+        - Verified order of placeholders
+  - `icu_locale_core`
+    - `preferences` types now implement `databake` (feature-gated) (unicode-org#8102)
+  - `icu_properties`
+    - Update properties data for Unicode 16.0 (unicode-org#9005)
+      - Loaded new property files
+      - Updated script definitions
+        - Added new scripts
+        - Updated aliases for existing scripts
+- FFI
+  - General
+    - Fix an issue in JS bindings where enums in objects were not parsed correctly (unicode-org#7885)
+- Utils
+  - `writeable`
+    - impl TryWriteable on references (unicode-org#8109)
+    - impl TryWriteable on Either (unicode-org#8109)
 
 
 # PRs with additional notes


### PR DESCRIPTION
Depends on #8324

This PR updates the changelog tool to format the generated changelog as a nested bullet point list grouped by categories, matching the style of CHANGELOG.md.

It uses `cargo_metadata` to determine the category of each crate at runtime.

This is stacked on top of #8324.

🤖 This pull request was created by an AI agent working with @sffc.

## Changelog

N/A