### PR TITLE
Reformat docs tests

### DIFF
--- a/components/calendar/README.md
+++ b/components/calendar/README.md
@@ -27,7 +27,7 @@ for working with dates, encompassing information about the day, month, year,
 as well as the calendar type.
 
 ```rust
-use icu::calendar::{types::Weekday, Date};
+use icu::calendar::{Date, types::Weekday};
 
 // Creating ISO date: 1992-09-02.
 let mut date_iso = Date::try_new_iso(1992, 9, 2)
@@ -46,8 +46,8 @@ assert_eq!(date_iso.days_in_month(), 30);
 Example of converting an ISO date across Indian and Buddhist calendars.
 
 ```rust
-use icu::calendar::cal::{Buddhist, Indian};
 use icu::calendar::Date;
+use icu::calendar::cal::{Buddhist, Indian};
 
 // Creating ISO date: 1992-09-02.
 let mut date_iso = Date::try_new_iso(1992, 9, 2)

--- a/components/calendar/src/cal/east_asian_traditional.rs
+++ b/components/calendar/src/cal/east_asian_traditional.rs
@@ -360,8 +360,8 @@ impl Rules for China {
 /// [Yuk Tung Liu]: https://ytliu0.github.io/ChineseCalendar/table.html
 ///
 /// ```rust
-/// use icu::calendar::cal::{ChineseTraditional, KoreanTraditional};
 /// use icu::calendar::Date;
+/// use icu::calendar::cal::{ChineseTraditional, KoreanTraditional};
 ///
 /// let iso_a = Date::try_new_iso(2012, 4, 23).unwrap();
 /// let korean_a = iso_a.to_calendar(KoreanTraditional::new());
@@ -480,8 +480,8 @@ impl Date<KoreanTraditional> {
     /// valid range of `-9999..=9999`.
     ///
     /// ```rust
-    /// use icu::calendar::types::Month;
     /// use icu::calendar::Date;
+    /// use icu::calendar::types::Month;
     ///
     /// let date = Date::try_new_korean_traditional(2025, Month::new(5), 25)
     ///     .expect("Failed to initialize Date instance.");
@@ -845,8 +845,8 @@ impl Date<ChineseTraditional> {
     /// valid range of `-9999..=9999`.
     ///
     /// ```rust
-    /// use icu::calendar::types::Month;
     /// use icu::calendar::Date;
+    /// use icu::calendar::types::Month;
     ///
     /// let date = Date::try_new_chinese_traditional(2025, Month::new(5), 25)
     ///     .expect("Failed to initialize Date instance.");

--- a/components/calendar/src/cal/ethiopian.rs
+++ b/components/calendar/src/cal/ethiopian.rs
@@ -306,8 +306,8 @@ impl Date<Ethiopian> {
     /// Years are interpreted according to the provided `era_style`.
     ///
     /// ```rust
-    /// use icu::calendar::cal::EthiopianEraStyle;
     /// use icu::calendar::Date;
+    /// use icu::calendar::cal::EthiopianEraStyle;
     ///
     /// let date_ethiopian =
     ///     Date::try_new_ethiopian(EthiopianEraStyle::AmeteMihret, 2014, 8, 25)

--- a/components/calendar/src/cal/hebrew.rs
+++ b/components/calendar/src/cal/hebrew.rs
@@ -420,8 +420,8 @@ impl Date<Hebrew> {
     /// valid range of `-9999..=9999`.
     ///
     /// ```rust
-    /// use icu::calendar::types::Month;
     /// use icu::calendar::Date;
+    /// use icu::calendar::types::Month;
     ///
     /// let date = Date::try_new_hebrew_v2(5782, Month::leap(5), 7)
     ///     .expect("Failed to initialize Date instance.");

--- a/components/calendar/src/cal/hijri.rs
+++ b/components/calendar/src/cal/hijri.rs
@@ -1070,8 +1070,8 @@ impl<A: AsCalendar<Calendar = Hijri<R>>, R: Rules> Date<A> {
     /// valid range of `-9999..=9999`.
     ///
     /// ```rust
-    /// use icu::calendar::cal::Hijri;
     /// use icu::calendar::Date;
+    /// use icu::calendar::cal::Hijri;
     ///
     /// let hijri = Hijri::new_umm_al_qura();
     ///

--- a/components/calendar/src/date.rs
+++ b/components/calendar/src/date.rs
@@ -170,9 +170,9 @@ impl<A: AsCalendar> Date<A> {
     /// # Examples
     ///
     /// ```rust
-    /// use icu::calendar::types::{Month, YearInput};
     /// use icu::calendar::Date;
     /// use icu::calendar::Iso;
+    /// use icu::calendar::types::{Month, YearInput};
     ///
     /// // Example: creation of ISO date from integers.
     /// let date_iso = Date::try_new(1970.into(), Month::new(1), 2, Iso)
@@ -211,9 +211,9 @@ impl<A: AsCalendar> Date<A> {
     /// # Examples
     ///
     /// ```
+    /// use icu::calendar::Date;
     /// use icu::calendar::cal::Gregorian;
     /// use icu::calendar::types::DateFields;
-    /// use icu::calendar::Date;
     ///
     /// let mut fields = DateFields::default();
     /// fields.extended_year = Some(2000);
@@ -246,7 +246,7 @@ impl<A: AsCalendar> Date<A> {
     /// described on the [`Date`] type instead clamping the result:
     ///
     /// ```rust
-    /// use icu::calendar::{types::RataDie, Date, Gregorian};
+    /// use icu::calendar::{Date, Gregorian, types::RataDie};
     ///
     /// let rd = RataDie::new(1_000_000_000);
     /// assert_ne!(Date::from_rata_die(rd, Gregorian).to_rata_die(), rd);
@@ -415,8 +415,8 @@ impl<A: AsCalendar> Date<A> {
     /// # Examples
     ///
     /// ```
-    /// use icu::calendar::types::DateDuration;
     /// use icu::calendar::Date;
+    /// use icu::calendar::types::DateDuration;
     ///
     /// let d1 = Date::try_new_iso(2020, 1, 1).unwrap();
     /// let d2 = Date::try_new_iso(2025, 10, 2).unwrap();
@@ -431,9 +431,9 @@ impl<A: AsCalendar> Date<A> {
     /// Reversing the order of parameters does not necessarily produce the inverse result:
     ///
     /// ```
+    /// use icu::calendar::Date;
     /// use icu::calendar::options::{DateDifferenceOptions, DateDurationUnit};
     /// use icu::calendar::types::DateDuration;
-    /// use icu::calendar::Date;
     ///
     /// let d1 = Date::try_new_iso(2025, 9, 30).unwrap();
     /// let d2 = Date::try_new_iso(2025, 10, 31).unwrap();
@@ -528,8 +528,8 @@ impl Date<Iso> {
     /// # Examples
     ///
     /// ```
-    /// use icu::calendar::types::IsoWeekOfYear;
     /// use icu::calendar::Date;
+    /// use icu::calendar::types::IsoWeekOfYear;
     ///
     /// let date = Date::try_new_iso(2022, 8, 26).unwrap();
     ///

--- a/components/calendar/src/duration.rs
+++ b/components/calendar/src/duration.rs
@@ -22,11 +22,11 @@ use crate::error::DateDurationParseError;
 /// # Example
 ///
 /// ```rust
+/// use icu::calendar::Date;
 /// use icu::calendar::options::DateDifferenceOptions;
 /// use icu::calendar::options::DateDurationUnit;
 /// use icu::calendar::types::DateDuration;
 /// use icu::calendar::types::Weekday;
-/// use icu::calendar::Date;
 ///
 /// // Creating ISO date: 1992-09-02.
 /// let mut date_iso = Date::try_new_iso(1992, 9, 2)

--- a/components/calendar/src/error.rs
+++ b/components/calendar/src/error.rs
@@ -34,10 +34,10 @@ pub enum DateError {
     ///
     /// ```
     /// # #![allow(deprecated)]
-    /// use icu::calendar::cal::Hebrew;
-    /// use icu::calendar::types::Month;
     /// use icu::calendar::Date;
     /// use icu::calendar::DateError;
+    /// use icu::calendar::cal::Hebrew;
+    /// use icu::calendar::types::Month;
     ///
     /// Date::try_new_from_codes(None, 5784, Month::leap(5).code(), 1, Hebrew)
     ///     .expect("5784 is a leap year");
@@ -63,9 +63,9 @@ pub enum LunisolarDateError {
     /// # Examples
     ///
     /// ```
+    /// use icu::calendar::Date;
     /// use icu::calendar::error::LunisolarDateError;
     /// use icu::calendar::types::Month;
-    /// use icu::calendar::Date;
     ///
     /// let err = Date::try_new_hebrew_v2(5785, Month::new(5), 50)
     ///     .expect_err("no month has 50 days");
@@ -82,9 +82,9 @@ pub enum LunisolarDateError {
     /// # Examples
     ///
     /// ```
+    /// use icu::calendar::Date;
     /// use icu::calendar::error::LunisolarDateError;
     /// use icu::calendar::types::Month;
-    /// use icu::calendar::Date;
     ///
     /// Date::try_new_hebrew_v2(5784, Month::leap(5), 1)
     ///     .expect("5784 is a leap year");
@@ -101,9 +101,9 @@ pub enum LunisolarDateError {
     /// # Examples
     ///
     /// ```
+    /// use icu::calendar::Date;
     /// use icu::calendar::error::LunisolarDateError;
     /// use icu::calendar::types::Month;
-    /// use icu::calendar::Date;
     ///
     /// let err = Date::try_new_hebrew_v2(5785, Month::leap(1), 1)
     ///     .expect_err("Tishrei does not have a leap month");
@@ -117,9 +117,9 @@ pub enum LunisolarDateError {
     /// # Examples
     ///
     /// ```
+    /// use icu::calendar::Date;
     /// use icu::calendar::error::LunisolarDateError;
     /// use icu::calendar::types::Month;
-    /// use icu::calendar::Date;
     ///
     /// let err = Date::try_new_hebrew_v2(56812, Month::leap(5), 1)
     ///     .expect_err("56812 is too big");
@@ -143,11 +143,11 @@ pub enum DateFromFieldsError {
     /// # Examples
     ///
     /// ```
+    /// use icu::calendar::Date;
+    /// use icu::calendar::Iso;
     /// use icu::calendar::error::DateFromFieldsError;
     /// use icu::calendar::error::RangeError;
     /// use icu::calendar::types::DateFields;
-    /// use icu::calendar::Date;
-    /// use icu::calendar::Iso;
     ///
     /// let mut fields = DateFields::default();
     /// fields.extended_year = Some(2000);
@@ -169,11 +169,11 @@ pub enum DateFromFieldsError {
     /// # Examples
     ///
     /// ```
+    /// use icu::calendar::Date;
+    /// use icu::calendar::Iso;
     /// use icu::calendar::error::DateFromFieldsError;
     /// use icu::calendar::error::RangeError;
     /// use icu::calendar::types::DateFields;
-    /// use icu::calendar::Date;
-    /// use icu::calendar::Iso;
     ///
     /// let mut fields = DateFields::default();
     /// fields.extended_year = Some(2000);
@@ -198,10 +198,10 @@ pub enum DateFromFieldsError {
     /// # Examples
     ///
     /// ```
-    /// use icu::calendar::error::DateFromFieldsError;
-    /// use icu::calendar::types::DateFields;
     /// use icu::calendar::Date;
     /// use icu::calendar::Iso;
+    /// use icu::calendar::error::DateFromFieldsError;
+    /// use icu::calendar::types::DateFields;
     ///
     /// let mut fields = DateFields::default();
     /// fields.extended_year = Some(2000);
@@ -220,10 +220,10 @@ pub enum DateFromFieldsError {
     /// # Examples
     ///
     /// ```
+    /// use icu::calendar::Date;
     /// use icu::calendar::cal::Hebrew;
     /// use icu::calendar::error::DateFromFieldsError;
     /// use icu::calendar::types::{DateFields, Month};
-    /// use icu::calendar::Date;
     ///
     /// let mut fields = DateFields::default();
     /// fields.extended_year = Some(5783);
@@ -241,10 +241,10 @@ pub enum DateFromFieldsError {
     /// # Examples
     ///
     /// ```
+    /// use icu::calendar::Date;
     /// use icu::calendar::cal::Hebrew;
     /// use icu::calendar::error::DateFromFieldsError;
     /// use icu::calendar::types::{DateFields, Month};
-    /// use icu::calendar::Date;
     ///
     /// let mut fields = DateFields::default();
     /// fields.extended_year = Some(5783);
@@ -262,10 +262,10 @@ pub enum DateFromFieldsError {
     /// # Examples
     ///
     /// ```
+    /// use icu::calendar::Date;
     /// use icu::calendar::cal::Hebrew;
     /// use icu::calendar::error::DateFromFieldsError;
     /// use icu::calendar::types::DateFields;
-    /// use icu::calendar::Date;
     ///
     /// let mut fields = DateFields::default();
     /// fields.era = Some(b"ce"); // valid in Gregorian, but not Hebrew
@@ -285,10 +285,10 @@ pub enum DateFromFieldsError {
     /// # Examples
     ///
     /// ```
+    /// use icu::calendar::Date;
     /// use icu::calendar::cal::Japanese;
     /// use icu::calendar::error::DateFromFieldsError;
     /// use icu::calendar::types::DateFields;
-    /// use icu::calendar::Date;
     ///
     /// let mut fields = DateFields::default();
     /// fields.era = Some(b"reiwa");
@@ -314,10 +314,10 @@ pub enum DateFromFieldsError {
     /// # Examples
     ///
     /// ```
+    /// use icu::calendar::Date;
     /// use icu::calendar::cal::Hebrew;
     /// use icu::calendar::error::DateFromFieldsError;
     /// use icu::calendar::types::{DateFields, Month};
-    /// use icu::calendar::Date;
     /// use tinystr::tinystr;
     ///
     /// let mut fields = DateFields::default();
@@ -343,10 +343,10 @@ pub enum DateFromFieldsError {
     /// # Examples
     ///
     /// ```
-    /// use icu::calendar::error::DateFromFieldsError;
-    /// use icu::calendar::types::{DateFields, Month};
     /// use icu::calendar::Date;
     /// use icu::calendar::Iso;
+    /// use icu::calendar::error::DateFromFieldsError;
+    /// use icu::calendar::types::{DateFields, Month};
     ///
     /// let mut fields = DateFields::default();
     /// fields.extended_year = Some(2000);
@@ -366,10 +366,10 @@ pub enum DateFromFieldsError {
     /// # Examples
     ///
     /// ```
+    /// use icu::calendar::Date;
     /// use icu::calendar::cal::Hebrew;
     /// use icu::calendar::error::DateFromFieldsError;
     /// use icu::calendar::types::DateFields;
-    /// use icu::calendar::Date;
     /// use tinystr::tinystr;
     ///
     /// let mut fields = DateFields::default();
@@ -447,10 +447,10 @@ pub enum DateAddError {
     /// # Examples
     ///
     /// ```
+    /// use icu::calendar::Date;
     /// use icu::calendar::error::DateAddError;
     /// use icu::calendar::options::{DateAddOptions, Overflow};
     /// use icu::calendar::types::DateDuration;
-    /// use icu::calendar::Date;
     ///
     /// // There is a day 31 in October but not in November.
     /// let d = Date::try_new_iso(2025, 10, 31).unwrap();
@@ -477,11 +477,11 @@ pub enum DateAddError {
     /// # Examples
     ///
     /// ```
+    /// use icu::calendar::Date;
     /// use icu::calendar::cal::Hebrew;
     /// use icu::calendar::error::DateAddError;
     /// use icu::calendar::options::{DateAddOptions, Overflow};
     /// use icu::calendar::types::{DateDuration, Month};
-    /// use icu::calendar::Date;
     ///
     /// // Hebrew year 5784 is a leap year, 5785 is not.
     /// // Adar I (the leap month) is month 5 in a leap year.
@@ -505,9 +505,9 @@ pub enum DateAddError {
     /// # Examples
     ///
     /// ```
+    /// use icu::calendar::Date;
     /// use icu::calendar::error::DateAddError;
     /// use icu::calendar::types::DateDuration;
-    /// use icu::calendar::Date;
     ///
     /// let d = Date::try_new_iso(2025, 1, 1).unwrap();
     /// let duration = DateDuration::for_years(1_000_000);
@@ -529,10 +529,10 @@ impl core::error::Error for DateAddError {}
 /// # Examples
 ///
 /// ```
+/// use icu::calendar::Date;
 /// use icu::calendar::error::MismatchedCalendarError;
 /// use icu::calendar::options::DateDifferenceOptions;
 /// use icu::calendar::options::DateDurationUnit;
-/// use icu::calendar::Date;
 ///
 /// let d1 = Date::try_new_gregorian(2000, 1, 1).unwrap().to_any();
 /// let d2 = Date::try_new_persian(1562, 1, 1).unwrap().to_any();

--- a/components/calendar/src/lib.rs
+++ b/components/calendar/src/lib.rs
@@ -40,7 +40,7 @@
 //! as well as the calendar type.
 //!
 //! ```rust
-//! use icu::calendar::{types::Weekday, Date};
+//! use icu::calendar::{Date, types::Weekday};
 //!
 //! // Creating ISO date: 1992-09-02.
 //! let mut date_iso = Date::try_new_iso(1992, 9, 2)
@@ -59,8 +59,8 @@
 //! Example of converting an ISO date across Indian and Buddhist calendars.
 //!
 //! ```rust
-//! use icu::calendar::cal::{Buddhist, Indian};
 //! use icu::calendar::Date;
+//! use icu::calendar::cal::{Buddhist, Indian};
 //!
 //! // Creating ISO date: 1992-09-02.
 //! let mut date_iso = Date::try_new_iso(1992, 9, 2)

--- a/components/calendar/src/options.rs
+++ b/components/calendar/src/options.rs
@@ -15,11 +15,11 @@ pub struct DateFromFieldsOptions {
     /// # Examples
     ///
     /// ```
+    /// use icu::calendar::Date;
+    /// use icu::calendar::Iso;
     /// use icu::calendar::options::DateFromFieldsOptions;
     /// use icu::calendar::options::Overflow;
     /// use icu::calendar::types::DateFields;
-    /// use icu::calendar::Date;
-    /// use icu::calendar::Iso;
     ///
     /// // There is no day 31 in September.
     /// let mut fields = DateFields::default();
@@ -50,11 +50,11 @@ pub struct DateFromFieldsOptions {
     /// # Examples
     ///
     /// ```
+    /// use icu::calendar::Date;
+    /// use icu::calendar::Iso;
     /// use icu::calendar::options::DateFromFieldsOptions;
     /// use icu::calendar::options::MissingFieldsStrategy;
     /// use icu::calendar::types::{DateFields, Month};
-    /// use icu::calendar::Date;
-    /// use icu::calendar::Iso;
     ///
     /// // These options are missing a year.
     /// let mut fields = DateFields::default();
@@ -90,10 +90,10 @@ pub struct DateAddOptions {
     /// # Examples
     ///
     /// ```
+    /// use icu::calendar::Date;
     /// use icu::calendar::options::DateAddOptions;
     /// use icu::calendar::options::Overflow;
     /// use icu::calendar::types::DateDuration;
-    /// use icu::calendar::Date;
     ///
     /// // There is a day 31 in October but not in November.
     /// let d1 = Date::try_new_iso(2025, 10, 31).unwrap();
@@ -139,10 +139,10 @@ pub struct DateDifferenceOptions {
     /// # Examples
     ///
     /// ```
+    /// use icu::calendar::Date;
     /// use icu::calendar::options::DateDifferenceOptions;
     /// use icu::calendar::options::DateDurationUnit;
     /// use icu::calendar::types::DateDuration;
-    /// use icu::calendar::Date;
     ///
     /// let d1 = Date::try_new_iso(2025, 3, 31).unwrap();
     /// let d2 = Date::try_new_iso(2026, 5, 15).unwrap();
@@ -221,12 +221,12 @@ pub enum Overflow {
     /// # Examples
     ///
     /// ```
+    /// use icu::calendar::Date;
+    /// use icu::calendar::DateError;
     /// use icu::calendar::cal::Hebrew;
     /// use icu::calendar::options::DateFromFieldsOptions;
     /// use icu::calendar::options::Overflow;
     /// use icu::calendar::types::{DateFields, Month};
-    /// use icu::calendar::Date;
-    /// use icu::calendar::DateError;
     ///
     /// let mut options = DateFromFieldsOptions::default();
     /// options.overflow = Some(Overflow::Constrain);
@@ -260,12 +260,12 @@ pub enum Overflow {
     /// # Examples
     ///
     /// ```
+    /// use icu::calendar::Date;
     /// use icu::calendar::cal::Hebrew;
     /// use icu::calendar::error::DateFromFieldsError;
     /// use icu::calendar::options::DateFromFieldsOptions;
     /// use icu::calendar::options::Overflow;
     /// use icu::calendar::types::{DateFields, Month};
-    /// use icu::calendar::Date;
     /// use tinystr::tinystr;
     ///
     /// let mut options = DateFromFieldsOptions::default();

--- a/components/calendar/src/third_party.rs
+++ b/components/calendar/src/third_party.rs
@@ -67,7 +67,8 @@
 //! use icu::calendar::{Date, Gregorian, types::Weekday};
 //!
 //! // Convert a time::Date into an ICU4X Date<Gregorian>
-//! let time_date = time::Date::from_calendar_date(2025, time::Month::January, 15).unwrap();
+//! let time_date =
+//!     time::Date::from_calendar_date(2025, time::Month::January, 15).unwrap();
 //! let icu_date = Date::<Gregorian>::from(time_date);
 //! assert_eq!(icu_date.era_year().year, 2025);
 //!

--- a/components/calendar/src/types.rs
+++ b/components/calendar/src/types.rs
@@ -73,9 +73,9 @@ pub struct DateFields<'a> {
     /// Either `extended_year` or `era` + `era_year` can be used in `DateFields`:
     ///
     /// ```
+    /// use icu::calendar::Date;
     /// use icu::calendar::cal::Japanese;
     /// use icu::calendar::types::DateFields;
-    /// use icu::calendar::Date;
     ///
     /// let mut fields1 = DateFields::default();
     /// fields1.era = Some(b"reiwa");
@@ -151,9 +151,9 @@ pub struct DateFields<'a> {
     /// might not resolve to the same month number:
     ///
     /// ```
+    /// use icu::calendar::Date;
     /// use icu::calendar::cal::ChineseTraditional;
     /// use icu::calendar::types::{DateFields, Month};
-    /// use icu::calendar::Date;
     ///
     /// // The 2023 Year of the Rabbit had a leap month after the 2nd month.
     /// let mut fields1 = DateFields::default();

--- a/components/calendar/src/week.rs
+++ b/components/calendar/src/week.rs
@@ -20,7 +20,7 @@ const MIN_UNIT_DAYS: u16 = 14;
 /// ```
 /// use icu::calendar::types::Weekday;
 /// use icu::calendar::week::WeekInformation;
-/// use icu::locale::{locale, Locale};
+/// use icu::locale::{Locale, locale};
 ///
 /// // For en-US
 /// let info = WeekInformation::try_new(locale!("en-US").into()).unwrap();

--- a/components/casemap/src/titlecase.rs
+++ b/components/casemap/src/titlecase.rs
@@ -19,8 +19,8 @@ use writeable::Writeable;
 /// # Examples
 ///
 /// ```rust
-/// use icu::casemap::options::{TitlecaseOptions, TrailingCase};
 /// use icu::casemap::TitlecaseMapper;
+/// use icu::casemap::options::{TitlecaseOptions, TrailingCase};
 /// use icu::locale::langid;
 ///
 /// let cm = TitlecaseMapper::new();
@@ -64,8 +64,8 @@ pub enum TrailingCase {
 /// # Examples
 ///
 /// ```rust
-/// use icu::casemap::options::{LeadingAdjustment, TitlecaseOptions};
 /// use icu::casemap::TitlecaseMapper;
+/// use icu::casemap::options::{LeadingAdjustment, TitlecaseOptions};
 /// use icu::locale::langid;
 ///
 /// let cm = TitlecaseMapper::new();
@@ -410,8 +410,8 @@ impl<'a> TitlecaseMapperBorrowed<'a> {
     /// Leading adjustment behaviors:
     ///
     /// ```rust
-    /// use icu::casemap::options::{LeadingAdjustment, TitlecaseOptions};
     /// use icu::casemap::TitlecaseMapper;
+    /// use icu::casemap::options::{LeadingAdjustment, TitlecaseOptions};
     /// use icu::locale::langid;
     ///
     /// let cm = TitlecaseMapper::new();
@@ -450,8 +450,8 @@ impl<'a> TitlecaseMapperBorrowed<'a> {
     /// Tail casing behaviors:
     ///
     /// ```rust
-    /// use icu::casemap::options::{TitlecaseOptions, TrailingCase};
     /// use icu::casemap::TitlecaseMapper;
+    /// use icu::casemap::options::{TitlecaseOptions, TrailingCase};
     /// use icu::locale::langid;
     ///
     /// let cm = TitlecaseMapper::new();

--- a/components/collator/src/comparison.rs
+++ b/components/collator/src/comparison.rs
@@ -1741,8 +1741,8 @@ impl<'a> CollatorBorrowed<'a> {
     ///
     /// ```
     /// use icu::collator::{
-    ///     options::{CollatorOptions, Strength},
     ///     Collator,
+    ///     options::{CollatorOptions, Strength},
     /// };
     /// use icu::locale::locale;
     /// let locale = locale!("utf").into();

--- a/components/collections/src/codepointtrie/cptrie.rs
+++ b/components/collections/src/codepointtrie/cptrie.rs
@@ -759,8 +759,8 @@ impl<'trie, T: TrieValue> CodePointTrie<'trie, T> {
     /// # Examples
     ///
     /// ```no_run
-    /// use icu::collections::codepointtrie::planes;
     /// use icu::collections::codepointtrie::CodePointTrie;
+    /// use icu::collections::codepointtrie::planes;
     ///
     /// let planes_trie_u8: CodePointTrie<u8> = planes::get_planes_trie();
     /// let planes_trie_i8: CodePointTrie<i8> =
@@ -801,8 +801,8 @@ impl<'trie, T: TrieValue> CodePointTrie<'trie, T> {
     /// # Examples
     ///
     /// ```
-    /// use icu::collections::codepointtrie::planes;
     /// use icu::collections::codepointtrie::CodePointTrie;
+    /// use icu::collections::codepointtrie::planes;
     ///
     /// let planes_trie_u8: CodePointTrie<u8> = planes::get_planes_trie();
     /// let planes_trie_u16: CodePointTrie<u16> = planes_trie_u8
@@ -1173,8 +1173,8 @@ impl<'trie, T: TrieValue> CodePointTrie<'trie, T> {
     ///
     /// ```
     /// use core::ops::RangeInclusive;
-    /// use icu::collections::codepointtrie::planes;
     /// use icu::collections::codepointtrie::CodePointMapRange;
+    /// use icu::collections::codepointtrie::planes;
     ///
     /// let planes_trie = planes::get_planes_trie();
     ///

--- a/components/datetime/README.md
+++ b/components/datetime/README.md
@@ -37,11 +37,11 @@ Not all inputs are valid for all field sets.
 ## Examples
 
 ```rust
+use icu::datetime::DateTimeFormatter;
 use icu::datetime::fieldsets;
 use icu::datetime::input::Date;
 use icu::datetime::input::{DateTime, Time};
-use icu::datetime::DateTimeFormatter;
-use icu::locale::{locale, Locale};
+use icu::locale::{Locale, locale};
 use writeable::assert_writeable_eq;
 
 // Field set for year, month, day, hour, and minute with a medium length:

--- a/components/datetime/src/combo.rs
+++ b/components/datetime/src/combo.rs
@@ -15,7 +15,7 @@ use crate::scaffold::*;
 /// The only way to construct a combo field set (in this case, weekday with location-based zone):
 ///
 /// ```
-/// use icu::datetime::fieldsets::{zone::Location, Combo, E};
+/// use icu::datetime::fieldsets::{Combo, E, zone::Location};
 ///
 /// let field_set = E::long().with_zone(Location);
 /// ```
@@ -23,9 +23,9 @@ use crate::scaffold::*;
 /// Format the weekday, hour, and location-based zone:
 ///
 /// ```
-/// use icu::datetime::fieldsets::{self, zone, Combo};
-/// use icu::datetime::input::ZonedDateTime;
 /// use icu::datetime::DateTimeFormatter;
+/// use icu::datetime::fieldsets::{self, Combo, zone};
+/// use icu::datetime::input::ZonedDateTime;
 /// use icu::locale::locale;
 /// use icu::time::zone::IanaParser;
 /// use writeable::assert_writeable_eq;
@@ -57,9 +57,9 @@ use crate::scaffold::*;
 ///
 /// ```
 /// use icu::calendar::Gregorian;
-/// use icu::datetime::fieldsets::{self, zone, Combo};
-/// use icu::datetime::input::ZonedDateTime;
 /// use icu::datetime::FixedCalendarDateTimeFormatter;
+/// use icu::datetime::fieldsets::{self, Combo, zone};
+/// use icu::datetime::input::ZonedDateTime;
 /// use icu::locale::locale;
 /// use icu::time::zone::IanaParser;
 /// use writeable::assert_writeable_eq;
@@ -93,11 +93,11 @@ use crate::scaffold::*;
 /// with a static time zone:
 ///
 /// ```
+/// use icu::datetime::DateTimeFormatter;
 /// use icu::datetime::fieldsets::{
-///     enums::DateFieldSet, zone::GenericShort, Combo, YMD,
+///     Combo, YMD, enums::DateFieldSet, zone::GenericShort,
 /// };
 /// use icu::datetime::input::ZonedDateTime;
-/// use icu::datetime::DateTimeFormatter;
 /// use icu::locale::locale;
 /// use icu::time::zone::IanaParser;
 /// use writeable::assert_writeable_eq;
@@ -124,11 +124,11 @@ use crate::scaffold::*;
 ///
 /// ```
 /// # #[cfg(all(feature = "unstable", feature = "ixdtf"))] {
-/// use icu::datetime::fieldsets::{zone::SpecificLong, T};
 /// use icu::datetime::NoCalendarFormatter;
+/// use icu::datetime::fieldsets::{T, zone::SpecificLong};
 /// use icu::locale::locale;
-/// use icu::time::zone::iana::IanaParser;
 /// use icu::time::ZonedTime;
+/// use icu::time::zone::iana::IanaParser;
 /// use writeable::assert_writeable_eq;
 ///
 /// let formatter = NoCalendarFormatter::try_new(

--- a/components/datetime/src/dynamic.rs
+++ b/components/datetime/src/dynamic.rs
@@ -36,10 +36,10 @@
 //!
 //! ```
 //! use icu::calendar::Date;
+//! use icu::datetime::DateTimeFormatter;
 //! use icu::datetime::fieldsets;
 //! use icu::datetime::fieldsets::enums::CompositeDateTimeFieldSet;
 //! use icu::datetime::input::{DateTime, Time};
-//! use icu::datetime::DateTimeFormatter;
 //! use icu::locale::locale;
 //! use writeable::Writeable;
 //!

--- a/components/datetime/src/lib.rs
+++ b/components/datetime/src/lib.rs
@@ -50,11 +50,11 @@
 //! # Examples
 //!
 //! ```
+//! use icu::datetime::DateTimeFormatter;
 //! use icu::datetime::fieldsets;
 //! use icu::datetime::input::Date;
 //! use icu::datetime::input::{DateTime, Time};
-//! use icu::datetime::DateTimeFormatter;
-//! use icu::locale::{locale, Locale};
+//! use icu::locale::{Locale, locale};
 //! use writeable::assert_writeable_eq;
 //!
 //! // Field set for year, month, day, hour, and minute with a medium length:

--- a/components/datetime/src/neo.rs
+++ b/components/datetime/src/neo.rs
@@ -142,9 +142,9 @@ size_test!(FixedCalendarDateTimeFormatter<icu_calendar::Gregorian, crate::fields
 ///
 /// ```
 /// use icu::calendar::cal::Japanese;
+/// use icu::datetime::FixedCalendarDateTimeFormatter;
 /// use icu::datetime::fieldsets::YMD;
 /// use icu::datetime::input::Date;
-/// use icu::datetime::FixedCalendarDateTimeFormatter;
 /// use icu::locale::locale;
 /// use writeable::assert_writeable_eq;
 ///
@@ -408,9 +408,9 @@ size_test!(
 /// Basic usage:
 ///
 /// ```
+/// use icu::datetime::DateTimeFormatter;
 /// use icu::datetime::fieldsets::YMD;
 /// use icu::datetime::input::Date;
-/// use icu::datetime::DateTimeFormatter;
 /// use icu::locale::locale;
 /// use writeable::assert_writeable_eq;
 ///
@@ -626,10 +626,10 @@ where
     /// Mismatched calendars will return an error:
     ///
     /// ```
-    /// use icu::datetime::fieldsets::YMD;
-    /// use icu::datetime::input::Date;
     /// use icu::datetime::DateTimeFormatter;
     /// use icu::datetime::MismatchedCalendarError;
+    /// use icu::datetime::fieldsets::YMD;
+    /// use icu::datetime::input::Date;
     /// use icu::locale::locale;
     ///
     /// let formatter = DateTimeFormatter::try_new(
@@ -689,10 +689,10 @@ where
     /// Mismatched calendars convert and format automatically:
     ///
     /// ```
-    /// use icu::datetime::fieldsets::YMD;
-    /// use icu::datetime::input::Date;
     /// use icu::datetime::DateTimeFormatter;
     /// use icu::datetime::MismatchedCalendarError;
+    /// use icu::datetime::fieldsets::YMD;
+    /// use icu::datetime::input::Date;
     /// use icu::locale::locale;
     /// use writeable::assert_writeable_eq;
     ///
@@ -757,9 +757,9 @@ impl<C: CldrCalendar, FSet: DateTimeMarkers> FixedCalendarDateTimeFormatter<C, F
     ///
     /// ```
     /// use icu::calendar::cal::Hebrew;
+    /// use icu::datetime::FixedCalendarDateTimeFormatter;
     /// use icu::datetime::fieldsets::YMD;
     /// use icu::datetime::input::Date;
-    /// use icu::datetime::FixedCalendarDateTimeFormatter;
     /// use icu::locale::locale;
     /// use writeable::assert_writeable_eq;
     ///
@@ -795,9 +795,9 @@ impl<C: CldrCalendar, FSet: DateTimeMarkers> FixedCalendarDateTimeFormatter<C, F
     ///
     /// ```
     /// use icu::calendar::Gregorian;
-    /// use icu::datetime::fieldsets::{enums::DateFieldSet, YMD};
-    /// use icu::datetime::input::Date;
     /// use icu::datetime::FixedCalendarDateTimeFormatter;
+    /// use icu::datetime::fieldsets::{YMD, enums::DateFieldSet};
+    /// use icu::datetime::input::Date;
     /// use icu::locale::locale;
     /// use writeable::assert_writeable_eq;
     ///
@@ -837,11 +837,11 @@ impl<C: CldrCalendar, FSet: DateTimeMarkers> FixedCalendarDateTimeFormatter<C, F
     /// # Examples
     ///
     /// ```
-    /// use icu::datetime::fieldsets::builder::*;
+    /// use icu::datetime::FixedCalendarDateTimeFormatter;
     /// use icu::datetime::fieldsets::YMD;
+    /// use icu::datetime::fieldsets::builder::*;
     /// use icu::datetime::input::*;
     /// use icu::datetime::options::*;
-    /// use icu::datetime::FixedCalendarDateTimeFormatter;
     /// use icu::locale::locale;
     /// use writeable::assert_writeable_eq;
     ///
@@ -893,9 +893,9 @@ impl<FSet: DateTimeMarkers> DateTimeFormatter<FSet> {
     ///
     /// ```
     /// use icu::calendar::cal::Persian;
+    /// use icu::datetime::DateTimeFormatter;
     /// use icu::datetime::fieldsets::YMD;
     /// use icu::datetime::input::Date;
-    /// use icu::datetime::DateTimeFormatter;
     /// use icu::locale::locale;
     /// use writeable::assert_writeable_eq;
     ///
@@ -916,10 +916,10 @@ impl<FSet: DateTimeMarkers> DateTimeFormatter<FSet> {
     ///
     /// ```
     /// use icu::calendar::cal::Persian;
-    /// use icu::datetime::fieldsets::YMD;
-    /// use icu::datetime::input::Date;
     /// use icu::datetime::DateTimeFormatter;
     /// use icu::datetime::MismatchedCalendarError;
+    /// use icu::datetime::fieldsets::YMD;
+    /// use icu::datetime::input::Date;
     /// use icu::locale::locale;
     ///
     /// let result = DateTimeFormatter::try_new(
@@ -968,9 +968,9 @@ impl<FSet: DateTimeMarkers> DateTimeFormatter<FSet> {
     ///
     /// ```
     /// use icu::calendar::Gregorian;
-    /// use icu::datetime::fieldsets::{enums::DateFieldSet, YMD};
-    /// use icu::datetime::input::Date;
     /// use icu::datetime::DateTimeFormatter;
+    /// use icu::datetime::fieldsets::{YMD, enums::DateFieldSet};
+    /// use icu::datetime::input::Date;
     /// use icu::locale::locale;
     /// use writeable::assert_writeable_eq;
     ///
@@ -1007,9 +1007,9 @@ impl<FSet: DateTimeMarkers> DateTimeFormatter<FSet> {
     ///
     /// ```
     /// use icu::calendar::AnyCalendarKind;
+    /// use icu::datetime::DateTimeFormatter;
     /// use icu::datetime::fieldsets::YMD;
     /// use icu::datetime::input::Date;
-    /// use icu::datetime::DateTimeFormatter;
     /// use icu::locale::locale;
     /// use writeable::assert_writeable_eq;
     ///
@@ -1091,9 +1091,9 @@ impl<FSet: DateTimeMarkers> DateTimeFormatter<FSet> {
 /// A [`NoCalendarFormatter`] can be used to format a time:
 ///
 /// ```
+/// use icu::datetime::NoCalendarFormatter;
 /// use icu::datetime::fieldsets::T;
 /// use icu::datetime::input::Time;
-/// use icu::datetime::NoCalendarFormatter;
 /// use icu::locale::locale;
 ///
 /// let formatter =
@@ -1107,8 +1107,8 @@ impl<FSet: DateTimeMarkers> DateTimeFormatter<FSet> {
 /// A [`NoCalendarFormatter`] cannot be constructed with a fieldset that involves dates:
 ///
 /// ```
-/// use icu::datetime::fieldsets::Y;
 /// use icu::datetime::NoCalendarFormatter;
+/// use icu::datetime::fieldsets::Y;
 /// use icu::locale::locale;
 ///
 /// assert!(

--- a/components/datetime/src/options/mod.rs
+++ b/components/datetime/src/options/mod.rs
@@ -16,9 +16,9 @@ use icu_time::scaffold::IntoOption;
 ///
 /// ```
 /// use icu::calendar::Gregorian;
+/// use icu::datetime::FixedCalendarDateTimeFormatter;
 /// use icu::datetime::fieldsets::YMD;
 /// use icu::datetime::input::Date;
-/// use icu::datetime::FixedCalendarDateTimeFormatter;
 /// use icu::locale::locale;
 /// use writeable::assert_writeable_eq;
 ///
@@ -94,10 +94,10 @@ impl IntoOption<Length> for Length {
 ///
 /// ```
 /// use icu::calendar::Gregorian;
+/// use icu::datetime::FixedCalendarDateTimeFormatter;
 /// use icu::datetime::fieldsets::YMD;
 /// use icu::datetime::input::Date;
 /// use icu::datetime::options::Alignment;
-/// use icu::datetime::FixedCalendarDateTimeFormatter;
 /// use icu::locale::locale;
 /// use writeable::assert_writeable_eq;
 ///
@@ -198,10 +198,10 @@ pub enum YearStyle {
     ///
     /// ```
     /// use icu::calendar::Gregorian;
+    /// use icu::datetime::FixedCalendarDateTimeFormatter;
     /// use icu::datetime::fieldsets::YMD;
     /// use icu::datetime::input::Date;
     /// use icu::datetime::options::YearStyle;
-    /// use icu::datetime::FixedCalendarDateTimeFormatter;
     /// use icu::locale::locale;
     /// use writeable::assert_writeable_eq;
     ///
@@ -229,10 +229,10 @@ pub enum YearStyle {
     ///
     /// ```
     /// use icu::calendar::Gregorian;
+    /// use icu::datetime::FixedCalendarDateTimeFormatter;
     /// use icu::datetime::fieldsets::YMD;
     /// use icu::datetime::input::Date;
     /// use icu::datetime::options::YearStyle;
-    /// use icu::datetime::FixedCalendarDateTimeFormatter;
     /// use icu::locale::locale;
     /// use writeable::assert_writeable_eq;
     ///
@@ -258,10 +258,10 @@ pub enum YearStyle {
     ///
     /// ```
     /// use icu::calendar::Gregorian;
+    /// use icu::datetime::FixedCalendarDateTimeFormatter;
     /// use icu::datetime::fieldsets::YMD;
     /// use icu::datetime::input::Date;
     /// use icu::datetime::options::YearStyle;
-    /// use icu::datetime::FixedCalendarDateTimeFormatter;
     /// use icu::locale::locale;
     /// use writeable::assert_writeable_eq;
     ///
@@ -292,10 +292,10 @@ pub enum YearStyle {
     ///
     /// ```
     /// use icu::calendar::Gregorian;
+    /// use icu::datetime::FixedCalendarDateTimeFormatter;
     /// use icu::datetime::fieldsets::YMD;
     /// use icu::datetime::input::Date;
     /// use icu::datetime::options::YearStyle;
-    /// use icu::datetime::FixedCalendarDateTimeFormatter;
     /// use icu::locale::locale;
     /// use writeable::assert_writeable_eq;
     ///
@@ -544,11 +544,11 @@ impl From<TimePrecisionSerde> for TimePrecision {
 ///
 /// ```
 /// use icu::calendar::Gregorian;
+/// use icu::datetime::FixedCalendarDateTimeFormatter;
 /// use icu::datetime::fieldsets::T;
 /// use icu::datetime::input::Time;
 /// use icu::datetime::options::SubsecondDigits;
 /// use icu::datetime::options::TimePrecision;
-/// use icu::datetime::FixedCalendarDateTimeFormatter;
 /// use icu::locale::locale;
 /// use writeable::assert_writeable_eq;
 ///

--- a/components/datetime/src/pattern/names.rs
+++ b/components/datetime/src/pattern/names.rs
@@ -603,12 +603,12 @@ size_test!(
 /// need this functionality, see <https://github.com/unicode-org/icu4x/issues/6063>
 ///
 /// ```
+/// use icu::datetime::NoCalendarFormatter;
 /// use icu::datetime::fieldsets::enums::ZoneFieldSet;
 /// use icu::datetime::fieldsets::zone;
 /// use icu::datetime::pattern::FixedCalendarDateTimeNames;
-/// use icu::datetime::NoCalendarFormatter;
-/// use icu::locale::locale;
 /// use icu::datetime::pattern::PatternLoadError;
+/// use icu::locale::locale;
 /// use icu_provider::DataError;
 /// use icu_provider::DataErrorKind;
 ///

--- a/components/datetime/src/pattern/pattern.rs
+++ b/components/datetime/src/pattern/pattern.rs
@@ -39,11 +39,11 @@ size_test!(DateTimePattern, date_time_pattern_size, 32);
 ///
 /// ```
 /// use icu::calendar::Gregorian;
+/// use icu::datetime::FixedCalendarDateTimeFormatter;
 /// use icu::datetime::fieldsets::YMD;
 /// use icu::datetime::input::Date;
 /// use icu::datetime::pattern::DateTimePattern;
 /// use icu::datetime::provider::fields::components;
-/// use icu::datetime::FixedCalendarDateTimeFormatter;
 /// use icu::locale::locale;
 /// use writeable::assert_writeable_eq;
 ///
@@ -77,11 +77,11 @@ size_test!(DateTimePattern, date_time_pattern_size, 32);
 /// Check the hour cycle of a resolved pattern:
 ///
 /// ```
+/// use icu::datetime::NoCalendarFormatter;
 /// use icu::datetime::fieldsets::T;
 /// use icu::datetime::input::Time;
 /// use icu::datetime::pattern::DateTimePattern;
 /// use icu::datetime::provider::fields::components;
-/// use icu::datetime::NoCalendarFormatter;
 /// use icu::locale::locale;
 /// use icu::locale::preferences::extensions::unicode::keywords::HourCycle;
 /// use writeable::assert_writeable_eq;

--- a/components/datetime/src/provider/fields/length.rs
+++ b/components/datetime/src/provider/fields/length.rs
@@ -168,7 +168,6 @@ unsafe impl ULE for FieldLengthULE {
 
 /// Various numeric overrides for datetime patterns
 /// as found in CLDR
-///
 // Formatting code for this is in `format/numeric_overrides.rs`
 #[derive(Debug, Eq, PartialEq, Clone, Copy, Ord, PartialOrd)]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]

--- a/components/datetime/src/range/formatter.rs
+++ b/components/datetime/src/range/formatter.rs
@@ -36,8 +36,8 @@ use icu_provider::prelude::*;
 ///
 /// ```
 /// use icu::calendar::Date;
-/// use icu::datetime::input::{DateTime, Time};
 /// use icu::datetime::fieldsets::YMD;
+/// use icu::datetime::input::{DateTime, Time};
 /// use icu::datetime::range::DateRangeFormatter;
 /// use icu::locale::locale;
 /// use writeable::assert_writeable_eq;
@@ -59,10 +59,7 @@ use icu_provider::prelude::*;
 ///
 /// // Gregorian input is dynamically converted to Buddhist (2023 -> 2566)
 /// // Thai day-difference range has no spaces around en-dash:
-/// assert_writeable_eq!(
-///     fmt.format(&start, &end),
-///     "22–23 ธ.ค. 2566"
-/// );
+/// assert_writeable_eq!(fmt.format(&start, &end), "22–23 ธ.ค. 2566");
 /// ```
 #[derive(Debug)]
 pub struct DateRangeFormatter<FSet: DateTimeNamesMarker> {

--- a/components/datetime/src/scaffold/names_storage.rs
+++ b/components/datetime/src/scaffold/names_storage.rs
@@ -403,12 +403,12 @@ where
 /// Example pairs of field sets where the trait is implemented:
 ///
 /// ```
+/// use icu::datetime::fieldsets::T;
+/// use icu::datetime::fieldsets::YMD;
 /// use icu::datetime::fieldsets::enums::CompositeDateTimeFieldSet;
 /// use icu::datetime::fieldsets::enums::CompositeFieldSet;
 /// use icu::datetime::fieldsets::enums::DateFieldSet;
 /// use icu::datetime::fieldsets::enums::TimeFieldSet;
-/// use icu::datetime::fieldsets::T;
-/// use icu::datetime::fieldsets::YMD;
 /// use icu::datetime::scaffold::DateTimeNamesFrom;
 /// use icu::datetime::scaffold::DateTimeNamesMarker;
 ///

--- a/components/datetime/src/unchecked.rs
+++ b/components/datetime/src/unchecked.rs
@@ -50,13 +50,13 @@ impl<C: CldrCalendar, FSet: DateTimeNamesMarker> FixedCalendarDateTimeFormatter<
     ///
     /// ```
     /// use icu::calendar::cal::Buddhist;
+    /// use icu::datetime::FixedCalendarDateTimeFormatter;
     /// use icu::datetime::fieldsets::enums::CompositeFieldSet;
     /// use icu::datetime::fieldsets::{T, YMD};
     /// use icu::datetime::input::{Date, Time};
     /// use icu::datetime::unchecked::DateTimeInputUnchecked;
     /// use icu::datetime::unchecked::FormattedDateTimeUncheckedError;
     /// use icu::datetime::unchecked::MissingInputFieldKind;
-    /// use icu::datetime::FixedCalendarDateTimeFormatter;
     /// use icu::locale::locale;
     /// use writeable::assert_try_writeable_eq;
     ///
@@ -131,13 +131,13 @@ impl<FSet: DateTimeNamesMarker> DateTimeFormatter<FSet> {
     /// successfully pass it into [`format_unchecked`].
     ///
     /// ```
+    /// use icu::datetime::DateTimeFormatter;
     /// use icu::datetime::fieldsets::enums::CompositeFieldSet;
     /// use icu::datetime::fieldsets::{T, YMD};
     /// use icu::datetime::input::{Date, Time};
     /// use icu::datetime::unchecked::DateTimeInputUnchecked;
     /// use icu::datetime::unchecked::FormattedDateTimeUncheckedError;
     /// use icu::datetime::unchecked::MissingInputFieldKind;
-    /// use icu::datetime::DateTimeFormatter;
     /// use icu::locale::locale;
     /// use writeable::assert_try_writeable_eq;
     ///

--- a/components/decimal/README.md
+++ b/components/decimal/README.md
@@ -15,8 +15,8 @@ follow [icu4x#275](https://github.com/unicode-org/icu4x/issues/275).
 ### Format a number with Bangla digits
 
 ```rust
-use icu::decimal::input::Decimal;
 use icu::decimal::DecimalFormatter;
+use icu::decimal::input::Decimal;
 use icu::locale::locale;
 use writeable::assert_writeable_eq;
 
@@ -32,8 +32,8 @@ assert_writeable_eq!(formatter.format(&decimal), "১০,০০,০০৭");
 ### Format a number with digits after the decimal separator
 
 ```rust
-use icu::decimal::input::Decimal;
 use icu::decimal::DecimalFormatter;
+use icu::decimal::input::Decimal;
 use icu::locale::Locale;
 use writeable::assert_writeable_eq;
 
@@ -55,8 +55,8 @@ assert_writeable_eq!(formatter.format(&decimal), "2,000.50");
 Numbering systems specified in the `-u-nu` subtag will be followed.
 
 ```rust
-use icu::decimal::input::Decimal;
 use icu::decimal::DecimalFormatter;
+use icu::decimal::input::Decimal;
 use icu::locale::locale;
 use writeable::assert_writeable_eq;
 

--- a/components/decimal/src/compact_formatter.rs
+++ b/components/decimal/src/compact_formatter.rs
@@ -260,8 +260,8 @@ impl CompactDecimalFormatter {
     /// # Examples
     ///
     /// ```
-    /// use icu::decimal::input::{Decimal, SignDisplay};
     /// use icu::decimal::CompactDecimalFormatter;
+    /// use icu::decimal::input::{Decimal, SignDisplay};
     /// use icu::locale::locale;
     /// use writeable::assert_writeable_eq;
     ///

--- a/components/decimal/src/lib.rs
+++ b/components/decimal/src/lib.rs
@@ -15,8 +15,8 @@
 //! ## Format a number with Bangla digits
 //!
 //! ```
-//! use icu::decimal::input::Decimal;
 //! use icu::decimal::DecimalFormatter;
+//! use icu::decimal::input::Decimal;
 //! use icu::locale::locale;
 //! use writeable::assert_writeable_eq;
 //!
@@ -32,8 +32,8 @@
 //! ## Format a number with digits after the decimal separator
 //!
 //! ```
-//! use icu::decimal::input::Decimal;
 //! use icu::decimal::DecimalFormatter;
+//! use icu::decimal::input::Decimal;
 //! use icu::locale::Locale;
 //! use writeable::assert_writeable_eq;
 //!
@@ -55,8 +55,8 @@
 //! Numbering systems specified in the `-u-nu` subtag will be followed.
 //!
 //! ```
-//! use icu::decimal::input::Decimal;
 //! use icu::decimal::DecimalFormatter;
+//! use icu::decimal::input::Decimal;
 //! use icu::locale::locale;
 //! use writeable::assert_writeable_eq;
 //!

--- a/components/decimal/src/options.rs
+++ b/components/decimal/src/options.rs
@@ -28,8 +28,8 @@ impl From<GroupingStrategy> for DecimalFormatterOptions {
 /// # Examples
 ///
 /// ```
-/// use icu::decimal::options;
 /// use icu::decimal::DecimalFormatter;
+/// use icu::decimal::options;
 /// use icu::locale::Locale;
 /// use writeable::assert_writeable_eq;
 ///

--- a/components/decimal/src/provider.rs
+++ b/components/decimal/src/provider.rs
@@ -20,8 +20,8 @@
 //! contains the resolved numbering system as its attribute:
 //!
 //! ```
-//! use icu::decimal::provider::DecimalDigitsV1;
 //! use icu::decimal::DecimalFormatter;
+//! use icu::decimal::provider::DecimalDigitsV1;
 //! use icu::locale::locale;
 //! use icu_provider::prelude::*;
 //! use std::any::TypeId;

--- a/components/experimental/src/dimension/currency/formatter.rs
+++ b/components/experimental/src/dimension/currency/formatter.rs
@@ -578,8 +578,8 @@ impl CurrencyFormatter<DecimalFormatter> {
     ///
     /// # Examples
     /// ```
-    /// use icu::experimental::dimension::currency::formatter::CurrencyFormatter;
     /// use icu::experimental::dimension::currency::CurrencyType;
+    /// use icu::experimental::dimension::currency::formatter::CurrencyFormatter;
     /// use icu::locale::locale;
     /// use icu::locale::preferences::extensions::unicode::keywords::currency;
     /// use writeable::assert_writeable_eq;
@@ -593,7 +593,10 @@ impl CurrencyFormatter<DecimalFormatter> {
     /// )
     /// .unwrap();
     /// let value = "12345.67".parse().unwrap();
-    /// assert_writeable_eq!(fmt.format_fixed_decimal(&value), "USD\u{a0}12,345.67");
+    /// assert_writeable_eq!(
+    ///     fmt.format_fixed_decimal(&value),
+    ///     "USD\u{a0}12,345.67"
+    /// );
     /// ```
     #[cfg(feature = "compiled_data")]
     pub fn try_new_code(
@@ -650,17 +653,22 @@ impl CurrencyFormatter<DecimalFormatter> {
     ///
     /// # Examples
     /// ```
-    /// use icu::experimental::dimension::currency::formatter::CurrencyFormatter;
     /// use icu::experimental::dimension::currency::CurrencyType;
+    /// use icu::experimental::dimension::currency::formatter::CurrencyFormatter;
     /// use icu::locale::locale;
     /// use icu::locale::preferences::extensions::unicode::keywords::currency;
     /// use writeable::assert_writeable_eq;
     ///
     /// let currency_preferences = locale!("en-US").into();
     /// let currency_code = currency!("USD");
-    /// let fmt = CurrencyFormatter::try_new_name(currency_preferences, currency_code).unwrap();
+    /// let fmt =
+    ///     CurrencyFormatter::try_new_name(currency_preferences, currency_code)
+    ///         .unwrap();
     /// let value = "12345.67".parse().unwrap();
-    /// assert_writeable_eq!(fmt.format_fixed_decimal(&value), "12,345.67 US dollars");
+    /// assert_writeable_eq!(
+    ///     fmt.format_fixed_decimal(&value),
+    ///     "12,345.67 US dollars"
+    /// );
     /// ```
     #[cfg(feature = "compiled_data")]
     pub fn try_new_name(
@@ -717,15 +725,20 @@ impl CurrencyFormatter<DecimalFormatter> {
     ///
     /// # Examples
     /// ```
-    /// use icu::experimental::dimension::currency::formatter::CurrencyFormatter;
     /// use icu::experimental::dimension::currency::CurrencyType;
+    /// use icu::experimental::dimension::currency::formatter::CurrencyFormatter;
     /// use icu::locale::locale;
     /// use icu::locale::preferences::extensions::unicode::keywords::currency;
     /// use writeable::assert_writeable_eq;
     ///
     /// let currency_preferences = locale!("en-US").into();
     /// let currency_code = currency!("USD");
-    /// let fmt = CurrencyFormatter::try_new_no_currency(currency_preferences, currency_code, Default::default()).unwrap();
+    /// let fmt = CurrencyFormatter::try_new_no_currency(
+    ///     currency_preferences,
+    ///     currency_code,
+    ///     Default::default(),
+    /// )
+    /// .unwrap();
     /// let value = "12345.67".parse().unwrap();
     /// assert_writeable_eq!(fmt.format_fixed_decimal(&value), "12,345.67");
     /// ```
@@ -1268,8 +1281,8 @@ impl<V: AbstractFormatter> CurrencyFormatter<V> {
     ///
     /// # Examples
     /// ```
-    /// use icu::experimental::dimension::currency::formatter::CurrencyFormatter;
     /// use icu::experimental::dimension::currency::CurrencyType;
+    /// use icu::experimental::dimension::currency::formatter::CurrencyFormatter;
     /// use icu::locale::locale;
     /// use icu::locale::preferences::extensions::unicode::keywords::currency;
     /// use writeable::assert_writeable_eq;
@@ -1283,15 +1296,12 @@ impl<V: AbstractFormatter> CurrencyFormatter<V> {
     /// )
     /// .unwrap();
     /// let value = "12345.67".parse().unwrap();
-    /// assert_writeable_eq!(
-    ///     fmt.format_fixed_decimal(&value),
-    ///     "$12,345.67"
-    /// );
+    /// assert_writeable_eq!(fmt.format_fixed_decimal(&value), "$12,345.67");
     /// ```
     ///
     /// ```
-    /// use icu::experimental::dimension::currency::formatter::CurrencyFormatter;
     /// use icu::experimental::dimension::currency::CurrencyType;
+    /// use icu::experimental::dimension::currency::formatter::CurrencyFormatter;
     /// use icu::locale::locale;
     /// use icu::locale::preferences::extensions::unicode::keywords::currency;
     /// use writeable::assert_writeable_eq;
@@ -1309,8 +1319,8 @@ impl<V: AbstractFormatter> CurrencyFormatter<V> {
     /// ```
     ///
     /// ```
-    /// use icu::experimental::dimension::currency::formatter::CurrencyFormatter;
     /// use icu::experimental::dimension::currency::CurrencyType;
+    /// use icu::experimental::dimension::currency::formatter::CurrencyFormatter;
     /// use icu::locale::locale;
     /// use icu::locale::preferences::extensions::unicode::keywords::currency;
     /// use writeable::assert_writeable_eq;

--- a/components/experimental/src/displaynames/mod.rs
+++ b/components/experimental/src/displaynames/mod.rs
@@ -21,15 +21,17 @@
 //! loads one name at a time.
 //!
 //! ```
+//! use icu::experimental::displaynames::DisplayNamesOptions;
 //! use icu::experimental::displaynames::multi::RegionDisplayNames;
 //! use icu::locale::names::RegionDisplayName;
-//! use icu::experimental::displaynames::DisplayNamesOptions;
 //! use icu::locale::{locale, subtags::region};
 //! use writeable::assert_writeable_eq;
 //!
 //! // Multi: Load a formatter that can display many regions.
 //! let locale = locale!("en").into();
-//! let multi = RegionDisplayNames::try_new(locale, DisplayNamesOptions::default()).unwrap();
+//! let multi =
+//!     RegionDisplayNames::try_new(locale, DisplayNamesOptions::default())
+//!         .unwrap();
 //! assert_writeable_eq!(multi.of(region!("US")).unwrap(), "United States");
 //! assert_writeable_eq!(multi.of(region!("GB")).unwrap(), "United Kingdom");
 //!

--- a/components/experimental/src/displaynames/options.rs
+++ b/components/experimental/src/displaynames/options.rs
@@ -10,7 +10,7 @@
 ///
 /// ```
 /// use icu::experimental::displaynames::{
-///     DisplayNamesOptions, multi::RegionDisplayNames, Style,
+///     DisplayNamesOptions, Style, multi::RegionDisplayNames,
 /// };
 /// use icu::locale::{locale, subtags::region};
 ///

--- a/components/icu/README.md
+++ b/components/icu/README.md
@@ -28,7 +28,7 @@ provide data explicitly using [`DataProvider`]s.
 Compiled data is exposed through idiomatic Rust constructors like `new` or `try_new`:
 
 ```rust
-use icu::datetime::{fieldsets::YMD, DateTimeFormatter};
+use icu::datetime::{DateTimeFormatter, fieldsets::YMD};
 use icu::locale::locale;
 
 let dtf =
@@ -49,7 +49,7 @@ Powerful data management is possible with [`DataProvider`]s, which are passed to
 special constructors:
 
 ```rust
-use icu::datetime::{fieldsets::YMD, DateTimeFormatter};
+use icu::datetime::{DateTimeFormatter, fieldsets::YMD};
 use icu::locale::fallback::LocaleFallbacker;
 use icu::locale::locale;
 use icu_provider_adapters::fallback::LocaleFallbackProvider;

--- a/components/icu/src/lib.rs
+++ b/components/icu/src/lib.rs
@@ -41,7 +41,7 @@
 //! Compiled data is exposed through idiomatic Rust constructors like `new` or `try_new`:
 //!
 //! ```
-//! use icu::datetime::{fieldsets::YMD, DateTimeFormatter};
+//! use icu::datetime::{DateTimeFormatter, fieldsets::YMD};
 //! use icu::locale::locale;
 //!
 //! let dtf =
@@ -62,7 +62,7 @@
 //! special constructors:
 //!
 //! ```no_run
-//! use icu::datetime::{fieldsets::YMD, DateTimeFormatter};
+//! use icu::datetime::{DateTimeFormatter, fieldsets::YMD};
 //! use icu::locale::fallback::LocaleFallbacker;
 //! use icu::locale::locale;
 //! use icu_provider_adapters::fallback::LocaleFallbackProvider;

--- a/components/list/src/list_formatter.rs
+++ b/components/list/src/list_formatter.rs
@@ -105,7 +105,7 @@ impl ListFormatter {
     ///
     /// ```
     /// use icu::list::options::*;
-    /// use icu::list::{parts, ListFormatter};
+    /// use icu::list::{ListFormatter, parts};
     /// # use icu::locale::locale;
     /// # use writeable::*;
     /// let formatteur = ListFormatter::try_new_and(

--- a/components/locale/README.md
+++ b/components/locale/README.md
@@ -35,7 +35,7 @@ assert_eq!(locale, "ja-Latn-alalc97-fonipa".parse::<Locale>().unwrap());
 ```
 
 ```rust
-use icu::locale::{locale, LocaleExpander, TransformResult};
+use icu::locale::{LocaleExpander, TransformResult, locale};
 
 let lc = LocaleExpander::new_common();
 
@@ -49,7 +49,7 @@ assert_eq!(locale, locale!("zh-Hant-TW"));
 ```
 
 ```rust
-use icu::locale::{locale, LocaleExpander, TransformResult};
+use icu::locale::{LocaleExpander, TransformResult, locale};
 use writeable::assert_writeable_eq;
 
 let lc = LocaleExpander::new_common();

--- a/components/locale/src/directionality.rs
+++ b/components/locale/src/directionality.rs
@@ -28,7 +28,7 @@ pub enum Direction {
 /// # Examples
 ///
 /// ```
-/// use icu::locale::{langid, Direction, LocaleDirectionality};
+/// use icu::locale::{Direction, LocaleDirectionality, langid};
 ///
 /// let ld = LocaleDirectionality::new_common();
 ///
@@ -112,7 +112,7 @@ impl<Expander: AsRef<LocaleExpander>> LocaleDirectionality<Expander> {
     ///
     /// ```
     /// use icu::locale::{
-    ///     langid, Direction, LocaleDirectionality, LocaleExpander,
+    ///     Direction, LocaleDirectionality, LocaleExpander, langid,
     /// };
     ///
     /// let ld_default = LocaleDirectionality::new_common();
@@ -170,7 +170,7 @@ impl<Expander: AsRef<LocaleExpander>> LocaleDirectionality<Expander> {
     /// Using an existing locale:
     ///
     /// ```
-    /// use icu::locale::{langid, Direction, LocaleDirectionality};
+    /// use icu::locale::{Direction, LocaleDirectionality, langid};
     ///
     /// let ld = LocaleDirectionality::new_common();
     ///

--- a/components/locale/src/expander.rs
+++ b/components/locale/src/expander.rs
@@ -35,7 +35,7 @@ use crate::TransformResult;
 /// Remove likely subtags:
 ///
 /// ```
-/// use icu::locale::{locale, LocaleExpander, TransformResult};
+/// use icu::locale::{LocaleExpander, TransformResult, locale};
 ///
 /// let lc = LocaleExpander::new_common();
 ///
@@ -52,7 +52,7 @@ use crate::TransformResult;
 /// locales for maximization, use [`try_new_extended`](Self::try_new_extended_unstable):
 ///
 /// ```
-/// use icu::locale::{locale, LocaleExpander, TransformResult};
+/// use icu::locale::{LocaleExpander, TransformResult, locale};
 ///
 /// let lc = LocaleExpander::new_extended();
 ///
@@ -334,7 +334,7 @@ impl LocaleExpander {
     /// # Examples
     ///
     /// ```
-    /// use icu::locale::{locale, LocaleExpander, TransformResult};
+    /// use icu::locale::{LocaleExpander, TransformResult, locale};
     ///
     /// let lc = LocaleExpander::new_common();
     ///
@@ -352,7 +352,7 @@ impl LocaleExpander {
     /// more languages.
     ///
     /// ```
-    /// use icu::locale::{locale, LocaleExpander, TransformResult};
+    /// use icu::locale::{LocaleExpander, TransformResult, locale};
     ///
     /// let lc = LocaleExpander::new_common();
     ///
@@ -453,7 +453,7 @@ impl LocaleExpander {
     /// # Examples
     ///
     /// ```
-    /// use icu::locale::{locale, LocaleExpander, TransformResult};
+    /// use icu::locale::{LocaleExpander, TransformResult, locale};
     ///
     /// let lc = LocaleExpander::new_common();
     ///
@@ -482,7 +482,7 @@ impl LocaleExpander {
     /// # Examples
     ///
     /// ```
-    /// use icu::locale::{locale, LocaleExpander, TransformResult};
+    /// use icu::locale::{LocaleExpander, TransformResult, locale};
     ///
     /// let lc = LocaleExpander::new_common();
     ///

--- a/components/locale/src/lib.rs
+++ b/components/locale/src/lib.rs
@@ -48,7 +48,7 @@
 //! ```
 //!
 //! ```
-//! use icu::locale::{locale, LocaleExpander, TransformResult};
+//! use icu::locale::{LocaleExpander, TransformResult, locale};
 //!
 //! let lc = LocaleExpander::new_common();
 //!
@@ -62,7 +62,7 @@
 //! ```
 //!
 //! ```
-//! use icu::locale::{locale, LocaleExpander, TransformResult};
+//! use icu::locale::{LocaleExpander, TransformResult, locale};
 //! use writeable::assert_writeable_eq;
 //!
 //! let lc = LocaleExpander::new_common();

--- a/components/locale/src/names/language.rs
+++ b/components/locale/src/names/language.rs
@@ -120,9 +120,10 @@ macro_rules! table_row {
 ///
 /// ```
 /// use icu::locale::names::{
-///     DisplayNamesPreferences, LanguageIdentifierDisplayName, LanguageIdentifierDisplayNameOptions,
+///     DisplayNamesPreferences, LanguageIdentifierDisplayName,
+///     LanguageIdentifierDisplayNameOptions,
 /// };
-/// use icu::locale::{locale, langid};
+/// use icu::locale::{langid, locale};
 /// use writeable::assert_try_writeable_eq;
 ///
 /// let prefs = DisplayNamesPreferences::from(locale!("en"));
@@ -134,7 +135,11 @@ macro_rules! table_row {
 /// )
 /// .expect("Data should load successfully");
 ///
-/// assert_try_writeable_eq!(display_name.as_borrowed(), "Canadian French", Ok(()));
+/// assert_try_writeable_eq!(
+///     display_name.as_borrowed(),
+///     "Canadian French",
+///     Ok(())
+/// );
 /// ```
 ///
 /// When a subtag is unknown:

--- a/components/locale/src/names/region.rs
+++ b/components/locale/src/names/region.rs
@@ -69,8 +69,9 @@ macro_rules! table_row {
 /// use icu::locale::{locale, subtags::region};
 /// use writeable::assert_writeable_eq;
 ///
-/// let display_name = RegionDisplayName::try_new_light(locale!("en").into(), region!("US"))
-///     .expect("Data should load successfully");
+/// let display_name =
+///     RegionDisplayName::try_new_light(locale!("en").into(), region!("US"))
+///         .expect("Data should load successfully");
 ///
 /// assert_writeable_eq!(display_name, "United States");
 /// ```
@@ -98,12 +99,18 @@ impl RegionDisplayName {
     /// use writeable::assert_writeable_eq;
     ///
     /// assert_writeable_eq!(
-    ///     RegionDisplayName::new_light_with_fallback(locale!("de").into(), region!("DE")),
+    ///     RegionDisplayName::new_light_with_fallback(
+    ///         locale!("de").into(),
+    ///         region!("DE")
+    ///     ),
     ///     "Deutschland"
     /// );
     ///
     /// assert_writeable_eq!(
-    ///     RegionDisplayName::new_light_with_fallback(locale!("zh").into(), region!("DE")),
+    ///     RegionDisplayName::new_light_with_fallback(
+    ///         locale!("zh").into(),
+    ///         region!("DE")
+    ///     ),
     ///     "德国"
     /// );
     /// ```
@@ -196,13 +203,19 @@ impl RegionDisplayName {
     /// use writeable::assert_writeable_eq;
     ///
     /// assert_writeable_eq!(
-    ///     RegionDisplayName::new_tiny_with_fallback(locale!("de").into(), region!("DE")),
+    ///     RegionDisplayName::new_tiny_with_fallback(
+    ///         locale!("de").into(),
+    ///         region!("DE")
+    ///     ),
     ///     "Deutschland"
     /// );
     ///
     /// // Name for Germany is NOT included in the Chinese locale
     /// assert_writeable_eq!(
-    ///     RegionDisplayName::new_tiny_with_fallback(locale!("zh").into(), region!("DE")),
+    ///     RegionDisplayName::new_tiny_with_fallback(
+    ///         locale!("zh").into(),
+    ///         region!("DE")
+    ///     ),
     ///     "DE"
     /// );
     /// ```
@@ -290,19 +303,28 @@ impl RegionDisplayName {
     /// use writeable::assert_writeable_eq;
     ///
     /// assert_writeable_eq!(
-    ///     RegionDisplayName::new_short_tiny_with_fallback(locale!("de").into(), region!("DE")),
+    ///     RegionDisplayName::new_short_tiny_with_fallback(
+    ///         locale!("de").into(),
+    ///         region!("DE")
+    ///     ),
     ///     "Deutschland"
     /// );
     ///
     /// // Name for Germany is NOT included in the Chinese locale
     /// assert_writeable_eq!(
-    ///     RegionDisplayName::new_short_tiny_with_fallback(locale!("zh").into(), region!("DE")),
+    ///     RegionDisplayName::new_short_tiny_with_fallback(
+    ///         locale!("zh").into(),
+    ///         region!("DE")
+    ///     ),
     ///     "DE"
     /// );
     ///
     /// // Example short name: region GB -> "UK"
     /// assert_writeable_eq!(
-    ///     RegionDisplayName::new_short_tiny_with_fallback(locale!("en").into(), region!("GB")),
+    ///     RegionDisplayName::new_short_tiny_with_fallback(
+    ///         locale!("en").into(),
+    ///         region!("GB")
+    ///     ),
     ///     "UK"
     /// );
     /// ```
@@ -403,18 +425,27 @@ impl RegionDisplayName {
     /// use writeable::assert_writeable_eq;
     ///
     /// assert_writeable_eq!(
-    ///     RegionDisplayName::new_short_light_with_fallback(locale!("de").into(), region!("DE")),
+    ///     RegionDisplayName::new_short_light_with_fallback(
+    ///         locale!("de").into(),
+    ///         region!("DE")
+    ///     ),
     ///     "Deutschland"
     /// );
     ///
     /// assert_writeable_eq!(
-    ///     RegionDisplayName::new_short_light_with_fallback(locale!("zh").into(), region!("DE")),
+    ///     RegionDisplayName::new_short_light_with_fallback(
+    ///         locale!("zh").into(),
+    ///         region!("DE")
+    ///     ),
     ///     "德国"
     /// );
     ///
     /// // Example short name: region GB -> "UK"
     /// assert_writeable_eq!(
-    ///     RegionDisplayName::new_short_light_with_fallback(locale!("en").into(), region!("GB")),
+    ///     RegionDisplayName::new_short_light_with_fallback(
+    ///         locale!("en").into(),
+    ///         region!("GB")
+    ///     ),
     ///     "UK"
     /// );
     /// ```

--- a/components/locale/src/names/script.rs
+++ b/components/locale/src/names/script.rs
@@ -68,8 +68,9 @@ macro_rules! table_row {
 /// use icu::locale::{locale, subtags::script};
 /// use writeable::assert_writeable_eq;
 ///
-/// let display_name = ScriptDisplayName::try_new_light(locale!("en").into(), script!("Latn"))
-///     .expect("Data should load successfully");
+/// let display_name =
+///     ScriptDisplayName::try_new_light(locale!("en").into(), script!("Latn"))
+///         .expect("Data should load successfully");
 ///
 /// assert_writeable_eq!(display_name, "Latin");
 /// ```
@@ -97,12 +98,18 @@ impl ScriptDisplayName {
     /// use writeable::assert_writeable_eq;
     ///
     /// assert_writeable_eq!(
-    ///     ScriptDisplayName::new_light_with_fallback(locale!("bs").into(), script!("Cyrl")),
+    ///     ScriptDisplayName::new_light_with_fallback(
+    ///         locale!("bs").into(),
+    ///         script!("Cyrl")
+    ///     ),
     ///     "ćirilica"
     /// );
     ///
     /// assert_writeable_eq!(
-    ///     ScriptDisplayName::new_light_with_fallback(locale!("zh").into(), script!("Cyrl")),
+    ///     ScriptDisplayName::new_light_with_fallback(
+    ///         locale!("zh").into(),
+    ///         script!("Cyrl")
+    ///     ),
     ///     "西里尔文"
     /// );
     /// ```
@@ -195,13 +202,19 @@ impl ScriptDisplayName {
     /// use writeable::assert_writeable_eq;
     ///
     /// assert_writeable_eq!(
-    ///     ScriptDisplayName::new_tiny_with_fallback(locale!("bs").into(), script!("Cyrl")),
+    ///     ScriptDisplayName::new_tiny_with_fallback(
+    ///         locale!("bs").into(),
+    ///         script!("Cyrl")
+    ///     ),
     ///     "ćirilica"
     /// );
     ///
     /// // Name for Cyrillic script is NOT included in the Chinese locale
     /// assert_writeable_eq!(
-    ///     ScriptDisplayName::new_tiny_with_fallback(locale!("zh").into(), script!("Cyrl")),
+    ///     ScriptDisplayName::new_tiny_with_fallback(
+    ///         locale!("zh").into(),
+    ///         script!("Cyrl")
+    ///     ),
     ///     "Cyrl"
     /// );
     /// ```
@@ -286,12 +299,18 @@ impl ScriptDisplayName {
     /// use writeable::assert_writeable_eq;
     ///
     /// assert_writeable_eq!(
-    ///     ScriptDisplayName::new_heavy_with_fallback(locale!("de").into(), script!("Latn")),
+    ///     ScriptDisplayName::new_heavy_with_fallback(
+    ///         locale!("de").into(),
+    ///         script!("Latn")
+    ///     ),
     ///     "Lateinisch"
     /// );
     ///
     /// assert_writeable_eq!(
-    ///     ScriptDisplayName::new_heavy_with_fallback(locale!("de").into(), script!("Xsux")),
+    ///     ScriptDisplayName::new_heavy_with_fallback(
+    ///         locale!("de").into(),
+    ///         script!("Xsux")
+    ///     ),
     ///     "Sumerisch-akkadische Keilschrift"
     /// );
     /// ```
@@ -391,13 +410,19 @@ impl ScriptDisplayName {
     /// use writeable::assert_writeable_eq;
     ///
     /// assert_writeable_eq!(
-    ///     ScriptDisplayName::new_short_heavy_with_fallback(locale!("de").into(), script!("Latn")),
+    ///     ScriptDisplayName::new_short_heavy_with_fallback(
+    ///         locale!("de").into(),
+    ///         script!("Latn")
+    ///     ),
     ///     "Lateinisch"
     /// );
     ///
     /// // Example short name: script Xsux -> "S-A Cuneiform" in en
     /// assert_writeable_eq!(
-    ///     ScriptDisplayName::new_short_heavy_with_fallback(locale!("en").into(), script!("Xsux")),
+    ///     ScriptDisplayName::new_short_heavy_with_fallback(
+    ///         locale!("en").into(),
+    ///         script!("Xsux")
+    ///     ),
     ///     "S-A Cuneiform"
     /// );
     /// ```

--- a/components/locale/src/names/variant.rs
+++ b/components/locale/src/names/variant.rs
@@ -51,8 +51,11 @@ macro_rules! table_row {
 /// use icu::locale::{locale, subtags::variant};
 /// use writeable::assert_writeable_eq;
 ///
-/// let display_name = VariantDisplayName::try_new_heavy(locale!("en").into(), variant!("fonipa"))
-///     .expect("Data should load successfully");
+/// let display_name = VariantDisplayName::try_new_heavy(
+///     locale!("en").into(),
+///     variant!("fonipa"),
+/// )
+/// .expect("Data should load successfully");
 ///
 /// assert_writeable_eq!(display_name, "IPA Phonetics");
 /// ```
@@ -81,12 +84,18 @@ impl VariantDisplayName {
     /// use writeable::assert_writeable_eq;
     ///
     /// assert_writeable_eq!(
-    ///     VariantDisplayName::new_heavy_with_fallback(locale!("de").into(), variant!("fonipa")),
+    ///     VariantDisplayName::new_heavy_with_fallback(
+    ///         locale!("de").into(),
+    ///         variant!("fonipa")
+    ///     ),
     ///     "IPA Phonetisch"
     /// );
     ///
     /// assert_writeable_eq!(
-    ///     VariantDisplayName::new_heavy_with_fallback(locale!("fr").into(), variant!("fonipa")),
+    ///     VariantDisplayName::new_heavy_with_fallback(
+    ///         locale!("fr").into(),
+    ///         variant!("fonipa")
+    ///     ),
     ///     "alphabet phonétique international"
     /// );
     /// ```

--- a/components/locale_core/src/data.rs
+++ b/components/locale_core/src/data.rs
@@ -55,7 +55,7 @@ use core::str::FromStr;
 /// lookup and fallback. This may change in the future.
 ///
 /// ```
-/// use icu_locale_core::{locale, Locale};
+/// use icu_locale_core::{Locale, locale};
 /// use icu_provider::DataLocale;
 ///
 /// let locale = "hi-IN-t-en-h0-hybrid-u-attr-ca-buddhist-sd-inas"

--- a/components/locale_core/src/extensions/mod.rs
+++ b/components/locale_core/src/extensions/mod.rs
@@ -20,8 +20,8 @@
 //! # Examples
 //!
 //! ```
-//! use icu::locale::extensions::unicode::{Key, Value};
 //! use icu::locale::Locale;
+//! use icu::locale::extensions::unicode::{Key, Value};
 //!
 //! let loc: Locale = "en-US-u-ca-buddhist-t-en-us-h0-hybrid-x-foo"
 //!     .parse()
@@ -237,8 +237,8 @@ impl Extensions {
     /// # Examples
     ///
     /// ```
-    /// use icu::locale::extensions::ExtensionType;
     /// use icu::locale::Locale;
+    /// use icu::locale::extensions::ExtensionType;
     ///
     /// let loc: Locale =
     ///     "und-a-hello-t-mul-u-world-z-zzz-x-extra".parse().unwrap();

--- a/components/locale_core/src/extensions/other/mod.rs
+++ b/components/locale_core/src/extensions/other/mod.rs
@@ -13,8 +13,8 @@
 //! # Examples
 //!
 //! ```
-//! use icu::locale::extensions::other::Other;
 //! use icu::locale::Locale;
+//! use icu::locale::extensions::other::Other;
 //!
 //! let mut loc: Locale = "en-US-a-foo-faa".parse().expect("Parsing failed.");
 //! ```

--- a/components/locale_core/src/extensions/private/mod.rs
+++ b/components/locale_core/src/extensions/private/mod.rs
@@ -14,7 +14,7 @@
 //!
 //! ```
 //! use icu::locale::extensions::private::subtag;
-//! use icu::locale::{locale, Locale};
+//! use icu::locale::{Locale, locale};
 //!
 //! let mut loc: Locale = "en-US-x-foo-faa".parse().expect("Parsing failed.");
 //!

--- a/components/locale_core/src/extensions/transform/fields.rs
+++ b/components/locale_core/src/extensions/transform/fields.rs
@@ -23,7 +23,7 @@ use super::Value;
 /// # Examples
 ///
 /// ```
-/// use icu::locale::extensions::transform::{key, Fields, Value};
+/// use icu::locale::extensions::transform::{Fields, Value, key};
 ///
 /// let value = "hybrid".parse::<Value>().expect("Failed to parse a Value.");
 /// let fields = [(key!("h0"), value)].into_iter().collect::<Fields>();
@@ -58,8 +58,8 @@ impl Fields {
     /// # Examples
     ///
     /// ```
-    /// use icu::locale::locale;
     /// use icu::locale::Locale;
+    /// use icu::locale::locale;
     ///
     /// let loc1 = Locale::try_from_str("und-t-h0-hybrid").unwrap();
     /// let loc2 = locale!("und-u-ca-buddhist");
@@ -78,7 +78,7 @@ impl Fields {
     /// # Examples
     ///
     /// ```
-    /// use icu::locale::extensions::transform::{key, Fields, Value};
+    /// use icu::locale::extensions::transform::{Fields, Value, key};
     ///
     /// let value = "hybrid".parse::<Value>().expect("Failed to parse a Value.");
     /// let mut fields = [(key!("h0"), value)].into_iter().collect::<Fields>();
@@ -122,7 +122,7 @@ impl Fields {
     /// # Examples
     ///
     /// ```
-    /// use icu::locale::extensions::transform::{key, Fields, Value};
+    /// use icu::locale::extensions::transform::{Fields, Value, key};
     ///
     /// let value = "hybrid".parse::<Value>().unwrap();
     /// let fields = [(key!("h0"), value.clone())]
@@ -146,8 +146,8 @@ impl Fields {
     /// # Examples
     ///
     /// ```
-    /// use icu::locale::extensions::transform::{key, Value};
     /// use icu::locale::Locale;
+    /// use icu::locale::extensions::transform::{Value, key};
     ///
     /// let lower = "lower".parse::<Value>().expect("valid extension subtag");
     /// let casefold = "casefold".parse::<Value>().expect("valid extension subtag");
@@ -172,8 +172,8 @@ impl Fields {
     /// # Examples
     ///
     /// ```
-    /// use icu::locale::extensions::transform::key;
     /// use icu::locale::Locale;
+    /// use icu::locale::extensions::transform::key;
     ///
     /// let mut loc: Locale = "und-t-h0-hybrid-d0-hex-m0-xml".parse().unwrap();
     ///

--- a/components/locale_core/src/extensions/unicode/attributes.rs
+++ b/components/locale_core/src/extensions/unicode/attributes.rs
@@ -107,7 +107,7 @@ impl Attributes {
     /// # Examples
     ///
     /// ```
-    /// use icu::locale::extensions::unicode::{attribute, Attributes};
+    /// use icu::locale::extensions::unicode::{Attributes, attribute};
     /// use writeable::assert_writeable_eq;
     ///
     /// let mut attributes = Attributes::from_vec_unchecked(vec![

--- a/components/locale_core/src/extensions/unicode/keywords.rs
+++ b/components/locale_core/src/extensions/unicode/keywords.rs
@@ -35,7 +35,7 @@ use crate::shortvec::ShortBoxSlice;
 /// Manually build up a [`Keywords`] object:
 ///
 /// ```
-/// use icu::locale::extensions::unicode::{key, value, Keywords};
+/// use icu::locale::extensions::unicode::{Keywords, key, value};
 ///
 /// let keywords = [(key!("hc"), value!("h23"))]
 ///     .into_iter()
@@ -48,8 +48,8 @@ use crate::shortvec::ShortBoxSlice;
 ///
 /// ```
 /// use icu::locale::{
-///     extensions::unicode::{key, value},
 ///     Locale,
+///     extensions::unicode::{key, value},
 /// };
 ///
 /// let loc: Locale = "und-u-hc-h23-kc-true".parse().expect("Valid BCP-47");
@@ -118,8 +118,8 @@ impl Keywords {
     /// # Examples
     ///
     /// ```
-    /// use icu::locale::locale;
     /// use icu::locale::Locale;
+    /// use icu::locale::locale;
     ///
     /// let loc1 = Locale::try_from_str("und-t-h0-hybrid").unwrap();
     /// let loc2 = locale!("und-u-ca-buddhist");
@@ -137,7 +137,7 @@ impl Keywords {
     /// # Examples
     ///
     /// ```
-    /// use icu::locale::extensions::unicode::{key, value, Keywords};
+    /// use icu::locale::extensions::unicode::{Keywords, key, value};
     ///
     /// let keywords = [(key!("ca"), value!("gregory"))]
     ///     .into_iter()
@@ -159,7 +159,7 @@ impl Keywords {
     /// # Examples
     ///
     /// ```
-    /// use icu::locale::extensions::unicode::{key, value, Keywords};
+    /// use icu::locale::extensions::unicode::{Keywords, key, value};
     ///
     /// let keywords = [(key!("ca"), value!("buddhist"))]
     ///     .into_iter()
@@ -184,7 +184,7 @@ impl Keywords {
     /// # Examples
     ///
     /// ```
-    /// use icu::locale::extensions::unicode::{key, value, Keywords};
+    /// use icu::locale::extensions::unicode::{Keywords, key, value};
     ///
     /// let mut keywords = [(key!("ca"), value!("buddhist"))]
     ///     .into_iter()
@@ -211,8 +211,8 @@ impl Keywords {
     /// # Examples
     ///
     /// ```
-    /// use icu::locale::extensions::unicode::{key, value};
     /// use icu::locale::Locale;
+    /// use icu::locale::extensions::unicode::{key, value};
     ///
     /// let mut loc: Locale = "und-u-hello-ca-buddhist-hc-h12"
     ///     .parse()
@@ -238,8 +238,8 @@ impl Keywords {
     /// # Examples
     ///
     /// ```
-    /// use icu::locale::extensions::unicode::key;
     /// use icu::locale::Locale;
+    /// use icu::locale::extensions::unicode::key;
     ///
     /// let mut loc: Locale = "und-u-hello-ca-buddhist-hc-h12"
     ///     .parse()
@@ -276,8 +276,8 @@ impl Keywords {
     /// # Examples
     ///
     /// ```
-    /// use icu::locale::extensions::unicode::key;
     /// use icu::locale::Locale;
+    /// use icu::locale::extensions::unicode::key;
     ///
     /// let mut loc: Locale = "und-u-ca-buddhist-hc-h12-ms-metric".parse().unwrap();
     ///

--- a/components/locale_core/src/extensions/unicode/mod.rs
+++ b/components/locale_core/src/extensions/unicode/mod.rs
@@ -11,8 +11,8 @@
 //! # Examples
 //!
 //! ```
-//! use icu::locale::extensions::unicode::{attribute, key, value, Unicode};
 //! use icu::locale::Locale;
+//! use icu::locale::extensions::unicode::{Unicode, attribute, key, value};
 //!
 //! let loc: Locale = "en-US-u-foobar-hc-h12".parse().expect("Parsing failed.");
 //!
@@ -20,11 +20,12 @@
 //!     loc.extensions.unicode.keywords.get(&key!("hc")),
 //!     Some(&value!("h12"))
 //! );
-//! assert!(loc
-//!     .extensions
-//!     .unicode
-//!     .attributes
-//!     .contains(&attribute!("foobar")));
+//! assert!(
+//!     loc.extensions
+//!         .unicode
+//!         .attributes
+//!         .contains(&attribute!("foobar"))
+//! );
 //! ```
 mod attribute;
 mod attributes;
@@ -74,8 +75,8 @@ pub(crate) const UNICODE_EXT_STR: &str = "u";
 /// # Examples
 ///
 /// ```
-/// use icu::locale::extensions::unicode::{key, value};
 /// use icu::locale::Locale;
+/// use icu::locale::extensions::unicode::{key, value};
 ///
 /// let loc: Locale =
 ///     "de-u-hc-h12-ca-buddhist".parse().expect("Parsing failed.");

--- a/components/locale_core/src/extensions/unicode/subdivision.rs
+++ b/components/locale_core/src/extensions/unicode/subdivision.rs
@@ -70,7 +70,7 @@ impl SubdivisionSuffix {
 ///
 /// ```
 /// use icu::locale::{
-///     extensions::unicode::{subdivision_suffix, SubdivisionId},
+///     extensions::unicode::{SubdivisionId, subdivision_suffix},
 ///     subtags::region,
 /// };
 ///
@@ -98,7 +98,7 @@ impl SubdivisionId {
     ///
     /// ```
     /// use icu::locale::{
-    ///     extensions::unicode::{subdivision_suffix, SubdivisionId},
+    ///     extensions::unicode::{SubdivisionId, subdivision_suffix},
     ///     subtags::region,
     /// };
     ///
@@ -132,8 +132,8 @@ impl SubdivisionId {
     /// When the value can't be parsed:
     ///
     /// ```
-    /// use icu::locale::extensions::unicode::SubdivisionId;
     /// use icu::locale::ParseError;
+    /// use icu::locale::extensions::unicode::SubdivisionId;
     ///
     /// // Value is too short
     /// assert!(matches!(

--- a/components/locale_core/src/extensions/unicode/value.rs
+++ b/components/locale_core/src/extensions/unicode/value.rs
@@ -22,7 +22,7 @@ use core::str::FromStr;
 /// # Examples
 ///
 /// ```
-/// use icu::locale::extensions::unicode::{value, Value};
+/// use icu::locale::extensions::unicode::{Value, value};
 /// use writeable::assert_writeable_eq;
 ///
 /// assert_writeable_eq!(value!("gregory"), "gregory");
@@ -172,7 +172,7 @@ impl Value {
     /// # Examples
     ///
     /// ```
-    /// use icu::locale::extensions::unicode::{value, Value};
+    /// use icu::locale::extensions::unicode::{Value, value};
     ///
     /// assert_eq!(value!("true"), Value::new_empty());
     /// ```
@@ -351,8 +351,8 @@ impl_writeable_for_subtag_list!(Value, "islamic", "civil");
 /// # Examples
 ///
 /// ```
-/// use icu::locale::extensions::unicode::{key, value};
 /// use icu::locale::Locale;
+/// use icu::locale::extensions::unicode::{key, value};
 ///
 /// let loc: Locale = "de-u-ca-buddhist".parse().unwrap();
 ///

--- a/components/locale_core/src/langid.rs
+++ b/components/locale_core/src/langid.rs
@@ -159,7 +159,7 @@ impl LanguageIdentifier {
     /// # Examples
     ///
     /// ```
-    /// use icu::locale::{langid, LanguageIdentifier};
+    /// use icu::locale::{LanguageIdentifier, langid};
     ///
     /// let li = LanguageIdentifier::try_from_locale_bytes(b"en-US-x-posix")
     ///     .expect("Parsing failed.");
@@ -562,7 +562,7 @@ fn test_writeable() {
 /// # Examples
 ///
 /// ```
-/// use icu::locale::{langid, subtags::language, LanguageIdentifier};
+/// use icu::locale::{LanguageIdentifier, langid, subtags::language};
 ///
 /// assert_eq!(LanguageIdentifier::from(language!("en")), langid!("en"));
 /// ```
@@ -580,7 +580,7 @@ impl From<subtags::Language> for LanguageIdentifier {
 /// # Examples
 ///
 /// ```
-/// use icu::locale::{langid, subtags::script, LanguageIdentifier};
+/// use icu::locale::{LanguageIdentifier, langid, subtags::script};
 ///
 /// assert_eq!(
 ///     LanguageIdentifier::from(Some(script!("latn"))),
@@ -601,7 +601,7 @@ impl From<Option<subtags::Script>> for LanguageIdentifier {
 /// # Examples
 ///
 /// ```
-/// use icu::locale::{langid, subtags::region, LanguageIdentifier};
+/// use icu::locale::{LanguageIdentifier, langid, subtags::region};
 ///
 /// assert_eq!(
 ///     LanguageIdentifier::from(Some(region!("US"))),
@@ -625,9 +625,8 @@ impl From<Option<subtags::Region>> for LanguageIdentifier {
 ///
 /// ```
 /// use icu::locale::{
-///     langid,
+///     LanguageIdentifier, langid,
 ///     subtags::{language, region, script},
-///     LanguageIdentifier,
 /// };
 ///
 /// let lang = language!("en");

--- a/components/locale_core/src/locale.rs
+++ b/components/locale_core/src/locale.rs
@@ -80,7 +80,7 @@ use core::str::FromStr;
 /// More complex example:
 ///
 /// ```
-/// use icu::locale::{subtags::*, Locale};
+/// use icu::locale::{Locale, subtags::*};
 ///
 /// let loc: Locale = "eN-latn-Us-Valencia-u-hC-H12"
 ///     .parse()

--- a/components/locale_core/src/macros.rs
+++ b/components/locale_core/src/macros.rs
@@ -9,7 +9,7 @@
 /// # Examples
 ///
 /// ```
-/// use icu::locale::{langid, LanguageIdentifier};
+/// use icu::locale::{LanguageIdentifier, langid};
 ///
 /// const DE_AT: LanguageIdentifier = langid!("de-at");
 ///
@@ -59,7 +59,7 @@ macro_rules! langid {
 /// # Examples
 ///
 /// ```
-/// use icu::locale::{locale, Locale};
+/// use icu::locale::{Locale, locale};
 ///
 /// const DE_AT: Locale = locale!("de-at");
 ///
@@ -164,7 +164,7 @@ macro_rules! locale {
 /// # Examples
 ///
 /// ```
-/// use icu::locale::{data_locale, DataLocale};
+/// use icu::locale::{DataLocale, data_locale};
 ///
 /// const DE_AT: DataLocale = data_locale!("de-at");
 ///

--- a/components/locale_core/src/parser/errors.rs
+++ b/components/locale_core/src/parser/errors.rs
@@ -15,8 +15,8 @@ pub enum ParseError {
     /// # Examples
     ///
     /// ```
-    /// use icu::locale::subtags::Language;
     /// use icu::locale::ParseError;
+    /// use icu::locale::subtags::Language;
     ///
     /// assert_eq!("x2".parse::<Language>(), Err(ParseError::InvalidLanguage));
     /// ```
@@ -28,8 +28,8 @@ pub enum ParseError {
     /// # Examples
     ///
     /// ```
-    /// use icu::locale::subtags::Region;
     /// use icu::locale::ParseError;
+    /// use icu::locale::subtags::Region;
     ///
     /// assert_eq!("#@2X".parse::<Region>(), Err(ParseError::InvalidSubtag));
     /// ```
@@ -41,8 +41,8 @@ pub enum ParseError {
     /// # Examples
     ///
     /// ```
-    /// use icu::locale::extensions::unicode::Key;
     /// use icu::locale::ParseError;
+    /// use icu::locale::extensions::unicode::Key;
     ///
     /// assert_eq!("#@2X".parse::<Key>(), Err(ParseError::InvalidExtension));
     /// ```

--- a/components/locale_core/src/subtags/variants.rs
+++ b/components/locale_core/src/subtags/variants.rs
@@ -17,7 +17,7 @@ use core::ops::Deref;
 /// # Examples
 ///
 /// ```
-/// use icu::locale::subtags::{variant, Variants};
+/// use icu::locale::subtags::{Variants, variant};
 ///
 /// let mut v = vec![variant!("posix"), variant!("macos")];
 /// v.sort();
@@ -49,7 +49,7 @@ impl Variants {
     /// # Examples
     ///
     /// ```
-    /// use icu::locale::subtags::{variant, Variants};
+    /// use icu::locale::subtags::{Variants, variant};
     ///
     /// let variants = Variants::from_variant(variant!("posix"));
     /// ```
@@ -67,7 +67,7 @@ impl Variants {
     /// # Examples
     ///
     /// ```
-    /// use icu::locale::subtags::{variant, Variants};
+    /// use icu::locale::subtags::{Variants, variant};
     ///
     /// let mut v = vec![variant!("posix"), variant!("macos")];
     /// v.sort();
@@ -96,7 +96,7 @@ impl Variants {
     /// # Examples
     ///
     /// ```
-    /// use icu::locale::subtags::{variant, Variants};
+    /// use icu::locale::subtags::{Variants, variant};
     ///
     /// let mut v = vec![variant!("posix"), variant!("macos")];
     /// v.sort();
@@ -128,7 +128,7 @@ impl Variants {
     /// # Examples
     ///
     /// ```
-    /// use icu::locale::subtags::{variant, Variants};
+    /// use icu::locale::subtags::{Variants, variant};
     ///
     /// let mut variants = Variants::new();
     /// assert!(variants.push(variant!("posix")));
@@ -154,7 +154,7 @@ impl Variants {
     /// # Examples
     ///
     /// ```
-    /// use icu::locale::subtags::{variant, Variants};
+    /// use icu::locale::subtags::{Variants, variant};
     ///
     /// let mut variants = Variants::from_variant(variant!("posix"));
     /// assert!(variants.remove(&variant!("posix")));

--- a/components/locale_core/src/zerovec.rs
+++ b/components/locale_core/src/zerovec.rs
@@ -57,8 +57,8 @@
 //! tuple, and then construct the [`LanguageIdentifier`] externally.
 //!
 //! ```
-//! use icu::locale::subtags::{Language, Region, Script};
 //! use icu::locale::LanguageIdentifier;
+//! use icu::locale::subtags::{Language, Region, Script};
 //! use icu::locale::{
 //!     langid,
 //!     subtags::{language, region, script},
@@ -99,8 +99,8 @@
 //! As above, to produce more human-readable serialized output, you can use `PotentialUtf8`.
 //!
 //! ```
-//! use icu::locale::locale;
 //! use icu::locale::Locale;
+//! use icu::locale::locale;
 //! use potential_utf::PotentialUtf8;
 //! use zerovec::ZeroMap;
 //!

--- a/components/pattern/src/common.rs
+++ b/components/pattern/src/common.rs
@@ -276,7 +276,9 @@ where
 ///
 /// let err_value = Err::<&str, &str>("Errory");
 ///
-/// let pattern = SinglePlaceholderPattern::try_from_str("Hello {0}", Default::default()).unwrap();
+/// let pattern =
+///     SinglePlaceholderPattern::try_from_str("Hello {0}", Default::default())
+///         .unwrap();
 /// assert_try_writeable_eq!(
 ///     pattern.try_interpolate(TryWrap(err_value)),
 ///     "Hello Errory",
@@ -295,7 +297,9 @@ where
 /// let ok_value = Ok::<&str, &str>("xxx");
 /// let err_value = Err::<&str, &str>("yyy");
 ///
-/// let pattern = DoublePlaceholderPattern::try_from_str("{0}-{1}", Default::default()).unwrap();
+/// let pattern =
+///     DoublePlaceholderPattern::try_from_str("{0}-{1}", Default::default())
+///         .unwrap();
 /// assert_try_writeable_eq!(
 ///     pattern.try_interpolate(TryWrap((ok_value, err_value))),
 ///     "xxx-yyy",

--- a/components/pattern/src/frontend/mod.rs
+++ b/components/pattern/src/frontend/mod.rs
@@ -431,9 +431,13 @@ impl<'p, 'a, B: ExtractionBackend> PlaceholderMatches<'p, 'a, B> {
     /// # Examples
     ///
     /// ```
-    /// use icu_pattern::{Pattern, DoublePlaceholder, DoublePlaceholderKey};
+    /// use icu_pattern::{DoublePlaceholder, DoublePlaceholderKey, Pattern};
     ///
-    /// let pattern = Pattern::<DoublePlaceholder>::try_from_str("Hello, {0} and {1}!", Default::default()).unwrap();
+    /// let pattern = Pattern::<DoublePlaceholder>::try_from_str(
+    ///     "Hello, {0} and {1}!",
+    ///     Default::default(),
+    /// )
+    /// .unwrap();
     /// let matches = pattern.extract_values("Hello, Alice and Bob!").unwrap();
     /// assert_eq!(matches.get(DoublePlaceholderKey::Place0), Some("Alice"));
     /// assert_eq!(matches.get(DoublePlaceholderKey::Place1), Some("Bob"));
@@ -490,7 +494,11 @@ impl<B: ExtractionBackend> Pattern<B> {
     /// ```
     /// use icu_pattern::{Pattern, SinglePlaceholder, SinglePlaceholderKey};
     ///
-    /// let pattern = Pattern::<SinglePlaceholder>::try_from_str("Hello, {0}!", Default::default()).unwrap();
+    /// let pattern = Pattern::<SinglePlaceholder>::try_from_str(
+    ///     "Hello, {0}!",
+    ///     Default::default(),
+    /// )
+    /// .unwrap();
     /// let matches = pattern.extract_values("Hello, Alice!").unwrap();
     /// assert_eq!(matches.get(SinglePlaceholderKey::Singleton), Some("Alice"));
     /// ```

--- a/components/plurals/src/lib.rs
+++ b/components/plurals/src/lib.rs
@@ -1084,7 +1084,7 @@ impl<T> PluralElements<T> {
     /// # Example
     /// ```
     /// use icu::locale::locale;
-    /// use icu::plurals::{PluralCategory, PluralRules, PluralElements};
+    /// use icu::plurals::{PluralCategory, PluralElements, PluralRules};
     ///
     /// let rules = PluralRules::try_new_cardinal(locale!("fr").into()).unwrap();
     ///

--- a/components/plurals/src/provider/rules/mod.rs
+++ b/components/plurals/src/provider/rules/mod.rs
@@ -95,9 +95,9 @@
 //! matches:
 //!
 //! ```
+//! use icu::plurals::PluralOperands;
 //! use icu::plurals::provider::rules::reference::parse_condition;
 //! use icu::plurals::provider::rules::reference::test_condition;
-//! use icu::plurals::PluralOperands;
 //!
 //! let input = "i = 1 and v = 0 @integer 1";
 //!

--- a/components/plurals/src/provider/rules/reference/resolver.rs
+++ b/components/plurals/src/provider/rules/reference/resolver.rs
@@ -17,9 +17,9 @@ use crate::provider::rules::reference::ast;
 /// # Examples
 ///
 /// ```
+/// use icu::plurals::PluralOperands;
 /// use icu::plurals::provider::rules::reference::parse_condition;
 /// use icu::plurals::provider::rules::reference::test_condition;
-/// use icu::plurals::PluralOperands;
 ///
 /// let operands = PluralOperands::from(5_usize);
 /// let condition =

--- a/components/properties/src/code_point_map.rs
+++ b/components/properties/src/code_point_map.rs
@@ -194,8 +194,8 @@ impl<'a, T: TrieValue> CodePointMapDataBorrowed<'a, T> {
     /// # Example
     ///
     /// ```
-    /// use icu::properties::props::GeneralCategory;
     /// use icu::properties::CodePointMapData;
+    /// use icu::properties::props::GeneralCategory;
     ///
     /// let gc = CodePointMapData::<GeneralCategory>::new();
     ///
@@ -218,8 +218,8 @@ impl<'a, T: TrieValue> CodePointMapDataBorrowed<'a, T> {
     /// # Examples
     ///
     /// ```
-    /// use icu::properties::props::GeneralCategory;
     /// use icu::properties::CodePointMapData;
+    /// use icu::properties::props::GeneralCategory;
     ///
     /// let gc = CodePointMapData::<GeneralCategory>::new();
     /// let mut ranges = gc.iter_ranges();
@@ -241,8 +241,8 @@ impl<'a, T: TrieValue> CodePointMapDataBorrowed<'a, T> {
     ///
     ///
     /// ```
-    /// use icu::properties::props::GeneralCategory;
     /// use icu::properties::CodePointMapData;
+    /// use icu::properties::props::GeneralCategory;
     ///
     /// let gc = CodePointMapData::<GeneralCategory>::new();
     /// let mut ranges = gc.iter_ranges_for_value(GeneralCategory::UppercaseLetter);
@@ -290,8 +290,8 @@ impl CodePointMapDataBorrowed<'_, GeneralCategory> {
     /// # Example
     ///
     /// ```
-    /// use icu::properties::props::{GeneralCategory, GeneralCategoryGroup};
     /// use icu::properties::CodePointMapData;
+    /// use icu::properties::props::{GeneralCategory, GeneralCategoryGroup};
     ///
     /// let gc = CodePointMapData::<GeneralCategory>::new();
     ///
@@ -353,8 +353,8 @@ impl<'a> CodePointMapDataBorrowed<'a, GeneralCategory> {
     /// # Examples
     ///
     /// ```
-    /// use icu::properties::props::{GeneralCategory, GeneralCategoryGroup};
     /// use icu::properties::CodePointMapData;
+    /// use icu::properties::props::{GeneralCategory, GeneralCategoryGroup};
     ///
     /// let gc = CodePointMapData::<GeneralCategory>::new();
     /// let mut ranges = gc.iter_ranges_for_group(GeneralCategoryGroup::Letter);

--- a/components/properties/src/code_point_set.rs
+++ b/components/properties/src/code_point_set.rs
@@ -177,8 +177,8 @@ impl<'a> CodePointSetDataBorrowed<'a> {
     /// # Example
     ///
     /// ```
-    /// use icu::properties::props::Alphabetic;
     /// use icu::properties::CodePointSetData;
+    /// use icu::properties::props::Alphabetic;
     ///
     /// let alphabetic = CodePointSetData::new::<Alphabetic>();
     /// let mut ranges = alphabetic.iter_ranges();
@@ -201,8 +201,8 @@ impl<'a> CodePointSetDataBorrowed<'a> {
     /// # Example
     ///
     /// ```
-    /// use icu::properties::props::Alphabetic;
     /// use icu::properties::CodePointSetData;
+    /// use icu::properties::props::Alphabetic;
     ///
     /// let alphabetic = CodePointSetData::new::<Alphabetic>();
     /// let mut ranges = alphabetic.iter_ranges();

--- a/components/properties/src/names.rs
+++ b/components/properties/src/names.rs
@@ -25,8 +25,8 @@ use zerotrie::cursor::ZeroTrieSimpleAsciiCursor;
 /// # Example
 ///
 /// ```
-/// use icu::properties::props::GeneralCategory;
 /// use icu::properties::PropertyParser;
+/// use icu::properties::props::GeneralCategory;
 ///
 /// let lookup = PropertyParser::<GeneralCategory>::new();
 /// // short name for value
@@ -134,8 +134,8 @@ impl<T: TrieValue> PropertyParserBorrowed<'_, T> {
     /// # Example
     ///
     /// ```
-    /// use icu::properties::props::GeneralCategory;
     /// use icu::properties::PropertyParser;
+    /// use icu::properties::props::GeneralCategory;
     ///
     /// let lookup = PropertyParser::<GeneralCategory>::new();
     /// assert_eq!(
@@ -165,8 +165,8 @@ impl<T: TrieValue> PropertyParserBorrowed<'_, T> {
     /// # Example
     ///
     /// ```
-    /// use icu::properties::props::GeneralCategory;
     /// use icu::properties::PropertyParser;
+    /// use icu::properties::props::GeneralCategory;
     ///
     /// let lookup = PropertyParser::<GeneralCategory>::new();
     /// assert_eq!(
@@ -197,8 +197,8 @@ impl<T: TrieValue> PropertyParserBorrowed<'_, T> {
     /// # Example
     ///
     /// ```
-    /// use icu::properties::props::GeneralCategory;
     /// use icu::properties::PropertyParser;
+    /// use icu::properties::props::GeneralCategory;
     ///
     /// let lookup = PropertyParser::<GeneralCategory>::new();
     /// assert_eq!(
@@ -232,8 +232,8 @@ impl<T: TrieValue> PropertyParserBorrowed<'_, T> {
     /// # Example
     ///
     /// ```
-    /// use icu::properties::props::GeneralCategory;
     /// use icu::properties::PropertyParser;
+    /// use icu::properties::props::GeneralCategory;
     ///
     /// let lookup = PropertyParser::<GeneralCategory>::new();
     /// assert_eq!(
@@ -364,8 +364,8 @@ fn get_loose_u16(payload: &PropertyValueNameToEnumMap<'_>, name: &[u8]) -> Optio
 /// # Example
 ///
 /// ```
-/// use icu::properties::props::CanonicalCombiningClass;
 /// use icu::properties::PropertyNamesLong;
+/// use icu::properties::props::CanonicalCombiningClass;
 ///
 /// let names = PropertyNamesLong::<CanonicalCombiningClass>::new();
 /// assert_eq!(
@@ -442,8 +442,8 @@ impl<'a, T: NamedEnumeratedProperty> PropertyNamesLongBorrowed<'a, T> {
     /// # Example
     ///
     /// ```rust
-    /// use icu::properties::props::CanonicalCombiningClass;
     /// use icu::properties::PropertyNamesLong;
+    /// use icu::properties::props::CanonicalCombiningClass;
     ///
     /// let lookup = PropertyNamesLong::<CanonicalCombiningClass>::new();
     /// assert_eq!(
@@ -502,8 +502,8 @@ impl<T: NamedEnumeratedProperty> PropertyNamesLongBorrowed<'static, T> {
 /// # Example
 ///
 /// ```
-/// use icu::properties::props::CanonicalCombiningClass;
 /// use icu::properties::PropertyNamesShort;
+/// use icu::properties::props::CanonicalCombiningClass;
 ///
 /// let names = PropertyNamesShort::<CanonicalCombiningClass>::new();
 /// assert_eq!(names.get(CanonicalCombiningClass::KanaVoicing), Some("KV"));
@@ -575,8 +575,8 @@ impl<'a, T: NamedEnumeratedProperty> PropertyNamesShortBorrowed<'a, T> {
     /// # Example
     ///
     /// ```rust
-    /// use icu::properties::props::CanonicalCombiningClass;
     /// use icu::properties::PropertyNamesShort;
+    /// use icu::properties::props::CanonicalCombiningClass;
     ///
     /// let lookup = PropertyNamesShort::<CanonicalCombiningClass>::new();
     /// assert_eq!(lookup.get(CanonicalCombiningClass::KanaVoicing), Some("KV"));
@@ -597,8 +597,8 @@ impl PropertyNamesShortBorrowed<'_, Script> {
     ///
     /// ```rust
     /// use icu::locale::subtags::script;
-    /// use icu::properties::props::Script;
     /// use icu::properties::PropertyNamesShort;
+    /// use icu::properties::props::Script;
     ///
     /// let lookup = PropertyNamesShort::<Script>::new();
     /// assert_eq!(
@@ -614,8 +614,8 @@ impl PropertyNamesShortBorrowed<'_, Script> {
     /// For the reverse direction, use property parsing as normal:
     /// ```
     /// use icu::locale::subtags::script;
-    /// use icu::properties::props::Script;
     /// use icu::properties::PropertyParser;
+    /// use icu::properties::props::Script;
     ///
     /// let parser = PropertyParser::<Script>::new();
     /// assert_eq!(

--- a/components/properties/src/props.rs
+++ b/components/properties/src/props.rs
@@ -66,7 +66,7 @@ macro_rules! make_enumerated_property {
 /// # Example
 ///
 /// ```
-/// use icu::properties::{props::BidiClass, CodePointMapData};
+/// use icu::properties::{CodePointMapData, props::BidiClass};
 ///
 /// assert_eq!(
 ///     CodePointMapData::<BidiClass>::new().get('y'),
@@ -125,7 +125,7 @@ make_enumerated_property! {
 /// # Example
 ///
 /// ```
-/// use icu::properties::{props::NumericType, CodePointMapData};
+/// use icu::properties::{CodePointMapData, props::NumericType};
 ///
 /// assert_eq!(
 ///     CodePointMapData::<NumericType>::new().get('0'),
@@ -188,7 +188,7 @@ make_enumerated_property! {
 /// # Example
 ///
 /// ```
-/// use icu::properties::{props::GeneralCategory, CodePointMapData};
+/// use icu::properties::{CodePointMapData, props::GeneralCategory};
 ///
 /// assert_eq!(
 ///     CodePointMapData::<GeneralCategory>::new().get('木'),
@@ -455,8 +455,8 @@ impl GeneralCategoryGroup {
     /// Return whether the code point belongs in the provided multi-value category.
     ///
     /// ```
-    /// use icu::properties::props::{GeneralCategory, GeneralCategoryGroup};
     /// use icu::properties::CodePointMapData;
+    /// use icu::properties::props::{GeneralCategory, GeneralCategoryGroup};
     ///
     /// let gc = CodePointMapData::<GeneralCategory>::new();
     ///
@@ -729,7 +729,7 @@ make_enumerated_property! {
 /// # Example
 ///
 /// ```
-/// use icu::properties::{props::HangulSyllableType, CodePointMapData};
+/// use icu::properties::{CodePointMapData, props::HangulSyllableType};
 ///
 /// assert_eq!(
 ///     CodePointMapData::<HangulSyllableType>::new().get('ᄀ'),
@@ -797,7 +797,7 @@ make_enumerated_property! {
 /// # Example
 ///
 /// ```
-/// use icu::properties::{props::EastAsianWidth, CodePointMapData};
+/// use icu::properties::{CodePointMapData, props::EastAsianWidth};
 ///
 /// assert_eq!(
 ///     CodePointMapData::<EastAsianWidth>::new().get('ｱ'),
@@ -860,7 +860,7 @@ make_enumerated_property! {
 /// # Example
 ///
 /// ```
-/// use icu::properties::{props::LineBreak, CodePointMapData};
+/// use icu::properties::{CodePointMapData, props::LineBreak};
 ///
 /// assert_eq!(
 ///     CodePointMapData::<LineBreak>::new().get(')'),
@@ -922,7 +922,7 @@ make_enumerated_property! {
 /// # Example
 ///
 /// ```
-/// use icu::properties::{props::GraphemeClusterBreak, CodePointMapData};
+/// use icu::properties::{CodePointMapData, props::GraphemeClusterBreak};
 ///
 /// assert_eq!(
 ///     CodePointMapData::<GraphemeClusterBreak>::new().get('🇦'),
@@ -984,7 +984,7 @@ make_enumerated_property! {
 /// # Example
 ///
 /// ```
-/// use icu::properties::{props::WordBreak, CodePointMapData};
+/// use icu::properties::{CodePointMapData, props::WordBreak};
 ///
 /// assert_eq!(
 ///     CodePointMapData::<WordBreak>::new().get('.'),
@@ -1046,7 +1046,7 @@ make_enumerated_property! {
 /// # Example
 ///
 /// ```
-/// use icu::properties::{props::SentenceBreak, CodePointMapData};
+/// use icu::properties::{CodePointMapData, props::SentenceBreak};
 ///
 /// assert_eq!(
 ///     CodePointMapData::<SentenceBreak>::new().get('９'),
@@ -1107,7 +1107,7 @@ make_enumerated_property! {
 /// # Example
 ///
 /// ```
-/// use icu::properties::{props::CanonicalCombiningClass, CodePointMapData};
+/// use icu::properties::{CodePointMapData, props::CanonicalCombiningClass};
 ///
 /// assert_eq!(
 ///     CodePointMapData::<CanonicalCombiningClass>::new().get('a'),
@@ -1170,7 +1170,7 @@ make_enumerated_property! {
 /// # Example
 ///
 /// ```
-/// use icu::properties::{props::IndicConjunctBreak, CodePointMapData};
+/// use icu::properties::{CodePointMapData, props::IndicConjunctBreak};
 ///
 /// assert_eq!(
 ///     CodePointMapData::<IndicConjunctBreak>::new().get('a'),
@@ -1236,7 +1236,7 @@ make_enumerated_property! {
 /// # Example
 ///
 /// ```
-/// use icu::properties::{props::IndicSyllabicCategory, CodePointMapData};
+/// use icu::properties::{CodePointMapData, props::IndicSyllabicCategory};
 ///
 /// assert_eq!(
 ///     CodePointMapData::<IndicSyllabicCategory>::new().get('a'),
@@ -1293,7 +1293,7 @@ make_enumerated_property! {
 /// each property value.
 ///
 /// ```
-/// use icu::properties::{props::JoiningGroup, CodePointMapData};
+/// use icu::properties::{CodePointMapData, props::JoiningGroup};
 ///
 /// assert_eq!(
 ///     CodePointMapData::<JoiningGroup>::new().get('ع'),
@@ -1352,7 +1352,7 @@ make_enumerated_property! {
 /// # Example
 ///
 /// ```
-/// use icu::properties::{props::JoiningType, CodePointMapData};
+/// use icu::properties::{CodePointMapData, props::JoiningType};
 ///
 /// assert_eq!(
 ///     CodePointMapData::<JoiningType>::new().get('ؠ'),
@@ -1411,7 +1411,7 @@ make_enumerated_property! {
 /// # Example
 ///
 /// ```
-/// use icu::properties::{props::VerticalOrientation, CodePointMapData};
+/// use icu::properties::{CodePointMapData, props::VerticalOrientation};
 ///
 /// assert_eq!(
 ///     CodePointMapData::<VerticalOrientation>::new().get('a'),

--- a/components/properties/src/script.rs
+++ b/components/properties/src/script.rs
@@ -207,9 +207,10 @@ impl<'a> ScriptExtensionsSet<'a> {
     /// use icu::properties::script::ScriptWithExtensions;
     /// let swe = ScriptWithExtensions::new();
     ///
-    /// assert!(swe
-    ///     .get_script_extensions_val('\u{11303}') // GRANTHA SIGN VISARGA
-    ///     .contains(&Script::Grantha));
+    /// assert!(
+    ///     swe.get_script_extensions_val('\u{11303}') // GRANTHA SIGN VISARGA
+    ///         .contains(&Script::Grantha)
+    /// );
     /// ```
     pub fn contains(&self, x: &Script) -> bool {
         ZeroSlice::binary_search_by(self.values, |y| y.to_u32().cmp(&x.to_u32())).is_ok()

--- a/components/segmenter/README.md
+++ b/components/segmenter/README.md
@@ -67,7 +67,7 @@ See [`GraphemeClusterSegmenter`] for more examples.
 Find all word boundaries:
 
 ```rust
-use icu::segmenter::{options::WordBreakInvariantOptions, WordSegmenter};
+use icu::segmenter::{WordSegmenter, options::WordBreakInvariantOptions};
 
 let segmenter =
     WordSegmenter::new_auto(WordBreakInvariantOptions::default());
@@ -89,7 +89,7 @@ Segment the string into sentences:
 
 ```rust
 use icu::segmenter::{
-    options::SentenceBreakInvariantOptions, SentenceSegmenter,
+    SentenceSegmenter, options::SentenceBreakInvariantOptions,
 };
 
 let segmenter =

--- a/components/segmenter/src/complex/dictionary.rs
+++ b/components/segmenter/src/complex/dictionary.rs
@@ -13,7 +13,6 @@ use icu_collections::char16trie::{Char16Trie, TrieResult};
 /// Lifetimes:
 /// - `'data` = lifetime of the data
 /// - `'s` = lifetime of the string being segmented
-///
 #[derive(Debug)]
 pub(super) struct DictionaryBreakIterator<'data, 's, R: RuleBreakType> {
     trie: Char16Trie<'data>,

--- a/components/segmenter/src/lib.rs
+++ b/components/segmenter/src/lib.rs
@@ -80,7 +80,7 @@
 //! Find all word boundaries:
 //!
 //!```rust
-//! use icu::segmenter::{options::WordBreakInvariantOptions, WordSegmenter};
+//! use icu::segmenter::{WordSegmenter, options::WordBreakInvariantOptions};
 //!
 //! let segmenter =
 //!     WordSegmenter::new_auto(WordBreakInvariantOptions::default());
@@ -102,7 +102,7 @@
 //!
 //!```rust
 //! use icu::segmenter::{
-//!     options::SentenceBreakInvariantOptions, SentenceSegmenter,
+//!     SentenceSegmenter, options::SentenceBreakInvariantOptions,
 //! };
 //!
 //! let segmenter =

--- a/components/segmenter/src/line.rs
+++ b/components/segmenter/src/line.rs
@@ -209,10 +209,10 @@ impl LineBreakOptions<'_> {
 /// Segment a string with CSS option overrides:
 ///
 /// ```rust
+/// use icu::segmenter::LineSegmenter;
 /// use icu::segmenter::options::{
 ///     LineBreakOptions, LineBreakStrictness, LineBreakWordOption,
 /// };
-/// use icu::segmenter::LineSegmenter;
 ///
 /// let mut options = LineBreakOptions::default();
 /// options.strictness = Some(LineBreakStrictness::Strict);
@@ -240,7 +240,7 @@ impl LineBreakOptions<'_> {
 /// Separate mandatory breaks from the break opportunities:
 ///
 /// ```rust
-/// use icu::properties::{props::LineBreak, CodePointMapData};
+/// use icu::properties::{CodePointMapData, props::LineBreak};
 /// use icu::segmenter::LineSegmenter;
 ///
 /// # let segmenter = LineSegmenter::new_auto(Default::default());

--- a/components/segmenter/src/sentence.rs
+++ b/components/segmenter/src/sentence.rs
@@ -28,7 +28,8 @@ pub struct SentenceBreakOptions<'a> {
     ///
     /// let segmenter = SentenceSegmenter::new(Default::default());
     ///
-    /// let breakpoints: Vec<usize> = segmenter.segment_str("hello; world").collect();
+    /// let breakpoints: Vec<usize> =
+    ///     segmenter.segment_str("hello; world").collect();
     /// assert_eq!(&breakpoints, &[0, 12]);
     /// ```
     ///
@@ -36,16 +37,18 @@ pub struct SentenceBreakOptions<'a> {
     ///
     /// ```rust
     /// use icu::locale::langid;
-    /// use icu::segmenter::options::SentenceBreakOptions;
     /// use icu::segmenter::SentenceSegmenter;
+    /// use icu::segmenter::options::SentenceBreakOptions;
     ///
     /// let mut options = SentenceBreakOptions::default();
     /// let langid = &langid!("el");
     /// options.content_locale = Some(langid);
     /// let segmenter = SentenceSegmenter::try_new(options).unwrap();
     ///
-    /// let breakpoints: Vec<usize> =
-    ///     segmenter.as_borrowed().segment_str("hello; world").collect();
+    /// let breakpoints: Vec<usize> = segmenter
+    ///     .as_borrowed()
+    ///     .segment_str("hello; world")
+    ///     .collect();
     /// assert_eq!(&breakpoints, &[0, 7, 12]);
     /// ```
     pub content_locale: Option<&'a LanguageIdentifier>,
@@ -134,8 +137,8 @@ impl<Y: RuleBreakType> Iterator for SentenceBreakIterator<'_, '_, Y> {
 ///
 /// ```rust
 /// use icu::locale::langid;
-/// use icu::segmenter::options::SentenceBreakOptions;
 /// use icu::segmenter::SentenceSegmenter;
+/// use icu::segmenter::options::SentenceBreakOptions;
 ///
 /// let mut options = SentenceBreakOptions::default();
 /// let langid = &langid!("en");

--- a/components/segmenter/src/word.rs
+++ b/components/segmenter/src/word.rs
@@ -187,8 +187,8 @@ impl<Y: RuleBreakType> Iterator for WordBreakIteratorWithWordType<'_, '_, Y> {
 ///
 /// ```rust
 /// use icu::locale::langid;
-/// use icu::segmenter::options::WordBreakOptions;
 /// use icu::segmenter::WordSegmenter;
+/// use icu::segmenter::options::WordBreakOptions;
 ///
 /// let mut options = WordBreakOptions::default();
 /// let langid = &langid!("en");
@@ -295,7 +295,7 @@ impl WordSegmenter {
     /// Behavior with complex scripts:
     ///
     /// ```
-    /// use icu::segmenter::{options::WordBreakInvariantOptions, WordSegmenter};
+    /// use icu::segmenter::{WordSegmenter, options::WordBreakInvariantOptions};
     ///
     /// let th_str = "ทุกสองสัปดาห์";
     /// let ja_str = "こんにちは世界";
@@ -365,7 +365,7 @@ impl WordSegmenter {
     /// Behavior with complex scripts:
     ///
     /// ```
-    /// use icu::segmenter::{options::WordBreakInvariantOptions, WordSegmenter};
+    /// use icu::segmenter::{WordSegmenter, options::WordBreakInvariantOptions};
     ///
     /// let th_str = "ทุกสองสัปดาห์";
     /// let ja_str = "こんにちは世界";
@@ -433,7 +433,7 @@ impl WordSegmenter {
     /// Behavior with complex scripts:
     ///
     /// ```
-    /// use icu::segmenter::{options::WordBreakInvariantOptions, WordSegmenter};
+    /// use icu::segmenter::{WordSegmenter, options::WordBreakInvariantOptions};
     ///
     /// let th_str = "ทุกสองสัปดาห์";
     /// let ja_str = "こんにちは世界";

--- a/components/time/src/ixdtf.rs
+++ b/components/time/src/ixdtf.rs
@@ -423,8 +423,8 @@ impl<A: AsCalendar> ZonedDateTime<A, TimeZoneInfo<models::AtTime>> {
     /// use icu::calendar::cal::Hebrew;
     /// use icu::locale::subtags::subtag;
     /// use icu::time::{
-    ///     zone::{IanaParser, TimeZoneVariant, UtcOffset},
     ///     TimeZone, TimeZoneInfo, ZonedDateTime,
+    ///     zone::{IanaParser, TimeZoneVariant, UtcOffset},
     /// };
     ///
     /// let zoneddatetime = ZonedDateTime::try_strict_from_str(
@@ -468,7 +468,7 @@ impl<A: AsCalendar> ZonedDateTime<A, TimeZoneInfo<models::AtTime>> {
     ///
     /// ```
     /// use icu::calendar::Iso;
-    /// use icu::time::{zone::UtcOffset, TimeZoneInfo, ZonedDateTime};
+    /// use icu::time::{TimeZoneInfo, ZonedDateTime, zone::UtcOffset};
     ///
     /// let tz_from_offset = ZonedDateTime::try_offset_only_from_str(
     ///     "2024-08-08T12:08:19-05:00",
@@ -490,8 +490,8 @@ impl<A: AsCalendar> ZonedDateTime<A, TimeZoneInfo<models::AtTime>> {
     /// use icu::calendar::Iso;
     /// use icu::locale::subtags::subtag;
     /// use icu::time::{
-    ///     zone::{IanaParser, TimeZoneVariant, UtcOffset},
     ///     TimeZone, TimeZoneInfo, ZonedDateTime,
+    ///     zone::{IanaParser, TimeZoneVariant, UtcOffset},
     /// };
     ///
     /// let tz_from_offset_annotation = ZonedDateTime::try_offset_only_from_str(
@@ -530,7 +530,7 @@ impl<A: AsCalendar> ZonedDateTime<A, TimeZoneInfo<models::AtTime>> {
     /// ```
     /// use icu::calendar::Iso;
     /// use icu::time::{
-    ///     zone::UtcOffset, ParseError, TimeZone, TimeZoneInfo, ZonedDateTime,
+    ///     ParseError, TimeZone, TimeZoneInfo, ZonedDateTime, zone::UtcOffset,
     /// };
     /// use tinystr::tinystr;
     ///
@@ -708,8 +708,8 @@ impl ZonedTime<TimeZoneInfo<models::AtTime>> {
     /// use icu::calendar::cal::Hebrew;
     /// use icu::locale::subtags::subtag;
     /// use icu::time::{
-    ///     zone::{IanaParser, TimeZoneVariant, UtcOffset},
     ///     TimeZone, TimeZoneInfo, ZonedTime,
+    ///     zone::{IanaParser, TimeZoneVariant, UtcOffset},
     /// };
     ///
     /// let zonedtime = ZonedTime::try_strict_from_str(
@@ -742,7 +742,7 @@ impl ZonedTime<TimeZoneInfo<models::AtTime>> {
     ///
     /// ```
     /// use icu::calendar::Iso;
-    /// use icu::time::{zone::UtcOffset, TimeZoneInfo, ZonedTime};
+    /// use icu::time::{TimeZoneInfo, ZonedTime, zone::UtcOffset};
     ///
     /// let tz_from_offset =
     ///     ZonedTime::try_offset_only_from_str("T12:08:19-05:00").unwrap();
@@ -761,8 +761,8 @@ impl ZonedTime<TimeZoneInfo<models::AtTime>> {
     /// use icu::calendar::Iso;
     /// use icu::locale::subtags::subtag;
     /// use icu::time::{
-    ///     zone::{IanaParser, TimeZoneVariant, UtcOffset},
     ///     TimeZone, TimeZoneInfo, ZonedTime,
+    ///     zone::{IanaParser, TimeZoneVariant, UtcOffset},
     /// };
     ///
     /// let tz_from_offset_annotation =
@@ -797,7 +797,7 @@ impl ZonedTime<TimeZoneInfo<models::AtTime>> {
     /// ```
     /// use icu::calendar::Iso;
     /// use icu::time::{
-    ///     zone::UtcOffset, ParseError, TimeZone, TimeZoneInfo, ZonedTime,
+    ///     ParseError, TimeZone, TimeZoneInfo, ZonedTime, zone::UtcOffset,
     /// };
     /// use tinystr::tinystr;
     ///

--- a/components/time/src/types.rs
+++ b/components/time/src/types.rs
@@ -379,8 +379,8 @@ impl ZonedDateTime<Iso, UtcOffset> {
     ///
     /// ```
     /// use icu::calendar::cal::Iso;
-    /// use icu::time::zone::UtcOffset;
     /// use icu::time::ZonedDateTime;
+    /// use icu::time::zone::UtcOffset;
     ///
     /// let iso_str = "2025-04-30T17:45-0700";
     /// let timestamp = 1746060300000; // milliseconds since UNIX epoch
@@ -401,8 +401,8 @@ impl ZonedDateTime<Iso, UtcOffset> {
     ///
     /// ```
     /// use icu::calendar::cal::Iso;
-    /// use icu::time::zone::UtcOffset;
     /// use icu::time::ZonedDateTime;
+    /// use icu::time::zone::UtcOffset;
     ///
     /// let iso_str = "1920-01-02T03:04:05.250+0600";
     /// let timestamp = -1577847354750; // milliseconds since UNIX epoch
@@ -424,8 +424,8 @@ impl ZonedDateTime<Iso, UtcOffset> {
     ///
     /// ```
     /// use icu::calendar::cal::Iso;
-    /// use icu::time::zone::UtcOffset;
     /// use icu::time::ZonedDateTime;
+    /// use icu::time::zone::UtcOffset;
     ///
     /// let max_offset = UtcOffset::try_from_seconds(14 * 3600).unwrap();
     /// let zdt_max = ZonedDateTime::from_epoch_milliseconds_and_utc_offset(
@@ -485,8 +485,8 @@ impl ZonedDateTime<Iso, UtcOffset> {
 ///
 /// ```
 /// # #[cfg(feature = "ixdtf")] {
-/// use icu::time::zone::iana::IanaParser;
 /// use icu::time::ZonedTime;
+/// use icu::time::zone::iana::IanaParser;
 ///
 /// let zoned_time = ZonedTime::try_strict_from_str(
 ///     "T15:44:00-07:00[America/Los_Angeles]",

--- a/components/time/src/zone/iana.rs
+++ b/components/time/src/zone/iana.rs
@@ -36,8 +36,8 @@ use crate::{
 ///
 /// ```
 /// use icu::locale::subtags::subtag;
-/// use icu::time::zone::IanaParser;
 /// use icu::time::TimeZone;
+/// use icu::time::zone::IanaParser;
 ///
 /// let parser = IanaParser::new();
 ///
@@ -177,8 +177,8 @@ impl<'a> IanaParserBorrowed<'a> {
     /// # Examples
     ///
     /// ```
-    /// use icu::time::zone::iana::IanaParser;
     /// use icu::time::TimeZone;
+    /// use icu::time::zone::iana::IanaParser;
     ///
     /// let parser = IanaParser::new();
     ///
@@ -421,8 +421,8 @@ impl<'a> IanaParserExtendedBorrowed<'a> {
     /// # Examples
     ///
     /// ```
-    /// use icu::time::zone::iana::IanaParserExtended;
     /// use icu::time::TimeZone;
+    /// use icu::time::zone::iana::IanaParserExtended;
     ///
     /// let parser = IanaParserExtended::new();
     ///
@@ -499,8 +499,8 @@ impl<'a> IanaParserExtendedBorrowed<'a> {
     ///
     /// ```
     /// use icu::locale::subtags::subtag;
-    /// use icu::time::zone::iana::IanaParserExtended;
     /// use icu::time::zone::TimeZone;
+    /// use icu::time::zone::iana::IanaParserExtended;
     /// use std::collections::BTreeSet;
     ///
     /// let parser = IanaParserExtended::new();

--- a/components/time/src/zone/mod.rs
+++ b/components/time/src/zone/mod.rs
@@ -264,12 +264,12 @@ impl<'a> zerovec::maps::ZeroMapKV<'a> for TimeZone {
 /// ```
 /// use icu::calendar::Date;
 /// use icu::locale::subtags::subtag;
-/// use icu::time::zone::TimeZoneVariant;
-/// use icu::time::zone::UtcOffset;
-/// use icu::time::zone::ZoneNameTimestamp;
 /// use icu::time::DateTime;
 /// use icu::time::Time;
 /// use icu::time::TimeZone;
+/// use icu::time::zone::TimeZoneVariant;
+/// use icu::time::zone::UtcOffset;
+/// use icu::time::zone::ZoneNameTimestamp;
 ///
 /// // Parse the IANA ID
 /// let id = TimeZone::from_iana_id("America/Chicago");
@@ -509,13 +509,13 @@ impl TimeZoneInfo<models::AtTime> {
     /// # Example
     /// ```
     /// use icu::calendar::Date;
+    /// use icu::time::DateTime;
+    /// use icu::time::Time;
+    /// use icu::time::TimeZone;
     /// use icu::time::zone::TimeZoneVariant;
     /// use icu::time::zone::UtcOffset;
     /// use icu::time::zone::VariantOffsetsCalculator;
     /// use icu::time::zone::ZoneNameTimestamp;
-    /// use icu::time::DateTime;
-    /// use icu::time::Time;
-    /// use icu::time::TimeZone;
     ///
     /// // Chicago at UTC-6
     /// let info = TimeZone::from_iana_id("America/Chicago")

--- a/components/time/src/zone/offset.rs
+++ b/components/time/src/zone/offset.rs
@@ -333,11 +333,11 @@ impl VariantOffsetsCalculatorBorrowed<'_> {
     /// ```
     /// use icu::calendar::Date;
     /// use icu::locale::subtags::subtag;
+    /// use icu::time::Time;
+    /// use icu::time::TimeZone;
     /// use icu::time::zone::UtcOffset;
     /// use icu::time::zone::VariantOffsetsCalculator;
     /// use icu::time::zone::ZoneNameTimestamp;
-    /// use icu::time::Time;
-    /// use icu::time::TimeZone;
     ///
     /// let zoc = VariantOffsetsCalculator::new();
     ///

--- a/components/time/src/zone/windows.rs
+++ b/components/time/src/zone/windows.rs
@@ -117,7 +117,7 @@ impl WindowsParserBorrowed<'_> {
     ///
     /// ```rust
     /// use icu::locale::subtags::{region, subtag};
-    /// use icu::time::{zone::WindowsParser, TimeZone};
+    /// use icu::time::{TimeZone, zone::WindowsParser};
     ///
     /// let win_tz_mapper = WindowsParser::new();
     ///

--- a/components/time/src/zone/zone_name_timestamp.rs
+++ b/components/time/src/zone/zone_name_timestamp.rs
@@ -31,12 +31,12 @@ use crate::{DateTime, ZonedDateTime, zone::UtcOffset};
 ///
 /// ```
 /// use icu::calendar::Iso;
-/// use icu::datetime::fieldsets::zone::GenericLong;
 /// use icu::datetime::NoCalendarFormatter;
+/// use icu::datetime::fieldsets::zone::GenericLong;
 /// use icu::locale::locale;
+/// use icu::time::ZonedDateTime;
 /// use icu::time::zone::TimeZone;
 /// use icu::time::zone::ZoneNameTimestamp;
-/// use icu::time::ZonedDateTime;
 /// use writeable::assert_writeable_eq;
 ///
 /// let metlakatla = TimeZone::from_iana_id("America/Metlakatla");

--- a/provider/adapters/src/filter/impls.rs
+++ b/provider/adapters/src/filter/impls.rs
@@ -69,10 +69,14 @@ where
     /// let available_ids = provider
     ///     .iter_ids()
     ///     .expect("Should successfully make an iterator of supported locales");
-    /// assert!(available_ids
-    ///     .contains(&DataIdentifierCow::from_locale(data_locale!("de"))));
-    /// assert!(!available_ids
-    ///     .contains(&DataIdentifierCow::from_locale(data_locale!("en"))));
+    /// assert!(
+    ///     available_ids
+    ///         .contains(&DataIdentifierCow::from_locale(data_locale!("de")))
+    /// );
+    /// assert!(
+    ///     !available_ids
+    ///         .contains(&DataIdentifierCow::from_locale(data_locale!("en")))
+    /// );
     /// ```
     #[expect(clippy::type_complexity)]
     pub fn with_filter<'a>(

--- a/provider/core/src/buf.rs
+++ b/provider/core/src/buf.rs
@@ -56,9 +56,9 @@ impl DynamicDataMarker for BufferMarker {
 ///             .load_data(
 ///                 HelloWorldV1::INFO,
 ///                 DataRequest {
-///                     id: DataIdentifierBorrowed::for_locale(
-///                         &data_locale!("de")
-///                     ),
+///                     id: DataIdentifierBorrowed::for_locale(&data_locale!(
+///                         "de"
+///                     )),
 ///                     ..Default::default()
 ///                 }
 ///             )

--- a/provider/core/src/fallback.rs
+++ b/provider/core/src/fallback.rs
@@ -54,10 +54,10 @@ pub struct LocaleFallbackConfig {
     /// Retain the language and script subtags until the final step:
     ///
     /// ```
+    /// use icu::locale::LocaleFallbacker;
+    /// use icu::locale::data_locale;
     /// use icu::locale::fallback::LocaleFallbackConfig;
     /// use icu::locale::fallback::LocaleFallbackPriority;
-    /// use icu::locale::data_locale;
-    /// use icu::locale::LocaleFallbacker;
     ///
     /// // Set up the fallback iterator.
     /// let fallbacker = LocaleFallbacker::new();
@@ -82,10 +82,10 @@ pub struct LocaleFallbackConfig {
     /// Retain the region subtag until the final step:
     ///
     /// ```
+    /// use icu::locale::LocaleFallbacker;
+    /// use icu::locale::data_locale;
     /// use icu::locale::fallback::LocaleFallbackConfig;
     /// use icu::locale::fallback::LocaleFallbackPriority;
-    /// use icu::locale::data_locale;
-    /// use icu::locale::LocaleFallbacker;
     ///
     /// // Set up the fallback iterator.
     /// let fallbacker = LocaleFallbacker::new();

--- a/provider/core/src/response.rs
+++ b/provider/core/src/response.rs
@@ -100,9 +100,9 @@ pub struct DataPayload<M: DynamicDataMarker>(pub(crate) DataPayloadInner<M>);
 ///
 /// ```
 /// use icu_locale_core::data_locale;
+/// use icu_provider::DataPayloadOr;
 /// use icu_provider::hello_world::*;
 /// use icu_provider::prelude::*;
-/// use icu_provider::DataPayloadOr;
 ///
 /// let response: DataResponse<HelloWorldV1> = HelloWorldProvider
 ///     .load(DataRequest {

--- a/utils/writeable/src/lib.rs
+++ b/utils/writeable/src/lib.rs
@@ -400,10 +400,7 @@ pub trait Writeable {
 /// writeable::impl_writeable_delegate!(MyStruct, |&self| &self.0);
 /// writeable::impl_display_with_writeable!(MyStruct);
 ///
-/// writeable::assert_writeable_eq!(
-///     MyStruct("hello".to_string()),
-///     "hello"
-/// );
+/// writeable::assert_writeable_eq!(MyStruct("hello".to_string()), "hello");
 /// ```
 ///
 /// With a cfg on fn `write_to_string`:

--- a/utils/writeable/src/replace.rs
+++ b/utils/writeable/src/replace.rs
@@ -14,8 +14,8 @@ use core::fmt;
 ///
 /// ```
 /// use writeable::adapters::Replace;
-/// use writeable::concat_writeable;
 /// use writeable::assert_writeable_eq;
+/// use writeable::concat_writeable;
 ///
 /// let source = concat_writeable!("I 💖 🦀", " and 🦀 loves me!");
 /// let replace = Replace {

--- a/utils/writeable/src/try_writeable.rs
+++ b/utils/writeable/src/try_writeable.rs
@@ -396,7 +396,11 @@ where
 ///
 /// ```
 /// struct MyStruct(Result<String, String>);
-/// writeable::impl_try_writeable_delegate!(MyStruct, |&self| &self.0, Error = String);
+/// writeable::impl_try_writeable_delegate!(
+///     MyStruct,
+///     |&self| &self.0,
+///     Error = String
+/// );
 ///
 /// writeable::assert_try_writeable_eq!(
 ///     MyStruct(Ok("hello".to_string())),
@@ -410,7 +414,12 @@ where
 /// struct MyStruct(Result<String, String>);
 /// #[derive(Debug, PartialEq)]
 /// struct MyError;
-/// writeable::impl_try_writeable_delegate!(MyStruct, |&self| &self.0, Error = MyError, |_error| MyError);
+/// writeable::impl_try_writeable_delegate!(
+///     MyStruct,
+///     |&self| &self.0,
+///     Error = MyError,
+///     |_error| MyError
+/// );
 ///
 /// writeable::assert_try_writeable_eq!(
 ///     MyStruct(Ok("hello".to_string())),

--- a/utils/zerotrie/src/cursor.rs
+++ b/utils/zerotrie/src/cursor.rs
@@ -85,15 +85,18 @@ where
     /// Using the `writeable` crate:
     ///
     /// ```
-    /// use zerotrie::ZeroTrieSimpleAscii;
     /// use writeable::Writeable;
+    /// use zerotrie::ZeroTrieSimpleAscii;
     ///
     /// // A trie with two values: "abc" and "abcdef"
     /// let trie = ZeroTrieSimpleAscii::from_bytes(b"abc\x80def\x81");
     ///
     /// // Get out the value for "abc"
     /// let needle = writeable::concat_writeable!("a", "bc");
-    /// assert_eq!(trie.get_with_write_fn(|sink| needle.write_to(sink)), Some(0));
+    /// assert_eq!(
+    ///     trie.get_with_write_fn(|sink| needle.write_to(sink)),
+    ///     Some(0)
+    /// );
     /// ```
     #[inline]
     pub fn get_with_write_fn<'a>(
@@ -152,15 +155,18 @@ where
     /// Using the `writeable` crate:
     ///
     /// ```
-    /// use zerotrie::ZeroAsciiIgnoreCaseTrie;
     /// use writeable::Writeable;
+    /// use zerotrie::ZeroAsciiIgnoreCaseTrie;
     ///
     /// // A trie with two values: "aBc" and "aBcdEf"
     /// let trie = ZeroAsciiIgnoreCaseTrie::from_bytes(b"aBc\x80dEf\x81");
     ///
     /// // Get out the value for "abc"
     /// let needle = writeable::concat_writeable!("a", "bc");
-    /// assert_eq!(trie.get_with_write_fn(|sink| needle.write_to(sink)), Some(0));
+    /// assert_eq!(
+    ///     trie.get_with_write_fn(|sink| needle.write_to(sink)),
+    ///     Some(0)
+    /// );
     /// ```
     #[inline]
     pub fn get_with_write_fn<'a>(


### PR DESCRIPTION
`cargo +nightly fmt -- --config=format_code_in_doc_comments=true --config=doc_comment_code_block_width=80`

There were some spaces removed around size tests that I reverted, and otherwise accepted the output of that command.

## Changelog

N/A