### PR TITLE
test(currency): Use consts and currency! macro across tests

### DIFF
--- a/components/experimental/src/dimension/currency/format.rs
+++ b/components/experimental/src/dimension/currency/format.rs
@@ -235,7 +235,7 @@ mod tests {
         // The explicit negative pattern is used as-is for negative values instead of
         // prepending a minus sign to the positive pattern.
         let prefs = locale!("ar-EG-u-nu-latn").into();
-        let currency_code = "EGP".parse().unwrap();
+        let currency_code = currency!("EGP");
         let negative_value = "-12345.67".parse().unwrap();
 
         let fmt_symbol =
@@ -253,7 +253,7 @@ mod tests {
         // - Literal: "¤ #,##0.00;¤-#,##0.00"
         // This behavior can only be expressed via an explicit negative pattern.
         let prefs = locale!("de-CH").into();
-        let currency_code = "CHF".parse().unwrap();
+        let currency_code = currency!("CHF");
         let fmt_symbol =
             CurrencyFormatter::try_new_symbol(prefs, currency_code, Default::default()).unwrap();
         assert_writeable_eq!(

--- a/provider/source/src/currency/symbols.rs
+++ b/provider/source/src/currency/symbols.rs
@@ -107,8 +107,8 @@ fn test_symbols() {
     use icu::locale::{DataLocale, data_locale};
     use tinystr::TinyAsciiStr;
 
-    let usd: CurrencyType = currency!("USD");
-    let egp: CurrencyType = currency!("EGP");
+    const USD: CurrencyType = currency!("USD");
+    const EGP: CurrencyType = currency!("EGP");
     const EN: DataLocale = data_locale!("en");
     const AR_EG: DataLocale = data_locale!("ar-EG");
 
@@ -132,35 +132,35 @@ fn test_symbols() {
     };
 
     assert_eq!(
-        load(EN, usd, CurrencySymbolsV1::SHORT).unwrap().get(),
+        load(EN, USD, CurrencySymbolsV1::SHORT).unwrap().get(),
         &CurrencySymbol::new("$", false, false)
     );
     assert_eq!(
-        load(EN, usd, CurrencySymbolsV1::NARROW).unwrap().get(),
+        load(EN, USD, CurrencySymbolsV1::NARROW).unwrap().get(),
         &CurrencySymbol::new("$", false, false)
     );
 
-    assert_eq!(load(EN, egp, CurrencySymbolsV1::SHORT), None);
+    assert_eq!(load(EN, EGP, CurrencySymbolsV1::SHORT), None);
     assert_eq!(
-        load(EN, egp, CurrencySymbolsV1::NARROW).unwrap().get(),
+        load(EN, EGP, CurrencySymbolsV1::NARROW).unwrap().get(),
         &CurrencySymbol::new("E£", true, false)
     );
 
     assert_eq!(
-        load(AR_EG, egp, CurrencySymbolsV1::SHORT).unwrap().get(),
+        load(AR_EG, EGP, CurrencySymbolsV1::SHORT).unwrap().get(),
         &CurrencySymbol::new("ج.م.\u{200f}", true, false)
     );
     assert_eq!(
-        load(AR_EG, egp, CurrencySymbolsV1::NARROW).unwrap().get(),
+        load(AR_EG, EGP, CurrencySymbolsV1::NARROW).unwrap().get(),
         &CurrencySymbol::new("E£", true, false)
     );
 
     assert_eq!(
-        load(AR_EG, usd, CurrencySymbolsV1::SHORT).unwrap().get(),
+        load(AR_EG, USD, CurrencySymbolsV1::SHORT).unwrap().get(),
         &CurrencySymbol::new("US$", true, false)
     );
     assert_eq!(
-        load(AR_EG, usd, CurrencySymbolsV1::NARROW).unwrap().get(),
+        load(AR_EG, USD, CurrencySymbolsV1::NARROW).unwrap().get(),
         &CurrencySymbol::new("US$", true, false)
     );
 }


### PR DESCRIPTION
## Overview
Follow-up test cleanups after #8314:
1. Defines `USD` and `EGP` `CurrencyType` test fixtures as `const` rather than `let` in `provider/source/src/currency/symbols.rs` (addressing review comment https://github.com/unicode-org/icu4x/pull/8314#discussion_r3758528095).
2. Updates `test_explicit_negative_pattern` in `components/experimental/src/dimension/currency/format.rs` to use the `currency!(...)` compile-time macro instead of `.parse().unwrap()`.

### Changes
* `provider/source/src/currency/symbols.rs`: Changed `let usd` / `let egp` to `const USD` / `const EGP`.
* `components/experimental/src/dimension/currency/format.rs`: Changed `.parse().unwrap()` to `currency!("EGP")` and `currency!("CHF")`.

## Changelog
N/A