### PR TITLE
Install pinned yq from GitHub Releases on Windows CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -341,7 +341,10 @@ jobs:
         sdk: ${{ github.event_name == 'schedule' && github.event.schedule == '0 14 * * *' && 'dev' || 'stable' }}
     - name: Install yq if Windows
       if: ${{ matrix.os == 'windows-latest' }}
-      run: choco install yq
+      shell: bash
+      run: |
+        curl -sSL https://github.com/mikefarah/yq/releases/download/v4.53.3/yq_windows_amd64.exe -o /usr/bin/yq.exe
+        chmod +x /usr/bin/yq.exe
 
     # Actual job
     - name: Run `cargo make ci-job-test-dart`


### PR DESCRIPTION
Chocolatey community repository (`community.chocolatey.org`) frequently rate-limits (HTTP 429) or times out on GitHub Actions Windows runner IP addresses during `choco install yq`, causing intermittent failures in the `test-dart (windows-latest)` CI job.

This replaces `choco install yq` with a direct binary download of pinned `yq` release `v4.53.3` (from `mikefarah/yq`) into `/usr/bin/yq.exe`.

🤖 This pull request was created by an AI agent working with @sffc.

## Changelog (N/A)