### PR TITLE
Improve ergonomics of try_interpolate in icu_pattern

### DIFF
--- a/components/pattern/README.md
+++ b/components/pattern/README.md
@@ -24,7 +24,7 @@ let pattern = SinglePlaceholderPattern::try_from_str(
 .unwrap();
 
 // Interpolate into the pattern string:
-assert_writeable_eq!(pattern.interpolate(["World"]), "Hello, World!");
+assert_writeable_eq!(pattern.interpolate("World"), "Hello, World!");
 ```
 
 [`ICU4X`]: ../icu/index.html

--- a/components/pattern/src/common.rs
+++ b/components/pattern/src/common.rs
@@ -302,7 +302,7 @@ where
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[allow(clippy::exhaustive_structs)] // newtype
-pub struct TryWrap<T>(pub T);
+pub struct TryInterpolatePlaceholderValueProviderWrap<T>(pub T);
 
 /// Types that implement backing data models for [`Pattern`] and support placeholder extraction
 /// implement this trait.

--- a/components/pattern/src/common.rs
+++ b/components/pattern/src/common.rs
@@ -262,6 +262,50 @@ where
     }
 }
 
+/// A wrapper for input types that may bubble up errors via [`TryWriteable`].
+///
+/// # Examples
+///
+/// Format a pattern with one placeholder, which holds an error:
+///
+/// ```
+/// use either::Either;
+/// use icu_pattern::SinglePlaceholderPattern;
+/// use icu_pattern::TryWrap;
+/// use writeable::assert_try_writeable_eq;
+///
+/// let err_value = Err::<&str, &str>("Errory");
+///
+/// let pattern = SinglePlaceholderPattern::try_from_str("Hello {0}", Default::default()).unwrap();
+/// assert_try_writeable_eq!(
+///     pattern.try_interpolate(TryWrap(err_value)),
+///     "Hello Errory",
+///     Err("Errory")
+/// );
+/// ```
+///
+/// Format a pattern with two placeholders, where the second value is an error:
+///
+/// ```
+/// use either::Either;
+/// use icu_pattern::DoublePlaceholderPattern;
+/// use icu_pattern::TryWrap;
+/// use writeable::assert_try_writeable_eq;
+///
+/// let ok_value = Ok::<&str, &str>("xxx");
+/// let err_value = Err::<&str, &str>("yyy");
+///
+/// let pattern = DoublePlaceholderPattern::try_from_str("{0}-{1}", Default::default()).unwrap();
+/// assert_try_writeable_eq!(
+///     pattern.try_interpolate(TryWrap((ok_value, err_value))),
+///     "xxx-yyy",
+///     Err(Either::Right("yyy"))
+/// );
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(clippy::exhaustive_structs)] // newtype
+pub struct TryWrap<T>(pub T);
+
 /// Types that implement backing data models for [`Pattern`] and support placeholder extraction
 /// implement this trait.
 ///

--- a/components/pattern/src/common.rs
+++ b/components/pattern/src/common.rs
@@ -132,6 +132,7 @@ pub trait PatternBackend: crate::private::Sealed + 'static + core::fmt::Debug {
 /// use icu_pattern::DoublePlaceholder;
 /// use icu_pattern::DoublePlaceholderKey;
 /// use icu_pattern::PlaceholderValueProvider;
+/// use icu_pattern::InterpolatePlaceholderValueProviderWrap;
 /// use writeable::adapters::WithPart;
 /// use writeable::adapters::WriteableAsTryWriteableInfallible;
 /// use writeable::assert_writeable_parts_eq;
@@ -159,7 +160,7 @@ pub trait PatternBackend: crate::private::Sealed + 'static + core::fmt::Debug {
 ///     value: "literal",
 /// };
 ///
-/// impl PlaceholderValueProvider<DoublePlaceholderKey> for ValuesWithParts<'_> {
+/// impl PlaceholderValueProvider<DoublePlaceholderKey> for InterpolatePlaceholderValueProviderWrap<ValuesWithParts<'_>> {
 ///     type Error = core::convert::Infallible;
 ///
 ///     type W<'a> = WriteableAsTryWriteableInfallible<WithPart<&'a str>>
@@ -174,11 +175,11 @@ pub trait PatternBackend: crate::private::Sealed + 'static + core::fmt::Debug {
 ///     fn value_for(&self, key: DoublePlaceholderKey) -> Self::W<'_> {
 ///         let writeable = match key {
 ///             DoublePlaceholderKey::Place0 => WithPart {
-///                 writeable: self.0,
+///                 writeable: self.0.0,
 ///                 part: PART_PLACEHOLDER_0,
 ///             },
 ///             DoublePlaceholderKey::Place1 => WithPart {
-///                 writeable: self.1,
+///                 writeable: self.0.1,
 ///                 part: PART_PLACEHOLDER_1,
 ///             },
 ///         };
@@ -261,6 +262,10 @@ where
         (*self).map_literal(literal)
     }
 }
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(clippy::exhaustive_structs)] // newtype
+pub struct InterpolatePlaceholderValueProviderWrap<T>(pub T);
 
 /// A wrapper for input types that may bubble up errors via [`TryWriteable`].
 ///

--- a/components/pattern/src/common.rs
+++ b/components/pattern/src/common.rs
@@ -271,14 +271,13 @@ where
 /// ```
 /// use either::Either;
 /// use icu_pattern::SinglePlaceholderPattern;
-/// use icu_pattern::TryWrap;
 /// use writeable::assert_try_writeable_eq;
 ///
 /// let err_value = Err::<&str, &str>("Errory");
 ///
 /// let pattern = SinglePlaceholderPattern::try_from_str("Hello {0}", Default::default()).unwrap();
 /// assert_try_writeable_eq!(
-///     pattern.try_interpolate(TryWrap(err_value)),
+///     pattern.try_interpolate(err_value),
 ///     "Hello Errory",
 ///     Err("Errory")
 /// );
@@ -289,7 +288,6 @@ where
 /// ```
 /// use either::Either;
 /// use icu_pattern::DoublePlaceholderPattern;
-/// use icu_pattern::TryWrap;
 /// use writeable::assert_try_writeable_eq;
 ///
 /// let ok_value = Ok::<&str, &str>("xxx");
@@ -297,7 +295,7 @@ where
 ///
 /// let pattern = DoublePlaceholderPattern::try_from_str("{0}-{1}", Default::default()).unwrap();
 /// assert_try_writeable_eq!(
-///     pattern.try_interpolate(TryWrap((ok_value, err_value))),
+///     pattern.try_interpolate((ok_value, err_value)),
 ///     "xxx-yyy",
 ///     Err(Either::Right("yyy"))
 /// );

--- a/components/pattern/src/double.rs
+++ b/components/pattern/src/double.rs
@@ -131,31 +131,7 @@ where
     }
 }
 
-/// A pair of values for [`DoublePlaceholder`] that may bubble up errors.
-///
-/// # Examples
-///
-/// Format a pattern with two placeholders, where the second value is an error:
-///
-/// ```
-/// use either::Either;
-/// use icu_pattern::DoublePlaceholderPattern;
-/// use icu_pattern::DoublePlaceholderValueProviderTry;
-/// use writeable::assert_try_writeable_eq;
-///
-/// let pattern = DoublePlaceholderPattern::try_from_str("{0}-{1}", Default::default()).unwrap();
-/// assert_try_writeable_eq!(
-///     pattern.try_interpolate(DoublePlaceholderValueProviderTry(Ok::<&str, &str>("xxx"), Err::<&str, &str>("yyy"))),
-///     "xxx-yyy",
-///     Err(Either::Right("yyy"))
-/// );
-/// ```
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[allow(clippy::exhaustive_structs)] // holds two placeholder values
-pub struct DoublePlaceholderValueProviderTry<W0, W1>(pub W0, pub W1);
-
-impl<W0, W1> PlaceholderValueProvider<DoublePlaceholderKey>
-    for DoublePlaceholderValueProviderTry<W0, W1>
+impl<W0, W1> PlaceholderValueProvider<DoublePlaceholderKey> for TryWrap<(W0, W1)>
 where
     W0: TryWriteable,
     W1: TryWriteable,
@@ -175,8 +151,8 @@ where
     #[inline]
     fn value_for(&self, key: DoublePlaceholderKey) -> Self::W<'_> {
         match key {
-            DoublePlaceholderKey::Place0 => Either::Left(&self.0),
-            DoublePlaceholderKey::Place1 => Either::Right(&self.1),
+            DoublePlaceholderKey::Place0 => Either::Left(&self.0.0),
+            DoublePlaceholderKey::Place1 => Either::Right(&self.0.1),
         }
     }
     #[inline]

--- a/components/pattern/src/double.rs
+++ b/components/pattern/src/double.rs
@@ -131,7 +131,8 @@ where
     }
 }
 
-impl<W0, W1> PlaceholderValueProvider<DoublePlaceholderKey> for TryWrap<(W0, W1)>
+impl<W0, W1> PlaceholderValueProvider<DoublePlaceholderKey>
+    for TryInterpolatePlaceholderValueProviderWrap<(W0, W1)>
 where
     W0: TryWriteable,
     W1: TryWriteable,

--- a/components/pattern/src/double.rs
+++ b/components/pattern/src/double.rs
@@ -69,7 +69,8 @@ impl FromStr for DoublePlaceholderKey {
     }
 }
 
-impl<W0, W1> PlaceholderValueProvider<DoublePlaceholderKey> for (W0, W1)
+impl<W0, W1> PlaceholderValueProvider<DoublePlaceholderKey>
+    for InterpolatePlaceholderValueProviderWrap<(W0, W1)>
 where
     W0: Writeable,
     W1: Writeable,
@@ -89,8 +90,8 @@ where
     #[inline]
     fn value_for(&self, key: DoublePlaceholderKey) -> Self::W<'_> {
         let writeable = match key {
-            DoublePlaceholderKey::Place0 => Either::Left(&self.0),
-            DoublePlaceholderKey::Place1 => Either::Right(&self.1),
+            DoublePlaceholderKey::Place0 => Either::Left(&self.0.0),
+            DoublePlaceholderKey::Place1 => Either::Right(&self.0.1),
         };
         WriteableAsTryWriteableInfallible(writeable)
     }
@@ -100,7 +101,8 @@ where
     }
 }
 
-impl<W> PlaceholderValueProvider<DoublePlaceholderKey> for [W; 2]
+impl<W> PlaceholderValueProvider<DoublePlaceholderKey>
+    for InterpolatePlaceholderValueProviderWrap<[W; 2]>
 where
     W: Writeable,
 {
@@ -118,7 +120,7 @@ where
 
     #[inline]
     fn value_for(&self, key: DoublePlaceholderKey) -> Self::W<'_> {
-        let [item0, item1] = self;
+        let [item0, item1] = &self.0;
         let writeable = match key {
             DoublePlaceholderKey::Place0 => item0,
             DoublePlaceholderKey::Place1 => item1,

--- a/components/pattern/src/frontend/mod.rs
+++ b/components/pattern/src/frontend/mod.rs
@@ -258,13 +258,16 @@ where
     pub fn try_interpolate<'a, P>(
         &'a self,
         value_provider: P,
-    ) -> impl TryWriteable<Error = P::Error> + fmt::Display + 'a
+    ) -> impl TryWriteable<
+        Error = <TryWrap<P> as PlaceholderValueProvider<B::PlaceholderKey<'a>>>::Error,
+    > + fmt::Display
+    + 'a
     where
-        P: PlaceholderValueProvider<B::PlaceholderKey<'a>> + 'a,
+        TryWrap<P>: PlaceholderValueProvider<B::PlaceholderKey<'a>> + 'a,
     {
-        WriteablePattern::<B, P> {
+        WriteablePattern::<B, TryWrap<P>> {
             store: &self.store,
-            value_provider,
+            value_provider: TryWrap(value_provider),
         }
     }
 
@@ -277,9 +280,15 @@ where
     pub fn try_interpolate_to_string<'a, P>(
         &'a self,
         value_provider: P,
-    ) -> Result<String, (P::Error, String)>
+    ) -> Result<
+        String,
+        (
+            <TryWrap<P> as PlaceholderValueProvider<B::PlaceholderKey<'a>>>::Error,
+            String,
+        ),
+    >
     where
-        P: PlaceholderValueProvider<B::PlaceholderKey<'a>> + 'a,
+        TryWrap<P>: PlaceholderValueProvider<B::PlaceholderKey<'a>> + 'a,
     {
         self.try_interpolate(value_provider)
             .try_write_to_string()

--- a/components/pattern/src/frontend/mod.rs
+++ b/components/pattern/src/frontend/mod.rs
@@ -57,7 +57,7 @@ use writeable::{PartsWrite, TryWriteable, Writeable, adapters::TryWriteableInfal
 /// )
 /// .unwrap();
 ///
-/// assert_writeable_eq!(pattern.interpolate(["Alice"]), "Hello, Alice!");
+/// assert_writeable_eq!(pattern.interpolate("Alice"), "Hello, Alice!");
 /// ```
 ///
 /// [`SinglePlaceholder`]: crate::SinglePlaceholder
@@ -308,11 +308,15 @@ where
     /// This is defined only on infallible inputs.
     pub fn interpolate<'a, P>(&'a self, value_provider: P) -> impl Writeable + fmt::Display + 'a
     where
-        P: PlaceholderValueProvider<B::PlaceholderKey<'a>, Error = Infallible> + 'a,
+        InterpolatePlaceholderValueProviderWrap<P>:
+            PlaceholderValueProvider<B::PlaceholderKey<'a>, Error = Infallible> + 'a,
     {
-        TryWriteableInfallibleAsWriteable(WriteablePattern::<B, P> {
+        TryWriteableInfallibleAsWriteable(WriteablePattern::<
+            B,
+            InterpolatePlaceholderValueProviderWrap<P>,
+        > {
             store: &self.store,
-            value_provider,
+            value_provider: InterpolatePlaceholderValueProviderWrap(value_provider),
         })
     }
 
@@ -324,7 +328,8 @@ where
     /// ✨ *Enabled with the `alloc` Cargo feature.*
     pub fn interpolate_to_string<'a, P>(&'a self, value_provider: P) -> String
     where
-        P: PlaceholderValueProvider<B::PlaceholderKey<'a>, Error = Infallible> + 'a,
+        InterpolatePlaceholderValueProviderWrap<P>:
+            PlaceholderValueProvider<B::PlaceholderKey<'a>, Error = Infallible> + 'a,
     {
         self.interpolate(value_provider)
             .write_to_string()

--- a/components/pattern/src/frontend/mod.rs
+++ b/components/pattern/src/frontend/mod.rs
@@ -259,15 +259,18 @@ where
         &'a self,
         value_provider: P,
     ) -> impl TryWriteable<
-        Error = <TryWrap<P> as PlaceholderValueProvider<B::PlaceholderKey<'a>>>::Error,
+        Error = <TryInterpolatePlaceholderValueProviderWrap<P> as PlaceholderValueProvider<
+            B::PlaceholderKey<'a>,
+        >>::Error,
     > + fmt::Display
     + 'a
     where
-        TryWrap<P>: PlaceholderValueProvider<B::PlaceholderKey<'a>> + 'a,
+        TryInterpolatePlaceholderValueProviderWrap<P>:
+            PlaceholderValueProvider<B::PlaceholderKey<'a>> + 'a,
     {
-        WriteablePattern::<B, TryWrap<P>> {
+        WriteablePattern::<B, TryInterpolatePlaceholderValueProviderWrap<P>> {
             store: &self.store,
-            value_provider: TryWrap(value_provider),
+            value_provider: TryInterpolatePlaceholderValueProviderWrap(value_provider),
         }
     }
 
@@ -283,12 +286,15 @@ where
     ) -> Result<
         String,
         (
-            <TryWrap<P> as PlaceholderValueProvider<B::PlaceholderKey<'a>>>::Error,
+            <TryInterpolatePlaceholderValueProviderWrap<P> as PlaceholderValueProvider<
+                B::PlaceholderKey<'a>,
+            >>::Error,
             String,
         ),
     >
     where
-        TryWrap<P>: PlaceholderValueProvider<B::PlaceholderKey<'a>> + 'a,
+        TryInterpolatePlaceholderValueProviderWrap<P>:
+            PlaceholderValueProvider<B::PlaceholderKey<'a>> + 'a,
     {
         self.try_interpolate(value_provider)
             .try_write_to_string()

--- a/components/pattern/src/lib.rs
+++ b/components/pattern/src/lib.rs
@@ -37,7 +37,7 @@
 //! .unwrap();
 //!
 //! // Interpolate into the pattern string:
-//! assert_writeable_eq!(pattern.interpolate(["World"]), "Hello, World!");
+//! assert_writeable_eq!(pattern.interpolate("World"), "Hello, World!");
 //! ```
 //!
 //! [`ICU4X`]: ../icu/index.html
@@ -61,6 +61,7 @@ mod single;
 pub use PatternError as Error;
 #[cfg(feature = "unstable")]
 pub use common::ExtractionBackend;
+pub use common::InterpolatePlaceholderValueProviderWrap;
 pub use common::PatternBackend;
 pub use common::PatternItem;
 #[cfg(feature = "alloc")]
@@ -110,7 +111,7 @@ mod private {
 /// .unwrap();
 ///
 /// // Interpolate some values into the pattern:
-/// assert_writeable_eq!(pattern.interpolate(["Alice"]), "Hello, Alice!");
+/// assert_writeable_eq!(pattern.interpolate("Alice"), "Hello, Alice!");
 /// ```
 pub type SinglePlaceholderPattern = Pattern<SinglePlaceholder>;
 
@@ -131,7 +132,7 @@ impl SinglePlaceholderPattern {
     /// );
     ///
     /// assert_writeable_eq!(
-    ///     SinglePlaceholderPattern::PASS_THROUGH.interpolate(["hello, world!"]),
+    ///     SinglePlaceholderPattern::PASS_THROUGH.interpolate("hello, world!"),
     ///     "hello, world!"
     /// );
     /// ```

--- a/components/pattern/src/lib.rs
+++ b/components/pattern/src/lib.rs
@@ -66,9 +66,9 @@ pub use common::PatternItem;
 #[cfg(feature = "alloc")]
 pub use common::PatternItemCow;
 pub use common::PlaceholderValueProvider;
+pub use common::TryWrap;
 pub use double::DoublePlaceholder;
 pub use double::DoublePlaceholderKey;
-pub use double::DoublePlaceholderValueProviderTry;
 pub use error::PatternError;
 pub use frontend::Pattern;
 #[cfg(feature = "unstable")]
@@ -90,7 +90,6 @@ pub use parser::ParserOptions;
 pub use parser::QuoteMode;
 pub use single::SinglePlaceholder;
 pub use single::SinglePlaceholderKey;
-pub use single::SinglePlaceholderValueProviderTry;
 
 mod private {
     pub trait Sealed {}

--- a/components/pattern/src/lib.rs
+++ b/components/pattern/src/lib.rs
@@ -66,7 +66,7 @@ pub use common::PatternItem;
 #[cfg(feature = "alloc")]
 pub use common::PatternItemCow;
 pub use common::PlaceholderValueProvider;
-pub use common::TryWrap;
+pub use common::TryInterpolatePlaceholderValueProviderWrap;
 pub use double::DoublePlaceholder;
 pub use double::DoublePlaceholderKey;
 pub use error::PatternError;

--- a/components/pattern/src/multi_named.rs
+++ b/components/pattern/src/multi_named.rs
@@ -148,6 +148,38 @@ where
     }
 }
 
+// NOTE: This impl allows `BTreeMap` and `LiteMap` to be passed directly into
+// `Pattern::try_interpolate`. However, it does not offer a built-in impl to
+// bubble up TryWriteable errors in MultiNamedPlaceholder. In other words, one
+// might expect `TryWrap<LiteMap<K, V>>` to bubble up errors from `V: TryWriteable`,
+// but this impl prevents that from happening. Instead, a further impl will be
+// needed in the future (which could be outside this crate).
+impl<'k, T> PlaceholderValueProvider<MultiNamedPlaceholderKey<'k>> for TryWrap<T>
+where
+    T: PlaceholderValueProvider<MultiNamedPlaceholderKey<'k>>,
+{
+    type Error = T::Error;
+
+    type W<'a>
+        = T::W<'a>
+    where
+        Self: 'a;
+
+    type L<'a, 'l>
+        = T::L<'a, 'l>
+    where
+        Self: 'a;
+
+    #[inline]
+    fn value_for<'a>(&'a self, key: MultiNamedPlaceholderKey<'k>) -> Self::W<'a> {
+        self.0.value_for(key)
+    }
+    #[inline]
+    fn map_literal<'a, 'l>(&'a self, literal: &'l str) -> Self::L<'a, 'l> {
+        self.0.map_literal(literal)
+    }
+}
+
 /// Backend for patterns containing zero or more named placeholders.
 ///
 /// This empty type is not constructible.

--- a/components/pattern/src/multi_named.rs
+++ b/components/pattern/src/multi_named.rs
@@ -151,10 +151,12 @@ where
 // NOTE: This impl allows `BTreeMap` and `LiteMap` to be passed directly into
 // `Pattern::try_interpolate`. However, it does not offer a built-in impl to
 // bubble up TryWriteable errors in MultiNamedPlaceholder. In other words, one
-// might expect `TryWrap<LiteMap<K, V>>` to bubble up errors from `V: TryWriteable`,
-// but this impl prevents that from happening. Instead, a further impl will be
-// needed in the future (which could be outside this crate).
-impl<'k, T> PlaceholderValueProvider<MultiNamedPlaceholderKey<'k>> for TryWrap<T>
+// might expect `TryInterpolatePlaceholderValueProviderWrap<LiteMap<K, V>>`
+// to bubble up errors from `V: TryWriteable`, but this impl prevents that
+// from happening. Instead, a further impl will be needed in the future
+// (which could be outside this crate).
+impl<'k, T> PlaceholderValueProvider<MultiNamedPlaceholderKey<'k>>
+    for TryInterpolatePlaceholderValueProviderWrap<T>
 where
     T: PlaceholderValueProvider<MultiNamedPlaceholderKey<'k>>,
 {

--- a/components/pattern/src/single.rs
+++ b/components/pattern/src/single.rs
@@ -111,7 +111,8 @@ where
     }
 }
 
-impl<W> PlaceholderValueProvider<SinglePlaceholderKey> for TryWrap<W>
+impl<W> PlaceholderValueProvider<SinglePlaceholderKey>
+    for TryInterpolatePlaceholderValueProviderWrap<W>
 where
     W: TryWriteable,
 {

--- a/components/pattern/src/single.rs
+++ b/components/pattern/src/single.rs
@@ -60,7 +60,8 @@ impl FromStr for SinglePlaceholderKey {
     }
 }
 
-impl<W> PlaceholderValueProvider<SinglePlaceholderKey> for (W,)
+impl<W> PlaceholderValueProvider<SinglePlaceholderKey>
+    for InterpolatePlaceholderValueProviderWrap<W>
 where
     W: Writeable,
 {
@@ -78,32 +79,6 @@ where
 
     fn value_for(&self, _key: SinglePlaceholderKey) -> Self::W<'_> {
         WriteableAsTryWriteableInfallible(&self.0)
-    }
-    #[inline]
-    fn map_literal<'a, 'l>(&'a self, literal: &'l str) -> Self::L<'a, 'l> {
-        literal
-    }
-}
-
-impl<W> PlaceholderValueProvider<SinglePlaceholderKey> for [W; 1]
-where
-    W: Writeable,
-{
-    type Error = Infallible;
-
-    type W<'a>
-        = WriteableAsTryWriteableInfallible<&'a W>
-    where
-        Self: 'a;
-
-    type L<'a, 'l>
-        = &'l str
-    where
-        Self: 'a;
-
-    fn value_for(&self, _key: SinglePlaceholderKey) -> Self::W<'_> {
-        let [value] = self;
-        WriteableAsTryWriteableInfallible(value)
     }
     #[inline]
     fn map_literal<'a, 'l>(&'a self, literal: &'l str) -> Self::L<'a, 'l> {
@@ -187,7 +162,7 @@ where
 ///         Default::default()
 ///     )
 ///     .unwrap()
-///     .interpolate_to_string([5]),
+///     .interpolate_to_string(5),
 ///     "5 days ago",
 /// );
 ///
@@ -198,7 +173,7 @@ where
 ///         Default::default()
 ///     )
 ///     .unwrap()
-///     .interpolate_to_string(["Alice"]),
+///     .interpolate_to_string("Alice"),
 ///     "Alice",
 /// );
 ///
@@ -209,7 +184,7 @@ where
 ///         Default::default()
 ///     )
 ///     .unwrap()
-///     .interpolate_to_string(["hi"]),
+///     .interpolate_to_string("hi"),
 ///     "yesterday",
 /// );
 ///
@@ -220,7 +195,7 @@ where
 ///         QuoteMode::QuotingSupported.into()
 ///     )
 ///     .unwrap()
-///     .interpolate_to_string(("hi",)),
+///     .interpolate_to_string("hi"),
 ///     "{0} hi",
 /// );
 /// ```

--- a/components/pattern/src/single.rs
+++ b/components/pattern/src/single.rs
@@ -111,30 +111,7 @@ where
     }
 }
 
-/// A value for [`SinglePlaceholder`] that may bubble up errors.
-///
-/// # Examples
-///
-/// Format a pattern with one placeholder, which holds an error:
-///
-/// ```
-/// use either::Either;
-/// use icu_pattern::SinglePlaceholderPattern;
-/// use icu_pattern::SinglePlaceholderValueProviderTry;
-/// use writeable::assert_try_writeable_eq;
-///
-/// let pattern = SinglePlaceholderPattern::try_from_str("Hello {0}", Default::default()).unwrap();
-/// assert_try_writeable_eq!(
-///     pattern.try_interpolate(SinglePlaceholderValueProviderTry(Err::<&str, &str>("Errory"))),
-///     "Hello Errory",
-///     Err("Errory")
-/// );
-/// ```
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[allow(clippy::exhaustive_structs)] // holds a single placeholder value
-pub struct SinglePlaceholderValueProviderTry<W>(pub W);
-
-impl<W> PlaceholderValueProvider<SinglePlaceholderKey> for SinglePlaceholderValueProviderTry<W>
+impl<W> PlaceholderValueProvider<SinglePlaceholderKey> for TryWrap<W>
 where
     W: TryWriteable,
 {


### PR DESCRIPTION
Fixes https://github.com/unicode-org/icu4x/issues/8130

REVIEW REQUEST: There are 3 commits, each independent.

- Commit 1: I would like to land this one. I think it is a clear improvement.
- Commit 2: I could go either way on this one. See the long comment in multi_named.rs for a caveat.
- Commit 3: If we go with Commit 2, I think I probably want to rename the type to sound more scaffoldy.

## Changelog

icu_pattern: add TryWrap or TryInterpolatePlaceholderValueProviderWrap; maybe change bounds on try_interpolate