### PR TITLE
In icu_datetime, limit use of the icu crate to doctests

### DIFF
--- a/components/datetime/src/provider/names.rs
+++ b/components/datetime/src/provider/names.rs
@@ -831,7 +831,7 @@ fn test_dayperiod_names() {
         DataRequest {
             id: DataIdentifierBorrowed::for_marker_attributes_and_locale(
                 DataMarkerAttributes::from_str_or_panic("5"),
-                &icu::locale::data_locale!("zh"),
+                &icu_locale_core::data_locale!("zh"),
             ),
             ..Default::default()
         },
@@ -852,7 +852,7 @@ fn test_dayperiod_names() {
         DataRequest {
             id: DataIdentifierBorrowed::for_marker_attributes_and_locale(
                 DataMarkerAttributes::from_str_or_panic("5"),
-                &icu::locale::data_locale!("zh-Hant"),
+                &icu_locale_core::data_locale!("zh-Hant"),
             ),
             ..Default::default()
         },


### PR DESCRIPTION
<!--
Thank you for your pull request to ICU4X!

Reminder: try to use [Conventional Comments](https://conventionalcomments.org/) to make comments clearer.

Please see https://github.com/unicode-org/icu4x/blob/main/CONTRIBUTING.md for general
information on contributing to ICU4X.
-->
This is a continuation of the “in component crates, limit use of the `icu` crate to doctests” idea from https://github.com/unicode-org/icu4x/pull/7750 and https://github.com/unicode-org/icu4x/pull/7742. See the previous PRs for discussion and commentary. 

As @sffc noted in https://github.com/unicode-org/icu4x/pull/7750#pullrequestreview-3920231057, this isn’t a policy that’s written down or enforced in any way, but even maintaining the general pattern via ad-hoc PRs like these is still helpful for downstream packaging.

## Changelog

<!-- Please fill in according to documents/process/changelog.md -->
N/A