### PR TITLE
Add infallible display name fns; make FFI fns infallible, too

### DIFF
--- a/components/locale/src/names/language.rs
+++ b/components/locale/src/names/language.rs
@@ -307,7 +307,40 @@ macro_rules! try_load_dialect_name {
 impl LanguageIdentifierDisplayName {
     icu_provider::gen_buffer_data_constructors!(
         (prefs: DisplayNamesPreferences, subject: LanguageIdentifier, options: LanguageIdentifierDisplayNameOptions) -> result: Result<Self, DataError>,
-        /// Loads the language display name for a given language identifier and locale using compiled data.
+        /// Loads a language display name in a formatting locale using compiled data.
+        ///
+        /// The `light` constructor links data for all common languages.
+        /// See the [class docs](Self) for information on which constructor to use.
+        ///
+        /// ✨ *Enabled with the `compiled_data` Cargo feature.*
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use icu::locale::names::{
+        ///     DisplayNamesPreferences, LanguageIdentifierDisplayName,
+        ///     LanguageIdentifierDisplayNameOptions, LanguageIdentifierNameFallbackError,
+        /// };
+        /// use icu::locale::{langid, locale};
+        /// use writeable::assert_try_writeable_eq;
+        ///
+        /// let prefs = DisplayNamesPreferences::from(locale!("de"));
+        /// let options = LanguageIdentifierDisplayNameOptions::default();
+        ///
+        /// // Light dataset formats common languages and subtags (e.g. region qualification):
+        /// let display_name = LanguageIdentifierDisplayName::try_new_light(
+        ///     prefs,
+        ///     langid!("fr-CA"),
+        ///     options,
+        /// )
+        /// .expect("Data should load successfully");
+        /// assert_try_writeable_eq!(display_name.as_borrowed(), "Französisch (Kanada)", Ok(()));
+        ///
+        /// // Light data does not include rare languages like Klingon ("tlh"), returning a fallback error:
+        /// let tlh = LanguageIdentifierDisplayName::try_new_light(prefs, langid!("tlh"), options)
+        ///     .expect("Data should load successfully");
+        /// assert_try_writeable_eq!(tlh.as_borrowed(), "tlh", Err(LanguageIdentifierNameFallbackError));
+        /// ```
         functions: [
             try_new_light,
             try_new_light_with_buffer_provider,
@@ -378,10 +411,13 @@ impl LanguageIdentifierDisplayName {
 
     icu_provider::gen_buffer_data_constructors!(
         (prefs: DisplayNamesPreferences, subject: LanguageIdentifier, options: LanguageIdentifierDisplayNameOptions) -> result: Result<Self, DataError>,
-        /// Loads the minimal language display name for a given language identifier and locale using compiled data.
+        /// Loads a language display name in a formatting locale using compiled data.
         ///
-        /// The `minimal` constructor links an *extremely limited* amount of data: for example,
-        /// only the language of the formatting locale itself.
+        /// The `tiny` constructor links an extremely limited amount of data, with a focus on
+        /// languages associated with the formatting locale.
+        /// See the [class docs](Self) for more information on which constructor to use.
+        ///
+        /// ✨ *Enabled with the `compiled_data` Cargo feature.*
         ///
         /// # Examples
         ///
@@ -477,47 +513,41 @@ impl LanguageIdentifierDisplayName {
 
     icu_provider::gen_buffer_data_constructors!(
         (prefs: DisplayNamesPreferences, subject: LanguageIdentifier, options: LanguageIdentifierDisplayNameOptions) -> result: Result<Self, DataError>,
-        /// Loads the short language display name for a given language identifier and locale using compiled data.
+        /// Loads a short language display name in a formatting locale using compiled data.
         ///
         /// Falls back to default (medium) length if a short name is not available.
+        ///
+        /// The `light` constructor links data for all common languages.
+        /// See the [class docs](Self) for information on which constructor to use.
+        ///
+        /// ✨ *Enabled with the `compiled_data` Cargo feature.*
         ///
         /// # Examples
         ///
         /// ```
         /// use icu::locale::names::{
-        ///     DisplayNamesPreferences, LanguageIdentifierDisplayName, LanguageIdentifierDisplayNameOptions,
+        ///     DisplayNamesPreferences, LanguageIdentifierDisplayName,
+        ///     LanguageIdentifierDisplayNameOptions, LanguageIdentifierNameFallbackError,
         /// };
-        /// use icu::locale::{locale, langid};
+        /// use icu::locale::{langid, locale};
         /// use writeable::assert_try_writeable_eq;
         ///
         /// let prefs = DisplayNamesPreferences::from(locale!("en"));
         /// let options = LanguageIdentifierDisplayNameOptions::default();
         ///
-        /// // Default (Medium) length format:
-        /// let display_name_medium = LanguageIdentifierDisplayName::try_new_light(
+        /// // Short length format uses shorter subtag/qualifier names when available (e.g. "US English"):
+        /// let display_name = LanguageIdentifierDisplayName::try_new_short_light(
         ///     prefs,
         ///     langid!("en-US"),
         ///     options,
         /// )
         /// .expect("Data should load successfully");
-        /// assert_try_writeable_eq!(
-        ///     display_name_medium.as_borrowed(),
-        ///     "American English",
-        ///     Ok(())
-        /// );
+        /// assert_try_writeable_eq!(display_name.as_borrowed(), "US English", Ok(()));
         ///
-        /// // Short length format uses shorter subtag/qualifier names when available:
-        /// let display_name_short = LanguageIdentifierDisplayName::try_new_short_light(
-        ///     prefs,
-        ///     langid!("en-US"),
-        ///     options,
-        /// )
-        /// .expect("Data should load successfully");
-        /// assert_try_writeable_eq!(
-        ///     display_name_short.as_borrowed(),
-        ///     "US English",
-        ///     Ok(())
-        /// );
+        /// // Light data does not include rare languages like Klingon ("tlh"), returning a fallback error:
+        /// let tlh = LanguageIdentifierDisplayName::try_new_short_light(prefs, langid!("tlh"), options)
+        ///     .expect("Data should load successfully");
+        /// assert_try_writeable_eq!(tlh.as_borrowed(), "tlh", Err(LanguageIdentifierNameFallbackError));
         /// ```
         functions: [
             try_new_short_light,
@@ -601,47 +631,41 @@ impl LanguageIdentifierDisplayName {
 
     icu_provider::gen_buffer_data_constructors!(
         (prefs: DisplayNamesPreferences, subject: LanguageIdentifier, options: LanguageIdentifierDisplayNameOptions) -> result: Result<Self, DataError>,
-        /// Loads the long language display name for a given language identifier and locale using compiled data.
+        /// Loads a long language display name in a formatting locale using compiled data.
         ///
         /// Falls back to default (medium) length if a long name is not available.
+        ///
+        /// The `light` constructor links data for all common languages.
+        /// See the [class docs](Self) for information on which constructor to use.
+        ///
+        /// ✨ *Enabled with the `compiled_data` Cargo feature.*
         ///
         /// # Examples
         ///
         /// ```
         /// use icu::locale::names::{
-        ///     DisplayNamesPreferences, LanguageIdentifierDisplayName, LanguageIdentifierDisplayNameOptions,
+        ///     DisplayNamesPreferences, LanguageIdentifierDisplayName,
+        ///     LanguageIdentifierDisplayNameOptions, LanguageIdentifierNameFallbackError,
         /// };
-        /// use icu::locale::{locale, langid};
+        /// use icu::locale::{langid, locale};
         /// use writeable::assert_try_writeable_eq;
         ///
         /// let prefs = DisplayNamesPreferences::from(locale!("en"));
         /// let options = LanguageIdentifierDisplayNameOptions::default();
         ///
-        /// // Default (Medium) length format:
-        /// let display_name_medium = LanguageIdentifierDisplayName::try_new_light(
+        /// // Long length format uses longer subtag names when available (e.g. "Mandarin Chinese"):
+        /// let display_name = LanguageIdentifierDisplayName::try_new_long_light(
         ///     prefs,
         ///     langid!("zh"),
         ///     options,
         /// )
         /// .expect("Data should load successfully");
-        /// assert_try_writeable_eq!(
-        ///     display_name_medium.as_borrowed(),
-        ///     "Chinese",
-        ///     Ok(())
-        /// );
+        /// assert_try_writeable_eq!(display_name.as_borrowed(), "Mandarin Chinese", Ok(()));
         ///
-        /// // Long length format uses longer subtag names when available:
-        /// let display_name_long = LanguageIdentifierDisplayName::try_new_long_heavy(
-        ///     prefs,
-        ///     langid!("zh"),
-        ///     options,
-        /// )
-        /// .expect("Data should load successfully");
-        /// assert_try_writeable_eq!(
-        ///     display_name_long.as_borrowed(),
-        ///     "Mandarin Chinese",
-        ///     Ok(())
-        /// );
+        /// // Light data does not include rare languages like Klingon ("tlh"), returning a fallback error:
+        /// let tlh = LanguageIdentifierDisplayName::try_new_long_light(prefs, langid!("tlh"), options)
+        ///     .expect("Data should load successfully");
+        /// assert_try_writeable_eq!(tlh.as_borrowed(), "tlh", Err(LanguageIdentifierNameFallbackError));
         /// ```
         functions: [
             try_new_long_light,
@@ -723,27 +747,39 @@ impl LanguageIdentifierDisplayName {
 
     icu_provider::gen_buffer_data_constructors!(
         (prefs: DisplayNamesPreferences, subject: LanguageIdentifier, options: LanguageIdentifierDisplayNameOptions) -> result: Result<Self, DataError>,
-        /// Loads the menu-style language display name for a given language identifier and locale using compiled data.
+        /// Loads a menu-style language display name in a formatting locale using compiled data.
+        ///
+        /// The `light` constructor links data for all common languages.
+        /// See the [class docs](Self) for information on which constructor to use.
+        ///
+        /// ✨ *Enabled with the `compiled_data` Cargo feature.*
         ///
         /// # Examples
         ///
         /// ```
         /// use icu::locale::names::{
-        ///     DisplayNamesPreferences, LanguageIdentifierDisplayName, LanguageIdentifierDisplayNameOptions,
+        ///     DisplayNamesPreferences, LanguageIdentifierDisplayName,
+        ///     LanguageIdentifierDisplayNameOptions, LanguageIdentifierNameFallbackError,
         /// };
-        /// use icu::locale::{locale, langid};
+        /// use icu::locale::{langid, locale};
         /// use writeable::assert_try_writeable_eq;
         ///
         /// let prefs = DisplayNamesPreferences::from(locale!("en"));
         /// let options = LanguageIdentifierDisplayNameOptions::default();
+        ///
+        /// // Menu-style format places primary language name first for dropdown sorting (e.g. "Chinese, Mandarin"):
         /// let display_name = LanguageIdentifierDisplayName::try_new_menu_light(
         ///     prefs,
-        ///     langid!("fr-CA"),
+        ///     langid!("zh"),
         ///     options,
         /// )
         /// .expect("Data should load successfully");
+        /// assert_try_writeable_eq!(display_name.as_borrowed(), "Chinese, Mandarin", Ok(()));
         ///
-        /// assert_try_writeable_eq!(display_name.as_borrowed(), "French (Canada)", Ok(()));
+        /// // Light data does not include rare languages like Klingon ("tlh"), returning a fallback error:
+        /// let tlh = LanguageIdentifierDisplayName::try_new_menu_light(prefs, langid!("tlh"), options)
+        ///     .expect("Data should load successfully");
+        /// assert_try_writeable_eq!(tlh.as_borrowed(), "tlh", Err(LanguageIdentifierNameFallbackError));
         /// ```
         functions: [
             try_new_menu_light,
@@ -810,29 +846,41 @@ impl LanguageIdentifierDisplayName {
 
     icu_provider::gen_buffer_data_constructors!(
         (prefs: DisplayNamesPreferences, subject: LanguageIdentifier, options: LanguageIdentifierDisplayNameOptions) -> result: Result<Self, DataError>,
-        /// Loads the short menu-style language display name for a given language identifier and locale using compiled data.
+        /// Loads a short menu-style language display name in a formatting locale using compiled data.
         ///
         /// Falls back to default (medium) length if a short name is not available.
+        ///
+        /// The `light` constructor links data for all common languages.
+        /// See the [class docs](Self) for information on which constructor to use.
+        ///
+        /// ✨ *Enabled with the `compiled_data` Cargo feature.*
         ///
         /// # Examples
         ///
         /// ```
         /// use icu::locale::names::{
-        ///     DisplayNamesPreferences, LanguageIdentifierDisplayName, LanguageIdentifierDisplayNameOptions,
+        ///     DisplayNamesPreferences, LanguageIdentifierDisplayName,
+        ///     LanguageIdentifierDisplayNameOptions, LanguageIdentifierNameFallbackError,
         /// };
-        /// use icu::locale::{locale, langid};
+        /// use icu::locale::{langid, locale};
         /// use writeable::assert_try_writeable_eq;
         ///
         /// let prefs = DisplayNamesPreferences::from(locale!("en"));
         /// let options = LanguageIdentifierDisplayNameOptions::default();
+        ///
+        /// // Short menu format uses abbreviated region name in menu layout (e.g. "English (US)"):
         /// let display_name = LanguageIdentifierDisplayName::try_new_short_menu_light(
         ///     prefs,
         ///     langid!("en-US"),
         ///     options,
         /// )
         /// .expect("Data should load successfully");
-        ///
         /// assert_try_writeable_eq!(display_name.as_borrowed(), "English (US)", Ok(()));
+        ///
+        /// // Light data does not include rare languages like Klingon ("tlh"), returning a fallback error:
+        /// let tlh = LanguageIdentifierDisplayName::try_new_short_menu_light(prefs, langid!("tlh"), options)
+        ///     .expect("Data should load successfully");
+        /// assert_try_writeable_eq!(tlh.as_borrowed(), "tlh", Err(LanguageIdentifierNameFallbackError));
         /// ```
         functions: [
             try_new_short_menu_light,
@@ -910,10 +958,35 @@ impl LanguageIdentifierDisplayName {
 
     icu_provider::gen_buffer_data_constructors!(
         (prefs: DisplayNamesPreferences, subject: LanguageIdentifier, options: LanguageIdentifierDisplayNameOptions) -> result: Result<Self, DataError>,
-        /// Loads the extended language display name for a given language identifier and locale using compiled data.
+        /// Loads a language display name in a formatting locale using compiled data.
         ///
         /// The `heavy` constructor includes additional data coverage for subtags that are
         /// less commonly formatted in the target locale.
+        /// See the [class docs](Self) for information on which constructor to use.
+        ///
+        /// ✨ *Enabled with the `compiled_data` Cargo feature.*
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use icu::locale::names::{
+        ///     DisplayNamesPreferences, LanguageIdentifierDisplayName, LanguageIdentifierDisplayNameOptions,
+        /// };
+        /// use icu::locale::{langid, locale};
+        /// use writeable::assert_try_writeable_eq;
+        ///
+        /// let prefs = DisplayNamesPreferences::from(locale!("nl"));
+        /// let options = LanguageIdentifierDisplayNameOptions::default();
+        ///
+        /// // Heavy dataset includes data coverage for rare languages like Klingon ("tlh"):
+        /// let display_name = LanguageIdentifierDisplayName::try_new_heavy(
+        ///     prefs,
+        ///     langid!("tlh"),
+        ///     options,
+        /// )
+        /// .expect("Data should load successfully");
+        /// assert_try_writeable_eq!(display_name.as_borrowed(), "Klingon", Ok(()));
+        /// ```
         functions: [
             try_new_heavy,
             try_new_heavy_with_buffer_provider,
@@ -998,12 +1071,37 @@ impl LanguageIdentifierDisplayName {
 
     icu_provider::gen_buffer_data_constructors!(
         (prefs: DisplayNamesPreferences, subject: LanguageIdentifier, options: LanguageIdentifierDisplayNameOptions) -> result: Result<Self, DataError>,
-        /// Loads the extended short language display name for a given language identifier and locale using compiled data.
+        /// Loads a short language display name in a formatting locale using compiled data.
+        ///
+        /// Falls back to default (medium) length if a short name is not available.
         ///
         /// The `heavy` constructor includes additional data coverage for subtags that are
         /// less commonly formatted in the target locale.
+        /// See the [class docs](Self) for information on which constructor to use.
         ///
-        /// Falls back to default (medium) length if a short name is not available.
+        /// ✨ *Enabled with the `compiled_data` Cargo feature.*
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use icu::locale::names::{
+        ///     DisplayNamesPreferences, LanguageIdentifierDisplayName, LanguageIdentifierDisplayNameOptions,
+        /// };
+        /// use icu::locale::{langid, locale};
+        /// use writeable::assert_try_writeable_eq;
+        ///
+        /// let prefs = DisplayNamesPreferences::from(locale!("nl"));
+        /// let options = LanguageIdentifierDisplayNameOptions::default();
+        ///
+        /// // Short heavy formats short names with full data coverage for rare subtags:
+        /// let display_name = LanguageIdentifierDisplayName::try_new_short_heavy(
+        ///     prefs,
+        ///     langid!("tlh-001"),
+        ///     options,
+        /// )
+        /// .expect("Data should load successfully");
+        /// assert_try_writeable_eq!(display_name.as_borrowed(), "Klingon (wereld)", Ok(()));
+        /// ```
         functions: [
             try_new_short_heavy,
             try_new_short_heavy_with_buffer_provider,
@@ -1111,12 +1209,37 @@ impl LanguageIdentifierDisplayName {
 
     icu_provider::gen_buffer_data_constructors!(
         (prefs: DisplayNamesPreferences, subject: LanguageIdentifier, options: LanguageIdentifierDisplayNameOptions) -> result: Result<Self, DataError>,
-        /// Loads the extended long language display name for a given language identifier and locale using compiled data.
+        /// Loads a long language display name in a formatting locale using compiled data.
+        ///
+        /// Falls back to default (medium) length if a long name is not available.
         ///
         /// The `heavy` constructor includes additional data coverage for subtags that are
         /// less commonly formatted in the target locale.
+        /// See the [class docs](Self) for information on which constructor to use.
         ///
-        /// Falls back to default (medium) length if a long name is not available.
+        /// ✨ *Enabled with the `compiled_data` Cargo feature.*
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use icu::locale::names::{
+        ///     DisplayNamesPreferences, LanguageIdentifierDisplayName, LanguageIdentifierDisplayNameOptions,
+        /// };
+        /// use icu::locale::{langid, locale};
+        /// use writeable::assert_try_writeable_eq;
+        ///
+        /// let prefs = DisplayNamesPreferences::from(locale!("nl"));
+        /// let options = LanguageIdentifierDisplayNameOptions::default();
+        ///
+        /// // Long heavy formats long names with full data coverage for rare subtags:
+        /// let display_name = LanguageIdentifierDisplayName::try_new_long_heavy(
+        ///     prefs,
+        ///     langid!("tlh-001"),
+        ///     options,
+        /// )
+        /// .expect("Data should load successfully");
+        /// assert_try_writeable_eq!(display_name.as_borrowed(), "Klingon (wereld)", Ok(()));
+        /// ```
         functions: [
             try_new_long_heavy,
             try_new_long_heavy_with_buffer_provider,
@@ -1218,10 +1341,13 @@ impl LanguageIdentifierDisplayName {
 
     icu_provider::gen_buffer_data_constructors!(
         (prefs: DisplayNamesPreferences, subject: LanguageIdentifier, options: LanguageIdentifierDisplayNameOptions) -> result: Result<Self, DataError>,
-        /// Loads the menu-style language display name for a given language identifier and locale using compiled data.
+        /// Loads a menu-style language display name in a formatting locale using compiled data.
         ///
         /// The `heavy` constructor includes additional data coverage for subtags that are
         /// less commonly formatted in the target locale.
+        /// See the [class docs](Self) for information on which constructor to use.
+        ///
+        /// ✨ *Enabled with the `compiled_data` Cargo feature.*
         ///
         /// # Examples
         ///
@@ -1229,19 +1355,20 @@ impl LanguageIdentifierDisplayName {
         /// use icu::locale::names::{
         ///     DisplayNamesPreferences, LanguageIdentifierDisplayName, LanguageIdentifierDisplayNameOptions,
         /// };
-        /// use icu::locale::{locale, langid};
+        /// use icu::locale::{langid, locale};
         /// use writeable::assert_try_writeable_eq;
         ///
-        /// let prefs = DisplayNamesPreferences::from(locale!("en"));
+        /// let prefs = DisplayNamesPreferences::from(locale!("nl"));
         /// let options = LanguageIdentifierDisplayNameOptions::default();
+        ///
+        /// // Menu heavy formats menu-style names with full data coverage for rare subtags:
         /// let display_name = LanguageIdentifierDisplayName::try_new_menu_heavy(
         ///     prefs,
-        ///     langid!("en-US"),
+        ///     langid!("tlh-001"),
         ///     options,
         /// )
         /// .expect("Data should load successfully");
-        ///
-        /// assert_try_writeable_eq!(display_name.as_borrowed(), "English (United States)", Ok(()));
+        /// assert_try_writeable_eq!(display_name.as_borrowed(), "Klingon (wereld)", Ok(()));
         /// ```
         functions: [
             try_new_menu_heavy,
@@ -1326,12 +1453,15 @@ impl LanguageIdentifierDisplayName {
 
     icu_provider::gen_buffer_data_constructors!(
         (prefs: DisplayNamesPreferences, subject: LanguageIdentifier, options: LanguageIdentifierDisplayNameOptions) -> result: Result<Self, DataError>,
-        /// Loads the short menu-style language display name for a given language identifier and locale using compiled data.
+        /// Loads a short menu-style language display name in a formatting locale using compiled data.
+        ///
+        /// Falls back to default (medium) length if a short name is not available.
         ///
         /// The `heavy` constructor includes additional data coverage for subtags that are
         /// less commonly formatted in the target locale.
+        /// See the [class docs](Self) for information on which constructor to use.
         ///
-        /// Falls back to default (medium) length if a short name is not available.
+        /// ✨ *Enabled with the `compiled_data` Cargo feature.*
         ///
         /// # Examples
         ///
@@ -1339,19 +1469,20 @@ impl LanguageIdentifierDisplayName {
         /// use icu::locale::names::{
         ///     DisplayNamesPreferences, LanguageIdentifierDisplayName, LanguageIdentifierDisplayNameOptions,
         /// };
-        /// use icu::locale::{locale, langid};
+        /// use icu::locale::{langid, locale};
         /// use writeable::assert_try_writeable_eq;
         ///
-        /// let prefs = DisplayNamesPreferences::from(locale!("en"));
+        /// let prefs = DisplayNamesPreferences::from(locale!("nl"));
         /// let options = LanguageIdentifierDisplayNameOptions::default();
+        ///
+        /// // Short menu heavy formats short menu-style names with full data coverage for rare subtags:
         /// let display_name = LanguageIdentifierDisplayName::try_new_short_menu_heavy(
         ///     prefs,
-        ///     langid!("en-US"),
+        ///     langid!("tlh-001"),
         ///     options,
         /// )
         /// .expect("Data should load successfully");
-        ///
-        /// assert_try_writeable_eq!(display_name.as_borrowed(), "English (US)", Ok(()));
+        /// assert_try_writeable_eq!(display_name.as_borrowed(), "Klingon (wereld)", Ok(()));
         /// ```
         functions: [
             try_new_short_menu_heavy,

--- a/components/locale/src/names/language.rs
+++ b/components/locale/src/names/language.rs
@@ -912,7 +912,8 @@ impl LanguageIdentifierDisplayName {
         (prefs: DisplayNamesPreferences, subject: LanguageIdentifier, options: LanguageIdentifierDisplayNameOptions) -> result: Result<Self, DataError>,
         /// Loads the extended language display name for a given language identifier and locale using compiled data.
         ///
-        /// The `extended` constructor includes additional data coverage for subtags that are less commonly formatted in the target locale.
+        /// The `heavy` constructor includes additional data coverage for subtags that are
+        /// less commonly formatted in the target locale.
         functions: [
             try_new_heavy,
             try_new_heavy_with_buffer_provider,
@@ -999,7 +1000,8 @@ impl LanguageIdentifierDisplayName {
         (prefs: DisplayNamesPreferences, subject: LanguageIdentifier, options: LanguageIdentifierDisplayNameOptions) -> result: Result<Self, DataError>,
         /// Loads the extended short language display name for a given language identifier and locale using compiled data.
         ///
-        /// The `extended` constructor includes additional data coverage for subtags that are less commonly formatted in the target locale.
+        /// The `heavy` constructor includes additional data coverage for subtags that are
+        /// less commonly formatted in the target locale.
         ///
         /// Falls back to default (medium) length if a short name is not available.
         functions: [
@@ -1111,7 +1113,8 @@ impl LanguageIdentifierDisplayName {
         (prefs: DisplayNamesPreferences, subject: LanguageIdentifier, options: LanguageIdentifierDisplayNameOptions) -> result: Result<Self, DataError>,
         /// Loads the extended long language display name for a given language identifier and locale using compiled data.
         ///
-        /// The `extended` constructor includes additional data coverage for subtags that are less commonly formatted in the target locale.
+        /// The `heavy` constructor includes additional data coverage for subtags that are
+        /// less commonly formatted in the target locale.
         ///
         /// Falls back to default (medium) length if a long name is not available.
         functions: [
@@ -1217,7 +1220,8 @@ impl LanguageIdentifierDisplayName {
         (prefs: DisplayNamesPreferences, subject: LanguageIdentifier, options: LanguageIdentifierDisplayNameOptions) -> result: Result<Self, DataError>,
         /// Loads the menu-style language display name for a given language identifier and locale using compiled data.
         ///
-        /// The `extended` constructor includes additional data coverage for subtags that are less commonly formatted in the target locale.
+        /// The `heavy` constructor includes additional data coverage for subtags that are
+        /// less commonly formatted in the target locale.
         ///
         /// # Examples
         ///
@@ -1324,7 +1328,8 @@ impl LanguageIdentifierDisplayName {
         (prefs: DisplayNamesPreferences, subject: LanguageIdentifier, options: LanguageIdentifierDisplayNameOptions) -> result: Result<Self, DataError>,
         /// Loads the short menu-style language display name for a given language identifier and locale using compiled data.
         ///
-        /// The `extended` constructor includes additional data coverage for subtags that are less commonly formatted in the target locale.
+        /// The `heavy` constructor includes additional data coverage for subtags that are
+        /// less commonly formatted in the target locale.
         ///
         /// Falls back to default (medium) length if a short name is not available.
         ///

--- a/components/locale/src/names/region.rs
+++ b/components/locale/src/names/region.rs
@@ -59,6 +59,9 @@ macro_rules! table_row {
 ///
 /// > Note: :x: means that the constructor returns an error.
 ///
+/// There are fallible (`try_new_*`) and infallible (`new_*_with_fallback`) versions of
+/// all constructors.
+///
 /// # Example
 ///
 /// ```
@@ -431,8 +434,8 @@ impl RegionDisplayName {
         /// The `light` constructor links data for all modern regions.
         /// See the [class docs](Self) for information on which constructor to use.
         ///
-        /// If the display name is not found in data, the BCP-47 code is returned. To detect this case
-        /// and return an error instead, use [`RegionDisplayName::try_new_short_light()`].
+        /// Returns an error if the display name is not found in data. To return the BCP-47 code
+        /// instead, use [`RegionDisplayName::new_short_light_with_fallback()`].
         ///
         /// ✨ *Enabled with the `compiled_data` Cargo feature.*
         ///

--- a/components/locale/src/names/region.rs
+++ b/components/locale/src/names/region.rs
@@ -77,7 +77,7 @@ pub struct RegionDisplayName {
 }
 
 impl RegionDisplayName {
-    /// Loads the region display name for a given region and locale using compiled data.
+    /// Loads a region display name in a formatting locale using compiled data.
     ///
     /// The `light` constructor links data for all modern regions.
     /// See the [class docs](Self) for information on which constructor to use.
@@ -105,11 +105,7 @@ impl RegionDisplayName {
     /// );
     /// ```
     #[cfg(feature = "compiled_data")]
-    pub fn new_light_with_fallback(prefs: DisplayNamesPreferences, region: Region) -> Self
-    where
-        crate::provider::Baked: DataProvider<LocaleNamesRegionMediumLightV1>
-            + DataProvider<LocaleNamesRegionMediumTinyV1>,
-    {
+    pub fn new_light_with_fallback(prefs: DisplayNamesPreferences, region: Region) -> Self {
         Self::try_new_light(prefs, region).unwrap_or(Self {
             payload: DataPayloadOr::from_other(region),
         })
@@ -117,7 +113,7 @@ impl RegionDisplayName {
 
     icu_provider::gen_buffer_data_constructors!(
         (prefs: DisplayNamesPreferences, region: Region) -> result: Result<Self, DataError>,
-        /// Loads the region display name for a given region and locale using compiled data.
+        /// Loads a region display name in a formatting locale using compiled data.
         ///
         /// The `light` constructor links data for all modern regions.
         /// See the [class docs](Self) for information on which constructor to use.
@@ -177,7 +173,7 @@ impl RegionDisplayName {
         Ok(Self { payload })
     }
 
-    /// Loads the region display name for a given region and locale using compiled data.
+    /// Loads a region display name in a formatting locale using compiled data.
     ///
     /// The `tiny` constructor links an extremely limited amount of data, with a focus on
     /// regions where the formatting locale is in common use. For example, the word for
@@ -208,10 +204,7 @@ impl RegionDisplayName {
     /// );
     /// ```
     #[cfg(feature = "compiled_data")]
-    pub fn new_tiny_with_fallback(prefs: DisplayNamesPreferences, region: Region) -> Self
-    where
-        crate::provider::Baked: DataProvider<LocaleNamesRegionMediumTinyV1>,
-    {
+    pub fn new_tiny_with_fallback(prefs: DisplayNamesPreferences, region: Region) -> Self {
         Self::try_new_tiny(prefs, region).unwrap_or(Self {
             payload: DataPayloadOr::from_other(region),
         })
@@ -219,7 +212,7 @@ impl RegionDisplayName {
 
     icu_provider::gen_buffer_data_constructors!(
         (prefs: DisplayNamesPreferences, region: Region) -> result: Result<Self, DataError>,
-        /// Loads the region display name for a given region and locale using compiled data.
+        /// Loads a region display name in a formatting locale using compiled data.
         ///
         /// The `tiny` constructor links an extremely limited amount of data, with a focus on
         /// regions where the formatting locale is in common use. For example, the word for
@@ -272,14 +265,90 @@ impl RegionDisplayName {
         Ok(Self { payload })
     }
 
+    /// Loads a short region display name in a formatting locale using compiled data.
+    ///
+    /// Falls back to default (medium) length if a short name is not available.
+    ///
+    /// The `tiny` constructor links an extremely limited amount of data, with a focus on
+    /// regions where the formatting locale is in common use. For example, the word for
+    /// Germany is included in `de` (German) but not `zh` (Chinese).
+    /// See the [class docs](Self) for more information on which constructor to use.
+    ///
+    /// If the display name is not found in data, the BCP-47 code is returned. To detect this case
+    /// and return an error instead, use [`RegionDisplayName::try_new_short_tiny()`].
+    ///
+    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu::locale::names::RegionDisplayName;
+    /// use icu::locale::{locale, subtags::region};
+    /// use writeable::assert_writeable_eq;
+    ///
+    /// assert_writeable_eq!(
+    ///     RegionDisplayName::new_short_tiny_with_fallback(locale!("de").into(), region!("DE")),
+    ///     "Deutschland"
+    /// );
+    ///
+    /// // Name for Germany is NOT included in the Chinese locale
+    /// assert_writeable_eq!(
+    ///     RegionDisplayName::new_short_tiny_with_fallback(locale!("zh").into(), region!("DE")),
+    ///     "DE"
+    /// );
+    ///
+    /// // Example short name: region GB -> "UK"
+    /// assert_writeable_eq!(
+    ///     RegionDisplayName::new_short_tiny_with_fallback(locale!("en").into(), region!("GB")),
+    ///     "UK"
+    /// );
+    /// ```
+    #[cfg(feature = "compiled_data")]
+    pub fn new_short_tiny_with_fallback(prefs: DisplayNamesPreferences, region: Region) -> Self {
+        Self::try_new_short_tiny(prefs, region).unwrap_or(Self {
+            payload: DataPayloadOr::from_other(region),
+        })
+    }
+
     icu_provider::gen_buffer_data_constructors!(
         (prefs: DisplayNamesPreferences, region: Region) -> result: Result<Self, DataError>,
-        /// Loads the minimal short region display name for a given region and locale using compiled data.
-        ///
-        /// The `minimal` constructor links an extremely limited amount of data: for example,
-        /// only those regions where the formatting locale is spoken.
+        /// Loads a short region display name in a formatting locale using compiled data.
         ///
         /// Falls back to default (medium) length if a short name is not available.
+        ///
+        /// The `tiny` constructor links an extremely limited amount of data, with a focus on
+        /// regions where the formatting locale is in common use. For example, the word for
+        /// Germany is included in `de` (German) but not `zh` (Chinese).
+        /// See the [class docs](Self) for more information on which constructor to use.
+        ///
+        /// Returns an error if the display name is not found in data. To return the BCP-47 code
+        /// instead, use [`RegionDisplayName::new_short_tiny_with_fallback()`].
+        ///
+        /// ✨ *Enabled with the `compiled_data` Cargo feature.*
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use icu::locale::names::RegionDisplayName;
+        /// use icu::locale::{locale, subtags::region};
+        /// use writeable::assert_writeable_eq;
+        ///
+        /// let name = RegionDisplayName::try_new_short_tiny(locale!("de").into(), region!("DE")).unwrap();
+        /// assert_writeable_eq!(
+        ///     name,
+        ///     "Deutschland"
+        /// );
+        ///
+        /// // Name for Germany is NOT included in the Chinese locale
+        /// RegionDisplayName::try_new_short_tiny(locale!("zh").into(), region!("DE")).unwrap_err();
+        ///
+        /// // Example short name: region GB -> "UK"
+        /// let name = RegionDisplayName::try_new_short_tiny(locale!("en").into(), region!("GB")).unwrap();
+        /// assert_writeable_eq!(
+        ///     name,
+        ///     "UK"
+        /// );
+        /// ```
         functions: [
             try_new_short_tiny,
             try_new_short_tiny_with_buffer_provider,
@@ -311,30 +380,87 @@ impl RegionDisplayName {
         Ok(Self { payload })
     }
 
+    /// Loads a short region display name in a formatting locale using compiled data.
+    ///
+    /// Falls back to default (medium) length if a short name is not available.
+    ///
+    /// The `light` constructor links data for all modern regions.
+    /// See the [class docs](Self) for information on which constructor to use.
+    ///
+    /// If the display name is not found in data, the BCP-47 code is returned. To detect this case
+    /// and return an error instead, use [`RegionDisplayName::try_new_short_light()`].
+    ///
+    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu::locale::names::RegionDisplayName;
+    /// use icu::locale::{locale, subtags::region};
+    /// use writeable::assert_writeable_eq;
+    ///
+    /// assert_writeable_eq!(
+    ///     RegionDisplayName::new_short_light_with_fallback(locale!("de").into(), region!("DE")),
+    ///     "Deutschland"
+    /// );
+    ///
+    /// assert_writeable_eq!(
+    ///     RegionDisplayName::new_short_light_with_fallback(locale!("zh").into(), region!("DE")),
+    ///     "德国"
+    /// );
+    ///
+    /// // Example short name: region GB -> "UK"
+    /// assert_writeable_eq!(
+    ///     RegionDisplayName::new_short_light_with_fallback(locale!("en").into(), region!("GB")),
+    ///     "UK"
+    /// );
+    /// ```
+    #[cfg(feature = "compiled_data")]
+    pub fn new_short_light_with_fallback(prefs: DisplayNamesPreferences, region: Region) -> Self {
+        Self::try_new_short_light(prefs, region).unwrap_or(Self {
+            payload: DataPayloadOr::from_other(region),
+        })
+    }
+
     icu_provider::gen_buffer_data_constructors!(
         (prefs: DisplayNamesPreferences, region: Region) -> result: Result<Self, DataError>,
-        /// Loads the short region display name for a given region and locale using compiled data.
+        /// Loads a short region display name in a formatting locale using compiled data.
         ///
         /// Falls back to default (medium) length if a short name is not available.
         ///
-        /// # Example
+        /// The `light` constructor links data for all modern regions.
+        /// See the [class docs](Self) for information on which constructor to use.
+        ///
+        /// If the display name is not found in data, the BCP-47 code is returned. To detect this case
+        /// and return an error instead, use [`RegionDisplayName::try_new_short_light()`].
+        ///
+        /// ✨ *Enabled with the `compiled_data` Cargo feature.*
+        ///
+        /// # Examples
         ///
         /// ```
-        /// use icu::locale::names::{DisplayNamesPreferences, RegionDisplayName};
+        /// use icu::locale::names::RegionDisplayName;
         /// use icu::locale::{locale, subtags::region};
         /// use writeable::assert_writeable_eq;
         ///
-        /// let prefs: DisplayNamesPreferences = locale!("en-US").into();
+        /// let name = RegionDisplayName::try_new_short_light(locale!("de").into(), region!("DE")).unwrap();
+        /// assert_writeable_eq!(
+        ///     name,
+        ///     "Deutschland"
+        /// );
         ///
-        /// // "US" has a short display name in en-US
-        /// let display_name_short = RegionDisplayName::try_new_short_light(prefs, region!("US"))
-        ///     .expect("Data should load successfully");
-        /// assert_writeable_eq!(display_name_short, "US");
+        /// let name = RegionDisplayName::try_new_short_light(locale!("zh").into(), region!("DE")).unwrap();
+        /// assert_writeable_eq!(
+        ///     name,
+        ///     "德国"
+        /// );
         ///
-        /// // "AD" does not have a short display name, so it falls back to the long display name
-        /// let display_name_long = RegionDisplayName::try_new_short_light(prefs, region!("AD"))
-        ///     .expect("Data should load successfully");
-        /// assert_writeable_eq!(display_name_long, "Andorra");
+        /// // Example short name: region GB -> "UK"
+        /// let name = RegionDisplayName::try_new_short_light(locale!("en").into(), region!("GB")).unwrap();
+        /// assert_writeable_eq!(
+        ///     name,
+        ///     "UK"
+        /// );
         /// ```
         functions: [
             try_new_short_light,

--- a/components/locale/src/names/region.rs
+++ b/components/locale/src/names/region.rs
@@ -111,6 +111,43 @@ impl RegionDisplayName {
         Ok(Self { payload })
     }
 
+    /// Infallibly create a [`RegionDisplayName`], falling back to the BCP-47 code if unavailable.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu::locale::names::RegionDisplayName;
+    /// use icu::locale::{locale, subtags::region};
+    /// use writeable::assert_writeable_eq;
+    ///
+    /// assert_writeable_eq!(
+    ///     RegionDisplayName::new_light_with_fallback(locale!("en").into(), region!("GB")),
+    ///     "United Kingdom"
+    /// );
+    ///
+    /// // Region not found
+    /// assert_writeable_eq!(
+    ///     RegionDisplayName::new_light_with_fallback(locale!("en").into(), region!("XZ")),
+    ///     "XZ"
+    /// );
+    ///
+    /// // Formatting locale not found
+    /// assert_writeable_eq!(
+    ///     RegionDisplayName::new_light_with_fallback(locale!("tlh").into(), region!("GB")),
+    ///     "GB"
+    /// );
+    /// ```
+    #[cfg(feature = "compiled_data")]
+    pub fn new_light_with_fallback(prefs: DisplayNamesPreferences, region: Region) -> Self
+    where
+        crate::provider::Baked: DataProvider<LocaleNamesRegionMediumLightV1>
+            + DataProvider<LocaleNamesRegionMediumTinyV1>,
+    {
+        Self::try_new_light(prefs, region).unwrap_or(Self {
+            payload: DataPayloadOr::from_other(region),
+        })
+    }
+
     icu_provider::gen_buffer_data_constructors!(
         (prefs: DisplayNamesPreferences, region: Region) -> result: Result<Self, DataError>,
         /// Loads the minimal region display name for a given region and locale using compiled data.

--- a/components/locale/src/names/region.rs
+++ b/components/locale/src/names/region.rs
@@ -77,9 +77,75 @@ pub struct RegionDisplayName {
 }
 
 impl RegionDisplayName {
+    /// Loads the region display name for a given region and locale using compiled data.
+    ///
+    /// The `light` constructor links data for all modern regions.
+    /// See the [class docs](Self) for information on which constructor to use.
+    ///
+    /// If the display name is not found in data, the BCP-47 code is returned. To detect this case
+    /// and return an error instead, use [`RegionDisplayName::try_new_light()`].
+    ///
+    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu::locale::names::RegionDisplayName;
+    /// use icu::locale::{locale, subtags::region};
+    /// use writeable::assert_writeable_eq;
+    ///
+    /// assert_writeable_eq!(
+    ///     RegionDisplayName::new_light_with_fallback(locale!("de").into(), region!("DE")),
+    ///     "Deutschland"
+    /// );
+    ///
+    /// assert_writeable_eq!(
+    ///     RegionDisplayName::new_light_with_fallback(locale!("zh").into(), region!("DE")),
+    ///     "德国"
+    /// );
+    /// ```
+    #[cfg(feature = "compiled_data")]
+    pub fn new_light_with_fallback(prefs: DisplayNamesPreferences, region: Region) -> Self
+    where
+        crate::provider::Baked: DataProvider<LocaleNamesRegionMediumLightV1>
+            + DataProvider<LocaleNamesRegionMediumTinyV1>,
+    {
+        Self::try_new_light(prefs, region).unwrap_or(Self {
+            payload: DataPayloadOr::from_other(region),
+        })
+    }
+
     icu_provider::gen_buffer_data_constructors!(
         (prefs: DisplayNamesPreferences, region: Region) -> result: Result<Self, DataError>,
         /// Loads the region display name for a given region and locale using compiled data.
+        ///
+        /// The `light` constructor links data for all modern regions.
+        /// See the [class docs](Self) for information on which constructor to use.
+        ///
+        /// Returns an error if the display name is not found in data. To return the BCP-47 code
+        /// instead, use [`RegionDisplayName::new_light_with_fallback()`].
+        ///
+        /// ✨ *Enabled with the `compiled_data` Cargo feature.*
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use icu::locale::names::RegionDisplayName;
+        /// use icu::locale::{locale, subtags::region};
+        /// use writeable::assert_writeable_eq;
+        ///
+        /// let name = RegionDisplayName::try_new_light(locale!("de").into(), region!("DE")).unwrap();
+        /// assert_writeable_eq!(
+        ///     name,
+        ///     "Deutschland"
+        /// );
+        ///
+        /// let name = RegionDisplayName::try_new_light(locale!("zh").into(), region!("DE")).unwrap();
+        /// assert_writeable_eq!(
+        ///     name,
+        ///     "德国"
+        /// );
+        /// ```
         functions: [
             try_new_light,
             try_new_light_with_buffer_provider,
@@ -111,7 +177,17 @@ impl RegionDisplayName {
         Ok(Self { payload })
     }
 
-    /// Infallibly create a [`RegionDisplayName`], falling back to the BCP-47 code if unavailable.
+    /// Loads the region display name for a given region and locale using compiled data.
+    ///
+    /// The `tiny` constructor links an extremely limited amount of data, with a focus on
+    /// regions where the formatting locale is in common use. For example, the word for
+    /// Germany is included in `de` (German) but not `zh` (Chinese).
+    /// See the [class docs](Self) for more information on which constructor to use.
+    ///
+    /// If the display name is not found in data, the BCP-47 code is returned. To detect this case
+    /// and return an error instead, use [`RegionDisplayName::try_new_tiny()`].
+    ///
+    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
     ///
     /// # Examples
     ///
@@ -121,39 +197,39 @@ impl RegionDisplayName {
     /// use writeable::assert_writeable_eq;
     ///
     /// assert_writeable_eq!(
-    ///     RegionDisplayName::new_light_with_fallback(locale!("en").into(), region!("GB")),
-    ///     "United Kingdom"
+    ///     RegionDisplayName::new_tiny_with_fallback(locale!("de").into(), region!("DE")),
+    ///     "Deutschland"
     /// );
     ///
-    /// // Region not found
+    /// // Name for Germany is NOT included in the Chinese locale
     /// assert_writeable_eq!(
-    ///     RegionDisplayName::new_light_with_fallback(locale!("en").into(), region!("XZ")),
-    ///     "XZ"
-    /// );
-    ///
-    /// // Formatting locale not found
-    /// assert_writeable_eq!(
-    ///     RegionDisplayName::new_light_with_fallback(locale!("tlh").into(), region!("GB")),
-    ///     "GB"
+    ///     RegionDisplayName::new_tiny_with_fallback(locale!("zh").into(), region!("DE")),
+    ///     "DE"
     /// );
     /// ```
     #[cfg(feature = "compiled_data")]
-    pub fn new_light_with_fallback(prefs: DisplayNamesPreferences, region: Region) -> Self
+    pub fn new_tiny_with_fallback(prefs: DisplayNamesPreferences, region: Region) -> Self
     where
-        crate::provider::Baked: DataProvider<LocaleNamesRegionMediumLightV1>
-            + DataProvider<LocaleNamesRegionMediumTinyV1>,
+        crate::provider::Baked: DataProvider<LocaleNamesRegionMediumTinyV1>,
     {
-        Self::try_new_light(prefs, region).unwrap_or(Self {
+        Self::try_new_tiny(prefs, region).unwrap_or(Self {
             payload: DataPayloadOr::from_other(region),
         })
     }
 
     icu_provider::gen_buffer_data_constructors!(
         (prefs: DisplayNamesPreferences, region: Region) -> result: Result<Self, DataError>,
-        /// Loads the minimal region display name for a given region and locale using compiled data.
+        /// Loads the region display name for a given region and locale using compiled data.
         ///
-        /// The `minimal` constructor links an extremely limited amount of data: for example,
-        /// only those regions where the formatting locale is spoken.
+        /// The `tiny` constructor links an extremely limited amount of data, with a focus on
+        /// regions where the formatting locale is in common use. For example, the word for
+        /// Germany is included in `de` (German) but not `zh` (Chinese).
+        /// See the [class docs](Self) for more information on which constructor to use.
+        ///
+        /// Returns an error if the display name is not found in data. To return the BCP-47 code
+        /// instead, use [`RegionDisplayName::new_tiny_with_fallback()`].
+        ///
+        /// ✨ *Enabled with the `compiled_data` Cargo feature.*
         ///
         /// # Examples
         ///
@@ -162,10 +238,14 @@ impl RegionDisplayName {
         /// use icu::locale::{locale, subtags::region};
         /// use writeable::assert_writeable_eq;
         ///
-        /// let display_name = RegionDisplayName::try_new_tiny(locale!("en").into(), region!("US"))
-        ///     .expect("Data should load successfully");
+        /// let name = RegionDisplayName::try_new_tiny(locale!("de").into(), region!("DE")).unwrap();
+        /// assert_writeable_eq!(
+        ///     name,
+        ///     "Deutschland"
+        /// );
         ///
-        /// assert_writeable_eq!(display_name, "United States");
+        /// // Name for Germany is NOT included in the Chinese locale
+        /// RegionDisplayName::try_new_tiny(locale!("zh").into(), region!("DE")).unwrap_err();
         /// ```
         functions: [
             try_new_tiny,

--- a/components/locale/src/names/script.rs
+++ b/components/locale/src/names/script.rs
@@ -58,6 +58,9 @@ macro_rules! table_row {
 ///
 /// > Note: :x: means that the constructor returns an error.
 ///
+/// There are fallible (`try_new_*`) and infallible (`new_*_with_fallback`) versions of
+/// all constructors.
+///
 /// # Example
 ///
 /// ```
@@ -76,9 +79,57 @@ pub struct ScriptDisplayName {
 }
 
 impl ScriptDisplayName {
+    /// Loads a script display name in a formatting locale using compiled data.
+    ///
+    /// The `light` constructor links data for all common scripts.
+    /// See the [class docs](Self) for information on which constructor to use.
+    ///
+    /// If the display name is not found in data, the BCP-47 code is returned. To detect this case
+    /// and return an error instead, use [`ScriptDisplayName::try_new_light()`].
+    ///
+    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu::locale::names::ScriptDisplayName;
+    /// use icu::locale::{locale, subtags::script};
+    /// use writeable::assert_writeable_eq;
+    ///
+    /// assert_writeable_eq!(
+    ///     ScriptDisplayName::new_light_with_fallback(locale!("en").into(), script!("Latn")),
+    ///     "Latin"
+    /// );
+    /// ```
+    #[cfg(feature = "compiled_data")]
+    pub fn new_light_with_fallback(prefs: DisplayNamesPreferences, script: Script) -> Self {
+        Self::try_new_light(prefs, script).unwrap_or(Self {
+            payload: DataPayloadOr::from_other(script),
+        })
+    }
+
     icu_provider::gen_buffer_data_constructors!(
         (prefs: DisplayNamesPreferences, script: Script) -> result: Result<Self, DataError>,
-        /// Loads the script display name for a given script and locale using compiled data.
+        /// Loads a script display name in a formatting locale using compiled data.
+        ///
+        /// The `light` constructor links data for all common scripts.
+        /// See the [class docs](Self) for information on which constructor to use.
+        ///
+        /// Returns an error if the display name is not found in data. To return the BCP-47 code
+        /// instead, use [`ScriptDisplayName::new_light_with_fallback()`].
+        ///
+        /// ✨ *Enabled with the `compiled_data` Cargo feature.*
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use icu::locale::names::ScriptDisplayName;
+        /// use icu::locale::{locale, subtags::script};
+        /// use writeable::assert_writeable_eq;
+        ///
+        /// let name = ScriptDisplayName::try_new_light(locale!("en").into(), script!("Latn")).unwrap();
+        /// assert_writeable_eq!(name, "Latin");
+        /// ```
         functions: [
             try_new_light,
             try_new_light_with_buffer_provider,
@@ -110,12 +161,48 @@ impl ScriptDisplayName {
         Ok(Self { payload })
     }
 
+    /// Loads a script display name in a formatting locale using compiled data.
+    ///
+    /// The `tiny` constructor links an extremely limited amount of data, with a focus on
+    /// scripts associated with the formatting locale.
+    /// See the [class docs](Self) for information on which constructor to use.
+    ///
+    /// If the display name is not found in data, the BCP-47 code is returned. To detect this case
+    /// and return an error instead, use [`ScriptDisplayName::try_new_tiny()`].
+    ///
+    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu::locale::names::ScriptDisplayName;
+    /// use icu::locale::{locale, subtags::script};
+    /// use writeable::assert_writeable_eq;
+    ///
+    /// assert_writeable_eq!(
+    ///     ScriptDisplayName::new_tiny_with_fallback(locale!("en").into(), script!("Latn")),
+    ///     "Latin"
+    /// );
+    /// ```
+    #[cfg(feature = "compiled_data")]
+    pub fn new_tiny_with_fallback(prefs: DisplayNamesPreferences, script: Script) -> Self {
+        Self::try_new_tiny(prefs, script).unwrap_or(Self {
+            payload: DataPayloadOr::from_other(script),
+        })
+    }
+
     icu_provider::gen_buffer_data_constructors!(
         (prefs: DisplayNamesPreferences, script: Script) -> result: Result<Self, DataError>,
-        /// Loads the minimal script display name for a given script and locale using compiled data.
+        /// Loads a script display name in a formatting locale using compiled data.
         ///
-        /// The `minimal` constructor links an extremely limited amount of data: for example,
-        /// only those scripts associated with the formatting locale.
+        /// The `tiny` constructor links an extremely limited amount of data, with a focus on
+        /// scripts associated with the formatting locale.
+        /// See the [class docs](Self) for information on which constructor to use.
+        ///
+        /// Returns an error if the display name is not found in data. To return the BCP-47 code
+        /// instead, use [`ScriptDisplayName::new_tiny_with_fallback()`].
+        ///
+        /// ✨ *Enabled with the `compiled_data` Cargo feature.*
         ///
         /// # Examples
         ///
@@ -124,9 +211,8 @@ impl ScriptDisplayName {
         /// use icu::locale::{locale, subtags::script};
         /// use writeable::assert_writeable_eq;
         ///
-        /// // Minimal script names contain Latn for en
-        /// let display_name = ScriptDisplayName::try_new_tiny(locale!("en").into(), script!("Latn")).unwrap();
-        /// assert_writeable_eq!(display_name, "Latin");
+        /// let name = ScriptDisplayName::try_new_tiny(locale!("en").into(), script!("Latn")).unwrap();
+        /// assert_writeable_eq!(name, "Latin");
         /// ```
         functions: [
             try_new_tiny,
@@ -153,11 +239,46 @@ impl ScriptDisplayName {
         Ok(Self { payload })
     }
 
+    /// Loads a script display name in a formatting locale using compiled data.
+    ///
+    /// The `heavy` constructor includes additional data coverage for subtags that are less commonly formatted in the target locale.
+    /// See the [class docs](Self) for information on which constructor to use.
+    ///
+    /// If the display name is not found in data, the BCP-47 code is returned. To detect this case
+    /// and return an error instead, use [`ScriptDisplayName::try_new_heavy()`].
+    ///
+    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu::locale::names::ScriptDisplayName;
+    /// use icu::locale::{locale, subtags::script};
+    /// use writeable::assert_writeable_eq;
+    ///
+    /// assert_writeable_eq!(
+    ///     ScriptDisplayName::new_heavy_with_fallback(locale!("en").into(), script!("Latn")),
+    ///     "Latin"
+    /// );
+    /// ```
+    #[cfg(feature = "compiled_data")]
+    pub fn new_heavy_with_fallback(prefs: DisplayNamesPreferences, script: Script) -> Self {
+        Self::try_new_heavy(prefs, script).unwrap_or(Self {
+            payload: DataPayloadOr::from_other(script),
+        })
+    }
+
     icu_provider::gen_buffer_data_constructors!(
         (prefs: DisplayNamesPreferences, script: Script) -> result: Result<Self, DataError>,
-        /// Loads the extended script display name for a given script and locale using compiled data.
+        /// Loads a script display name in a formatting locale using compiled data.
         ///
-        /// The `extended` constructor includes additional data coverage for subtags that are less commonly formatted in the target locale.
+        /// The `heavy` constructor includes additional data coverage for subtags that are less commonly formatted in the target locale.
+        /// See the [class docs](Self) for information on which constructor to use.
+        ///
+        /// Returns an error if the display name is not found in data. To return the BCP-47 code
+        /// instead, use [`ScriptDisplayName::new_heavy_with_fallback()`].
+        ///
+        /// ✨ *Enabled with the `compiled_data` Cargo feature.*
         ///
         /// # Examples
         ///
@@ -207,13 +328,50 @@ impl ScriptDisplayName {
         Ok(Self { payload })
     }
 
+    /// Loads a short script display name in a formatting locale using compiled data.
+    ///
+    /// Falls back to default (medium) length if a short name is not available.
+    ///
+    /// The `heavy` constructor includes additional data coverage for subtags that are less commonly formatted in the target locale.
+    /// See the [class docs](Self) for information on which constructor to use.
+    ///
+    /// If the display name is not found in data, the BCP-47 code is returned. To detect this case
+    /// and return an error instead, use [`ScriptDisplayName::try_new_short_heavy()`].
+    ///
+    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu::locale::names::ScriptDisplayName;
+    /// use icu::locale::{locale, subtags::script};
+    /// use writeable::assert_writeable_eq;
+    ///
+    /// assert_writeable_eq!(
+    ///     ScriptDisplayName::new_short_heavy_with_fallback(locale!("en").into(), script!("Xsux")),
+    ///     "S-A Cuneiform"
+    /// );
+    /// ```
+    #[cfg(feature = "compiled_data")]
+    pub fn new_short_heavy_with_fallback(prefs: DisplayNamesPreferences, script: Script) -> Self {
+        Self::try_new_short_heavy(prefs, script).unwrap_or(Self {
+            payload: DataPayloadOr::from_other(script),
+        })
+    }
+
     icu_provider::gen_buffer_data_constructors!(
         (prefs: DisplayNamesPreferences, script: Script) -> result: Result<Self, DataError>,
-        /// Loads the extended short script display name for a given script and locale using compiled data.
-        ///
-        /// The `extended` constructor includes additional data coverage for subtags that are less commonly formatted in the target locale.
+        /// Loads a short script display name in a formatting locale using compiled data.
         ///
         /// Falls back to default (medium) length if a short name is not available.
+        ///
+        /// The `heavy` constructor includes additional data coverage for subtags that are less commonly formatted in the target locale.
+        /// See the [class docs](Self) for information on which constructor to use.
+        ///
+        /// Returns an error if the display name is not found in data. To return the BCP-47 code
+        /// instead, use [`ScriptDisplayName::new_short_heavy_with_fallback()`].
+        ///
+        /// ✨ *Enabled with the `compiled_data` Cargo feature.*
         ///
         /// # Examples
         ///

--- a/components/locale/src/names/script.rs
+++ b/components/locale/src/names/script.rs
@@ -97,8 +97,13 @@ impl ScriptDisplayName {
     /// use writeable::assert_writeable_eq;
     ///
     /// assert_writeable_eq!(
-    ///     ScriptDisplayName::new_light_with_fallback(locale!("en").into(), script!("Latn")),
-    ///     "Latin"
+    ///     ScriptDisplayName::new_light_with_fallback(locale!("bs").into(), script!("Cyrl")),
+    ///     "ćirilica"
+    /// );
+    ///
+    /// assert_writeable_eq!(
+    ///     ScriptDisplayName::new_light_with_fallback(locale!("zh").into(), script!("Cyrl")),
+    ///     "西里尔文"
     /// );
     /// ```
     #[cfg(feature = "compiled_data")]
@@ -127,8 +132,17 @@ impl ScriptDisplayName {
         /// use icu::locale::{locale, subtags::script};
         /// use writeable::assert_writeable_eq;
         ///
-        /// let name = ScriptDisplayName::try_new_light(locale!("en").into(), script!("Latn")).unwrap();
-        /// assert_writeable_eq!(name, "Latin");
+        /// let name = ScriptDisplayName::try_new_light(locale!("bs").into(), script!("Cyrl")).unwrap();
+        /// assert_writeable_eq!(
+        ///     name,
+        ///     "ćirilica"
+        /// );
+        ///
+        /// let name = ScriptDisplayName::try_new_light(locale!("zh").into(), script!("Cyrl")).unwrap();
+        /// assert_writeable_eq!(
+        ///     name,
+        ///     "西里尔文"
+        /// );
         /// ```
         functions: [
             try_new_light,
@@ -164,8 +178,9 @@ impl ScriptDisplayName {
     /// Loads a script display name in a formatting locale using compiled data.
     ///
     /// The `tiny` constructor links an extremely limited amount of data, with a focus on
-    /// scripts associated with the formatting locale.
-    /// See the [class docs](Self) for information on which constructor to use.
+    /// scripts associated with the formatting locale. For example, the Cyrillic script
+    /// is included in `bs` (Bosnian) but not `zh` (Chinese).
+    /// See the [class docs](Self) for more information on which constructor to use.
     ///
     /// If the display name is not found in data, the BCP-47 code is returned. To detect this case
     /// and return an error instead, use [`ScriptDisplayName::try_new_tiny()`].
@@ -180,8 +195,14 @@ impl ScriptDisplayName {
     /// use writeable::assert_writeable_eq;
     ///
     /// assert_writeable_eq!(
-    ///     ScriptDisplayName::new_tiny_with_fallback(locale!("en").into(), script!("Latn")),
-    ///     "Latin"
+    ///     ScriptDisplayName::new_tiny_with_fallback(locale!("bs").into(), script!("Cyrl")),
+    ///     "ćirilica"
+    /// );
+    ///
+    /// // Name for Cyrillic script is NOT included in the Chinese locale
+    /// assert_writeable_eq!(
+    ///     ScriptDisplayName::new_tiny_with_fallback(locale!("zh").into(), script!("Cyrl")),
+    ///     "Cyrl"
     /// );
     /// ```
     #[cfg(feature = "compiled_data")]
@@ -196,8 +217,9 @@ impl ScriptDisplayName {
         /// Loads a script display name in a formatting locale using compiled data.
         ///
         /// The `tiny` constructor links an extremely limited amount of data, with a focus on
-        /// scripts associated with the formatting locale.
-        /// See the [class docs](Self) for information on which constructor to use.
+        /// scripts associated with the formatting locale. For example, the Cyrillic script
+        /// is included in `bs` (Bosnian) but not `zh` (Chinese).
+        /// See the [class docs](Self) for more information on which constructor to use.
         ///
         /// Returns an error if the display name is not found in data. To return the BCP-47 code
         /// instead, use [`ScriptDisplayName::new_tiny_with_fallback()`].
@@ -211,8 +233,14 @@ impl ScriptDisplayName {
         /// use icu::locale::{locale, subtags::script};
         /// use writeable::assert_writeable_eq;
         ///
-        /// let name = ScriptDisplayName::try_new_tiny(locale!("en").into(), script!("Latn")).unwrap();
-        /// assert_writeable_eq!(name, "Latin");
+        /// let name = ScriptDisplayName::try_new_tiny(locale!("bs").into(), script!("Cyrl")).unwrap();
+        /// assert_writeable_eq!(
+        ///     name,
+        ///     "ćirilica"
+        /// );
+        ///
+        /// // Name for Cyrillic script is NOT included in the Chinese locale
+        /// ScriptDisplayName::try_new_tiny(locale!("zh").into(), script!("Cyrl")).unwrap_err();
         /// ```
         functions: [
             try_new_tiny,
@@ -241,7 +269,8 @@ impl ScriptDisplayName {
 
     /// Loads a script display name in a formatting locale using compiled data.
     ///
-    /// The `heavy` constructor includes additional data coverage for subtags that are less commonly formatted in the target locale.
+    /// The `heavy` constructor includes additional data coverage for subtags that are
+    /// less commonly formatted in the target locale.
     /// See the [class docs](Self) for information on which constructor to use.
     ///
     /// If the display name is not found in data, the BCP-47 code is returned. To detect this case
@@ -257,8 +286,13 @@ impl ScriptDisplayName {
     /// use writeable::assert_writeable_eq;
     ///
     /// assert_writeable_eq!(
-    ///     ScriptDisplayName::new_heavy_with_fallback(locale!("en").into(), script!("Latn")),
-    ///     "Latin"
+    ///     ScriptDisplayName::new_heavy_with_fallback(locale!("de").into(), script!("Latn")),
+    ///     "Lateinisch"
+    /// );
+    ///
+    /// assert_writeable_eq!(
+    ///     ScriptDisplayName::new_heavy_with_fallback(locale!("de").into(), script!("Xsux")),
+    ///     "Sumerisch-akkadische Keilschrift"
     /// );
     /// ```
     #[cfg(feature = "compiled_data")]
@@ -272,7 +306,8 @@ impl ScriptDisplayName {
         (prefs: DisplayNamesPreferences, script: Script) -> result: Result<Self, DataError>,
         /// Loads a script display name in a formatting locale using compiled data.
         ///
-        /// The `heavy` constructor includes additional data coverage for subtags that are less commonly formatted in the target locale.
+        /// The `heavy` constructor includes additional data coverage for subtags that are
+        /// less commonly formatted in the target locale.
         /// See the [class docs](Self) for information on which constructor to use.
         ///
         /// Returns an error if the display name is not found in data. To return the BCP-47 code
@@ -287,10 +322,17 @@ impl ScriptDisplayName {
         /// use icu::locale::{locale, subtags::script};
         /// use writeable::assert_writeable_eq;
         ///
-        /// let display_name = ScriptDisplayName::try_new_heavy(locale!("en").into(), script!("Latn"))
-        ///     .expect("Data should load successfully");
+        /// let name = ScriptDisplayName::try_new_heavy(locale!("de").into(), script!("Latn")).unwrap();
+        /// assert_writeable_eq!(
+        ///     name,
+        ///     "Lateinisch"
+        /// );
         ///
-        /// assert_writeable_eq!(display_name, "Latin");
+        /// let name = ScriptDisplayName::try_new_heavy(locale!("de").into(), script!("Xsux")).unwrap();
+        /// assert_writeable_eq!(
+        ///     name,
+        ///     "Sumerisch-akkadische Keilschrift"
+        /// );
         /// ```
         functions: [
             try_new_heavy,
@@ -332,7 +374,8 @@ impl ScriptDisplayName {
     ///
     /// Falls back to default (medium) length if a short name is not available.
     ///
-    /// The `heavy` constructor includes additional data coverage for subtags that are less commonly formatted in the target locale.
+    /// The `heavy` constructor includes additional data coverage for subtags that are
+    /// less commonly formatted in the target locale.
     /// See the [class docs](Self) for information on which constructor to use.
     ///
     /// If the display name is not found in data, the BCP-47 code is returned. To detect this case
@@ -347,6 +390,12 @@ impl ScriptDisplayName {
     /// use icu::locale::{locale, subtags::script};
     /// use writeable::assert_writeable_eq;
     ///
+    /// assert_writeable_eq!(
+    ///     ScriptDisplayName::new_short_heavy_with_fallback(locale!("de").into(), script!("Latn")),
+    ///     "Lateinisch"
+    /// );
+    ///
+    /// // Example short name: script Xsux -> "S-A Cuneiform" in en
     /// assert_writeable_eq!(
     ///     ScriptDisplayName::new_short_heavy_with_fallback(locale!("en").into(), script!("Xsux")),
     ///     "S-A Cuneiform"
@@ -365,7 +414,8 @@ impl ScriptDisplayName {
         ///
         /// Falls back to default (medium) length if a short name is not available.
         ///
-        /// The `heavy` constructor includes additional data coverage for subtags that are less commonly formatted in the target locale.
+        /// The `heavy` constructor includes additional data coverage for subtags that are
+        /// less commonly formatted in the target locale.
         /// See the [class docs](Self) for information on which constructor to use.
         ///
         /// Returns an error if the display name is not found in data. To return the BCP-47 code
@@ -380,10 +430,18 @@ impl ScriptDisplayName {
         /// use icu::locale::{locale, subtags::script};
         /// use writeable::assert_writeable_eq;
         ///
-        /// let display_name = ScriptDisplayName::try_new_short_heavy(locale!("en").into(), script!("Xsux"))
-        ///     .expect("Data should load successfully");
+        /// let name = ScriptDisplayName::try_new_short_heavy(locale!("de").into(), script!("Latn")).unwrap();
+        /// assert_writeable_eq!(
+        ///     name,
+        ///     "Lateinisch"
+        /// );
         ///
-        /// assert_writeable_eq!(display_name, "S-A Cuneiform");
+        /// // Example short name: script Xsux -> "S-A Cuneiform" in en
+        /// let name = ScriptDisplayName::try_new_short_heavy(locale!("en").into(), script!("Xsux")).unwrap();
+        /// assert_writeable_eq!(
+        ///     name,
+        ///     "S-A Cuneiform"
+        /// );
         /// ```
         functions: [
             try_new_short_heavy,

--- a/components/locale/src/names/variant.rs
+++ b/components/locale/src/names/variant.rs
@@ -41,6 +41,9 @@ macro_rules! table_row {
 /// | :--- | :--- | :--- |
 #[doc = concat!(table_row!(try_new_heavy), "\n")]
 ///
+/// There are fallible (`try_new_*`) and infallible (`new_*_with_fallback`) versions of
+/// all constructors.
+///
 /// # Example
 ///
 /// ```
@@ -59,9 +62,46 @@ pub struct VariantDisplayName {
 }
 
 impl VariantDisplayName {
+    /// Loads a variant display name in a formatting locale using compiled data.
+    ///
+    /// The `heavy` constructor includes additional data coverage for subtags that are less commonly formatted in the target locale.
+    /// See the [class docs](Self) for information on which constructor to use.
+    ///
+    /// If the display name is not found in data, the BCP-47 code is returned. To detect this case
+    /// and return an error instead, use [`VariantDisplayName::try_new_heavy()`].
+    ///
+    /// ✨ *Enabled with the `compiled_data` Cargo feature.*
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use icu::locale::names::VariantDisplayName;
+    /// use icu::locale::{locale, subtags::variant};
+    /// use writeable::assert_writeable_eq;
+    ///
+    /// assert_writeable_eq!(
+    ///     VariantDisplayName::new_heavy_with_fallback(locale!("en").into(), variant!("fonipa")),
+    ///     "IPA Phonetics"
+    /// );
+    /// ```
+    #[cfg(feature = "compiled_data")]
+    pub fn new_heavy_with_fallback(prefs: DisplayNamesPreferences, variant: Variant) -> Self {
+        Self::try_new_heavy(prefs, variant).unwrap_or(Self {
+            payload: DataPayloadOr::from_other(variant),
+        })
+    }
+
     icu_provider::gen_buffer_data_constructors!(
         (prefs: DisplayNamesPreferences, variant: Variant) -> result: Result<Self, DataError>,
-        /// Loads the display name for a given variant in a given locale using compiled data.
+        /// Loads a variant display name in a formatting locale using compiled data.
+        ///
+        /// The `heavy` constructor includes additional data coverage for subtags that are less commonly formatted in the target locale.
+        /// See the [class docs](Self) for information on which constructor to use.
+        ///
+        /// Returns an error if the display name is not found in data. To return the BCP-47 code
+        /// instead, use [`VariantDisplayName::new_heavy_with_fallback()`].
+        ///
+        /// ✨ *Enabled with the `compiled_data` Cargo feature.*
         ///
         /// # Examples
         ///

--- a/components/locale/src/names/variant.rs
+++ b/components/locale/src/names/variant.rs
@@ -64,7 +64,8 @@ pub struct VariantDisplayName {
 impl VariantDisplayName {
     /// Loads a variant display name in a formatting locale using compiled data.
     ///
-    /// The `heavy` constructor includes additional data coverage for subtags that are less commonly formatted in the target locale.
+    /// The `heavy` constructor includes additional data coverage for subtags that are
+    /// less commonly formatted in the target locale.
     /// See the [class docs](Self) for information on which constructor to use.
     ///
     /// If the display name is not found in data, the BCP-47 code is returned. To detect this case
@@ -80,8 +81,13 @@ impl VariantDisplayName {
     /// use writeable::assert_writeable_eq;
     ///
     /// assert_writeable_eq!(
-    ///     VariantDisplayName::new_heavy_with_fallback(locale!("en").into(), variant!("fonipa")),
-    ///     "IPA Phonetics"
+    ///     VariantDisplayName::new_heavy_with_fallback(locale!("de").into(), variant!("fonipa")),
+    ///     "IPA Phonetisch"
+    /// );
+    ///
+    /// assert_writeable_eq!(
+    ///     VariantDisplayName::new_heavy_with_fallback(locale!("fr").into(), variant!("fonipa")),
+    ///     "alphabet phonétique international"
     /// );
     /// ```
     #[cfg(feature = "compiled_data")]
@@ -95,7 +101,8 @@ impl VariantDisplayName {
         (prefs: DisplayNamesPreferences, variant: Variant) -> result: Result<Self, DataError>,
         /// Loads a variant display name in a formatting locale using compiled data.
         ///
-        /// The `heavy` constructor includes additional data coverage for subtags that are less commonly formatted in the target locale.
+        /// The `heavy` constructor includes additional data coverage for subtags that are
+        /// less commonly formatted in the target locale.
         /// See the [class docs](Self) for information on which constructor to use.
         ///
         /// Returns an error if the display name is not found in data. To return the BCP-47 code
@@ -110,10 +117,17 @@ impl VariantDisplayName {
         /// use icu::locale::{locale, subtags::variant};
         /// use writeable::assert_writeable_eq;
         ///
-        /// let display_name = VariantDisplayName::try_new_heavy(locale!("en").into(), variant!("fonipa"))
-        ///     .expect("Data should load successfully");
+        /// let name = VariantDisplayName::try_new_heavy(locale!("de").into(), variant!("fonipa")).unwrap();
+        /// assert_writeable_eq!(
+        ///     name,
+        ///     "IPA Phonetisch"
+        /// );
         ///
-        /// assert_writeable_eq!(display_name, "IPA Phonetics");
+        /// let name = VariantDisplayName::try_new_heavy(locale!("fr").into(), variant!("fonipa")).unwrap();
+        /// assert_writeable_eq!(
+        ///     name,
+        ///     "alphabet phonétique international"
+        /// );
         /// ```
         functions: [
             try_new_heavy,

--- a/examples/cpp/locale.cpp
+++ b/examples/cpp/locale.cpp
@@ -167,21 +167,21 @@ int main() {
 
   // Region display name
   std::unique_ptr<Locale> formattingLocale = Locale::from_string("fr").ok().value();
-  out = LocaleNamesUnstable::for_region_light(*formattingLocale.get(), "GB").ok().value();
+  out = LocaleNamesUnstable::for_region_light(*formattingLocale.get(), "GB");
   std::cout << "formatting locale 'fr', region 'GB': " << out << std::endl;
   if (!test_string(out, "Royaume-Uni", "Region display name in French")) {
     return 1;
   }
 
   // Script display name
-  out = LocaleNamesUnstable::for_script_light(*formattingLocale.get(), "Latn").ok().value();
+  out = LocaleNamesUnstable::for_script_light(*formattingLocale.get(), "Latn");
   std::cout << "formatting locale 'fr', script 'Latn': " << out << std::endl;
   if (!test_string(out, "latin", "Script display name in French")) {
     return 1;
   }
 
   // Variant display name
-  out = LocaleNamesUnstable::for_variant_heavy(*formattingLocale.get(), "fonipa").ok().value();
+  out = LocaleNamesUnstable::for_variant_heavy(*formattingLocale.get(), "fonipa");
   std::cout << "formatting locale 'fr', variant 'fonipa': " << out << std::endl;
   if (!test_string(out, "alphabet phonétique international", "Variant display name in French")) {
     return 1;

--- a/ffi/capi/bindings/c/LocaleNamesUnstable.h
+++ b/ffi/capi/bindings/c/LocaleNamesUnstable.h
@@ -19,56 +19,47 @@
 
 
 
-typedef struct icu4x_LocaleNamesUnstable_for_region_light_mv1_result {union { DataError err;}; bool is_ok;} icu4x_LocaleNamesUnstable_for_region_light_mv1_result;
-icu4x_LocaleNamesUnstable_for_region_light_mv1_result icu4x_LocaleNamesUnstable_for_region_light_mv1(const Locale* locale, DiplomatStringView region, DiplomatWrite* write);
+void icu4x_LocaleNamesUnstable_for_region_light_mv1(const Locale* locale, DiplomatStringView region, DiplomatWrite* write);
 
 typedef struct icu4x_LocaleNamesUnstable_for_region_light_with_provider_mv1_result {union { DataError err;}; bool is_ok;} icu4x_LocaleNamesUnstable_for_region_light_with_provider_mv1_result;
 icu4x_LocaleNamesUnstable_for_region_light_with_provider_mv1_result icu4x_LocaleNamesUnstable_for_region_light_with_provider_mv1(const DataProvider* provider, const Locale* locale, DiplomatStringView region, DiplomatWrite* write);
 
-typedef struct icu4x_LocaleNamesUnstable_for_region_tiny_mv1_result {union { DataError err;}; bool is_ok;} icu4x_LocaleNamesUnstable_for_region_tiny_mv1_result;
-icu4x_LocaleNamesUnstable_for_region_tiny_mv1_result icu4x_LocaleNamesUnstable_for_region_tiny_mv1(const Locale* locale, DiplomatStringView region, DiplomatWrite* write);
+void icu4x_LocaleNamesUnstable_for_region_tiny_mv1(const Locale* locale, DiplomatStringView region, DiplomatWrite* write);
 
 typedef struct icu4x_LocaleNamesUnstable_for_region_tiny_with_provider_mv1_result {union { DataError err;}; bool is_ok;} icu4x_LocaleNamesUnstable_for_region_tiny_with_provider_mv1_result;
 icu4x_LocaleNamesUnstable_for_region_tiny_with_provider_mv1_result icu4x_LocaleNamesUnstable_for_region_tiny_with_provider_mv1(const DataProvider* provider, const Locale* locale, DiplomatStringView region, DiplomatWrite* write);
 
-typedef struct icu4x_LocaleNamesUnstable_for_region_short_tiny_mv1_result {union { DataError err;}; bool is_ok;} icu4x_LocaleNamesUnstable_for_region_short_tiny_mv1_result;
-icu4x_LocaleNamesUnstable_for_region_short_tiny_mv1_result icu4x_LocaleNamesUnstable_for_region_short_tiny_mv1(const Locale* locale, DiplomatStringView region, DiplomatWrite* write);
+void icu4x_LocaleNamesUnstable_for_region_short_tiny_mv1(const Locale* locale, DiplomatStringView region, DiplomatWrite* write);
 
 typedef struct icu4x_LocaleNamesUnstable_for_region_short_tiny_with_provider_mv1_result {union { DataError err;}; bool is_ok;} icu4x_LocaleNamesUnstable_for_region_short_tiny_with_provider_mv1_result;
 icu4x_LocaleNamesUnstable_for_region_short_tiny_with_provider_mv1_result icu4x_LocaleNamesUnstable_for_region_short_tiny_with_provider_mv1(const DataProvider* provider, const Locale* locale, DiplomatStringView region, DiplomatWrite* write);
 
-typedef struct icu4x_LocaleNamesUnstable_for_region_short_light_mv1_result {union { DataError err;}; bool is_ok;} icu4x_LocaleNamesUnstable_for_region_short_light_mv1_result;
-icu4x_LocaleNamesUnstable_for_region_short_light_mv1_result icu4x_LocaleNamesUnstable_for_region_short_light_mv1(const Locale* locale, DiplomatStringView region, DiplomatWrite* write);
+void icu4x_LocaleNamesUnstable_for_region_short_light_mv1(const Locale* locale, DiplomatStringView region, DiplomatWrite* write);
 
 typedef struct icu4x_LocaleNamesUnstable_for_region_short_light_with_provider_mv1_result {union { DataError err;}; bool is_ok;} icu4x_LocaleNamesUnstable_for_region_short_light_with_provider_mv1_result;
 icu4x_LocaleNamesUnstable_for_region_short_light_with_provider_mv1_result icu4x_LocaleNamesUnstable_for_region_short_light_with_provider_mv1(const DataProvider* provider, const Locale* locale, DiplomatStringView region, DiplomatWrite* write);
 
-typedef struct icu4x_LocaleNamesUnstable_for_script_light_mv1_result {union { DataError err;}; bool is_ok;} icu4x_LocaleNamesUnstable_for_script_light_mv1_result;
-icu4x_LocaleNamesUnstable_for_script_light_mv1_result icu4x_LocaleNamesUnstable_for_script_light_mv1(const Locale* locale, DiplomatStringView script, DiplomatWrite* write);
+void icu4x_LocaleNamesUnstable_for_script_light_mv1(const Locale* locale, DiplomatStringView script, DiplomatWrite* write);
 
 typedef struct icu4x_LocaleNamesUnstable_for_script_light_with_provider_mv1_result {union { DataError err;}; bool is_ok;} icu4x_LocaleNamesUnstable_for_script_light_with_provider_mv1_result;
 icu4x_LocaleNamesUnstable_for_script_light_with_provider_mv1_result icu4x_LocaleNamesUnstable_for_script_light_with_provider_mv1(const DataProvider* provider, const Locale* locale, DiplomatStringView script, DiplomatWrite* write);
 
-typedef struct icu4x_LocaleNamesUnstable_for_script_tiny_mv1_result {union { DataError err;}; bool is_ok;} icu4x_LocaleNamesUnstable_for_script_tiny_mv1_result;
-icu4x_LocaleNamesUnstable_for_script_tiny_mv1_result icu4x_LocaleNamesUnstable_for_script_tiny_mv1(const Locale* locale, DiplomatStringView script, DiplomatWrite* write);
+void icu4x_LocaleNamesUnstable_for_script_tiny_mv1(const Locale* locale, DiplomatStringView script, DiplomatWrite* write);
 
 typedef struct icu4x_LocaleNamesUnstable_for_script_tiny_with_provider_mv1_result {union { DataError err;}; bool is_ok;} icu4x_LocaleNamesUnstable_for_script_tiny_with_provider_mv1_result;
 icu4x_LocaleNamesUnstable_for_script_tiny_with_provider_mv1_result icu4x_LocaleNamesUnstable_for_script_tiny_with_provider_mv1(const DataProvider* provider, const Locale* locale, DiplomatStringView script, DiplomatWrite* write);
 
-typedef struct icu4x_LocaleNamesUnstable_for_script_heavy_mv1_result {union { DataError err;}; bool is_ok;} icu4x_LocaleNamesUnstable_for_script_heavy_mv1_result;
-icu4x_LocaleNamesUnstable_for_script_heavy_mv1_result icu4x_LocaleNamesUnstable_for_script_heavy_mv1(const Locale* locale, DiplomatStringView script, DiplomatWrite* write);
+void icu4x_LocaleNamesUnstable_for_script_heavy_mv1(const Locale* locale, DiplomatStringView script, DiplomatWrite* write);
 
 typedef struct icu4x_LocaleNamesUnstable_for_script_heavy_with_provider_mv1_result {union { DataError err;}; bool is_ok;} icu4x_LocaleNamesUnstable_for_script_heavy_with_provider_mv1_result;
 icu4x_LocaleNamesUnstable_for_script_heavy_with_provider_mv1_result icu4x_LocaleNamesUnstable_for_script_heavy_with_provider_mv1(const DataProvider* provider, const Locale* locale, DiplomatStringView script, DiplomatWrite* write);
 
-typedef struct icu4x_LocaleNamesUnstable_for_script_short_heavy_mv1_result {union { DataError err;}; bool is_ok;} icu4x_LocaleNamesUnstable_for_script_short_heavy_mv1_result;
-icu4x_LocaleNamesUnstable_for_script_short_heavy_mv1_result icu4x_LocaleNamesUnstable_for_script_short_heavy_mv1(const Locale* locale, DiplomatStringView script, DiplomatWrite* write);
+void icu4x_LocaleNamesUnstable_for_script_short_heavy_mv1(const Locale* locale, DiplomatStringView script, DiplomatWrite* write);
 
 typedef struct icu4x_LocaleNamesUnstable_for_script_short_heavy_with_provider_mv1_result {union { DataError err;}; bool is_ok;} icu4x_LocaleNamesUnstable_for_script_short_heavy_with_provider_mv1_result;
 icu4x_LocaleNamesUnstable_for_script_short_heavy_with_provider_mv1_result icu4x_LocaleNamesUnstable_for_script_short_heavy_with_provider_mv1(const DataProvider* provider, const Locale* locale, DiplomatStringView script, DiplomatWrite* write);
 
-typedef struct icu4x_LocaleNamesUnstable_for_variant_heavy_mv1_result {union { DataError err;}; bool is_ok;} icu4x_LocaleNamesUnstable_for_variant_heavy_mv1_result;
-icu4x_LocaleNamesUnstable_for_variant_heavy_mv1_result icu4x_LocaleNamesUnstable_for_variant_heavy_mv1(const Locale* locale, DiplomatStringView variant, DiplomatWrite* write);
+void icu4x_LocaleNamesUnstable_for_variant_heavy_mv1(const Locale* locale, DiplomatStringView variant, DiplomatWrite* write);
 
 typedef struct icu4x_LocaleNamesUnstable_for_variant_heavy_with_provider_mv1_result {union { DataError err;}; bool is_ok;} icu4x_LocaleNamesUnstable_for_variant_heavy_with_provider_mv1_result;
 icu4x_LocaleNamesUnstable_for_variant_heavy_with_provider_mv1_result icu4x_LocaleNamesUnstable_for_variant_heavy_with_provider_mv1(const DataProvider* provider, const Locale* locale, DiplomatStringView variant, DiplomatWrite* write);

--- a/ffi/capi/bindings/cpp/icu4x/LocaleNamesUnstable.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/LocaleNamesUnstable.d.hpp
@@ -48,16 +48,16 @@ public:
   /**
    * 🚧 This API is unstable and may experience breaking changes outside major releases.
    *
-   * See the [Rust documentation for `try_new_light`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.try_new_light) for more information.
+   * See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.new_light_with_fallback) for more information.
    */
-  inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_region_light(const icu4x::Locale& locale, std::string_view region);
+  inline static std::string for_region_light(const icu4x::Locale& locale, std::string_view region);
   template<typename W>
-  inline static icu4x::diplomat::result<std::monostate, icu4x::DataError> for_region_light_write(const icu4x::Locale& locale, std::string_view region, W& writeable_output);
+  inline static void for_region_light_write(const icu4x::Locale& locale, std::string_view region, W& writeable_output);
 
   /**
    * 🚧 This API is unstable and may experience breaking changes outside major releases.
    *
-   * See the [Rust documentation for `try_new_light`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.try_new_light) for more information.
+   * See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.new_light_with_fallback) for more information.
    */
   inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_region_light_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::string_view region);
   template<typename W>
@@ -66,16 +66,16 @@ public:
   /**
    * 🚧 This API is unstable and may experience breaking changes outside major releases.
    *
-   * See the [Rust documentation for `try_new_tiny`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.try_new_tiny) for more information.
+   * See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.new_tiny_with_fallback) for more information.
    */
-  inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_region_tiny(const icu4x::Locale& locale, std::string_view region);
+  inline static std::string for_region_tiny(const icu4x::Locale& locale, std::string_view region);
   template<typename W>
-  inline static icu4x::diplomat::result<std::monostate, icu4x::DataError> for_region_tiny_write(const icu4x::Locale& locale, std::string_view region, W& writeable_output);
+  inline static void for_region_tiny_write(const icu4x::Locale& locale, std::string_view region, W& writeable_output);
 
   /**
    * 🚧 This API is unstable and may experience breaking changes outside major releases.
    *
-   * See the [Rust documentation for `try_new_tiny`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.try_new_tiny) for more information.
+   * See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.new_tiny_with_fallback) for more information.
    */
   inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_region_tiny_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::string_view region);
   template<typename W>
@@ -84,16 +84,16 @@ public:
   /**
    * 🚧 This API is unstable and may experience breaking changes outside major releases.
    *
-   * See the [Rust documentation for `try_new_short_tiny`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.try_new_short_tiny) for more information.
+   * See the [Rust documentation for `new_short_tiny_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.new_short_tiny_with_fallback) for more information.
    */
-  inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_region_short_tiny(const icu4x::Locale& locale, std::string_view region);
+  inline static std::string for_region_short_tiny(const icu4x::Locale& locale, std::string_view region);
   template<typename W>
-  inline static icu4x::diplomat::result<std::monostate, icu4x::DataError> for_region_short_tiny_write(const icu4x::Locale& locale, std::string_view region, W& writeable_output);
+  inline static void for_region_short_tiny_write(const icu4x::Locale& locale, std::string_view region, W& writeable_output);
 
   /**
    * 🚧 This API is unstable and may experience breaking changes outside major releases.
    *
-   * See the [Rust documentation for `try_new_short_tiny`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.try_new_short_tiny) for more information.
+   * See the [Rust documentation for `new_short_tiny_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.new_short_tiny_with_fallback) for more information.
    */
   inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_region_short_tiny_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::string_view region);
   template<typename W>
@@ -102,16 +102,16 @@ public:
   /**
    * 🚧 This API is unstable and may experience breaking changes outside major releases.
    *
-   * See the [Rust documentation for `try_new_short_light`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.try_new_short_light) for more information.
+   * See the [Rust documentation for `new_short_light_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.new_short_light_with_fallback) for more information.
    */
-  inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_region_short_light(const icu4x::Locale& locale, std::string_view region);
+  inline static std::string for_region_short_light(const icu4x::Locale& locale, std::string_view region);
   template<typename W>
-  inline static icu4x::diplomat::result<std::monostate, icu4x::DataError> for_region_short_light_write(const icu4x::Locale& locale, std::string_view region, W& writeable_output);
+  inline static void for_region_short_light_write(const icu4x::Locale& locale, std::string_view region, W& writeable_output);
 
   /**
    * 🚧 This API is unstable and may experience breaking changes outside major releases.
    *
-   * See the [Rust documentation for `try_new_short_light`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.try_new_short_light) for more information.
+   * See the [Rust documentation for `new_short_light_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.new_short_light_with_fallback) for more information.
    */
   inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_region_short_light_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::string_view region);
   template<typename W>
@@ -120,16 +120,16 @@ public:
   /**
    * 🚧 This API is unstable and may experience breaking changes outside major releases.
    *
-   * See the [Rust documentation for `try_new_light`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.try_new_light) for more information.
+   * See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.new_light_with_fallback) for more information.
    */
-  inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_script_light(const icu4x::Locale& locale, std::string_view script);
+  inline static std::string for_script_light(const icu4x::Locale& locale, std::string_view script);
   template<typename W>
-  inline static icu4x::diplomat::result<std::monostate, icu4x::DataError> for_script_light_write(const icu4x::Locale& locale, std::string_view script, W& writeable_output);
+  inline static void for_script_light_write(const icu4x::Locale& locale, std::string_view script, W& writeable_output);
 
   /**
    * 🚧 This API is unstable and may experience breaking changes outside major releases.
    *
-   * See the [Rust documentation for `try_new_light`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.try_new_light) for more information.
+   * See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.new_light_with_fallback) for more information.
    */
   inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_script_light_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::string_view script);
   template<typename W>
@@ -138,16 +138,16 @@ public:
   /**
    * 🚧 This API is unstable and may experience breaking changes outside major releases.
    *
-   * See the [Rust documentation for `try_new_tiny`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.try_new_tiny) for more information.
+   * See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.new_tiny_with_fallback) for more information.
    */
-  inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_script_tiny(const icu4x::Locale& locale, std::string_view script);
+  inline static std::string for_script_tiny(const icu4x::Locale& locale, std::string_view script);
   template<typename W>
-  inline static icu4x::diplomat::result<std::monostate, icu4x::DataError> for_script_tiny_write(const icu4x::Locale& locale, std::string_view script, W& writeable_output);
+  inline static void for_script_tiny_write(const icu4x::Locale& locale, std::string_view script, W& writeable_output);
 
   /**
    * 🚧 This API is unstable and may experience breaking changes outside major releases.
    *
-   * See the [Rust documentation for `try_new_tiny`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.try_new_tiny) for more information.
+   * See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.new_tiny_with_fallback) for more information.
    */
   inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_script_tiny_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::string_view script);
   template<typename W>
@@ -156,16 +156,16 @@ public:
   /**
    * 🚧 This API is unstable and may experience breaking changes outside major releases.
    *
-   * See the [Rust documentation for `try_new_heavy`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.try_new_heavy) for more information.
+   * See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.new_heavy_with_fallback) for more information.
    */
-  inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_script_heavy(const icu4x::Locale& locale, std::string_view script);
+  inline static std::string for_script_heavy(const icu4x::Locale& locale, std::string_view script);
   template<typename W>
-  inline static icu4x::diplomat::result<std::monostate, icu4x::DataError> for_script_heavy_write(const icu4x::Locale& locale, std::string_view script, W& writeable_output);
+  inline static void for_script_heavy_write(const icu4x::Locale& locale, std::string_view script, W& writeable_output);
 
   /**
    * 🚧 This API is unstable and may experience breaking changes outside major releases.
    *
-   * See the [Rust documentation for `try_new_heavy`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.try_new_heavy) for more information.
+   * See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.new_heavy_with_fallback) for more information.
    */
   inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_script_heavy_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::string_view script);
   template<typename W>
@@ -174,16 +174,16 @@ public:
   /**
    * 🚧 This API is unstable and may experience breaking changes outside major releases.
    *
-   * See the [Rust documentation for `try_new_short_heavy`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.try_new_short_heavy) for more information.
+   * See the [Rust documentation for `new_short_heavy_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.new_short_heavy_with_fallback) for more information.
    */
-  inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_script_short_heavy(const icu4x::Locale& locale, std::string_view script);
+  inline static std::string for_script_short_heavy(const icu4x::Locale& locale, std::string_view script);
   template<typename W>
-  inline static icu4x::diplomat::result<std::monostate, icu4x::DataError> for_script_short_heavy_write(const icu4x::Locale& locale, std::string_view script, W& writeable_output);
+  inline static void for_script_short_heavy_write(const icu4x::Locale& locale, std::string_view script, W& writeable_output);
 
   /**
    * 🚧 This API is unstable and may experience breaking changes outside major releases.
    *
-   * See the [Rust documentation for `try_new_short_heavy`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.try_new_short_heavy) for more information.
+   * See the [Rust documentation for `new_short_heavy_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.new_short_heavy_with_fallback) for more information.
    */
   inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_script_short_heavy_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::string_view script);
   template<typename W>
@@ -192,16 +192,16 @@ public:
   /**
    * 🚧 This API is unstable and may experience breaking changes outside major releases.
    *
-   * See the [Rust documentation for `try_new_heavy`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.VariantDisplayName.html#method.try_new_heavy) for more information.
+   * See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.VariantDisplayName.html#method.new_heavy_with_fallback) for more information.
    */
-  inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_variant_heavy(const icu4x::Locale& locale, std::string_view variant);
+  inline static std::string for_variant_heavy(const icu4x::Locale& locale, std::string_view variant);
   template<typename W>
-  inline static icu4x::diplomat::result<std::monostate, icu4x::DataError> for_variant_heavy_write(const icu4x::Locale& locale, std::string_view variant, W& writeable_output);
+  inline static void for_variant_heavy_write(const icu4x::Locale& locale, std::string_view variant, W& writeable_output);
 
   /**
    * 🚧 This API is unstable and may experience breaking changes outside major releases.
    *
-   * See the [Rust documentation for `try_new_heavy`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.VariantDisplayName.html#method.try_new_heavy) for more information.
+   * See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.VariantDisplayName.html#method.new_heavy_with_fallback) for more information.
    */
   inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_variant_heavy_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::string_view variant);
   template<typename W>

--- a/ffi/capi/bindings/cpp/icu4x/LocaleNamesUnstable.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/LocaleNamesUnstable.hpp
@@ -22,56 +22,47 @@ namespace icu4x {
 namespace capi {
     extern "C" {
 
-    typedef struct icu4x_LocaleNamesUnstable_for_region_light_mv1_result {union { icu4x::capi::DataError err;}; bool is_ok;} icu4x_LocaleNamesUnstable_for_region_light_mv1_result;
-    icu4x_LocaleNamesUnstable_for_region_light_mv1_result icu4x_LocaleNamesUnstable_for_region_light_mv1(const icu4x::capi::Locale* locale, icu4x::diplomat::capi::DiplomatStringView region, icu4x::diplomat::capi::DiplomatWrite* write);
+    void icu4x_LocaleNamesUnstable_for_region_light_mv1(const icu4x::capi::Locale* locale, icu4x::diplomat::capi::DiplomatStringView region, icu4x::diplomat::capi::DiplomatWrite* write);
 
     typedef struct icu4x_LocaleNamesUnstable_for_region_light_with_provider_mv1_result {union { icu4x::capi::DataError err;}; bool is_ok;} icu4x_LocaleNamesUnstable_for_region_light_with_provider_mv1_result;
     icu4x_LocaleNamesUnstable_for_region_light_with_provider_mv1_result icu4x_LocaleNamesUnstable_for_region_light_with_provider_mv1(const icu4x::capi::DataProvider* provider, const icu4x::capi::Locale* locale, icu4x::diplomat::capi::DiplomatStringView region, icu4x::diplomat::capi::DiplomatWrite* write);
 
-    typedef struct icu4x_LocaleNamesUnstable_for_region_tiny_mv1_result {union { icu4x::capi::DataError err;}; bool is_ok;} icu4x_LocaleNamesUnstable_for_region_tiny_mv1_result;
-    icu4x_LocaleNamesUnstable_for_region_tiny_mv1_result icu4x_LocaleNamesUnstable_for_region_tiny_mv1(const icu4x::capi::Locale* locale, icu4x::diplomat::capi::DiplomatStringView region, icu4x::diplomat::capi::DiplomatWrite* write);
+    void icu4x_LocaleNamesUnstable_for_region_tiny_mv1(const icu4x::capi::Locale* locale, icu4x::diplomat::capi::DiplomatStringView region, icu4x::diplomat::capi::DiplomatWrite* write);
 
     typedef struct icu4x_LocaleNamesUnstable_for_region_tiny_with_provider_mv1_result {union { icu4x::capi::DataError err;}; bool is_ok;} icu4x_LocaleNamesUnstable_for_region_tiny_with_provider_mv1_result;
     icu4x_LocaleNamesUnstable_for_region_tiny_with_provider_mv1_result icu4x_LocaleNamesUnstable_for_region_tiny_with_provider_mv1(const icu4x::capi::DataProvider* provider, const icu4x::capi::Locale* locale, icu4x::diplomat::capi::DiplomatStringView region, icu4x::diplomat::capi::DiplomatWrite* write);
 
-    typedef struct icu4x_LocaleNamesUnstable_for_region_short_tiny_mv1_result {union { icu4x::capi::DataError err;}; bool is_ok;} icu4x_LocaleNamesUnstable_for_region_short_tiny_mv1_result;
-    icu4x_LocaleNamesUnstable_for_region_short_tiny_mv1_result icu4x_LocaleNamesUnstable_for_region_short_tiny_mv1(const icu4x::capi::Locale* locale, icu4x::diplomat::capi::DiplomatStringView region, icu4x::diplomat::capi::DiplomatWrite* write);
+    void icu4x_LocaleNamesUnstable_for_region_short_tiny_mv1(const icu4x::capi::Locale* locale, icu4x::diplomat::capi::DiplomatStringView region, icu4x::diplomat::capi::DiplomatWrite* write);
 
     typedef struct icu4x_LocaleNamesUnstable_for_region_short_tiny_with_provider_mv1_result {union { icu4x::capi::DataError err;}; bool is_ok;} icu4x_LocaleNamesUnstable_for_region_short_tiny_with_provider_mv1_result;
     icu4x_LocaleNamesUnstable_for_region_short_tiny_with_provider_mv1_result icu4x_LocaleNamesUnstable_for_region_short_tiny_with_provider_mv1(const icu4x::capi::DataProvider* provider, const icu4x::capi::Locale* locale, icu4x::diplomat::capi::DiplomatStringView region, icu4x::diplomat::capi::DiplomatWrite* write);
 
-    typedef struct icu4x_LocaleNamesUnstable_for_region_short_light_mv1_result {union { icu4x::capi::DataError err;}; bool is_ok;} icu4x_LocaleNamesUnstable_for_region_short_light_mv1_result;
-    icu4x_LocaleNamesUnstable_for_region_short_light_mv1_result icu4x_LocaleNamesUnstable_for_region_short_light_mv1(const icu4x::capi::Locale* locale, icu4x::diplomat::capi::DiplomatStringView region, icu4x::diplomat::capi::DiplomatWrite* write);
+    void icu4x_LocaleNamesUnstable_for_region_short_light_mv1(const icu4x::capi::Locale* locale, icu4x::diplomat::capi::DiplomatStringView region, icu4x::diplomat::capi::DiplomatWrite* write);
 
     typedef struct icu4x_LocaleNamesUnstable_for_region_short_light_with_provider_mv1_result {union { icu4x::capi::DataError err;}; bool is_ok;} icu4x_LocaleNamesUnstable_for_region_short_light_with_provider_mv1_result;
     icu4x_LocaleNamesUnstable_for_region_short_light_with_provider_mv1_result icu4x_LocaleNamesUnstable_for_region_short_light_with_provider_mv1(const icu4x::capi::DataProvider* provider, const icu4x::capi::Locale* locale, icu4x::diplomat::capi::DiplomatStringView region, icu4x::diplomat::capi::DiplomatWrite* write);
 
-    typedef struct icu4x_LocaleNamesUnstable_for_script_light_mv1_result {union { icu4x::capi::DataError err;}; bool is_ok;} icu4x_LocaleNamesUnstable_for_script_light_mv1_result;
-    icu4x_LocaleNamesUnstable_for_script_light_mv1_result icu4x_LocaleNamesUnstable_for_script_light_mv1(const icu4x::capi::Locale* locale, icu4x::diplomat::capi::DiplomatStringView script, icu4x::diplomat::capi::DiplomatWrite* write);
+    void icu4x_LocaleNamesUnstable_for_script_light_mv1(const icu4x::capi::Locale* locale, icu4x::diplomat::capi::DiplomatStringView script, icu4x::diplomat::capi::DiplomatWrite* write);
 
     typedef struct icu4x_LocaleNamesUnstable_for_script_light_with_provider_mv1_result {union { icu4x::capi::DataError err;}; bool is_ok;} icu4x_LocaleNamesUnstable_for_script_light_with_provider_mv1_result;
     icu4x_LocaleNamesUnstable_for_script_light_with_provider_mv1_result icu4x_LocaleNamesUnstable_for_script_light_with_provider_mv1(const icu4x::capi::DataProvider* provider, const icu4x::capi::Locale* locale, icu4x::diplomat::capi::DiplomatStringView script, icu4x::diplomat::capi::DiplomatWrite* write);
 
-    typedef struct icu4x_LocaleNamesUnstable_for_script_tiny_mv1_result {union { icu4x::capi::DataError err;}; bool is_ok;} icu4x_LocaleNamesUnstable_for_script_tiny_mv1_result;
-    icu4x_LocaleNamesUnstable_for_script_tiny_mv1_result icu4x_LocaleNamesUnstable_for_script_tiny_mv1(const icu4x::capi::Locale* locale, icu4x::diplomat::capi::DiplomatStringView script, icu4x::diplomat::capi::DiplomatWrite* write);
+    void icu4x_LocaleNamesUnstable_for_script_tiny_mv1(const icu4x::capi::Locale* locale, icu4x::diplomat::capi::DiplomatStringView script, icu4x::diplomat::capi::DiplomatWrite* write);
 
     typedef struct icu4x_LocaleNamesUnstable_for_script_tiny_with_provider_mv1_result {union { icu4x::capi::DataError err;}; bool is_ok;} icu4x_LocaleNamesUnstable_for_script_tiny_with_provider_mv1_result;
     icu4x_LocaleNamesUnstable_for_script_tiny_with_provider_mv1_result icu4x_LocaleNamesUnstable_for_script_tiny_with_provider_mv1(const icu4x::capi::DataProvider* provider, const icu4x::capi::Locale* locale, icu4x::diplomat::capi::DiplomatStringView script, icu4x::diplomat::capi::DiplomatWrite* write);
 
-    typedef struct icu4x_LocaleNamesUnstable_for_script_heavy_mv1_result {union { icu4x::capi::DataError err;}; bool is_ok;} icu4x_LocaleNamesUnstable_for_script_heavy_mv1_result;
-    icu4x_LocaleNamesUnstable_for_script_heavy_mv1_result icu4x_LocaleNamesUnstable_for_script_heavy_mv1(const icu4x::capi::Locale* locale, icu4x::diplomat::capi::DiplomatStringView script, icu4x::diplomat::capi::DiplomatWrite* write);
+    void icu4x_LocaleNamesUnstable_for_script_heavy_mv1(const icu4x::capi::Locale* locale, icu4x::diplomat::capi::DiplomatStringView script, icu4x::diplomat::capi::DiplomatWrite* write);
 
     typedef struct icu4x_LocaleNamesUnstable_for_script_heavy_with_provider_mv1_result {union { icu4x::capi::DataError err;}; bool is_ok;} icu4x_LocaleNamesUnstable_for_script_heavy_with_provider_mv1_result;
     icu4x_LocaleNamesUnstable_for_script_heavy_with_provider_mv1_result icu4x_LocaleNamesUnstable_for_script_heavy_with_provider_mv1(const icu4x::capi::DataProvider* provider, const icu4x::capi::Locale* locale, icu4x::diplomat::capi::DiplomatStringView script, icu4x::diplomat::capi::DiplomatWrite* write);
 
-    typedef struct icu4x_LocaleNamesUnstable_for_script_short_heavy_mv1_result {union { icu4x::capi::DataError err;}; bool is_ok;} icu4x_LocaleNamesUnstable_for_script_short_heavy_mv1_result;
-    icu4x_LocaleNamesUnstable_for_script_short_heavy_mv1_result icu4x_LocaleNamesUnstable_for_script_short_heavy_mv1(const icu4x::capi::Locale* locale, icu4x::diplomat::capi::DiplomatStringView script, icu4x::diplomat::capi::DiplomatWrite* write);
+    void icu4x_LocaleNamesUnstable_for_script_short_heavy_mv1(const icu4x::capi::Locale* locale, icu4x::diplomat::capi::DiplomatStringView script, icu4x::diplomat::capi::DiplomatWrite* write);
 
     typedef struct icu4x_LocaleNamesUnstable_for_script_short_heavy_with_provider_mv1_result {union { icu4x::capi::DataError err;}; bool is_ok;} icu4x_LocaleNamesUnstable_for_script_short_heavy_with_provider_mv1_result;
     icu4x_LocaleNamesUnstable_for_script_short_heavy_with_provider_mv1_result icu4x_LocaleNamesUnstable_for_script_short_heavy_with_provider_mv1(const icu4x::capi::DataProvider* provider, const icu4x::capi::Locale* locale, icu4x::diplomat::capi::DiplomatStringView script, icu4x::diplomat::capi::DiplomatWrite* write);
 
-    typedef struct icu4x_LocaleNamesUnstable_for_variant_heavy_mv1_result {union { icu4x::capi::DataError err;}; bool is_ok;} icu4x_LocaleNamesUnstable_for_variant_heavy_mv1_result;
-    icu4x_LocaleNamesUnstable_for_variant_heavy_mv1_result icu4x_LocaleNamesUnstable_for_variant_heavy_mv1(const icu4x::capi::Locale* locale, icu4x::diplomat::capi::DiplomatStringView variant, icu4x::diplomat::capi::DiplomatWrite* write);
+    void icu4x_LocaleNamesUnstable_for_variant_heavy_mv1(const icu4x::capi::Locale* locale, icu4x::diplomat::capi::DiplomatStringView variant, icu4x::diplomat::capi::DiplomatWrite* write);
 
     typedef struct icu4x_LocaleNamesUnstable_for_variant_heavy_with_provider_mv1_result {union { icu4x::capi::DataError err;}; bool is_ok;} icu4x_LocaleNamesUnstable_for_variant_heavy_with_provider_mv1_result;
     icu4x_LocaleNamesUnstable_for_variant_heavy_with_provider_mv1_result icu4x_LocaleNamesUnstable_for_variant_heavy_with_provider_mv1(const icu4x::capi::DataProvider* provider, const icu4x::capi::Locale* locale, icu4x::diplomat::capi::DiplomatStringView variant, icu4x::diplomat::capi::DiplomatWrite* write);
@@ -148,21 +139,20 @@ namespace capi {
 } // namespace capi
 } // namespace
 
-inline icu4x::diplomat::result<std::string, icu4x::DataError> icu4x::LocaleNamesUnstable::for_region_light(const icu4x::Locale& locale, std::string_view region) {
+inline std::string icu4x::LocaleNamesUnstable::for_region_light(const icu4x::Locale& locale, std::string_view region) {
     std::string output;
     icu4x::diplomat::capi::DiplomatWrite write = icu4x::diplomat::WriteFromString(output);
-    auto result = icu4x::capi::icu4x_LocaleNamesUnstable_for_region_light_mv1(locale.AsFFI(),
+    icu4x::capi::icu4x_LocaleNamesUnstable_for_region_light_mv1(locale.AsFFI(),
         {region.data(), region.size()},
         &write);
-    return result.is_ok ? icu4x::diplomat::result<std::string, icu4x::DataError>(icu4x::diplomat::Ok<std::string>(std::move(output))) : icu4x::diplomat::result<std::string, icu4x::DataError>(icu4x::diplomat::Err<icu4x::DataError>(icu4x::DataError::FromFFI(result.err)));
+    return output;
 }
 template<typename W>
-inline icu4x::diplomat::result<std::monostate, icu4x::DataError> icu4x::LocaleNamesUnstable::for_region_light_write(const icu4x::Locale& locale, std::string_view region, W& writeable) {
+inline void icu4x::LocaleNamesUnstable::for_region_light_write(const icu4x::Locale& locale, std::string_view region, W& writeable) {
     icu4x::diplomat::capi::DiplomatWrite write = icu4x::diplomat::WriteTrait<W>::Construct(writeable);
-    auto result = icu4x::capi::icu4x_LocaleNamesUnstable_for_region_light_mv1(locale.AsFFI(),
+    icu4x::capi::icu4x_LocaleNamesUnstable_for_region_light_mv1(locale.AsFFI(),
         {region.data(), region.size()},
         &write);
-    return result.is_ok ? icu4x::diplomat::result<std::monostate, icu4x::DataError>(icu4x::diplomat::Ok<std::monostate>()) : icu4x::diplomat::result<std::monostate, icu4x::DataError>(icu4x::diplomat::Err<icu4x::DataError>(icu4x::DataError::FromFFI(result.err)));
 }
 
 inline icu4x::diplomat::result<std::string, icu4x::DataError> icu4x::LocaleNamesUnstable::for_region_light_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::string_view region) {
@@ -184,21 +174,20 @@ inline icu4x::diplomat::result<std::monostate, icu4x::DataError> icu4x::LocaleNa
     return result.is_ok ? icu4x::diplomat::result<std::monostate, icu4x::DataError>(icu4x::diplomat::Ok<std::monostate>()) : icu4x::diplomat::result<std::monostate, icu4x::DataError>(icu4x::diplomat::Err<icu4x::DataError>(icu4x::DataError::FromFFI(result.err)));
 }
 
-inline icu4x::diplomat::result<std::string, icu4x::DataError> icu4x::LocaleNamesUnstable::for_region_tiny(const icu4x::Locale& locale, std::string_view region) {
+inline std::string icu4x::LocaleNamesUnstable::for_region_tiny(const icu4x::Locale& locale, std::string_view region) {
     std::string output;
     icu4x::diplomat::capi::DiplomatWrite write = icu4x::diplomat::WriteFromString(output);
-    auto result = icu4x::capi::icu4x_LocaleNamesUnstable_for_region_tiny_mv1(locale.AsFFI(),
+    icu4x::capi::icu4x_LocaleNamesUnstable_for_region_tiny_mv1(locale.AsFFI(),
         {region.data(), region.size()},
         &write);
-    return result.is_ok ? icu4x::diplomat::result<std::string, icu4x::DataError>(icu4x::diplomat::Ok<std::string>(std::move(output))) : icu4x::diplomat::result<std::string, icu4x::DataError>(icu4x::diplomat::Err<icu4x::DataError>(icu4x::DataError::FromFFI(result.err)));
+    return output;
 }
 template<typename W>
-inline icu4x::diplomat::result<std::monostate, icu4x::DataError> icu4x::LocaleNamesUnstable::for_region_tiny_write(const icu4x::Locale& locale, std::string_view region, W& writeable) {
+inline void icu4x::LocaleNamesUnstable::for_region_tiny_write(const icu4x::Locale& locale, std::string_view region, W& writeable) {
     icu4x::diplomat::capi::DiplomatWrite write = icu4x::diplomat::WriteTrait<W>::Construct(writeable);
-    auto result = icu4x::capi::icu4x_LocaleNamesUnstable_for_region_tiny_mv1(locale.AsFFI(),
+    icu4x::capi::icu4x_LocaleNamesUnstable_for_region_tiny_mv1(locale.AsFFI(),
         {region.data(), region.size()},
         &write);
-    return result.is_ok ? icu4x::diplomat::result<std::monostate, icu4x::DataError>(icu4x::diplomat::Ok<std::monostate>()) : icu4x::diplomat::result<std::monostate, icu4x::DataError>(icu4x::diplomat::Err<icu4x::DataError>(icu4x::DataError::FromFFI(result.err)));
 }
 
 inline icu4x::diplomat::result<std::string, icu4x::DataError> icu4x::LocaleNamesUnstable::for_region_tiny_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::string_view region) {
@@ -220,21 +209,20 @@ inline icu4x::diplomat::result<std::monostate, icu4x::DataError> icu4x::LocaleNa
     return result.is_ok ? icu4x::diplomat::result<std::monostate, icu4x::DataError>(icu4x::diplomat::Ok<std::monostate>()) : icu4x::diplomat::result<std::monostate, icu4x::DataError>(icu4x::diplomat::Err<icu4x::DataError>(icu4x::DataError::FromFFI(result.err)));
 }
 
-inline icu4x::diplomat::result<std::string, icu4x::DataError> icu4x::LocaleNamesUnstable::for_region_short_tiny(const icu4x::Locale& locale, std::string_view region) {
+inline std::string icu4x::LocaleNamesUnstable::for_region_short_tiny(const icu4x::Locale& locale, std::string_view region) {
     std::string output;
     icu4x::diplomat::capi::DiplomatWrite write = icu4x::diplomat::WriteFromString(output);
-    auto result = icu4x::capi::icu4x_LocaleNamesUnstable_for_region_short_tiny_mv1(locale.AsFFI(),
+    icu4x::capi::icu4x_LocaleNamesUnstable_for_region_short_tiny_mv1(locale.AsFFI(),
         {region.data(), region.size()},
         &write);
-    return result.is_ok ? icu4x::diplomat::result<std::string, icu4x::DataError>(icu4x::diplomat::Ok<std::string>(std::move(output))) : icu4x::diplomat::result<std::string, icu4x::DataError>(icu4x::diplomat::Err<icu4x::DataError>(icu4x::DataError::FromFFI(result.err)));
+    return output;
 }
 template<typename W>
-inline icu4x::diplomat::result<std::monostate, icu4x::DataError> icu4x::LocaleNamesUnstable::for_region_short_tiny_write(const icu4x::Locale& locale, std::string_view region, W& writeable) {
+inline void icu4x::LocaleNamesUnstable::for_region_short_tiny_write(const icu4x::Locale& locale, std::string_view region, W& writeable) {
     icu4x::diplomat::capi::DiplomatWrite write = icu4x::diplomat::WriteTrait<W>::Construct(writeable);
-    auto result = icu4x::capi::icu4x_LocaleNamesUnstable_for_region_short_tiny_mv1(locale.AsFFI(),
+    icu4x::capi::icu4x_LocaleNamesUnstable_for_region_short_tiny_mv1(locale.AsFFI(),
         {region.data(), region.size()},
         &write);
-    return result.is_ok ? icu4x::diplomat::result<std::monostate, icu4x::DataError>(icu4x::diplomat::Ok<std::monostate>()) : icu4x::diplomat::result<std::monostate, icu4x::DataError>(icu4x::diplomat::Err<icu4x::DataError>(icu4x::DataError::FromFFI(result.err)));
 }
 
 inline icu4x::diplomat::result<std::string, icu4x::DataError> icu4x::LocaleNamesUnstable::for_region_short_tiny_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::string_view region) {
@@ -256,21 +244,20 @@ inline icu4x::diplomat::result<std::monostate, icu4x::DataError> icu4x::LocaleNa
     return result.is_ok ? icu4x::diplomat::result<std::monostate, icu4x::DataError>(icu4x::diplomat::Ok<std::monostate>()) : icu4x::diplomat::result<std::monostate, icu4x::DataError>(icu4x::diplomat::Err<icu4x::DataError>(icu4x::DataError::FromFFI(result.err)));
 }
 
-inline icu4x::diplomat::result<std::string, icu4x::DataError> icu4x::LocaleNamesUnstable::for_region_short_light(const icu4x::Locale& locale, std::string_view region) {
+inline std::string icu4x::LocaleNamesUnstable::for_region_short_light(const icu4x::Locale& locale, std::string_view region) {
     std::string output;
     icu4x::diplomat::capi::DiplomatWrite write = icu4x::diplomat::WriteFromString(output);
-    auto result = icu4x::capi::icu4x_LocaleNamesUnstable_for_region_short_light_mv1(locale.AsFFI(),
+    icu4x::capi::icu4x_LocaleNamesUnstable_for_region_short_light_mv1(locale.AsFFI(),
         {region.data(), region.size()},
         &write);
-    return result.is_ok ? icu4x::diplomat::result<std::string, icu4x::DataError>(icu4x::diplomat::Ok<std::string>(std::move(output))) : icu4x::diplomat::result<std::string, icu4x::DataError>(icu4x::diplomat::Err<icu4x::DataError>(icu4x::DataError::FromFFI(result.err)));
+    return output;
 }
 template<typename W>
-inline icu4x::diplomat::result<std::monostate, icu4x::DataError> icu4x::LocaleNamesUnstable::for_region_short_light_write(const icu4x::Locale& locale, std::string_view region, W& writeable) {
+inline void icu4x::LocaleNamesUnstable::for_region_short_light_write(const icu4x::Locale& locale, std::string_view region, W& writeable) {
     icu4x::diplomat::capi::DiplomatWrite write = icu4x::diplomat::WriteTrait<W>::Construct(writeable);
-    auto result = icu4x::capi::icu4x_LocaleNamesUnstable_for_region_short_light_mv1(locale.AsFFI(),
+    icu4x::capi::icu4x_LocaleNamesUnstable_for_region_short_light_mv1(locale.AsFFI(),
         {region.data(), region.size()},
         &write);
-    return result.is_ok ? icu4x::diplomat::result<std::monostate, icu4x::DataError>(icu4x::diplomat::Ok<std::monostate>()) : icu4x::diplomat::result<std::monostate, icu4x::DataError>(icu4x::diplomat::Err<icu4x::DataError>(icu4x::DataError::FromFFI(result.err)));
 }
 
 inline icu4x::diplomat::result<std::string, icu4x::DataError> icu4x::LocaleNamesUnstable::for_region_short_light_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::string_view region) {
@@ -292,21 +279,20 @@ inline icu4x::diplomat::result<std::monostate, icu4x::DataError> icu4x::LocaleNa
     return result.is_ok ? icu4x::diplomat::result<std::monostate, icu4x::DataError>(icu4x::diplomat::Ok<std::monostate>()) : icu4x::diplomat::result<std::monostate, icu4x::DataError>(icu4x::diplomat::Err<icu4x::DataError>(icu4x::DataError::FromFFI(result.err)));
 }
 
-inline icu4x::diplomat::result<std::string, icu4x::DataError> icu4x::LocaleNamesUnstable::for_script_light(const icu4x::Locale& locale, std::string_view script) {
+inline std::string icu4x::LocaleNamesUnstable::for_script_light(const icu4x::Locale& locale, std::string_view script) {
     std::string output;
     icu4x::diplomat::capi::DiplomatWrite write = icu4x::diplomat::WriteFromString(output);
-    auto result = icu4x::capi::icu4x_LocaleNamesUnstable_for_script_light_mv1(locale.AsFFI(),
+    icu4x::capi::icu4x_LocaleNamesUnstable_for_script_light_mv1(locale.AsFFI(),
         {script.data(), script.size()},
         &write);
-    return result.is_ok ? icu4x::diplomat::result<std::string, icu4x::DataError>(icu4x::diplomat::Ok<std::string>(std::move(output))) : icu4x::diplomat::result<std::string, icu4x::DataError>(icu4x::diplomat::Err<icu4x::DataError>(icu4x::DataError::FromFFI(result.err)));
+    return output;
 }
 template<typename W>
-inline icu4x::diplomat::result<std::monostate, icu4x::DataError> icu4x::LocaleNamesUnstable::for_script_light_write(const icu4x::Locale& locale, std::string_view script, W& writeable) {
+inline void icu4x::LocaleNamesUnstable::for_script_light_write(const icu4x::Locale& locale, std::string_view script, W& writeable) {
     icu4x::diplomat::capi::DiplomatWrite write = icu4x::diplomat::WriteTrait<W>::Construct(writeable);
-    auto result = icu4x::capi::icu4x_LocaleNamesUnstable_for_script_light_mv1(locale.AsFFI(),
+    icu4x::capi::icu4x_LocaleNamesUnstable_for_script_light_mv1(locale.AsFFI(),
         {script.data(), script.size()},
         &write);
-    return result.is_ok ? icu4x::diplomat::result<std::monostate, icu4x::DataError>(icu4x::diplomat::Ok<std::monostate>()) : icu4x::diplomat::result<std::monostate, icu4x::DataError>(icu4x::diplomat::Err<icu4x::DataError>(icu4x::DataError::FromFFI(result.err)));
 }
 
 inline icu4x::diplomat::result<std::string, icu4x::DataError> icu4x::LocaleNamesUnstable::for_script_light_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::string_view script) {
@@ -328,21 +314,20 @@ inline icu4x::diplomat::result<std::monostate, icu4x::DataError> icu4x::LocaleNa
     return result.is_ok ? icu4x::diplomat::result<std::monostate, icu4x::DataError>(icu4x::diplomat::Ok<std::monostate>()) : icu4x::diplomat::result<std::monostate, icu4x::DataError>(icu4x::diplomat::Err<icu4x::DataError>(icu4x::DataError::FromFFI(result.err)));
 }
 
-inline icu4x::diplomat::result<std::string, icu4x::DataError> icu4x::LocaleNamesUnstable::for_script_tiny(const icu4x::Locale& locale, std::string_view script) {
+inline std::string icu4x::LocaleNamesUnstable::for_script_tiny(const icu4x::Locale& locale, std::string_view script) {
     std::string output;
     icu4x::diplomat::capi::DiplomatWrite write = icu4x::diplomat::WriteFromString(output);
-    auto result = icu4x::capi::icu4x_LocaleNamesUnstable_for_script_tiny_mv1(locale.AsFFI(),
+    icu4x::capi::icu4x_LocaleNamesUnstable_for_script_tiny_mv1(locale.AsFFI(),
         {script.data(), script.size()},
         &write);
-    return result.is_ok ? icu4x::diplomat::result<std::string, icu4x::DataError>(icu4x::diplomat::Ok<std::string>(std::move(output))) : icu4x::diplomat::result<std::string, icu4x::DataError>(icu4x::diplomat::Err<icu4x::DataError>(icu4x::DataError::FromFFI(result.err)));
+    return output;
 }
 template<typename W>
-inline icu4x::diplomat::result<std::monostate, icu4x::DataError> icu4x::LocaleNamesUnstable::for_script_tiny_write(const icu4x::Locale& locale, std::string_view script, W& writeable) {
+inline void icu4x::LocaleNamesUnstable::for_script_tiny_write(const icu4x::Locale& locale, std::string_view script, W& writeable) {
     icu4x::diplomat::capi::DiplomatWrite write = icu4x::diplomat::WriteTrait<W>::Construct(writeable);
-    auto result = icu4x::capi::icu4x_LocaleNamesUnstable_for_script_tiny_mv1(locale.AsFFI(),
+    icu4x::capi::icu4x_LocaleNamesUnstable_for_script_tiny_mv1(locale.AsFFI(),
         {script.data(), script.size()},
         &write);
-    return result.is_ok ? icu4x::diplomat::result<std::monostate, icu4x::DataError>(icu4x::diplomat::Ok<std::monostate>()) : icu4x::diplomat::result<std::monostate, icu4x::DataError>(icu4x::diplomat::Err<icu4x::DataError>(icu4x::DataError::FromFFI(result.err)));
 }
 
 inline icu4x::diplomat::result<std::string, icu4x::DataError> icu4x::LocaleNamesUnstable::for_script_tiny_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::string_view script) {
@@ -364,21 +349,20 @@ inline icu4x::diplomat::result<std::monostate, icu4x::DataError> icu4x::LocaleNa
     return result.is_ok ? icu4x::diplomat::result<std::monostate, icu4x::DataError>(icu4x::diplomat::Ok<std::monostate>()) : icu4x::diplomat::result<std::monostate, icu4x::DataError>(icu4x::diplomat::Err<icu4x::DataError>(icu4x::DataError::FromFFI(result.err)));
 }
 
-inline icu4x::diplomat::result<std::string, icu4x::DataError> icu4x::LocaleNamesUnstable::for_script_heavy(const icu4x::Locale& locale, std::string_view script) {
+inline std::string icu4x::LocaleNamesUnstable::for_script_heavy(const icu4x::Locale& locale, std::string_view script) {
     std::string output;
     icu4x::diplomat::capi::DiplomatWrite write = icu4x::diplomat::WriteFromString(output);
-    auto result = icu4x::capi::icu4x_LocaleNamesUnstable_for_script_heavy_mv1(locale.AsFFI(),
+    icu4x::capi::icu4x_LocaleNamesUnstable_for_script_heavy_mv1(locale.AsFFI(),
         {script.data(), script.size()},
         &write);
-    return result.is_ok ? icu4x::diplomat::result<std::string, icu4x::DataError>(icu4x::diplomat::Ok<std::string>(std::move(output))) : icu4x::diplomat::result<std::string, icu4x::DataError>(icu4x::diplomat::Err<icu4x::DataError>(icu4x::DataError::FromFFI(result.err)));
+    return output;
 }
 template<typename W>
-inline icu4x::diplomat::result<std::monostate, icu4x::DataError> icu4x::LocaleNamesUnstable::for_script_heavy_write(const icu4x::Locale& locale, std::string_view script, W& writeable) {
+inline void icu4x::LocaleNamesUnstable::for_script_heavy_write(const icu4x::Locale& locale, std::string_view script, W& writeable) {
     icu4x::diplomat::capi::DiplomatWrite write = icu4x::diplomat::WriteTrait<W>::Construct(writeable);
-    auto result = icu4x::capi::icu4x_LocaleNamesUnstable_for_script_heavy_mv1(locale.AsFFI(),
+    icu4x::capi::icu4x_LocaleNamesUnstable_for_script_heavy_mv1(locale.AsFFI(),
         {script.data(), script.size()},
         &write);
-    return result.is_ok ? icu4x::diplomat::result<std::monostate, icu4x::DataError>(icu4x::diplomat::Ok<std::monostate>()) : icu4x::diplomat::result<std::monostate, icu4x::DataError>(icu4x::diplomat::Err<icu4x::DataError>(icu4x::DataError::FromFFI(result.err)));
 }
 
 inline icu4x::diplomat::result<std::string, icu4x::DataError> icu4x::LocaleNamesUnstable::for_script_heavy_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::string_view script) {
@@ -400,21 +384,20 @@ inline icu4x::diplomat::result<std::monostate, icu4x::DataError> icu4x::LocaleNa
     return result.is_ok ? icu4x::diplomat::result<std::monostate, icu4x::DataError>(icu4x::diplomat::Ok<std::monostate>()) : icu4x::diplomat::result<std::monostate, icu4x::DataError>(icu4x::diplomat::Err<icu4x::DataError>(icu4x::DataError::FromFFI(result.err)));
 }
 
-inline icu4x::diplomat::result<std::string, icu4x::DataError> icu4x::LocaleNamesUnstable::for_script_short_heavy(const icu4x::Locale& locale, std::string_view script) {
+inline std::string icu4x::LocaleNamesUnstable::for_script_short_heavy(const icu4x::Locale& locale, std::string_view script) {
     std::string output;
     icu4x::diplomat::capi::DiplomatWrite write = icu4x::diplomat::WriteFromString(output);
-    auto result = icu4x::capi::icu4x_LocaleNamesUnstable_for_script_short_heavy_mv1(locale.AsFFI(),
+    icu4x::capi::icu4x_LocaleNamesUnstable_for_script_short_heavy_mv1(locale.AsFFI(),
         {script.data(), script.size()},
         &write);
-    return result.is_ok ? icu4x::diplomat::result<std::string, icu4x::DataError>(icu4x::diplomat::Ok<std::string>(std::move(output))) : icu4x::diplomat::result<std::string, icu4x::DataError>(icu4x::diplomat::Err<icu4x::DataError>(icu4x::DataError::FromFFI(result.err)));
+    return output;
 }
 template<typename W>
-inline icu4x::diplomat::result<std::monostate, icu4x::DataError> icu4x::LocaleNamesUnstable::for_script_short_heavy_write(const icu4x::Locale& locale, std::string_view script, W& writeable) {
+inline void icu4x::LocaleNamesUnstable::for_script_short_heavy_write(const icu4x::Locale& locale, std::string_view script, W& writeable) {
     icu4x::diplomat::capi::DiplomatWrite write = icu4x::diplomat::WriteTrait<W>::Construct(writeable);
-    auto result = icu4x::capi::icu4x_LocaleNamesUnstable_for_script_short_heavy_mv1(locale.AsFFI(),
+    icu4x::capi::icu4x_LocaleNamesUnstable_for_script_short_heavy_mv1(locale.AsFFI(),
         {script.data(), script.size()},
         &write);
-    return result.is_ok ? icu4x::diplomat::result<std::monostate, icu4x::DataError>(icu4x::diplomat::Ok<std::monostate>()) : icu4x::diplomat::result<std::monostate, icu4x::DataError>(icu4x::diplomat::Err<icu4x::DataError>(icu4x::DataError::FromFFI(result.err)));
 }
 
 inline icu4x::diplomat::result<std::string, icu4x::DataError> icu4x::LocaleNamesUnstable::for_script_short_heavy_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::string_view script) {
@@ -436,21 +419,20 @@ inline icu4x::diplomat::result<std::monostate, icu4x::DataError> icu4x::LocaleNa
     return result.is_ok ? icu4x::diplomat::result<std::monostate, icu4x::DataError>(icu4x::diplomat::Ok<std::monostate>()) : icu4x::diplomat::result<std::monostate, icu4x::DataError>(icu4x::diplomat::Err<icu4x::DataError>(icu4x::DataError::FromFFI(result.err)));
 }
 
-inline icu4x::diplomat::result<std::string, icu4x::DataError> icu4x::LocaleNamesUnstable::for_variant_heavy(const icu4x::Locale& locale, std::string_view variant) {
+inline std::string icu4x::LocaleNamesUnstable::for_variant_heavy(const icu4x::Locale& locale, std::string_view variant) {
     std::string output;
     icu4x::diplomat::capi::DiplomatWrite write = icu4x::diplomat::WriteFromString(output);
-    auto result = icu4x::capi::icu4x_LocaleNamesUnstable_for_variant_heavy_mv1(locale.AsFFI(),
+    icu4x::capi::icu4x_LocaleNamesUnstable_for_variant_heavy_mv1(locale.AsFFI(),
         {variant.data(), variant.size()},
         &write);
-    return result.is_ok ? icu4x::diplomat::result<std::string, icu4x::DataError>(icu4x::diplomat::Ok<std::string>(std::move(output))) : icu4x::diplomat::result<std::string, icu4x::DataError>(icu4x::diplomat::Err<icu4x::DataError>(icu4x::DataError::FromFFI(result.err)));
+    return output;
 }
 template<typename W>
-inline icu4x::diplomat::result<std::monostate, icu4x::DataError> icu4x::LocaleNamesUnstable::for_variant_heavy_write(const icu4x::Locale& locale, std::string_view variant, W& writeable) {
+inline void icu4x::LocaleNamesUnstable::for_variant_heavy_write(const icu4x::Locale& locale, std::string_view variant, W& writeable) {
     icu4x::diplomat::capi::DiplomatWrite write = icu4x::diplomat::WriteTrait<W>::Construct(writeable);
-    auto result = icu4x::capi::icu4x_LocaleNamesUnstable_for_variant_heavy_mv1(locale.AsFFI(),
+    icu4x::capi::icu4x_LocaleNamesUnstable_for_variant_heavy_mv1(locale.AsFFI(),
         {variant.data(), variant.size()},
         &write);
-    return result.is_ok ? icu4x::diplomat::result<std::monostate, icu4x::DataError>(icu4x::diplomat::Ok<std::monostate>()) : icu4x::diplomat::result<std::monostate, icu4x::DataError>(icu4x::diplomat::Err<icu4x::DataError>(icu4x::DataError::FromFFI(result.err)));
 }
 
 inline icu4x::diplomat::result<std::string, icu4x::DataError> icu4x::LocaleNamesUnstable::for_variant_heavy_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::string_view variant) {

--- a/ffi/capi/src/locale_names.rs
+++ b/ffi/capi/src/locale_names.rs
@@ -44,7 +44,10 @@ pub mod ffi {
 
         /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "compiled_data")]
-        #[diplomat::rust_link(icu::locale::names::RegionDisplayName::try_new_light, FnInStruct)]
+        #[diplomat::rust_link(
+            icu::locale::names::RegionDisplayName::new_light_with_fallback,
+            FnInStruct
+        )]
         #[diplomat::rust_link(icu::locale::names::RegionDisplayName::write_to, FnInStruct, hidden)]
         #[diplomat::rust_link(icu::locale::names::RegionDisplayName::to_string, FnInStruct, hidden)]
         #[diplomat::rust_link(icu::locale::names::RegionDisplayNameBorrowed, Struct, hidden)]
@@ -62,20 +65,24 @@ pub mod ffi {
             locale: &Locale,
             region: &DiplomatStr,
             write: &mut diplomat_runtime::DiplomatWrite,
-        ) -> Result<(), DataError> {
+        ) {
             // TODO: Consider returning LocaleParseError or a dedicated DataError variant for invalid subtag syntax.
             let region = icu_locale_core::subtags::Region::try_from_utf8(region)
-                .map_err(|_| icu_provider::DataErrorKind::IdentifierNotFound.into_error())?;
-            let display_name =
-                icu_locale::names::RegionDisplayName::try_new_light((&locale.0).into(), region)?;
+                .unwrap_or(icu_locale_core::subtags::region!("ZZ"));
+            let display_name = icu_locale::names::RegionDisplayName::new_light_with_fallback(
+                (&locale.0).into(),
+                region,
+            );
             let _infallible = display_name.write_to(write);
-            Ok(())
         }
 
         /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "buffer_provider")]
         #[diplomat::attr(demo_gen, disable)]
-        #[diplomat::rust_link(icu::locale::names::RegionDisplayName::try_new_light, FnInStruct)]
+        #[diplomat::rust_link(
+            icu::locale::names::RegionDisplayName::new_light_with_fallback,
+            FnInStruct
+        )]
         pub fn for_region_light_with_provider(
             provider: &DataProvider,
             locale: &Locale,
@@ -84,7 +91,7 @@ pub mod ffi {
         ) -> Result<(), DataError> {
             // TODO: Consider returning LocaleParseError or a dedicated DataError variant for invalid subtag syntax.
             let region = icu_locale_core::subtags::Region::try_from_utf8(region)
-                .map_err(|_| icu_provider::DataErrorKind::IdentifierNotFound.into_error())?;
+                .unwrap_or(icu_locale_core::subtags::region!("ZZ"));
             let display_name =
                 icu_locale::names::RegionDisplayName::try_new_light_with_buffer_provider(
                     provider.get()?,
@@ -97,32 +104,41 @@ pub mod ffi {
 
         /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "compiled_data")]
-        #[diplomat::rust_link(icu::locale::names::RegionDisplayName::try_new_tiny, FnInStruct)]
+        #[diplomat::rust_link(
+            icu::locale::names::RegionDisplayName::new_tiny_with_fallback,
+            FnInStruct
+        )]
         pub fn for_region_tiny(
             locale: &Locale,
             region: &DiplomatStr,
             write: &mut diplomat_runtime::DiplomatWrite,
-        ) -> Result<(), DataError> {
+        ) {
+            // TODO: Consider returning LocaleParseError or a dedicated DataError variant for invalid subtag syntax.
             let region = icu_locale_core::subtags::Region::try_from_utf8(region)
-                .map_err(|_| icu_provider::DataErrorKind::IdentifierNotFound.into_error())?;
-            let display_name =
-                icu_locale::names::RegionDisplayName::try_new_tiny((&locale.0).into(), region)?;
+                .unwrap_or(icu_locale_core::subtags::region!("ZZ"));
+            let display_name = icu_locale::names::RegionDisplayName::new_tiny_with_fallback(
+                (&locale.0).into(),
+                region,
+            );
             let _infallible = display_name.write_to(write);
-            Ok(())
         }
 
         /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "buffer_provider")]
         #[diplomat::attr(demo_gen, disable)]
-        #[diplomat::rust_link(icu::locale::names::RegionDisplayName::try_new_tiny, FnInStruct)]
+        #[diplomat::rust_link(
+            icu::locale::names::RegionDisplayName::new_tiny_with_fallback,
+            FnInStruct
+        )]
         pub fn for_region_tiny_with_provider(
             provider: &DataProvider,
             locale: &Locale,
             region: &DiplomatStr,
             write: &mut diplomat_runtime::DiplomatWrite,
         ) -> Result<(), DataError> {
+            // TODO: Consider returning LocaleParseError or a dedicated DataError variant for invalid subtag syntax.
             let region = icu_locale_core::subtags::Region::try_from_utf8(region)
-                .map_err(|_| icu_provider::DataErrorKind::IdentifierNotFound.into_error())?;
+                .unwrap_or(icu_locale_core::subtags::region!("ZZ"));
             let display_name =
                 icu_locale::names::RegionDisplayName::try_new_tiny_with_buffer_provider(
                     provider.get()?,
@@ -136,29 +152,29 @@ pub mod ffi {
         /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "compiled_data")]
         #[diplomat::rust_link(
-            icu::locale::names::RegionDisplayName::try_new_short_tiny,
+            icu::locale::names::RegionDisplayName::new_short_tiny_with_fallback,
             FnInStruct
         )]
         pub fn for_region_short_tiny(
             locale: &Locale,
             region: &DiplomatStr,
             write: &mut diplomat_runtime::DiplomatWrite,
-        ) -> Result<(), DataError> {
+        ) {
+            // TODO: Consider returning LocaleParseError or a dedicated DataError variant for invalid subtag syntax.
             let region = icu_locale_core::subtags::Region::try_from_utf8(region)
-                .map_err(|_| icu_provider::DataErrorKind::IdentifierNotFound.into_error())?;
-            let display_name = icu_locale::names::RegionDisplayName::try_new_short_tiny(
+                .unwrap_or(icu_locale_core::subtags::region!("ZZ"));
+            let display_name = icu_locale::names::RegionDisplayName::new_short_tiny_with_fallback(
                 (&locale.0).into(),
                 region,
-            )?;
+            );
             let _infallible = display_name.write_to(write);
-            Ok(())
         }
 
         /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "buffer_provider")]
         #[diplomat::attr(demo_gen, disable)]
         #[diplomat::rust_link(
-            icu::locale::names::RegionDisplayName::try_new_short_tiny,
+            icu::locale::names::RegionDisplayName::new_short_tiny_with_fallback,
             FnInStruct
         )]
         pub fn for_region_short_tiny_with_provider(
@@ -167,8 +183,9 @@ pub mod ffi {
             region: &DiplomatStr,
             write: &mut diplomat_runtime::DiplomatWrite,
         ) -> Result<(), DataError> {
+            // TODO: Consider returning LocaleParseError or a dedicated DataError variant for invalid subtag syntax.
             let region = icu_locale_core::subtags::Region::try_from_utf8(region)
-                .map_err(|_| icu_provider::DataErrorKind::IdentifierNotFound.into_error())?;
+                .unwrap_or(icu_locale_core::subtags::region!("ZZ"));
             let display_name =
                 icu_locale::names::RegionDisplayName::try_new_short_tiny_with_buffer_provider(
                     provider.get()?,
@@ -182,29 +199,29 @@ pub mod ffi {
         /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "compiled_data")]
         #[diplomat::rust_link(
-            icu::locale::names::RegionDisplayName::try_new_short_light,
+            icu::locale::names::RegionDisplayName::new_short_light_with_fallback,
             FnInStruct
         )]
         pub fn for_region_short_light(
             locale: &Locale,
             region: &DiplomatStr,
             write: &mut diplomat_runtime::DiplomatWrite,
-        ) -> Result<(), DataError> {
+        ) {
+            // TODO: Consider returning LocaleParseError or a dedicated DataError variant for invalid subtag syntax.
             let region = icu_locale_core::subtags::Region::try_from_utf8(region)
-                .map_err(|_| icu_provider::DataErrorKind::IdentifierNotFound.into_error())?;
-            let display_name = icu_locale::names::RegionDisplayName::try_new_short_light(
+                .unwrap_or(icu_locale_core::subtags::region!("ZZ"));
+            let display_name = icu_locale::names::RegionDisplayName::new_short_light_with_fallback(
                 (&locale.0).into(),
                 region,
-            )?;
+            );
             let _infallible = display_name.write_to(write);
-            Ok(())
         }
 
         /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "buffer_provider")]
         #[diplomat::attr(demo_gen, disable)]
         #[diplomat::rust_link(
-            icu::locale::names::RegionDisplayName::try_new_short_light,
+            icu::locale::names::RegionDisplayName::new_short_light_with_fallback,
             FnInStruct
         )]
         pub fn for_region_short_light_with_provider(
@@ -213,8 +230,9 @@ pub mod ffi {
             region: &DiplomatStr,
             write: &mut diplomat_runtime::DiplomatWrite,
         ) -> Result<(), DataError> {
+            // TODO: Consider returning LocaleParseError or a dedicated DataError variant for invalid subtag syntax.
             let region = icu_locale_core::subtags::Region::try_from_utf8(region)
-                .map_err(|_| icu_provider::DataErrorKind::IdentifierNotFound.into_error())?;
+                .unwrap_or(icu_locale_core::subtags::region!("ZZ"));
             let display_name =
                 icu_locale::names::RegionDisplayName::try_new_short_light_with_buffer_provider(
                     provider.get()?,
@@ -229,7 +247,10 @@ pub mod ffi {
 
         /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "compiled_data")]
-        #[diplomat::rust_link(icu::locale::names::ScriptDisplayName::try_new_light, FnInStruct)]
+        #[diplomat::rust_link(
+            icu::locale::names::ScriptDisplayName::new_light_with_fallback,
+            FnInStruct
+        )]
         #[diplomat::rust_link(icu::locale::names::ScriptDisplayName::write_to, FnInStruct, hidden)]
         #[diplomat::rust_link(icu::locale::names::ScriptDisplayName::to_string, FnInStruct, hidden)]
         #[diplomat::rust_link(icu::locale::names::ScriptDisplayNameBorrowed, Struct, hidden)]
@@ -247,27 +268,33 @@ pub mod ffi {
             locale: &Locale,
             script: &DiplomatStr,
             write: &mut diplomat_runtime::DiplomatWrite,
-        ) -> Result<(), DataError> {
+        ) {
+            // TODO: Consider returning LocaleParseError or a dedicated DataError variant for invalid subtag syntax.
             let script = icu_locale_core::subtags::Script::try_from_utf8(script)
-                .map_err(|_| icu_provider::DataErrorKind::IdentifierNotFound.into_error())?;
-            let display_name =
-                icu_locale::names::ScriptDisplayName::try_new_light((&locale.0).into(), script)?;
+                .unwrap_or(icu_locale_core::subtags::script!("Zzzz"));
+            let display_name = icu_locale::names::ScriptDisplayName::new_light_with_fallback(
+                (&locale.0).into(),
+                script,
+            );
             let _infallible = display_name.write_to(write);
-            Ok(())
         }
 
         /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "buffer_provider")]
         #[diplomat::attr(demo_gen, disable)]
-        #[diplomat::rust_link(icu::locale::names::ScriptDisplayName::try_new_light, FnInStruct)]
+        #[diplomat::rust_link(
+            icu::locale::names::ScriptDisplayName::new_light_with_fallback,
+            FnInStruct
+        )]
         pub fn for_script_light_with_provider(
             provider: &DataProvider,
             locale: &Locale,
             script: &DiplomatStr,
             write: &mut diplomat_runtime::DiplomatWrite,
         ) -> Result<(), DataError> {
+            // TODO: Consider returning LocaleParseError or a dedicated DataError variant for invalid subtag syntax.
             let script = icu_locale_core::subtags::Script::try_from_utf8(script)
-                .map_err(|_| icu_provider::DataErrorKind::IdentifierNotFound.into_error())?;
+                .unwrap_or(icu_locale_core::subtags::script!("Zzzz"));
             let display_name =
                 icu_locale::names::ScriptDisplayName::try_new_light_with_buffer_provider(
                     provider.get()?,
@@ -280,32 +307,41 @@ pub mod ffi {
 
         /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "compiled_data")]
-        #[diplomat::rust_link(icu::locale::names::ScriptDisplayName::try_new_tiny, FnInStruct)]
+        #[diplomat::rust_link(
+            icu::locale::names::ScriptDisplayName::new_tiny_with_fallback,
+            FnInStruct
+        )]
         pub fn for_script_tiny(
             locale: &Locale,
             script: &DiplomatStr,
             write: &mut diplomat_runtime::DiplomatWrite,
-        ) -> Result<(), DataError> {
+        ) {
+            // TODO: Consider returning LocaleParseError or a dedicated DataError variant for invalid subtag syntax.
             let script = icu_locale_core::subtags::Script::try_from_utf8(script)
-                .map_err(|_| icu_provider::DataErrorKind::IdentifierNotFound.into_error())?;
-            let display_name =
-                icu_locale::names::ScriptDisplayName::try_new_tiny((&locale.0).into(), script)?;
+                .unwrap_or(icu_locale_core::subtags::script!("Zzzz"));
+            let display_name = icu_locale::names::ScriptDisplayName::new_tiny_with_fallback(
+                (&locale.0).into(),
+                script,
+            );
             let _infallible = display_name.write_to(write);
-            Ok(())
         }
 
         /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "buffer_provider")]
         #[diplomat::attr(demo_gen, disable)]
-        #[diplomat::rust_link(icu::locale::names::ScriptDisplayName::try_new_tiny, FnInStruct)]
+        #[diplomat::rust_link(
+            icu::locale::names::ScriptDisplayName::new_tiny_with_fallback,
+            FnInStruct
+        )]
         pub fn for_script_tiny_with_provider(
             provider: &DataProvider,
             locale: &Locale,
             script: &DiplomatStr,
             write: &mut diplomat_runtime::DiplomatWrite,
         ) -> Result<(), DataError> {
+            // TODO: Consider returning LocaleParseError or a dedicated DataError variant for invalid subtag syntax.
             let script = icu_locale_core::subtags::Script::try_from_utf8(script)
-                .map_err(|_| icu_provider::DataErrorKind::IdentifierNotFound.into_error())?;
+                .unwrap_or(icu_locale_core::subtags::script!("Zzzz"));
             let display_name =
                 icu_locale::names::ScriptDisplayName::try_new_tiny_with_buffer_provider(
                     provider.get()?,
@@ -318,32 +354,41 @@ pub mod ffi {
 
         /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "compiled_data")]
-        #[diplomat::rust_link(icu::locale::names::ScriptDisplayName::try_new_heavy, FnInStruct)]
+        #[diplomat::rust_link(
+            icu::locale::names::ScriptDisplayName::new_heavy_with_fallback,
+            FnInStruct
+        )]
         pub fn for_script_heavy(
             locale: &Locale,
             script: &DiplomatStr,
             write: &mut diplomat_runtime::DiplomatWrite,
-        ) -> Result<(), DataError> {
+        ) {
+            // TODO: Consider returning LocaleParseError or a dedicated DataError variant for invalid subtag syntax.
             let script = icu_locale_core::subtags::Script::try_from_utf8(script)
-                .map_err(|_| icu_provider::DataErrorKind::IdentifierNotFound.into_error())?;
-            let display_name =
-                icu_locale::names::ScriptDisplayName::try_new_heavy((&locale.0).into(), script)?;
+                .unwrap_or(icu_locale_core::subtags::script!("Zzzz"));
+            let display_name = icu_locale::names::ScriptDisplayName::new_heavy_with_fallback(
+                (&locale.0).into(),
+                script,
+            );
             let _infallible = display_name.write_to(write);
-            Ok(())
         }
 
         /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "buffer_provider")]
         #[diplomat::attr(demo_gen, disable)]
-        #[diplomat::rust_link(icu::locale::names::ScriptDisplayName::try_new_heavy, FnInStruct)]
+        #[diplomat::rust_link(
+            icu::locale::names::ScriptDisplayName::new_heavy_with_fallback,
+            FnInStruct
+        )]
         pub fn for_script_heavy_with_provider(
             provider: &DataProvider,
             locale: &Locale,
             script: &DiplomatStr,
             write: &mut diplomat_runtime::DiplomatWrite,
         ) -> Result<(), DataError> {
+            // TODO: Consider returning LocaleParseError or a dedicated DataError variant for invalid subtag syntax.
             let script = icu_locale_core::subtags::Script::try_from_utf8(script)
-                .map_err(|_| icu_provider::DataErrorKind::IdentifierNotFound.into_error())?;
+                .unwrap_or(icu_locale_core::subtags::script!("Zzzz"));
             let display_name =
                 icu_locale::names::ScriptDisplayName::try_new_heavy_with_buffer_provider(
                     provider.get()?,
@@ -357,29 +402,29 @@ pub mod ffi {
         /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "compiled_data")]
         #[diplomat::rust_link(
-            icu::locale::names::ScriptDisplayName::try_new_short_heavy,
+            icu::locale::names::ScriptDisplayName::new_short_heavy_with_fallback,
             FnInStruct
         )]
         pub fn for_script_short_heavy(
             locale: &Locale,
             script: &DiplomatStr,
             write: &mut diplomat_runtime::DiplomatWrite,
-        ) -> Result<(), DataError> {
+        ) {
+            // TODO: Consider returning LocaleParseError or a dedicated DataError variant for invalid subtag syntax.
             let script = icu_locale_core::subtags::Script::try_from_utf8(script)
-                .map_err(|_| icu_provider::DataErrorKind::IdentifierNotFound.into_error())?;
-            let display_name = icu_locale::names::ScriptDisplayName::try_new_short_heavy(
+                .unwrap_or(icu_locale_core::subtags::script!("Zzzz"));
+            let display_name = icu_locale::names::ScriptDisplayName::new_short_heavy_with_fallback(
                 (&locale.0).into(),
                 script,
-            )?;
+            );
             let _infallible = display_name.write_to(write);
-            Ok(())
         }
 
         /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "buffer_provider")]
         #[diplomat::attr(demo_gen, disable)]
         #[diplomat::rust_link(
-            icu::locale::names::ScriptDisplayName::try_new_short_heavy,
+            icu::locale::names::ScriptDisplayName::new_short_heavy_with_fallback,
             FnInStruct
         )]
         pub fn for_script_short_heavy_with_provider(
@@ -388,8 +433,9 @@ pub mod ffi {
             script: &DiplomatStr,
             write: &mut diplomat_runtime::DiplomatWrite,
         ) -> Result<(), DataError> {
+            // TODO: Consider returning LocaleParseError or a dedicated DataError variant for invalid subtag syntax.
             let script = icu_locale_core::subtags::Script::try_from_utf8(script)
-                .map_err(|_| icu_provider::DataErrorKind::IdentifierNotFound.into_error())?;
+                .unwrap_or(icu_locale_core::subtags::script!("Zzzz"));
             let display_name =
                 icu_locale::names::ScriptDisplayName::try_new_short_heavy_with_buffer_provider(
                     provider.get()?,
@@ -404,7 +450,10 @@ pub mod ffi {
 
         /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "compiled_data")]
-        #[diplomat::rust_link(icu::locale::names::VariantDisplayName::try_new_heavy, FnInStruct)]
+        #[diplomat::rust_link(
+            icu::locale::names::VariantDisplayName::new_heavy_with_fallback,
+            FnInStruct
+        )]
         #[diplomat::rust_link(icu::locale::names::VariantDisplayName::write_to, FnInStruct, hidden)]
         #[diplomat::rust_link(
             icu::locale::names::VariantDisplayName::to_string,
@@ -426,27 +475,33 @@ pub mod ffi {
             locale: &Locale,
             variant: &DiplomatStr,
             write: &mut diplomat_runtime::DiplomatWrite,
-        ) -> Result<(), DataError> {
+        ) {
+            // TODO: Consider returning LocaleParseError or a dedicated DataError variant for invalid subtag syntax.
             let variant = icu_locale_core::subtags::Variant::try_from_utf8(variant)
-                .map_err(|_| icu_provider::DataErrorKind::IdentifierNotFound.into_error())?;
-            let display_name =
-                icu_locale::names::VariantDisplayName::try_new_heavy((&locale.0).into(), variant)?;
+                .unwrap_or(icu_locale_core::subtags::variant!("posix"));
+            let display_name = icu_locale::names::VariantDisplayName::new_heavy_with_fallback(
+                (&locale.0).into(),
+                variant,
+            );
             let _infallible = display_name.write_to(write);
-            Ok(())
         }
 
         /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "buffer_provider")]
         #[diplomat::attr(demo_gen, disable)]
-        #[diplomat::rust_link(icu::locale::names::VariantDisplayName::try_new_heavy, FnInStruct)]
+        #[diplomat::rust_link(
+            icu::locale::names::VariantDisplayName::new_heavy_with_fallback,
+            FnInStruct
+        )]
         pub fn for_variant_heavy_with_provider(
             provider: &DataProvider,
             locale: &Locale,
             variant: &DiplomatStr,
             write: &mut diplomat_runtime::DiplomatWrite,
         ) -> Result<(), DataError> {
+            // TODO: Consider returning LocaleParseError or a dedicated DataError variant for invalid subtag syntax.
             let variant = icu_locale_core::subtags::Variant::try_from_utf8(variant)
-                .map_err(|_| icu_provider::DataErrorKind::IdentifierNotFound.into_error())?;
+                .unwrap_or(icu_locale_core::subtags::variant!("posix"));
             let display_name =
                 icu_locale::names::VariantDisplayName::try_new_heavy_with_buffer_provider(
                     provider.get()?,

--- a/ffi/capi/tests/missing_apis.txt
+++ b/ffi/capi/tests/missing_apis.txt
@@ -34,6 +34,15 @@ icu::locale::names::LanguageIdentifierDisplayNameBorrowed::try_write_to#FnInStru
 icu::locale::names::LanguageIdentifierDisplayNameBorrowed::try_write_to_parts#FnInStruct
 icu::locale::names::LanguageIdentifierDisplayNameBorrowed::try_write_to_string#FnInStruct
 icu::locale::names::LanguageIdentifierDisplayNameBorrowed::try_writeable_borrow#FnInStruct
+icu::locale::names::RegionDisplayName::try_new_light#FnInStruct
+icu::locale::names::RegionDisplayName::try_new_short_light#FnInStruct
+icu::locale::names::RegionDisplayName::try_new_short_tiny#FnInStruct
+icu::locale::names::RegionDisplayName::try_new_tiny#FnInStruct
+icu::locale::names::ScriptDisplayName::try_new_heavy#FnInStruct
+icu::locale::names::ScriptDisplayName::try_new_light#FnInStruct
+icu::locale::names::ScriptDisplayName::try_new_short_heavy#FnInStruct
+icu::locale::names::ScriptDisplayName::try_new_tiny#FnInStruct
+icu::locale::names::VariantDisplayName::try_new_heavy#FnInStruct
 icu::segmenter::GraphemeClusterSegmenter::new_neo#FnInStruct
 icu::segmenter::LineSegmenter::new_17_for_non_complex_scripts#FnInStruct
 icu::segmenter::LineSegmenter::new_neo_for_non_complex_scripts#FnInStruct

--- a/ffi/dart/lib/src/bindings/LocaleNamesUnstable.g.dart
+++ b/ffi/dart/lib/src/bindings/LocaleNamesUnstable.g.dart
@@ -41,22 +41,17 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
 
   /// 🚧 This API is unstable and may experience breaking changes outside major releases.
   ///
-  /// See the [Rust documentation for `try_new_light`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.try_new_light) for more information.
-  ///
-  /// Throws [DataError] on failure.
+  /// See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.new_light_with_fallback) for more information.
   static String forRegionLight(Locale locale, String region) {
     final temp = _FinalizedArena();
     final write = _Write();
-    final result = _icu4x_LocaleNamesUnstable_for_region_light_mv1(locale._ffi, region._utf8AllocIn(temp.arena), write._ffi);
-    if (!result.isOk) {
-      throw DataError.values[result.union.err];
-    }
+    _icu4x_LocaleNamesUnstable_for_region_light_mv1(locale._ffi, region._utf8AllocIn(temp.arena), write._ffi);
     return write.finalize();
   }
 
   /// 🚧 This API is unstable and may experience breaking changes outside major releases.
   ///
-  /// See the [Rust documentation for `try_new_light`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.try_new_light) for more information.
+  /// See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.new_light_with_fallback) for more information.
   ///
   /// Throws [DataError] on failure.
   static String forRegionLightWithProvider(DataProvider provider, Locale locale, String region) {
@@ -71,22 +66,17 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
 
   /// 🚧 This API is unstable and may experience breaking changes outside major releases.
   ///
-  /// See the [Rust documentation for `try_new_tiny`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.try_new_tiny) for more information.
-  ///
-  /// Throws [DataError] on failure.
+  /// See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.new_tiny_with_fallback) for more information.
   static String forRegionTiny(Locale locale, String region) {
     final temp = _FinalizedArena();
     final write = _Write();
-    final result = _icu4x_LocaleNamesUnstable_for_region_tiny_mv1(locale._ffi, region._utf8AllocIn(temp.arena), write._ffi);
-    if (!result.isOk) {
-      throw DataError.values[result.union.err];
-    }
+    _icu4x_LocaleNamesUnstable_for_region_tiny_mv1(locale._ffi, region._utf8AllocIn(temp.arena), write._ffi);
     return write.finalize();
   }
 
   /// 🚧 This API is unstable and may experience breaking changes outside major releases.
   ///
-  /// See the [Rust documentation for `try_new_tiny`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.try_new_tiny) for more information.
+  /// See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.new_tiny_with_fallback) for more information.
   ///
   /// Throws [DataError] on failure.
   static String forRegionTinyWithProvider(DataProvider provider, Locale locale, String region) {
@@ -101,22 +91,17 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
 
   /// 🚧 This API is unstable and may experience breaking changes outside major releases.
   ///
-  /// See the [Rust documentation for `try_new_short_tiny`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.try_new_short_tiny) for more information.
-  ///
-  /// Throws [DataError] on failure.
+  /// See the [Rust documentation for `new_short_tiny_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.new_short_tiny_with_fallback) for more information.
   static String forRegionShortTiny(Locale locale, String region) {
     final temp = _FinalizedArena();
     final write = _Write();
-    final result = _icu4x_LocaleNamesUnstable_for_region_short_tiny_mv1(locale._ffi, region._utf8AllocIn(temp.arena), write._ffi);
-    if (!result.isOk) {
-      throw DataError.values[result.union.err];
-    }
+    _icu4x_LocaleNamesUnstable_for_region_short_tiny_mv1(locale._ffi, region._utf8AllocIn(temp.arena), write._ffi);
     return write.finalize();
   }
 
   /// 🚧 This API is unstable and may experience breaking changes outside major releases.
   ///
-  /// See the [Rust documentation for `try_new_short_tiny`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.try_new_short_tiny) for more information.
+  /// See the [Rust documentation for `new_short_tiny_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.new_short_tiny_with_fallback) for more information.
   ///
   /// Throws [DataError] on failure.
   static String forRegionShortTinyWithProvider(DataProvider provider, Locale locale, String region) {
@@ -131,22 +116,17 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
 
   /// 🚧 This API is unstable and may experience breaking changes outside major releases.
   ///
-  /// See the [Rust documentation for `try_new_short_light`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.try_new_short_light) for more information.
-  ///
-  /// Throws [DataError] on failure.
+  /// See the [Rust documentation for `new_short_light_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.new_short_light_with_fallback) for more information.
   static String forRegionShortLight(Locale locale, String region) {
     final temp = _FinalizedArena();
     final write = _Write();
-    final result = _icu4x_LocaleNamesUnstable_for_region_short_light_mv1(locale._ffi, region._utf8AllocIn(temp.arena), write._ffi);
-    if (!result.isOk) {
-      throw DataError.values[result.union.err];
-    }
+    _icu4x_LocaleNamesUnstable_for_region_short_light_mv1(locale._ffi, region._utf8AllocIn(temp.arena), write._ffi);
     return write.finalize();
   }
 
   /// 🚧 This API is unstable and may experience breaking changes outside major releases.
   ///
-  /// See the [Rust documentation for `try_new_short_light`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.try_new_short_light) for more information.
+  /// See the [Rust documentation for `new_short_light_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.new_short_light_with_fallback) for more information.
   ///
   /// Throws [DataError] on failure.
   static String forRegionShortLightWithProvider(DataProvider provider, Locale locale, String region) {
@@ -161,22 +141,17 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
 
   /// 🚧 This API is unstable and may experience breaking changes outside major releases.
   ///
-  /// See the [Rust documentation for `try_new_light`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.try_new_light) for more information.
-  ///
-  /// Throws [DataError] on failure.
+  /// See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.new_light_with_fallback) for more information.
   static String forScriptLight(Locale locale, String script) {
     final temp = _FinalizedArena();
     final write = _Write();
-    final result = _icu4x_LocaleNamesUnstable_for_script_light_mv1(locale._ffi, script._utf8AllocIn(temp.arena), write._ffi);
-    if (!result.isOk) {
-      throw DataError.values[result.union.err];
-    }
+    _icu4x_LocaleNamesUnstable_for_script_light_mv1(locale._ffi, script._utf8AllocIn(temp.arena), write._ffi);
     return write.finalize();
   }
 
   /// 🚧 This API is unstable and may experience breaking changes outside major releases.
   ///
-  /// See the [Rust documentation for `try_new_light`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.try_new_light) for more information.
+  /// See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.new_light_with_fallback) for more information.
   ///
   /// Throws [DataError] on failure.
   static String forScriptLightWithProvider(DataProvider provider, Locale locale, String script) {
@@ -191,22 +166,17 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
 
   /// 🚧 This API is unstable and may experience breaking changes outside major releases.
   ///
-  /// See the [Rust documentation for `try_new_tiny`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.try_new_tiny) for more information.
-  ///
-  /// Throws [DataError] on failure.
+  /// See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.new_tiny_with_fallback) for more information.
   static String forScriptTiny(Locale locale, String script) {
     final temp = _FinalizedArena();
     final write = _Write();
-    final result = _icu4x_LocaleNamesUnstable_for_script_tiny_mv1(locale._ffi, script._utf8AllocIn(temp.arena), write._ffi);
-    if (!result.isOk) {
-      throw DataError.values[result.union.err];
-    }
+    _icu4x_LocaleNamesUnstable_for_script_tiny_mv1(locale._ffi, script._utf8AllocIn(temp.arena), write._ffi);
     return write.finalize();
   }
 
   /// 🚧 This API is unstable and may experience breaking changes outside major releases.
   ///
-  /// See the [Rust documentation for `try_new_tiny`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.try_new_tiny) for more information.
+  /// See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.new_tiny_with_fallback) for more information.
   ///
   /// Throws [DataError] on failure.
   static String forScriptTinyWithProvider(DataProvider provider, Locale locale, String script) {
@@ -221,22 +191,17 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
 
   /// 🚧 This API is unstable and may experience breaking changes outside major releases.
   ///
-  /// See the [Rust documentation for `try_new_heavy`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.try_new_heavy) for more information.
-  ///
-  /// Throws [DataError] on failure.
+  /// See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.new_heavy_with_fallback) for more information.
   static String forScriptHeavy(Locale locale, String script) {
     final temp = _FinalizedArena();
     final write = _Write();
-    final result = _icu4x_LocaleNamesUnstable_for_script_heavy_mv1(locale._ffi, script._utf8AllocIn(temp.arena), write._ffi);
-    if (!result.isOk) {
-      throw DataError.values[result.union.err];
-    }
+    _icu4x_LocaleNamesUnstable_for_script_heavy_mv1(locale._ffi, script._utf8AllocIn(temp.arena), write._ffi);
     return write.finalize();
   }
 
   /// 🚧 This API is unstable and may experience breaking changes outside major releases.
   ///
-  /// See the [Rust documentation for `try_new_heavy`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.try_new_heavy) for more information.
+  /// See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.new_heavy_with_fallback) for more information.
   ///
   /// Throws [DataError] on failure.
   static String forScriptHeavyWithProvider(DataProvider provider, Locale locale, String script) {
@@ -251,22 +216,17 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
 
   /// 🚧 This API is unstable and may experience breaking changes outside major releases.
   ///
-  /// See the [Rust documentation for `try_new_short_heavy`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.try_new_short_heavy) for more information.
-  ///
-  /// Throws [DataError] on failure.
+  /// See the [Rust documentation for `new_short_heavy_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.new_short_heavy_with_fallback) for more information.
   static String forScriptShortHeavy(Locale locale, String script) {
     final temp = _FinalizedArena();
     final write = _Write();
-    final result = _icu4x_LocaleNamesUnstable_for_script_short_heavy_mv1(locale._ffi, script._utf8AllocIn(temp.arena), write._ffi);
-    if (!result.isOk) {
-      throw DataError.values[result.union.err];
-    }
+    _icu4x_LocaleNamesUnstable_for_script_short_heavy_mv1(locale._ffi, script._utf8AllocIn(temp.arena), write._ffi);
     return write.finalize();
   }
 
   /// 🚧 This API is unstable and may experience breaking changes outside major releases.
   ///
-  /// See the [Rust documentation for `try_new_short_heavy`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.try_new_short_heavy) for more information.
+  /// See the [Rust documentation for `new_short_heavy_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.new_short_heavy_with_fallback) for more information.
   ///
   /// Throws [DataError] on failure.
   static String forScriptShortHeavyWithProvider(DataProvider provider, Locale locale, String script) {
@@ -281,22 +241,17 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
 
   /// 🚧 This API is unstable and may experience breaking changes outside major releases.
   ///
-  /// See the [Rust documentation for `try_new_heavy`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.VariantDisplayName.html#method.try_new_heavy) for more information.
-  ///
-  /// Throws [DataError] on failure.
+  /// See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.VariantDisplayName.html#method.new_heavy_with_fallback) for more information.
   static String forVariantHeavy(Locale locale, String variant) {
     final temp = _FinalizedArena();
     final write = _Write();
-    final result = _icu4x_LocaleNamesUnstable_for_variant_heavy_mv1(locale._ffi, variant._utf8AllocIn(temp.arena), write._ffi);
-    if (!result.isOk) {
-      throw DataError.values[result.union.err];
-    }
+    _icu4x_LocaleNamesUnstable_for_variant_heavy_mv1(locale._ffi, variant._utf8AllocIn(temp.arena), write._ffi);
     return write.finalize();
   }
 
   /// 🚧 This API is unstable and may experience breaking changes outside major releases.
   ///
-  /// See the [Rust documentation for `try_new_heavy`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.VariantDisplayName.html#method.try_new_heavy) for more information.
+  /// See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.VariantDisplayName.html#method.new_heavy_with_fallback) for more information.
   ///
   /// Throws [DataError] on failure.
   static String forVariantHeavyWithProvider(DataProvider provider, Locale locale, String variant) {
@@ -627,9 +582,9 @@ external void _internal_icu4x_LocaleNamesUnstable_destroy_mv1(ffi.Pointer<ffi.Vo
 
 // ignore: experimental_member_use
 @meta.RecordUse()
-@ffi.Native<_ResultVoidInt32 Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_LocaleNamesUnstable_for_region_light_mv1')
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_LocaleNamesUnstable_for_region_light_mv1')
 // ignore: non_constant_identifier_names
-external _ResultVoidInt32 _icu4x_LocaleNamesUnstable_for_region_light_mv1(ffi.Pointer<ffi.Opaque> locale, _SliceUtf8 region, ffi.Pointer<ffi.Opaque> write);
+external void _icu4x_LocaleNamesUnstable_for_region_light_mv1(ffi.Pointer<ffi.Opaque> locale, _SliceUtf8 region, ffi.Pointer<ffi.Opaque> write);
 
 // ignore: experimental_member_use
 @meta.RecordUse()
@@ -639,9 +594,9 @@ external _ResultVoidInt32 _icu4x_LocaleNamesUnstable_for_region_light_with_provi
 
 // ignore: experimental_member_use
 @meta.RecordUse()
-@ffi.Native<_ResultVoidInt32 Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_LocaleNamesUnstable_for_region_tiny_mv1')
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_LocaleNamesUnstable_for_region_tiny_mv1')
 // ignore: non_constant_identifier_names
-external _ResultVoidInt32 _icu4x_LocaleNamesUnstable_for_region_tiny_mv1(ffi.Pointer<ffi.Opaque> locale, _SliceUtf8 region, ffi.Pointer<ffi.Opaque> write);
+external void _icu4x_LocaleNamesUnstable_for_region_tiny_mv1(ffi.Pointer<ffi.Opaque> locale, _SliceUtf8 region, ffi.Pointer<ffi.Opaque> write);
 
 // ignore: experimental_member_use
 @meta.RecordUse()
@@ -651,9 +606,9 @@ external _ResultVoidInt32 _icu4x_LocaleNamesUnstable_for_region_tiny_with_provid
 
 // ignore: experimental_member_use
 @meta.RecordUse()
-@ffi.Native<_ResultVoidInt32 Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_LocaleNamesUnstable_for_region_short_tiny_mv1')
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_LocaleNamesUnstable_for_region_short_tiny_mv1')
 // ignore: non_constant_identifier_names
-external _ResultVoidInt32 _icu4x_LocaleNamesUnstable_for_region_short_tiny_mv1(ffi.Pointer<ffi.Opaque> locale, _SliceUtf8 region, ffi.Pointer<ffi.Opaque> write);
+external void _icu4x_LocaleNamesUnstable_for_region_short_tiny_mv1(ffi.Pointer<ffi.Opaque> locale, _SliceUtf8 region, ffi.Pointer<ffi.Opaque> write);
 
 // ignore: experimental_member_use
 @meta.RecordUse()
@@ -663,9 +618,9 @@ external _ResultVoidInt32 _icu4x_LocaleNamesUnstable_for_region_short_tiny_with_
 
 // ignore: experimental_member_use
 @meta.RecordUse()
-@ffi.Native<_ResultVoidInt32 Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_LocaleNamesUnstable_for_region_short_light_mv1')
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_LocaleNamesUnstable_for_region_short_light_mv1')
 // ignore: non_constant_identifier_names
-external _ResultVoidInt32 _icu4x_LocaleNamesUnstable_for_region_short_light_mv1(ffi.Pointer<ffi.Opaque> locale, _SliceUtf8 region, ffi.Pointer<ffi.Opaque> write);
+external void _icu4x_LocaleNamesUnstable_for_region_short_light_mv1(ffi.Pointer<ffi.Opaque> locale, _SliceUtf8 region, ffi.Pointer<ffi.Opaque> write);
 
 // ignore: experimental_member_use
 @meta.RecordUse()
@@ -675,9 +630,9 @@ external _ResultVoidInt32 _icu4x_LocaleNamesUnstable_for_region_short_light_with
 
 // ignore: experimental_member_use
 @meta.RecordUse()
-@ffi.Native<_ResultVoidInt32 Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_LocaleNamesUnstable_for_script_light_mv1')
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_LocaleNamesUnstable_for_script_light_mv1')
 // ignore: non_constant_identifier_names
-external _ResultVoidInt32 _icu4x_LocaleNamesUnstable_for_script_light_mv1(ffi.Pointer<ffi.Opaque> locale, _SliceUtf8 script, ffi.Pointer<ffi.Opaque> write);
+external void _icu4x_LocaleNamesUnstable_for_script_light_mv1(ffi.Pointer<ffi.Opaque> locale, _SliceUtf8 script, ffi.Pointer<ffi.Opaque> write);
 
 // ignore: experimental_member_use
 @meta.RecordUse()
@@ -687,9 +642,9 @@ external _ResultVoidInt32 _icu4x_LocaleNamesUnstable_for_script_light_with_provi
 
 // ignore: experimental_member_use
 @meta.RecordUse()
-@ffi.Native<_ResultVoidInt32 Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_LocaleNamesUnstable_for_script_tiny_mv1')
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_LocaleNamesUnstable_for_script_tiny_mv1')
 // ignore: non_constant_identifier_names
-external _ResultVoidInt32 _icu4x_LocaleNamesUnstable_for_script_tiny_mv1(ffi.Pointer<ffi.Opaque> locale, _SliceUtf8 script, ffi.Pointer<ffi.Opaque> write);
+external void _icu4x_LocaleNamesUnstable_for_script_tiny_mv1(ffi.Pointer<ffi.Opaque> locale, _SliceUtf8 script, ffi.Pointer<ffi.Opaque> write);
 
 // ignore: experimental_member_use
 @meta.RecordUse()
@@ -699,9 +654,9 @@ external _ResultVoidInt32 _icu4x_LocaleNamesUnstable_for_script_tiny_with_provid
 
 // ignore: experimental_member_use
 @meta.RecordUse()
-@ffi.Native<_ResultVoidInt32 Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_LocaleNamesUnstable_for_script_heavy_mv1')
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_LocaleNamesUnstable_for_script_heavy_mv1')
 // ignore: non_constant_identifier_names
-external _ResultVoidInt32 _icu4x_LocaleNamesUnstable_for_script_heavy_mv1(ffi.Pointer<ffi.Opaque> locale, _SliceUtf8 script, ffi.Pointer<ffi.Opaque> write);
+external void _icu4x_LocaleNamesUnstable_for_script_heavy_mv1(ffi.Pointer<ffi.Opaque> locale, _SliceUtf8 script, ffi.Pointer<ffi.Opaque> write);
 
 // ignore: experimental_member_use
 @meta.RecordUse()
@@ -711,9 +666,9 @@ external _ResultVoidInt32 _icu4x_LocaleNamesUnstable_for_script_heavy_with_provi
 
 // ignore: experimental_member_use
 @meta.RecordUse()
-@ffi.Native<_ResultVoidInt32 Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_LocaleNamesUnstable_for_script_short_heavy_mv1')
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_LocaleNamesUnstable_for_script_short_heavy_mv1')
 // ignore: non_constant_identifier_names
-external _ResultVoidInt32 _icu4x_LocaleNamesUnstable_for_script_short_heavy_mv1(ffi.Pointer<ffi.Opaque> locale, _SliceUtf8 script, ffi.Pointer<ffi.Opaque> write);
+external void _icu4x_LocaleNamesUnstable_for_script_short_heavy_mv1(ffi.Pointer<ffi.Opaque> locale, _SliceUtf8 script, ffi.Pointer<ffi.Opaque> write);
 
 // ignore: experimental_member_use
 @meta.RecordUse()
@@ -723,9 +678,9 @@ external _ResultVoidInt32 _icu4x_LocaleNamesUnstable_for_script_short_heavy_with
 
 // ignore: experimental_member_use
 @meta.RecordUse()
-@ffi.Native<_ResultVoidInt32 Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_LocaleNamesUnstable_for_variant_heavy_mv1')
+@ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Opaque>, _SliceUtf8, ffi.Pointer<ffi.Opaque>)>(isLeaf: true, symbol: 'icu4x_LocaleNamesUnstable_for_variant_heavy_mv1')
 // ignore: non_constant_identifier_names
-external _ResultVoidInt32 _icu4x_LocaleNamesUnstable_for_variant_heavy_mv1(ffi.Pointer<ffi.Opaque> locale, _SliceUtf8 variant, ffi.Pointer<ffi.Opaque> write);
+external void _icu4x_LocaleNamesUnstable_for_variant_heavy_mv1(ffi.Pointer<ffi.Opaque> locale, _SliceUtf8 variant, ffi.Pointer<ffi.Opaque> write);
 
 // ignore: experimental_member_use
 @meta.RecordUse()

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LocaleNamesUnstable.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LocaleNamesUnstable.kt
@@ -7,23 +7,23 @@ import com.sun.jna.Structure
 
 internal interface LocaleNamesUnstableLib: Library {
     fun icu4x_LocaleNamesUnstable_destroy_mv1(handle: Pointer)
-    fun icu4x_LocaleNamesUnstable_for_region_light_mv1(locale: Pointer, region: Slice, write: Pointer): ResultUnitInt
+    fun icu4x_LocaleNamesUnstable_for_region_light_mv1(locale: Pointer, region: Slice, write: Pointer): Unit
     fun icu4x_LocaleNamesUnstable_for_region_light_with_provider_mv1(provider: Pointer, locale: Pointer, region: Slice, write: Pointer): ResultUnitInt
-    fun icu4x_LocaleNamesUnstable_for_region_tiny_mv1(locale: Pointer, region: Slice, write: Pointer): ResultUnitInt
+    fun icu4x_LocaleNamesUnstable_for_region_tiny_mv1(locale: Pointer, region: Slice, write: Pointer): Unit
     fun icu4x_LocaleNamesUnstable_for_region_tiny_with_provider_mv1(provider: Pointer, locale: Pointer, region: Slice, write: Pointer): ResultUnitInt
-    fun icu4x_LocaleNamesUnstable_for_region_short_tiny_mv1(locale: Pointer, region: Slice, write: Pointer): ResultUnitInt
+    fun icu4x_LocaleNamesUnstable_for_region_short_tiny_mv1(locale: Pointer, region: Slice, write: Pointer): Unit
     fun icu4x_LocaleNamesUnstable_for_region_short_tiny_with_provider_mv1(provider: Pointer, locale: Pointer, region: Slice, write: Pointer): ResultUnitInt
-    fun icu4x_LocaleNamesUnstable_for_region_short_light_mv1(locale: Pointer, region: Slice, write: Pointer): ResultUnitInt
+    fun icu4x_LocaleNamesUnstable_for_region_short_light_mv1(locale: Pointer, region: Slice, write: Pointer): Unit
     fun icu4x_LocaleNamesUnstable_for_region_short_light_with_provider_mv1(provider: Pointer, locale: Pointer, region: Slice, write: Pointer): ResultUnitInt
-    fun icu4x_LocaleNamesUnstable_for_script_light_mv1(locale: Pointer, script: Slice, write: Pointer): ResultUnitInt
+    fun icu4x_LocaleNamesUnstable_for_script_light_mv1(locale: Pointer, script: Slice, write: Pointer): Unit
     fun icu4x_LocaleNamesUnstable_for_script_light_with_provider_mv1(provider: Pointer, locale: Pointer, script: Slice, write: Pointer): ResultUnitInt
-    fun icu4x_LocaleNamesUnstable_for_script_tiny_mv1(locale: Pointer, script: Slice, write: Pointer): ResultUnitInt
+    fun icu4x_LocaleNamesUnstable_for_script_tiny_mv1(locale: Pointer, script: Slice, write: Pointer): Unit
     fun icu4x_LocaleNamesUnstable_for_script_tiny_with_provider_mv1(provider: Pointer, locale: Pointer, script: Slice, write: Pointer): ResultUnitInt
-    fun icu4x_LocaleNamesUnstable_for_script_heavy_mv1(locale: Pointer, script: Slice, write: Pointer): ResultUnitInt
+    fun icu4x_LocaleNamesUnstable_for_script_heavy_mv1(locale: Pointer, script: Slice, write: Pointer): Unit
     fun icu4x_LocaleNamesUnstable_for_script_heavy_with_provider_mv1(provider: Pointer, locale: Pointer, script: Slice, write: Pointer): ResultUnitInt
-    fun icu4x_LocaleNamesUnstable_for_script_short_heavy_mv1(locale: Pointer, script: Slice, write: Pointer): ResultUnitInt
+    fun icu4x_LocaleNamesUnstable_for_script_short_heavy_mv1(locale: Pointer, script: Slice, write: Pointer): Unit
     fun icu4x_LocaleNamesUnstable_for_script_short_heavy_with_provider_mv1(provider: Pointer, locale: Pointer, script: Slice, write: Pointer): ResultUnitInt
-    fun icu4x_LocaleNamesUnstable_for_variant_heavy_mv1(locale: Pointer, variant: Slice, write: Pointer): ResultUnitInt
+    fun icu4x_LocaleNamesUnstable_for_variant_heavy_mv1(locale: Pointer, variant: Slice, write: Pointer): Unit
     fun icu4x_LocaleNamesUnstable_for_variant_heavy_with_provider_mv1(provider: Pointer, locale: Pointer, variant: Slice, write: Pointer): ResultUnitInt
     fun icu4x_LocaleNamesUnstable_for_language_identifier_light_mv1(locale: Pointer, langid: Pointer, languageDisplay: Int, write: Pointer): ResultUnitInt
     fun icu4x_LocaleNamesUnstable_for_language_identifier_light_with_provider_mv1(provider: Pointer, locale: Pointer, langid: Pointer, languageDisplay: Int, write: Pointer): ResultUnitInt
@@ -91,21 +91,16 @@ class LocaleNamesUnstable internal constructor (
         
         /** 🚧 This API is unstable and may experience breaking changes outside major releases.
         *
-        *See the [Rust documentation for `try_new_light`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.try_new_light) for more information.
+        *See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.new_light_with_fallback) for more information.
         */
-        fun forRegionLight(locale: Locale, region: String): Result<String> {
+        fun forRegionLight(locale: Locale, region: String): String {
             val regionSliceMemory = PrimitiveArrayTools.borrowUtf8(region)
             val write = DW.lib.diplomat_buffer_write_create(0)
             val returnVal = lib.icu4x_LocaleNamesUnstable_for_region_light_mv1(locale.handle, regionSliceMemory.slice, write);
             try {
-                val nativeOkVal = returnVal.getNativeOk();
-                if (nativeOkVal != null) {
-                    
-                    val returnString = DW.writeToString(write)
-                    return returnString.ok()
-                } else {
-                    return DataErrorError(DataError.fromNative(returnVal.getNativeErr()!!)).err()
-                }
+                
+                val returnString = DW.writeToString(write)
+                return returnString
             } finally {
                 regionSliceMemory.close()
             }
@@ -114,7 +109,7 @@ class LocaleNamesUnstable internal constructor (
         
         /** 🚧 This API is unstable and may experience breaking changes outside major releases.
         *
-        *See the [Rust documentation for `try_new_light`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.try_new_light) for more information.
+        *See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.new_light_with_fallback) for more information.
         */
         fun forRegionLightWithProvider(provider: DataProvider, locale: Locale, region: String): Result<String> {
             val regionSliceMemory = PrimitiveArrayTools.borrowUtf8(region)
@@ -137,21 +132,16 @@ class LocaleNamesUnstable internal constructor (
         
         /** 🚧 This API is unstable and may experience breaking changes outside major releases.
         *
-        *See the [Rust documentation for `try_new_tiny`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.try_new_tiny) for more information.
+        *See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.new_tiny_with_fallback) for more information.
         */
-        fun forRegionTiny(locale: Locale, region: String): Result<String> {
+        fun forRegionTiny(locale: Locale, region: String): String {
             val regionSliceMemory = PrimitiveArrayTools.borrowUtf8(region)
             val write = DW.lib.diplomat_buffer_write_create(0)
             val returnVal = lib.icu4x_LocaleNamesUnstable_for_region_tiny_mv1(locale.handle, regionSliceMemory.slice, write);
             try {
-                val nativeOkVal = returnVal.getNativeOk();
-                if (nativeOkVal != null) {
-                    
-                    val returnString = DW.writeToString(write)
-                    return returnString.ok()
-                } else {
-                    return DataErrorError(DataError.fromNative(returnVal.getNativeErr()!!)).err()
-                }
+                
+                val returnString = DW.writeToString(write)
+                return returnString
             } finally {
                 regionSliceMemory.close()
             }
@@ -160,7 +150,7 @@ class LocaleNamesUnstable internal constructor (
         
         /** 🚧 This API is unstable and may experience breaking changes outside major releases.
         *
-        *See the [Rust documentation for `try_new_tiny`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.try_new_tiny) for more information.
+        *See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.new_tiny_with_fallback) for more information.
         */
         fun forRegionTinyWithProvider(provider: DataProvider, locale: Locale, region: String): Result<String> {
             val regionSliceMemory = PrimitiveArrayTools.borrowUtf8(region)
@@ -183,21 +173,16 @@ class LocaleNamesUnstable internal constructor (
         
         /** 🚧 This API is unstable and may experience breaking changes outside major releases.
         *
-        *See the [Rust documentation for `try_new_short_tiny`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.try_new_short_tiny) for more information.
+        *See the [Rust documentation for `new_short_tiny_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.new_short_tiny_with_fallback) for more information.
         */
-        fun forRegionShortTiny(locale: Locale, region: String): Result<String> {
+        fun forRegionShortTiny(locale: Locale, region: String): String {
             val regionSliceMemory = PrimitiveArrayTools.borrowUtf8(region)
             val write = DW.lib.diplomat_buffer_write_create(0)
             val returnVal = lib.icu4x_LocaleNamesUnstable_for_region_short_tiny_mv1(locale.handle, regionSliceMemory.slice, write);
             try {
-                val nativeOkVal = returnVal.getNativeOk();
-                if (nativeOkVal != null) {
-                    
-                    val returnString = DW.writeToString(write)
-                    return returnString.ok()
-                } else {
-                    return DataErrorError(DataError.fromNative(returnVal.getNativeErr()!!)).err()
-                }
+                
+                val returnString = DW.writeToString(write)
+                return returnString
             } finally {
                 regionSliceMemory.close()
             }
@@ -206,7 +191,7 @@ class LocaleNamesUnstable internal constructor (
         
         /** 🚧 This API is unstable and may experience breaking changes outside major releases.
         *
-        *See the [Rust documentation for `try_new_short_tiny`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.try_new_short_tiny) for more information.
+        *See the [Rust documentation for `new_short_tiny_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.new_short_tiny_with_fallback) for more information.
         */
         fun forRegionShortTinyWithProvider(provider: DataProvider, locale: Locale, region: String): Result<String> {
             val regionSliceMemory = PrimitiveArrayTools.borrowUtf8(region)
@@ -229,21 +214,16 @@ class LocaleNamesUnstable internal constructor (
         
         /** 🚧 This API is unstable and may experience breaking changes outside major releases.
         *
-        *See the [Rust documentation for `try_new_short_light`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.try_new_short_light) for more information.
+        *See the [Rust documentation for `new_short_light_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.new_short_light_with_fallback) for more information.
         */
-        fun forRegionShortLight(locale: Locale, region: String): Result<String> {
+        fun forRegionShortLight(locale: Locale, region: String): String {
             val regionSliceMemory = PrimitiveArrayTools.borrowUtf8(region)
             val write = DW.lib.diplomat_buffer_write_create(0)
             val returnVal = lib.icu4x_LocaleNamesUnstable_for_region_short_light_mv1(locale.handle, regionSliceMemory.slice, write);
             try {
-                val nativeOkVal = returnVal.getNativeOk();
-                if (nativeOkVal != null) {
-                    
-                    val returnString = DW.writeToString(write)
-                    return returnString.ok()
-                } else {
-                    return DataErrorError(DataError.fromNative(returnVal.getNativeErr()!!)).err()
-                }
+                
+                val returnString = DW.writeToString(write)
+                return returnString
             } finally {
                 regionSliceMemory.close()
             }
@@ -252,7 +232,7 @@ class LocaleNamesUnstable internal constructor (
         
         /** 🚧 This API is unstable and may experience breaking changes outside major releases.
         *
-        *See the [Rust documentation for `try_new_short_light`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.try_new_short_light) for more information.
+        *See the [Rust documentation for `new_short_light_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.new_short_light_with_fallback) for more information.
         */
         fun forRegionShortLightWithProvider(provider: DataProvider, locale: Locale, region: String): Result<String> {
             val regionSliceMemory = PrimitiveArrayTools.borrowUtf8(region)
@@ -275,21 +255,16 @@ class LocaleNamesUnstable internal constructor (
         
         /** 🚧 This API is unstable and may experience breaking changes outside major releases.
         *
-        *See the [Rust documentation for `try_new_light`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.try_new_light) for more information.
+        *See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.new_light_with_fallback) for more information.
         */
-        fun forScriptLight(locale: Locale, script: String): Result<String> {
+        fun forScriptLight(locale: Locale, script: String): String {
             val scriptSliceMemory = PrimitiveArrayTools.borrowUtf8(script)
             val write = DW.lib.diplomat_buffer_write_create(0)
             val returnVal = lib.icu4x_LocaleNamesUnstable_for_script_light_mv1(locale.handle, scriptSliceMemory.slice, write);
             try {
-                val nativeOkVal = returnVal.getNativeOk();
-                if (nativeOkVal != null) {
-                    
-                    val returnString = DW.writeToString(write)
-                    return returnString.ok()
-                } else {
-                    return DataErrorError(DataError.fromNative(returnVal.getNativeErr()!!)).err()
-                }
+                
+                val returnString = DW.writeToString(write)
+                return returnString
             } finally {
                 scriptSliceMemory.close()
             }
@@ -298,7 +273,7 @@ class LocaleNamesUnstable internal constructor (
         
         /** 🚧 This API is unstable and may experience breaking changes outside major releases.
         *
-        *See the [Rust documentation for `try_new_light`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.try_new_light) for more information.
+        *See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.new_light_with_fallback) for more information.
         */
         fun forScriptLightWithProvider(provider: DataProvider, locale: Locale, script: String): Result<String> {
             val scriptSliceMemory = PrimitiveArrayTools.borrowUtf8(script)
@@ -321,21 +296,16 @@ class LocaleNamesUnstable internal constructor (
         
         /** 🚧 This API is unstable and may experience breaking changes outside major releases.
         *
-        *See the [Rust documentation for `try_new_tiny`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.try_new_tiny) for more information.
+        *See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.new_tiny_with_fallback) for more information.
         */
-        fun forScriptTiny(locale: Locale, script: String): Result<String> {
+        fun forScriptTiny(locale: Locale, script: String): String {
             val scriptSliceMemory = PrimitiveArrayTools.borrowUtf8(script)
             val write = DW.lib.diplomat_buffer_write_create(0)
             val returnVal = lib.icu4x_LocaleNamesUnstable_for_script_tiny_mv1(locale.handle, scriptSliceMemory.slice, write);
             try {
-                val nativeOkVal = returnVal.getNativeOk();
-                if (nativeOkVal != null) {
-                    
-                    val returnString = DW.writeToString(write)
-                    return returnString.ok()
-                } else {
-                    return DataErrorError(DataError.fromNative(returnVal.getNativeErr()!!)).err()
-                }
+                
+                val returnString = DW.writeToString(write)
+                return returnString
             } finally {
                 scriptSliceMemory.close()
             }
@@ -344,7 +314,7 @@ class LocaleNamesUnstable internal constructor (
         
         /** 🚧 This API is unstable and may experience breaking changes outside major releases.
         *
-        *See the [Rust documentation for `try_new_tiny`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.try_new_tiny) for more information.
+        *See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.new_tiny_with_fallback) for more information.
         */
         fun forScriptTinyWithProvider(provider: DataProvider, locale: Locale, script: String): Result<String> {
             val scriptSliceMemory = PrimitiveArrayTools.borrowUtf8(script)
@@ -367,21 +337,16 @@ class LocaleNamesUnstable internal constructor (
         
         /** 🚧 This API is unstable and may experience breaking changes outside major releases.
         *
-        *See the [Rust documentation for `try_new_heavy`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.try_new_heavy) for more information.
+        *See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.new_heavy_with_fallback) for more information.
         */
-        fun forScriptHeavy(locale: Locale, script: String): Result<String> {
+        fun forScriptHeavy(locale: Locale, script: String): String {
             val scriptSliceMemory = PrimitiveArrayTools.borrowUtf8(script)
             val write = DW.lib.diplomat_buffer_write_create(0)
             val returnVal = lib.icu4x_LocaleNamesUnstable_for_script_heavy_mv1(locale.handle, scriptSliceMemory.slice, write);
             try {
-                val nativeOkVal = returnVal.getNativeOk();
-                if (nativeOkVal != null) {
-                    
-                    val returnString = DW.writeToString(write)
-                    return returnString.ok()
-                } else {
-                    return DataErrorError(DataError.fromNative(returnVal.getNativeErr()!!)).err()
-                }
+                
+                val returnString = DW.writeToString(write)
+                return returnString
             } finally {
                 scriptSliceMemory.close()
             }
@@ -390,7 +355,7 @@ class LocaleNamesUnstable internal constructor (
         
         /** 🚧 This API is unstable and may experience breaking changes outside major releases.
         *
-        *See the [Rust documentation for `try_new_heavy`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.try_new_heavy) for more information.
+        *See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.new_heavy_with_fallback) for more information.
         */
         fun forScriptHeavyWithProvider(provider: DataProvider, locale: Locale, script: String): Result<String> {
             val scriptSliceMemory = PrimitiveArrayTools.borrowUtf8(script)
@@ -413,21 +378,16 @@ class LocaleNamesUnstable internal constructor (
         
         /** 🚧 This API is unstable and may experience breaking changes outside major releases.
         *
-        *See the [Rust documentation for `try_new_short_heavy`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.try_new_short_heavy) for more information.
+        *See the [Rust documentation for `new_short_heavy_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.new_short_heavy_with_fallback) for more information.
         */
-        fun forScriptShortHeavy(locale: Locale, script: String): Result<String> {
+        fun forScriptShortHeavy(locale: Locale, script: String): String {
             val scriptSliceMemory = PrimitiveArrayTools.borrowUtf8(script)
             val write = DW.lib.diplomat_buffer_write_create(0)
             val returnVal = lib.icu4x_LocaleNamesUnstable_for_script_short_heavy_mv1(locale.handle, scriptSliceMemory.slice, write);
             try {
-                val nativeOkVal = returnVal.getNativeOk();
-                if (nativeOkVal != null) {
-                    
-                    val returnString = DW.writeToString(write)
-                    return returnString.ok()
-                } else {
-                    return DataErrorError(DataError.fromNative(returnVal.getNativeErr()!!)).err()
-                }
+                
+                val returnString = DW.writeToString(write)
+                return returnString
             } finally {
                 scriptSliceMemory.close()
             }
@@ -436,7 +396,7 @@ class LocaleNamesUnstable internal constructor (
         
         /** 🚧 This API is unstable and may experience breaking changes outside major releases.
         *
-        *See the [Rust documentation for `try_new_short_heavy`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.try_new_short_heavy) for more information.
+        *See the [Rust documentation for `new_short_heavy_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.new_short_heavy_with_fallback) for more information.
         */
         fun forScriptShortHeavyWithProvider(provider: DataProvider, locale: Locale, script: String): Result<String> {
             val scriptSliceMemory = PrimitiveArrayTools.borrowUtf8(script)
@@ -459,21 +419,16 @@ class LocaleNamesUnstable internal constructor (
         
         /** 🚧 This API is unstable and may experience breaking changes outside major releases.
         *
-        *See the [Rust documentation for `try_new_heavy`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.VariantDisplayName.html#method.try_new_heavy) for more information.
+        *See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.VariantDisplayName.html#method.new_heavy_with_fallback) for more information.
         */
-        fun forVariantHeavy(locale: Locale, variant: String): Result<String> {
+        fun forVariantHeavy(locale: Locale, variant: String): String {
             val variantSliceMemory = PrimitiveArrayTools.borrowUtf8(variant)
             val write = DW.lib.diplomat_buffer_write_create(0)
             val returnVal = lib.icu4x_LocaleNamesUnstable_for_variant_heavy_mv1(locale.handle, variantSliceMemory.slice, write);
             try {
-                val nativeOkVal = returnVal.getNativeOk();
-                if (nativeOkVal != null) {
-                    
-                    val returnString = DW.writeToString(write)
-                    return returnString.ok()
-                } else {
-                    return DataErrorError(DataError.fromNative(returnVal.getNativeErr()!!)).err()
-                }
+                
+                val returnString = DW.writeToString(write)
+                return returnString
             } finally {
                 variantSliceMemory.close()
             }
@@ -482,7 +437,7 @@ class LocaleNamesUnstable internal constructor (
         
         /** 🚧 This API is unstable and may experience breaking changes outside major releases.
         *
-        *See the [Rust documentation for `try_new_heavy`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.VariantDisplayName.html#method.try_new_heavy) for more information.
+        *See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.VariantDisplayName.html#method.new_heavy_with_fallback) for more information.
         */
         fun forVariantHeavyWithProvider(provider: DataProvider, locale: Locale, variant: String): Result<String> {
             val variantSliceMemory = PrimitiveArrayTools.borrowUtf8(variant)

--- a/ffi/npm/lib/LocaleNamesUnstable.d.ts
+++ b/ffi/npm/lib/LocaleNamesUnstable.d.ts
@@ -31,126 +31,126 @@ export class LocaleNamesUnstable {
     /**
      * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
-     * See the [Rust documentation for `try_new_light`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.try_new_light) for more information.
+     * See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.new_light_with_fallback) for more information.
      */
     static forRegionLight(locale: Locale, region: string): string;
 
     /**
      * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
-     * See the [Rust documentation for `try_new_light`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.try_new_light) for more information.
+     * See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.new_light_with_fallback) for more information.
      */
     static forRegionLightWithProvider(provider: DataProvider, locale: Locale, region: string): string;
 
     /**
      * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
-     * See the [Rust documentation for `try_new_tiny`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.try_new_tiny) for more information.
+     * See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.new_tiny_with_fallback) for more information.
      */
     static forRegionTiny(locale: Locale, region: string): string;
 
     /**
      * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
-     * See the [Rust documentation for `try_new_tiny`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.try_new_tiny) for more information.
+     * See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.new_tiny_with_fallback) for more information.
      */
     static forRegionTinyWithProvider(provider: DataProvider, locale: Locale, region: string): string;
 
     /**
      * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
-     * See the [Rust documentation for `try_new_short_tiny`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.try_new_short_tiny) for more information.
+     * See the [Rust documentation for `new_short_tiny_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.new_short_tiny_with_fallback) for more information.
      */
     static forRegionShortTiny(locale: Locale, region: string): string;
 
     /**
      * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
-     * See the [Rust documentation for `try_new_short_tiny`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.try_new_short_tiny) for more information.
+     * See the [Rust documentation for `new_short_tiny_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.new_short_tiny_with_fallback) for more information.
      */
     static forRegionShortTinyWithProvider(provider: DataProvider, locale: Locale, region: string): string;
 
     /**
      * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
-     * See the [Rust documentation for `try_new_short_light`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.try_new_short_light) for more information.
+     * See the [Rust documentation for `new_short_light_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.new_short_light_with_fallback) for more information.
      */
     static forRegionShortLight(locale: Locale, region: string): string;
 
     /**
      * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
-     * See the [Rust documentation for `try_new_short_light`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.try_new_short_light) for more information.
+     * See the [Rust documentation for `new_short_light_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.new_short_light_with_fallback) for more information.
      */
     static forRegionShortLightWithProvider(provider: DataProvider, locale: Locale, region: string): string;
 
     /**
      * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
-     * See the [Rust documentation for `try_new_light`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.try_new_light) for more information.
+     * See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.new_light_with_fallback) for more information.
      */
     static forScriptLight(locale: Locale, script: string): string;
 
     /**
      * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
-     * See the [Rust documentation for `try_new_light`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.try_new_light) for more information.
+     * See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.new_light_with_fallback) for more information.
      */
     static forScriptLightWithProvider(provider: DataProvider, locale: Locale, script: string): string;
 
     /**
      * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
-     * See the [Rust documentation for `try_new_tiny`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.try_new_tiny) for more information.
+     * See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.new_tiny_with_fallback) for more information.
      */
     static forScriptTiny(locale: Locale, script: string): string;
 
     /**
      * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
-     * See the [Rust documentation for `try_new_tiny`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.try_new_tiny) for more information.
+     * See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.new_tiny_with_fallback) for more information.
      */
     static forScriptTinyWithProvider(provider: DataProvider, locale: Locale, script: string): string;
 
     /**
      * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
-     * See the [Rust documentation for `try_new_heavy`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.try_new_heavy) for more information.
+     * See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.new_heavy_with_fallback) for more information.
      */
     static forScriptHeavy(locale: Locale, script: string): string;
 
     /**
      * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
-     * See the [Rust documentation for `try_new_heavy`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.try_new_heavy) for more information.
+     * See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.new_heavy_with_fallback) for more information.
      */
     static forScriptHeavyWithProvider(provider: DataProvider, locale: Locale, script: string): string;
 
     /**
      * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
-     * See the [Rust documentation for `try_new_short_heavy`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.try_new_short_heavy) for more information.
+     * See the [Rust documentation for `new_short_heavy_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.new_short_heavy_with_fallback) for more information.
      */
     static forScriptShortHeavy(locale: Locale, script: string): string;
 
     /**
      * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
-     * See the [Rust documentation for `try_new_short_heavy`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.try_new_short_heavy) for more information.
+     * See the [Rust documentation for `new_short_heavy_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.new_short_heavy_with_fallback) for more information.
      */
     static forScriptShortHeavyWithProvider(provider: DataProvider, locale: Locale, script: string): string;
 
     /**
      * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
-     * See the [Rust documentation for `try_new_heavy`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.VariantDisplayName.html#method.try_new_heavy) for more information.
+     * See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.VariantDisplayName.html#method.new_heavy_with_fallback) for more information.
      */
     static forVariantHeavy(locale: Locale, variant: string): string;
 
     /**
      * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
-     * See the [Rust documentation for `try_new_heavy`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.VariantDisplayName.html#method.try_new_heavy) for more information.
+     * See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.VariantDisplayName.html#method.new_heavy_with_fallback) for more information.
      */
     static forVariantHeavyWithProvider(provider: DataProvider, locale: Locale, variant: string): string;
 

--- a/ffi/npm/lib/LocaleNamesUnstable.mjs
+++ b/ffi/npm/lib/LocaleNamesUnstable.mjs
@@ -56,24 +56,17 @@ export class LocaleNamesUnstable {
     /**
      * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
-     * See the [Rust documentation for `try_new_light`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.try_new_light) for more information.
+     * See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.new_light_with_fallback) for more information.
      */
     static forRegionLight(locale, region) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
 
         const regionSlice = functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.sliceWrapper(wasm, diplomatRuntime.DiplomatBuf.str8(wasm, region)));
-        const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
-
         const write = new diplomatRuntime.DiplomatWriteBuf(wasm);
 
-
-        const result = wasm.icu4x_LocaleNamesUnstable_for_region_light_mv1(diplomatReceive.buffer, locale.ffiValue, regionSlice.ptr, write.buffer);
+    wasm.icu4x_LocaleNamesUnstable_for_region_light_mv1(locale.ffiValue, regionSlice.ptr, write.buffer);
 
         try {
-            if (!diplomatReceive.resultFlag) {
-                const cause = new DataError(diplomatRuntime.internalConstructor, diplomatRuntime.enumDiscriminant(wasm, diplomatReceive.buffer));
-                throw new globalThis.Error('DataError.' + cause.value, { cause });
-            }
             return write.readString8();
         }
 
@@ -81,7 +74,6 @@ export class LocaleNamesUnstable {
             diplomatRuntime.FUNCTION_PARAM_ALLOC.clean();
             functionCleanupArena.free();
 
-            diplomatReceive.free();
             write.free();
         }
     }
@@ -89,7 +81,7 @@ export class LocaleNamesUnstable {
     /**
      * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
-     * See the [Rust documentation for `try_new_light`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.try_new_light) for more information.
+     * See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.new_light_with_fallback) for more information.
      */
     static forRegionLightWithProvider(provider, locale, region) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -122,24 +114,17 @@ export class LocaleNamesUnstable {
     /**
      * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
-     * See the [Rust documentation for `try_new_tiny`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.try_new_tiny) for more information.
+     * See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.new_tiny_with_fallback) for more information.
      */
     static forRegionTiny(locale, region) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
 
         const regionSlice = functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.sliceWrapper(wasm, diplomatRuntime.DiplomatBuf.str8(wasm, region)));
-        const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
-
         const write = new diplomatRuntime.DiplomatWriteBuf(wasm);
 
-
-        const result = wasm.icu4x_LocaleNamesUnstable_for_region_tiny_mv1(diplomatReceive.buffer, locale.ffiValue, regionSlice.ptr, write.buffer);
+    wasm.icu4x_LocaleNamesUnstable_for_region_tiny_mv1(locale.ffiValue, regionSlice.ptr, write.buffer);
 
         try {
-            if (!diplomatReceive.resultFlag) {
-                const cause = new DataError(diplomatRuntime.internalConstructor, diplomatRuntime.enumDiscriminant(wasm, diplomatReceive.buffer));
-                throw new globalThis.Error('DataError.' + cause.value, { cause });
-            }
             return write.readString8();
         }
 
@@ -147,7 +132,6 @@ export class LocaleNamesUnstable {
             diplomatRuntime.FUNCTION_PARAM_ALLOC.clean();
             functionCleanupArena.free();
 
-            diplomatReceive.free();
             write.free();
         }
     }
@@ -155,7 +139,7 @@ export class LocaleNamesUnstable {
     /**
      * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
-     * See the [Rust documentation for `try_new_tiny`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.try_new_tiny) for more information.
+     * See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.new_tiny_with_fallback) for more information.
      */
     static forRegionTinyWithProvider(provider, locale, region) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -188,24 +172,17 @@ export class LocaleNamesUnstable {
     /**
      * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
-     * See the [Rust documentation for `try_new_short_tiny`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.try_new_short_tiny) for more information.
+     * See the [Rust documentation for `new_short_tiny_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.new_short_tiny_with_fallback) for more information.
      */
     static forRegionShortTiny(locale, region) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
 
         const regionSlice = functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.sliceWrapper(wasm, diplomatRuntime.DiplomatBuf.str8(wasm, region)));
-        const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
-
         const write = new diplomatRuntime.DiplomatWriteBuf(wasm);
 
-
-        const result = wasm.icu4x_LocaleNamesUnstable_for_region_short_tiny_mv1(diplomatReceive.buffer, locale.ffiValue, regionSlice.ptr, write.buffer);
+    wasm.icu4x_LocaleNamesUnstable_for_region_short_tiny_mv1(locale.ffiValue, regionSlice.ptr, write.buffer);
 
         try {
-            if (!diplomatReceive.resultFlag) {
-                const cause = new DataError(diplomatRuntime.internalConstructor, diplomatRuntime.enumDiscriminant(wasm, diplomatReceive.buffer));
-                throw new globalThis.Error('DataError.' + cause.value, { cause });
-            }
             return write.readString8();
         }
 
@@ -213,7 +190,6 @@ export class LocaleNamesUnstable {
             diplomatRuntime.FUNCTION_PARAM_ALLOC.clean();
             functionCleanupArena.free();
 
-            diplomatReceive.free();
             write.free();
         }
     }
@@ -221,7 +197,7 @@ export class LocaleNamesUnstable {
     /**
      * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
-     * See the [Rust documentation for `try_new_short_tiny`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.try_new_short_tiny) for more information.
+     * See the [Rust documentation for `new_short_tiny_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.new_short_tiny_with_fallback) for more information.
      */
     static forRegionShortTinyWithProvider(provider, locale, region) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -254,24 +230,17 @@ export class LocaleNamesUnstable {
     /**
      * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
-     * See the [Rust documentation for `try_new_short_light`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.try_new_short_light) for more information.
+     * See the [Rust documentation for `new_short_light_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.new_short_light_with_fallback) for more information.
      */
     static forRegionShortLight(locale, region) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
 
         const regionSlice = functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.sliceWrapper(wasm, diplomatRuntime.DiplomatBuf.str8(wasm, region)));
-        const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
-
         const write = new diplomatRuntime.DiplomatWriteBuf(wasm);
 
-
-        const result = wasm.icu4x_LocaleNamesUnstable_for_region_short_light_mv1(diplomatReceive.buffer, locale.ffiValue, regionSlice.ptr, write.buffer);
+    wasm.icu4x_LocaleNamesUnstable_for_region_short_light_mv1(locale.ffiValue, regionSlice.ptr, write.buffer);
 
         try {
-            if (!diplomatReceive.resultFlag) {
-                const cause = new DataError(diplomatRuntime.internalConstructor, diplomatRuntime.enumDiscriminant(wasm, diplomatReceive.buffer));
-                throw new globalThis.Error('DataError.' + cause.value, { cause });
-            }
             return write.readString8();
         }
 
@@ -279,7 +248,6 @@ export class LocaleNamesUnstable {
             diplomatRuntime.FUNCTION_PARAM_ALLOC.clean();
             functionCleanupArena.free();
 
-            diplomatReceive.free();
             write.free();
         }
     }
@@ -287,7 +255,7 @@ export class LocaleNamesUnstable {
     /**
      * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
-     * See the [Rust documentation for `try_new_short_light`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.try_new_short_light) for more information.
+     * See the [Rust documentation for `new_short_light_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.RegionDisplayName.html#method.new_short_light_with_fallback) for more information.
      */
     static forRegionShortLightWithProvider(provider, locale, region) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -320,24 +288,17 @@ export class LocaleNamesUnstable {
     /**
      * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
-     * See the [Rust documentation for `try_new_light`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.try_new_light) for more information.
+     * See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.new_light_with_fallback) for more information.
      */
     static forScriptLight(locale, script) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
 
         const scriptSlice = functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.sliceWrapper(wasm, diplomatRuntime.DiplomatBuf.str8(wasm, script)));
-        const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
-
         const write = new diplomatRuntime.DiplomatWriteBuf(wasm);
 
-
-        const result = wasm.icu4x_LocaleNamesUnstable_for_script_light_mv1(diplomatReceive.buffer, locale.ffiValue, scriptSlice.ptr, write.buffer);
+    wasm.icu4x_LocaleNamesUnstable_for_script_light_mv1(locale.ffiValue, scriptSlice.ptr, write.buffer);
 
         try {
-            if (!diplomatReceive.resultFlag) {
-                const cause = new DataError(diplomatRuntime.internalConstructor, diplomatRuntime.enumDiscriminant(wasm, diplomatReceive.buffer));
-                throw new globalThis.Error('DataError.' + cause.value, { cause });
-            }
             return write.readString8();
         }
 
@@ -345,7 +306,6 @@ export class LocaleNamesUnstable {
             diplomatRuntime.FUNCTION_PARAM_ALLOC.clean();
             functionCleanupArena.free();
 
-            diplomatReceive.free();
             write.free();
         }
     }
@@ -353,7 +313,7 @@ export class LocaleNamesUnstable {
     /**
      * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
-     * See the [Rust documentation for `try_new_light`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.try_new_light) for more information.
+     * See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.new_light_with_fallback) for more information.
      */
     static forScriptLightWithProvider(provider, locale, script) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -386,24 +346,17 @@ export class LocaleNamesUnstable {
     /**
      * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
-     * See the [Rust documentation for `try_new_tiny`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.try_new_tiny) for more information.
+     * See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.new_tiny_with_fallback) for more information.
      */
     static forScriptTiny(locale, script) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
 
         const scriptSlice = functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.sliceWrapper(wasm, diplomatRuntime.DiplomatBuf.str8(wasm, script)));
-        const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
-
         const write = new diplomatRuntime.DiplomatWriteBuf(wasm);
 
-
-        const result = wasm.icu4x_LocaleNamesUnstable_for_script_tiny_mv1(diplomatReceive.buffer, locale.ffiValue, scriptSlice.ptr, write.buffer);
+    wasm.icu4x_LocaleNamesUnstable_for_script_tiny_mv1(locale.ffiValue, scriptSlice.ptr, write.buffer);
 
         try {
-            if (!diplomatReceive.resultFlag) {
-                const cause = new DataError(diplomatRuntime.internalConstructor, diplomatRuntime.enumDiscriminant(wasm, diplomatReceive.buffer));
-                throw new globalThis.Error('DataError.' + cause.value, { cause });
-            }
             return write.readString8();
         }
 
@@ -411,7 +364,6 @@ export class LocaleNamesUnstable {
             diplomatRuntime.FUNCTION_PARAM_ALLOC.clean();
             functionCleanupArena.free();
 
-            diplomatReceive.free();
             write.free();
         }
     }
@@ -419,7 +371,7 @@ export class LocaleNamesUnstable {
     /**
      * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
-     * See the [Rust documentation for `try_new_tiny`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.try_new_tiny) for more information.
+     * See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.new_tiny_with_fallback) for more information.
      */
     static forScriptTinyWithProvider(provider, locale, script) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -452,24 +404,17 @@ export class LocaleNamesUnstable {
     /**
      * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
-     * See the [Rust documentation for `try_new_heavy`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.try_new_heavy) for more information.
+     * See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.new_heavy_with_fallback) for more information.
      */
     static forScriptHeavy(locale, script) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
 
         const scriptSlice = functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.sliceWrapper(wasm, diplomatRuntime.DiplomatBuf.str8(wasm, script)));
-        const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
-
         const write = new diplomatRuntime.DiplomatWriteBuf(wasm);
 
-
-        const result = wasm.icu4x_LocaleNamesUnstable_for_script_heavy_mv1(diplomatReceive.buffer, locale.ffiValue, scriptSlice.ptr, write.buffer);
+    wasm.icu4x_LocaleNamesUnstable_for_script_heavy_mv1(locale.ffiValue, scriptSlice.ptr, write.buffer);
 
         try {
-            if (!diplomatReceive.resultFlag) {
-                const cause = new DataError(diplomatRuntime.internalConstructor, diplomatRuntime.enumDiscriminant(wasm, diplomatReceive.buffer));
-                throw new globalThis.Error('DataError.' + cause.value, { cause });
-            }
             return write.readString8();
         }
 
@@ -477,7 +422,6 @@ export class LocaleNamesUnstable {
             diplomatRuntime.FUNCTION_PARAM_ALLOC.clean();
             functionCleanupArena.free();
 
-            diplomatReceive.free();
             write.free();
         }
     }
@@ -485,7 +429,7 @@ export class LocaleNamesUnstable {
     /**
      * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
-     * See the [Rust documentation for `try_new_heavy`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.try_new_heavy) for more information.
+     * See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.new_heavy_with_fallback) for more information.
      */
     static forScriptHeavyWithProvider(provider, locale, script) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -518,24 +462,17 @@ export class LocaleNamesUnstable {
     /**
      * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
-     * See the [Rust documentation for `try_new_short_heavy`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.try_new_short_heavy) for more information.
+     * See the [Rust documentation for `new_short_heavy_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.new_short_heavy_with_fallback) for more information.
      */
     static forScriptShortHeavy(locale, script) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
 
         const scriptSlice = functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.sliceWrapper(wasm, diplomatRuntime.DiplomatBuf.str8(wasm, script)));
-        const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
-
         const write = new diplomatRuntime.DiplomatWriteBuf(wasm);
 
-
-        const result = wasm.icu4x_LocaleNamesUnstable_for_script_short_heavy_mv1(diplomatReceive.buffer, locale.ffiValue, scriptSlice.ptr, write.buffer);
+    wasm.icu4x_LocaleNamesUnstable_for_script_short_heavy_mv1(locale.ffiValue, scriptSlice.ptr, write.buffer);
 
         try {
-            if (!diplomatReceive.resultFlag) {
-                const cause = new DataError(diplomatRuntime.internalConstructor, diplomatRuntime.enumDiscriminant(wasm, diplomatReceive.buffer));
-                throw new globalThis.Error('DataError.' + cause.value, { cause });
-            }
             return write.readString8();
         }
 
@@ -543,7 +480,6 @@ export class LocaleNamesUnstable {
             diplomatRuntime.FUNCTION_PARAM_ALLOC.clean();
             functionCleanupArena.free();
 
-            diplomatReceive.free();
             write.free();
         }
     }
@@ -551,7 +487,7 @@ export class LocaleNamesUnstable {
     /**
      * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
-     * See the [Rust documentation for `try_new_short_heavy`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.try_new_short_heavy) for more information.
+     * See the [Rust documentation for `new_short_heavy_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.ScriptDisplayName.html#method.new_short_heavy_with_fallback) for more information.
      */
     static forScriptShortHeavyWithProvider(provider, locale, script) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -584,24 +520,17 @@ export class LocaleNamesUnstable {
     /**
      * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
-     * See the [Rust documentation for `try_new_heavy`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.VariantDisplayName.html#method.try_new_heavy) for more information.
+     * See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.VariantDisplayName.html#method.new_heavy_with_fallback) for more information.
      */
     static forVariantHeavy(locale, variant) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
 
         const variantSlice = functionCleanupArena.alloc(diplomatRuntime.DiplomatBuf.sliceWrapper(wasm, diplomatRuntime.DiplomatBuf.str8(wasm, variant)));
-        const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
-
         const write = new diplomatRuntime.DiplomatWriteBuf(wasm);
 
-
-        const result = wasm.icu4x_LocaleNamesUnstable_for_variant_heavy_mv1(diplomatReceive.buffer, locale.ffiValue, variantSlice.ptr, write.buffer);
+    wasm.icu4x_LocaleNamesUnstable_for_variant_heavy_mv1(locale.ffiValue, variantSlice.ptr, write.buffer);
 
         try {
-            if (!diplomatReceive.resultFlag) {
-                const cause = new DataError(diplomatRuntime.internalConstructor, diplomatRuntime.enumDiscriminant(wasm, diplomatReceive.buffer));
-                throw new globalThis.Error('DataError.' + cause.value, { cause });
-            }
             return write.readString8();
         }
 
@@ -609,7 +538,6 @@ export class LocaleNamesUnstable {
             diplomatRuntime.FUNCTION_PARAM_ALLOC.clean();
             functionCleanupArena.free();
 
-            diplomatReceive.free();
             write.free();
         }
     }
@@ -617,7 +545,7 @@ export class LocaleNamesUnstable {
     /**
      * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
-     * See the [Rust documentation for `try_new_heavy`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.VariantDisplayName.html#method.try_new_heavy) for more information.
+     * See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.2.0/icu/locale/names/struct.VariantDisplayName.html#method.new_heavy_with_fallback) for more information.
      */
     static forVariantHeavyWithProvider(provider, locale, variant) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();


### PR DESCRIPTION
Fixes #8100

Depends on #8346
Depends on https://github.com/unicode-org/icu4x/pull/8347

This is slightly bigger than I wanted it to be. I can hold this back from the release if you think it needs more design.

This is hand-written. I plan to AI-generate the rest of these, if this design looks good.

## Changelog

icu_locale::names: Adds infallible fn for RegionDisplayName