### PR TITLE
Introduce DataIdentifierCached wrapping DataIdentifierCow

### DIFF
--- a/provider/core/src/request.rs
+++ b/provider/core/src/request.rs
@@ -47,7 +47,7 @@ pub struct DataRequestMetadata {
 }
 
 /// The borrowed version of a [`DataIdentifierCow`].
-#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub struct DataIdentifierBorrowed<'a> {
     /// Marker-specific request attributes

--- a/provider/source/src/calendar/eras.rs
+++ b/provider/source/src/calendar/eras.rs
@@ -2,6 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use crate::DataIdentifierCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
 use crate::cldr_serde::eras::EraData;
@@ -139,7 +140,7 @@ impl DataProvider<CalendarJapaneseModernV1> for SourceDataProvider {
 }
 
 impl crate::IterableDataProviderCached<CalendarJapaneseModernV1> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         Ok(HashSet::from_iter([Default::default()]))
     }
 }

--- a/provider/source/src/calendar/mod.rs
+++ b/provider/source/src/calendar/mod.rs
@@ -2,6 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use crate::DataIdentifierCached;
 use crate::{IterableDataProviderCached, SourceDataProvider};
 use icu::calendar::preferences::CalendarAlgorithm;
 use icu::calendar::provider::{CalendarPreference, CalendarPreferredV1};
@@ -71,7 +72,7 @@ impl DataProvider<CalendarPreferredV1> for SourceDataProvider {
 }
 
 impl IterableDataProviderCached<CalendarPreferredV1> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         Ok(self
             .cldr()
             .unwrap()
@@ -82,11 +83,7 @@ impl IterableDataProviderCached<CalendarPreferredV1> for SourceDataProvider {
             .calendar_preference_data
             .keys()
             .map(|&region| {
-                DataIdentifierCow::from_locale(DataLocale::from((
-                    Language::UNKNOWN,
-                    None,
-                    Some(region),
-                )))
+                DataIdentifierCached::from_locale((Language::UNKNOWN, None, Some(region)))
             })
             .chain([Default::default()])
             .collect())

--- a/provider/source/src/casemap/mod.rs
+++ b/provider/source/src/casemap/mod.rs
@@ -2,6 +2,12 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+#![cfg_attr(
+    not(any(feature = "use_wasm", feature = "use_icu4c")),
+    allow(unused_imports, dead_code)
+)]
+
+use crate::DataIdentifierCached;
 use crate::SourceDataProvider;
 use crate::properties::ucd_helpers;
 use icu::casemap::provider::data::{CaseMapData, CaseType, DotType};
@@ -311,7 +317,7 @@ impl DataProvider<CaseMapV1> for SourceDataProvider {
 }
 
 impl crate::IterableDataProviderCached<CaseMapV1> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         Ok(HashSet::from_iter([Default::default()]))
     }
 }
@@ -353,7 +359,7 @@ impl DataProvider<CaseMapUnfoldV1> for SourceDataProvider {
 }
 
 impl crate::IterableDataProviderCached<CaseMapUnfoldV1> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         Ok(HashSet::from_iter([Default::default()]))
     }
 }

--- a/provider/source/src/characters/mod.rs
+++ b/provider/source/src/characters/mod.rs
@@ -5,6 +5,7 @@
 use core::ops::Deref;
 use std::collections::HashSet;
 
+use crate::DataIdentifierCached;
 use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
@@ -39,12 +40,12 @@ macro_rules! exemplar_chars_impls {
         }
 
         impl IterableDataProviderCached<$data_marker_name> for SourceDataProvider {
-            fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+            fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
                 Ok(self
                     .cldr()?
                     .misc()
                     .list_locales()?
-                    .map(DataIdentifierCow::from_locale)
+                    .map(DataIdentifierCached::from_locale)
                     .collect())
             }
         }

--- a/provider/source/src/collator/mod.rs
+++ b/provider/source/src/collator/mod.rs
@@ -7,6 +7,7 @@
 
 use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
+use crate::{DataIdentifierCached, DataIdentifierCachedWithLifetime};
 use icu::collator::provider::*;
 use icu::locale::{
     data_locale,
@@ -52,7 +53,7 @@ fn id_to_file_name(id: DataIdentifierBorrowed) -> String {
     s
 }
 
-fn file_name_to_ids(file_name: &str) -> Vec<DataIdentifierCow<'static>> {
+fn file_name_to_ids(file_name: &str) -> Vec<DataIdentifierCached> {
     let (mut language, mut variant) = file_name.rsplit_once('_').unwrap();
     if language == "root" {
         language = "und";
@@ -69,32 +70,27 @@ fn file_name_to_ids(file_name: &str) -> Vec<DataIdentifierCow<'static>> {
         locale.script = Some(script!("Hani"));
         if variant == "pinyin" {
             // Pinyin is stored in both und-Hans and und-Hani/pinyin
-            r.push(DataIdentifierCow::from_borrowed_and_owned(
-                Default::default(),
-                data_locale!("und-Hans"),
-            ));
+            r.push(DataIdentifierCached::from_locale(data_locale!("und-Hans")));
         } else if variant == "stroke" {
             // Stroke is stored in both und-Hans and und-Hani/stroke
-            r.push(DataIdentifierCow::from_borrowed_and_owned(
-                Default::default(),
-                data_locale!("und-Hant"),
-            ));
+            r.push(DataIdentifierCached::from_locale(data_locale!("und-Hant")));
         }
     } else if variant == "standard" {
         variant = "";
     }
 
     let marker_attributes = match variant {
-        "traditional" => DataMarkerAttributes::from_str_or_panic("trad").to_owned(),
-        "phonebook" => DataMarkerAttributes::from_str_or_panic("phonebk").to_owned(),
-        "dictionary" => DataMarkerAttributes::from_str_or_panic("dict").to_owned(),
-        v => match DataMarkerAttributes::try_from_str(v) {
-            Ok(s) => s.to_owned(),
-            _ => return r,
-        },
+        "traditional" => "trad",
+        "phonebook" => "phonebk",
+        "dictionary" => "dict",
+        v => v,
     };
 
-    r.push(DataIdentifierCow::from_owned(marker_attributes, locale));
+    if let Ok(id) =
+        DataIdentifierCached::from_writeable_attributes_and_locale(marker_attributes, locale)
+    {
+        r.push(id);
+    }
     r
 }
 
@@ -119,7 +115,7 @@ impl SourceDataProvider {
             })
     }
 
-    fn list_ids(&self, suffix: &str) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn list_ids(&self, suffix: &str) -> Result<HashSet<DataIdentifierCached>, DataError> {
         Ok(self
             .icuexport()?
             .list(&format!("collation/{}", self.collation_root_han()))?
@@ -152,7 +148,7 @@ macro_rules! collation_provider {
                         self.check_req::<$marker>(req)?;
 
                         let has_tailoring = self.list_ids("_data")?
-                            .contains(&DataIdentifierCow::from_borrowed_and_owned(&req.id.marker_attributes, *req.id.locale));
+                            .contains(&DataIdentifierCachedWithLifetime::from_attributes_and_locale(&req.id.marker_attributes, *req.id.locale));
 
                         Ok(DataResponse {
                             metadata: Default::default(),
@@ -163,7 +159,7 @@ macro_rules! collation_provider {
             }
 
             impl IterableDataProviderCached<$marker> for SourceDataProvider {
-                fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+                fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
                     self.list_ids(<collator_serde::$serde_struct>::suffix())
                 }
             }

--- a/provider/source/src/currency/compact.rs
+++ b/provider/source/src/currency/compact.rs
@@ -1,0 +1,291 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use crate::DataIdentifierCached;
+use crate::IterableDataProviderCached;
+use crate::SourceDataProvider;
+use crate::cldr_serde;
+use crate::cldr_serde::numbers::NumberPatternItem;
+
+use std::borrow::Cow;
+use std::collections::BTreeMap;
+use std::collections::HashSet;
+
+use icu::decimal::provider::CompactPatterns;
+use icu::experimental::dimension::provider::currency::compact::*;
+use icu::plurals::PluralElements;
+use icu_pattern::DoublePlaceholderKey;
+use icu_pattern::DoublePlaceholderPattern;
+use icu_pattern::PatternItemCow;
+use icu_provider::DataProvider;
+use icu_provider::prelude::*;
+use itertools::Itertools;
+
+impl DataProvider<ShortCurrencyCompactV1> for SourceDataProvider {
+    fn load(&self, req: DataRequest) -> Result<DataResponse<ShortCurrencyCompactV1>, DataError> {
+        self.check_req::<ShortCurrencyCompactV1>(req)?;
+
+        let numbers_resource: &cldr_serde::numbers::Resource = self
+            .cldr()?
+            .numbers()
+            .read_and_parse(req.id.locale, "numbers.json")?;
+
+        let numbering_system = if req.id.marker_attributes.is_empty() {
+            numbers_resource
+                .main
+                .value
+                .numbers
+                .default_numbering_system
+                .as_str()
+        } else {
+            req.id.marker_attributes.as_str()
+        };
+
+        let Some(compact_patterns) = numbers_resource
+            .main
+            .value
+            .numbers
+            .numsys_data
+            .currency_patterns
+            .get(numbering_system)
+            .and_then(|patterns| patterns.compact_short.as_ref())
+            .map(|short_compact| &short_compact.standard)
+        else {
+            return Err(
+                DataErrorKind::IdentifierNotFound.with_req(ShortCurrencyCompactV1::INFO, req)
+            );
+        };
+
+        let mut standard_patterns: BTreeMap<
+            u8,
+            (u8, PluralElements<Box<DoublePlaceholderPattern>>),
+        > = BTreeMap::new();
+        let mut alpha_next_to_number_patterns: BTreeMap<
+            u8,
+            (u8, PluralElements<Box<DoublePlaceholderPattern>>),
+        > = BTreeMap::new();
+
+        for (target, source) in [
+            (&mut standard_patterns, &compact_patterns.standard),
+            (
+                &mut alpha_next_to_number_patterns,
+                &compact_patterns.alpha_next_to_number,
+            ),
+        ] {
+            for (&log10_type, pattern) in source {
+                let pattern = pattern.as_ref().try_map(|pattern| {
+
+                if pattern.negative.is_some() {
+                    log::warn!(
+                        "Unexpected negative pattern for {}: {}",
+                        req.id.locale,
+                        pattern
+                    );
+                }
+
+                let number_of_0s = Some(
+                    pattern.positive
+                        .iter()
+                        .filter(|&i| *i == NumberPatternItem::MandatoryDigit)
+                        .count() as u8,
+                )
+                .filter(|&n| n != 0);
+
+                let parsed = DoublePlaceholderPattern::try_from_items(
+                    pattern.positive
+                        .iter()
+                        .map(|i| match i {
+                            NumberPatternItem::MandatoryDigit => {
+                                PatternItemCow::Placeholder(DoublePlaceholderKey::Place0)
+                            }
+                            NumberPatternItem::Currency => {
+                                PatternItemCow::Placeholder(DoublePlaceholderKey::Place1)
+                            }
+                            i => PatternItemCow::Literal(Cow::Borrowed(i.as_str())),
+                        })
+                        .dedup(),
+                )
+                .map_err(|e| DataError::custom("Could not parse compact currency pattern").with_display_context(&e))?;
+
+                if log10_type < number_of_0s.unwrap_or_default() {
+                    return Err(DataError::custom("pattern").with_display_context(&format!(
+                        "Too many 0s in type 10^{}, ({}, implying nonpositive exponent c={}), pattern = {:?}",
+                        log10_type,
+                        number_of_0s.unwrap_or_default(),
+                        log10_type as i8 - number_of_0s.unwrap_or_default() as i8 + 1,
+                        pattern
+                    )));
+                }
+
+                Ok((number_of_0s, parsed))
+                })?;
+
+                let other_number_of_0s = pattern.other().0.ok_or_else(|| {
+                    DataError::custom("Missing placeholder in other case")
+                        .with_display_context(&log10_type)
+                })?;
+
+                pattern.try_for_each(|pattern| {
+                    if let Some(number_of_0s) = pattern.0
+                        && number_of_0s != other_number_of_0s
+                    {
+                        return Err(DataError::custom("Inconsistent placeholders within")
+                            .with_debug_context(&log10_type)
+                            .with_debug_context(&other_number_of_0s)
+                            .with_debug_context(&number_of_0s));
+                    }
+                    Ok(())
+                })?;
+
+                let exponent = log10_type - other_number_of_0s + 1;
+
+                target.insert(log10_type, (exponent, pattern.map(|pattern| pattern.1)));
+            }
+        }
+
+        Ok(DataResponse {
+            metadata: Default::default(),
+            payload: DataPayload::from_owned(ShortCurrencyCompact {
+                standard: CompactPatterns::new(standard_patterns, None).map_err(|e| {
+                    DataError::custom("Invalid standard compact patterns").with_display_context(&e)
+                })?,
+                alpha_next_to_number: CompactPatterns::new(alpha_next_to_number_patterns, None)
+                    .map_err(|e| {
+                        DataError::custom("Invalid alpha-next-to-number compact patterns")
+                            .with_display_context(&e)
+                    })?,
+            }),
+        })
+    }
+}
+
+impl IterableDataProviderCached<ShortCurrencyCompactV1> for SourceDataProvider {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
+        let cldr = self.cldr()?;
+        let mut r = self.iter_ids_for_numbers_with_locales()?;
+        // TODO(#7493): This filtering might not be needed
+        let mut err = None;
+        r.retain(|id| {
+            if err.is_some() {
+                return true;
+            }
+            let numbers_resource = match cldr
+                .numbers()
+                .read_and_parse::<cldr_serde::numbers::Resource>(&id.locale, "numbers.json")
+            {
+                Ok(r) => r,
+                Err(e) => {
+                    err = Some(e);
+                    return true;
+                }
+            };
+
+            let numbering_system = if id.marker_attributes.is_empty() {
+                numbers_resource
+                    .main
+                    .value
+                    .numbers
+                    .default_numbering_system
+                    .as_str()
+            } else {
+                id.marker_attributes.as_str()
+            };
+
+            numbers_resource
+                .main
+                .value
+                .numbers
+                .numsys_data
+                .currency_patterns
+                .get(numbering_system)
+                .and_then(|patterns| patterns.compact_short.as_ref())
+                .is_some()
+        });
+        if let Some(e) = err { Err(e) } else { Ok(r) }
+    }
+}
+
+#[test]
+fn test_basic() {
+    use icu::experimental::dimension::provider::currency::compact::*;
+    use icu::locale::langid;
+    use icu::plurals::provider::FourBitMetadata;
+
+    let provider = SourceDataProvider::new_testing();
+    let en: DataResponse<ShortCurrencyCompactV1> = provider
+        .load(DataRequest {
+            id: DataIdentifierBorrowed::for_locale(&langid!("en").into()),
+            ..Default::default()
+        })
+        .unwrap();
+
+    let en_patterns = &en.payload.get();
+
+    assert_eq!(
+        en_patterns
+            .standard
+            .0
+            .iter()
+            .find(|t| t.sized == 3)
+            .unwrap()
+            .variable
+            .decode(),
+        PluralElements::new((
+            FourBitMetadata::try_from_byte(0).unwrap(),
+            &*DoublePlaceholderPattern::try_from_str("{1}{0}K", Default::default()).unwrap()
+        ))
+    );
+    assert_eq!(
+        en_patterns
+            .alpha_next_to_number
+            .0
+            .iter()
+            .find(|t| t.sized == 3)
+            .unwrap()
+            .variable
+            .decode(),
+        PluralElements::new((
+            FourBitMetadata::try_from_byte(0).unwrap(),
+            &*DoublePlaceholderPattern::try_from_str("{1} {0}K", Default::default()).unwrap()
+        ))
+    );
+
+    let ja: DataResponse<ShortCurrencyCompactV1> = provider
+        .load(DataRequest {
+            id: DataIdentifierBorrowed::for_locale(&langid!("ja").into()),
+            ..Default::default()
+        })
+        .unwrap();
+
+    let ja_patterns = &ja.payload.get();
+
+    assert_eq!(
+        ja_patterns
+            .standard
+            .0
+            .iter()
+            .find(|t| t.sized == 4)
+            .unwrap()
+            .variable
+            .decode(),
+        PluralElements::new((
+            FourBitMetadata::try_from_byte(0).unwrap(),
+            &*DoublePlaceholderPattern::try_from_str("{1}{0}万", Default::default()).unwrap()
+        ))
+    );
+    assert_eq!(
+        ja_patterns
+            .alpha_next_to_number
+            .0
+            .iter()
+            .find(|t| t.sized == 4)
+            .unwrap()
+            .variable
+            .decode(),
+        PluralElements::new((
+            FourBitMetadata::try_from_byte(0).unwrap(),
+            &*DoublePlaceholderPattern::try_from_str("{1} {0}万", Default::default()).unwrap()
+        ))
+    );
+}

--- a/provider/source/src/currency/displayname.rs
+++ b/provider/source/src/currency/displayname.rs
@@ -2,6 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use crate::DataIdentifierCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
 use icu::experimental::dimension::provider::currency::displayname::*;
@@ -44,7 +45,7 @@ impl DataProvider<CurrencyDisplaynameV1> for SourceDataProvider {
 }
 
 impl crate::IterableDataProviderCached<CurrencyDisplaynameV1> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         let mut result = HashSet::new();
         let numbers = self.cldr()?.numbers();
         let locales = numbers.list_locales()?;
@@ -61,8 +62,10 @@ impl crate::IterableDataProviderCached<CurrencyDisplaynameV1> for SourceDataProv
                 if currency_data.display_name.is_none() {
                     continue;
                 }
-                if let Ok(attributes) = DataMarkerAttributes::try_from_string(iso.clone()) {
-                    result.insert(DataIdentifierCow::from_owned(attributes, locale));
+                if let Ok(id) =
+                    DataIdentifierCached::from_writeable_attributes_and_locale(iso, locale)
+                {
+                    result.insert(id);
                 }
             }
         }

--- a/provider/source/src/currency/essentials.rs
+++ b/provider/source/src/currency/essentials.rs
@@ -2,6 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use crate::DataIdentifierCached;
 use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
@@ -45,7 +46,7 @@ impl DataProvider<CurrencyEssentialsV1> for SourceDataProvider {
 }
 
 impl IterableDataProviderCached<CurrencyEssentialsV1> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         super::iter_numsys_pattern_ids(self, |patterns| !patterns.standard.positive.is_empty())
     }
 }

--- a/provider/source/src/currency/extended.rs
+++ b/provider/source/src/currency/extended.rs
@@ -2,6 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use crate::DataIdentifierCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
 use icu::experimental::dimension::provider::currency::extended::*;
@@ -51,7 +52,7 @@ impl DataProvider<CurrencyExtendedDataV1> for SourceDataProvider {
 }
 
 impl crate::IterableDataProviderCached<CurrencyExtendedDataV1> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         let mut result = HashSet::new();
         let numbers = self.cldr()?.numbers();
         let locales = numbers.list_locales()?;
@@ -72,8 +73,10 @@ impl crate::IterableDataProviderCached<CurrencyExtendedDataV1> for SourceDataPro
                 if displaynames.other.is_none() {
                     continue;
                 }
-                if let Ok(attributes) = DataMarkerAttributes::try_from_string(currency.clone()) {
-                    result.insert(DataIdentifierCow::from_owned(attributes, locale));
+                if let Ok(id) =
+                    DataIdentifierCached::from_writeable_attributes_and_locale(currency, locale)
+                {
+                    result.insert(id);
                 }
             }
         }

--- a/provider/source/src/currency/fractions.rs
+++ b/provider/source/src/currency/fractions.rs
@@ -2,6 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use crate::DataIdentifierCached;
 use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
@@ -45,7 +46,7 @@ impl DataProvider<CurrencyFractionsV1> for SourceDataProvider {
 }
 
 impl IterableDataProviderCached<CurrencyFractionsV1> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         // Singleton data = one identifier (empty/default)
         Ok(HashSet::from_iter([Default::default()]))
     }

--- a/provider/source/src/currency/mod.rs
+++ b/provider/source/src/currency/mod.rs
@@ -17,6 +17,7 @@ use icu_pattern::DoublePlaceholderPattern;
 use icu_provider::prelude::*;
 use zerovec::VarZeroVec;
 
+use crate::DataIdentifierCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
 
@@ -53,7 +54,7 @@ impl PatternSet {
 fn iter_numsys_pattern_ids<F>(
     provider: &SourceDataProvider,
     predicate: F,
-) -> Result<HashSet<DataIdentifierCow<'static>>, DataError>
+) -> Result<HashSet<DataIdentifierCached>, DataError>
 where
     F: Fn(&cldr_serde::numbers::CurrencyFormattingPatterns) -> bool,
 {
@@ -71,13 +72,10 @@ where
                 continue;
             }
             if nsname == default_numsys {
-                ids.insert(DataIdentifierCow::from_locale(locale));
+                ids.insert(DataIdentifierCached::from_locale(locale));
             } else {
-                let attr = DataMarkerAttributes::try_from_str(nsname).map_err(|_| {
-                    DataError::custom("Invalid numbering system name").with_display_context(nsname)
-                })?;
                 ids.insert(
-                    DataIdentifierBorrowed::for_marker_attributes_and_locale(attr, &locale)
+                    DataIdentifierCached::from_writeable_attributes_and_locale(nsname, locale)?
                         .into_owned(),
                 );
             }

--- a/provider/source/src/currency/no_currency.rs
+++ b/provider/source/src/currency/no_currency.rs
@@ -2,6 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use crate::DataIdentifierCached;
 use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
@@ -56,7 +57,7 @@ fn has_no_currency_pattern(patterns: &cldr_serde::numbers::CurrencyFormattingPat
 }
 
 impl IterableDataProviderCached<CurrencyPatternsNoCurrencyV1> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         super::iter_numsys_pattern_ids(self, has_no_currency_pattern)
     }
 }

--- a/provider/source/src/currency/patterns.rs
+++ b/provider/source/src/currency/patterns.rs
@@ -2,6 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use crate::DataIdentifierCached;
 use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
@@ -77,12 +78,12 @@ impl DataProvider<CurrencyPatternsDataV1> for SourceDataProvider {
 }
 
 impl IterableDataProviderCached<CurrencyPatternsDataV1> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         Ok(self
             .cldr()?
             .numbers()
             .list_locales()?
-            .map(DataIdentifierCow::from_locale)
+            .map(DataIdentifierCached::from_locale)
             .collect())
     }
 }

--- a/provider/source/src/currency/symbols.rs
+++ b/provider/source/src/currency/symbols.rs
@@ -2,6 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use crate::DataIdentifierCached;
 use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
@@ -65,7 +66,7 @@ impl DataProvider<CurrencySymbolsV1> for SourceDataProvider {
 }
 
 impl IterableDataProviderCached<CurrencySymbolsV1> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         let cldr = self.cldr()?.numbers();
 
         let mut ids = HashSet::new();
@@ -82,16 +83,16 @@ impl IterableDataProviderCached<CurrencySymbolsV1> for SourceDataProvider {
                 .currencies
             {
                 if patterns.short.as_ref().is_some_and(|s| s != currency) {
-                    ids.insert(DataIdentifierCow::from_owned(
-                        DataMarkerAttributes::try_from_string(format!("s/{currency}")).unwrap(),
+                    ids.insert(DataIdentifierCached::from_writeable_attributes_and_locale(
+                        writeable::concat_writeable!("s/", currency),
                         locale,
-                    ));
+                    )?);
                 }
                 if patterns.narrow.as_ref().is_some_and(|s| s != currency) {
-                    ids.insert(DataIdentifierCow::from_owned(
-                        DataMarkerAttributes::try_from_string(format!("n/{currency}")).unwrap(),
+                    ids.insert(DataIdentifierCached::from_writeable_attributes_and_locale(
+                        writeable::concat_writeable!("n/", currency),
                         locale,
-                    ));
+                    )?);
                 }
             }
         }

--- a/provider/source/src/datetime/mod.rs
+++ b/provider/source/src/datetime/mod.rs
@@ -2,6 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use crate::DataIdentifierCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
 use icu::calendar::AnyCalendarKind;
@@ -217,7 +218,7 @@ pub(crate) fn iter_skeleton_supported_locales(
     provider: &SourceDataProvider,
     calendar: Option<DatagenCalendar>,
     fieldset_attributes: &[&[&'static DataMarkerAttributes]],
-) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+) -> Result<HashSet<DataIdentifierCached>, DataError> {
     Ok(provider
         .cldr()?
         .dates(calendar)
@@ -226,7 +227,7 @@ pub(crate) fn iter_skeleton_supported_locales(
             fieldset_attributes
                 .iter()
                 .flat_map(|list| list.iter())
-                .map(move |attrs| DataIdentifierCow::from_borrowed_and_owned(attrs, locale))
+                .map(move |attrs| DataIdentifierCached::from_attributes_and_locale(attrs, locale))
         })
         .collect())
 }

--- a/provider/source/src/datetime/names.rs
+++ b/provider/source/src/datetime/names.rs
@@ -3,6 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use super::DatagenCalendar;
+use crate::DataIdentifierCached;
 use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde::ca;
@@ -148,15 +149,15 @@ impl SourceDataProvider {
         &self,
         calendar: DatagenCalendar,
         keylengths: &'static [&DataMarkerAttributes],
-    ) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    ) -> Result<HashSet<DataIdentifierCached>, DataError> {
         Ok(self
             .cldr()?
             .dates(Some(calendar))
             .list_locales()?
             .flat_map(|locale| {
-                keylengths
-                    .iter()
-                    .map(move |&length| DataIdentifierCow::from_borrowed_and_owned(length, locale))
+                keylengths.iter().map(move |&length| {
+                    DataIdentifierCached::from_attributes_and_locale(length, locale)
+                })
             })
             .collect())
     }
@@ -642,7 +643,7 @@ macro_rules! impl_symbols_datagen {
         }
 
         impl IterableDataProviderCached<$marker> for SourceDataProvider {
-            fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+            fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
                 self.iter_datetime_ids($calendar, $lengths)
             }
         }
@@ -658,7 +659,7 @@ macro_rules! impl_pattern_datagen {
         }
 
         impl IterableDataProviderCached<$marker> for SourceDataProvider {
-            fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+            fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
                 self.iter_datetime_ids($calendar, $lengths)
             }
         }

--- a/provider/source/src/datetime/range_patterns.rs
+++ b/provider/source/src/datetime/range_patterns.rs
@@ -5,7 +5,8 @@
 use super::semantic_skeletons::{gen_date_components, gen_time_components};
 use super::{DatagenCalendar, PackedPatternItem};
 use crate::{
-    IterableDataProviderCached, SourceDataProvider, cldr_serde, debug_provider::DebugProvider,
+    DataIdentifierCached, IterableDataProviderCached, SourceDataProvider, cldr_serde,
+    debug_provider::DebugProvider,
 };
 use icu::datetime::fieldsets::enums::*;
 use icu::datetime::provider::fields::{self, Field, components};
@@ -392,7 +393,7 @@ impl SourceDataProvider {
     /// Returns the set of supported locales for time range skeletons.
     fn time_range_skeleton_supported_locales(
         &self,
-    ) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    ) -> Result<HashSet<DataIdentifierCached>, DataError> {
         super::iter_skeleton_supported_locales(
             self,
             None,
@@ -404,7 +405,7 @@ impl SourceDataProvider {
     fn date_range_skeleton_supported_locales(
         &self,
         calendar: DatagenCalendar,
-    ) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    ) -> Result<HashSet<DataIdentifierCached>, DataError> {
         super::iter_skeleton_supported_locales(
             self,
             Some(calendar),
@@ -444,12 +445,12 @@ impl DataProvider<DatetimePatternsRangeGlueV1> for SourceDataProvider {
 }
 
 impl IterableDataProviderCached<DatetimePatternsRangeGlueV1> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         Ok(self
             .cldr()?
             .dates(None)
             .list_locales()?
-            .map(DataIdentifierCow::from_locale)
+            .map(DataIdentifierCached::from_locale)
             .collect())
     }
 }
@@ -474,7 +475,7 @@ impl DataProvider<DatetimePatternsRangeTimeV1> for SourceDataProvider {
 }
 
 impl IterableDataProviderCached<DatetimePatternsRangeTimeV1> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         self.time_range_skeleton_supported_locales()
     }
 }
@@ -498,7 +499,7 @@ macro_rules! impl_datetime_range_skeleton_datagen {
         }
 
         impl IterableDataProviderCached<$marker> for SourceDataProvider {
-            fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+            fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
                 self.date_range_skeleton_supported_locales($calendar)
             }
         }

--- a/provider/source/src/datetime/semantic_skeletons.rs
+++ b/provider/source/src/datetime/semantic_skeletons.rs
@@ -3,6 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use super::{DatagenCalendar, PackedPatternItem, select_pattern, transpose_with_fallback};
+use crate::DataIdentifierCached;
 use crate::datetime::available_formats::DatetimeAsciiPreference;
 use crate::debug_provider::DebugProvider;
 use crate::{IterableDataProviderCached, SourceDataProvider, cldr_serde};
@@ -383,9 +384,7 @@ impl SourceDataProvider {
 
         Ok(T::build_packed(builder))
     }
-    fn time_skeleton_supported_locales(
-        &self,
-    ) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn time_skeleton_supported_locales(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         super::iter_skeleton_supported_locales(
             self,
             None,
@@ -396,7 +395,7 @@ impl SourceDataProvider {
     fn date_skeleton_supported_locales(
         &self,
         calendar: DatagenCalendar,
-    ) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    ) -> Result<HashSet<DataIdentifierCached>, DataError> {
         super::iter_skeleton_supported_locales(
             self,
             Some(calendar),
@@ -595,7 +594,7 @@ impl DataProvider<DatetimePatternsTimeV1> for SourceDataProvider {
 }
 
 impl IterableDataProviderCached<DatetimePatternsTimeV1> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         self.time_skeleton_supported_locales()
     }
 }
@@ -609,7 +608,7 @@ macro_rules! impl_datetime_skeleton_datagen {
         }
 
         impl IterableDataProviderCached<$marker> for SourceDataProvider {
-            fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+            fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
                 self.date_skeleton_supported_locales($calendar)
             }
         }

--- a/provider/source/src/datetime/week_data.rs
+++ b/provider/source/src/datetime/week_data.rs
@@ -2,6 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use crate::DataIdentifierCached;
 use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde::{
@@ -67,7 +68,7 @@ impl DataProvider<CalendarWeekV1> for SourceDataProvider {
 }
 
 impl IterableDataProviderCached<CalendarWeekV1> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         let week_data: &cldr_serde::week_data::Resource = self
             .cldr()?
             .core()
@@ -87,7 +88,7 @@ impl IterableDataProviderCached<CalendarWeekV1> for SourceDataProvider {
             .map(|region| {
                 let mut locale = DataLocale::default();
                 locale.region = region;
-                DataIdentifierCow::from_locale(locale)
+                DataIdentifierCached::from_locale(locale)
             })
             .collect())
     }
@@ -111,7 +112,7 @@ fn test_basic_cldr_week_data_v2() {
 
     let fr_week_data: DataResponse<CalendarWeekV1> = provider
         .load(DataRequest {
-            id: DataIdentifierCow::from_locale(data_locale!("und-FR")).as_borrowed(),
+            id: DataIdentifierBorrowed::for_locale(&data_locale!("und-FR")),
             ..Default::default()
         })
         .unwrap();
@@ -123,7 +124,7 @@ fn test_basic_cldr_week_data_v2() {
 
     let iq_week_data: DataResponse<CalendarWeekV1> = provider
         .load(DataRequest {
-            id: DataIdentifierCow::from_locale(data_locale!("und-IQ")).as_borrowed(),
+            id: DataIdentifierBorrowed::for_locale(&data_locale!("und-IQ")),
             ..Default::default()
         })
         .unwrap();
@@ -136,7 +137,7 @@ fn test_basic_cldr_week_data_v2() {
 
     let gg_week_data: DataResponse<CalendarWeekV1> = provider
         .load(DataRequest {
-            id: DataIdentifierCow::from_locale(data_locale!("und-GG")).as_borrowed(),
+            id: DataIdentifierBorrowed::for_locale(&data_locale!("und-GG")),
             ..Default::default()
         })
         .unwrap();
@@ -152,7 +153,7 @@ fn test_basic_cldr_week_data_v2() {
 
     let ir_week_data: DataResponse<CalendarWeekV1> = provider
         .load(DataRequest {
-            id: DataIdentifierCow::from_locale(data_locale!("und-IR")).as_borrowed(),
+            id: DataIdentifierBorrowed::for_locale(&data_locale!("und-IR")),
             ..Default::default()
         })
         .unwrap();

--- a/provider/source/src/decimal/compact.rs
+++ b/provider/source/src/decimal/compact.rs
@@ -2,6 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use crate::DataIdentifierCached;
 use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
@@ -92,13 +93,13 @@ impl DataProvider<DecimalCompactLongV1> for SourceDataProvider {
 }
 
 impl IterableDataProviderCached<DecimalCompactShortV1> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         self.iter_ids_for_numbers_with_locales()
     }
 }
 
 impl IterableDataProviderCached<DecimalCompactLongV1> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         self.iter_ids_for_numbers_with_locales()
     }
 }
@@ -178,7 +179,7 @@ mod tests {
 
         let ja_compact_short: DataPayload<DecimalCompactShortV1> = provider
             .load(DataRequest {
-                id: DataIdentifierCow::from_locale(data_locale!("ja")).as_borrowed(),
+                id: DataIdentifierBorrowed::for_locale(&data_locale!("ja")),
                 ..Default::default()
             })
             .unwrap()

--- a/provider/source/src/decimal/digits.rs
+++ b/provider/source/src/decimal/digits.rs
@@ -2,6 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use crate::DataIdentifierCached;
 use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use icu::decimal::provider::*;
@@ -28,7 +29,7 @@ impl DataProvider<DecimalDigitsV1> for SourceDataProvider {
 }
 
 impl IterableDataProviderCached<DecimalDigitsV1> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         self.iter_ids_for_used_numbers()
     }
 }

--- a/provider/source/src/decimal/mod.rs
+++ b/provider/source/src/decimal/mod.rs
@@ -4,6 +4,8 @@
 
 use std::collections::HashSet;
 
+use crate::DataIdentifierCached;
+use crate::DataIdentifierCachedWithLifetime;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
 use icu_provider::prelude::*;
@@ -76,7 +78,7 @@ impl SourceDataProvider {
     /// This also includes a bare <locale>
     pub(crate) fn iter_ids_for_numbers_with_locales(
         &self,
-    ) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    ) -> Result<HashSet<DataIdentifierCached>, DataError> {
         Ok(self
             .cldr()?
             .numbers()
@@ -87,19 +89,18 @@ impl SourceDataProvider {
                     .expect("All languages from list_locales should be present")
                     .into_iter()
                     .map(move |nsname| {
-                        DataIdentifierBorrowed::for_marker_attributes_and_locale(
-                            DataMarkerAttributes::try_from_str(&nsname).unwrap(),
-                            &locale,
+                        DataIdentifierCachedWithLifetime::from_attributes_and_locale(
+                            &nsname, locale,
                         )
                         .into_owned()
                     })
-                    .chain([DataIdentifierCow::from_locale(last)])
+                    .chain([DataIdentifierCached::from_locale(last)])
             })
             .collect())
     }
 
     /// Produce `DataIdentifier`'s for all *used* numbering systems in the form und/<numsys>
-    fn iter_ids_for_used_numbers(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_for_used_numbers(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         Ok(self
             .cldr()?
             .numbers()
@@ -109,8 +110,9 @@ impl SourceDataProvider {
                     .expect("All languages from list_locales should be present")
                     .into_iter()
                     .map(move |nsname| {
-                        DataIdentifierBorrowed::for_marker_attributes(
-                            DataMarkerAttributes::try_from_str(&nsname).unwrap(),
+                        DataIdentifierCachedWithLifetime::from_attributes_and_locale(
+                            &nsname,
+                            DataLocale::default(),
                         )
                         .into_owned()
                     })
@@ -120,7 +122,7 @@ impl SourceDataProvider {
 
     /// Produce `DataIdentifier`'s for all digit-based numbering systems in the form und/<numsys>
     #[allow(unused)] // TODO(#5824): Support user-specified numbering systems
-    fn iter_all_number_ids(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_all_number_ids(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         use cldr_serde::numbering_systems::NumberingSystemType;
         let resource: &cldr_serde::numbering_systems::Resource = self
             .cldr()?
@@ -133,11 +135,11 @@ impl SourceDataProvider {
             .iter()
             .filter(|(_nsname, data)| data.nstype == NumberingSystemType::Numeric)
             .map(|(nsname, _data)| {
-                DataIdentifierBorrowed::for_marker_attributes(
-                    DataMarkerAttributes::try_from_str(nsname).unwrap(),
+                DataIdentifierCachedWithLifetime::from_writeable_attributes_and_locale(
+                    &nsname,
+                    DataLocale::default(),
                 )
-                .into_owned()
             })
-            .collect())
+            .collect::<Result<_, _>>()?)
     }
 }

--- a/provider/source/src/decimal/mod.rs
+++ b/provider/source/src/decimal/mod.rs
@@ -129,17 +129,17 @@ impl SourceDataProvider {
             .core()
             .read_and_parse("supplemental/numberingSystems.json")?;
 
-        Ok(resource
+        resource
             .supplemental
             .numbering_systems
             .iter()
             .filter(|(_nsname, data)| data.nstype == NumberingSystemType::Numeric)
             .map(|(nsname, _data)| {
                 DataIdentifierCachedWithLifetime::from_writeable_attributes_and_locale(
-                    &nsname,
+                    nsname,
                     DataLocale::default(),
                 )
             })
-            .collect::<Result<_, _>>()?)
+            .collect()
     }
 }

--- a/provider/source/src/decimal/mod.rs
+++ b/provider/source/src/decimal/mod.rs
@@ -135,10 +135,7 @@ impl SourceDataProvider {
             .iter()
             .filter(|(_nsname, data)| data.nstype == NumberingSystemType::Numeric)
             .map(|(nsname, _data)| {
-                DataIdentifierCachedWithLifetime::from_writeable_attributes_and_locale(
-                    nsname,
-                    DataLocale::default(),
-                )
+                DataIdentifierCachedWithLifetime::from_writeable_attributes(nsname)
             })
             .collect()
     }

--- a/provider/source/src/decimal/symbols.rs
+++ b/provider/source/src/decimal/symbols.rs
@@ -2,6 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use crate::DataIdentifierCached;
 use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
@@ -103,7 +104,7 @@ impl DataProvider<DecimalSymbolsV1> for SourceDataProvider {
 }
 
 impl IterableDataProviderCached<DecimalSymbolsV1> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         self.iter_ids_for_numbers_with_locales()
     }
 }
@@ -116,7 +117,7 @@ fn test_basic() {
 
     let ar_decimal: DataResponse<DecimalSymbolsV1> = provider
         .load(DataRequest {
-            id: DataIdentifierCow::from_locale(data_locale!("ar-EG")).as_borrowed(),
+            id: DataIdentifierBorrowed::for_locale(&data_locale!("ar-EG")),
             ..Default::default()
         })
         .unwrap();

--- a/provider/source/src/displaynames/mod.rs
+++ b/provider/source/src/displaynames/mod.rs
@@ -265,7 +265,7 @@ macro_rules! impl_displaynames_menu_v1 {
         }
 
         impl IterableDataProviderCached<$marker> for SourceDataProvider {
-            fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+            fn iter_ids_cached(&self) -> Result<HashSet<$crate::DataIdentifierCached>, DataError> {
                 let mut result = HashSet::new();
                 let cldr = self.cldr()?;
                 let displaynames = cldr.displaynames();
@@ -301,14 +301,7 @@ macro_rules! impl_displaynames_menu_v1 {
                                     .coverage_tier(&locale, &xpath, cldr)?,
                                 $tier
                             ) {
-                                let data_identifier = DataIdentifierCow::from_owned(
-                                    DataMarkerAttributes::try_from_string(key.subtag.to_string())
-                                        .map_err(|_| {
-                                        DataError::custom("Failed to parse attribute")
-                                            .with_debug_context(&key.subtag)
-                                    })?,
-                                    locale,
-                                );
+                                let data_identifier = crate::DataIdentifierCached::from_writeable_attributes_and_locale(&key.subtag, locale)?;
                                 result.insert(data_identifier);
                             }
                         }
@@ -345,7 +338,7 @@ macro_rules! impl_displaynames_menu_v1 {
 macro_rules! impl_displaynames_iter_v1 {
     ($marker:ident, $subtag_ty:ty, $resource:path, $file:literal, $field:ident, $alt_variant:expr, $xpath_prefix:literal, $tier:pat) => {
         impl IterableDataProviderCached<$marker> for SourceDataProvider {
-            fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+            fn iter_ids_cached(&self) -> Result<HashSet<$crate::DataIdentifierCached>, DataError> {
                 let mut result = HashSet::new();
                 let cldr = self.cldr()?;
                 let displaynames = cldr.displaynames();
@@ -370,14 +363,7 @@ macro_rules! impl_displaynames_iter_v1 {
                                     .coverage_tier(&locale, &xpath, cldr)?,
                                 $tier
                             ) {
-                                let data_identifier = DataIdentifierCow::from_owned(
-                                    DataMarkerAttributes::try_from_string(key.subtag.to_string())
-                                        .map_err(|_| {
-                                        DataError::custom("Failed to parse attribute")
-                                            .with_debug_context(&key.subtag)
-                                    })?,
-                                    locale,
-                                );
+                                let data_identifier = crate::DataIdentifierCached::from_writeable_attributes_and_locale(&key.subtag, locale)?;
                                 result.insert(data_identifier);
                             }
                         }
@@ -397,7 +383,7 @@ macro_rules! impl_displaynames_iter_v1 {
 macro_rules! impl_displaynames_legacy_iter_v1 {
     ($marker:ident, $file:literal) => {
         impl IterableDataProviderCached<$marker> for SourceDataProvider {
-            fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+            fn iter_ids_cached(&self) -> Result<HashSet<$crate::DataIdentifierCached>, DataError> {
                 let displaynames = self.cldr()?.displaynames();
                 Ok(displaynames
                     .list_locales()?
@@ -405,7 +391,7 @@ macro_rules! impl_displaynames_legacy_iter_v1 {
                         // The directory might exist without the file
                         displaynames.file_exists(locale, $file).unwrap_or_default()
                     })
-                    .map(DataIdentifierCow::from_locale)
+                    .map($crate::DataIdentifierCached::from_locale)
                     .collect())
             }
         }

--- a/provider/source/src/duration/mod.rs
+++ b/provider/source/src/duration/mod.rs
@@ -2,6 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use crate::DataIdentifierCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
 use crate::cldr_serde::units::data::DurationUnits;
@@ -159,7 +160,7 @@ impl SourceDataProvider {
 
 #[cfg(feature = "unstable")]
 impl crate::IterableDataProviderCached<DigitalDurationDataV1> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         Ok(self
             .cldr()?
             .numbers()
@@ -171,7 +172,7 @@ impl crate::IterableDataProviderCached<DigitalDurationDataV1> for SourceDataProv
                     .read_and_parse::<cldr_serde::units::data::Resource>(locale, "units.json")
                     .is_ok()
             })
-            .map(DataIdentifierCow::from_locale)
+            .map(DataIdentifierCached::from_locale)
             .collect())
     }
 }

--- a/provider/source/src/lib.rs
+++ b/provider/source/src/lib.rs
@@ -111,10 +111,7 @@ pub struct SourceDataProvider {
     pub(crate) timezone_horizon: time_zones::Timestamp,
     #[expect(clippy::type_complexity)] // not as complex as it appears
     requests_cache: Arc<
-        FrozenMap<
-            DataMarkerInfo,
-            Box<OnceLock<Result<HashSet<DataIdentifierCow<'static>>, DataError>>>,
-        >,
+        FrozenMap<DataMarkerInfo, Box<OnceLock<Result<HashSet<DataIdentifierCached>, DataError>>>>,
     >,
 }
 
@@ -521,6 +518,87 @@ impl SourceDataProvider {
     }
 }
 
+/// A crate-internal data identifier representation for cache storage wrapping [`DataIdentifierCow<'static>`].
+#[derive(Default, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct DataIdentifierCachedWithLifetime<'a>(pub(crate) DataIdentifierCow<'a>);
+
+pub(crate) type DataIdentifierCached = DataIdentifierCachedWithLifetime<'static>;
+
+impl<'a> core::ops::Deref for DataIdentifierCachedWithLifetime<'a> {
+    type Target = DataIdentifierCow<'a>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'a> DataIdentifierCachedWithLifetime<'a> {
+    pub(crate) fn from_locale(locale: impl Into<DataLocale>) -> Self {
+        Self(DataIdentifierCow::from_locale(locale.into()))
+    }
+
+    pub(crate) fn from_attributes(attr: &'a DataMarkerAttributes) -> Self {
+        Self(DataIdentifierCow::from_marker_attributes(attr))
+    }
+
+    pub(crate) fn from_attributes_and_locale(
+        attr: &'a DataMarkerAttributes,
+        locale: impl Into<DataLocale>,
+    ) -> Self {
+        Self(DataIdentifierCow::from_borrowed_and_owned(
+            attr,
+            locale.into(),
+        ))
+    }
+
+    pub(crate) fn from_cow(cow: DataIdentifierCow<'a>) -> Self {
+        Self(cow)
+    }
+
+    pub(crate) fn as_cow(&self) -> DataIdentifierCow<'_> {
+        self.0.clone()
+    }
+
+    pub(crate) fn into_owned(self) -> DataIdentifierCached {
+        DataIdentifierCachedWithLifetime(DataIdentifierCow::from_owned(
+            self.0.marker_attributes.into_owned(),
+            self.0.locale,
+        ))
+    }
+}
+
+impl DataIdentifierCached {
+    pub(crate) fn from_writeable_attributes(
+        attr: impl writeable::Writeable + Debug,
+    ) -> Result<Self, DataError> {
+        let s = attr.write_to_string();
+        if s.is_empty() {
+            Ok(Self(DataIdentifierCow::from_marker_attributes(
+                DataMarkerAttributes::empty(),
+            )))
+        } else {
+            let boxed = DataMarkerAttributes::try_from_string(s.into_owned()).map_err(|_| {
+                DataError::custom("Invalid marker attributes").with_debug_context(&attr)
+            })?;
+            Ok(Self(DataIdentifierCow::from_marker_attributes_owned(boxed)))
+        }
+    }
+
+    pub(crate) fn from_writeable_attributes_and_locale(
+        attr: impl writeable::Writeable + Debug,
+        locale: impl Into<DataLocale>,
+    ) -> Result<Self, DataError> {
+        let s = attr.write_to_string();
+        if s.is_empty() {
+            Ok(Self(DataIdentifierCow::from_locale(locale.into())))
+        } else {
+            let boxed = DataMarkerAttributes::try_from_string(s.into_owned()).map_err(|_| {
+                DataError::custom("Invalid marker attributes").with_debug_context(&attr)
+            })?;
+            Ok(Self(DataIdentifierCow::from_owned(boxed, locale.into())))
+        }
+    }
+}
+
 impl SourceDataProvider {
     fn check_req<M: DataMarker>(&self, req: DataRequest) -> Result<(), DataError>
     where
@@ -532,7 +610,10 @@ impl SourceDataProvider {
             } else {
                 Ok(())
             }
-        } else if !self.populate_requests_cache()?.contains(&req.id.as_cow()) {
+        } else if !self
+            .populate_requests_cache()?
+            .contains(&DataIdentifierCachedWithLifetime(req.id.as_cow()))
+        {
             Err(DataErrorKind::IdentifierNotFound)
         } else {
             Ok(())
@@ -555,8 +636,12 @@ fn test_check_req() {
 
     #[allow(non_local_definitions)] // test-scoped, only place that uses it
     impl IterableDataProviderCached<HelloWorldV1> for SourceDataProvider {
-        fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
-            Ok(HelloWorldProvider.iter_ids()?.into_iter().collect())
+        fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
+            Ok(HelloWorldProvider
+                .iter_ids()?
+                .into_iter()
+                .map(DataIdentifierCachedWithLifetime)
+                .collect())
         }
     }
 
@@ -580,13 +665,13 @@ fn test_check_req() {
 }
 
 trait IterableDataProviderCached<M: DataMarker>: DataProvider<M> {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError>;
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError>;
 }
 
 impl SourceDataProvider {
     fn populate_requests_cache<M: DataMarker>(
         &self,
-    ) -> Result<&HashSet<DataIdentifierCow<'_>>, DataError>
+    ) -> Result<&HashSet<DataIdentifierCached>, DataError>
     where
         SourceDataProvider: IterableDataProviderCached<M>,
     {
@@ -609,7 +694,7 @@ where
         } else {
             self.populate_requests_cache()?
                 .iter()
-                .map(|id| id.as_borrowed().as_cow())
+                .map(|id| id.as_cow())
                 .collect()
         })
     }

--- a/provider/source/src/lib.rs
+++ b/provider/source/src/lib.rs
@@ -518,7 +518,7 @@ impl SourceDataProvider {
     }
 }
 
-/// A crate-internal data identifier representation for cache storage wrapping [`DataIdentifierCow<'static>`].
+/// A crate-internal data identifier representation for cache storage wrapping [`DataIdentifierCow<'a>`].
 #[derive(Default, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct DataIdentifierCachedWithLifetime<'a>(pub(crate) DataIdentifierCow<'a>);
 
@@ -554,7 +554,7 @@ impl<'a> DataIdentifierCachedWithLifetime<'a> {
         Self(cow)
     }
 
-    pub(crate) fn as_cow(&self) -> DataIdentifierCow<'_> {
+    pub(crate) fn as_cow(&self) -> DataIdentifierCow<'a> {
         self.0.clone()
     }
 
@@ -570,17 +570,7 @@ impl DataIdentifierCached {
     pub(crate) fn from_writeable_attributes(
         attr: impl writeable::Writeable + Debug,
     ) -> Result<Self, DataError> {
-        let s = attr.write_to_string();
-        if s.is_empty() {
-            Ok(Self(DataIdentifierCow::from_marker_attributes(
-                DataMarkerAttributes::empty(),
-            )))
-        } else {
-            let boxed = DataMarkerAttributes::try_from_string(s.into_owned()).map_err(|_| {
-                DataError::custom("Invalid marker attributes").with_debug_context(&attr)
-            })?;
-            Ok(Self(DataIdentifierCow::from_marker_attributes_owned(boxed)))
-        }
+        Self::from_writeable_attributes_and_locale(attr, DataLocale::default())
     }
 
     pub(crate) fn from_writeable_attributes_and_locale(

--- a/provider/source/src/list/mod.rs
+++ b/provider/source/src/list/mod.rs
@@ -2,6 +2,8 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use crate::DataIdentifierCached;
+use crate::DataIdentifierCachedWithLifetime;
 use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
@@ -168,7 +170,7 @@ macro_rules! implement {
         }
 
         impl IterableDataProviderCached<$marker> for SourceDataProvider {
-            fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+            fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
                 Ok(self
                     .cldr()?
                     .misc()
@@ -180,7 +182,10 @@ macro_rules! implement {
                             ListFormatterPatterns::WIDE,
                         ]
                         .into_iter()
-                        .map(move |a| DataIdentifierCow::from_borrowed_and_owned(a, l.clone()))
+                        .map(move |a| {
+                            DataIdentifierCachedWithLifetime::from_attributes_and_locale(a, l)
+                                .into_owned()
+                        })
                     })
                     .collect())
             }

--- a/provider/source/src/locale/aliases.rs
+++ b/provider/source/src/locale/aliases.rs
@@ -2,6 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use crate::DataIdentifierCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
 use core::cmp::Ordering;
@@ -30,7 +31,7 @@ impl DataProvider<LocaleAliasesV1> for SourceDataProvider {
 }
 
 impl crate::IterableDataProviderCached<LocaleAliasesV1> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         Ok(HashSet::from_iter([Default::default()]))
     }
 }

--- a/provider/source/src/locale/directionality.rs
+++ b/provider/source/src/locale/directionality.rs
@@ -4,6 +4,7 @@
 
 use std::collections::HashSet;
 
+use crate::DataIdentifierCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
 use icu::locale::provider::*;
@@ -23,7 +24,7 @@ impl DataProvider<LocaleScriptDirectionV1> for SourceDataProvider {
 }
 
 impl crate::IterableDataProviderCached<LocaleScriptDirectionV1> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         Ok(HashSet::from_iter([Default::default()]))
     }
 }

--- a/provider/source/src/locale/likely_subtags.rs
+++ b/provider/source/src/locale/likely_subtags.rs
@@ -3,6 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use crate::CoverageLevel;
+use crate::DataIdentifierCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
 use icu::locale::LanguageIdentifier;
@@ -23,7 +24,7 @@ impl DataProvider<LocaleLikelySubtagsExtendedV1> for SourceDataProvider {
 }
 
 impl crate::IterableDataProviderCached<LocaleLikelySubtagsExtendedV1> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         Ok(HashSet::from_iter([Default::default()]))
     }
 }
@@ -39,7 +40,7 @@ impl DataProvider<LocaleLikelySubtagsLanguageV1> for SourceDataProvider {
 }
 
 impl crate::IterableDataProviderCached<LocaleLikelySubtagsLanguageV1> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         Ok(HashSet::from_iter([Default::default()]))
     }
 }
@@ -55,7 +56,7 @@ impl DataProvider<LocaleLikelySubtagsScriptRegionV1> for SourceDataProvider {
 }
 
 impl crate::IterableDataProviderCached<LocaleLikelySubtagsScriptRegionV1> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         Ok(HashSet::from_iter([Default::default()]))
     }
 }

--- a/provider/source/src/locale/parents.rs
+++ b/provider/source/src/locale/parents.rs
@@ -2,6 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use crate::DataIdentifierCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
 
@@ -29,7 +30,7 @@ impl DataProvider<LocaleParentsV1> for SourceDataProvider {
 }
 
 impl crate::IterableDataProviderCached<LocaleParentsV1> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         Ok(HashSet::from_iter([Default::default()]))
     }
 }

--- a/provider/source/src/normalizer/mod.rs
+++ b/provider/source/src/normalizer/mod.rs
@@ -5,6 +5,7 @@
 //! This module contains provider implementations backed by TOML files
 //! exported from ICU.
 
+use crate::DataIdentifierCached;
 use crate::SourceDataProvider;
 use crate::TrieType;
 use icu::collections::char16trie::Char16Trie;
@@ -43,7 +44,7 @@ macro_rules! normalization_provider {
         }
 
         impl crate::IterableDataProviderCached<$marker> for SourceDataProvider {
-            fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+            fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
                 Ok(HashSet::from_iter([Default::default()]))
             }
         }
@@ -221,7 +222,7 @@ macro_rules! impl_decomposition_inert_property {
         impl crate::IterableDataProviderCached<icu::properties::provider::$marker>
             for SourceDataProvider
         {
-            fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+            fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
                 Ok(HashSet::from_iter([Default::default()]))
             }
         }
@@ -347,7 +348,7 @@ macro_rules! impl_composition_inert_property {
         impl crate::IterableDataProviderCached<icu::properties::provider::$marker>
             for SourceDataProvider
         {
-            fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+            fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
                 Ok(HashSet::from_iter([Default::default()]))
             }
         }

--- a/provider/source/src/percent/mod.rs
+++ b/provider/source/src/percent/mod.rs
@@ -5,6 +5,7 @@
 use std::borrow::Cow;
 use std::collections::HashSet;
 
+use crate::DataIdentifierCached;
 use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
@@ -38,12 +39,12 @@ impl DataProvider<PercentEssentialsV1> for SourceDataProvider {
 }
 
 impl IterableDataProviderCached<PercentEssentialsV1> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         Ok(self
             .cldr()?
             .numbers()
             .list_locales()?
-            .map(DataIdentifierCow::from_locale)
+            .map(DataIdentifierCached::from_locale)
             .collect())
     }
 }
@@ -232,7 +233,7 @@ fn test_basic() {
 
     let en: DataResponse<PercentEssentialsV1> = provider
         .load(DataRequest {
-            id: DataIdentifierCow::from_locale(data_locale!("en")).as_borrowed(),
+            id: DataIdentifierBorrowed::for_locale(&data_locale!("en")),
             ..Default::default()
         })
         .unwrap();
@@ -244,7 +245,7 @@ fn test_basic() {
 
     let tr: DataResponse<PercentEssentialsV1> = provider
         .load(DataRequest {
-            id: DataIdentifierCow::from_locale(data_locale!("tr")).as_borrowed(),
+            id: DataIdentifierBorrowed::for_locale(&data_locale!("tr")),
             ..Default::default()
         })
         .unwrap();
@@ -256,7 +257,7 @@ fn test_basic() {
 
     let ar_eg: DataResponse<PercentEssentialsV1> = provider
         .load(DataRequest {
-            id: DataIdentifierCow::from_locale(data_locale!("ar-EG")).as_borrowed(),
+            id: DataIdentifierBorrowed::for_locale(&data_locale!("ar-EG")),
             ..Default::default()
         })
         .unwrap();

--- a/provider/source/src/personnames/person_names_format_data_providers.rs
+++ b/provider/source/src/personnames/person_names_format_data_providers.rs
@@ -10,6 +10,7 @@ use icu::experimental::personnames::provider::*;
 use icu_provider::prelude::*;
 use zerovec::VarZeroVec;
 
+use crate::DataIdentifierCached;
 use crate::IterableDataProviderCached;
 use crate::cldr_serde::personnames::person_name_format_json_struct::Resource;
 
@@ -33,7 +34,7 @@ impl DataProvider<PersonNamesFormatV1> for crate::SourceDataProvider {
 }
 
 impl IterableDataProviderCached<PersonNamesFormatV1> for crate::SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         Ok(self
             .cldr()?
             .personnames()
@@ -46,7 +47,7 @@ impl IterableDataProviderCached<PersonNamesFormatV1> for crate::SourceDataProvid
                     .file_exists(locale, "personNames.json")
                     .unwrap_or_default()
             })
-            .map(DataIdentifierCow::from_locale)
+            .map(DataIdentifierCached::from_locale)
             .collect())
     }
 }

--- a/provider/source/src/plurals/mod.rs
+++ b/provider/source/src/plurals/mod.rs
@@ -6,6 +6,7 @@
 use std::collections::BTreeMap;
 use std::collections::HashSet;
 
+use crate::DataIdentifierCached;
 use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
@@ -77,12 +78,12 @@ macro_rules! implement {
         }
 
         impl IterableDataProviderCached<$marker> for SourceDataProvider {
-            fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+            fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
                 Ok(self
                     .get_rules_for(<$marker>::INFO)?
                     .0
                     .keys()
-                    .map(|l| DataIdentifierCow::from_locale(DataLocale::from(l)))
+                    .map(|l| DataIdentifierCached::from_locale(DataLocale::from(l)))
                     .collect())
             }
         }
@@ -140,12 +141,12 @@ impl DataProvider<PluralsRangesV1> for SourceDataProvider {
 
 #[cfg(feature = "unstable")]
 impl IterableDataProviderCached<PluralsRangesV1> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         Ok(self
             .get_plural_ranges()?
             .0
             .keys()
-            .map(|l| DataIdentifierCow::from_locale(DataLocale::from(l)))
+            .map(|l| DataIdentifierCached::from_locale(DataLocale::from(l)))
             .chain([Default::default()]) // `und` is not included in the locales of plural ranges.
             .collect())
     }

--- a/provider/source/src/properties/bidi.rs
+++ b/provider/source/src/properties/bidi.rs
@@ -4,6 +4,7 @@
 
 use std::collections::HashSet;
 
+use crate::DataIdentifierCached;
 use crate::SourceDataProvider;
 use icu::properties::provider::PropertyEnumBidiMirroringGlyphV1;
 use icu_provider::prelude::*;
@@ -137,7 +138,7 @@ impl DataProvider<PropertyEnumBidiMirroringGlyphV1> for SourceDataProvider {
 }
 
 impl crate::IterableDataProviderCached<PropertyEnumBidiMirroringGlyphV1> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         Ok(HashSet::from_iter([Default::default()]))
     }
 }

--- a/provider/source/src/properties/bin_cp_set.rs
+++ b/provider/source/src/properties/bin_cp_set.rs
@@ -2,6 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use crate::DataIdentifierCached;
 use crate::SourceDataProvider;
 use icu::casemap::options::TitlecaseOptions;
 use icu::collections::codepointinvlist::{CodePointInversionList, CodePointInversionListBuilder};
@@ -121,7 +122,7 @@ macro_rules! impl_ucd_property {
             }
 
             impl crate::IterableDataProviderCached<$marker> for SourceDataProvider {
-                fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+                fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
                     Ok(HashSet::from_iter([Default::default()]))
                 }
             }
@@ -366,7 +367,7 @@ impl DataProvider<PropertyBinarySegmentStarterV1> for SourceDataProvider {
 }
 
 impl crate::IterableDataProviderCached<PropertyBinarySegmentStarterV1> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         Ok(HashSet::from_iter([Default::default()]))
     }
 }
@@ -433,7 +434,7 @@ impl DataProvider<PropertyBinaryCaseSensitiveV1> for SourceDataProvider {
 }
 
 impl crate::IterableDataProviderCached<PropertyBinaryCaseSensitiveV1> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         Ok(HashSet::from_iter([Default::default()]))
     }
 }
@@ -468,7 +469,7 @@ macro_rules! impl_posix_property {
             }
 
             impl crate::IterableDataProviderCached<$marker> for SourceDataProvider {
-                fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+                fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
                     Ok(HashSet::from_iter([Default::default()]))
                 }
             }

--- a/provider/source/src/properties/emoji_set.rs
+++ b/provider/source/src/properties/emoji_set.rs
@@ -3,6 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 use super::ucd_helpers;
+use crate::DataIdentifierCached;
 use crate::SourceDataProvider;
 use icu::collections::codepointinvlist::CodePointInversionListBuilder;
 use icu::collections::codepointinvliststringlist::CodePointInversionListAndStringList;
@@ -83,7 +84,7 @@ macro_rules! expand {
             }
 
             impl crate::IterableDataProviderCached<$marker> for SourceDataProvider {
-                fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+                fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
                     Ok(HashSet::from_iter([Default::default()]))
                 }
             }

--- a/provider/source/src/properties/enum_codepointtrie.rs
+++ b/provider/source/src/properties/enum_codepointtrie.rs
@@ -2,6 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use crate::DataIdentifierCached;
 use crate::SourceDataProvider;
 use crate::properties::ucd_helpers::{self, UcdLine};
 use icu::collections::codepointtrie::{CodePointTrie, TrieValue};
@@ -393,25 +394,25 @@ macro_rules! expand {
             }
 
             impl crate::IterableDataProviderCached<$marker> for SourceDataProvider {
-                fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError>  {
+                fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError>  {
                     Ok(HashSet::from_iter([Default::default()]))
                 }
             }
 
             impl crate::IterableDataProviderCached<$parse_marker> for SourceDataProvider {
-                fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError>  {
+                fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError>  {
                     Ok(HashSet::from_iter([Default::default()]))
                 }
             }
 
             impl crate::IterableDataProviderCached<$short_marker> for SourceDataProvider {
-                fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError>  {
+                fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError>  {
                     Ok(HashSet::from_iter([Default::default()]))
                 }
             }
 
             impl crate::IterableDataProviderCached<$long_marker> for SourceDataProvider {
-                fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError>  {
+                fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError>  {
                     Ok(HashSet::from_iter([Default::default()]))
                 }
             }
@@ -459,7 +460,7 @@ impl DataProvider<PropertyNameParseGeneralCategoryMaskV1> for SourceDataProvider
 impl crate::IterableDataProviderCached<PropertyNameParseGeneralCategoryMaskV1>
     for SourceDataProvider
 {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         Ok(HashSet::from_iter([Default::default()]))
     }
 }

--- a/provider/source/src/properties/script.rs
+++ b/provider/source/src/properties/script.rs
@@ -2,6 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use crate::DataIdentifierCached;
 use crate::SourceDataProvider;
 use icu::collections::codepointtrie::TrieValue;
 use icu::properties::props::EnumeratedProperty;
@@ -130,7 +131,7 @@ impl DataProvider<PropertyScriptWithExtensionsV1> for SourceDataProvider {
 }
 
 impl crate::IterableDataProviderCached<PropertyScriptWithExtensionsV1> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         Ok(HashSet::from_iter([Default::default()]))
     }
 }

--- a/provider/source/src/relativetime/mod.rs
+++ b/provider/source/src/relativetime/mod.rs
@@ -2,6 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use crate::DataIdentifierCached;
 use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
@@ -79,12 +80,12 @@ macro_rules! make_data_provider {
             }
 
             impl IterableDataProviderCached<$marker> for SourceDataProvider {
-                fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+                fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
                     Ok(self
                         .cldr()?
                         .dates(None)
                         .list_locales()?
-                        .map(DataIdentifierCow::from_locale)
+                        .map(DataIdentifierCached::from_locale)
                         .collect())
                 }
             }

--- a/provider/source/src/segmenter/dictionary.rs
+++ b/provider/source/src/segmenter/dictionary.rs
@@ -2,6 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use crate::DataIdentifierCached;
 use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use icu::segmenter::provider::SegmenterDictionaryAutoV1;
@@ -53,12 +54,12 @@ macro_rules! implement {
         impl IterableDataProviderCached<$marker> for SourceDataProvider {
             fn iter_ids_cached(
                 &self,
-            ) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+            ) -> Result<HashSet<DataIdentifierCached>, DataError> {
                 const SUPPORTED: &[&DataMarkerAttributes] = &[$(DataMarkerAttributes::from_str_or_panic($supported)),*];
                 Ok(SUPPORTED
                     .iter()
                     .copied()
-                    .map(DataIdentifierCow::from_marker_attributes)
+                    .map(DataIdentifierCached::from_attributes)
                     .collect())
             }
         }

--- a/provider/source/src/segmenter/lstm.rs
+++ b/provider/source/src/segmenter/lstm.rs
@@ -4,6 +4,7 @@
 
 //! This module contains provider implementations backed by LSTM segmentation data.
 
+use crate::DataIdentifierCached;
 use crate::{IterableDataProviderCached, SourceDataProvider};
 use icu::segmenter::provider::{
     LstmData, LstmDataFloat32, LstmMatrix1, LstmMatrix2, LstmMatrix3, ModelType,
@@ -206,12 +207,11 @@ impl DataProvider<SegmenterLstmAutoV1> for SourceDataProvider {
 }
 
 impl IterableDataProviderCached<SegmenterLstmAutoV1> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         Ok(self
             .segmenter_lstm()?
             .list("")?
-            .filter_map(|p| DataMarkerAttributes::try_from_string(p).ok())
-            .map(DataIdentifierCow::from_marker_attributes_owned)
+            .filter_map(|p| DataIdentifierCached::from_writeable_attributes(p).ok())
             .collect())
     }
 }

--- a/provider/source/src/segmenter/mod.rs
+++ b/provider/source/src/segmenter/mod.rs
@@ -1347,6 +1347,7 @@ impl SourceDataProvider {
 
                 let id = if prefix == "LineBreak" {
                     let x;
+                    // TODO: Avoid allocating a string here; use a Writeable
                     DataIdentifierCached::from_writeable_attributes(format!(
                         "{}{}{}",
                         if locale.is_unknown() {
@@ -1368,6 +1369,7 @@ impl SourceDataProvider {
                     ))
                     .unwrap()
                 } else {
+                    // TODO: Avoid allocating a string here; use a Writeable
                     DataIdentifierCached::from_writeable_attributes_and_locale(
                         keywords
                             .get(&key!("lb"))

--- a/provider/source/src/segmenter/mod.rs
+++ b/provider/source/src/segmenter/mod.rs
@@ -1939,7 +1939,7 @@ impl IterableDataProviderCached<SegmenterBreakSentenceOverrideV2> for SourceData
             .sentence_segmenter()?
             .1
             .keys()
-            .map(|x| x.clone())
+            .cloned()
             .collect())
     }
 }

--- a/provider/source/src/segmenter/mod.rs
+++ b/provider/source/src/segmenter/mod.rs
@@ -1345,40 +1345,28 @@ impl SourceDataProvider {
                     }
                 }
 
+                let kw = keywords
+                    .get(&key!("lb"))
+                    .or_else(|| keywords.get(&key!("lw")));
                 let id = if prefix == "LineBreak" {
-                    let x;
-                    // TODO: Avoid allocating a string here; use a Writeable
-                    DataIdentifierCached::from_writeable_attributes(format!(
-                        "{}{}{}",
-                        if locale.is_unknown() {
-                            ""
+                    if locale.is_unknown() {
+                        if let Some(kw) = kw {
+                            DataIdentifierCached::from_writeable_attributes(kw)
                         } else {
-                            x = locale.to_string();
-                            &x
-                        },
-                        if locale.is_unknown() || keywords.is_empty() {
-                            ""
-                        } else {
-                            "-"
-                        },
-                        keywords
-                            .get(&key!("lb"))
-                            .or_else(|| keywords.get(&key!("lw")))
-                            .map(|v| v.to_string())
-                            .unwrap_or_default()
-                    ))
+                            DataIdentifierCached::from_writeable_attributes("")
+                        }
+                    } else if let Some(kw) = kw {
+                        DataIdentifierCached::from_writeable_attributes(
+                            writeable::concat_writeable!(locale, "-", kw),
+                        )
+                    } else {
+                        DataIdentifierCached::from_writeable_attributes(locale)
+                    }
                     .unwrap()
+                } else if let Some(kw) = kw {
+                    DataIdentifierCached::from_writeable_attributes_and_locale(kw, locale).unwrap()
                 } else {
-                    // TODO: Avoid allocating a string here; use a Writeable
-                    DataIdentifierCached::from_writeable_attributes_and_locale(
-                        keywords
-                            .get(&key!("lb"))
-                            .or_else(|| keywords.get(&key!("lw")))
-                            .map(|v| v.to_string())
-                            .unwrap_or_default(),
-                        locale,
-                    )
-                    .unwrap()
+                    DataIdentifierCached::from_locale(locale)
                 };
 
                 tailorings.insert(

--- a/provider/source/src/segmenter/mod.rs
+++ b/provider/source/src/segmenter/mod.rs
@@ -1935,12 +1935,7 @@ impl IterableDataProviderCached<SegmenterBreakSentenceOverrideV2> for SourceData
         .with_marker(SegmenterBreakSentenceOverrideV2::INFO));
 
         #[cfg(any(feature = "use_wasm", feature = "use_icu4c"))]
-        Ok(self
-            .sentence_segmenter()?
-            .1
-            .keys()
-            .cloned()
-            .collect())
+        Ok(self.sentence_segmenter()?.1.keys().cloned().collect())
     }
 }
 

--- a/provider/source/src/segmenter/mod.rs
+++ b/provider/source/src/segmenter/mod.rs
@@ -4,6 +4,8 @@
 
 //! This module contains provider implementations backed by built-in segmentation data.
 
+use crate::DataIdentifierCached;
+use crate::DataIdentifierCachedWithLifetime;
 #[cfg(feature = "unstable")]
 use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
@@ -962,7 +964,7 @@ macro_rules! implement {
         }
 
         impl crate::IterableDataProviderCached<$marker> for SourceDataProvider {
-            fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+            fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
                 Ok(HashSet::from_iter([Default::default()]))
             }
         }
@@ -996,11 +998,11 @@ macro_rules! implement_override {
         }
 
         impl crate::IterableDataProviderCached<$marker> for SourceDataProvider {
-            fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+            fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
                 const SUPPORTED: &[&str] = &[$($supported),*];
                 Ok(SUPPORTED
                    .iter()
-                   .map(|l|DataIdentifierCow::from_locale(DataLocale::try_from_str(l).unwrap()))
+                   .map(|l|DataIdentifierCached::from_locale(DataLocale::try_from_str(l).unwrap()))
                    .collect())
             }
         }
@@ -1101,7 +1103,7 @@ fn download() {
 #[cfg(feature = "unstable")]
 type TailoredSegmenter = (
     SegmenterStateMachine<'static>,
-    BTreeMap<DataIdentifierCow<'static>, SegmenterStateMachineOverride<'static>>,
+    BTreeMap<DataIdentifierCached, SegmenterStateMachineOverride<'static>>,
     u64,
 );
 
@@ -1345,40 +1347,36 @@ impl SourceDataProvider {
 
                 let id = if prefix == "LineBreak" {
                     let x;
-                    DataIdentifierCow::from_marker_attributes_owned(
-                        DataMarkerAttributes::try_from_string(format!(
-                            "{}{}{}",
-                            if locale.is_unknown() {
-                                ""
-                            } else {
-                                x = locale.to_string();
-                                &x
-                            },
-                            if locale.is_unknown() || keywords.is_empty() {
-                                ""
-                            } else {
-                                "-"
-                            },
-                            keywords
-                                .get(&key!("lb"))
-                                .or_else(|| keywords.get(&key!("lw")))
-                                .map(|v| v.to_string())
-                                .unwrap_or_default()
-                        ))
-                        .unwrap(),
-                    )
+                    DataIdentifierCached::from_writeable_attributes(format!(
+                        "{}{}{}",
+                        if locale.is_unknown() {
+                            ""
+                        } else {
+                            x = locale.to_string();
+                            &x
+                        },
+                        if locale.is_unknown() || keywords.is_empty() {
+                            ""
+                        } else {
+                            "-"
+                        },
+                        keywords
+                            .get(&key!("lb"))
+                            .or_else(|| keywords.get(&key!("lw")))
+                            .map(|v| v.to_string())
+                            .unwrap_or_default()
+                    ))
+                    .unwrap()
                 } else {
-                    DataIdentifierCow::from_owned(
-                        DataMarkerAttributes::try_from_string(
-                            keywords
-                                .get(&key!("lb"))
-                                .or_else(|| keywords.get(&key!("lw")))
-                                .map(|v| v.to_string())
-                                .unwrap_or_default(),
-                        )
-                        .unwrap(),
+                    DataIdentifierCached::from_writeable_attributes_and_locale(
+                        keywords
+                            .get(&key!("lb"))
+                            .or_else(|| keywords.get(&key!("lw")))
+                            .map(|v| v.to_string())
+                            .unwrap_or_default(),
                         locale,
                     )
+                    .unwrap()
                 };
 
                 tailorings.insert(
@@ -1476,7 +1474,7 @@ impl SourceDataProvider {
                 for (symbol, set2) in symbols.clone().into_iter().collect::<Vec<_>>() {
                     if set.iter_chars().any(|c| set2.contains(c)) {
                         // Overlapping sets. We need to create a new pseudo-symbol.
-                        let pseudo_symbol = format!("{symbol}_{tailoring}_{rule}");
+                        let pseudo_symbol = format!("{symbol}_{}_{rule}", tailoring.0);
                         // Add the intersection as a new symbol.
                         symbols.insert(pseudo_symbol.clone(), {
                             let mut builder = CodePointInversionListBuilder::new();
@@ -1823,28 +1821,28 @@ impl DataProvider<SegmenterBreakGraphemeClusterV2> for SourceDataProvider {
 
 #[cfg(feature = "unstable")]
 impl IterableDataProviderCached<SegmenterBreakLineV2> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         Ok([Default::default()].into_iter().collect())
     }
 }
 
 #[cfg(feature = "unstable")]
 impl IterableDataProviderCached<SegmenterBreakSentenceV2> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         Ok([Default::default()].into_iter().collect())
     }
 }
 
 #[cfg(feature = "unstable")]
 impl IterableDataProviderCached<SegmenterBreakWordV2> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         Ok([Default::default()].into_iter().collect())
     }
 }
 
 #[cfg(feature = "unstable")]
 impl IterableDataProviderCached<SegmenterBreakGraphemeClusterV2> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         Ok([Default::default()].into_iter().collect())
     }
 }
@@ -1869,7 +1867,7 @@ impl DataProvider<SegmenterBreakLineOverrideV2> for SourceDataProvider {
             payload: DataPayload::from_owned(
                 self.line_segmenter()?
                     .1
-                    .get(&req.id.as_cow())
+                    .get(&DataIdentifierCachedWithLifetime::from_cow(req.id.as_cow()))
                     .ok_or_else(|| {
                         DataErrorKind::IdentifierNotFound
                             .with_req(SegmenterBreakLineOverrideV2::INFO, req)
@@ -1882,7 +1880,7 @@ impl DataProvider<SegmenterBreakLineOverrideV2> for SourceDataProvider {
 
 #[cfg(feature = "unstable")]
 impl IterableDataProviderCached<SegmenterBreakLineOverrideV2> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         #[cfg(not(any(feature = "use_wasm", feature = "use_icu4c")))]
         return Err(DataError::custom(
             "icu_provider_source must be built with use_icu4c or use_wasm to build segmentation rules",
@@ -1914,7 +1912,7 @@ impl DataProvider<SegmenterBreakSentenceOverrideV2> for SourceDataProvider {
             payload: DataPayload::from_owned(
                 self.sentence_segmenter()?
                     .1
-                    .get(&req.id.as_cow())
+                    .get(&DataIdentifierCachedWithLifetime::from_cow(req.id.as_cow()))
                     .ok_or_else(|| {
                         DataErrorKind::IdentifierNotFound
                             .with_req(SegmenterBreakSentenceOverrideV2::INFO, req)
@@ -1927,7 +1925,7 @@ impl DataProvider<SegmenterBreakSentenceOverrideV2> for SourceDataProvider {
 
 #[cfg(feature = "unstable")]
 impl IterableDataProviderCached<SegmenterBreakSentenceOverrideV2> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         #[cfg(not(any(feature = "use_wasm", feature = "use_icu4c")))]
         return Err(DataError::custom(
             "icu_provider_source must be built with use_icu4c or use_wasm to build segmentation rules",
@@ -1935,7 +1933,12 @@ impl IterableDataProviderCached<SegmenterBreakSentenceOverrideV2> for SourceData
         .with_marker(SegmenterBreakSentenceOverrideV2::INFO));
 
         #[cfg(any(feature = "use_wasm", feature = "use_icu4c"))]
-        Ok(self.sentence_segmenter()?.1.keys().cloned().collect())
+        Ok(self
+            .sentence_segmenter()?
+            .1
+            .keys()
+            .map(|x| x.clone())
+            .collect())
     }
 }
 

--- a/provider/source/src/segmenter/unihan.rs
+++ b/provider/source/src/segmenter/unihan.rs
@@ -4,6 +4,7 @@
 
 //! This module contains provider implementations for Unihan radicals.
 
+use crate::DataIdentifierCached;
 use crate::source::RscdCache;
 use crate::{IterableDataProviderCached, SourceDataProvider};
 use icu::collections::codepointinvlist::CodePointInversionListBuilder;
@@ -95,7 +96,7 @@ impl DataProvider<SegmenterUnihanRadicalV1> for SourceDataProvider {
 }
 
 impl IterableDataProviderCached<SegmenterUnihanRadicalV1> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         Ok(HashSet::new())
     }
 }

--- a/provider/source/src/time_zones/mod.rs
+++ b/provider/source/src/time_zones/mod.rs
@@ -2,6 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use crate::DataIdentifierCached;
 use crate::IterableDataProviderCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
@@ -599,12 +600,12 @@ macro_rules! impl_iterable_data_provider {
     ($($marker:ident),+) => {
         $(
             impl IterableDataProviderCached<$marker> for SourceDataProvider {
-                fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+                fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
                     Ok(self
                         .cldr()?
                         .dates(None)
                         .list_locales()?
-                        .map(DataIdentifierCow::from_locale)
+                        .map(DataIdentifierCached::from_locale)
                         .collect())
                 }
             }
@@ -626,7 +627,7 @@ impl_iterable_data_provider!(
 );
 
 impl IterableDataProviderCached<TimezonePeriodsV1> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         Ok(HashSet::from_iter([Default::default()]))
     }
 }

--- a/provider/source/src/time_zones/names.rs
+++ b/provider/source/src/time_zones/names.rs
@@ -2,6 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use crate::DataIdentifierCached;
 use crate::SourceDataProvider;
 use core::hash::Hash;
 use icu::time::TimeZone;
@@ -67,7 +68,7 @@ impl DataProvider<TimezoneIdentifiersIanaCoreV1> for SourceDataProvider {
 }
 
 impl crate::IterableDataProviderCached<TimezoneIdentifiersIanaCoreV1> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         Ok(HashSet::from_iter([Default::default()]))
     }
 }
@@ -116,7 +117,7 @@ impl DataProvider<TimezoneIdentifiersIanaExtendedV1> for SourceDataProvider {
 }
 
 impl crate::IterableDataProviderCached<TimezoneIdentifiersIanaExtendedV1> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         Ok(HashSet::from_iter([Default::default()]))
     }
 }

--- a/provider/source/src/time_zones/windows.rs
+++ b/provider/source/src/time_zones/windows.rs
@@ -4,6 +4,7 @@
 
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 
+use crate::DataIdentifierCached;
 use crate::{SourceDataProvider, cldr_serde};
 use icu::time::{
     TimeZone,
@@ -79,7 +80,7 @@ impl DataProvider<TimezoneIdentifiersWindowsV1> for SourceDataProvider {
 }
 
 impl crate::IterableDataProviderCached<TimezoneIdentifiersWindowsV1> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         Ok(HashSet::from_iter([Default::default()]))
     }
 }

--- a/provider/source/src/transforms/mod.rs
+++ b/provider/source/src/transforms/mod.rs
@@ -4,6 +4,8 @@
 
 use super::CldrCache;
 use super::cldr_serde::transforms;
+use crate::DataIdentifierCached;
+use crate::DataIdentifierCachedWithLifetime;
 use crate::SourceDataProvider;
 use icu::experimental::transliterate::RuleCollection;
 use icu::experimental::transliterate::provider::*;
@@ -192,7 +194,7 @@ impl DataProvider<TransliteratorRulesV1> for SourceDataProvider {
 }
 
 impl crate::IterableDataProviderCached<TransliteratorRulesV1> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         Ok(self
             .cldr()?
             .transforms()?
@@ -201,7 +203,13 @@ impl crate::IterableDataProviderCached<TransliteratorRulesV1> for SourceDataProv
             .as_provider_unstable(self, self, self)?
             .iter_ids()?
             .into_iter()
-            .map(|id| id.as_borrowed().into_owned())
+            .map(|id| {
+                DataIdentifierCachedWithLifetime::from_attributes_and_locale(
+                    &id.marker_attributes,
+                    id.locale,
+                )
+                .into_owned()
+            })
             .collect())
     }
 }
@@ -216,10 +224,9 @@ mod tests {
 
         let _data: DataPayload<TransliteratorRulesV1> = provider
             .load(DataRequest {
-                id: DataIdentifierCow::from_marker_attributes(
+                id: DataIdentifierBorrowed::for_marker_attributes(
                     DataMarkerAttributes::from_str_or_panic("de-t-de-d0-ascii"),
-                )
-                .as_borrowed(),
+                ),
                 ..Default::default()
             })
             .unwrap()
@@ -232,10 +239,9 @@ mod tests {
 
         let _data: DataPayload<TransliteratorRulesV1> = provider
             .load(DataRequest {
-                id: DataIdentifierCow::from_marker_attributes(
+                id: DataIdentifierBorrowed::for_marker_attributes(
                     DataMarkerAttributes::from_str_or_panic("und-latn-t-s0-ascii"),
-                )
-                .as_borrowed(),
+                ),
                 ..Default::default()
             })
             .unwrap()

--- a/provider/source/src/units/categorized_display_name.rs
+++ b/provider/source/src/units/categorized_display_name.rs
@@ -115,7 +115,7 @@ impl SourceDataProvider {
 
                     let id = DataIdentifierCached::from_writeable_attributes_and_locale(
                         writeable::concat_writeable!(length, "-", unit),
-                        locale.clone(),
+                        locale,
                     )?;
                     data_locales.insert(id);
                 }

--- a/provider/source/src/units/categorized_display_name.rs
+++ b/provider/source/src/units/categorized_display_name.rs
@@ -2,6 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use crate::DataIdentifierCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
 use cldr_serde::units::preferences::UnitType;
@@ -13,7 +14,6 @@ use icu::experimental::dimension::provider::units::categorized_display_names::{
     UnitsNamesVolumeCoreV1, UnitsNamesVolumeExtendedV1, UnitsNamesVolumeOutlierV1,
 };
 use icu::experimental::dimension::provider::units::display_names::UnitsDisplayNames;
-use icu_provider::DataMarkerAttributes;
 use icu_provider::prelude::*;
 use std::collections::HashSet;
 
@@ -64,7 +64,7 @@ impl SourceDataProvider {
         &self,
         unit_type: UnitType,
         category: &str,
-    ) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    ) -> Result<HashSet<DataIdentifierCached>, DataError> {
         let mut data_locales = HashSet::new();
         let numbers = self.cldr()?.numbers();
         let locales = numbers.list_locales()?;
@@ -113,15 +113,11 @@ impl SourceDataProvider {
                         continue;
                     }
 
-                    data_locales.insert(DataIdentifierCow::from_owned(
-                        DataMarkerAttributes::try_from_string(format!("{length}-{unit}")).map_err(
-                            |_| {
-                                DataError::custom("Failed to parse the attribute")
-                                    .with_debug_context(&unit)
-                            },
-                        )?,
-                        locale,
-                    ));
+                    let id = DataIdentifierCached::from_writeable_attributes_and_locale(
+                        writeable::concat_writeable!(length, "-", unit),
+                        locale.clone(),
+                    )?;
+                    data_locales.insert(id);
                 }
             }
         }
@@ -140,7 +136,7 @@ macro_rules! impl_units_display_names_provider {
         }
 
         impl crate::IterableDataProviderCached<$marker> for SourceDataProvider {
-            fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+            fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
                 self.get_display_name_iter_ids_cached($unit_type, $category)
             }
         }

--- a/provider/source/src/units/display_names.rs
+++ b/provider/source/src/units/display_names.rs
@@ -1,0 +1,179 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use crate::DataIdentifierCached;
+use crate::SourceDataProvider;
+use crate::cldr_serde;
+use icu::experimental::dimension::provider::units::display_names::{
+    UnitsDisplayNames, UnitsDisplayNamesV1,
+};
+use icu_provider::prelude::*;
+use std::collections::HashSet;
+
+impl DataProvider<UnitsDisplayNamesV1> for SourceDataProvider {
+    fn load(&self, req: DataRequest) -> Result<DataResponse<UnitsDisplayNamesV1>, DataError> {
+        self.check_req::<UnitsDisplayNamesV1>(req)?;
+
+        let (length, unit) = req.id.marker_attributes.split_once('-').ok_or_else(|| {
+            DataErrorKind::InvalidRequest
+                .into_error()
+                .with_req(UnitsDisplayNamesV1::INFO, req)
+        })?;
+
+        let units_format_data: &cldr_serde::units::data::Resource = self
+            .cldr()?
+            .units()
+            .read_and_parse(req.id.locale, "units.json")?;
+        let units_format_data = &units_format_data.main.value.units;
+
+        let unit_patterns = match length {
+            "long" => &units_format_data.long,
+            "short" => &units_format_data.short,
+            "narrow" => &units_format_data.narrow,
+            _ => {
+                return Err(DataErrorKind::InvalidRequest
+                    .into_error()
+                    .with_debug_context(length));
+            }
+        }
+        .categories
+        .iter()
+        .find_map(|(_, units_map)| units_map.get(unit))
+        .ok_or_else(|| {
+            DataErrorKind::IdentifierNotFound
+                .into_error()
+                .with_debug_context(length)
+        })?;
+
+        Ok(DataResponse {
+            metadata: Default::default(),
+            payload: DataPayload::from_owned(UnitsDisplayNames {
+                patterns: unit_patterns.try_into_plural_elements_packed_cow()?,
+            }),
+        })
+    }
+}
+
+impl crate::IterableDataProviderCached<UnitsDisplayNamesV1> for SourceDataProvider {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
+        let mut data_locales = HashSet::new();
+
+        let numbers = self.cldr()?.numbers();
+        let locales = numbers.list_locales()?;
+        for locale in locales {
+            let units_format_data: &cldr_serde::units::data::Resource =
+                self.cldr()?.units().read_and_parse(&locale, "units.json")?;
+            let units_format_data = &units_format_data.main.value.units;
+
+            for length in &["long", "short", "narrow"] {
+                let length_patterns = match *length {
+                    "long" => &units_format_data.long,
+                    "short" => &units_format_data.short,
+                    "narrow" => &units_format_data.narrow,
+                    _ => {
+                        return Err(DataErrorKind::IdentifierNotFound
+                            .into_error()
+                            .with_debug_context(length));
+                    }
+                };
+
+                // TODO: category is not used for now, but will be used when we have categorized data markers.
+                for units_map in length_patterns.categories.values() {
+                    for (unit, patterns) in units_map {
+                        if patterns.other.is_none() {
+                            continue;
+                        }
+                        let id = DataIdentifierCached::from_writeable_attributes_and_locale(
+                            writeable::concat_writeable!(length, "-", unit),
+                            locale.clone(),
+                        )?;
+                        data_locales.insert(id);
+                    }
+                }
+            }
+        }
+
+        Ok(data_locales)
+    }
+}
+
+#[test]
+fn test_basic() {
+    use icu::locale::langid;
+    use icu::plurals::PluralRules;
+    use icu_provider::prelude::*;
+    use writeable::assert_writeable_eq;
+
+    let provider = SourceDataProvider::new_testing();
+
+    let us_locale_long_meter: DataPayload<UnitsDisplayNamesV1> = provider
+        .load(DataRequest {
+            id: DataIdentifierBorrowed::for_marker_attributes_and_locale(
+                DataMarkerAttributes::from_str_or_panic("long-meter"),
+                &langid!("en").into(),
+            ),
+            ..Default::default()
+        })
+        .unwrap()
+        .payload;
+
+    let units_us = us_locale_long_meter.get().to_owned();
+
+    let en_rules = PluralRules::try_new_cardinal_unstable(&provider, langid!("en").into()).unwrap();
+    let long = units_us.patterns.get(1.into(), &en_rules).interpolate([1]);
+    assert_writeable_eq!(long, "1 meter");
+
+    let us_locale_short_meter: DataPayload<UnitsDisplayNamesV1> = provider
+        .load(DataRequest {
+            id: DataIdentifierBorrowed::for_marker_attributes_and_locale(
+                DataMarkerAttributes::from_str_or_panic("short-meter"),
+                &langid!("en").into(),
+            ),
+            ..Default::default()
+        })
+        .unwrap()
+        .payload;
+
+    let units_us_short = us_locale_short_meter.get().to_owned();
+    let short = units_us_short
+        .patterns
+        .get(5.into(), &en_rules)
+        .interpolate([5]);
+    assert_writeable_eq!(short, "5 m");
+
+    let ar_eg_locale: DataPayload<UnitsDisplayNamesV1> = provider
+        .load(DataRequest {
+            id: DataIdentifierBorrowed::for_marker_attributes_and_locale(
+                DataMarkerAttributes::from_str_or_panic("long-meter"),
+                &langid!("ar-EG").into(),
+            ),
+            ..Default::default()
+        })
+        .unwrap()
+        .payload;
+
+    let ar_eg_units = ar_eg_locale.get().to_owned();
+    let ar_rules = PluralRules::try_new_cardinal_unstable(&provider, langid!("ar").into()).unwrap();
+    let long = ar_eg_units
+        .patterns
+        .get(1.into(), &ar_rules)
+        .interpolate([1]);
+    assert_writeable_eq!(long, "متر");
+
+    let fr_locale: DataPayload<UnitsDisplayNamesV1> = provider
+        .load(DataRequest {
+            id: DataIdentifierBorrowed::for_marker_attributes_and_locale(
+                DataMarkerAttributes::from_str_or_panic("short-meter"),
+                &langid!("fr").into(),
+            ),
+            ..Default::default()
+        })
+        .unwrap()
+        .payload;
+
+    let fr_units = fr_locale.get().to_owned();
+    let fr_rules = PluralRules::try_new_cardinal_unstable(&provider, langid!("fr").into()).unwrap();
+    let short = fr_units.patterns.get(5.into(), &fr_rules).interpolate([5]);
+    assert_writeable_eq!(short, "5 m");
+}

--- a/provider/source/src/units/essentials.rs
+++ b/provider/source/src/units/essentials.rs
@@ -4,6 +4,7 @@
 
 use std::collections::{BTreeMap, HashSet};
 
+use crate::DataIdentifierCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde::{self};
 
@@ -130,7 +131,7 @@ impl DataProvider<UnitsEssentialsV1> for SourceDataProvider {
 }
 
 impl crate::IterableDataProviderCached<UnitsEssentialsV1> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         let units = self.cldr()?.units();
         let locales = units.list_locales()?;
         Ok(locales
@@ -142,7 +143,7 @@ impl crate::IterableDataProviderCached<UnitsEssentialsV1> for SourceDataProvider
                     DataMarkerAttributes::from_str_or_panic("narrow"),
                 ]
                 .into_iter()
-                .map(move |length| DataIdentifierCow::from_borrowed_and_owned(length, locale))
+                .map(move |length| DataIdentifierCached::from_attributes_and_locale(length, locale))
             })
             .collect())
     }

--- a/provider/source/src/units/ids.rs
+++ b/provider/source/src/units/ids.rs
@@ -7,12 +7,12 @@ use std::collections::HashSet;
 use icu::experimental::measure::parser::ids::unit_id;
 use icu::experimental::measure::provider::UnitIdsV1;
 use icu_provider::DataError;
-use icu_provider::DataMarkerAttributes;
 use icu_provider::DataProvider;
 use icu_provider::DataRequest;
 use icu_provider::DataResponse;
 use icu_provider::prelude::*;
 
+use crate::DataIdentifierCached;
 use crate::SourceDataProvider;
 use crate::cldr_serde;
 
@@ -31,7 +31,7 @@ impl DataProvider<UnitIdsV1> for SourceDataProvider {
 }
 
 impl crate::IterableDataProviderCached<UnitIdsV1> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         let units_data: &cldr_serde::units::info::Resource = self
             .cldr()?
             .core()
@@ -50,12 +50,8 @@ impl crate::IterableDataProviderCached<UnitIdsV1> for SourceDataProvider {
                     false
                 }
             })
-            .map(|unit_name| {
-                DataIdentifierCow::from_marker_attributes_owned(
-                    DataMarkerAttributes::try_from_string(unit_name.clone()).unwrap(),
-                )
-            })
-            .collect();
+            .map(|unit_name| DataIdentifierCached::from_writeable_attributes(unit_name))
+            .collect::<Result<_, _>>()?;
 
         Ok(ids_set)
     }

--- a/provider/source/src/units/info.rs
+++ b/provider/source/src/units/info.rs
@@ -4,6 +4,7 @@
 
 use std::collections::HashSet;
 
+use crate::DataIdentifierCached;
 use crate::SourceDataProvider;
 use crate::{cldr_serde, units::helpers::ScientificNumber};
 use icu::experimental::measure::provider::single_unit::UnitID;
@@ -83,7 +84,7 @@ impl DataProvider<UnitsInfoV1> for SourceDataProvider {
 }
 
 impl crate::IterableDataProviderCached<UnitsInfoV1> for SourceDataProvider {
-    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCached>, DataError> {
         Ok(HashSet::from_iter([Default::default()]))
     }
 }
@@ -105,7 +106,7 @@ fn test_basic() {
 
     let und: DataResponse<UnitsInfoV1> = provider
         .load(DataRequest {
-            id: DataIdentifierCow::from_locale(data_locale!("und")).as_borrowed(),
+            id: DataIdentifierBorrowed::for_locale(&data_locale!("und")),
             ..Default::default()
         })
         .unwrap();


### PR DESCRIPTION
I did some timing analysis of icu_provider_source. A fairly substantial amount of time in the finely slice data markers is spent allocating and storing these boxed DataMarkerAttributes in icu_provider_source. I want to explore ways to optimize this, but first I need to make a crate-internal DataIdentifier type where I can play with the representation, constructors, etc.

🤖 I used an AI agent to help with parts of this.

## Changelog

icu_provider: impl Hash on DataIdentifierBorrowed