### PR TITLE
dart: Cache downloaded pre-built binaries in outputDirectoryShared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Several crates have had patch releases in the 2.3 stream:
   - (2.3.1) `icu_capi`
     - Add missing docs to properties (unicode-org#8407)
   - Dart
+    - Cache downloaded pre-built binaries across build hook invocations in `outputDirectoryShared` (unicode-org#8426)
     - (2.3.1) Add `Error` and `Exception` to classes/enums which are used as errors and exceptions (https://github.com/rust-diplomat/diplomat/pull/1220) (unicode-org#8411)
   - JavaScript
     - (2.3.1) Add validation to arguments to assure type correctness (https://github.com/rust-diplomat/diplomat/pull/902) (unicode-org#8411)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ Several crates have had patch releases in the 2.3 stream:
   - (2.3.1) `icu_capi`
     - Add missing docs to properties (unicode-org#8407)
   - Dart
-    - Cache downloaded pre-built binaries across build hook invocations in `outputDirectoryShared` (unicode-org#8426)
     - (2.3.1) Add `Error` and `Exception` to classes/enums which are used as errors and exceptions (https://github.com/rust-diplomat/diplomat/pull/1220) (unicode-org#8411)
   - JavaScript
     - (2.3.1) Add validation to arguments to assure type correctness (https://github.com/rust-diplomat/diplomat/pull/902) (unicode-org#8411)

--- a/ffi/dart/hook/build.dart
+++ b/ffi/dart/hook/build.dart
@@ -132,8 +132,8 @@ final class FetchMode extends BuildMode {
 
     final cachedLibrary = File.fromUri(
       input.outputDirectoryShared
-          .resolve('icu4x-$version/')
-          .resolve('$rustTarget-$libraryType-$targetFilename'),
+          .resolve('icu4x-$version/$rustTarget-$libraryType/')
+          .resolve(targetFilename),
     );
     if (await cachedLibrary.exists()) {
       final fileHash = sha256

--- a/ffi/dart/hook/build.dart
+++ b/ffi/dart/hook/build.dart
@@ -127,6 +127,26 @@ final class FetchMode extends BuildMode {
     final libraryType = input.config.buildStatic
         ? 'static-with_data'
         : 'dynamic-with_data';
+    final targetFilename = input.config.filename('icu4x');
+    final expectedFileHash = fileHashes[(rustTarget, libraryType)];
+    final library = File.fromUri(input.outputDirectory.resolve(targetFilename));
+
+    final cachedLibrary = File.fromUri(
+      input.outputDirectoryShared
+          .resolve('icu4x-$version/')
+          .resolve('$rustTarget-$libraryType-$targetFilename'),
+    );
+    if (await cachedLibrary.exists()) {
+      final fileHash = sha256
+          .convert(await cachedLibrary.readAsBytes())
+          .toString();
+      if (fileHash == expectedFileHash) {
+        print('Using cached binary from shared output directory.');
+        await cachedLibrary.copy(library.path);
+        return library.uri;
+      }
+    }
+
     print('Fetching pre-built binary for $version, $rustTarget, $libraryType');
     final dylibRemoteUri = Uri.parse(
       'https://github.com/unicode-org/icu4x/releases/'
@@ -139,7 +159,6 @@ final class FetchMode extends BuildMode {
     }
     final bytes = await response.fold<List<int>>([], (a, b) => a..addAll(b));
     final fileHash = sha256.convert(bytes).toString();
-    final expectedFileHash = fileHashes[(rustTarget, libraryType)];
     if (fileHash != expectedFileHash) {
       throw Exception(
         'The pre-built binary for the target $rustTarget-$libraryType at '
@@ -147,10 +166,9 @@ final class FetchMode extends BuildMode {
         '$expectedFileHash fixed in the build hook of package:icu4x.',
       );
     }
-    final library = File.fromUri(
-      input.outputDirectory.resolve(input.config.filename('icu4x')),
-    );
-    await library.writeAsBytes(bytes);
+    await cachedLibrary.parent.create(recursive: true);
+    await cachedLibrary.writeAsBytes(bytes);
+    await cachedLibrary.copy(library.path);
     return library.uri;
   }
 

--- a/ffi/dart/hook/build.dart
+++ b/ffi/dart/hook/build.dart
@@ -129,7 +129,6 @@ final class FetchMode extends BuildMode {
         : 'dynamic-with_data';
     final targetFilename = input.config.filename('icu4x');
     final expectedFileHash = fileHashes[(rustTarget, libraryType)];
-    final library = File.fromUri(input.outputDirectory.resolve(targetFilename));
 
     final cachedLibrary = File.fromUri(
       input.outputDirectoryShared
@@ -142,8 +141,7 @@ final class FetchMode extends BuildMode {
           .toString();
       if (fileHash == expectedFileHash) {
         print('Using cached binary from shared output directory.');
-        await cachedLibrary.copy(library.path);
-        return library.uri;
+        return cachedLibrary.uri;
       }
     }
 
@@ -168,8 +166,7 @@ final class FetchMode extends BuildMode {
     }
     await cachedLibrary.parent.create(recursive: true);
     await cachedLibrary.writeAsBytes(bytes);
-    await cachedLibrary.copy(library.path);
-    return library.uri;
+    return cachedLibrary.uri;
   }
 
   @override

--- a/ffi/dart/pubspec.yaml
+++ b/ffi/dart/pubspec.yaml
@@ -5,7 +5,7 @@
 name: icu4x
 description: > 
   Dart bindings for the Rust `icu` internationalization crate.
-version: 2.3.1
+version: 2.3.2-wip
 repository: https://github.com/unicode-org/icu4x/tree/main/ffi/dart
 issue_tracker: https://github.com/unicode-org/icu4x/issues?q=is%3Aissue%20is%3Aopen%20label%3AU-flutter
 


### PR DESCRIPTION
Cache the downloaded binary. While Dart has built-in caching for the hook, any change in env variables for example would lead to re-downloading the binary. This prevents that.

## Changelog
* dart: Cache downloaded pre-built binaries across build hook invocations in `outputDirectoryShared`.