### PR TITLE
Use weak dependency syntax for icu_locale dep on icu_pattern

### DIFF
--- a/components/locale/Cargo.toml
+++ b/components/locale/Cargo.toml
@@ -55,8 +55,8 @@ bench = false  # This option is required for Benchmark CI
 [features]
 unstable = ["dep:writeable", "dep:displaydoc", "dep:either", "dep:icu_pattern", "zerovec/derive"]
 default = ["compiled_data"]
-serde = ["dep:serde", "icu_locale_core/serde", "icu_locale_fallback/serde", "tinystr/serde", "zerovec/serde", "icu_provider/serde", "icu_collections/serde", "icu_pattern/serde"]
-datagen = ["serde", "dep:databake", "zerovec/databake", "icu_locale_core/databake", "icu_locale_fallback/datagen", "tinystr/databake", "icu_collections/databake", "icu_provider/export", "icu_pattern/databake"]
+serde = ["dep:serde", "icu_locale_core/serde", "icu_locale_fallback/serde", "tinystr/serde", "zerovec/serde", "icu_provider/serde", "icu_collections/serde", "icu_pattern?/serde"]
+datagen = ["serde", "dep:databake", "zerovec/databake", "icu_locale_core/databake", "icu_locale_fallback/datagen", "tinystr/databake", "icu_collections/databake", "icu_provider/export", "icu_pattern?/databake"]
 compiled_data = ["dep:icu_locale_data", "icu_locale_fallback/compiled_data", "icu_provider/baked"]
 
 [[bench]]


### PR DESCRIPTION
Serde/datagen users were unnecessarily pulling in `icu_pattern`.


## Changelog

icu_locale: Remove unnecessary dependencies on icu_pattern when `unstable` feature is not enabled
