### PR TITLE
Reset default writeable version to published version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,7 +204,7 @@ potential_utf = { version = "0.1.3", path = "utils/potential_utf", default-featu
 resb = { version = "0.2.0-dev", path = "utils/resb", default-features = false }
 tzif = { version = "0.5.0", path = "utils/tzif", default-features = false }
 tinystr = { version = "0.8.3", path = "utils/tinystr", default-features = false }
-writeable = { version = "0.6.1", path = "utils/writeable", default-features = false } # Current version: 0.6.2
+writeable = { version = "0.6.3", path = "utils/writeable", default-features = false }
 yoke = { version = "0.8.3", path = "utils/yoke", default-features = false }
 yoke-derive = { version = "0.8.2", path = "utils/yoke/derive", default-features = false }
 zerofrom = { version = "0.1.6", path = "utils/zerofrom", default-features = false } # Current version: 0.1.8


### PR DESCRIPTION
Fixes #8241 

We have these divergences to make it easier to upgrade but we should (a) not have them be too far behind and (b) be very free about "fixing" them,

## Changelog: N/A

Dependency changes that happen anyway during a release