### PR TITLE
Update zip crate to v8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,15 +120,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
-dependencies = [
- "derive_arbitrary",
-]
-
-[[package]]
 name = "arrayvec"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -719,17 +710,6 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-
-[[package]]
-name = "derive_arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
 
 [[package]]
 name = "detone"
@@ -3604,10 +3584,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9"
 
 [[package]]
-name = "typed-arena"
-version = "2.0.2"
+name = "typed-path"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typeid"
@@ -4370,19 +4350,15 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.4.2"
+version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
- "arbitrary",
  "crc32fast",
- "crossbeam-utils",
- "displaydoc",
  "flate2",
  "indexmap",
  "memchr",
- "thiserror",
- "zopfli",
+ "typed-path",
 ]
 
 [[package]]
@@ -4405,16 +4381,4 @@ dependencies = [
  "potential_utf",
  "resb",
  "serde",
-]
-
-[[package]]
-name = "zopfli"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1f48f3508a3a3f2faee01629564400bc12260f6214a056d06a3aaaa6ef0736"
-dependencies = [
- "crc32fast",
- "log",
- "simd-adler32",
- "typed-arena",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -281,9 +281,9 @@ utf8_iter = { version = "1.0.2", default-features = false }
 write16 = { version = "1.0.0", default-features = false }
 
 ## External Deps Group 2: Heavy Dev and Datagen deps. No default features.
-zip = { version = "2", default-features = false }
+zip = { version = "8", default-features = false }
 tar = { version = "0.4.46", default-features = false }
-flate2 = { version = "1.0.35", default-features = false }
+flate2 = { version = "1.0.35", default-features = false, features = ["rust_backend"] }
 serde-aux = { version = "4.0.0", default-features = false }
 toml = { version = "0.8.0", default-features = false, features = ["parse"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -281,7 +281,7 @@ utf8_iter = { version = "1.0.2", default-features = false }
 write16 = { version = "1.0.0", default-features = false }
 
 ## External Deps Group 2: Heavy Dev and Datagen deps. No default features.
-zip = { version = "8", default-features = false }
+zip = { version = "8", default-features = false, features = ["deflate-flate2"] }
 tar = { version = "0.4.46", default-features = false }
 flate2 = { version = "1.0.35", default-features = false, features = ["rust_backend"] }
 serde-aux = { version = "4.0.0", default-features = false }

--- a/provider/source/Cargo.toml
+++ b/provider/source/Cargo.toml
@@ -62,7 +62,7 @@ serde-aux = { workspace = true }
 toml = { workspace = true }
 tar = { workspace = true }
 twox-hash = { workspace = true }
-zip = { workspace = true, features = ["deflate-flate2"] }
+zip = { workspace = true }
 
 # `networking` feature
 ureq = { workspace = true, optional = true}

--- a/provider/source/Cargo.toml
+++ b/provider/source/Cargo.toml
@@ -62,7 +62,7 @@ serde-aux = { workspace = true }
 toml = { workspace = true }
 tar = { workspace = true }
 twox-hash = { workspace = true }
-zip = { workspace = true, features = ["deflate"] }
+zip = { workspace = true, features = ["deflate-flate2"] }
 
 # `networking` feature
 ureq = { workspace = true, optional = true}

--- a/tools/make/depcheck/src/allowlist.rs
+++ b/tools/make/depcheck/src/allowlist.rs
@@ -225,20 +225,14 @@ pub const EXTRA_LOGGING_DEPS: &[&str] = &["cfg-if", "log"];
 /// This should rarely change, and if it does consider toggling features until it doesn't
 pub const EXTRA_ZIP_DEPS: &[&str] = &[
     "adler2",
-    "bumpalo",
-    "byteorder",
     "crc32fast",
     "flate2",
-    "lockfree-object-pool",
     "miniz_oxide",
-    "once_cell",
     "ordered-float",
-    "serde-spanned",
     "serde-value",
     "simd-adler32",
-    "typed-arena",
+    "typed-path",
     "zip",
-    "zopfli",
 ];
 
 /// Dependencies needed by the `rayon` crate


### PR DESCRIPTION
Updates to v8, we were on v2 (8 years old!)

Adds `features = ["deflate-flate2"]` avoiding extra unused decompression engines.


## Changelog (N/A)

Update zip to v8