### PR TITLE
Dart: Use stable record-use and remove enable-experiment flag

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -338,7 +338,7 @@ jobs:
 
     - uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672 # v1.6.5
       with:
-        sdk: stable
+        sdk: ${{ github.event_name == 'schedule' && github.event.schedule == '0 14 * * *' && 'dev' || 'stable' }}```
     - name: Install yq if Windows
       if: ${{ matrix.os == 'windows-latest' }}
       run: choco install yq

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -336,15 +336,9 @@ jobs:
     - name: Show the selected Rust toolchain
       run: rustup show
 
-    # Job-specific dependencies
     - uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672 # v1.6.5
       with:
-        sdk: 3.13.0-215.0.dev
-        # Currently disabled: There are a lot of incoming changes to Dart native-assets' JSON format,
-        # so we won't do nightly builds for now. The first failing build is 3.12.0-62.0.dev.
-        # Tracked upstream in https://github.com/orgs/dart-lang/projects/99
-        # Revisit in August 2026.
-        # sdk: ${{ github.event_name == 'schedule' && github.event.schedule == '0 14 * * *' && 'dev' || '3.11.0-46.0.dev' }}
+        sdk: stable
     - name: Install yq if Windows
       if: ${{ matrix.os == 'windows-latest' }}
       run: choco install yq

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -338,7 +338,7 @@ jobs:
 
     - uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672 # v1.6.5
       with:
-        sdk: ${{ github.event_name == 'schedule' && github.event.schedule == '0 14 * * *' && 'dev' || 'stable' }}```
+        sdk: ${{ github.event_name == 'schedule' && github.event.schedule == '0 14 * * *' && 'dev' || 'stable' }}
     - name: Install yq if Windows
       if: ${{ matrix.os == 'windows-latest' }}
       run: choco install yq

--- a/ffi/dart/README.md
+++ b/ffi/dart/README.md
@@ -42,7 +42,7 @@ dart run
 
 ## Optimizing binary size
 
-By default, this package will fetch a platform specific static or dynamic library from the [ICU4X GitHub releases](https://github.com/unicode-org/icu4x/releases) and link it using `package:hooks`. On supported platforms (currently Linux, `dev` Dart with `--enable-experiment=record-use`), `package:hooks` performs tree-shaking, meaning only APIs that are used by the final binary are included. On other platforms, the whole ICU4X dynamic library is included, which can add about 15MB to the resulting binary size. This can, however, be customized by building a tailored ICU4X dylib manually and adding the following to your `pubspec.yaml`:
+By default, this package will fetch a platform specific static library from the [ICU4X GitHub releases](https://github.com/unicode-org/icu4x/releases) and link it using `package:hooks`. `package:hooks` performs tree-shaking, meaning only APIs that are used by the final binary are included. This can, however, be customized by building a tailored ICU4X dylib manually and adding the following to your `pubspec.yaml`:
 
 ```yaml
 hooks:

--- a/ffi/dart/hook/link.dart
+++ b/ffi/dart/hook/link.dart
@@ -24,15 +24,10 @@ Future<void> main(List<String> args) async {
       return;
     }
 
-    final recordedUses = input
-        // ignore: experimental_member_use
-        .recordedUses;
+    final recordedUses = input.recordedUses;
     Iterable<String>? usedSymbols;
     if (recordedUses == null) {
-      print(
-        'Enable the --enable-experiment=record-use experiment'
-        ' to use treeshake unused symbols.',
-      );
+      print('No recorded uses found to treeshake unused symbols.');
     } else {
       usedSymbols = recordedUses.calls.keys
           .where(

--- a/ffi/dart/pubspec.yaml
+++ b/ffi/dart/pubspec.yaml
@@ -27,12 +27,11 @@ dependencies:
   code_assets: ^1.0.0
   crypto: ^3.0.7
   ffi: ^2.1.4
-  # Pinned as we use unstable APIs
-  hooks: 2.0.2
+  hooks: ^2.1.0
   logging: ^1.3.0
   meta: ^1.17.0
   native_toolchain_c: ^0.19.1
-  record_use: ^0.6.0
+  record_use: ^1.1.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/tools/make/ffi.toml
+++ b/tools/make/ffi.toml
@@ -86,7 +86,7 @@ cd examples/dart
 exec --fail-on-error dart pub get
 exec --fail-on-error dart format --set-exit-if-changed .
 exec --fail-on-error dart analyze
-exec --fail-on-error dart --enable-experiment=record-use build cli --target bin/example.dart
+exec --fail-on-error dart build cli --target bin/example.dart
 bins = glob_array ./build/cli/*/bundle/bin/*
 bin = array_pop ${bins}
 exec --fail-on-error ${bin}
@@ -97,8 +97,8 @@ println ${size} "bytes"
 pubspec = readfile pubspec.yaml
 is_local = contains ${pubspec} "buildMode: local"
 if not ${is_local} # local dylib is not treeshaken
-    if greater_than ${size} 10000000
-        trigger_error "Dart example binary >10MB"
+    if greater_than ${size} 3000000
+        trigger_error "Dart example binary >3MB"
     end
 end
 '''


### PR DESCRIPTION
With the `record-use` feature now available in stable Dart:
- Remove `--enable-experiment=record-use` from build commands and documentation.
- Update GitHub Actions workflow to use `sdk: stable`.
- Update `hooks` and `record_use` dependencies in `ffi/dart/pubspec.yaml`.
- Update tree-shaking documentation in `ffi/dart/README.md` to remove platform restriction notes.

## Changelog

N/A