### PR TITLE
Miri CI Job

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -539,35 +539,32 @@ jobs:
 
   # ci-job-miri
   miri:
+    if: github.event_name == 'schedule' && github.event.schedule != '1 14 * * *'
     runs-on: ubuntu-latest
     continue-on-error: true
     env:
       CI_TOOLCHAIN: nightly
 
     steps:
-    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-    # Cargo-make boilerplate
-    - name: Install cargo-make
-      uses: taiki-e/install-action@64e4e2f995104968c78bd697b253d55bf557af66 # v2.41.11
-      with:
-        tool: cargo-make@0.37.13
+      # Cargo-make boilerplate
+      - name: Install cargo-make
+        uses: taiki-e/install-action@64e4e2f995104968c78bd697b253d55bf557af66 # v2.41.11
+        with:
+          tool: cargo-make@0.37.13
+      
+      # Toolchain boilerplate
+      - name: Potentially override rust version with nightly
+        run: cargo make set-ci-toolchain
+      - name: Show the selected Rust toolchain
+        run: rustup show
 
-    # Toolchain boilerplate
-    - name: Potentially override rust version with nightly
-      run: cargo make set-ci-toolchain
+      - name: Install Miri
+        run: rustup component add miri --toolchain nightly
 
-    - name: Show the selected Rust toolchain
-      run: rustup show
-
-    # job specific dependencies
-    - name: Install Miri
-      run: rustup component add miri
-
-    # Actual job
-    - name: Run `cargo make ci-job-miri`
-      run: cargo make ci-job-miri
-
+      - name: Run `cargo make ci-job-miri`
+        run: cargo make ci-job-miri
 
   # ci-job-doc
   doc:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -562,7 +562,7 @@ jobs:
 
     # job specific dependencies
     - name: Install Miri
-      run: rustup component add miri
+      run: rustup component add miri --toolchain ${PINNED_CI_NIGHTLY}
 
     # Actual job
     - name: Run `cargo make ci-job-miri`

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -562,7 +562,7 @@ jobs:
 
     # job specific dependencies
     - name: Install Miri
-      run: rustup component add miri --toolchain ${PINNED_CI_NIGHTLY}
+      run: rustup component add miri
 
     # Actual job
     - name: Run `cargo make ci-job-miri`

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -311,7 +311,7 @@ jobs:
     - name: Run `cargo make ci-job-test-js`
       run: cargo make ci-job-test-js
 
-
+  
   # ci-job-test-dart
   test-dart:
     strategy:
@@ -536,6 +536,37 @@ jobs:
     # Actual job
     - name: Run `ci-job-clippy`
       run: cargo make ci-job-clippy
+
+  # ci-job-miri
+  miri:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    env:
+      CI_TOOLCHAIN: nightly
+
+    steps:
+    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+    # Cargo-make boilerplate
+    - name: Install cargo-make
+      uses: taiki-e/install-action@64e4e2f995104968c78bd697b253d55bf557af66 # v2.41.11
+      with:
+        tool: cargo-make@0.37.13
+
+    # Toolchain boilerplate
+    - name: Potentially override rust version with nightly
+      run: cargo make set-ci-toolchain
+
+    - name: Show the selected Rust toolchain
+      run: rustup show
+
+    # job specific dependencies
+    - name: Install Miri
+      run: rustup component add miri
+
+    # Actual job
+    - name: Run `cargo make ci-job-miri`
+      run: cargo make ci-job-miri
 
 
   # ci-job-doc

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -226,6 +226,12 @@ dependencies = [
     "clippy-all",
 ]
 
+[tasks.ci-job-miri]
+description = "run miri tests for unsafe crates"
+category = "CI"
+script_runner = "@duckscript"
+script = '''exec --fail-on-error cargo +${PINNED_CI_NIGHTLY} miri test -p zerovec --features serde,derive -p yoke'''
+
 [tasks.ci-job-doc]
 description = "Runs rustdoc generation for the CI 'doc' job"
 category = "CI"
@@ -252,6 +258,7 @@ dependencies = [
     "ci-job-nostd",
     "ci-job-check",
     "check-tutorials-local",
+    "ci-job-miri",
 
     # Get a coffee
     "ci-job-test",


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->
Fixes #1259 

added a Miri CI job for `zerovec` and `yoke` using the pinned nightly rust toolchain. the job runs as an allowed failure while existing miri issues are tracked.

<!-- Please fill in according to documents/process/changelog.md -->
