### PR TITLE
Bump icu_codepointtrie_builder to 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,7 +1478,7 @@ version = "2.3.0"
 
 [[package]]
 name = "icu_codepointtrie_builder"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "icu",
  "icu_collections",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,7 @@ include = [
 icu_locale_core = { version = "2.3.0", path = "components/locale_core", default-features = false }
 icu_provider = { version = "2.3.0", path = "provider/core", default-features = false }
 icu_pattern = { version = "0.5.0", path = "components/pattern", default-features = false }
-icu_codepointtrie_builder = { version = "0.6.0", path = "components/collections/codepointtrie_builder", default-features = false }
+icu_codepointtrie_builder = { version = "0.6.0", path = "components/collections/codepointtrie_builder", default-features = false } # Current version: 0.6.1
 
 # Components
 icu = { version = "~2.3.0", path = "components/icu", default-features = false }

--- a/components/collections/codepointtrie_builder/Cargo.toml
+++ b/components/collections/codepointtrie_builder/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "icu_codepointtrie_builder"
 description = "Runtime builder for CodePointTrie"
-version = "0.6.0"
+version = "0.6.1"
 categories.workspace = true
 keywords = ["unicode", "collections", "internationalization"]
 license = "Unicode-3.0"


### PR DESCRIPTION
It needs to get released in order to change its deps from ~2.2.0 to ~2.3.0

## Changelog (N/A)