### PR TITLE
Add the fn being gated to the new writeable macros

### DIFF
--- a/components/decimal/src/decimal_formatter.rs
+++ b/components/decimal/src/decimal_formatter.rs
@@ -245,7 +245,7 @@ impl Writeable for FormattedUnsignedDecimal<'_> {
     }
 }
 
-writeable::impl_writeable_delegate!(FormattedDecimal<'_>, |&self| &self.0, #[cfg(feature = "alloc")]);
+writeable::impl_writeable_delegate!(FormattedDecimal<'_>, |&self| &self.0, #[cfg(feature = "alloc")] fn write_to_string);
 writeable::impl_display_with_writeable!(FormattedDecimal<'_>, #[cfg(feature = "alloc")]);
 writeable::impl_display_with_writeable!(FormattedUnsignedDecimal<'_>, #[cfg(feature = "alloc")]);
 writeable::impl_display_with_writeable!(FormattedSign<'_, T>, #[cfg(feature = "alloc")], where T: Writeable);

--- a/components/locale_core/src/helpers.rs
+++ b/components/locale_core/src/helpers.rs
@@ -146,7 +146,7 @@ macro_rules! impl_tinystr_subtag {
             }
         }
 
-        writeable::impl_writeable_delegate!($name, |&self| self.as_str(), #[cfg(feature = "alloc")]);
+        writeable::impl_writeable_delegate!($name, |&self| self.as_str(), #[cfg(feature = "alloc")] fn write_to_string);
         writeable::impl_display_with_writeable!($name, #[cfg(feature = "alloc")]);
 
         #[doc = concat!("A macro allowing for compile-time construction of valid [`", stringify!($name), "`] subtags.")]

--- a/utils/writeable/src/impls.rs
+++ b/utils/writeable/src/impls.rs
@@ -135,7 +135,7 @@ impl Writeable for char {
     }
 }
 
-crate::impl_writeable_delegate!(&T, |&self| *self, #[cfg(feature = "alloc")], where T: Writeable + ?Sized);
+crate::impl_writeable_delegate!(&T, |&self| *self, #[cfg(feature = "alloc")] fn write_to_string, where T: Writeable + ?Sized);
 
 #[cfg(feature = "alloc")]
 macro_rules! impl_write_smart_pointer {

--- a/utils/writeable/src/lib.rs
+++ b/utils/writeable/src/lib.rs
@@ -435,7 +435,7 @@ pub trait Writeable {
 /// ```
 #[macro_export]
 macro_rules! impl_writeable_delegate {
-    ($ty:ty, |&$self:ident| $delegate:expr $(, #[$alloc_feature:meta])? $(, where $($generics:tt)*)?) => {
+    ($ty:ty, |&$self:ident| $delegate:expr $(, #[$alloc_feature:meta] fn write_to_string)? $(, where $($generics:tt)*)?) => {
         impl $(<$($generics)*>)? $crate::Writeable for $ty {
             #[inline]
             fn write_to<W: core::fmt::Write + ?Sized>(&$self, sink: &mut W) -> core::fmt::Result {

--- a/utils/writeable/src/lib.rs
+++ b/utils/writeable/src/lib.rs
@@ -410,7 +410,7 @@ pub trait Writeable {
 ///
 /// ```
 /// struct MyStruct(String);
-/// writeable::impl_writeable_delegate!(MyStruct, |&self| &self.0, #[cfg(feature = "alloc")]);
+/// writeable::impl_writeable_delegate!(MyStruct, |&self| &self.0, #[cfg(feature = "alloc")] fn write_to_string);
 /// writeable::impl_display_with_writeable!(MyStruct, #[cfg(feature = "alloc")]);
 ///
 /// writeable::assert_writeable_eq!(

--- a/utils/writeable/src/try_writeable.rs
+++ b/utils/writeable/src/try_writeable.rs
@@ -427,7 +427,7 @@ where
 ///
 /// ```
 /// struct MyStruct(Result<String, String>);
-/// writeable::impl_try_writeable_delegate!(MyStruct, |&self| &self.0, Error = String, #[cfg(feature = "alloc")]);
+/// writeable::impl_try_writeable_delegate!(MyStruct, |&self| &self.0, Error = String, #[cfg(feature = "alloc")] fn try_write_to_string);
 ///
 /// writeable::assert_try_writeable_eq!(
 ///     MyStruct(Ok("hello".to_string())),

--- a/utils/writeable/src/try_writeable.rs
+++ b/utils/writeable/src/try_writeable.rs
@@ -472,7 +472,7 @@ where
 /// ```
 #[macro_export]
 macro_rules! impl_try_writeable_delegate {
-    ($ty:ty, |&$self:ident| $delegate:expr, Error = $error:ty $(, |$error_arg:ident| $error_map:expr)? $(, #[$alloc_feature:meta])? $(, where $($generics:tt)*)?) => {
+    ($ty:ty, |&$self:ident| $delegate:expr, Error = $error:ty $(, |$error_arg:ident| $error_map:expr)? $(, #[$alloc_feature:meta] fn try_write_to_string)? $(, where $($generics:tt)*)?) => {
         impl$(<$($generics)*>)? $crate::TryWriteable for $ty {
             type Error = $error;
             #[inline]
@@ -533,7 +533,7 @@ impl_try_writeable_delegate!(
     &T,
     |&self| *self,
     Error = T::Error,
-    #[cfg(feature = "alloc")],
+    #[cfg(feature = "alloc")] fn try_write_to_string,
     where T: TryWriteable + ?Sized
 );
 


### PR DESCRIPTION
Fixes https://github.com/unicode-org/icu4x/issues/8165

## Changelog

N/A (changes an unpublished macro)