### PR TITLE
Add icu_pattern::TryWrap; remove single and double wrappers

### DIFF
--- a/components/locale/src/names/language.rs
+++ b/components/locale/src/names/language.rs
@@ -20,7 +20,7 @@ use crate::size_test_macro::size_test;
 use alloc::vec::Vec;
 use icu_locale_core::LanguageIdentifier;
 use icu_locale_core::subtags::{Language, Region, Script, Variant};
-use icu_pattern::{DoublePlaceholderPattern, DoublePlaceholderValueProviderTry, PatternItem};
+use icu_pattern::{DoublePlaceholderPattern, PatternItem, TryWrap};
 use icu_provider::DataPayloadOr;
 use icu_provider::marker::ErasedMarker;
 use icu_provider::prelude::*;
@@ -2041,10 +2041,7 @@ impl<'a> TryWriteable for LanguageIdentifierDisplayNameInner<'a> {
             let result = self
                 .qualifiers
                 .glue
-                .try_interpolate(DoublePlaceholderValueProviderTry(
-                    self.base_name,
-                    self.qualifiers,
-                ))
+                .try_interpolate(TryWrap((self.base_name, self.qualifiers)))
                 .try_write_to_parts(sink)?;
             Ok(result.map_err(either::Either::into_inner))
         }
@@ -2056,10 +2053,7 @@ impl<'a> TryWriteable for LanguageIdentifierDisplayNameInner<'a> {
         } else {
             self.qualifiers
                 .glue
-                .try_interpolate(DoublePlaceholderValueProviderTry(
-                    self.base_name,
-                    self.qualifiers,
-                ))
+                .try_interpolate(TryWrap((self.base_name, self.qualifiers)))
                 .writeable_length_hint()
         }
     }

--- a/components/pattern/src/common.rs
+++ b/components/pattern/src/common.rs
@@ -262,6 +262,50 @@ where
     }
 }
 
+/// A wrapper for input types that may bubble up errors via [`TryWriteable`].
+///
+/// # Examples
+///
+/// Format a pattern with one placeholder, which holds an error:
+///
+/// ```
+/// use either::Either;
+/// use icu_pattern::SinglePlaceholderPattern;
+/// use icu_pattern::TryWrap;
+/// use writeable::assert_try_writeable_eq;
+///
+/// let err_value = Err::<&str, &str>("Errory");
+///
+/// let pattern = SinglePlaceholderPattern::try_from_str("Hello {0}", Default::default()).unwrap();
+/// assert_try_writeable_eq!(
+///     pattern.try_interpolate(TryWrap(err_value)),
+///     "Hello Errory",
+///     Err("Errory")
+/// );
+/// ```
+///
+/// Format a pattern with two placeholders, where the second value is an error:
+///
+/// ```
+/// use either::Either;
+/// use icu_pattern::DoublePlaceholderPattern;
+/// use icu_pattern::TryWrap;
+/// use writeable::assert_try_writeable_eq;
+///
+/// let ok_value = Ok::<&str, &str>("xxx");
+/// let err_value = Err::<&str, &str>("yyy");
+///
+/// let pattern = DoublePlaceholderPattern::try_from_str("{0}-{1}", Default::default()).unwrap();
+/// assert_try_writeable_eq!(
+///     pattern.try_interpolate(TryWrap((ok_value, err_value))),
+///     "xxx-yyy",
+///     Err(Either::Right("yyy"))
+/// );
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(clippy::exhaustive_structs)] // newtype
+pub struct TryWrap<T>(pub T);
+
 /// Types that implement backing data models for [`Pattern`] and support placeholder extraction
 /// implement this trait.
 ///

--- a/components/pattern/src/double.rs
+++ b/components/pattern/src/double.rs
@@ -131,31 +131,7 @@ where
     }
 }
 
-/// A pair of values for [`DoublePlaceholder`] that may bubble up errors.
-///
-/// # Examples
-///
-/// Format a pattern with two placeholders, where the second value is an error:
-///
-/// ```
-/// use either::Either;
-/// use icu_pattern::DoublePlaceholderPattern;
-/// use icu_pattern::DoublePlaceholderValueProviderTry;
-/// use writeable::assert_try_writeable_eq;
-///
-/// let pattern = DoublePlaceholderPattern::try_from_str("{0}-{1}", Default::default()).unwrap();
-/// assert_try_writeable_eq!(
-///     pattern.try_interpolate(DoublePlaceholderValueProviderTry(Ok::<&str, &str>("xxx"), Err::<&str, &str>("yyy"))),
-///     "xxx-yyy",
-///     Err(Either::Right("yyy"))
-/// );
-/// ```
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[allow(clippy::exhaustive_structs)] // holds two placeholder values
-pub struct DoublePlaceholderValueProviderTry<W0, W1>(pub W0, pub W1);
-
-impl<W0, W1> PlaceholderValueProvider<DoublePlaceholderKey>
-    for DoublePlaceholderValueProviderTry<W0, W1>
+impl<W0, W1> PlaceholderValueProvider<DoublePlaceholderKey> for TryWrap<(W0, W1)>
 where
     W0: TryWriteable,
     W1: TryWriteable,
@@ -175,8 +151,8 @@ where
     #[inline]
     fn value_for(&self, key: DoublePlaceholderKey) -> Self::W<'_> {
         match key {
-            DoublePlaceholderKey::Place0 => Either::Left(&self.0),
-            DoublePlaceholderKey::Place1 => Either::Right(&self.1),
+            DoublePlaceholderKey::Place0 => Either::Left(&self.0.0),
+            DoublePlaceholderKey::Place1 => Either::Right(&self.0.1),
         }
     }
     #[inline]

--- a/components/pattern/src/lib.rs
+++ b/components/pattern/src/lib.rs
@@ -66,9 +66,9 @@ pub use common::PatternItem;
 #[cfg(feature = "alloc")]
 pub use common::PatternItemCow;
 pub use common::PlaceholderValueProvider;
+pub use common::TryWrap;
 pub use double::DoublePlaceholder;
 pub use double::DoublePlaceholderKey;
-pub use double::DoublePlaceholderValueProviderTry;
 pub use error::PatternError;
 pub use frontend::Pattern;
 #[cfg(feature = "unstable")]
@@ -90,7 +90,6 @@ pub use parser::ParserOptions;
 pub use parser::QuoteMode;
 pub use single::SinglePlaceholder;
 pub use single::SinglePlaceholderKey;
-pub use single::SinglePlaceholderValueProviderTry;
 
 mod private {
     pub trait Sealed {}

--- a/components/pattern/src/single.rs
+++ b/components/pattern/src/single.rs
@@ -111,30 +111,7 @@ where
     }
 }
 
-/// A value for [`SinglePlaceholder`] that may bubble up errors.
-///
-/// # Examples
-///
-/// Format a pattern with one placeholder, which holds an error:
-///
-/// ```
-/// use either::Either;
-/// use icu_pattern::SinglePlaceholderPattern;
-/// use icu_pattern::SinglePlaceholderValueProviderTry;
-/// use writeable::assert_try_writeable_eq;
-///
-/// let pattern = SinglePlaceholderPattern::try_from_str("Hello {0}", Default::default()).unwrap();
-/// assert_try_writeable_eq!(
-///     pattern.try_interpolate(SinglePlaceholderValueProviderTry(Err::<&str, &str>("Errory"))),
-///     "Hello Errory",
-///     Err("Errory")
-/// );
-/// ```
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[allow(clippy::exhaustive_structs)] // holds a single placeholder value
-pub struct SinglePlaceholderValueProviderTry<W>(pub W);
-
-impl<W> PlaceholderValueProvider<SinglePlaceholderKey> for SinglePlaceholderValueProviderTry<W>
+impl<W> PlaceholderValueProvider<SinglePlaceholderKey> for TryWrap<W>
 where
     W: TryWriteable,
 {


### PR DESCRIPTION
Fixes #8130

There's potential for future improvement here. See #8363

## Changelog

icu_pattern: add `TryWrap` for bubbling through TryWriteable errors