### PR TITLE
Fix unsound cast box

### DIFF
--- a/utils/zerovec/src/ule/mod.rs
+++ b/utils/zerovec/src/ule/mod.rs
@@ -471,6 +471,15 @@ impl core::error::Error for UleError {}
 /// - `T::from_bytes_unchecked` must be safe to call on the slice behind bytes
 pub(crate) unsafe fn cast_box<T: VarULE + ?Sized>(bytes: Box<[u8]>) -> Box<T> {
     use core::alloc::Layout;
+
+    const {
+        assert!(size_of::<&T>() == size_of::<(*const u8, usize)>());
+        assert!(size_of::<&T>() == size_of::<(*mut u8, usize)>());
+        let expected_layout = Layout::new::<&[u8]>();
+        let actual_layout = Layout::new::<&T>();
+        assert!(expected_layout.size() == actual_layout.size());
+        assert!(expected_layout.align() == actual_layout.align());
+    }
     let raw = Box::into_raw(bytes);
     // SAFETY: we just produced `raw`; it is valid
     let slice: &[u8] = unsafe { &*raw };
@@ -478,11 +487,9 @@ pub(crate) unsafe fn cast_box<T: VarULE + ?Sized>(bytes: Box<[u8]>) -> Box<T> {
     let ref_t: &T = unsafe { T::from_bytes_unchecked(slice) };
 
     // Extract metadata from ref_t.
-    debug_assert_eq!(size_of::<&T>(), size_of::<(*const u8, usize)>());
     let (_, metadata) = unsafe { core::mem::transmute_copy::<&T, (*const u8, usize)>(&ref_t) };
 
     // Construct *mut T from (raw_data_ptr, metadata).
-    debug_assert_eq!(size_of::<*mut T>(), size_of::<(*mut u8, usize)>());
     let ptr: *mut T = unsafe {
         core::mem::transmute_copy::<(*mut u8, usize), *mut T>(&(raw.cast::<u8>(), metadata))
     };

--- a/utils/zerovec/src/ule/mod.rs
+++ b/utils/zerovec/src/ule/mod.rs
@@ -246,8 +246,8 @@ where
 /// If you need to implement this trait, consider using [`#[make_varule]`](crate::make_varule) or
 ///  [`#[derive(VarULE)]`](macro@VarULE) instead.
 ///
-/// This trait is mostly for unsized types like `str` and `[T]`. It can be implemented on sized types;
-/// however, it is much more preferable to use [`ULE`] for that purpose. The [`custom`] module contains
+/// This trait is for unsized types like `str` and `[T]`. For sized types use [`ULE`] instead.
+/// The [`custom`] module contains
 /// additional documentation on how this type can be implemented on custom types.
 ///
 /// If deserialization with `VarZeroVec` is desired is recommended to implement `Deserialize` for
@@ -271,6 +271,8 @@ where
 /// 6. All other methods *must* be left with their default impl, or else implemented according to
 ///    their respective safety guidelines.
 /// 7. Acknowledge the following note about the equality invariant.
+/// 8. The type **must** be a unsized, slice like type. Specifically this trait requires that a fat
+///    pointer to this type is represented by the pointer to the first element and the number of elements.
 ///
 /// If the ULE type is a struct only containing other ULE/VarULE types (or other types which satisfy invariants 1 and 2,
 /// like `[u8; N]`), invariants 1 and 2 can be achieved via `#[repr(C, packed)]` or `#[repr(transparent)]`.

--- a/utils/zerovec/src/ule/mod.rs
+++ b/utils/zerovec/src/ule/mod.rs
@@ -448,6 +448,13 @@ impl UleError {
 impl core::error::Error for UleError {}
 
 #[cfg(feature = "alloc")]
+#[repr(C)]
+struct DstMetadata<Ptr> {
+    ptr: Ptr,
+    metadata: usize,
+}
+
+#[cfg(feature = "alloc")]
 /// Reconstructs a `Box<T>` from a `Box<[u8]>` while preserving unique pointer provenance
 /// and correctly resolving DST metadata.
 ///
@@ -473,8 +480,8 @@ pub(crate) unsafe fn cast_box<T: VarULE + ?Sized>(bytes: Box<[u8]>) -> Box<T> {
     use core::alloc::Layout;
 
     const {
-        assert!(size_of::<&T>() == size_of::<(*const u8, usize)>());
-        assert!(size_of::<&T>() == size_of::<(*mut u8, usize)>());
+        assert!(size_of::<&T>() == size_of::<DstMetadata<*const u8>>());
+        assert!(size_of::<&T>() == size_of::<DstMetadata<*mut u8>>());
         let expected_layout = Layout::new::<&[u8]>();
         let actual_layout = Layout::new::<&T>();
         assert!(expected_layout.size() == actual_layout.size());
@@ -485,13 +492,16 @@ pub(crate) unsafe fn cast_box<T: VarULE + ?Sized>(bytes: Box<[u8]>) -> Box<T> {
     let slice: &[u8] = unsafe { &*raw };
     // SAFETY: caller guarantees `from_bytes_unchecked` is safe.
     let ref_t: &T = unsafe { T::from_bytes_unchecked(slice) };
-
     // Extract metadata from ref_t.
-    let (_, metadata) = unsafe { core::mem::transmute_copy::<&T, (*const u8, usize)>(&ref_t) };
+    let DstMetadata { metadata, .. } =
+        unsafe { core::mem::transmute_copy::<&T, DstMetadata<*const u8>>(&ref_t) };
 
     // Construct *mut T from (raw_data_ptr, metadata).
     let ptr: *mut T = unsafe {
-        core::mem::transmute_copy::<(*mut u8, usize), *mut T>(&(raw.cast::<u8>(), metadata))
+        core::mem::transmute_copy::<DstMetadata<*mut u8>, *mut T>(&DstMetadata {
+            ptr: raw.cast::<u8>(),
+            metadata,
+        })
     };
 
     let expected_layout = Layout::for_value(slice);


### PR DESCRIPTION
This PR seeks to address #8408 

It contains 3 commits with various fixes and workarounds for the issues mentioned in the report.

The first commit is just a documentation update. It places the requirement of only implementing `VarULE` for unsized types as safety requirement onto users implementing this trait. This resolves the issue that the provided example triggers undefined behaviour while not violating any safety requirement.

The second commit turns all of the asserts in `cast_box` into a asserts in a `const` block. This forces the compiler to check these asserts at monomorpication time, which in turn enforces them at compile time. As consequence the example provided in the bug report does not compile anymore. This commit will also make sure that *if* the layout of DST changes in future Rust versions any usage of this code will stop to compile. I personally find that preferable to having runtime panics, but I put it into a separate commit as this might be something you want to handle differently.

The third commit changes the extracted representation of the DST metadata from a tuple to a `#[repr(C)]` struct. This seeks to address the fact that tuples have a unspecified layout, while the layout for a `#[repr(C)]` struct is specified. This is again a safe guard against any future layout changes in rustc. This change has in my opinion no real downside (beside that it requires defining an additional type), but removes a potential failure point.

The fourth commit changes how the slice metadata are extracted. Instead of using `transmute_copy` with an unspecified layout we just get the length of the slice of the converted type as bytes. In practice this results to the same value, but accessed through a safe stable method. This is a purely cosmetic change, the code still relies on the unspecified layout for the second transmute. I guess this might be controversial. 

I put the various changes into different commits so that you can easily decide what to take and what to drop. I guess especially the last change might be a candidate to drop.

There are still the following potential issues in that function:

* The existing layout assert in the end runs after the `Box<T>` is constructed. So for the theoretical case that the layout is not the same and the type `T` has a non-trivial `Drop` function it might cause invoking undefined behaviour while calling `Drop` for the already constructed `Box`. It might be possible to address this by either using a `ManualDrop` wrapper around the box and just leak the memory in this case or to turn the assert into a check that reconstructs the original `Box<[u8]>` again before panicing or to just remove the assert and solely rely on the const asserts above. Given that I don't even know how to trigger this path I just left everything as is, as hopefully the const assert makes this already impossible
* The code still relies on the unspecified layout of DST types. There is not much we could do there, without support from stable Rust. The asserts should at least make sure that we inspected the layout as much as possible.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->

## Changelog

zerovec: Improve soundness of `cast_box` so that it extracts DST metadata in a more stable (though not 100% stable) way. Full soundness will have to wait for stable ptr metadata APIs.
