### PR TITLE
Add benchmark for loading the preferred calendar

### DIFF
--- a/components/calendar/Cargo.toml
+++ b/components/calendar/Cargo.toml
@@ -84,6 +84,10 @@ harness = false
 name = "convert"
 harness = false
 
+[[bench]]
+name = "preferred"
+harness = false
+
 [[test]]
 name = "arithmetic"
 required-features = ["ixdtf"]

--- a/components/calendar/benches/preferred.rs
+++ b/components/calendar/benches/preferred.rs
@@ -1,0 +1,26 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use icu::calendar::AnyCalendarKind;
+use icu::calendar::preferences::CalendarPreferences;
+use icu::locale::locale;
+
+fn preferred_benches(c: &mut Criterion) {
+    let prefs = &[
+        CalendarPreferences::from(locale!("en")),
+        CalendarPreferences::from(locale!("fa")),
+        CalendarPreferences::from(locale!("ar-EG")),
+        CalendarPreferences::from(locale!("ar-SA-u-ca-islamic")),
+        CalendarPreferences::from(locale!("he-u-ca-hebrew")),
+    ];
+    let mut group = c.benchmark_group("preferred");
+    group.bench_function("try_new", |b| {
+        b.iter(|| black_box(&prefs).map(AnyCalendarKind::try_new))
+    });
+    group.finish();
+}
+
+criterion_group!(benches, preferred_benches);
+criterion_main!(benches);

--- a/components/calendar/benches/preferred.rs
+++ b/components/calendar/benches/preferred.rs
@@ -7,6 +7,8 @@ use icu::calendar::AnyCalendarKind;
 use icu::calendar::preferences::CalendarPreferences;
 use icu::locale::locale;
 
+/// Loading the preferred calendar is an operation often in the critical path
+/// for datetime formatting. We want to keep it from regressing. See #8375.
 fn preferred_benches(c: &mut Criterion) {
     let prefs = &[
         CalendarPreferences::from(locale!("en")),


### PR DESCRIPTION
Microbenchmark for #8375

Although #8375 is about `icu_datetime`, the code path in `icu_calendar` loads the same data and is more narrow. We already have a datetime benchmark that covers this (the one that detected the issue).

## Changelog

N/A