### PR TITLE
Make pre-UNIX-epoch times representable in `ZoneNameTimestamp`

### DIFF
--- a/components/datetime/tests/patterns/tests/time_zones.json
+++ b/components/datetime/tests/patterns/tests/time_zones.json
@@ -55,6 +55,23 @@
   },
   {
     "locale": "en",
+    "datetime": "1947-06-01T00:00:00.000+03:00[Europe/Berlin]",
+    "expectations": {
+      "z": "GMT+3",
+      "zzzz": "GMT+03:00",
+
+      "v": "Germany Time",
+      "vvvv": "Germany Time",
+
+      "VVV": "Berlin",
+      "VVVV": "Germany Time",
+
+      "O": "GMT+3",
+      "OOOO": "GMT+03:00"
+    }
+  },
+  {
+    "locale": "en",
     "datetime": "2021-07-11T12:00:00.000+01:00[Europe/London]",
     "expectations": {
       "z": "GMT+1",

--- a/components/time/src/provider/mod.rs
+++ b/components/time/src/provider/mod.rs
@@ -399,7 +399,7 @@ pub struct TimezonePeriods<'a> {
     pub offsets: ZeroVec<'a, VariantOffsetsWithMetazoneMembershipKind>,
 }
 
-/// Encodes [`ZoneNameTimestamp`] in 3 bytes by dropping the unused metadata
+/// Encodes [`ZoneNameTimestamp`] in 3 bytes by dropping the sign byte.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize))]
@@ -449,7 +449,7 @@ impl serde::Serialize for TimezonePeriods<'_> {
                 if let Some(value) = self.list.get(idx) {
                     map.serialize_entry(
                         &tz,
-                        &[ZoneNameTimestamp::far_in_past()]
+                        &[ZoneNameTimestamp::from_epoch_seconds(0)]
                             .into_iter()
                             .chain(value.variable.iter().map(|(t, _, _)| t.0))
                             .map(|t| {
@@ -566,6 +566,10 @@ impl TimezonePeriods<'_> {
         idx: usize,
         timestamp: ZoneNameTimestamp,
     ) -> Option<(u8, NichedOption<MetazoneId, 1>)> {
+        if timestamp < ZoneNameTimestamp::from_epoch_seconds(0) {
+            return None;
+        }
+
         use zerovec::ule::AsULE;
         use zerovec::ule::vartuple::VarTupleULE;
         let &VarTupleULE {
@@ -573,7 +577,7 @@ impl TimezonePeriods<'_> {
             variable: ref rest,
         } = self.list.get(idx)?;
 
-        let i = match rest.binary_search_by(|(t, ..)| t.cmp(&Timestamp24(timestamp))) {
+        let i = match rest.binary_search_by(|(t, ..)| t.0.cmp(&timestamp)) {
             Err(0) => return Some(<(u8, NichedOption<MetazoneId, 1>)>::from_unaligned(first)),
             Err(i) => i - 1,
             Ok(i) => i,

--- a/components/time/src/zone/zone_name_timestamp.rs
+++ b/components/time/src/zone/zone_name_timestamp.rs
@@ -47,7 +47,7 @@ use crate::{DateTime, ZonedDateTime, zone::UtcOffset};
 ///
 /// let time_zone_info_past = metlakatla
 ///     .without_offset()
-///     .with_zone_name_timestamp(ZoneNameTimestamp::far_in_past());
+///     .with_zone_name_timestamp(ZoneNameTimestamp::from_epoch_seconds(0));
 /// let time_zone_info_future = metlakatla
 ///     .without_offset()
 ///     .with_zone_name_timestamp(ZoneNameTimestamp::far_in_future());
@@ -131,6 +131,10 @@ impl ZoneNameTimestamp {
 
     /// Creates an instance of [`ZoneNameTimestamp`] from a number of seconds since the UNIX epoch.
     pub fn from_epoch_seconds(seconds: i64) -> Self {
+        if seconds < 0 {
+            // Special value for all pre-epoch timestamps.
+            return Self(-1);
+        }
         let seconds = match seconds {
             // Values that are not multiples of 15, that we map to the next multiple
             // of 15 (which is always 00:15 or 00:45, values that are otherwise unused).
@@ -146,7 +150,7 @@ impl ZoneNameTimestamp {
             s => s,
         };
         let qh = seconds / 60 / 15;
-        Self(qh.clamp(i32::MIN as i64, i32::MAX as i64) as i32)
+        Self(qh.clamp(0, 0xFFFFFF) as i32)
     }
 
     /// Returns the *approximate* number of seconds since the UNIX epoch represented by this
@@ -328,15 +332,15 @@ mod test {
             // Min Value Clamping
             TestCase {
                 input: "1969-12-31T23:59Z",
-                output: "1970-01-01T00:00Z",
+                output: "1969-12-31T23:45Z",
             },
             TestCase {
                 input: "1969-12-31T12:00Z",
-                output: "1970-01-01T00:00Z",
+                output: "1969-12-31T23:45Z",
             },
             TestCase {
                 input: "1900-07-15T12:34Z",
-                output: "1970-01-01T00:00Z",
+                output: "1969-12-31T23:45Z",
             },
             // Max Value Clamping
             TestCase {

--- a/components/time/src/zone/zone_name_timestamp.rs
+++ b/components/time/src/zone/zone_name_timestamp.rs
@@ -60,7 +60,7 @@ use crate::{DateTime, ZonedDateTime, zone::UtcOffset};
 /// assert_writeable_eq!(name_future, "Alaska Time");
 /// ```
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct ZoneNameTimestamp(u32);
+pub struct ZoneNameTimestamp(i32);
 
 const RD_EPOCH: RataDie = calendrical_calculations::gregorian::fixed_from_gregorian(1970, 1, 1);
 
@@ -146,9 +146,7 @@ impl ZoneNameTimestamp {
             s => s,
         };
         let qh = seconds / 60 / 15;
-        let qh_clamped = qh.clamp(Self::far_in_past().0 as i64, Self::far_in_future().0 as i64);
-        // Valid cast as the value is clamped to u32 values.
-        Self(qh_clamped as u32)
+        Self(qh.clamp(i32::MIN as i64, i32::MAX as i64) as i32)
     }
 
     /// Returns the *approximate* number of seconds since the UNIX epoch represented by this
@@ -203,12 +201,12 @@ impl ZoneNameTimestamp {
 
     /// Returns a [`ZoneNameTimestamp`] for a time far in the past.
     pub fn far_in_past() -> Self {
-        Self(0)
+        Self::from_epoch_seconds(i64::MIN)
     }
 
     /// Returns a [`ZoneNameTimestamp`] for a time far in the future.
     pub fn far_in_future() -> Self {
-        Self(0xFFFFFF)
+        Self::from_epoch_seconds(i64::MAX)
     }
 }
 
@@ -222,11 +220,12 @@ impl AsULE for ZoneNameTimestamp {
     type ULE = <u32 as AsULE>::ULE;
     #[inline]
     fn to_unaligned(self) -> Self::ULE {
-        self.0.to_unaligned()
+        debug_assert!(self.0 >= 0, "serializing a negative ZoneNameTimestamp");
+        self.0.max(0).unsigned_abs().to_unaligned()
     }
     #[inline]
     fn from_unaligned(unaligned: Self::ULE) -> Self {
-        Self(u32::from_unaligned(unaligned))
+        Self(u32::from_unaligned(unaligned) as i32)
     }
 }
 
@@ -258,10 +257,9 @@ impl serde::Serialize for ZoneNameTimestamp {
                 use core::fmt::Write;
                 let _infallible = write!(&mut s, ":{second:02}");
             }
-            // don't serialize the metadata for now
             return serializer.serialize_str(&s);
         }
-        serializer.serialize_u32(self.0)
+        serializer.serialize_i32(self.0.max(0))
     }
 }
 
@@ -294,7 +292,7 @@ impl<'de> serde::Deserialize<'de> for ZoneNameTimestamp {
                 zone: UtcOffset::zero(),
             }));
         }
-        u32::deserialize(deserializer).map(Self)
+        i32::deserialize(deserializer).map(Self)
     }
 }
 

--- a/provider/source/src/time_zones/convert.rs
+++ b/provider/source/src/time_zones/convert.rs
@@ -373,7 +373,7 @@ impl DataProvider<TimezonePeriodsV1> for SourceDataProvider {
 
                     let (past, os, mz) = convert(&ps[0]);
 
-                    assert_eq!(past.0, ZoneNameTimestamp::far_in_past());
+                    assert_eq!(past.0, ZoneNameTimestamp::from_epoch_seconds(0));
 
                     let rest = ps[1..].iter().map(convert).collect::<ZeroVec<_>>();
 


### PR DESCRIPTION
Currently the lowest possible `ZoneNameTimestamp` (`::far_in_past()`) is `1970-01-01T00:00:00Z`, which is also the earliest time stamp at which CLDR has metazone data. However, as smaller time stamps cannot be represented, earlier `DateTime`s saturate to this, which leads to incorrect metazone information.

## Changelog

* `icu_datetime`
   * Fixed a bug where dates before 1970 would use confusing time zone names