### PR TITLE
Use slice_from_raw_parts in make_varule to fix Miri violation

### DIFF
--- a/utils/zerovec/derive/Cargo.toml
+++ b/utils/zerovec/derive/Cargo.toml
@@ -27,7 +27,7 @@ quote = { workspace = true }
 syn = { workspace = true, features = ["extra-traits"]}
 
 [dev-dependencies]
-zerovec = { path = "..", features = ["serde", "derive"] }
+zerovec = { path = "..", features = ["serde", "derive", "alloc"] }
 serde = { workspace = true, features = ["derive"] }
 zerofrom = { path = "../../../utils/zerofrom" }
 bincode = { workspace = true }

--- a/utils/zerovec/derive/src/varule.rs
+++ b/utils/zerovec/derive/src/varule.rs
@@ -121,7 +121,7 @@ pub fn derive_impl(
                 // We should use the pointer metadata APIs here when they are stable: https://github.com/rust-lang/rust/issues/81513
                 // For now we rely on all DST metadata being a usize to extract it via a fake slice pointer
                 let (_ptr, metadata) = ::core::mem::transmute::<&#unsized_field, (usize, usize)>(unsized_ref);
-                let entire_struct_as_slice: *const [u8] = ::core::slice::from_raw_parts(bytes.as_ptr(), metadata);
+                let entire_struct_as_slice: *const [u8] = ::core::ptr::slice_from_raw_parts(bytes.as_ptr(), metadata);
                 &*(entire_struct_as_slice as *const Self)
             }
         }

--- a/utils/zerovec/derive/tests/make_varule_miri_test.rs
+++ b/utils/zerovec/derive/tests/make_varule_miri_test.rs
@@ -1,0 +1,24 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use zerovec::ule::{AsULE, VarULE};
+
+// https://github.com/unicode-org/icu4x/issues/6723
+#[zerovec::make_varule(CustomVarULE)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct CustomVar<'a> {
+    a: u32,
+    b: &'a str,
+}
+
+#[test]
+fn test_make_varule_from_bytes_unchecked_miri() {
+    // https://github.com/unicode-org/icu4x/issues/6723
+    let custom = CustomVar { a: 12345, b: "x" };
+    let boxed: Box<CustomVarULE> = zerovec::ule::encode_varule_to_box(&custom);
+    let bytes = boxed.as_bytes();
+    let ule = unsafe { CustomVarULE::from_bytes_unchecked(bytes) };
+    assert_eq!(u32::from_unaligned(ule.a), 12345);
+    assert_eq!(&ule.b, "x");
+}


### PR DESCRIPTION
Fixes #6723

I guess we didn't need a new API after all. This is probably due to Tree Borrows being better than Stacked Borrows, if I'm remembering the original discussion.

`zerovec` now passes with `MIRIFLAGS=-Zmiri-tree-borrows cargo +nightly miri test --features serde,derive,yoke,databake,alloc,std` Excluded the hashmap feature because it's _very_ slow to test, and the schemars feature because it needs `-Zmiri-disable-isolation`, which I decided to not deal with. There's a good chance it passes with `--all-features` too.

`zerovec-derive` now passes with `MIRIFLAGS=-Zmiri-tree-borrows cargo +nightly miri test --all-features`


## Changelog

zerovec-derive: Make pass with `MIRIFLAGS=-Zmiri-tree-borrows`