### PR TITLE
Update benchmark action to sffc-bot fork supporting interactive zoom & pan

### DIFF
--- a/.github/workflows/artifacts-build.yml
+++ b/.github/workflows/artifacts-build.yml
@@ -421,7 +421,7 @@ jobs:
         gsutil -m cp -rn gs://${{ env.GCP_MAIN_BUCKET_ID }}/gha/benchmarks/perf/${{ matrix.component }}/* benchmarks/perf/${{ matrix.component }}
 
     - name: Store benchmark result & create dashboard
-      uses: rhysd/github-action-benchmark@c3efd4d54319dbc90622069cc273cba59b46abbf # v1.15.0
+      uses: sffc-bot/github-action-benchmark@3886ebdfab795a7954d8e47822f4a2de6bb12f1e
       with:
         name: Rust Benchmark
         tool: 'cargo'
@@ -510,7 +510,7 @@ jobs:
       # The gregtatum fork of rhysd/github-action-benchmark contains support for ndjson.
       # If the PR gets merged, this can be switched back to the main project.
       # https://github.com/rhysd/github-action-benchmark/pull/54
-      uses: gregtatum/github-action-benchmark@d3f06f738e9612988d575db23fae5ca0008d3d12
+      uses: sffc-bot/github-action-benchmark@3886ebdfab795a7954d8e47822f4a2de6bb12f1e
       with:
         name: Heap – ${{ matrix.os }}
         # The ndjson tool is only supported by the gregtatum fork of github-action-benchmark.
@@ -598,7 +598,7 @@ jobs:
  
     - name: Store benchmark result & create dashboard (wasm)
       # Use gregtatum special feature to process ndjson-formatted benchmark data
-      uses: gregtatum/github-action-benchmark@d3f06f738e9612988d575db23fae5ca0008d3d12
+      uses: sffc-bot/github-action-benchmark@3886ebdfab795a7954d8e47822f4a2de6bb12f1e
       with:
         tool: 'ndjson'
         output-file-path: benchmarks/binsize/wasm/output.txt
@@ -614,7 +614,7 @@ jobs:
     - name: Store benchmark result & create dashboard (gz)
       if: success() || failure()
       # Use gregtatum special feature to process ndjson-formatted benchmark data
-      uses: gregtatum/github-action-benchmark@d3f06f738e9612988d575db23fae5ca0008d3d12
+      uses: sffc-bot/github-action-benchmark@3886ebdfab795a7954d8e47822f4a2de6bb12f1e
       with:
         tool: 'ndjson'
         output-file-path: benchmarks/binsize/gz/output.txt


### PR DESCRIPTION
Updates `.github/workflows/artifacts-build.yml` to use `sffc-bot/github-action-benchmark` (commit `3886ebdfab795a7954d8e47822f4a2de6bb12f1e`) which adds interactive Chart.js X-axis zooming, mouse drag selection box, horizontal panning, and reset zoom controls to the performance, memory, and binary size benchmark dashboards.

Upstream PR: https://github.com/gregtatum/github-action-benchmark/pull/1

### Interactive Visual Screencast

![Interactive Drag-to-Zoom & Pan Demo](https://raw.githubusercontent.com/sffc-bot/github-action-benchmark/assets/benchmark_zoom_demo_v2.gif)

🤖 This pull request was created by an AI agent working with @sffc.

## Changelog
- [ci] Update benchmark action to sffc-bot fork supporting interactive zoom & pan