### PR TITLE
Deprecate EqULE

### DIFF
--- a/utils/zerovec/src/ule/mod.rs
+++ b/utils/zerovec/src/ule/mod.rs
@@ -194,16 +194,29 @@ pub trait AsULE: Copy {
 /// This enables certain performance optimizations, such as
 /// [`ZeroVec::try_from_slice`](crate::ZeroVec::try_from_slice).
 ///
+/// # Deprecated
+///
+/// This trait is deprecated because it can unintuitively cause runtime panics
+/// when unwrapping on big-endian systems.
+///
+/// Instead of `where T: EqULE`, similar use cases can be solved with:
+///
+/// ```ignore
+/// where T: AsULE<ULE = T>
+/// ```
+///
 /// # Implementation safety
 ///
 /// This trait is safe to implement if the type's ULE (as defined by `impl `[`AsULE`]` for T`)
 /// has an equal byte sequence as the type itself on little-endian platforms; i.e., one where
 /// `*const T` can be cast to a valid `*const T::ULE`.
+#[deprecated(since = "0.11.9", note = "see EqULE docs")]
 pub unsafe trait EqULE: AsULE {}
 
 /// A trait for a type where aligned slices can be cast to unaligned slices.
 ///
 /// Auto-implemented on all types implementing [`EqULE`].
+#[deprecated(since = "0.11.9", note = "see EqULE docs")]
 pub trait SliceAsULE
 where
     Self: AsULE + Sized,
@@ -215,6 +228,7 @@ where
 }
 
 #[cfg(target_endian = "little")]
+#[allow(deprecated)]
 impl<T> SliceAsULE for T
 where
     T: EqULE,
@@ -231,6 +245,7 @@ where
 }
 
 #[cfg(not(target_endian = "little"))]
+#[allow(deprecated)]
 impl<T> SliceAsULE for T
 where
     T: EqULE,

--- a/utils/zerovec/src/ule/plain.rs
+++ b/utils/zerovec/src/ule/plain.rs
@@ -167,6 +167,7 @@ macro_rules! impl_byte_slice_type {
         }
         // EqULE is true because $type and RawBytesULE<{ size_of::<$type> }>
         // have the same byte sequence on little-endian
+        #[allow(deprecated)]
         unsafe impl EqULE for $type {}
 
         impl RawBytesULE<{ size_of::<$type>() }> {
@@ -209,6 +210,7 @@ impl AsULE for u8 {
 }
 
 // EqULE is true because u8 is its own ULE.
+#[allow(deprecated)]
 unsafe impl EqULE for u8 {}
 
 impl_const_constructors!(u8);
@@ -245,6 +247,7 @@ impl AsULE for NonZeroU8 {
     }
 }
 
+#[allow(deprecated)]
 unsafe impl EqULE for NonZeroU8 {}
 
 impl NicheBytes<1> for NonZeroU8 {
@@ -278,6 +281,7 @@ impl AsULE for i8 {
 }
 
 // EqULE is true because i8 is its own ULE.
+#[allow(deprecated)]
 unsafe impl EqULE for i8 {}
 
 impl AsULE for NonZeroI8 {
@@ -335,6 +339,7 @@ impl AsULE for bool {
 }
 
 // EqULE is true because bool is its own ULE.
+#[allow(deprecated)]
 unsafe impl EqULE for bool {}
 
 impl_const_constructors!(bool);
@@ -370,6 +375,7 @@ impl AsULE for () {
 }
 
 // EqULE is true because () is its own ULE.
+#[allow(deprecated)]
 unsafe impl EqULE for () {}
 
 impl_const_constructors!(());

--- a/utils/zerovec/src/ule/slices.rs
+++ b/utils/zerovec/src/ule/slices.rs
@@ -38,6 +38,7 @@ impl<T: AsULE, const N: usize> AsULE for [T; N] {
     }
 }
 
+#[allow(deprecated)]
 unsafe impl<T: EqULE, const N: usize> EqULE for [T; N] {}
 
 // Safety (based on the safety checklist on the VarULE trait):

--- a/utils/zerovec/src/zerovec/mod.rs
+++ b/utils/zerovec/src/zerovec/mod.rs
@@ -801,6 +801,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<'a, T> ZeroVec<'a, T>
 where
     T: EqULE,
@@ -823,6 +824,7 @@ where
     ///     assert_eq!(bytes, zerovec.as_bytes());
     /// }
     /// ```
+    #[deprecated(since = "0.11.9", note = "consider ZeroVec::from_aligned_slice; see EqULE")]
     #[inline]
     pub fn try_from_slice(slice: &'a [T]) -> Option<Self> {
         T::slice_to_unaligned(slice).map(|ule_slice| Self::new_borrowed(ule_slice))
@@ -850,10 +852,39 @@ where
     /// // Note: zerovec could be either borrowed or owned.
     /// assert_eq!(bytes, zerovec.as_bytes());
     /// ```
+    #[deprecated(since = "0.11.9", note = "consider ZeroVec::from_aligned_slice; see EqULE")]
     #[inline]
     #[cfg(feature = "alloc")]
     pub fn from_slice_or_alloc(slice: &'a [T]) -> Self {
         Self::try_from_slice(slice).unwrap_or_else(|| Self::alloc_from_slice(slice))
+    }
+}
+
+impl<'a, T> ZeroVec<'a, T>
+where
+    T: AsULE<ULE = T>,
+{
+    /// Creates a `ZeroVec<'a, T>` from a `&'a [T]` when T is its own ULE.
+    ///
+    /// ✨ *Enabled with the `alloc` Cargo feature.*
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use zerovec::ZeroVec;
+    ///
+    /// // The little-endian bytes correspond to the numbers on the following line.
+    /// let bytes: &[u8] = &[0xD3, 0x00, 0x19, 0x01, 0xA5, 0x01, 0xCD, 0x01];
+    /// let nums: &[u16] = &[211, 281, 421, 461];
+    ///
+    /// let zerovec = ZeroVec::from_aligned_slice(nums);
+    ///
+    /// assert_eq!(bytes, zerovec.as_bytes());
+    /// assert!(!zerovec.is_owned());
+    /// ```
+    #[inline]
+    pub fn from_aligned_slice(slice: &'a [T]) -> Self {
+        ZeroVec::new_borrowed(slice)
     }
 }
 


### PR DESCRIPTION
#8396

It seemed like a good idea a long time ago, but this fn has zero call sites except one where it was likely an LLM thought `ZeroVec::try_from_slice` was parsing the bytes.

## Changelog

zerovec:

- Deprecate `EqULE`, `SliceAsULE`, `ZeroVec::try_from_slice`, `ZeroVec::from_slice_or_alloc`
- Add `ZeroVec::from_aligned_slice`