### PR TITLE
Fix multi-element buffer validation in zerovec-derive ULE, publish 0.11.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## icu4x 2.3.x
+
+Several crates have had patch releases in the 2.3 stream:
+
+- Utils
+    - (0.11.5) `zerovec-derive`
+        - Fix soundness issue around multi element buffer validation in ULE derives (unicode-org#8393)
+
 ## icu4x 2.3
 
 - Components
@@ -1317,6 +1325,7 @@ Some major changes worth highlighting:
   - (0.10.4) Enforce C,packed on OptionVarULE (https://github.com/unicode-org/icu4x/pull/5143)
 - `zerovec_derive`
   - (0.10.3) Enforce C,packed, not just packed, on ULE types, fixing for incoming changes to `repr(Rust)` (https://github.com/unicode-org/icu4x/pull/5049)
+  - (0.10.4) Fix soundness issue around multi element buffer validation in ULE derives (unicode-org#8393)
   `icu_*_data`
   - (1.5.1) Add build.rs to workspace includes (unicode-org#6356)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4357,7 +4357,7 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "bincode",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -211,7 +211,7 @@ zerofrom = { version = "0.1.6", path = "utils/zerofrom", default-features = fals
 zerofrom-derive = { version = "0.1.6", path = "utils/zerofrom/derive", default-features = false } # Current version: 0.1.7
 zerotrie = { version = "0.2.5", path = "utils/zerotrie", default-features = false }
 zerovec = { version = "0.11.7", path = "utils/zerovec", default-features = false }
-zerovec-derive = { version = "0.11.4", path = "utils/zerovec/derive", default-features = false }
+zerovec-derive = { version = "0.11.5", path = "utils/zerovec/derive", default-features = false }
 zoneinfo64 = { version = "0.3.0", path = "utils/zoneinfo64", default-features = false }
 
 # Tools

--- a/utils/zerovec/derive/Cargo.toml
+++ b/utils/zerovec/derive/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "zerovec-derive"
 description = "Custom derive for the zerovec crate"
-version = "0.11.4"
+version = "0.11.5"
 authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
 categories = ["rust-patterns", "memory-management", "caching", "no-std", "data-structures"]
 keywords = ["macros", "derive", "serialization", "zero-copy"]

--- a/utils/zerovec/derive/src/ule.rs
+++ b/utils/zerovec/derive/src/ule.rs
@@ -58,15 +58,15 @@ pub fn derive_impl(input: &DeriveInput) -> TokenStream2 {
     quote! {
         unsafe impl zerovec::ule::ULE for #name {
             #[inline]
-            fn validate_bytes(bytes: &[u8]) -> Result<(), zerovec::ule::UleError> {
+            fn validate_bytes(bytes_all: &[u8]) -> Result<(), zerovec::ule::UleError> {
                 const SIZE: usize = ::core::mem::size_of::<#name>();
                 #[expect(clippy::modulo_one)]
-                if bytes.len() % SIZE != 0 {
-                    return Err(zerovec::ule::UleError::length::<Self>(bytes.len()));
+                if bytes_all.len() % SIZE != 0 {
+                    return Err(zerovec::ule::UleError::length::<Self>(bytes_all.len()));
                 }
                 // Validate the bytes
                 #[expect(clippy::indexing_slicing)] // We're slicing a chunk of known size
-                for chunk in bytes.chunks_exact(SIZE) {
+                for bytes_one in bytes_all.chunks_exact(SIZE) {
                     #validators
                     debug_assert_eq!(#remaining_offset, SIZE);
                 }
@@ -76,7 +76,7 @@ pub fn derive_impl(input: &DeriveInput) -> TokenStream2 {
     }
 }
 
-/// Given an slice over ULE struct fields, returns code validating that a slice variable `bytes` contains valid instances of those ULE types
+/// Given an slice over ULE struct fields, returns code validating that a slice variable `bytes_one` contains valid instances of those ULE types
 /// in order, plus the byte offset of any remaining unvalidated bytes. ULE types should not have any remaining bytes, but `VarULE` types will since
 /// the last field is the unsized one.
 pub(crate) fn generate_ule_validators(
@@ -86,7 +86,7 @@ pub(crate) fn generate_ule_validators(
     utils::generate_per_field_offsets(fields, false, |field, prev_offset_ident, size_ident| {
         let ty = &field.field.ty;
         quote! {
-            if let Some(bytes) = bytes.get(#prev_offset_ident .. #prev_offset_ident + #size_ident) {
+            if let Some(bytes) = bytes_one.get(#prev_offset_ident .. #prev_offset_ident + #size_ident) {
                 <#ty as zerovec::ule::ULE>::validate_bytes(bytes)?;
             } else {
                 return Err(zerovec::ule::UleError::parse::<Self>());

--- a/utils/zerovec/derive/src/varule.rs
+++ b/utils/zerovec/derive/src/varule.rs
@@ -101,10 +101,10 @@ pub fn derive_impl(
         const #ule_size: usize = 0 #(+ #sizes)*;
         unsafe impl zerovec::ule::VarULE for #name {
             #[inline]
-            fn validate_bytes(bytes: &[u8]) -> Result<(), zerovec::ule::UleError> {
+            fn validate_bytes(bytes_one: &[u8]) -> Result<(), zerovec::ule::UleError> {
                 debug_assert_eq!(#remaining_offset, #ule_size);
 
-                let Some(last_field_bytes) = bytes.get(#remaining_offset..) else {
+                let Some(last_field_bytes) = bytes_one.get(#remaining_offset..) else {
                     return Err(zerovec::ule::UleError::parse::<Self>());
                 };
                 #validators

--- a/utils/zerovec/derive/tests/derive_ule_test.rs
+++ b/utils/zerovec/derive/tests/derive_ule_test.rs
@@ -1,0 +1,73 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use zerovec::ule::AsULE;
+use zerovec::ule::UleError;
+use zerovec::ule::ULE;
+use zerovec::ZeroSlice;
+use zerovec::ZeroVec;
+
+#[derive(Debug, Copy, Clone)]
+struct MyTuple(u16, char);
+
+#[derive(ULE, Copy, Clone)]
+#[repr(C, packed)]
+struct MyTupleULE(<u16 as AsULE>::ULE, <char as AsULE>::ULE);
+
+impl AsULE for MyTuple {
+    type ULE = MyTupleULE;
+    fn to_unaligned(self) -> Self::ULE {
+        MyTupleULE(self.0.to_unaligned(), self.1.to_unaligned())
+    }
+    fn from_unaligned(ule: Self::ULE) -> Self {
+        MyTuple(u16::from_unaligned(ule.0), char::from_unaligned(ule.1))
+    }
+}
+
+#[zerovec::make_ule(MyStructULE)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct MyStruct {
+    a: u16,
+    b: char,
+}
+
+#[test]
+fn test_vec_validation() {
+    // Construct a valid ZeroVec<MyTuple>
+    let zv = ZeroVec::alloc_from_slice(&[MyTuple(1, 'a'), MyTuple(2, 'ß'), MyTuple(3, 'ç')]);
+    // Should succeed
+    ZeroSlice::<MyTuple>::parse_bytes(zv.as_bytes()).unwrap();
+
+    // Construct invalid bytes: 0xff are invalid bytes for char
+    let mut invalid_bytes = zv.as_bytes().to_vec();
+    // 0xff is invalid for char, which starts at index 7
+    invalid_bytes[7] = 0xff;
+    invalid_bytes[8] = 0xff;
+    invalid_bytes[9] = 0xff;
+    // Should fail
+    let err = ZeroSlice::<MyTuple>::parse_bytes(&invalid_bytes).unwrap_err();
+    assert!(matches!(err, UleError::ParseError { .. }));
+}
+
+#[test]
+fn test_make_ule_vec_validation() {
+    // Construct a valid ZeroVec<MyStruct>
+    let zv = ZeroVec::alloc_from_slice(&[
+        MyStruct { a: 1, b: 'a' },
+        MyStruct { a: 2, b: 'ß' },
+        MyStruct { a: 3, b: 'ç' },
+    ]);
+    // Should succeed
+    ZeroSlice::<MyStruct>::parse_bytes(zv.as_bytes()).unwrap();
+
+    // Construct invalid bytes: 0xff are invalid bytes for char
+    let mut invalid_bytes = zv.as_bytes().to_vec();
+    // 0xff is invalid for char, which starts at index 7
+    invalid_bytes[7] = 0xff;
+    invalid_bytes[8] = 0xff;
+    invalid_bytes[9] = 0xff;
+    // Should fail
+    let err = ZeroSlice::<MyStruct>::parse_bytes(&invalid_bytes).unwrap_err();
+    assert!(matches!(err, UleError::ParseError { .. }));
+}


### PR DESCRIPTION
In zerovec-derive, the generated `validate_bytes()` for `#[derive(ULE)]` looped over chunks of size SIZE, but the per-field validators indexed into the outer `bytes` parameter rather than the per-chunk slice. As a result, subsequent elements in a multi-element buffer only re-validated byte offsets starting at index 0 in the full buffer instead of checking each element's bytes.

This fixes the loop variable in utils/zerovec/derive/src/ule.rs to bind each chunk to bytes so #validators validates each element chunk correctly.

Advisory: https://github.com/unicode-org/icu4x/security/advisories/GHSA-7fx9-626j-vqph

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->

## Changelog


zerovec-derive: Fix soundness issue around multi element buffer validation in ULE derives
