### PR TITLE
Add instruction to patch-release all crates in release.md

### DIFF
--- a/documents/process/release.md
+++ b/documents/process/release.md
@@ -51,6 +51,7 @@ Once the release checklist is complete, the assigned release driver will perform
   * [ ] Update all ICU4X crate versions
     * [ ] Update the workspace version to the new version
     * [ ] Some `icu_*` crates do not follow the ICU4X versioning scheme: `icu_codepointtrie_builder`, `icu_pattern`, and `icu_experimental`. Be sure to give them an appropriate version based on the changelog. Major releases are always paired with a `0.x.0` release of `icu_experimental`.
+      * Important: even if these crates have no code diff, they should always be re-released with a new patch version in order to pick up the latest ICU4X dependency versions. Otherwise, the latest release of, for example, `icu_codepointtrie_builder` may tilde-depend on the previous release of `icu_collections`.
     * [ ] Reset baked data versions: Make sure all non-experimental entries in `COMPONENTS` in `tools/make/bakeddata/src/main.rs` use `REPO_VERSION` and not some override.
       * [ ] Make sure `experimental` is using the version for `icu_experimental` chosen above.
     * [ ] Find all ICU4X component/provider crates that have an overridden version in their `Cargo.toml` and reset it to `version.workspace = true`.


### PR DESCRIPTION
From https://github.com/unicode-org/icu4x/pull/8425#discussion_r3882620370

In both 2.1 (55c44ca800f1332126cfbf2d5b529ec4e5451e2c) and 2.3 (https://github.com/unicode-org/icu4x/pull/8379), we ran into an issue where `icu_codepointtrie_builder` was depending on an old version of an ICU4X component crate (`icu_collections`).

This PR updates the instructions to handle this class of errors during release.

## Changelog

N/A (developer docs)
