### PR TITLE
Remove `icu_host_info` from `icu` examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1319,7 +1319,6 @@ dependencies = [
  "icu_datetime",
  "icu_decimal",
  "icu_experimental",
- "icu_host_info",
  "icu_list",
  "icu_locale",
  "icu_normalizer",

--- a/components/icu/Cargo.toml
+++ b/components/icu/Cargo.toml
@@ -46,7 +46,6 @@ icu_provider = { workspace = true }
 
 [dev-dependencies]
 icu_datetime = { path = "../../components/datetime", features = ["serde", "unstable_jiff_0_2", "unstable_chrono_0_4"] }
-icu_host_info = { path = "../../utils/host_info", features = ["datetime"] }
 icu_provider_adapters = { path = "../../provider/adapters", features = ["serde"] }
 icu_benchmark_macros = { path = "../../tools/benchmark/macros" }
 icu_provider_blob = { path = "../../provider/blob", features = ["alloc"] }

--- a/components/icu/examples/chrono_jiff.rs
+++ b/components/icu/examples/chrono_jiff.rs
@@ -60,17 +60,4 @@ fn main() {
             &chrono_tz::Tz::from_str("Pacific/Honolulu").unwrap_or(chrono_tz::Tz::UTC)
         ))
     );
-
-    // User locale, calendar, time zone
-
-    let formatter = DateTimeFormatter::try_new(
-        icu_host_info::datetime_preferences().unwrap(),
-        fieldsets::YMDT::medium().with_zone(fieldsets::zone::SpecificLong),
-    )
-    .expect("data is present");
-
-    println!(
-        "{}",
-        formatter.format(&jiff.to_zoned(jiff::tz::TimeZone::system()))
-    );
 }


### PR DESCRIPTION
Fixes #8335 

## Changelog

icu: Remove dev-dependency on unpublished crate `icu_host_info`