### PR TITLE
Add internal EarlyExitCursor optimization

### DIFF
--- a/provider/core/src/baked/zerotrie.rs
+++ b/provider/core/src/baked/zerotrie.rs
@@ -9,6 +9,7 @@
 /// Mostly for internal use
 pub const ID_SEPARATOR: u8 = 0x1E;
 
+use core::fmt;
 pub use crate::DynamicDataMarker;
 use crate::{
     prelude::{zerofrom::ZeroFrom, *},
@@ -17,7 +18,24 @@ use crate::{
 #[cfg(feature = "alloc")]
 use alloc::string::String;
 pub use zerotrie::ZeroTrieSimpleAscii;
+use zerotrie::cursor::ZeroTrieSimpleAsciiCursor;
 use zerovec::{VarZeroSlice, vecs::Index32};
+
+/// Optimization to stop writing to a ZeroTrie cursor when the ZeroTrie
+/// is empty. See #8375
+struct EarlyExitCursor<'a, 'b>(&'b mut ZeroTrieSimpleAsciiCursor<'a>);
+
+impl fmt::Write for EarlyExitCursor<'_, '_> {
+    #[inline]
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        self.0.write_str(s)?;
+        if self.0.is_empty() {
+            Err(fmt::Error)
+        } else {
+            Ok(())
+        }
+    }
+}
 
 fn get_index(
     trie: ZeroTrieSimpleAscii<&'static [u8]>,
@@ -26,10 +44,10 @@ fn get_index(
 ) -> Option<usize> {
     use writeable::Writeable;
     let mut cursor = trie.cursor();
-    let _is_ascii = id.locale.write_to(&mut cursor);
+    let _is_ascii = id.locale.write_to(&mut EarlyExitCursor(&mut cursor));
     if !id.marker_attributes.is_empty() {
         cursor.step(ID_SEPARATOR);
-        id.marker_attributes.write_to(&mut cursor).ok()?;
+        id.marker_attributes.write_to(&mut EarlyExitCursor(&mut cursor)).ok()?;
         loop {
             if let Some(v) = cursor.take_value() {
                 break Some(v);

--- a/provider/core/src/baked/zerotrie.rs
+++ b/provider/core/src/baked/zerotrie.rs
@@ -9,7 +9,6 @@
 /// Mostly for internal use
 pub const ID_SEPARATOR: u8 = 0x1E;
 
-use core::fmt;
 pub use crate::DynamicDataMarker;
 use crate::{
     prelude::{zerofrom::ZeroFrom, *},
@@ -17,11 +16,12 @@ use crate::{
 };
 #[cfg(feature = "alloc")]
 use alloc::string::String;
+use core::fmt;
 pub use zerotrie::ZeroTrieSimpleAscii;
 use zerotrie::cursor::ZeroTrieSimpleAsciiCursor;
 use zerovec::{VarZeroSlice, vecs::Index32};
 
-/// Optimization to stop writing to a ZeroTrie cursor when the ZeroTrie
+/// Optimization to stop writing to a `ZeroTrie` cursor when the `ZeroTrie`
 /// is empty. See #8375
 struct EarlyExitCursor<'a, 'b>(&'b mut ZeroTrieSimpleAsciiCursor<'a>);
 
@@ -47,7 +47,9 @@ fn get_index(
     let _is_ascii = id.locale.write_to(&mut EarlyExitCursor(&mut cursor));
     if !id.marker_attributes.is_empty() {
         cursor.step(ID_SEPARATOR);
-        id.marker_attributes.write_to(&mut EarlyExitCursor(&mut cursor)).ok()?;
+        id.marker_attributes
+            .write_to(&mut EarlyExitCursor(&mut cursor))
+            .ok()?;
         loop {
             if let Some(v) = cursor.take_value() {
                 break Some(v);


### PR DESCRIPTION
This is the narrowest, highest-impact individual change from my investigations on #8405.

```
preferred/try_new       time:   [727.37 ns 739.40 ns 751.90 ns]
                        change: [-22.413% -21.378% -20.287%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 21 outliers among 100 measurements (21.00%)
  10 (10.00%) high mild
  11 (11.00%) high severe
```

I may want to propose this as an API in the `zerotrie` crate but I will start with an internal change first.

## Changelog

icu_provider: Improve performance of data loading that uses locale fallback