### PR TITLE
Fix `iter_ranges_complemented`

### DIFF
--- a/components/collections/src/codepointinvlist/cpinvlist.rs
+++ b/components/collections/src/codepointinvlist/cpinvlist.rs
@@ -17,14 +17,8 @@ use zerovec::{ZeroVec, ule::AsULE, zerovec};
 use super::InvalidSetError;
 use crate::codepointinvlist::utils::{deconstruct_range, is_valid_zv};
 
-/// Represents the end code point of the Basic Multilingual Plane range, starting from code point 0, inclusive
-const BMP_MAX: u32 = 0xFFFF;
-
-/// Represents the inversion list for a set of all code points in the Basic Multilingual Plane.
-const BMP_INV_LIST_VEC: ZeroVec<PotentialCodePoint> = zerovec!(PotentialCodePoint; PotentialCodePoint::to_unaligned; [PotentialCodePoint::from_u24(0x0), PotentialCodePoint::from_u24(BMP_MAX + 1)]);
-
-/// Represents the inversion list for all of the code points in the Unicode range.
-const ALL_VEC: ZeroVec<PotentialCodePoint> = zerovec!(PotentialCodePoint; PotentialCodePoint::to_unaligned; [PotentialCodePoint::from_u24(0x0), PotentialCodePoint::from_u24((char::MAX as u32) + 1)]);
+/// The exclusive end value of the the Unicode code point range.
+const SENTINEL: u32 = char::MAX as u32 + 1;
 
 /// A membership wrapper for [`CodePointInversionList`].
 ///
@@ -117,7 +111,7 @@ struct UnicodeCodePoint(u32);
 #[cfg(feature = "serde")]
 impl UnicodeCodePoint {
     fn from_u32(cp: u32) -> Result<Self, String> {
-        if cp <= char::MAX as u32 {
+        if cp < SENTINEL {
             Ok(Self(cp))
         } else {
             Err(format!("Not a Unicode code point {cp}"))
@@ -331,8 +325,8 @@ impl<'data> CodePointInversionList<'data> {
     /// ```
     pub const fn all() -> Self {
         Self {
-            inv_list: ALL_VEC,
-            size: (char::MAX as u32) + 1,
+            inv_list: zerovec!(PotentialCodePoint; PotentialCodePoint::to_unaligned; [PotentialCodePoint::from_u24(0), PotentialCodePoint::from_u24(SENTINEL)]),
+            size: SENTINEL,
         }
     }
 
@@ -358,9 +352,12 @@ impl<'data> CodePointInversionList<'data> {
     /// );
     /// ```
     pub fn bmp() -> Self {
+        /// The exclusive end value of the Basic Multilingual Plane, i.e. the first code point in plane 2.
+        const BMP_SENTINEL: u32 = 0x10000;
+
         Self {
-            inv_list: BMP_INV_LIST_VEC,
-            size: BMP_MAX + 1,
+            inv_list: zerovec!(PotentialCodePoint; PotentialCodePoint::to_unaligned; [PotentialCodePoint::from_u24(0), PotentialCodePoint::from_u24(BMP_SENTINEL)]),
+            size: BMP_SENTINEL,
         }
     }
 
@@ -469,7 +466,7 @@ impl<'data> CodePointInversionList<'data> {
         };
         let end = if let Some(last) = self.inv_list.last() {
             let last = u32::from(last);
-            if last == char::MAX as u32 {
+            if last == SENTINEL {
                 None
             } else {
                 Some(last..=char::MAX as u32)


### PR DESCRIPTION
Fixes #7730

## Changelog

`icu_collections`
- Fix a bug in `CodePointInversionList::iter_ranges_complemented` when the last range includes U+10FFFF