### PR TITLE
Add more DataPayloadOr methods

### DIFF
--- a/provider/core/src/response.rs
+++ b/provider/core/src/response.rs
@@ -996,8 +996,12 @@ where
     pub fn map_other<O2>(self, f: impl FnOnce(O) -> O2) -> DataPayloadOr<M, O2> {
         DataPayloadOr(match self.0 {
             DataPayloadOrInner::Yoke(yoke) => DataPayloadOrInner::Yoke(yoke),
-            DataPayloadOrInner::Inner(DataPayloadOrInnerInner::StaticRef(r)) => DataPayloadOrInner::Inner(DataPayloadOrInnerInner::StaticRef(r)),
-            DataPayloadOrInner::Inner(DataPayloadOrInnerInner::Other(o)) => DataPayloadOrInner::Inner(DataPayloadOrInnerInner::Other(f(o))),
+            DataPayloadOrInner::Inner(DataPayloadOrInnerInner::StaticRef(r)) => {
+                DataPayloadOrInner::Inner(DataPayloadOrInnerInner::StaticRef(r))
+            }
+            DataPayloadOrInner::Inner(DataPayloadOrInnerInner::Other(o)) => {
+                DataPayloadOrInner::Inner(DataPayloadOrInnerInner::Other(f(o)))
+            }
         })
     }
 
@@ -1005,11 +1009,18 @@ where
     ///
     /// See [`DataResponse::cast`].
     #[inline]
-    pub fn cast<M2>(self) -> DataPayloadOr<M2, O> where M2: DynamicDataMarker<DataStruct = M::DataStruct> {
+    pub fn cast<M2>(self) -> DataPayloadOr<M2, O>
+    where
+        M2: DynamicDataMarker<DataStruct = M::DataStruct>,
+    {
         DataPayloadOr(match self.0 {
             DataPayloadOrInner::Yoke(yoke) => DataPayloadOrInner::Yoke(yoke),
-            DataPayloadOrInner::Inner(DataPayloadOrInnerInner::StaticRef(r)) => DataPayloadOrInner::Inner(DataPayloadOrInnerInner::StaticRef(r)),
-            DataPayloadOrInner::Inner(DataPayloadOrInnerInner::Other(o)) => DataPayloadOrInner::Inner(DataPayloadOrInnerInner::Other(o)),
+            DataPayloadOrInner::Inner(DataPayloadOrInnerInner::StaticRef(r)) => {
+                DataPayloadOrInner::Inner(DataPayloadOrInnerInner::StaticRef(r))
+            }
+            DataPayloadOrInner::Inner(DataPayloadOrInnerInner::Other(o)) => {
+                DataPayloadOrInner::Inner(DataPayloadOrInnerInner::Other(o))
+            }
         })
     }
 }

--- a/provider/core/src/response.rs
+++ b/provider/core/src/response.rs
@@ -990,6 +990,28 @@ where
             DataPayloadOrInner::Inner(DataPayloadOrInnerInner::Other(o)) => Err(o),
         }
     }
+
+    /// Maps the Other type to a new Other type.
+    #[inline]
+    pub fn map_other<O2>(self, f: impl FnOnce(O) -> O2) -> DataPayloadOr<M, O2> {
+        DataPayloadOr(match self.0 {
+            DataPayloadOrInner::Yoke(yoke) => DataPayloadOrInner::Yoke(yoke),
+            DataPayloadOrInner::Inner(DataPayloadOrInnerInner::StaticRef(r)) => DataPayloadOrInner::Inner(DataPayloadOrInnerInner::StaticRef(r)),
+            DataPayloadOrInner::Inner(DataPayloadOrInnerInner::Other(o)) => DataPayloadOrInner::Inner(DataPayloadOrInnerInner::Other(f(o))),
+        })
+    }
+
+    /// Maps the Marker type to a compatible Marker type.
+    ///
+    /// See [`DataResponse::cast`].
+    #[inline]
+    pub fn cast<M2>(self) -> DataPayloadOr<M2, O> where M2: DynamicDataMarker<DataStruct = M::DataStruct> {
+        DataPayloadOr(match self.0 {
+            DataPayloadOrInner::Yoke(yoke) => DataPayloadOrInner::Yoke(yoke),
+            DataPayloadOrInner::Inner(DataPayloadOrInnerInner::StaticRef(r)) => DataPayloadOrInner::Inner(DataPayloadOrInnerInner::StaticRef(r)),
+            DataPayloadOrInner::Inner(DataPayloadOrInnerInner::Other(o)) => DataPayloadOrInner::Inner(DataPayloadOrInnerInner::Other(o)),
+        })
+    }
 }
 
 impl<M> DataPayloadOr<M, ()>


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->

## Changelog

icu_provider: add more methods to DataPayloadOr

- New function: `DataPayloadOr::map_other`
- New function: `DataPayloadOr::cast`