### PR TITLE
zerovec: skip test_miri_repro_eyepatch_hack_truncate on big-endian

### DIFF
--- a/utils/zerovec/src/lib.rs
+++ b/utils/zerovec/src/lib.rs
@@ -574,6 +574,9 @@ mod tests {
     }
 
     #[test]
+    // This test includes a little-endian assumption:
+    // https://github.com/unicode-org/icu4x/issues/8396
+    #[cfg(target_endian = "little")]
     fn test_miri_repro_eyepatch_hack_truncate() {
         let slice: &[u16] = &[1, 2, 3, 4];
         let zv: ZeroVec<u16> = ZeroVec::try_from_slice(slice).unwrap();


### PR DESCRIPTION
Fixes #8396 by acknowledging that the test is endian-specific and running it only on little-endian targets.

<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->

## Changelog

<!-- Please fill in according to documents/process/changelog.md -->
```
- Acknowledge that `zerovec: tests::test_miri_repro_eyepatch_hack_truncate` contains a little-endian assumption, and skip it on big-endian targets
```