### PR TITLE
Stop running depcheck in cargo quick

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -29,7 +29,6 @@ run_task.name = [
     "ci-job-fmt",
     "ci-job-clippy",
     "check-no-features",
-    "depcheck",
     "ci-job-doc",
 ]
 


### PR DESCRIPTION
It is broken because `icu_locale_fallback` is not linked in most of the stubdata.

## Changelog

N/A (tooling)