### PR TITLE
Reset looked_ahead when resetting drain_from_upcoming

### DIFF
--- a/components/collator/src/elements.rs
+++ b/components/collator/src/elements.rs
@@ -2361,6 +2361,7 @@ where
                             // non-starters in order to maintain the invariant of
                             // `upcoming` on the next call to `next()`.
                             drain_from_upcoming = 0;
+                            looked_ahead = 0;
                             self.collect_combining(&mut combining_characters);
                             continue 'combining_outer;
                         }

--- a/components/collator/tests/tests.rs
+++ b/components/collator/tests/tests.rs
@@ -2047,6 +2047,20 @@ fn test_fffe_issue_6811() {
     );
 }
 
+#[test]
+fn test_burmese() {
+    let mut options = CollatorOptions::default();
+    options.strength = Some(Strength::Tertiary);
+    let collator = Collator::try_new(locale!("my").into(), options).unwrap();
+    assert_eq!(
+        collator.compare(
+            "",
+            "\u{102d}\u{102f}\u{1037}"
+        ),
+        Ordering::Less
+    );
+}
+
 #[cfg(feature = "latin1")]
 #[test]
 fn test_latin1_root() {

--- a/components/collator/tests/tests.rs
+++ b/components/collator/tests/tests.rs
@@ -2053,10 +2053,7 @@ fn test_burmese() {
     options.strength = Some(Strength::Tertiary);
     let collator = Collator::try_new(locale!("my").into(), options).unwrap();
     assert_eq!(
-        collator.compare(
-            "",
-            "\u{102d}\u{102f}\u{1037}"
-        ),
+        collator.compare("", "\u{102d}\u{102f}\u{1037}"),
         Ordering::Less
     );
 }


### PR DESCRIPTION
Mozilla bug https://bugzilla.mozilla.org/show_bug.cgi?id=2059047

Closes #8296

## Changelog

icu_collator: Fix panic

* Fixed panic when a contraction contracts a starter, does not contract a following non-starter, and the non-starter starts another contraction. (Occurs in Burmese.)