### PR TITLE
Optimize CoverageByXPathLevels data model and trie queries

### DIFF
--- a/provider/source/Cargo.toml
+++ b/provider/source/Cargo.toml
@@ -73,7 +73,7 @@ num-traits = { workspace = true, optional = true }
 [dev-dependencies]
 postcard = { workspace = true, features = ["alloc"] }
 icu_provider_adapters = { workspace = true }
-icu_provider_export = { workspace = true, features = ["fs_exporter", "baked_exporter", "rayon"] }
+icu_provider_export = { workspace = true, features = ["fs_exporter", "baked_exporter", "rayon", "blob_exporter"] }
 icu_provider = { workspace = true, features = ["deserialize_postcard_1"] }
 icu_segmenter = { path = "../../components/segmenter", features = ["lstm"] }
 simple_logger = { workspace = true }
@@ -107,3 +107,7 @@ max_combination_size = 3
 
 [lints]
 workspace = true
+
+[[test]]
+name = "e2e"
+required-features = ["networking"]

--- a/provider/source/Cargo.toml
+++ b/provider/source/Cargo.toml
@@ -105,9 +105,15 @@ icu_experimental = []
 skip_feature_sets = [["use_icu4c"], ["use_wasm"]]
 max_combination_size = 3
 
+[lib]
+bench = false  # This option is required for Benchmark CI
+
+# Standalone benchmark binary for display names data export performance.
+# We set `harness = false` so that it runs as a standalone binary with main() when
+# executing `cargo bench`, but is NOT executed during `cargo test` / `cargo make ci-job-test`.
+[[bench]]
+name = "displaynames"
+harness = false
+
 [lints]
 workspace = true
-
-[[test]]
-name = "e2e"
-required-features = ["networking"]

--- a/provider/source/benches/displaynames.rs
+++ b/provider/source/benches/displaynames.rs
@@ -2,6 +2,14 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+//! Standalone benchmark measuring performance of exporting display names data
+//! across modern coverage locales.
+//!
+//! Run using:
+//! ```text
+//! cargo bench -p icu_provider_source --bench displaynames
+//! ```
+
 use icu_provider_export::blob_exporter::BlobExporter;
 use icu_provider_export::prelude::*;
 use icu_provider_source::SourceDataProvider;

--- a/provider/source/benches/displaynames.rs
+++ b/provider/source/benches/displaynames.rs
@@ -6,8 +6,8 @@ use icu_provider_export::blob_exporter::BlobExporter;
 use icu_provider_export::prelude::*;
 use icu_provider_source::SourceDataProvider;
 
-#[test]
-fn test_export_language_identifier_display_names() {
+fn main() {
+    let t0 = std::time::Instant::now();
     let provider = SourceDataProvider::new();
     let mut blob_bytes = Vec::new();
     let exporter = BlobExporter::new_with_sink(Box::new(&mut blob_bytes));
@@ -19,9 +19,7 @@ fn test_export_language_identifier_display_names() {
     ExportDriver::new(
         modern_locales
             .into_iter()
-            .map(DataLocaleFamily::without_descendants)
-            // for the purposes of this test, use every 10th locale
-            .step_by(10),
+            .map(DataLocaleFamily::without_descendants),
         DeduplicationStrategy::None.into(),
         LocaleFallbacker::try_new_unstable(&provider).unwrap(),
     )
@@ -34,9 +32,10 @@ fn test_export_language_identifier_display_names() {
     .export(&provider, exporter)
     .unwrap();
 
-    assert!(
-        blob_bytes.len() >= 100_000,
-        "postcard blob size {} should be at least 100 kB",
+    let elapsed = t0.elapsed();
+    println!(
+        "displaynames bench: {:.3?} s, blob size: {} bytes",
+        elapsed.as_secs_f64(),
         blob_bytes.len()
     );
 }

--- a/provider/source/src/cldr_serde/displaynames/mod.rs
+++ b/provider/source/src/cldr_serde/displaynames/mod.rs
@@ -33,7 +33,7 @@ pub(crate) enum Alt {
 }
 
 impl Alt {
-    pub fn as_str(&self) -> &'static str {
+    pub fn as_str(self) -> &'static str {
         match self {
             Alt::Short => "short",
             Alt::Long => "long",
@@ -75,7 +75,7 @@ pub(crate) enum Menu {
 }
 
 impl Menu {
-    pub fn as_str(&self) -> &'static str {
+    pub fn as_str(self) -> &'static str {
         match self {
             Menu::Core => "core",
             Menu::Extension => "extension",

--- a/provider/source/src/cldr_serde/displaynames/mod.rs
+++ b/provider/source/src/cldr_serde/displaynames/mod.rs
@@ -33,6 +33,7 @@ pub(crate) enum Alt {
 }
 
 impl Alt {
+    /// Returns the string representation of the `Alt` variant, or `None` if `Unknown`.
     pub fn as_str(self) -> Option<&'static str> {
         match self {
             Alt::Short => Some("short"),
@@ -75,6 +76,7 @@ pub(crate) enum Menu {
 }
 
 impl Menu {
+    /// Returns the string representation of the `Menu` variant, or `None` if `Unknown`.
     pub fn as_str(self) -> Option<&'static str> {
         match self {
             Menu::Core => Some("core"),

--- a/provider/source/src/cldr_serde/displaynames/mod.rs
+++ b/provider/source/src/cldr_serde/displaynames/mod.rs
@@ -32,6 +32,23 @@ pub(crate) enum Alt {
     Menu,
 }
 
+impl Alt {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Alt::Short => "short",
+            Alt::Long => "long",
+            Alt::Variant => "variant",
+            Alt::StandAlone => "stand-alone",
+            Alt::Official => "official",
+            Alt::Secondary => "secondary",
+            Alt::Biot => "biot",
+            Alt::Chagos => "chagos",
+            Alt::Menu => "menu",
+            Alt::Unknown => "unknown",
+        }
+    }
+}
+
 impl FromStr for Alt {
     type Err = ();
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -55,6 +72,16 @@ pub(crate) enum Menu {
     Unknown,
     Core,
     Extension,
+}
+
+impl Menu {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Menu::Core => "core",
+            Menu::Extension => "extension",
+            Menu::Unknown => "unknown",
+        }
+    }
 }
 
 impl FromStr for Menu {

--- a/provider/source/src/cldr_serde/displaynames/mod.rs
+++ b/provider/source/src/cldr_serde/displaynames/mod.rs
@@ -33,18 +33,18 @@ pub(crate) enum Alt {
 }
 
 impl Alt {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(self) -> Option<&'static str> {
         match self {
-            Alt::Short => "short",
-            Alt::Long => "long",
-            Alt::Variant => "variant",
-            Alt::StandAlone => "stand-alone",
-            Alt::Official => "official",
-            Alt::Secondary => "secondary",
-            Alt::Biot => "biot",
-            Alt::Chagos => "chagos",
-            Alt::Menu => "menu",
-            Alt::Unknown => "unknown",
+            Alt::Short => Some("short"),
+            Alt::Long => Some("long"),
+            Alt::Variant => Some("variant"),
+            Alt::StandAlone => Some("stand-alone"),
+            Alt::Official => Some("official"),
+            Alt::Secondary => Some("secondary"),
+            Alt::Biot => Some("biot"),
+            Alt::Chagos => Some("chagos"),
+            Alt::Menu => Some("menu"),
+            Alt::Unknown => None,
         }
     }
 }
@@ -75,11 +75,11 @@ pub(crate) enum Menu {
 }
 
 impl Menu {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(self) -> Option<&'static str> {
         match self {
-            Menu::Core => "core",
-            Menu::Extension => "extension",
-            Menu::Unknown => "unknown",
+            Menu::Core => Some("core"),
+            Menu::Extension => Some("extension"),
+            Menu::Unknown => None,
         }
     }
 }

--- a/provider/source/src/displaynames/coverage_experimental.rs
+++ b/provider/source/src/displaynames/coverage_experimental.rs
@@ -155,30 +155,36 @@ pub(super) struct CoverageByXPathLevels {
     pub(super) variant: CoverageCategoryLevels,
 }
 
-struct XPathArraySeed<'a>(
-    &'a mut LiteMap<Vec<u8>, usize>,
-    &'a mut LiteMap<Vec<u8>, usize>,
-    &'a mut LiteMap<Vec<u8>, usize>,
-    &'a mut LiteMap<Vec<u8>, usize>,
-    usize,
-);
+struct XPathArraySeed<'a> {
+    lang: &'a mut LiteMap<Vec<u8>, usize>,
+    terr: &'a mut LiteMap<Vec<u8>, usize>,
+    script: &'a mut LiteMap<Vec<u8>, usize>,
+    var: &'a mut LiteMap<Vec<u8>, usize>,
+    level_val: usize,
+}
 
-struct XPathArrayVisitor<'a>(
-    &'a mut LiteMap<Vec<u8>, usize>,
-    &'a mut LiteMap<Vec<u8>, usize>,
-    &'a mut LiteMap<Vec<u8>, usize>,
-    &'a mut LiteMap<Vec<u8>, usize>,
-    usize,
-);
+struct XPathArrayVisitor<'a> {
+    lang: &'a mut LiteMap<Vec<u8>, usize>,
+    terr: &'a mut LiteMap<Vec<u8>, usize>,
+    script: &'a mut LiteMap<Vec<u8>, usize>,
+    var: &'a mut LiteMap<Vec<u8>, usize>,
+    level_val: usize,
+}
 
 impl<'de, 'a> DeserializeSeed<'de> for XPathArraySeed<'a> {
     type Value = ();
 
-    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    fn deserialize(self, deserializer: D) -> Result<Self::Value, D::Error>
     where
         D: Deserializer<'de>,
     {
-        deserializer.deserialize_seq(XPathArrayVisitor(self.0, self.1, self.2, self.3, self.4))
+        deserializer.deserialize_seq(XPathArrayVisitor {
+            lang: self.lang,
+            terr: self.terr,
+            script: self.script,
+            var: self.var,
+            level_val: self.level_val,
+        })
     }
 }
 
@@ -189,7 +195,7 @@ impl<'de, 'a> Visitor<'de> for XPathArrayVisitor<'a> {
         formatter.write_str("a sequence of CLDR XPaths")
     }
 
-    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    fn visit_seq<A>(mut self, mut seq: A) -> Result<Self::Value, A::Error>
     where
         A: SeqAccess<'de>,
     {
@@ -199,12 +205,12 @@ impl<'de, 'a> Visitor<'de> for XPathArrayVisitor<'a> {
             }
             if let Some((category, key)) = parse_cldr_xpath(xpath.as_ref()) {
                 let map = match category {
-                    CoverageCategory::Language => &mut *self.0,
-                    CoverageCategory::Territory => &mut *self.1,
-                    CoverageCategory::Script => &mut *self.2,
-                    CoverageCategory::Variant => &mut *self.3,
+                    CoverageCategory::Language => &mut *self.lang,
+                    CoverageCategory::Territory => &mut *self.terr,
+                    CoverageCategory::Script => &mut *self.script,
+                    CoverageCategory::Variant => &mut *self.var,
                 };
-                map.insert(key.into_bytes(), self.4);
+                map.insert(key.into_bytes(), self.level_val);
             }
         }
         Ok(())
@@ -245,13 +251,13 @@ impl<'de> Deserialize<'de> for CoverageByXPathLevels {
                             continue;
                         }
                     };
-                    map.next_value_seed(XPathArraySeed(
-                        &mut map_lang,
-                        &mut map_terr,
-                        &mut map_script,
-                        &mut map_var,
+                    map.next_value_seed(XPathArraySeed {
+                        lang: &mut map_lang,
+                        terr: &mut map_terr,
+                        script: &mut map_script,
+                        var: &mut map_var,
                         level_val,
-                    ))?;
+                    })?;
                 }
 
                 Ok(CoverageByXPathLevels {

--- a/provider/source/src/displaynames/coverage_experimental.rs
+++ b/provider/source/src/displaynames/coverage_experimental.rs
@@ -68,17 +68,7 @@ fn parse_cldr_xpath(xpath: &str) -> Option<(CoverageCategory, String)> {
     Some((category, key))
 }
 
-#[derive(Deserialize)]
-struct RawCoverageByXPathLevels {
-    #[serde(default)]
-    basic: Vec<String>,
-    #[serde(default)]
-    core: Vec<String>,
-    #[serde(default)]
-    moderate: Vec<String>,
-    #[serde(default)]
-    modern: Vec<String>,
-}
+use serde::de::{DeserializeSeed, Deserializer, MapAccess, SeqAccess, Visitor};
 
 /// Coverage level representation for display names categories (`language`, `territory`, `script`, `variant`).
 #[derive(Debug, Default)]
@@ -129,8 +119,7 @@ impl CoverageCategoryLevels {
 }
 
 /// Coverage level representation for display names categories (`language`, `territory`, `script`, `variant`).
-#[derive(Deserialize, Debug)]
-#[serde(try_from = "RawCoverageByXPathLevels")]
+#[derive(Debug)]
 pub(super) struct CoverageByXPathLevels {
     pub(super) language: CoverageCategoryLevels,
     pub(super) territory: CoverageCategoryLevels,
@@ -138,54 +127,127 @@ pub(super) struct CoverageByXPathLevels {
     pub(super) variant: CoverageCategoryLevels,
 }
 
-impl TryFrom<RawCoverageByXPathLevels> for CoverageByXPathLevels {
-    type Error = String;
+struct XPathArraySeed<'a>(
+    &'a mut LiteMap<Vec<u8>, usize>,
+    &'a mut LiteMap<Vec<u8>, usize>,
+    &'a mut LiteMap<Vec<u8>, usize>,
+    &'a mut LiteMap<Vec<u8>, usize>,
+    usize,
+);
 
-    fn try_from(raw: RawCoverageByXPathLevels) -> Result<Self, Self::Error> {
-        let mut map_lang = LiteMap::new_vec();
-        let mut map_terr = LiteMap::new_vec();
-        let mut map_script = LiteMap::new_vec();
-        let mut map_var = LiteMap::new_vec();
+struct XPathArrayVisitor<'a>(
+    &'a mut LiteMap<Vec<u8>, usize>,
+    &'a mut LiteMap<Vec<u8>, usize>,
+    &'a mut LiteMap<Vec<u8>, usize>,
+    &'a mut LiteMap<Vec<u8>, usize>,
+    usize,
+);
 
-        let levels = [
-            (CoverageLevelForXPath::Core, raw.core),
-            (CoverageLevelForXPath::Basic, raw.basic),
-            (CoverageLevelForXPath::Moderate, raw.moderate),
-            (CoverageLevelForXPath::Modern, raw.modern),
-        ];
+impl<'de, 'a> DeserializeSeed<'de> for XPathArraySeed<'a> {
+    type Value = ();
 
-        for (tier, xpaths) in levels {
-            let tier_val = tier.to_usize();
-            for xpath in xpaths {
-                if !xpath.is_ascii() {
-                    continue;
-                }
-                if let Some((category, key)) = parse_cldr_xpath(&xpath) {
-                    let map = match category {
-                        CoverageCategory::Language => &mut map_lang,
-                        CoverageCategory::Territory => &mut map_terr,
-                        CoverageCategory::Script => &mut map_script,
-                        CoverageCategory::Variant => &mut map_var,
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_seq(XPathArrayVisitor(self.0, self.1, self.2, self.3, self.4))
+    }
+}
+
+impl<'de, 'a> Visitor<'de> for XPathArrayVisitor<'a> {
+    type Value = ();
+
+    fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+        formatter.write_str("a sequence of CLDR XPaths")
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        while let Some(xpath) = seq.next_element::<std::borrow::Cow<'_, str>>()? {
+            if !xpath.is_ascii() {
+                continue;
+            }
+            if let Some((category, key)) = parse_cldr_xpath(xpath.as_ref()) {
+                let map = match category {
+                    CoverageCategory::Language => &mut *self.0,
+                    CoverageCategory::Territory => &mut *self.1,
+                    CoverageCategory::Script => &mut *self.2,
+                    CoverageCategory::Variant => &mut *self.3,
+                };
+                map.insert(key.into_bytes(), self.4);
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<'de> Deserialize<'de> for CoverageByXPathLevels {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct CoverageByXPathLevelsVisitor;
+
+        impl<'de> Visitor<'de> for CoverageByXPathLevelsVisitor {
+            type Value = CoverageByXPathLevels;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+                formatter.write_str("a struct CoverageByXPathLevels")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                let mut map_lang = LiteMap::new_vec();
+                let mut map_terr = LiteMap::new_vec();
+                let mut map_script = LiteMap::new_vec();
+                let mut map_var = LiteMap::new_vec();
+
+                while let Some(key) = map.next_key::<std::borrow::Cow<'_, str>>()? {
+                    let level_val = match key.as_ref() {
+                        "core" => CoverageLevelForXPath::Core.to_usize(),
+                        "basic" => CoverageLevelForXPath::Basic.to_usize(),
+                        "moderate" => CoverageLevelForXPath::Moderate.to_usize(),
+                        "modern" => CoverageLevelForXPath::Modern.to_usize(),
+                        _ => {
+                            let _ = map.next_value::<serde::de::IgnoredAny>()?;
+                            continue;
+                        }
                     };
-                    map.insert(key.into_bytes(), tier_val);
+                    map.next_value_seed(XPathArraySeed(
+                        &mut map_lang,
+                        &mut map_terr,
+                        &mut map_script,
+                        &mut map_var,
+                        level_val,
+                    ))?;
                 }
+
+                Ok(CoverageByXPathLevels {
+                    language: CoverageCategoryLevels(
+                        ZeroTrieSimpleAscii::try_from(&map_lang)
+                            .map_err(serde::de::Error::custom)?,
+                    ),
+                    territory: CoverageCategoryLevels(
+                        ZeroTrieSimpleAscii::try_from(&map_terr)
+                            .map_err(serde::de::Error::custom)?,
+                    ),
+                    script: CoverageCategoryLevels(
+                        ZeroTrieSimpleAscii::try_from(&map_script)
+                            .map_err(serde::de::Error::custom)?,
+                    ),
+                    variant: CoverageCategoryLevels(
+                        ZeroTrieSimpleAscii::try_from(&map_var)
+                            .map_err(serde::de::Error::custom)?,
+                    ),
+                })
             }
         }
 
-        Ok(CoverageByXPathLevels {
-            language: CoverageCategoryLevels(
-                ZeroTrieSimpleAscii::try_from(&map_lang).map_err(|e| format!("{e:?}"))?,
-            ),
-            territory: CoverageCategoryLevels(
-                ZeroTrieSimpleAscii::try_from(&map_terr).map_err(|e| format!("{e:?}"))?,
-            ),
-            script: CoverageCategoryLevels(
-                ZeroTrieSimpleAscii::try_from(&map_script).map_err(|e| format!("{e:?}"))?,
-            ),
-            variant: CoverageCategoryLevels(
-                ZeroTrieSimpleAscii::try_from(&map_var).map_err(|e| format!("{e:?}"))?,
-            ),
-        })
+        deserializer.deserialize_map(CoverageByXPathLevelsVisitor)
     }
 }
 

--- a/provider/source/src/displaynames/coverage_experimental.rs
+++ b/provider/source/src/displaynames/coverage_experimental.rs
@@ -201,6 +201,8 @@ impl<'de, 'a> Visitor<'de> for XPathArrayVisitor<'a> {
         A: SeqAccess<'de>,
     {
         while let Some(xpath) = seq.next_element::<Cow<'_, str>>()? {
+            // Non-ASCII XPaths (e.g. emoji annotations) are not display names subtags
+            // and cannot be stored in ZeroTrieSimpleAscii.
             if !xpath.is_ascii() {
                 continue;
             }

--- a/provider/source/src/displaynames/coverage_experimental.rs
+++ b/provider/source/src/displaynames/coverage_experimental.rs
@@ -223,6 +223,7 @@ impl CoverageLevelForXPath {
             1 => Some(Self::Basic),
             2 => Some(Self::Moderate),
             3 => Some(Self::Modern),
+            4 => Some(Self::Comprehensive),
             _ => None,
         }
     }

--- a/provider/source/src/displaynames/coverage_experimental.rs
+++ b/provider/source/src/displaynames/coverage_experimental.rs
@@ -14,6 +14,7 @@ use crate::source::SerdeCache;
 use icu_provider::prelude::*;
 use litemap::LiteMap;
 use serde::Deserialize;
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 #[cfg(test)]
 use std::collections::HashMap;
@@ -199,7 +200,7 @@ impl<'de, 'a> Visitor<'de> for XPathArrayVisitor<'a> {
     where
         A: SeqAccess<'de>,
     {
-        while let Some(xpath) = seq.next_element::<std::borrow::Cow<'_, str>>()? {
+        while let Some(xpath) = seq.next_element::<Cow<'_, str>>()? {
             if !xpath.is_ascii() {
                 continue;
             }
@@ -240,7 +241,7 @@ impl<'de> Deserialize<'de> for CoverageByXPathLevels {
                 let mut map_script = LiteMap::new_vec();
                 let mut map_var = LiteMap::new_vec();
 
-                while let Some(key) = map.next_key::<std::borrow::Cow<'_, str>>()? {
+                while let Some(key) = map.next_key::<Cow<'_, str>>()? {
                     let level_val = match key.as_ref() {
                         "core" => CoverageLevelForXPath::Core.to_usize(),
                         "basic" => CoverageLevelForXPath::Basic.to_usize(),

--- a/provider/source/src/displaynames/coverage_experimental.rs
+++ b/provider/source/src/displaynames/coverage_experimental.rs
@@ -57,10 +57,7 @@ fn parse_cldr_xpath(xpath: &str) -> Option<(DisplayNameCategory, String)> {
 
     let type_prefix = "[@type=\"";
     let rest = rest.strip_prefix(type_prefix)?;
-    let quote_idx = rest.find('"')?;
-    let val = &rest[..quote_idx];
-    let remaining_attrs = &rest[quote_idx + 1..];
-    let extra_attrs = remaining_attrs.strip_prefix(']')?;
+    let (val, extra_attrs) = rest.split_once("\"]")?;
 
     let key = if extra_attrs.is_empty() {
         val.to_string()

--- a/provider/source/src/displaynames/coverage_experimental.rs
+++ b/provider/source/src/displaynames/coverage_experimental.rs
@@ -59,10 +59,43 @@ fn parse_cldr_xpath(xpath: &str) -> Option<(CoverageCategory, String)> {
     let rest = rest.strip_prefix(type_prefix)?;
     let (val, extra_attrs) = rest.split_once("\"]")?;
 
+    let normalized_val = match category {
+        CoverageCategory::Language => {
+            if let Ok(lang) = val.parse::<icu_locale_core::subtags::Language>() {
+                lang.to_string()
+            } else if let Ok(lang_id) = val.parse::<icu_locale_core::LanguageIdentifier>() {
+                lang_id.to_string()
+            } else {
+                val.replace('_', "-")
+            }
+        }
+        CoverageCategory::Territory => {
+            if let Ok(region) = val.parse::<icu_locale_core::subtags::Region>() {
+                region.to_string()
+            } else {
+                val.to_string()
+            }
+        }
+        CoverageCategory::Script => {
+            if let Ok(script) = val.parse::<icu_locale_core::subtags::Script>() {
+                script.to_string()
+            } else {
+                val.to_string()
+            }
+        }
+        CoverageCategory::Variant => {
+            if let Ok(variant) = val.parse::<icu_locale_core::subtags::Variant>() {
+                variant.to_string()
+            } else {
+                val.to_string()
+            }
+        }
+    };
+
     let key = if extra_attrs.is_empty() {
-        val.to_string()
+        normalized_val
     } else {
-        format!("{val}{extra_attrs}")
+        format!("{normalized_val}{extra_attrs}")
     };
 
     Some((category, key))
@@ -83,13 +116,7 @@ impl CoverageCategoryLevels {
     ) -> Option<CoverageLevelForXPath> {
         use core::fmt::Write;
         let mut cursor = self.0.cursor();
-        writeable::adapters::Replace {
-            source: &subtag,
-            needle: "-",
-            replacement: '_',
-        }
-        .write_to(&mut cursor)
-        .ok()?;
+        subtag.write_to(&mut cursor).ok()?;
 
         if cursor.is_empty() {
             return None;

--- a/provider/source/src/displaynames/coverage_experimental.rs
+++ b/provider/source/src/displaynames/coverage_experimental.rs
@@ -11,6 +11,8 @@ use crate::cldr_cache::CldrCache;
 use crate::cldr_serde::displaynames::WithAlt;
 use crate::cldr_serde::displaynames::{Alt, Menu};
 use crate::source::SerdeCache;
+use icu_locale_core::LanguageIdentifier;
+use icu_locale_core::subtags::{Language, Region, Script, Variant};
 use icu_provider::prelude::*;
 use litemap::LiteMap;
 use serde::Deserialize;
@@ -62,30 +64,30 @@ fn parse_cldr_xpath(xpath: &str) -> Option<(CoverageCategory, String)> {
 
     let normalized_val = match category {
         CoverageCategory::Language => {
-            if let Ok(lang) = val.parse::<icu_locale_core::subtags::Language>() {
+            if let Ok(lang) = val.parse::<Language>() {
                 lang.to_string()
-            } else if let Ok(lang_id) = val.parse::<icu_locale_core::LanguageIdentifier>() {
+            } else if let Ok(lang_id) = val.parse::<LanguageIdentifier>() {
                 lang_id.to_string()
             } else {
                 val.replace('_', "-")
             }
         }
         CoverageCategory::Territory => {
-            if let Ok(region) = val.parse::<icu_locale_core::subtags::Region>() {
+            if let Ok(region) = val.parse::<Region>() {
                 region.to_string()
             } else {
                 val.to_string()
             }
         }
         CoverageCategory::Script => {
-            if let Ok(script) = val.parse::<icu_locale_core::subtags::Script>() {
+            if let Ok(script) = val.parse::<Script>() {
                 script.to_string()
             } else {
                 val.to_string()
             }
         }
         CoverageCategory::Variant => {
-            if let Ok(variant) = val.parse::<icu_locale_core::subtags::Variant>() {
+            if let Ok(variant) = val.parse::<Variant>() {
                 variant.to_string()
             } else {
                 val.to_string()

--- a/provider/source/src/displaynames/coverage_experimental.rs
+++ b/provider/source/src/displaynames/coverage_experimental.rs
@@ -50,10 +50,9 @@ fn parse_cldr_xpath(xpath: &str) -> Option<(DisplayNameCategory, String)> {
         (DisplayNameCategory::Territory, r)
     } else if let Some(r) = xpath.strip_prefix(prefix_script) {
         (DisplayNameCategory::Script, r)
-    } else if let Some(r) = xpath.strip_prefix(prefix_var) {
-        (DisplayNameCategory::Variant, r)
     } else {
-        return None;
+        let r = xpath.strip_prefix(prefix_var)?;
+        (DisplayNameCategory::Variant, r)
     };
 
     let type_prefix = "[@type=\"";
@@ -88,7 +87,7 @@ struct RawCoverageByXPathLevels {
 ///
 /// **Note on File Contents & Scope**:
 /// `CoverageByXPathLevels` contains parsed coverage level data specifically tailored for display names subtags.
-/// If additional CLDR XPaths (e.g., unit patterns, currency display names, or calendar fields) need to be supported
+/// If additional CLDR `XPaths` (e.g., unit patterns, currency display names, or calendar fields) need to be supported
 /// for coverage filtering in the future, they should be parsed into their own category-specific `ZeroTrie` fields
 /// on this struct or a dedicated coverage struct, following the pattern of the display names fields below.
 #[derive(Deserialize, Debug)]

--- a/provider/source/src/displaynames/coverage_experimental.rs
+++ b/provider/source/src/displaynames/coverage_experimental.rs
@@ -31,28 +31,28 @@ pub(super) struct CoverageByXPathResource {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub(super) enum DisplayNameCategory {
+enum CoverageCategory {
     Language,
     Territory,
     Script,
     Variant,
 }
 
-fn parse_cldr_xpath(xpath: &str) -> Option<(DisplayNameCategory, String)> {
+fn parse_cldr_xpath(xpath: &str) -> Option<(CoverageCategory, String)> {
     let prefix_lang = "//ldml/localeDisplayNames/languages/language";
     let prefix_terr = "//ldml/localeDisplayNames/territories/territory";
     let prefix_script = "//ldml/localeDisplayNames/scripts/script";
     let prefix_var = "//ldml/localeDisplayNames/variants/variant";
 
     let (category, rest) = if let Some(r) = xpath.strip_prefix(prefix_lang) {
-        (DisplayNameCategory::Language, r)
+        (CoverageCategory::Language, r)
     } else if let Some(r) = xpath.strip_prefix(prefix_terr) {
-        (DisplayNameCategory::Territory, r)
+        (CoverageCategory::Territory, r)
     } else if let Some(r) = xpath.strip_prefix(prefix_script) {
-        (DisplayNameCategory::Script, r)
+        (CoverageCategory::Script, r)
     } else {
         let r = xpath.strip_prefix(prefix_var)?;
-        (DisplayNameCategory::Variant, r)
+        (CoverageCategory::Variant, r)
     };
 
     let type_prefix = "[@type=\"";
@@ -81,19 +81,61 @@ struct RawCoverageByXPathLevels {
 }
 
 /// Coverage level representation for display names categories (`language`, `territory`, `script`, `variant`).
-///
-/// **Note on File Contents & Scope**:
-/// `CoverageByXPathLevels` contains parsed coverage level data specifically tailored for display names subtags.
-/// If additional CLDR `XPaths` (e.g., unit patterns, currency display names, or calendar fields) need to be supported
-/// for coverage filtering in the future, they should be parsed into their own category-specific `ZeroTrie` fields
-/// on this struct or a dedicated coverage struct, following the pattern of the display names fields below.
+#[derive(Debug, Default)]
+pub(super) struct CoverageCategoryLevels(pub(super) ZeroTrieSimpleAscii<Vec<u8>>);
+
+impl CoverageCategoryLevels {
+    pub(super) fn level(
+        &self,
+        subtag: impl Writeable,
+        is_language: bool,
+        alt: Option<Alt>,
+        menu: Option<Menu>,
+    ) -> Option<CoverageLevelForXPath> {
+        use core::fmt::Write;
+        let mut cursor = self.0.cursor();
+        if is_language {
+            writeable::adapters::Replace {
+                source: &subtag,
+                needle: "-",
+                replacement: '_',
+            }
+            .write_to(&mut cursor)
+            .ok()?;
+        } else {
+            subtag.write_to(&mut cursor).ok()?;
+        }
+
+        if cursor.is_empty() {
+            return None;
+        }
+
+        if let Some(alt) = alt {
+            cursor.write_str("[@alt=\"").ok()?;
+            cursor.write_str(alt.as_str()).ok()?;
+            cursor.write_str("\"]").ok()?;
+        }
+
+        if let Some(menu) = menu {
+            cursor.write_str("[@menu=\"").ok()?;
+            cursor.write_str(menu.as_str()).ok()?;
+            cursor.write_str("\"]").ok()?;
+        }
+
+        cursor
+            .take_value()
+            .and_then(CoverageLevelForXPath::from_usize)
+    }
+}
+
+/// Coverage level representation for display names categories (`language`, `territory`, `script`, `variant`).
 #[derive(Deserialize, Debug)]
 #[serde(try_from = "RawCoverageByXPathLevels")]
 pub(super) struct CoverageByXPathLevels {
-    pub(super) language: ZeroTrieSimpleAscii<Vec<u8>>,
-    pub(super) territory: ZeroTrieSimpleAscii<Vec<u8>>,
-    pub(super) script: ZeroTrieSimpleAscii<Vec<u8>>,
-    pub(super) variant: ZeroTrieSimpleAscii<Vec<u8>>,
+    pub(super) language: CoverageCategoryLevels,
+    pub(super) territory: CoverageCategoryLevels,
+    pub(super) script: CoverageCategoryLevels,
+    pub(super) variant: CoverageCategoryLevels,
 }
 
 impl TryFrom<RawCoverageByXPathLevels> for CoverageByXPathLevels {
@@ -120,10 +162,10 @@ impl TryFrom<RawCoverageByXPathLevels> for CoverageByXPathLevels {
                 }
                 if let Some((category, key)) = parse_cldr_xpath(&xpath) {
                     let map = match category {
-                        DisplayNameCategory::Language => &mut map_lang,
-                        DisplayNameCategory::Territory => &mut map_terr,
-                        DisplayNameCategory::Script => &mut map_script,
-                        DisplayNameCategory::Variant => &mut map_var,
+                        CoverageCategory::Language => &mut map_lang,
+                        CoverageCategory::Territory => &mut map_terr,
+                        CoverageCategory::Script => &mut map_script,
+                        CoverageCategory::Variant => &mut map_var,
                     };
                     map.insert(key.into_bytes(), tier_val);
                 }
@@ -131,63 +173,19 @@ impl TryFrom<RawCoverageByXPathLevels> for CoverageByXPathLevels {
         }
 
         Ok(CoverageByXPathLevels {
-            language: ZeroTrieSimpleAscii::try_from(&map_lang).map_err(|e| format!("{e:?}"))?,
-            territory: ZeroTrieSimpleAscii::try_from(&map_terr).map_err(|e| format!("{e:?}"))?,
-            script: ZeroTrieSimpleAscii::try_from(&map_script).map_err(|e| format!("{e:?}"))?,
-            variant: ZeroTrieSimpleAscii::try_from(&map_var).map_err(|e| format!("{e:?}"))?,
+            language: CoverageCategoryLevels(
+                ZeroTrieSimpleAscii::try_from(&map_lang).map_err(|e| format!("{e:?}"))?,
+            ),
+            territory: CoverageCategoryLevels(
+                ZeroTrieSimpleAscii::try_from(&map_terr).map_err(|e| format!("{e:?}"))?,
+            ),
+            script: CoverageCategoryLevels(
+                ZeroTrieSimpleAscii::try_from(&map_script).map_err(|e| format!("{e:?}"))?,
+            ),
+            variant: CoverageCategoryLevels(
+                ZeroTrieSimpleAscii::try_from(&map_var).map_err(|e| format!("{e:?}"))?,
+            ),
         })
-    }
-}
-
-impl CoverageByXPathLevels {
-    pub(super) fn level_for_category(
-        &self,
-        category: DisplayNameCategory,
-        subtag: impl Writeable,
-        alt: Option<Alt>,
-        menu: Option<Menu>,
-    ) -> Option<CoverageLevelForXPath> {
-        use core::fmt::Write;
-        let trie = match category {
-            DisplayNameCategory::Language => &self.language,
-            DisplayNameCategory::Territory => &self.territory,
-            DisplayNameCategory::Script => &self.script,
-            DisplayNameCategory::Variant => &self.variant,
-        };
-
-        let mut cursor = trie.cursor();
-        if category == DisplayNameCategory::Language {
-            writeable::adapters::Replace {
-                source: &subtag,
-                needle: "-",
-                replacement: '_',
-            }
-            .write_to(&mut cursor)
-            .ok()?;
-        } else {
-            subtag.write_to(&mut cursor).ok()?;
-        }
-
-        // return early
-        if cursor.is_empty() {
-            return None;
-        }
-
-        if let Some(alt) = alt {
-            cursor.write_str("[@alt=\"").ok()?;
-            cursor.write_str(alt.as_str()).ok()?;
-            cursor.write_str("\"]").ok()?;
-        }
-
-        if let Some(menu) = menu {
-            cursor.write_str("[@menu=\"").ok()?;
-            cursor.write_str(menu.as_str()).ok()?;
-            cursor.write_str("\"]").ok()?;
-        }
-
-        cursor
-            .take_value()
-            .and_then(CoverageLevelForXPath::from_usize)
     }
 }
 
@@ -255,18 +253,20 @@ impl CoverageByXPathCache {
         Ok(resource.coverage_by_xpath.get("root"))
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn coverage_tier_from_levels(
         locale_levels: Option<&CoverageByXPathLevels>,
         root_levels: Option<&CoverageByXPathLevels>,
-        category: DisplayNameCategory,
+        get_category: impl Fn(&CoverageByXPathLevels) -> &CoverageCategoryLevels,
+        is_language: bool,
         subtag: impl Writeable,
         alt: Option<Alt>,
         menu: Option<Menu>,
     ) -> CoverageLevelForXPath {
         locale_levels
-            .and_then(|l| l.level_for_category(category, &subtag, alt, menu))
+            .and_then(|l| get_category(l).level(&subtag, is_language, alt, menu))
             .or_else(|| {
-                root_levels.and_then(|l| l.level_for_category(category, &subtag, alt, menu))
+                root_levels.and_then(|l| get_category(l).level(&subtag, is_language, alt, menu))
             })
             .unwrap_or(CoverageLevelForXPath::Comprehensive)
     }
@@ -277,10 +277,12 @@ impl CoverageByXPathCache {
     /// 1. Locale-specific override file `displaynames/coverageByXPath/{locale}.json`
     /// 2. Root defaults file `displaynames/coverageByXPath.json`
     /// 3. Defaults to [`CoverageLevelForXPath::Comprehensive`] if unlisted everywhere.
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn coverage_tier(
         &self,
         locale: &DataLocale,
-        category: DisplayNameCategory,
+        get_category: impl Fn(&CoverageByXPathLevels) -> &CoverageCategoryLevels,
+        is_language: bool,
         subtag: impl Writeable,
         alt: Option<Alt>,
         menu: Option<Menu>,
@@ -291,7 +293,8 @@ impl CoverageByXPathCache {
         Ok(Self::coverage_tier_from_levels(
             locale_levels,
             root_levels,
-            category,
+            get_category,
+            is_language,
             subtag,
             alt,
             menu,
@@ -1108,7 +1111,8 @@ pub(super) trait CheckAltCoverage {
 pub(super) fn for_each_cldr_key_and_tier<Resource, T>(
     cldr: &CldrCache,
     file_name: &str,
-    category: DisplayNameCategory,
+    get_category: impl Fn(&CoverageByXPathLevels) -> &CoverageCategoryLevels,
+    is_language: bool,
     mut extract_keys: impl FnMut(&Resource) -> &HashMap<WithAlt<T>, String>,
     mut callback: impl FnMut(&DataLocale, &WithAlt<T>, CoverageLevelForXPath),
 ) where
@@ -1129,7 +1133,15 @@ pub(super) fn for_each_cldr_key_and_tier<Resource, T>(
                     return;
                 }
                 let tier = coverage_cldr
-                    .coverage_tier(&locale, category, &key.subtag, key.alt, key.menu, cldr)
+                    .coverage_tier(
+                        &locale,
+                        &get_category,
+                        is_language,
+                        &key.subtag,
+                        key.alt,
+                        key.menu,
+                        cldr,
+                    )
                     .unwrap();
                 callback(&locale, key, tier);
             }
@@ -1148,7 +1160,7 @@ fn test_coverage_tier() {
     let en = DataLocale::from_str("en").unwrap();
     assert_eq!(
         coverage_cldr
-            .coverage_tier(&en, DisplayNameCategory::Language, "en", None, None, cldr)
+            .coverage_tier(&en, |l| &l.language, true, "en", None, None, cldr)
             .unwrap(),
         CoverageLevelForXPath::Basic
     );
@@ -1157,7 +1169,8 @@ fn test_coverage_tier() {
         coverage_cldr
             .coverage_tier(
                 &en,
-                DisplayNameCategory::Language,
+                |l| &l.language,
+                true,
                 "unlisted_test_code",
                 None,
                 None,

--- a/provider/source/src/displaynames/coverage_experimental.rs
+++ b/provider/source/src/displaynames/coverage_experimental.rs
@@ -78,23 +78,18 @@ impl CoverageCategoryLevels {
     pub(super) fn level(
         &self,
         subtag: impl Writeable,
-        is_language: bool,
         alt: Option<Alt>,
         menu: Option<Menu>,
     ) -> Option<CoverageLevelForXPath> {
         use core::fmt::Write;
         let mut cursor = self.0.cursor();
-        if is_language {
-            writeable::adapters::Replace {
-                source: &subtag,
-                needle: "-",
-                replacement: '_',
-            }
-            .write_to(&mut cursor)
-            .ok()?;
-        } else {
-            subtag.write_to(&mut cursor).ok()?;
+        writeable::adapters::Replace {
+            source: &subtag,
+            needle: "-",
+            replacement: '_',
         }
+        .write_to(&mut cursor)
+        .ok()?;
 
         if cursor.is_empty() {
             return None;
@@ -315,21 +310,17 @@ impl CoverageByXPathCache {
         Ok(resource.coverage_by_xpath.get("root"))
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub(super) fn coverage_tier_from_levels(
         locale_levels: Option<&CoverageByXPathLevels>,
         root_levels: Option<&CoverageByXPathLevels>,
         get_category: impl Fn(&CoverageByXPathLevels) -> &CoverageCategoryLevels,
-        is_language: bool,
         subtag: impl Writeable,
         alt: Option<Alt>,
         menu: Option<Menu>,
     ) -> CoverageLevelForXPath {
         locale_levels
-            .and_then(|l| get_category(l).level(&subtag, is_language, alt, menu))
-            .or_else(|| {
-                root_levels.and_then(|l| get_category(l).level(&subtag, is_language, alt, menu))
-            })
+            .and_then(|l| get_category(l).level(&subtag, alt, menu))
+            .or_else(|| root_levels.and_then(|l| get_category(l).level(&subtag, alt, menu)))
             .unwrap_or(CoverageLevelForXPath::Comprehensive)
     }
 
@@ -339,12 +330,10 @@ impl CoverageByXPathCache {
     /// 1. Locale-specific override file `displaynames/coverageByXPath/{locale}.json`
     /// 2. Root defaults file `displaynames/coverageByXPath.json`
     /// 3. Defaults to [`CoverageLevelForXPath::Comprehensive`] if unlisted everywhere.
-    #[allow(clippy::too_many_arguments)]
     pub(super) fn coverage_tier(
         &self,
         locale: &DataLocale,
         get_category: impl Fn(&CoverageByXPathLevels) -> &CoverageCategoryLevels,
-        is_language: bool,
         subtag: impl Writeable,
         alt: Option<Alt>,
         menu: Option<Menu>,
@@ -356,7 +345,6 @@ impl CoverageByXPathCache {
             locale_levels,
             root_levels,
             get_category,
-            is_language,
             subtag,
             alt,
             menu,
@@ -1174,7 +1162,6 @@ pub(super) fn for_each_cldr_key_and_tier<Resource, T>(
     cldr: &CldrCache,
     file_name: &str,
     get_category: impl Fn(&CoverageByXPathLevels) -> &CoverageCategoryLevels,
-    is_language: bool,
     mut extract_keys: impl FnMut(&Resource) -> &HashMap<WithAlt<T>, String>,
     mut callback: impl FnMut(&DataLocale, &WithAlt<T>, CoverageLevelForXPath),
 ) where
@@ -1195,15 +1182,7 @@ pub(super) fn for_each_cldr_key_and_tier<Resource, T>(
                     return;
                 }
                 let tier = coverage_cldr
-                    .coverage_tier(
-                        &locale,
-                        &get_category,
-                        is_language,
-                        &key.subtag,
-                        key.alt,
-                        key.menu,
-                        cldr,
-                    )
+                    .coverage_tier(&locale, &get_category, &key.subtag, key.alt, key.menu, cldr)
                     .unwrap();
                 callback(&locale, key, tier);
             }
@@ -1222,22 +1201,14 @@ fn test_coverage_tier() {
     let en = DataLocale::from_str("en").unwrap();
     assert_eq!(
         coverage_cldr
-            .coverage_tier(&en, |l| &l.language, true, "en", None, None, cldr)
+            .coverage_tier(&en, |l| &l.language, "en", None, None, cldr)
             .unwrap(),
         CoverageLevelForXPath::Basic
     );
 
     assert_eq!(
         coverage_cldr
-            .coverage_tier(
-                &en,
-                |l| &l.language,
-                true,
-                "unlisted_test_code",
-                None,
-                None,
-                cldr
-            )
+            .coverage_tier(&en, |l| &l.language, "unlisted_test_code", None, None, cldr)
             .unwrap(),
         CoverageLevelForXPath::Comprehensive
     );

--- a/provider/source/src/displaynames/coverage_experimental.rs
+++ b/provider/source/src/displaynames/coverage_experimental.rs
@@ -114,6 +114,12 @@ impl CoverageCategoryLevels {
 }
 
 /// Coverage level representation for display names categories (`language`, `territory`, `script`, `variant`).
+///
+/// # Note on File Contents & Scope
+/// The raw source JSON files (`coverageByXPath.json` and `coverageByXPath/{locale}.json`) contain `XPaths`
+/// for many CLDR elements beyond display names. During Serde deserialization, only supported display name
+/// category `XPaths` are parsed into their respective trie maps (`language`, `territory`, `script`, `variant`),
+/// and all unrelated `XPaths` are ignored.
 #[derive(Debug)]
 pub(super) struct CoverageByXPathLevels {
     pub(super) language: CoverageCategoryLevels,
@@ -1154,9 +1160,8 @@ pub(super) trait CheckAltCoverage {
 ///
 /// For each entry found in `file_name` (e.g., `"languages.json"`), this function:
 /// 1. Extracts the map of subtag keys (`WithAlt<T>`) via `extract_keys`.
-/// 2. Constructs the corresponding CLDR `XPath` for `xpath_field` (e.g., `"languages"`).
-/// 3. Looks up the coverage tier (`CoverageLevelForXPath`) for that `XPath` in the given locale.
-/// 4. Invokes `callback(locale, key, tier)`.
+/// 2. Looks up the coverage tier (`CoverageLevelForXPath`) for that entry in the given locale using `get_category`.
+/// 3. Invokes `callback(locale, key, tier)`.
 #[cfg(test)]
 pub(super) fn for_each_cldr_key_and_tier<Resource, T>(
     cldr: &CldrCache,

--- a/provider/source/src/displaynames/coverage_experimental.rs
+++ b/provider/source/src/displaynames/coverage_experimental.rs
@@ -103,7 +103,7 @@ fn parse_cldr_xpath(xpath: &str) -> Option<(CoverageCategory, String)> {
 
 use serde::de::{DeserializeSeed, Deserializer, MapAccess, SeqAccess, Visitor};
 
-/// Coverage level representation for display names categories (`language`, `territory`, `script`, `variant`).
+/// Single-category trie mapping subtag keys to coverage levels (`CoverageLevelForXPath`).
 #[derive(Debug, Default)]
 pub(super) struct CoverageCategoryLevels(pub(super) ZeroTrieSimpleAscii<Vec<u8>>);
 

--- a/provider/source/src/displaynames/coverage_experimental.rs
+++ b/provider/source/src/displaynames/coverage_experimental.rs
@@ -175,7 +175,7 @@ struct XPathArrayVisitor<'a> {
 impl<'de, 'a> DeserializeSeed<'de> for XPathArraySeed<'a> {
     type Value = ();
 
-    fn deserialize(self, deserializer: D) -> Result<Self::Value, D::Error>
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
     where
         D: Deserializer<'de>,
     {
@@ -196,7 +196,7 @@ impl<'de, 'a> Visitor<'de> for XPathArrayVisitor<'a> {
         formatter.write_str("a sequence of CLDR XPaths")
     }
 
-    fn visit_seq<A>(mut self, mut seq: A) -> Result<Self::Value, A::Error>
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
     where
         A: SeqAccess<'de>,
     {

--- a/provider/source/src/displaynames/coverage_experimental.rs
+++ b/provider/source/src/displaynames/coverage_experimental.rs
@@ -95,15 +95,15 @@ impl CoverageCategoryLevels {
             return None;
         }
 
-        if let Some(alt) = alt {
+        if let Some(alt) = alt.and_then(Alt::as_str) {
             cursor.write_str("[@alt=\"").ok()?;
-            cursor.write_str(alt.as_str()).ok()?;
+            cursor.write_str(alt).ok()?;
             cursor.write_str("\"]").ok()?;
         }
 
-        if let Some(menu) = menu {
+        if let Some(menu) = menu.and_then(Menu::as_str) {
             cursor.write_str("[@menu=\"").ok()?;
-            cursor.write_str(menu.as_str()).ok()?;
+            cursor.write_str(menu).ok()?;
             cursor.write_str("\"]").ok()?;
         }
 

--- a/provider/source/src/displaynames/coverage_experimental.rs
+++ b/provider/source/src/displaynames/coverage_experimental.rs
@@ -14,11 +14,9 @@ use crate::source::SerdeCache;
 use icu_provider::prelude::*;
 use litemap::LiteMap;
 use serde::Deserialize;
-use serde::de::{Deserializer, Error as DeError, SeqAccess, Visitor};
 use std::collections::BTreeMap;
 #[cfg(test)]
 use std::collections::HashMap;
-use std::fmt;
 use std::sync::OnceLock;
 use writeable::Writeable;
 use zerotrie::ZeroTrieSimpleAscii;
@@ -32,76 +30,169 @@ pub(super) struct CoverageByXPathResource {
     pub(super) coverage_by_xpath: BTreeMap<String, CoverageByXPathLevels>,
 }
 
-/// Representation of coverage levels (`basic`, `core`, `moderate`, `modern`) containing sets of `XPaths`.
-/// If this is added to CLDR JSON, this should be moved to `cldr_serde`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub(super) enum DisplayNameCategory {
+    Language,
+    Territory,
+    Script,
+    Variant,
+}
+
+fn parse_cldr_xpath(xpath: &str) -> Option<(DisplayNameCategory, String)> {
+    let prefix_lang = "//ldml/localeDisplayNames/languages/language";
+    let prefix_terr = "//ldml/localeDisplayNames/territories/territory";
+    let prefix_script = "//ldml/localeDisplayNames/scripts/script";
+    let prefix_var = "//ldml/localeDisplayNames/variants/variant";
+
+    let (category, rest) = if let Some(r) = xpath.strip_prefix(prefix_lang) {
+        (DisplayNameCategory::Language, r)
+    } else if let Some(r) = xpath.strip_prefix(prefix_terr) {
+        (DisplayNameCategory::Territory, r)
+    } else if let Some(r) = xpath.strip_prefix(prefix_script) {
+        (DisplayNameCategory::Script, r)
+    } else if let Some(r) = xpath.strip_prefix(prefix_var) {
+        (DisplayNameCategory::Variant, r)
+    } else {
+        return None;
+    };
+
+    let type_prefix = "[@type=\"";
+    let rest = rest.strip_prefix(type_prefix)?;
+    let quote_idx = rest.find('"')?;
+    let val = &rest[..quote_idx];
+    let remaining_attrs = &rest[quote_idx + 1..];
+    let extra_attrs = remaining_attrs.strip_prefix(']')?;
+
+    let key = if extra_attrs.is_empty() {
+        val.to_string()
+    } else {
+        format!("{val}{extra_attrs}")
+    };
+
+    Some((category, key))
+}
+
+#[derive(Deserialize)]
+struct RawCoverageByXPathLevels {
+    #[serde(default)]
+    basic: Vec<String>,
+    #[serde(default)]
+    core: Vec<String>,
+    #[serde(default)]
+    moderate: Vec<String>,
+    #[serde(default)]
+    modern: Vec<String>,
+}
+
+/// Coverage level representation for display names categories (`language`, `territory`, `script`, `variant`).
+///
+/// **Note on File Contents & Scope**:
+/// `CoverageByXPathLevels` contains parsed coverage level data specifically tailored for display names subtags.
+/// If additional CLDR XPaths (e.g., unit patterns, currency display names, or calendar fields) need to be supported
+/// for coverage filtering in the future, they should be parsed into their own category-specific `ZeroTrie` fields
+/// on this struct or a dedicated coverage struct, following the pattern of the display names fields below.
 #[derive(Deserialize, Debug)]
+#[serde(try_from = "RawCoverageByXPathLevels")]
 pub(super) struct CoverageByXPathLevels {
-    /// `XPaths` classified under the `basic` coverage level.
-    #[serde(default, deserialize_with = "set_to_trie")]
-    pub(super) basic: ZeroTrieSimpleAscii<Vec<u8>>,
-    /// `XPaths` classified under the `core` coverage level.
-    #[serde(default, deserialize_with = "set_to_trie")]
-    pub(super) core: ZeroTrieSimpleAscii<Vec<u8>>,
-    /// `XPaths` classified under the `moderate` coverage level.
-    #[serde(default, deserialize_with = "set_to_trie")]
-    pub(super) moderate: ZeroTrieSimpleAscii<Vec<u8>>,
-    /// `XPaths` classified under the `modern` coverage level.
-    #[serde(default, deserialize_with = "set_to_trie")]
-    pub(super) modern: ZeroTrieSimpleAscii<Vec<u8>>,
+    pub(super) language: ZeroTrieSimpleAscii<Vec<u8>>,
+    pub(super) territory: ZeroTrieSimpleAscii<Vec<u8>>,
+    pub(super) script: ZeroTrieSimpleAscii<Vec<u8>>,
+    pub(super) variant: ZeroTrieSimpleAscii<Vec<u8>>,
+}
+
+impl TryFrom<RawCoverageByXPathLevels> for CoverageByXPathLevels {
+    type Error = String;
+
+    fn try_from(raw: RawCoverageByXPathLevels) -> Result<Self, Self::Error> {
+        let mut map_lang = LiteMap::new_vec();
+        let mut map_terr = LiteMap::new_vec();
+        let mut map_script = LiteMap::new_vec();
+        let mut map_var = LiteMap::new_vec();
+
+        let levels = [
+            (CoverageLevelForXPath::Core, raw.core),
+            (CoverageLevelForXPath::Basic, raw.basic),
+            (CoverageLevelForXPath::Moderate, raw.moderate),
+            (CoverageLevelForXPath::Modern, raw.modern),
+        ];
+
+        for (tier, xpaths) in levels {
+            let tier_val = tier.to_usize();
+            for xpath in xpaths {
+                if !xpath.is_ascii() {
+                    continue;
+                }
+                if let Some((category, key)) = parse_cldr_xpath(&xpath) {
+                    let map = match category {
+                        DisplayNameCategory::Language => &mut map_lang,
+                        DisplayNameCategory::Territory => &mut map_terr,
+                        DisplayNameCategory::Script => &mut map_script,
+                        DisplayNameCategory::Variant => &mut map_var,
+                    };
+                    map.insert(key.into_bytes(), tier_val);
+                }
+            }
+        }
+
+        Ok(CoverageByXPathLevels {
+            language: ZeroTrieSimpleAscii::try_from(&map_lang).map_err(|e| format!("{e:?}"))?,
+            territory: ZeroTrieSimpleAscii::try_from(&map_terr).map_err(|e| format!("{e:?}"))?,
+            script: ZeroTrieSimpleAscii::try_from(&map_script).map_err(|e| format!("{e:?}"))?,
+            variant: ZeroTrieSimpleAscii::try_from(&map_var).map_err(|e| format!("{e:?}"))?,
+        })
+    }
 }
 
 impl CoverageByXPathLevels {
-    pub(super) fn level_for_xpath(&self, xpath: &impl Writeable) -> Option<CoverageLevelForXPath> {
-        let contains = |trie: &ZeroTrieSimpleAscii<Vec<u8>>| {
-            trie.get_with_write_fn(|sink| xpath.write_to(sink))
-                .is_some()
+    pub(super) fn level_for_category(
+        &self,
+        category: DisplayNameCategory,
+        subtag: impl Writeable,
+        alt: Option<Alt>,
+        menu: Option<Menu>,
+    ) -> Option<CoverageLevelForXPath> {
+        use core::fmt::Write;
+        let trie = match category {
+            DisplayNameCategory::Language => &self.language,
+            DisplayNameCategory::Territory => &self.territory,
+            DisplayNameCategory::Script => &self.script,
+            DisplayNameCategory::Variant => &self.variant,
         };
-        if contains(&self.core) {
-            Some(CoverageLevelForXPath::Core)
-        } else if contains(&self.basic) {
-            Some(CoverageLevelForXPath::Basic)
-        } else if contains(&self.moderate) {
-            Some(CoverageLevelForXPath::Moderate)
-        } else if contains(&self.modern) {
-            Some(CoverageLevelForXPath::Modern)
-        } else {
-            None
-        }
-    }
-}
 
-struct ZeroTrieVisitor;
-
-impl<'de> Visitor<'de> for ZeroTrieVisitor {
-    type Value = ZeroTrieSimpleAscii<Vec<u8>>;
-    fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "a sequence of XPaths")
-    }
-    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-    where
-        A: SeqAccess<'de>,
-    {
-        let mut litemap = LiteMap::new_vec();
-        while let Some(elem) = seq.next_element::<String>()? {
-            // CLDR coverage files contain some non-ASCII XPaths, principally emoji annotations
-            // (e.g., //ldml/annotations/annotation[@cp="😀"]).
-            //
-            // However, we want to use a `ZeroTrieSimpleAscii` since it is faster to query.
-            // If we need to support non-ASCII XPaths in the future, this optimization will
-            // need to be revisited.
-            if elem.is_ascii() {
-                litemap.insert(elem.into_bytes(), 0);
+        let mut cursor = trie.cursor();
+        if category == DisplayNameCategory::Language {
+            writeable::adapters::Replace {
+                source: &subtag,
+                needle: "-",
+                replacement: '_',
             }
+            .write_to(&mut cursor)
+            .ok()?;
+        } else {
+            subtag.write_to(&mut cursor).ok()?;
         }
-        ZeroTrieSimpleAscii::try_from(&litemap).map_err(DeError::custom)
-    }
-}
 
-fn set_to_trie<'de, D>(deserializer: D) -> Result<ZeroTrieSimpleAscii<Vec<u8>>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    deserializer.deserialize_seq(ZeroTrieVisitor)
+        // return early
+        if cursor.is_empty() {
+            return None;
+        }
+
+        if let Some(alt) = alt {
+            cursor.write_str("[@alt=\"").ok()?;
+            cursor.write_str(alt.as_str()).ok()?;
+            cursor.write_str("\"]").ok()?;
+        }
+
+        if let Some(menu) = menu {
+            cursor.write_str("[@menu=\"").ok()?;
+            cursor.write_str(menu.as_str()).ok()?;
+            cursor.write_str("\"]").ok()?;
+        }
+
+        cursor
+            .take_value()
+            .and_then(CoverageLevelForXPath::from_usize)
+    }
 }
 
 pub(super) struct CoverageByXPathCache(SerdeCache);
@@ -110,19 +201,80 @@ pub(super) struct CoverageByXPathCache(SerdeCache);
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub(super) enum CoverageLevelForXPath {
     /// Items with `core` CLDR coverage level.
-    Core,
+    Core = 0,
     /// Items with `basic` CLDR coverage level.
-    Basic,
+    Basic = 1,
     /// Items with `moderate` CLDR coverage level.
-    Moderate,
+    Moderate = 2,
     /// Items with `modern` CLDR coverage level.
-    Modern,
+    Modern = 3,
     /// Items with `comprehensive` CLDR coverage level, or unlisted items.
-    Comprehensive,
+    Comprehensive = 4,
+}
+
+impl CoverageLevelForXPath {
+    fn to_usize(self) -> usize {
+        self as usize
+    }
+
+    fn from_usize(val: usize) -> Option<Self> {
+        match val {
+            0 => Some(Self::Core),
+            1 => Some(Self::Basic),
+            2 => Some(Self::Moderate),
+            3 => Some(Self::Modern),
+            _ => None,
+        }
+    }
 }
 
 impl CoverageByXPathCache {
-    /// Determines the [`CoverageLevelForXPath`] for a given `locale` and `xpath` target.
+    pub(super) fn get_levels_for_locale<'a>(
+        &'a self,
+        locale: &DataLocale,
+        cldr_cache: &'a CldrCache,
+    ) -> Result<Option<&'a CoverageByXPathLevels>, DataError> {
+        let locale_path = format!("displaynames/coverageByXPath/{locale}.json");
+        if self.0.file_exists(&locale_path)? {
+            let resource: &CoverageByXPathResource = self.0.read_and_parse_json(&locale_path)?;
+            Ok(resource.coverage_by_xpath.values().next())
+        } else {
+            if locale.variant.is_some() {
+                let mut new_locale = *locale;
+                new_locale.variant = None;
+                self.get_levels_for_locale(&new_locale, cldr_cache)
+            } else if let Some(new_locale) = cldr_cache.add_script_extended(locale)? {
+                self.get_levels_for_locale(&new_locale, cldr_cache)
+            } else {
+                Ok(None)
+            }
+        }
+    }
+
+    pub(super) fn get_root_levels(&self) -> Result<Option<&CoverageByXPathLevels>, DataError> {
+        let resource: &CoverageByXPathResource = self
+            .0
+            .read_and_parse_json("displaynames/coverageByXPath.json")?;
+        Ok(resource.coverage_by_xpath.get("root"))
+    }
+
+    pub(super) fn coverage_tier_from_levels(
+        locale_levels: Option<&CoverageByXPathLevels>,
+        root_levels: Option<&CoverageByXPathLevels>,
+        category: DisplayNameCategory,
+        subtag: impl Writeable,
+        alt: Option<Alt>,
+        menu: Option<Menu>,
+    ) -> CoverageLevelForXPath {
+        locale_levels
+            .and_then(|l| l.level_for_category(category, &subtag, alt, menu))
+            .or_else(|| {
+                root_levels.and_then(|l| l.level_for_category(category, &subtag, alt, menu))
+            })
+            .unwrap_or(CoverageLevelForXPath::Comprehensive)
+    }
+
+    /// Determines the [`CoverageLevelForXPath`] for a given `locale` and subtag item target.
     ///
     /// Resolution lookup precedence:
     /// 1. Locale-specific override file `displaynames/coverageByXPath/{locale}.json`
@@ -131,84 +283,23 @@ impl CoverageByXPathCache {
     pub(super) fn coverage_tier(
         &self,
         locale: &DataLocale,
-        xpath: impl Writeable,
+        category: DisplayNameCategory,
+        subtag: impl Writeable,
+        alt: Option<Alt>,
+        menu: Option<Menu>,
         cldr_cache: &CldrCache,
     ) -> Result<CoverageLevelForXPath, DataError> {
-        let locale_path = format!("displaynames/coverageByXPath/{locale}.json");
-        if self.0.file_exists(&locale_path)? {
-            let resource: &CoverageByXPathResource = self.0.read_and_parse_json(&locale_path)?;
-            let levels = resource.coverage_by_xpath.values().next();
-            if let Some(level) = levels.and_then(|l| l.level_for_xpath(&xpath)) {
-                return Ok(level);
-            }
-        } else {
-            if locale.variant.is_some() {
-                // el-polyton, ...
-                let mut new_locale = *locale;
-                new_locale.variant = None;
-                return self.coverage_tier(&new_locale, xpath, cldr_cache);
-            } else if let Some(new_locale) = cldr_cache.add_script_extended(locale)? {
-                return self.coverage_tier(&new_locale, xpath, cldr_cache);
-            } else {
-                log::warn!("Coverage data file not found for locale {locale}");
-            }
-        }
-
-        let resource: &CoverageByXPathResource = self
-            .0
-            .read_and_parse_json("displaynames/coverageByXPath.json")?;
-        if let Some(level) = resource
-            .coverage_by_xpath
-            .get("root")
-            .and_then(|l| l.level_for_xpath(&xpath))
-        {
-            return Ok(level);
-        }
-
-        // Not found: default to Comprehensive
-        Ok(CoverageLevelForXPath::Comprehensive)
+        let locale_levels = self.get_levels_for_locale(locale, cldr_cache)?;
+        let root_levels = self.get_root_levels()?;
+        Ok(Self::coverage_tier_from_levels(
+            locale_levels,
+            root_levels,
+            category,
+            subtag,
+            alt,
+            menu,
+        ))
     }
-}
-
-/// Helper to construct CLDR `XPath` string for a display name attribute and subtag.
-pub(crate) fn construct_xpath<'a>(
-    xpath_prefix: &'a str,
-    subtag_str: impl Writeable + 'a,
-    alt: Option<Alt>,
-    menu: Option<Menu>,
-) -> impl Writeable + 'a {
-    let alt_str = match (alt, menu) {
-        (None, None) => "",
-        (None, Some(Menu::Core)) => r#"[@menu="core"]"#,
-        (None, Some(Menu::Extension)) => r#"[@menu="extension"]"#,
-        (None, Some(Menu::Unknown)) => "",
-        (Some(Alt::Short), None) => r#"[@alt="short"]"#,
-        (Some(Alt::Long), None) => r#"[@alt="long"]"#,
-        (Some(Alt::Variant), None) => r#"[@alt="variant"]"#,
-        (Some(Alt::StandAlone), None) => r#"[@alt="stand-alone"]"#,
-        (Some(Alt::Official), None) => r#"[@alt="official"]"#,
-        (Some(Alt::Secondary), None) => r#"[@alt="secondary"]"#,
-        (Some(Alt::Biot), None) => r#"[@alt="biot"]"#,
-        (Some(Alt::Chagos), None) => r#"[@alt="chagos"]"#,
-        (Some(Alt::Menu), None) => r#"[@alt="menu"]"#,
-        (Some(Alt::Unknown), None) => "",
-        (Some(_), Some(_)) => {
-            debug_assert!(false, "unexpected alt and menu together: {alt:?} {menu:?}");
-            ""
-        }
-    };
-
-    writeable::concat_writeable!(
-        xpath_prefix,
-        r#"[@type=""#,
-        writeable::adapters::Replace {
-            source: subtag_str,
-            needle: "-",
-            replacement: '_'
-        },
-        r#""]"#,
-        alt_str
-    )
 }
 
 // Note: We statically embed coverage levels for all CLDR locales here so we can support
@@ -1020,7 +1111,7 @@ pub(super) trait CheckAltCoverage {
 pub(super) fn for_each_cldr_key_and_tier<Resource, T>(
     cldr: &CldrCache,
     file_name: &str,
-    xpath_prefix: &str,
+    category: DisplayNameCategory,
     mut extract_keys: impl FnMut(&Resource) -> &HashMap<WithAlt<T>, String>,
     mut callback: impl FnMut(&DataLocale, &WithAlt<T>, CoverageLevelForXPath),
 ) where
@@ -1040,8 +1131,9 @@ pub(super) fn for_each_cldr_key_and_tier<Resource, T>(
                     // TODO(#8012): Handle preference-specific alt variants, perhaps with datagen alt flags.
                     return;
                 }
-                let xpath = construct_xpath(xpath_prefix, &key.subtag, key.alt, key.menu);
-                let tier = coverage_cldr.coverage_tier(&locale, &xpath, cldr).unwrap();
+                let tier = coverage_cldr
+                    .coverage_tier(&locale, category, &key.subtag, key.alt, key.menu, cldr)
+                    .unwrap();
                 callback(&locale, key, tier);
             }
         }
@@ -1057,21 +1149,23 @@ fn test_coverage_tier() {
     let coverage_cldr = coverage_cldr_cache();
 
     let en = DataLocale::from_str("en").unwrap();
-    // Tiny tier XPath (basic language display name in root defaults)
-    let xpath_minimal = "//ldml/localeDisplayNames/languages/language[@type=\"en\"]";
     assert_eq!(
         coverage_cldr
-            .coverage_tier(&en, xpath_minimal, cldr)
+            .coverage_tier(&en, DisplayNameCategory::Language, "en", None, None, cldr)
             .unwrap(),
         CoverageLevelForXPath::Basic
     );
 
-    // Default/unlisted XPath falls back to Comprehensive tier
-    let xpath_unlisted =
-        "//ldml/localeDisplayNames/languages/language[@type=\"unlisted_test_code\"]";
     assert_eq!(
         coverage_cldr
-            .coverage_tier(&en, xpath_unlisted, cldr)
+            .coverage_tier(
+                &en,
+                DisplayNameCategory::Language,
+                "unlisted_test_code",
+                None,
+                None,
+                cldr
+            )
             .unwrap(),
         CoverageLevelForXPath::Comprehensive
     );

--- a/provider/source/src/displaynames/language.rs
+++ b/provider/source/src/displaynames/language.rs
@@ -65,7 +65,7 @@ crate::displaynames::impl_displaynames_v1!(
     "languages.json",
     languages,
     None,
-    crate::displaynames::coverage_experimental::DisplayNameCategory::Language,
+    language,
     CoverageLevelForXPath::Basic | CoverageLevelForXPath::Core,
 );
 crate::displaynames::impl_displaynames_v1!(
@@ -75,7 +75,7 @@ crate::displaynames::impl_displaynames_v1!(
     "languages.json",
     languages,
     None,
-    crate::displaynames::coverage_experimental::DisplayNameCategory::Language,
+    language,
     CoverageLevelForXPath::Moderate,
 );
 crate::displaynames::impl_displaynames_v1!(
@@ -85,7 +85,7 @@ crate::displaynames::impl_displaynames_v1!(
     "languages.json",
     languages,
     None,
-    crate::displaynames::coverage_experimental::DisplayNameCategory::Language,
+    language,
     CoverageLevelForXPath::Modern | CoverageLevelForXPath::Comprehensive,
 );
 
@@ -96,7 +96,7 @@ crate::displaynames::impl_displaynames_v1!(
     "languages.json",
     languages,
     Some(Alt::Short),
-    crate::displaynames::coverage_experimental::DisplayNameCategory::Language,
+    language,
     CoverageLevelForXPath::Moderate,
 );
 crate::displaynames::impl_displaynames_v1!(
@@ -106,7 +106,7 @@ crate::displaynames::impl_displaynames_v1!(
     "languages.json",
     languages,
     Some(Alt::Short),
-    crate::displaynames::coverage_experimental::DisplayNameCategory::Language,
+    language,
     CoverageLevelForXPath::Modern | CoverageLevelForXPath::Comprehensive,
 );
 
@@ -117,7 +117,7 @@ crate::displaynames::impl_displaynames_v1!(
     "languages.json",
     languages,
     Some(Alt::Long),
-    crate::displaynames::coverage_experimental::DisplayNameCategory::Language,
+    language,
     CoverageLevelForXPath::Moderate,
 );
 crate::displaynames::impl_displaynames_v1!(
@@ -127,7 +127,7 @@ crate::displaynames::impl_displaynames_v1!(
     "languages.json",
     languages,
     Some(Alt::Long),
-    crate::displaynames::coverage_experimental::DisplayNameCategory::Language,
+    language,
     CoverageLevelForXPath::Modern | CoverageLevelForXPath::Comprehensive,
 );
 crate::displaynames::impl_displaynames_menu_v1!(
@@ -136,7 +136,7 @@ crate::displaynames::impl_displaynames_menu_v1!(
     cldr_serde::displaynames::language::Resource,
     "languages.json",
     languages,
-    crate::displaynames::coverage_experimental::DisplayNameCategory::Language,
+    language,
     CoverageLevelForXPath::Moderate,
 );
 crate::displaynames::impl_displaynames_menu_v1!(
@@ -145,7 +145,7 @@ crate::displaynames::impl_displaynames_menu_v1!(
     cldr_serde::displaynames::language::Resource,
     "languages.json",
     languages,
-    crate::displaynames::coverage_experimental::DisplayNameCategory::Language,
+    language,
     CoverageLevelForXPath::Modern | CoverageLevelForXPath::Comprehensive,
 );
 
@@ -502,7 +502,8 @@ mod tests {
         crate::displaynames::coverage_experimental::for_each_cldr_key_and_tier(
             cldr,
             "languages.json",
-            crate::displaynames::coverage_experimental::DisplayNameCategory::Language,
+            |l| &l.language,
+            true,
             |res: &cldr_serde::displaynames::language::Resource| {
                 &res.main.value.localedisplaynames.languages
             },

--- a/provider/source/src/displaynames/language.rs
+++ b/provider/source/src/displaynames/language.rs
@@ -503,7 +503,6 @@ mod tests {
             cldr,
             "languages.json",
             |l| &l.language,
-            true,
             |res: &cldr_serde::displaynames::language::Resource| {
                 &res.main.value.localedisplaynames.languages
             },

--- a/provider/source/src/displaynames/language.rs
+++ b/provider/source/src/displaynames/language.rs
@@ -65,7 +65,7 @@ crate::displaynames::impl_displaynames_v1!(
     "languages.json",
     languages,
     None,
-    "//ldml/localeDisplayNames/languages/language",
+    crate::displaynames::coverage_experimental::DisplayNameCategory::Language,
     CoverageLevelForXPath::Basic | CoverageLevelForXPath::Core,
 );
 crate::displaynames::impl_displaynames_v1!(
@@ -75,7 +75,7 @@ crate::displaynames::impl_displaynames_v1!(
     "languages.json",
     languages,
     None,
-    "//ldml/localeDisplayNames/languages/language",
+    crate::displaynames::coverage_experimental::DisplayNameCategory::Language,
     CoverageLevelForXPath::Moderate,
 );
 crate::displaynames::impl_displaynames_v1!(
@@ -85,7 +85,7 @@ crate::displaynames::impl_displaynames_v1!(
     "languages.json",
     languages,
     None,
-    "//ldml/localeDisplayNames/languages/language",
+    crate::displaynames::coverage_experimental::DisplayNameCategory::Language,
     CoverageLevelForXPath::Modern | CoverageLevelForXPath::Comprehensive,
 );
 
@@ -96,7 +96,7 @@ crate::displaynames::impl_displaynames_v1!(
     "languages.json",
     languages,
     Some(Alt::Short),
-    "//ldml/localeDisplayNames/languages/language",
+    crate::displaynames::coverage_experimental::DisplayNameCategory::Language,
     CoverageLevelForXPath::Moderate,
 );
 crate::displaynames::impl_displaynames_v1!(
@@ -106,7 +106,7 @@ crate::displaynames::impl_displaynames_v1!(
     "languages.json",
     languages,
     Some(Alt::Short),
-    "//ldml/localeDisplayNames/languages/language",
+    crate::displaynames::coverage_experimental::DisplayNameCategory::Language,
     CoverageLevelForXPath::Modern | CoverageLevelForXPath::Comprehensive,
 );
 
@@ -117,7 +117,7 @@ crate::displaynames::impl_displaynames_v1!(
     "languages.json",
     languages,
     Some(Alt::Long),
-    "//ldml/localeDisplayNames/languages/language",
+    crate::displaynames::coverage_experimental::DisplayNameCategory::Language,
     CoverageLevelForXPath::Moderate,
 );
 crate::displaynames::impl_displaynames_v1!(
@@ -127,7 +127,7 @@ crate::displaynames::impl_displaynames_v1!(
     "languages.json",
     languages,
     Some(Alt::Long),
-    "//ldml/localeDisplayNames/languages/language",
+    crate::displaynames::coverage_experimental::DisplayNameCategory::Language,
     CoverageLevelForXPath::Modern | CoverageLevelForXPath::Comprehensive,
 );
 crate::displaynames::impl_displaynames_menu_v1!(
@@ -136,7 +136,7 @@ crate::displaynames::impl_displaynames_menu_v1!(
     cldr_serde::displaynames::language::Resource,
     "languages.json",
     languages,
-    "//ldml/localeDisplayNames/languages/language",
+    crate::displaynames::coverage_experimental::DisplayNameCategory::Language,
     CoverageLevelForXPath::Moderate,
 );
 crate::displaynames::impl_displaynames_menu_v1!(
@@ -145,7 +145,7 @@ crate::displaynames::impl_displaynames_menu_v1!(
     cldr_serde::displaynames::language::Resource,
     "languages.json",
     languages,
-    "//ldml/localeDisplayNames/languages/language",
+    crate::displaynames::coverage_experimental::DisplayNameCategory::Language,
     CoverageLevelForXPath::Modern | CoverageLevelForXPath::Comprehensive,
 );
 
@@ -502,7 +502,7 @@ mod tests {
         crate::displaynames::coverage_experimental::for_each_cldr_key_and_tier(
             cldr,
             "languages.json",
-            "//ldml/localeDisplayNames/languages/language",
+            crate::displaynames::coverage_experimental::DisplayNameCategory::Language,
             |res: &cldr_serde::displaynames::language::Resource| {
                 &res.main.value.localedisplaynames.languages
             },

--- a/provider/source/src/displaynames/mod.rs
+++ b/provider/source/src/displaynames/mod.rs
@@ -93,6 +93,7 @@ where
 /// - `$file`: The JSON file name in CLDR.
 /// - `$field`: The field name in `LocaleDisplayNames` containing the data.
 /// - `$alt_variant`: The alt variant (e.g., `None`, `Some(Alt::Short)`).
+/// - `$category`: The category field on `CoverageByXPathLevels` (`language`, `territory`, `script`, or `variant`).
 /// - `$tier`: The target coverage tier.
 macro_rules! impl_displaynames_v1 {
     ($marker:ident, $subtag_ty:ty, $resource:path, $file:literal, $field:ident, $alt_variant:expr, $category:ident, $tier:pat,) => {
@@ -180,6 +181,7 @@ macro_rules! impl_displaynames_v1 {
 /// - `$resource`: The CLDR serde resource type.
 /// - `$file`: The JSON file name in CLDR.
 /// - `$field`: The field name in `LocaleDisplayNames` containing the data.
+/// - `$category`: The category field on `CoverageByXPathLevels` (`language`, `territory`, `script`, or `variant`).
 /// - `$tier`: The target coverage tier.
 macro_rules! impl_displaynames_menu_v1 {
     ($marker:ident, $subtag_ty:ty, $resource:path, $file:literal, $field:ident, $category:ident, $tier:pat,) => {
@@ -341,6 +343,7 @@ macro_rules! impl_displaynames_menu_v1 {
 /// - `$file`: The JSON file name in CLDR.
 /// - `$field`: The field name in `LocaleDisplayNames` containing the data.
 /// - `$alt_variant`: The alt variant (e.g., `None`, `Some(Alt::Short)`).
+/// - `$category`: The category field on `CoverageByXPathLevels` (`language`, `territory`, `script`, or `variant`).
 /// - `$tier`: The target coverage tier.
 macro_rules! impl_displaynames_iter_v1 {
     ($marker:ident, $subtag_ty:ty, $resource:path, $file:literal, $field:ident, $alt_variant:expr, $category:ident, $tier:pat) => {

--- a/provider/source/src/displaynames/mod.rs
+++ b/provider/source/src/displaynames/mod.rs
@@ -270,15 +270,15 @@ macro_rules! impl_displaynames_menu_v1 {
                 let mut result = HashSet::new();
                 let cldr = self.cldr()?;
                 let displaynames = cldr.displaynames();
+                let coverage_cache =
+                    crate::displaynames::coverage_experimental::coverage_cldr_cache();
+                let root_levels = coverage_cache.get_root_levels()?;
                 for locale in displaynames.list_locales()?.filter(|locale| {
                     // The directory might exist without the file
                     displaynames.file_exists(locale, $file).unwrap_or_default()
                 }) {
                     let data: &$resource = displaynames.read_and_parse(&locale, $file)?;
-                    let coverage_cache =
-                        crate::displaynames::coverage_experimental::coverage_cldr_cache();
                     let locale_levels = coverage_cache.get_levels_for_locale(&locale, cldr)?;
-                    let root_levels = coverage_cache.get_root_levels()?;
 
                     for key in data.main.value.localedisplaynames.$field.keys() {
                         let matches = key.menu
@@ -352,15 +352,15 @@ macro_rules! impl_displaynames_iter_v1 {
                 let mut result = HashSet::new();
                 let cldr = self.cldr()?;
                 let displaynames = cldr.displaynames();
+                let coverage_cache =
+                    crate::displaynames::coverage_experimental::coverage_cldr_cache();
+                let root_levels = coverage_cache.get_root_levels()?;
                 for locale in displaynames.list_locales()?.filter(|locale| {
                     // The directory might exist without the file
                     displaynames.file_exists(locale, $file).unwrap_or_default()
                 }) {
                     let data: &$resource = displaynames.read_and_parse(&locale, $file)?;
-                    let coverage_cache =
-                        crate::displaynames::coverage_experimental::coverage_cldr_cache();
                     let locale_levels = coverage_cache.get_levels_for_locale(&locale, cldr)?;
-                    let root_levels = coverage_cache.get_root_levels()?;
 
                     for key in data.main.value.localedisplaynames.$field.keys() {
                         let matches = $alt_variant == key.alt && key.menu.is_none();

--- a/provider/source/src/displaynames/mod.rs
+++ b/provider/source/src/displaynames/mod.rs
@@ -366,9 +366,8 @@ macro_rules! impl_displaynames_iter_v1 {
                                     None,
                                 );
                             if matches!(item_tier, $tier) {
-                                let subtag_str = writeable::Writeable::write_to_string(&key.subtag);
                                 let data_identifier = DataIdentifierCow::from_owned(
-                                    DataMarkerAttributes::try_from_string(subtag_str.into_owned())
+                                    DataMarkerAttributes::try_from_string(key.subtag.to_string())
                                         .map_err(|_| {
                                         DataError::custom("Failed to parse attribute")
                                             .with_debug_context(&key.subtag)

--- a/provider/source/src/displaynames/mod.rs
+++ b/provider/source/src/displaynames/mod.rs
@@ -95,7 +95,7 @@ where
 /// - `$alt_variant`: The alt variant (e.g., `None`, `Some(Alt::Short)`).
 /// - `$tier`: The target coverage tier.
 macro_rules! impl_displaynames_v1 {
-    ($marker:ident, $subtag_ty:ty, $resource:path, $file:literal, $field:ident, $alt_variant:expr, $xpath_prefix:literal, $tier:pat,) => {
+    ($marker:ident, $subtag_ty:ty, $resource:path, $file:literal, $field:ident, $alt_variant:expr, $category:expr, $tier:pat,) => {
         impl DataProvider<$marker> for SourceDataProvider {
             fn load(&self, req: DataRequest) -> Result<DataResponse<$marker>, DataError> {
                 self.check_req::<$marker>(req)?;
@@ -127,14 +127,15 @@ macro_rules! impl_displaynames_v1 {
                             .with_req($marker::INFO, req)
                     })?;
 
-                let xpath = $crate::displaynames::coverage_experimental::construct_xpath(
-                    $xpath_prefix,
+                let item_tier = crate::displaynames::coverage_experimental::coverage_cldr_cache()
+                    .coverage_tier(
+                    req.id.locale,
+                    $category,
                     &subtag,
                     $alt_variant,
                     None,
-                );
-                let item_tier = crate::displaynames::coverage_experimental::coverage_cldr_cache()
-                    .coverage_tier(req.id.locale, &xpath, cldr)?;
+                    cldr,
+                )?;
                 if !matches!(item_tier, $tier) {
                     return Err(DataErrorKind::IdentifierNotFound
                         .into_error()
@@ -155,7 +156,7 @@ macro_rules! impl_displaynames_v1 {
             $file,
             $field,
             $alt_variant,
-            $xpath_prefix,
+            $category,
             $tier
         );
 
@@ -181,7 +182,7 @@ macro_rules! impl_displaynames_v1 {
 /// - `$field`: The field name in `LocaleDisplayNames` containing the data.
 /// - `$tier`: The target coverage tier.
 macro_rules! impl_displaynames_menu_v1 {
-    ($marker:ident, $subtag_ty:ty, $resource:path, $file:literal, $field:ident, $xpath_prefix:literal, $tier:pat,) => {
+    ($marker:ident, $subtag_ty:ty, $resource:path, $file:literal, $field:ident, $category:expr, $tier:pat,) => {
         impl DataProvider<$marker> for SourceDataProvider {
             fn load(&self, req: DataRequest) -> Result<DataResponse<$marker>, DataError> {
                 self.check_req::<$marker>(req)?;
@@ -231,23 +232,15 @@ macro_rules! impl_displaynames_menu_v1 {
                     (alt_menu.as_str(), "")
                 };
 
-                let xpath = if used_alt_menu {
-                    $crate::displaynames::coverage_experimental::construct_xpath(
-                        $xpath_prefix,
-                        &subtag,
-                        Some($crate::cldr_serde::displaynames::Alt::Menu),
-                        None,
-                    )
+                let (alt, menu) = if used_alt_menu {
+                    (Some($crate::cldr_serde::displaynames::Alt::Menu), None)
                 } else {
-                    $crate::displaynames::coverage_experimental::construct_xpath(
-                        $xpath_prefix,
-                        &subtag,
-                        None,
-                        Some($crate::cldr_serde::displaynames::Menu::Core),
-                    )
+                    (None, Some($crate::cldr_serde::displaynames::Menu::Core))
                 };
-                let item_tier = crate::displaynames::coverage_experimental::coverage_cldr_cache()
-                    .coverage_tier(req.id.locale, &xpath, cldr)?;
+                let subtag_str = writeable::Writeable::write_to_string(&subtag);
+                let item_tier =
+                    crate::displaynames::coverage_experimental::coverage_cldr_cache()
+                        .coverage_tier(req.id.locale, $category, &subtag_str, alt, menu, cldr)?;
                 if !matches!(item_tier, $tier) {
                     return Err(DataErrorKind::IdentifierNotFound
                         .into_error()
@@ -274,35 +267,36 @@ macro_rules! impl_displaynames_menu_v1 {
                     displaynames.file_exists(locale, $file).unwrap_or_default()
                 }) {
                     let data: &$resource = displaynames.read_and_parse(&locale, $file)?;
+                    let coverage_cache =
+                        crate::displaynames::coverage_experimental::coverage_cldr_cache();
+                    let locale_levels = coverage_cache.get_levels_for_locale(&locale, cldr)?;
+                    let root_levels = coverage_cache.get_root_levels()?;
+
                     for key in data.main.value.localedisplaynames.$field.keys() {
                         let matches = key.menu
                             == Some($crate::cldr_serde::displaynames::Menu::Core)
                             || key.alt == Some($crate::cldr_serde::displaynames::Alt::Menu);
 
                         if matches {
-                            let xpath =
+                            let (alt, menu) =
                                 if key.alt == Some($crate::cldr_serde::displaynames::Alt::Menu) {
-                                    $crate::displaynames::coverage_experimental::construct_xpath(
-                                        $xpath_prefix,
-                                        &key.subtag,
-                                        Some($crate::cldr_serde::displaynames::Alt::Menu),
-                                        None,
-                                    )
+                                    (Some($crate::cldr_serde::displaynames::Alt::Menu), None)
                                 } else {
-                                    $crate::displaynames::coverage_experimental::construct_xpath(
-                                        $xpath_prefix,
-                                        &key.subtag,
-                                        None,
-                                        Some($crate::cldr_serde::displaynames::Menu::Core),
-                                    )
+                                    (None, Some($crate::cldr_serde::displaynames::Menu::Core))
                                 };
-                            if matches!(
-                                crate::displaynames::coverage_experimental::coverage_cldr_cache()
-                                    .coverage_tier(&locale, &xpath, cldr)?,
-                                $tier
-                            ) {
+                            let item_tier =
+                                crate::displaynames::coverage_experimental::CoverageByXPathCache::coverage_tier_from_levels(
+                                    locale_levels,
+                                    root_levels,
+                                    $category,
+                                    &key.subtag,
+                                    alt,
+                                    menu,
+                                );
+                            if matches!(item_tier, $tier) {
+                                let subtag_str = writeable::Writeable::write_to_string(&key.subtag);
                                 let data_identifier = DataIdentifierCow::from_owned(
-                                    DataMarkerAttributes::try_from_string(key.subtag.to_string())
+                                    DataMarkerAttributes::try_from_string(subtag_str.into_owned())
                                         .map_err(|_| {
                                         DataError::custom("Failed to parse attribute")
                                             .with_debug_context(&key.subtag)
@@ -343,7 +337,7 @@ macro_rules! impl_displaynames_menu_v1 {
 /// - `$alt_variant`: The alt variant (e.g., `None`, `Some(Alt::Short)`).
 /// - `$tier`: The target coverage tier.
 macro_rules! impl_displaynames_iter_v1 {
-    ($marker:ident, $subtag_ty:ty, $resource:path, $file:literal, $field:ident, $alt_variant:expr, $xpath_prefix:literal, $tier:pat) => {
+    ($marker:ident, $subtag_ty:ty, $resource:path, $file:literal, $field:ident, $alt_variant:expr, $category:expr, $tier:pat) => {
         impl IterableDataProviderCached<$marker> for SourceDataProvider {
             fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
                 let mut result = HashSet::new();
@@ -354,24 +348,28 @@ macro_rules! impl_displaynames_iter_v1 {
                     displaynames.file_exists(locale, $file).unwrap_or_default()
                 }) {
                     let data: &$resource = displaynames.read_and_parse(&locale, $file)?;
+                    let coverage_cache =
+                        crate::displaynames::coverage_experimental::coverage_cldr_cache();
+                    let locale_levels = coverage_cache.get_levels_for_locale(&locale, cldr)?;
+                    let root_levels = coverage_cache.get_root_levels()?;
+
                     for key in data.main.value.localedisplaynames.$field.keys() {
                         let matches = $alt_variant == key.alt && key.menu.is_none();
 
                         if matches {
-                            let xpath =
-                                $crate::displaynames::coverage_experimental::construct_xpath(
-                                    $xpath_prefix,
+                            let item_tier =
+                                crate::displaynames::coverage_experimental::CoverageByXPathCache::coverage_tier_from_levels(
+                                    locale_levels,
+                                    root_levels,
+                                    $category,
                                     &key.subtag,
                                     $alt_variant,
                                     None,
                                 );
-                            if matches!(
-                                crate::displaynames::coverage_experimental::coverage_cldr_cache()
-                                    .coverage_tier(&locale, &xpath, cldr)?,
-                                $tier
-                            ) {
+                            if matches!(item_tier, $tier) {
+                                let subtag_str = writeable::Writeable::write_to_string(&key.subtag);
                                 let data_identifier = DataIdentifierCow::from_owned(
-                                    DataMarkerAttributes::try_from_string(key.subtag.to_string())
+                                    DataMarkerAttributes::try_from_string(subtag_str.into_owned())
                                         .map_err(|_| {
                                         DataError::custom("Failed to parse attribute")
                                             .with_debug_context(&key.subtag)

--- a/provider/source/src/displaynames/mod.rs
+++ b/provider/source/src/displaynames/mod.rs
@@ -237,10 +237,9 @@ macro_rules! impl_displaynames_menu_v1 {
                 } else {
                     (None, Some($crate::cldr_serde::displaynames::Menu::Core))
                 };
-                let subtag_str = writeable::Writeable::write_to_string(&subtag);
                 let item_tier =
                     crate::displaynames::coverage_experimental::coverage_cldr_cache()
-                        .coverage_tier(req.id.locale, $category, &subtag_str, alt, menu, cldr)?;
+                        .coverage_tier(req.id.locale, $category, &subtag, alt, menu, cldr)?;
                 if !matches!(item_tier, $tier) {
                     return Err(DataErrorKind::IdentifierNotFound
                         .into_error()

--- a/provider/source/src/displaynames/mod.rs
+++ b/provider/source/src/displaynames/mod.rs
@@ -131,7 +131,6 @@ macro_rules! impl_displaynames_v1 {
                     .coverage_tier(
                     req.id.locale,
                     |l| &l.$category,
-                    stringify!($category) == "language",
                     &subtag,
                     $alt_variant,
                     None,
@@ -243,7 +242,6 @@ macro_rules! impl_displaynames_menu_v1 {
                         .coverage_tier(
                             req.id.locale,
                             |l| &l.$category,
-                            stringify!($category) == "language",
                             &subtag,
                             alt,
                             menu,
@@ -297,7 +295,6 @@ macro_rules! impl_displaynames_menu_v1 {
                                     locale_levels,
                                     root_levels,
                                     |l| &l.$category,
-                                    stringify!($category) == "language",
                                     &key.subtag,
                                     alt,
                                     menu,
@@ -371,7 +368,6 @@ macro_rules! impl_displaynames_iter_v1 {
                                     locale_levels,
                                     root_levels,
                                     |l| &l.$category,
-                                    stringify!($category) == "language",
                                     &key.subtag,
                                     $alt_variant,
                                     None,

--- a/provider/source/src/displaynames/mod.rs
+++ b/provider/source/src/displaynames/mod.rs
@@ -95,7 +95,7 @@ where
 /// - `$alt_variant`: The alt variant (e.g., `None`, `Some(Alt::Short)`).
 /// - `$tier`: The target coverage tier.
 macro_rules! impl_displaynames_v1 {
-    ($marker:ident, $subtag_ty:ty, $resource:path, $file:literal, $field:ident, $alt_variant:expr, $category:expr, $tier:pat,) => {
+    ($marker:ident, $subtag_ty:ty, $resource:path, $file:literal, $field:ident, $alt_variant:expr, $category:ident, $tier:pat,) => {
         impl DataProvider<$marker> for SourceDataProvider {
             fn load(&self, req: DataRequest) -> Result<DataResponse<$marker>, DataError> {
                 self.check_req::<$marker>(req)?;
@@ -130,7 +130,8 @@ macro_rules! impl_displaynames_v1 {
                 let item_tier = crate::displaynames::coverage_experimental::coverage_cldr_cache()
                     .coverage_tier(
                     req.id.locale,
-                    $category,
+                    |l| &l.$category,
+                    stringify!($category) == "language",
                     &subtag,
                     $alt_variant,
                     None,
@@ -182,7 +183,7 @@ macro_rules! impl_displaynames_v1 {
 /// - `$field`: The field name in `LocaleDisplayNames` containing the data.
 /// - `$tier`: The target coverage tier.
 macro_rules! impl_displaynames_menu_v1 {
-    ($marker:ident, $subtag_ty:ty, $resource:path, $file:literal, $field:ident, $category:expr, $tier:pat,) => {
+    ($marker:ident, $subtag_ty:ty, $resource:path, $file:literal, $field:ident, $category:ident, $tier:pat,) => {
         impl DataProvider<$marker> for SourceDataProvider {
             fn load(&self, req: DataRequest) -> Result<DataResponse<$marker>, DataError> {
                 self.check_req::<$marker>(req)?;
@@ -239,7 +240,15 @@ macro_rules! impl_displaynames_menu_v1 {
                 };
                 let item_tier =
                     crate::displaynames::coverage_experimental::coverage_cldr_cache()
-                        .coverage_tier(req.id.locale, $category, &subtag, alt, menu, cldr)?;
+                        .coverage_tier(
+                            req.id.locale,
+                            |l| &l.$category,
+                            stringify!($category) == "language",
+                            &subtag,
+                            alt,
+                            menu,
+                            cldr,
+                        )?;
                 if !matches!(item_tier, $tier) {
                     return Err(DataErrorKind::IdentifierNotFound
                         .into_error()
@@ -287,7 +296,8 @@ macro_rules! impl_displaynames_menu_v1 {
                                 crate::displaynames::coverage_experimental::CoverageByXPathCache::coverage_tier_from_levels(
                                     locale_levels,
                                     root_levels,
-                                    $category,
+                                    |l| &l.$category,
+                                    stringify!($category) == "language",
                                     &key.subtag,
                                     alt,
                                     menu,
@@ -336,7 +346,7 @@ macro_rules! impl_displaynames_menu_v1 {
 /// - `$alt_variant`: The alt variant (e.g., `None`, `Some(Alt::Short)`).
 /// - `$tier`: The target coverage tier.
 macro_rules! impl_displaynames_iter_v1 {
-    ($marker:ident, $subtag_ty:ty, $resource:path, $file:literal, $field:ident, $alt_variant:expr, $category:expr, $tier:pat) => {
+    ($marker:ident, $subtag_ty:ty, $resource:path, $file:literal, $field:ident, $alt_variant:expr, $category:ident, $tier:pat) => {
         impl IterableDataProviderCached<$marker> for SourceDataProvider {
             fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
                 let mut result = HashSet::new();
@@ -360,14 +370,16 @@ macro_rules! impl_displaynames_iter_v1 {
                                 crate::displaynames::coverage_experimental::CoverageByXPathCache::coverage_tier_from_levels(
                                     locale_levels,
                                     root_levels,
-                                    $category,
+                                    |l| &l.$category,
+                                    stringify!($category) == "language",
                                     &key.subtag,
                                     $alt_variant,
                                     None,
                                 );
                             if matches!(item_tier, $tier) {
+                                let subtag_str = writeable::Writeable::write_to_string(&key.subtag);
                                 let data_identifier = DataIdentifierCow::from_owned(
-                                    DataMarkerAttributes::try_from_string(key.subtag.to_string())
+                                    DataMarkerAttributes::try_from_string(subtag_str.into_owned())
                                         .map_err(|_| {
                                         DataError::custom("Failed to parse attribute")
                                             .with_debug_context(&key.subtag)

--- a/provider/source/src/displaynames/region.rs
+++ b/provider/source/src/displaynames/region.rs
@@ -39,7 +39,7 @@ crate::displaynames::impl_displaynames_v1!(
     "territories.json",
     regions,
     None,
-    "//ldml/localeDisplayNames/territories/territory",
+    crate::displaynames::coverage_experimental::DisplayNameCategory::Territory,
     CoverageLevelForXPath::Basic | CoverageLevelForXPath::Core,
 );
 crate::displaynames::impl_displaynames_v1!(
@@ -49,7 +49,7 @@ crate::displaynames::impl_displaynames_v1!(
     "territories.json",
     regions,
     None,
-    "//ldml/localeDisplayNames/territories/territory",
+    crate::displaynames::coverage_experimental::DisplayNameCategory::Territory,
     CoverageLevelForXPath::Moderate,
 );
 
@@ -60,7 +60,7 @@ crate::displaynames::impl_displaynames_v1!(
     "territories.json",
     regions,
     Some(Alt::Short),
-    "//ldml/localeDisplayNames/territories/territory",
+    crate::displaynames::coverage_experimental::DisplayNameCategory::Territory,
     CoverageLevelForXPath::Basic,
 );
 crate::displaynames::impl_displaynames_v1!(
@@ -70,7 +70,7 @@ crate::displaynames::impl_displaynames_v1!(
     "territories.json",
     regions,
     Some(Alt::Short),
-    "//ldml/localeDisplayNames/territories/territory",
+    crate::displaynames::coverage_experimental::DisplayNameCategory::Territory,
     CoverageLevelForXPath::Moderate,
 );
 
@@ -227,7 +227,7 @@ mod tests {
         crate::displaynames::coverage_experimental::for_each_cldr_key_and_tier(
             cldr,
             "territories.json",
-            "//ldml/localeDisplayNames/territories/territory",
+            crate::displaynames::coverage_experimental::DisplayNameCategory::Territory,
             |res: &cldr_serde::displaynames::region::Resource| {
                 &res.main.value.localedisplaynames.regions
             },

--- a/provider/source/src/displaynames/region.rs
+++ b/provider/source/src/displaynames/region.rs
@@ -39,7 +39,7 @@ crate::displaynames::impl_displaynames_v1!(
     "territories.json",
     regions,
     None,
-    crate::displaynames::coverage_experimental::DisplayNameCategory::Territory,
+    territory,
     CoverageLevelForXPath::Basic | CoverageLevelForXPath::Core,
 );
 crate::displaynames::impl_displaynames_v1!(
@@ -49,7 +49,7 @@ crate::displaynames::impl_displaynames_v1!(
     "territories.json",
     regions,
     None,
-    crate::displaynames::coverage_experimental::DisplayNameCategory::Territory,
+    territory,
     CoverageLevelForXPath::Moderate,
 );
 
@@ -60,7 +60,7 @@ crate::displaynames::impl_displaynames_v1!(
     "territories.json",
     regions,
     Some(Alt::Short),
-    crate::displaynames::coverage_experimental::DisplayNameCategory::Territory,
+    territory,
     CoverageLevelForXPath::Basic,
 );
 crate::displaynames::impl_displaynames_v1!(
@@ -70,7 +70,7 @@ crate::displaynames::impl_displaynames_v1!(
     "territories.json",
     regions,
     Some(Alt::Short),
-    crate::displaynames::coverage_experimental::DisplayNameCategory::Territory,
+    territory,
     CoverageLevelForXPath::Moderate,
 );
 
@@ -227,7 +227,8 @@ mod tests {
         crate::displaynames::coverage_experimental::for_each_cldr_key_and_tier(
             cldr,
             "territories.json",
-            crate::displaynames::coverage_experimental::DisplayNameCategory::Territory,
+            |l| &l.territory,
+            false,
             |res: &cldr_serde::displaynames::region::Resource| {
                 &res.main.value.localedisplaynames.regions
             },

--- a/provider/source/src/displaynames/region.rs
+++ b/provider/source/src/displaynames/region.rs
@@ -228,7 +228,6 @@ mod tests {
             cldr,
             "territories.json",
             |l| &l.territory,
-            false,
             |res: &cldr_serde::displaynames::region::Resource| {
                 &res.main.value.localedisplaynames.regions
             },

--- a/provider/source/src/displaynames/script.rs
+++ b/provider/source/src/displaynames/script.rs
@@ -229,7 +229,6 @@ mod tests {
             cldr,
             "scripts.json",
             |l| &l.script,
-            false,
             |res: &cldr_serde::displaynames::script::Resource| {
                 &res.main.value.localedisplaynames.scripts
             },

--- a/provider/source/src/displaynames/script.rs
+++ b/provider/source/src/displaynames/script.rs
@@ -37,7 +37,7 @@ crate::displaynames::impl_displaynames_v1!(
     "scripts.json",
     scripts,
     None,
-    crate::displaynames::coverage_experimental::DisplayNameCategory::Script,
+    script,
     CoverageLevelForXPath::Basic | CoverageLevelForXPath::Core,
 );
 crate::displaynames::impl_displaynames_v1!(
@@ -47,7 +47,7 @@ crate::displaynames::impl_displaynames_v1!(
     "scripts.json",
     scripts,
     None,
-    crate::displaynames::coverage_experimental::DisplayNameCategory::Script,
+    script,
     CoverageLevelForXPath::Moderate,
 );
 crate::displaynames::impl_displaynames_v1!(
@@ -57,7 +57,7 @@ crate::displaynames::impl_displaynames_v1!(
     "scripts.json",
     scripts,
     None,
-    crate::displaynames::coverage_experimental::DisplayNameCategory::Script,
+    script,
     CoverageLevelForXPath::Modern | CoverageLevelForXPath::Comprehensive,
 );
 
@@ -68,7 +68,7 @@ crate::displaynames::impl_displaynames_v1!(
     "scripts.json",
     scripts,
     Some(Alt::Short),
-    crate::displaynames::coverage_experimental::DisplayNameCategory::Script,
+    script,
     CoverageLevelForXPath::Modern | CoverageLevelForXPath::Comprehensive,
 );
 
@@ -228,7 +228,8 @@ mod tests {
         crate::displaynames::coverage_experimental::for_each_cldr_key_and_tier(
             cldr,
             "scripts.json",
-            crate::displaynames::coverage_experimental::DisplayNameCategory::Script,
+            |l| &l.script,
+            false,
             |res: &cldr_serde::displaynames::script::Resource| {
                 &res.main.value.localedisplaynames.scripts
             },

--- a/provider/source/src/displaynames/script.rs
+++ b/provider/source/src/displaynames/script.rs
@@ -37,7 +37,7 @@ crate::displaynames::impl_displaynames_v1!(
     "scripts.json",
     scripts,
     None,
-    "//ldml/localeDisplayNames/scripts/script",
+    crate::displaynames::coverage_experimental::DisplayNameCategory::Script,
     CoverageLevelForXPath::Basic | CoverageLevelForXPath::Core,
 );
 crate::displaynames::impl_displaynames_v1!(
@@ -47,7 +47,7 @@ crate::displaynames::impl_displaynames_v1!(
     "scripts.json",
     scripts,
     None,
-    "//ldml/localeDisplayNames/scripts/script",
+    crate::displaynames::coverage_experimental::DisplayNameCategory::Script,
     CoverageLevelForXPath::Moderate,
 );
 crate::displaynames::impl_displaynames_v1!(
@@ -57,7 +57,7 @@ crate::displaynames::impl_displaynames_v1!(
     "scripts.json",
     scripts,
     None,
-    "//ldml/localeDisplayNames/scripts/script",
+    crate::displaynames::coverage_experimental::DisplayNameCategory::Script,
     CoverageLevelForXPath::Modern | CoverageLevelForXPath::Comprehensive,
 );
 
@@ -68,7 +68,7 @@ crate::displaynames::impl_displaynames_v1!(
     "scripts.json",
     scripts,
     Some(Alt::Short),
-    "//ldml/localeDisplayNames/scripts/script",
+    crate::displaynames::coverage_experimental::DisplayNameCategory::Script,
     CoverageLevelForXPath::Modern | CoverageLevelForXPath::Comprehensive,
 );
 
@@ -228,7 +228,7 @@ mod tests {
         crate::displaynames::coverage_experimental::for_each_cldr_key_and_tier(
             cldr,
             "scripts.json",
-            "//ldml/localeDisplayNames/scripts/script",
+            crate::displaynames::coverage_experimental::DisplayNameCategory::Script,
             |res: &cldr_serde::displaynames::script::Resource| {
                 &res.main.value.localedisplaynames.scripts
             },

--- a/provider/source/src/displaynames/variant.rs
+++ b/provider/source/src/displaynames/variant.rs
@@ -37,7 +37,7 @@ crate::displaynames::impl_displaynames_v1!(
     "variants.json",
     variants,
     None,
-    crate::displaynames::coverage_experimental::DisplayNameCategory::Variant,
+    variant,
     CoverageLevelForXPath::Modern | CoverageLevelForXPath::Comprehensive,
 );
 
@@ -122,7 +122,8 @@ mod tests {
         crate::displaynames::coverage_experimental::for_each_cldr_key_and_tier(
             cldr,
             "variants.json",
-            crate::displaynames::coverage_experimental::DisplayNameCategory::Variant,
+            |l| &l.variant,
+            false,
             |res: &cldr_serde::displaynames::variant::Resource| {
                 &res.main.value.localedisplaynames.variants
             },

--- a/provider/source/src/displaynames/variant.rs
+++ b/provider/source/src/displaynames/variant.rs
@@ -37,7 +37,7 @@ crate::displaynames::impl_displaynames_v1!(
     "variants.json",
     variants,
     None,
-    "//ldml/localeDisplayNames/variants/variant",
+    crate::displaynames::coverage_experimental::DisplayNameCategory::Variant,
     CoverageLevelForXPath::Modern | CoverageLevelForXPath::Comprehensive,
 );
 
@@ -122,7 +122,7 @@ mod tests {
         crate::displaynames::coverage_experimental::for_each_cldr_key_and_tier(
             cldr,
             "variants.json",
-            "//ldml/localeDisplayNames/variants/variant",
+            crate::displaynames::coverage_experimental::DisplayNameCategory::Variant,
             |res: &cldr_serde::displaynames::variant::Resource| {
                 &res.main.value.localedisplaynames.variants
             },

--- a/provider/source/src/displaynames/variant.rs
+++ b/provider/source/src/displaynames/variant.rs
@@ -123,7 +123,6 @@ mod tests {
             cldr,
             "variants.json",
             |l| &l.variant,
-            false,
             |res: &cldr_serde::displaynames::variant::Resource| {
                 &res.main.value.localedisplaynames.variants
             },

--- a/provider/source/tests/e2e.rs
+++ b/provider/source/tests/e2e.rs
@@ -19,7 +19,7 @@ fn test_export_language_identifier_display_names() {
     ExportDriver::new(
         modern_locales
             .into_iter()
-            .map(|loc| DataLocaleFamily::without_descendants(loc))
+            .map(DataLocaleFamily::without_descendants)
             // for the purposes of this test, use every 10th locale
             .step_by(10),
         DeduplicationStrategy::None.into(),

--- a/provider/source/tests/e2e.rs
+++ b/provider/source/tests/e2e.rs
@@ -1,0 +1,34 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use icu_provider_export::blob_exporter::BlobExporter;
+use icu_provider_export::prelude::*;
+use icu_provider_source::SourceDataProvider;
+
+#[test]
+fn test_export_language_identifier_display_names() {
+    let provider = SourceDataProvider::new();
+    let mut blob_bytes = Vec::new();
+    let exporter = BlobExporter::new_with_sink(Box::new(&mut blob_bytes));
+
+    ExportDriver::new(
+        [DataLocaleFamily::FULL],
+        DeduplicationStrategy::None.into(),
+        LocaleFallbacker::try_new_unstable(&provider).unwrap(),
+    )
+    .with_markers(
+        icu::experimental::provider::MARKERS
+            .iter()
+            .copied()
+            .filter(|info| info.id.name().starts_with("LocaleNames")),
+    )
+    .export(&provider, exporter)
+    .unwrap();
+
+    assert!(
+        blob_bytes.len() >= 5_000_000,
+        "postcard blob size {} should be at least 5 MB",
+        blob_bytes.len()
+    );
+}

--- a/provider/source/tests/e2e.rs
+++ b/provider/source/tests/e2e.rs
@@ -12,8 +12,16 @@ fn test_export_language_identifier_display_names() {
     let mut blob_bytes = Vec::new();
     let exporter = BlobExporter::new_with_sink(Box::new(&mut blob_bytes));
 
+    let modern_locales = provider
+        .locales_for_coverage_levels([icu_provider_source::CoverageLevel::Modern])
+        .unwrap();
+
     ExportDriver::new(
-        [DataLocaleFamily::FULL],
+        modern_locales
+            .into_iter()
+            .map(|loc| DataLocaleFamily::without_descendants(loc))
+            // for the purposes of this test, use every 10th locale
+            .step_by(10),
         DeduplicationStrategy::None.into(),
         LocaleFallbacker::try_new_unstable(&provider).unwrap(),
     )
@@ -27,8 +35,8 @@ fn test_export_language_identifier_display_names() {
     .unwrap();
 
     assert!(
-        blob_bytes.len() >= 5_000_000,
-        "postcard blob size {} should be at least 5 MB",
+        blob_bytes.len() >= 100_000,
+        "postcard blob size {} should be at least 100 kB",
         blob_bytes.len()
     );
 }


### PR DESCRIPTION
Redesigns `CoverageByXPathLevels` into 4 category-specific ZeroTrie fields (`language`, `territory`, `script`, `variant`), extracting subtag attribute keys and integer coverage level discriminators.

Stores only the short XPath suffixes in the trie and hoists per-locale coverage level lookups outside subtag loops.

Measured performance impact on `test_export_language_identifier_display_names`:
- Full test runtime reduced from **19.15 s** to **14.21 s** (**25.8% runtime reduction**).
- `coverage_tier` trie lookup time reduced from **9.60 s** to **2.62 s** (**3.66x speedup**).

🤖 This pull request was created by an AI agent working with @sffc.

## Changelog

N/A