### PR TITLE
Fix array length check in  `impl ULE for [T; N]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Several crates have had patch releases in the 2.3 stream:
 - Utils
     - (0.11.5) `zerovec-derive`
         - Fix soundness issue around multi element buffer validation in ULE derives (unicode-org#8393)
+    - (0.11.8) `zerovec`
+        - Fix length check in `impl ULE for [T; N]`
 
 ## icu4x 2.3
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4331,7 +4331,7 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "bincode",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -210,7 +210,7 @@ yoke-derive = { version = "0.8.2", path = "utils/yoke/derive", default-features 
 zerofrom = { version = "0.1.6", path = "utils/zerofrom", default-features = false } # Current version: 0.1.8
 zerofrom-derive = { version = "0.1.6", path = "utils/zerofrom/derive", default-features = false } # Current version: 0.1.7
 zerotrie = { version = "0.2.5", path = "utils/zerotrie", default-features = false }
-zerovec = { version = "0.11.7", path = "utils/zerovec", default-features = false }
+zerovec = { version = "0.11.8", path = "utils/zerovec", default-features = false }
 zerovec-derive = { version = "0.11.5", path = "utils/zerovec/derive", default-features = false }
 zoneinfo64 = { version = "0.3.0", path = "utils/zoneinfo64", default-features = false }
 

--- a/utils/zerovec/Cargo.toml
+++ b/utils/zerovec/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "zerovec"
 description = "Zero-copy vector backed by a byte array"
-version = "0.11.7"
+version = "0.11.8"
 categories = ["rust-patterns", "memory-management", "caching", "no-std", "data-structures"]
 keywords = ["zero-copy", "serialization", "memory-efficiency", "serde"]
 

--- a/utils/zerovec/src/ule/slices.rs
+++ b/utils/zerovec/src/ule/slices.rs
@@ -14,6 +14,13 @@ use crate::ule::*;
 unsafe impl<T: ULE, const N: usize> ULE for [T; N] {
     #[inline]
     fn validate_bytes(bytes: &[u8]) -> Result<(), UleError> {
+        if N == 0 {
+            // ZSTs shouldn't be ULE
+            return Err(UleError::length::<Self>(bytes.len()));
+        }
+        if bytes.len() % size_of::<Self>() != 0 {
+            return Err(UleError::length::<Self>(bytes.len()));
+        }
         // a slice of multiple Selfs is equivalent to just a larger slice of Ts
         T::validate_bytes(bytes)
     }
@@ -98,5 +105,40 @@ where
     #[inline]
     unsafe fn from_bytes_unchecked(bytes: &[u8]) -> &Self {
         T::slice_from_bytes_unchecked(bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ZeroSlice;
+
+    #[test]
+    fn test_array_ule_validate() {
+        let bytes: &[u8] = &[1, 2, 3, 4, 5, 6];
+        assert!(<[u8; 2] as ULE>::validate_bytes(bytes).is_ok());
+        assert!(<[u8; 3] as ULE>::validate_bytes(bytes).is_ok());
+        assert!(<[u8; 6] as ULE>::validate_bytes(bytes).is_ok());
+
+        // Length not a multiple of array size
+        assert!(<[u8; 4] as ULE>::validate_bytes(bytes).is_err());
+        assert!(<[u8; 5] as ULE>::validate_bytes(bytes).is_err());
+        assert!(<[u8; 7] as ULE>::validate_bytes(bytes).is_err());
+
+        // Multi-byte element types (CharULE is 3 bytes, [CharULE; 2] is 6 bytes)
+        let chars_6b: &[u8] = &[0x61, 0x00, 0x00, 0x62, 0x00, 0x00]; // 'a', 'b'
+        assert!(<[CharULE; 2] as ULE>::validate_bytes(chars_6b).is_ok());
+        let chars_9b: &[u8] = &[0x61, 0x00, 0x00, 0x62, 0x00, 0x00, 0x63, 0x00, 0x00]; // 'a', 'b', 'c' (9 bytes: multiple of CharULE (3), but not [CharULE; 2] (6))
+        assert!(<[CharULE; 2] as ULE>::validate_bytes(chars_9b).is_err());
+
+        // ZeroSlice::parse_bytes
+        assert!(ZeroSlice::<[u8; 3]>::parse_bytes(bytes).is_ok());
+        assert!(ZeroSlice::<[u8; 4]>::parse_bytes(bytes).is_err());
+
+        // Zero-length arrays unconditionally error
+        assert!(<[u8; 0] as ULE>::validate_bytes(&[]).is_err());
+        assert!(<[u8; 0] as ULE>::validate_bytes(bytes).is_err());
+        assert!(ZeroSlice::<[u8; 0]>::parse_bytes(&[]).is_err());
+        assert!(ZeroSlice::<[u8; 0]>::parse_bytes(bytes).is_err());
     }
 }


### PR DESCRIPTION
Similar to #8393

We validate that the underlying slice is a valid slice of subelements but we don't validate that it is the right number of subelements.

Including a backport for the 0.11 series

I don't think this is actually reachable as an exploit in ICU4X: the ULE derive also checks overall length anyway, and we never use arrays _directly_ in a ZeroVec.

Also using arrays directly in a ZeroVec isn't actually a problem either because the way ZeroVec works it will simply ignore the trailing bytes.

Because this isn't reachable in ICU4X I think we can just backport to 0.11 and not 0.10


## Changelog

zerovec: Fix length check in  `impl ULE for [T; N]`