### PR TITLE
Document date range formatters as unstable over FFI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1398,7 +1398,7 @@ version = "2.3.0"
 
 [[package]]
 name = "icu_capi"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "diplomat",
  "diplomat-runtime",

--- a/ffi/capi/Cargo.toml
+++ b/ffi/capi/Cargo.toml
@@ -18,13 +18,13 @@ include = [
     "LICENSE",
     "README.md"
 ]
+version = "2.3.2"
 
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-version = "2.3.1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/ffi/capi/bindings/cpp/icu4x/DateRangeFormatter.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/DateRangeFormatter.d.hpp
@@ -37,12 +37,16 @@ namespace capi {
 
 namespace icu4x {
 /**
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
+ *
  * See the [Rust documentation for `DateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html) for more information.
  */
 class DateRangeFormatter {
 public:
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
@@ -52,6 +56,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_d(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
@@ -61,6 +67,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_d_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
@@ -70,6 +78,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_md(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
@@ -79,6 +89,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_md_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
@@ -88,6 +100,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_ymd(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
@@ -97,6 +111,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_ymd_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
@@ -106,6 +122,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_de(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
@@ -115,6 +133,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_de_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
@@ -124,6 +144,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_mde(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
@@ -133,6 +155,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_mde_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
@@ -142,6 +166,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_ymde(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
@@ -151,6 +177,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_ymde_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
@@ -160,6 +188,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_e(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
@@ -169,6 +199,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_e_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
@@ -178,6 +210,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_m(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
@@ -187,6 +221,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_m_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
@@ -196,6 +232,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_ym(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
@@ -205,6 +243,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_ym_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
@@ -214,6 +254,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_y(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
@@ -223,6 +265,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_y_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
    */
   inline std::string format_iso(const icu4x::IsoDate& start_iso_date, const icu4x::IsoDate& end_iso_date) const;
@@ -230,6 +274,8 @@ public:
   inline void format_iso_write(const icu4x::IsoDate& start_iso_date, const icu4x::IsoDate& end_iso_date, W& writeable_output) const;
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
    */
   inline std::string format_same_calendar(const icu4x::Date& start_date, const icu4x::Date& end_date) const;

--- a/ffi/capi/bindings/cpp/icu4x/DateRangeFormatterGregorian.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/DateRangeFormatterGregorian.d.hpp
@@ -35,12 +35,16 @@ namespace capi {
 
 namespace icu4x {
 /**
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
+ *
  * See the [Rust documentation for `FixedCalendarDateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html) for more information.
  */
 class DateRangeFormatterGregorian {
 public:
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
@@ -50,6 +54,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_d(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
@@ -59,6 +65,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_d_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
@@ -68,6 +76,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_md(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
@@ -77,6 +87,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_md_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
@@ -86,6 +98,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_ymd(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
@@ -95,6 +109,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_ymd_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
@@ -104,6 +120,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_de(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
@@ -113,6 +131,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_de_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
@@ -122,6 +142,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_mde(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
@@ -131,6 +153,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_mde_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
@@ -140,6 +164,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_ymde(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
@@ -149,6 +175,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_ymde_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
@@ -158,6 +186,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_e(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
@@ -167,6 +197,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_e_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
@@ -176,6 +208,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_m(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
@@ -185,6 +219,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_m_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
@@ -194,6 +230,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_ym(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
@@ -203,6 +241,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_ym_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
@@ -212,6 +252,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_y(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
@@ -221,6 +263,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_y_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.format) for more information.
    */
   inline std::string format_iso(const icu4x::IsoDate& start_iso_date, const icu4x::IsoDate& end_iso_date) const;

--- a/ffi/capi/bindings/cpp/icu4x/DateTimeRangeFormatter.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/DateTimeRangeFormatter.d.hpp
@@ -40,12 +40,16 @@ namespace capi {
 
 namespace icu4x {
 /**
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
+ *
  * See the [Rust documentation for `DateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html) for more information.
  */
 class DateTimeRangeFormatter {
 public:
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
@@ -55,6 +59,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_dt(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
@@ -64,6 +70,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_dt_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
@@ -73,6 +81,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_mdt(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
@@ -82,6 +92,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_mdt_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
@@ -91,6 +103,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_ymdt(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
@@ -100,6 +114,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_ymdt_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
@@ -109,6 +125,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_det(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
@@ -118,6 +136,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_det_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
@@ -127,6 +147,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_mdet(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
@@ -136,6 +158,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_mdet_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
@@ -145,6 +169,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_ymdet(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
@@ -154,6 +180,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_ymdet_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
@@ -163,6 +191,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_et(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
@@ -172,6 +202,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_et_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
    */
   inline std::string format_iso(const icu4x::IsoDate& start_iso_date, const icu4x::Time& start_time, const icu4x::IsoDate& end_iso_date, const icu4x::Time& end_time) const;
@@ -179,6 +211,8 @@ public:
   inline void format_iso_write(const icu4x::IsoDate& start_iso_date, const icu4x::Time& start_time, const icu4x::IsoDate& end_iso_date, const icu4x::Time& end_time, W& writeable_output) const;
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
    */
   inline std::string format_same_calendar(const icu4x::Date& start_date, const icu4x::Time& start_time, const icu4x::Date& end_date, const icu4x::Time& end_time) const;

--- a/ffi/capi/bindings/cpp/icu4x/DateTimeRangeFormatterGregorian.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/DateTimeRangeFormatterGregorian.d.hpp
@@ -38,12 +38,16 @@ namespace capi {
 
 namespace icu4x {
 /**
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
+ *
  * See the [Rust documentation for `FixedCalendarDateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html) for more information.
  */
 class DateTimeRangeFormatterGregorian {
 public:
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
@@ -53,6 +57,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_dt(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
@@ -62,6 +68,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_dt_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
@@ -71,6 +79,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_mdt(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
@@ -80,6 +90,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_mdt_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
@@ -89,6 +101,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_ymdt(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
@@ -98,6 +112,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_ymdt_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
@@ -107,6 +123,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_det(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
@@ -116,6 +134,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_det_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
@@ -125,6 +145,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_mdet(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
@@ -134,6 +156,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_mdet_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
@@ -143,6 +167,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_ymdet(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
@@ -152,6 +178,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_ymdet_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
@@ -161,6 +189,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_et(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
@@ -170,6 +200,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_et_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.format) for more information.
    */
   inline std::string format_iso(const icu4x::IsoDate& start_iso_date, const icu4x::Time& start_time, const icu4x::IsoDate& end_iso_date, const icu4x::Time& end_time) const;

--- a/ffi/capi/bindings/cpp/icu4x/TimeRangeFormatter.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/TimeRangeFormatter.d.hpp
@@ -35,12 +35,16 @@ namespace capi {
 
 namespace icu4x {
 /**
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
+ *
  * See the [Rust documentation for `NoCalendarRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html) for more information.
  */
 class TimeRangeFormatter {
 public:
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `T`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html) for more information.
@@ -50,6 +54,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::TimeRangeFormatter>, icu4x::DateTimeFormatterLoadError> create(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `T`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html) for more information.
@@ -59,6 +65,8 @@ public:
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::TimeRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
+   *
    * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html#method.format) for more information.
    */
   inline std::string format(const icu4x::Time& start_time, const icu4x::Time& end_time) const;

--- a/ffi/capi/src/date_range_formatter.rs
+++ b/ffi/capi/src/date_range_formatter.rs
@@ -28,6 +28,7 @@ pub mod ffi {
     #[cfg(feature = "buffer_provider")]
     use crate::unstable::provider::ffi::DataProvider;
 
+    /// 🚧 This API is unstable and may experience breaking changes outside major releases.
     #[diplomat::opaque]
     #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter, Struct)]
     pub struct DateRangeFormatter(
@@ -38,6 +39,7 @@ pub mod ffi {
     );
 
     impl DateRangeFormatter {
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "d")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::D, Struct)]
@@ -71,6 +73,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "d_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::D, Struct)]
@@ -106,6 +109,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "md")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::MD, Struct)]
@@ -139,6 +143,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "md_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::MD, Struct)]
@@ -174,6 +179,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "ymd")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::YMD, Struct)]
@@ -211,6 +217,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "ymd_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::YMD, Struct)]
@@ -249,6 +256,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "de")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::DE, Struct)]
@@ -282,6 +290,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "de_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::DE, Struct)]
@@ -317,6 +326,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "mde")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::MDE, Struct)]
@@ -350,6 +360,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "mde_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::MDE, Struct)]
@@ -385,6 +396,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "ymde")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::YMDE, Struct)]
@@ -421,6 +433,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "ymde_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::YMDE, Struct)]
@@ -459,6 +472,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "e")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::E, Struct)]
@@ -490,6 +504,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "e_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::E, Struct)]
@@ -523,6 +538,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "m")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::M, Struct)]
@@ -552,6 +568,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "m_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::M, Struct)]
@@ -583,6 +600,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "ym")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::YM, Struct)]
@@ -615,6 +633,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "ym_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::YM, Struct)]
@@ -649,6 +668,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "y")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Y, Struct)]
@@ -681,6 +701,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "y_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Y, Struct)]
@@ -715,6 +736,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::format, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::range::FormattedDateRange, Struct, hidden)]
         #[diplomat::rust_link(icu::datetime::range::FormattedDateRange::to_string, FnInStruct, hidden)]
@@ -731,6 +753,7 @@ pub mod ffi {
             let _infallible = self.0.format(&start_value, &end_value).write_to(write);
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::format, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::range::FormattedDateRange, Struct, hidden)]
         #[diplomat::rust_link(icu::datetime::range::FormattedDateRange::to_string, FnInStruct, hidden)]
@@ -750,6 +773,7 @@ pub mod ffi {
     }
     
 
+    /// 🚧 This API is unstable and may experience breaking changes outside major releases.
     #[diplomat::opaque]
     #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter, Struct)]
     pub struct DateRangeFormatterGregorian(
@@ -761,6 +785,7 @@ pub mod ffi {
     );
 
     impl DateRangeFormatterGregorian {
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "d")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::D, Struct)]
@@ -794,6 +819,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "d_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::D, Struct)]
@@ -829,6 +855,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "md")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::MD, Struct)]
@@ -862,6 +889,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "md_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::MD, Struct)]
@@ -897,6 +925,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "ymd")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::YMD, Struct)]
@@ -934,6 +963,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "ymd_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::YMD, Struct)]
@@ -972,6 +1002,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "de")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::DE, Struct)]
@@ -1005,6 +1036,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "de_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::DE, Struct)]
@@ -1040,6 +1072,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "mde")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::MDE, Struct)]
@@ -1073,6 +1106,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "mde_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::MDE, Struct)]
@@ -1108,6 +1142,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "ymde")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::YMDE, Struct)]
@@ -1144,6 +1179,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "ymde_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::YMDE, Struct)]
@@ -1182,6 +1218,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "e")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::E, Struct)]
@@ -1213,6 +1250,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "e_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::E, Struct)]
@@ -1246,6 +1284,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "m")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::M, Struct)]
@@ -1275,6 +1314,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "m_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::M, Struct)]
@@ -1306,6 +1346,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "ym")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::YM, Struct)]
@@ -1338,6 +1379,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "ym_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::YM, Struct)]
@@ -1372,6 +1414,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "y")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Y, Struct)]
@@ -1404,6 +1447,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "y_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Y, Struct)]
@@ -1438,6 +1482,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::format, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::range::FormattedDateRange, Struct, hidden)]
         #[diplomat::rust_link(icu::datetime::range::FormattedDateRange::to_string, FnInStruct, hidden)]

--- a/ffi/capi/src/date_time_range_formatter.rs
+++ b/ffi/capi/src/date_time_range_formatter.rs
@@ -28,6 +28,7 @@ pub mod ffi {
     #[cfg(feature = "buffer_provider")]
     use crate::unstable::provider::ffi::DataProvider;
 
+    /// 🚧 This API is unstable and may experience breaking changes outside major releases.
     #[diplomat::opaque]
     #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter, Struct)]
     pub struct DateTimeRangeFormatter(
@@ -38,6 +39,7 @@ pub mod ffi {
     );
 
     impl DateTimeRangeFormatter {
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "dt")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::DT, Struct)]
@@ -70,6 +72,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "dt_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::DT, Struct)]
@@ -104,6 +107,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "mdt")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::MDT, Struct)]
@@ -136,6 +140,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "mdt_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::MDT, Struct)]
@@ -170,6 +175,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "ymdt")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::YMDT, Struct)]
@@ -206,6 +212,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "ymdt_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::YMDT, Struct)]
@@ -243,6 +250,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "det")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::DET, Struct)]
@@ -275,6 +283,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "det_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::DET, Struct)]
@@ -309,6 +318,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "mdet")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::MDET, Struct)]
@@ -341,6 +351,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "mdet_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::MDET, Struct)]
@@ -375,6 +386,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "ymdet")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::YMDET, Struct)]
@@ -410,6 +422,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "ymdet_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::YMDET, Struct)]
@@ -447,6 +460,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "et")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::ET, Struct)]
@@ -479,6 +493,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "et_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::ET, Struct)]
@@ -513,6 +528,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::format, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::range::FormattedDateRange, Struct, hidden)]
         #[diplomat::rust_link(icu::datetime::range::FormattedDateRange::to_string, FnInStruct, hidden)]
@@ -537,6 +553,7 @@ pub mod ffi {
             let _infallible = self.0.format(&start_value, &end_value).write_to(write);
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::format, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::range::FormattedDateRange, Struct, hidden)]
         #[diplomat::rust_link(icu::datetime::range::FormattedDateRange::to_string, FnInStruct, hidden)]
@@ -564,6 +581,7 @@ pub mod ffi {
     }
     
 
+    /// 🚧 This API is unstable and may experience breaking changes outside major releases.
     #[diplomat::opaque]
     #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter, Struct)]
     pub struct DateTimeRangeFormatterGregorian(
@@ -575,6 +593,7 @@ pub mod ffi {
     );
 
     impl DateTimeRangeFormatterGregorian {
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "dt")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::DT, Struct)]
@@ -607,6 +626,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "dt_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::DT, Struct)]
@@ -641,6 +661,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "mdt")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::MDT, Struct)]
@@ -673,6 +694,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "mdt_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::MDT, Struct)]
@@ -707,6 +729,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "ymdt")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::YMDT, Struct)]
@@ -743,6 +766,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "ymdt_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::YMDT, Struct)]
@@ -780,6 +804,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "det")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::DET, Struct)]
@@ -812,6 +837,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "det_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::DET, Struct)]
@@ -846,6 +872,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "mdet")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::MDET, Struct)]
@@ -878,6 +905,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "mdet_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::MDET, Struct)]
@@ -912,6 +940,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "ymdet")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::YMDET, Struct)]
@@ -947,6 +976,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "ymdet_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::YMDET, Struct)]
@@ -984,6 +1014,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "et")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::ET, Struct)]
@@ -1016,6 +1047,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "et_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::ET, Struct)]
@@ -1050,6 +1082,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::format, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::range::FormattedDateRange, Struct, hidden)]
         #[diplomat::rust_link(icu::datetime::range::FormattedDateRange::to_string, FnInStruct, hidden)]

--- a/ffi/capi/src/time_range_formatter.rs
+++ b/ffi/capi/src/time_range_formatter.rs
@@ -27,6 +27,7 @@ pub mod ffi {
     #[cfg(feature = "buffer_provider")]
     use crate::unstable::provider::ffi::DataProvider;
 
+    /// 🚧 This API is unstable and may experience breaking changes outside major releases.
     #[diplomat::opaque]
     #[diplomat::rust_link(icu::datetime::range::NoCalendarRangeFormatter, Typedef)]
     pub struct TimeRangeFormatter(
@@ -38,6 +39,7 @@ pub mod ffi {
     );
 
     impl TimeRangeFormatter {
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(supports = fallible_constructors, constructor)]
         #[diplomat::rust_link(icu::datetime::range::NoCalendarRangeFormatter::try_new, FnInTypedef)]
         #[diplomat::rust_link(icu::datetime::fieldsets::T, Struct)]
@@ -78,6 +80,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "with_provider")]
         #[diplomat::rust_link(icu::datetime::range::NoCalendarRangeFormatter::try_new, FnInTypedef)]
         #[diplomat::rust_link(icu::datetime::fieldsets::T, Struct)]
@@ -119,6 +122,7 @@ pub mod ffi {
             )))
         }
         
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::rust_link(icu::datetime::range::NoCalendarRangeFormatter::format, FnInTypedef)]
         #[diplomat::rust_link(icu::datetime::range::FormattedDateRange, Struct, hidden)]
         #[diplomat::rust_link(icu::datetime::range::FormattedDateRange::to_string, FnInStruct, hidden)]

--- a/ffi/dart/lib/src/bindings/DateRangeFormatter.g.dart
+++ b/ffi/dart/lib/src/bindings/DateRangeFormatter.g.dart
@@ -3,6 +3,8 @@
 
 part of 'lib.g.dart';
 
+/// 🚧 This API is unstable and may experience breaking changes outside major releases.
+///
 /// See the [Rust documentation for `DateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html) for more information.
 final class DateRangeFormatter implements ffi.Finalizable {
   final ffi.Pointer<ffi.Opaque> _ffi;
@@ -28,6 +30,8 @@ final class DateRangeFormatter implements ffi.Finalizable {
 
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_DateRangeFormatter_destroy_mv1));
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
@@ -43,6 +47,8 @@ final class DateRangeFormatter implements ffi.Finalizable {
     return DateRangeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
@@ -58,6 +64,8 @@ final class DateRangeFormatter implements ffi.Finalizable {
     return DateRangeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
@@ -73,6 +81,8 @@ final class DateRangeFormatter implements ffi.Finalizable {
     return DateRangeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
@@ -88,6 +98,8 @@ final class DateRangeFormatter implements ffi.Finalizable {
     return DateRangeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
@@ -103,6 +115,8 @@ final class DateRangeFormatter implements ffi.Finalizable {
     return DateRangeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
@@ -118,6 +132,8 @@ final class DateRangeFormatter implements ffi.Finalizable {
     return DateRangeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
@@ -133,6 +149,8 @@ final class DateRangeFormatter implements ffi.Finalizable {
     return DateRangeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
@@ -148,6 +166,8 @@ final class DateRangeFormatter implements ffi.Finalizable {
     return DateRangeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
@@ -163,6 +183,8 @@ final class DateRangeFormatter implements ffi.Finalizable {
     return DateRangeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
@@ -178,6 +200,8 @@ final class DateRangeFormatter implements ffi.Finalizable {
     return DateRangeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
@@ -193,6 +217,8 @@ final class DateRangeFormatter implements ffi.Finalizable {
     return DateRangeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
@@ -208,6 +234,8 @@ final class DateRangeFormatter implements ffi.Finalizable {
     return DateRangeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
@@ -223,6 +251,8 @@ final class DateRangeFormatter implements ffi.Finalizable {
     return DateRangeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
@@ -238,6 +268,8 @@ final class DateRangeFormatter implements ffi.Finalizable {
     return DateRangeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
@@ -253,6 +285,8 @@ final class DateRangeFormatter implements ffi.Finalizable {
     return DateRangeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
@@ -268,6 +302,8 @@ final class DateRangeFormatter implements ffi.Finalizable {
     return DateRangeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
@@ -283,6 +319,8 @@ final class DateRangeFormatter implements ffi.Finalizable {
     return DateRangeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
@@ -298,6 +336,8 @@ final class DateRangeFormatter implements ffi.Finalizable {
     return DateRangeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
@@ -313,6 +353,8 @@ final class DateRangeFormatter implements ffi.Finalizable {
     return DateRangeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
@@ -328,6 +370,8 @@ final class DateRangeFormatter implements ffi.Finalizable {
     return DateRangeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
   String formatIso(IsoDate startIsoDate, IsoDate endIsoDate) {
     final write = _Write();
@@ -335,6 +379,8 @@ final class DateRangeFormatter implements ffi.Finalizable {
     return write.finalize();
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
   String formatSameCalendar(Date startDate, Date endDate) {
     final write = _Write();

--- a/ffi/dart/lib/src/bindings/DateRangeFormatterGregorian.g.dart
+++ b/ffi/dart/lib/src/bindings/DateRangeFormatterGregorian.g.dart
@@ -3,6 +3,8 @@
 
 part of 'lib.g.dart';
 
+/// 🚧 This API is unstable and may experience breaking changes outside major releases.
+///
 /// See the [Rust documentation for `FixedCalendarDateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html) for more information.
 final class DateRangeFormatterGregorian implements ffi.Finalizable {
   final ffi.Pointer<ffi.Opaque> _ffi;
@@ -28,6 +30,8 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
 
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_DateRangeFormatterGregorian_destroy_mv1));
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
@@ -43,6 +47,8 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
     return DateRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
@@ -58,6 +64,8 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
     return DateRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
@@ -73,6 +81,8 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
     return DateRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
@@ -88,6 +98,8 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
     return DateRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
@@ -103,6 +115,8 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
     return DateRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
@@ -118,6 +132,8 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
     return DateRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
@@ -133,6 +149,8 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
     return DateRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
@@ -148,6 +166,8 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
     return DateRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
@@ -163,6 +183,8 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
     return DateRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
@@ -178,6 +200,8 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
     return DateRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
@@ -193,6 +217,8 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
     return DateRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
@@ -208,6 +234,8 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
     return DateRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
@@ -223,6 +251,8 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
     return DateRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
@@ -238,6 +268,8 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
     return DateRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
@@ -253,6 +285,8 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
     return DateRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
@@ -268,6 +302,8 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
     return DateRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
@@ -283,6 +319,8 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
     return DateRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
@@ -298,6 +336,8 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
     return DateRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
@@ -313,6 +353,8 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
     return DateRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
@@ -328,6 +370,8 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
     return DateRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.format) for more information.
   String formatIso(IsoDate startIsoDate, IsoDate endIsoDate) {
     final write = _Write();

--- a/ffi/dart/lib/src/bindings/DateTimeRangeFormatter.g.dart
+++ b/ffi/dart/lib/src/bindings/DateTimeRangeFormatter.g.dart
@@ -3,6 +3,8 @@
 
 part of 'lib.g.dart';
 
+/// 🚧 This API is unstable and may experience breaking changes outside major releases.
+///
 /// See the [Rust documentation for `DateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html) for more information.
 final class DateTimeRangeFormatter implements ffi.Finalizable {
   final ffi.Pointer<ffi.Opaque> _ffi;
@@ -28,6 +30,8 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
 
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_DateTimeRangeFormatter_destroy_mv1));
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
@@ -43,6 +47,8 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
     return DateTimeRangeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
@@ -58,6 +64,8 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
     return DateTimeRangeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
@@ -73,6 +81,8 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
     return DateTimeRangeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
@@ -88,6 +98,8 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
     return DateTimeRangeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
@@ -103,6 +115,8 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
     return DateTimeRangeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
@@ -118,6 +132,8 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
     return DateTimeRangeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
@@ -133,6 +149,8 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
     return DateTimeRangeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
@@ -148,6 +166,8 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
     return DateTimeRangeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
@@ -163,6 +183,8 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
     return DateTimeRangeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
@@ -178,6 +200,8 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
     return DateTimeRangeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
@@ -193,6 +217,8 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
     return DateTimeRangeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
@@ -208,6 +234,8 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
     return DateTimeRangeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
@@ -223,6 +251,8 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
     return DateTimeRangeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
@@ -238,6 +268,8 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
     return DateTimeRangeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
   String formatIso(IsoDate startIsoDate, Time startTime, IsoDate endIsoDate, Time endTime) {
     final write = _Write();
@@ -245,6 +277,8 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
     return write.finalize();
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
   String formatSameCalendar(Date startDate, Time startTime, Date endDate, Time endTime) {
     final write = _Write();

--- a/ffi/dart/lib/src/bindings/DateTimeRangeFormatterGregorian.g.dart
+++ b/ffi/dart/lib/src/bindings/DateTimeRangeFormatterGregorian.g.dart
@@ -3,6 +3,8 @@
 
 part of 'lib.g.dart';
 
+/// 🚧 This API is unstable and may experience breaking changes outside major releases.
+///
 /// See the [Rust documentation for `FixedCalendarDateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html) for more information.
 final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
   final ffi.Pointer<ffi.Opaque> _ffi;
@@ -28,6 +30,8 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
 
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_DateTimeRangeFormatterGregorian_destroy_mv1));
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
@@ -43,6 +47,8 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
     return DateTimeRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
@@ -58,6 +64,8 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
     return DateTimeRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
@@ -73,6 +81,8 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
     return DateTimeRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
@@ -88,6 +98,8 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
     return DateTimeRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
@@ -103,6 +115,8 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
     return DateTimeRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
@@ -118,6 +132,8 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
     return DateTimeRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
@@ -133,6 +149,8 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
     return DateTimeRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
@@ -148,6 +166,8 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
     return DateTimeRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
@@ -163,6 +183,8 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
     return DateTimeRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
@@ -178,6 +200,8 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
     return DateTimeRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
@@ -193,6 +217,8 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
     return DateTimeRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
@@ -208,6 +234,8 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
     return DateTimeRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
@@ -223,6 +251,8 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
     return DateTimeRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
@@ -238,6 +268,8 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
     return DateTimeRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.format) for more information.
   String formatIso(IsoDate startIsoDate, Time startTime, IsoDate endIsoDate, Time endTime) {
     final write = _Write();

--- a/ffi/dart/lib/src/bindings/TimeRangeFormatter.g.dart
+++ b/ffi/dart/lib/src/bindings/TimeRangeFormatter.g.dart
@@ -3,6 +3,8 @@
 
 part of 'lib.g.dart';
 
+/// 🚧 This API is unstable and may experience breaking changes outside major releases.
+///
 /// See the [Rust documentation for `NoCalendarRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html) for more information.
 final class TimeRangeFormatter implements ffi.Finalizable {
   final ffi.Pointer<ffi.Opaque> _ffi;
@@ -28,6 +30,8 @@ final class TimeRangeFormatter implements ffi.Finalizable {
 
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_TimeRangeFormatter_destroy_mv1));
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `T`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html) for more information.
@@ -43,6 +47,8 @@ final class TimeRangeFormatter implements ffi.Finalizable {
     return TimeRangeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `T`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html) for more information.
@@ -58,6 +64,8 @@ final class TimeRangeFormatter implements ffi.Finalizable {
     return TimeRangeFormatter._fromFfi(result.union.ok, []);
   }
 
+  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
+  ///
   /// See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html#method.format) for more information.
   String format(Time startTime, Time endTime) {
     final write = _Write();

--- a/ffi/dart/pubspec.yaml
+++ b/ffi/dart/pubspec.yaml
@@ -5,7 +5,7 @@
 name: icu4x
 description: > 
   Dart bindings for the Rust `icu` internationalization crate.
-version: 2.3.2-wip
+version: 2.3.2
 repository: https://github.com/unicode-org/icu4x/tree/main/ffi/dart
 issue_tracker: https://github.com/unicode-org/icu4x/issues?q=is%3Aissue%20is%3Aopen%20label%3AU-flutter
 

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateRangeFormatter.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateRangeFormatter.kt
@@ -30,7 +30,9 @@ internal interface DateRangeFormatterLib: Library {
     fun icu4x_DateRangeFormatter_format_iso_mv1(handle: Pointer, startIsoDate: Pointer, endIsoDate: Pointer, write: Pointer): Unit
     fun icu4x_DateRangeFormatter_format_same_calendar_mv1(handle: Pointer, startDate: Pointer, endDate: Pointer, write: Pointer): Unit
 }
-/** See the [Rust documentation for `DateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html) for more information.
+/** 🚧 This API is unstable and may experience breaking changes outside major releases.
+*
+*See the [Rust documentation for `DateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html) for more information.
 */
 class DateRangeFormatter internal constructor (
     internal val handle: Pointer,
@@ -60,7 +62,9 @@ class DateRangeFormatter internal constructor (
         internal val lib: DateRangeFormatterLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
         *
@@ -81,7 +85,9 @@ class DateRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
         *
@@ -102,7 +108,9 @@ class DateRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
         *
@@ -123,7 +131,9 @@ class DateRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
         *
@@ -144,7 +154,9 @@ class DateRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
         *
@@ -165,7 +177,9 @@ class DateRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
         *
@@ -186,7 +200,9 @@ class DateRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
         *
@@ -207,7 +223,9 @@ class DateRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
         *
@@ -228,7 +246,9 @@ class DateRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
         *
@@ -249,7 +269,9 @@ class DateRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
         *
@@ -270,7 +292,9 @@ class DateRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
         *
@@ -291,7 +315,9 @@ class DateRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
         *
@@ -312,7 +338,9 @@ class DateRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
         *
@@ -333,7 +361,9 @@ class DateRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
         *
@@ -354,7 +384,9 @@ class DateRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
         *
@@ -375,7 +407,9 @@ class DateRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
         *
@@ -396,7 +430,9 @@ class DateRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
         *
@@ -417,7 +453,9 @@ class DateRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
         *
@@ -438,7 +476,9 @@ class DateRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
         *
@@ -459,7 +499,9 @@ class DateRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
         *
@@ -480,7 +522,9 @@ class DateRangeFormatter internal constructor (
         }
     }
     
-    /** See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
+    /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+    *
+    *See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
     */
     fun formatIso(startIsoDate: IsoDate, endIsoDate: IsoDate): String {
         val write = DW.lib.diplomat_buffer_write_create(0)
@@ -490,7 +534,9 @@ class DateRangeFormatter internal constructor (
         return returnString
     }
     
-    /** See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
+    /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+    *
+    *See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
     */
     fun formatSameCalendar(startDate: Date, endDate: Date): String {
         val write = DW.lib.diplomat_buffer_write_create(0)

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateRangeFormatterGregorian.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateRangeFormatterGregorian.kt
@@ -29,7 +29,9 @@ internal interface DateRangeFormatterGregorianLib: Library {
     fun icu4x_DateRangeFormatterGregorian_create_y_with_provider_mv1(provider: Pointer, locale: Pointer, length: OptionInt, alignment: OptionInt, yearStyle: OptionInt): ResultPointerInt
     fun icu4x_DateRangeFormatterGregorian_format_iso_mv1(handle: Pointer, startIsoDate: Pointer, endIsoDate: Pointer, write: Pointer): Unit
 }
-/** See the [Rust documentation for `FixedCalendarDateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html) for more information.
+/** 🚧 This API is unstable and may experience breaking changes outside major releases.
+*
+*See the [Rust documentation for `FixedCalendarDateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html) for more information.
 */
 class DateRangeFormatterGregorian internal constructor (
     internal val handle: Pointer,
@@ -59,7 +61,9 @@ class DateRangeFormatterGregorian internal constructor (
         internal val lib: DateRangeFormatterGregorianLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
         *
@@ -80,7 +84,9 @@ class DateRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
         *
@@ -101,7 +107,9 @@ class DateRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
         *
@@ -122,7 +130,9 @@ class DateRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
         *
@@ -143,7 +153,9 @@ class DateRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
         *
@@ -164,7 +176,9 @@ class DateRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
         *
@@ -185,7 +199,9 @@ class DateRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
         *
@@ -206,7 +222,9 @@ class DateRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
         *
@@ -227,7 +245,9 @@ class DateRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
         *
@@ -248,7 +268,9 @@ class DateRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
         *
@@ -269,7 +291,9 @@ class DateRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
         *
@@ -290,7 +314,9 @@ class DateRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
         *
@@ -311,7 +337,9 @@ class DateRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
         *
@@ -332,7 +360,9 @@ class DateRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
         *
@@ -353,7 +383,9 @@ class DateRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
         *
@@ -374,7 +406,9 @@ class DateRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
         *
@@ -395,7 +429,9 @@ class DateRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
         *
@@ -416,7 +452,9 @@ class DateRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
         *
@@ -437,7 +475,9 @@ class DateRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
         *
@@ -458,7 +498,9 @@ class DateRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
         *
@@ -479,7 +521,9 @@ class DateRangeFormatterGregorian internal constructor (
         }
     }
     
-    /** See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.format) for more information.
+    /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+    *
+    *See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.format) for more information.
     */
     fun formatIso(startIsoDate: IsoDate, endIsoDate: IsoDate): String {
         val write = DW.lib.diplomat_buffer_write_create(0)

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateTimeRangeFormatter.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateTimeRangeFormatter.kt
@@ -24,7 +24,9 @@ internal interface DateTimeRangeFormatterLib: Library {
     fun icu4x_DateTimeRangeFormatter_format_iso_mv1(handle: Pointer, startIsoDate: Pointer, startTime: Pointer, endIsoDate: Pointer, endTime: Pointer, write: Pointer): Unit
     fun icu4x_DateTimeRangeFormatter_format_same_calendar_mv1(handle: Pointer, startDate: Pointer, startTime: Pointer, endDate: Pointer, endTime: Pointer, write: Pointer): Unit
 }
-/** See the [Rust documentation for `DateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html) for more information.
+/** 🚧 This API is unstable and may experience breaking changes outside major releases.
+*
+*See the [Rust documentation for `DateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html) for more information.
 */
 class DateTimeRangeFormatter internal constructor (
     internal val handle: Pointer,
@@ -54,7 +56,9 @@ class DateTimeRangeFormatter internal constructor (
         internal val lib: DateTimeRangeFormatterLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
         *
@@ -75,7 +79,9 @@ class DateTimeRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
         *
@@ -96,7 +102,9 @@ class DateTimeRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
         *
@@ -117,7 +125,9 @@ class DateTimeRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
         *
@@ -138,7 +148,9 @@ class DateTimeRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
         *
@@ -159,7 +171,9 @@ class DateTimeRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
         *
@@ -180,7 +194,9 @@ class DateTimeRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
         *
@@ -201,7 +217,9 @@ class DateTimeRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
         *
@@ -222,7 +240,9 @@ class DateTimeRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
         *
@@ -243,7 +263,9 @@ class DateTimeRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
         *
@@ -264,7 +286,9 @@ class DateTimeRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
         *
@@ -285,7 +309,9 @@ class DateTimeRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
         *
@@ -306,7 +332,9 @@ class DateTimeRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
         *
@@ -327,7 +355,9 @@ class DateTimeRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
         *
@@ -348,7 +378,9 @@ class DateTimeRangeFormatter internal constructor (
         }
     }
     
-    /** See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
+    /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+    *
+    *See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
     */
     fun formatIso(startIsoDate: IsoDate, startTime: Time, endIsoDate: IsoDate, endTime: Time): String {
         val write = DW.lib.diplomat_buffer_write_create(0)
@@ -358,7 +390,9 @@ class DateTimeRangeFormatter internal constructor (
         return returnString
     }
     
-    /** See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
+    /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+    *
+    *See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
     */
     fun formatSameCalendar(startDate: Date, startTime: Time, endDate: Date, endTime: Time): String {
         val write = DW.lib.diplomat_buffer_write_create(0)

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateTimeRangeFormatterGregorian.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateTimeRangeFormatterGregorian.kt
@@ -23,7 +23,9 @@ internal interface DateTimeRangeFormatterGregorianLib: Library {
     fun icu4x_DateTimeRangeFormatterGregorian_create_et_with_provider_mv1(provider: Pointer, locale: Pointer, length: OptionInt, timePrecision: OptionInt, alignment: OptionInt): ResultPointerInt
     fun icu4x_DateTimeRangeFormatterGregorian_format_iso_mv1(handle: Pointer, startIsoDate: Pointer, startTime: Pointer, endIsoDate: Pointer, endTime: Pointer, write: Pointer): Unit
 }
-/** See the [Rust documentation for `FixedCalendarDateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html) for more information.
+/** 🚧 This API is unstable and may experience breaking changes outside major releases.
+*
+*See the [Rust documentation for `FixedCalendarDateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html) for more information.
 */
 class DateTimeRangeFormatterGregorian internal constructor (
     internal val handle: Pointer,
@@ -53,7 +55,9 @@ class DateTimeRangeFormatterGregorian internal constructor (
         internal val lib: DateTimeRangeFormatterGregorianLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
         *
@@ -74,7 +78,9 @@ class DateTimeRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
         *
@@ -95,7 +101,9 @@ class DateTimeRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
         *
@@ -116,7 +124,9 @@ class DateTimeRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
         *
@@ -137,7 +147,9 @@ class DateTimeRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
         *
@@ -158,7 +170,9 @@ class DateTimeRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
         *
@@ -179,7 +193,9 @@ class DateTimeRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
         *
@@ -200,7 +216,9 @@ class DateTimeRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
         *
@@ -221,7 +239,9 @@ class DateTimeRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
         *
@@ -242,7 +262,9 @@ class DateTimeRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
         *
@@ -263,7 +285,9 @@ class DateTimeRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
         *
@@ -284,7 +308,9 @@ class DateTimeRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
         *
@@ -305,7 +331,9 @@ class DateTimeRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
         *
@@ -326,7 +354,9 @@ class DateTimeRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
         *
@@ -347,7 +377,9 @@ class DateTimeRangeFormatterGregorian internal constructor (
         }
     }
     
-    /** See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.format) for more information.
+    /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+    *
+    *See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.format) for more information.
     */
     fun formatIso(startIsoDate: IsoDate, startTime: Time, endIsoDate: IsoDate, endTime: Time): String {
         val write = DW.lib.diplomat_buffer_write_create(0)

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/TimeRangeFormatter.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/TimeRangeFormatter.kt
@@ -11,7 +11,9 @@ internal interface TimeRangeFormatterLib: Library {
     fun icu4x_TimeRangeFormatter_create_with_provider_mv1(provider: Pointer, locale: Pointer, length: OptionInt, timePrecision: OptionInt, alignment: OptionInt): ResultPointerInt
     fun icu4x_TimeRangeFormatter_format_mv1(handle: Pointer, startTime: Pointer, endTime: Pointer, write: Pointer): Unit
 }
-/** See the [Rust documentation for `NoCalendarRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html) for more information.
+/** 🚧 This API is unstable and may experience breaking changes outside major releases.
+*
+*See the [Rust documentation for `NoCalendarRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html) for more information.
 */
 class TimeRangeFormatter internal constructor (
     internal val handle: Pointer,
@@ -41,7 +43,9 @@ class TimeRangeFormatter internal constructor (
         internal val lib: TimeRangeFormatterLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `T`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html) for more information.
         *
@@ -62,7 +66,9 @@ class TimeRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html#method.try_new) for more information.
+        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+        *
+        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html#method.try_new) for more information.
         *
         *See the [Rust documentation for `T`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html) for more information.
         *
@@ -83,7 +89,9 @@ class TimeRangeFormatter internal constructor (
         }
     }
     
-    /** See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html#method.format) for more information.
+    /** 🚧 This API is unstable and may experience breaking changes outside major releases.
+    *
+    *See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html#method.format) for more information.
     */
     fun format(startTime: Time, endTime: Time): String {
         val write = DW.lib.diplomat_buffer_write_create(0)

--- a/ffi/npm/lib/DateRangeFormatter.d.ts
+++ b/ffi/npm/lib/DateRangeFormatter.d.ts
@@ -12,6 +12,8 @@ import type { pointer, codepoint } from "./diplomat-runtime.d.ts";
 
 
 /**
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
+ *
  * See the [Rust documentation for `DateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html) for more information.
  */
 export class DateRangeFormatter {
@@ -22,6 +24,8 @@ export class DateRangeFormatter {
 
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
@@ -31,6 +35,8 @@ export class DateRangeFormatter {
     static createD(locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null): DateRangeFormatter;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
@@ -40,6 +46,8 @@ export class DateRangeFormatter {
     static createDWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null): DateRangeFormatter;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
@@ -49,6 +57,8 @@ export class DateRangeFormatter {
     static createMd(locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null): DateRangeFormatter;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
@@ -58,6 +68,8 @@ export class DateRangeFormatter {
     static createMdWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null): DateRangeFormatter;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
@@ -67,6 +79,8 @@ export class DateRangeFormatter {
     static createYmd(locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateRangeFormatter;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
@@ -76,6 +90,8 @@ export class DateRangeFormatter {
     static createYmdWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateRangeFormatter;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
@@ -85,6 +101,8 @@ export class DateRangeFormatter {
     static createDe(locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null): DateRangeFormatter;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
@@ -94,6 +112,8 @@ export class DateRangeFormatter {
     static createDeWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null): DateRangeFormatter;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
@@ -103,6 +123,8 @@ export class DateRangeFormatter {
     static createMde(locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null): DateRangeFormatter;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
@@ -112,6 +134,8 @@ export class DateRangeFormatter {
     static createMdeWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null): DateRangeFormatter;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
@@ -121,6 +145,8 @@ export class DateRangeFormatter {
     static createYmde(locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateRangeFormatter;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
@@ -130,6 +156,8 @@ export class DateRangeFormatter {
     static createYmdeWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateRangeFormatter;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
@@ -139,6 +167,8 @@ export class DateRangeFormatter {
     static createE(locale: Locale, length: DateTimeLength | null): DateRangeFormatter;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
@@ -148,6 +178,8 @@ export class DateRangeFormatter {
     static createEWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null): DateRangeFormatter;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
@@ -157,6 +189,8 @@ export class DateRangeFormatter {
     static createM(locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null): DateRangeFormatter;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
@@ -166,6 +200,8 @@ export class DateRangeFormatter {
     static createMWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null): DateRangeFormatter;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
@@ -175,6 +211,8 @@ export class DateRangeFormatter {
     static createYm(locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateRangeFormatter;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
@@ -184,6 +222,8 @@ export class DateRangeFormatter {
     static createYmWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateRangeFormatter;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
@@ -193,6 +233,8 @@ export class DateRangeFormatter {
     static createY(locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateRangeFormatter;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
@@ -202,11 +244,15 @@ export class DateRangeFormatter {
     static createYWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateRangeFormatter;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
      */
     formatIso(startIsoDate: IsoDate, endIsoDate: IsoDate): string;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
      */
     formatSameCalendar(startDate: Date, endDate: Date): string;

--- a/ffi/npm/lib/DateRangeFormatter.mjs
+++ b/ffi/npm/lib/DateRangeFormatter.mjs
@@ -15,6 +15,8 @@ const DateRangeFormatter_box_destroy_registry = new FinalizationRegistry((ptr) =
 });
 
 /**
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
+ *
  * See the [Rust documentation for `DateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html) for more information.
  */
 export class DateRangeFormatter {
@@ -47,6 +49,8 @@ export class DateRangeFormatter {
 
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
@@ -78,6 +82,8 @@ export class DateRangeFormatter {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
@@ -109,6 +115,8 @@ export class DateRangeFormatter {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
@@ -140,6 +148,8 @@ export class DateRangeFormatter {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
@@ -171,6 +181,8 @@ export class DateRangeFormatter {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
@@ -202,6 +214,8 @@ export class DateRangeFormatter {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
@@ -233,6 +247,8 @@ export class DateRangeFormatter {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
@@ -264,6 +280,8 @@ export class DateRangeFormatter {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
@@ -295,6 +313,8 @@ export class DateRangeFormatter {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
@@ -326,6 +346,8 @@ export class DateRangeFormatter {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
@@ -357,6 +379,8 @@ export class DateRangeFormatter {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
@@ -388,6 +412,8 @@ export class DateRangeFormatter {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
@@ -419,6 +445,8 @@ export class DateRangeFormatter {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
@@ -450,6 +478,8 @@ export class DateRangeFormatter {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
@@ -481,6 +511,8 @@ export class DateRangeFormatter {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
@@ -512,6 +544,8 @@ export class DateRangeFormatter {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
@@ -543,6 +577,8 @@ export class DateRangeFormatter {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
@@ -574,6 +610,8 @@ export class DateRangeFormatter {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
@@ -605,6 +643,8 @@ export class DateRangeFormatter {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
@@ -636,6 +676,8 @@ export class DateRangeFormatter {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
@@ -667,6 +709,8 @@ export class DateRangeFormatter {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
      */
     formatIso(startIsoDate, endIsoDate) {
@@ -685,6 +729,8 @@ export class DateRangeFormatter {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
      */
     formatSameCalendar(startDate, endDate) {

--- a/ffi/npm/lib/DateRangeFormatterGregorian.d.ts
+++ b/ffi/npm/lib/DateRangeFormatterGregorian.d.ts
@@ -11,6 +11,8 @@ import type { pointer, codepoint } from "./diplomat-runtime.d.ts";
 
 
 /**
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
+ *
  * See the [Rust documentation for `FixedCalendarDateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html) for more information.
  */
 export class DateRangeFormatterGregorian {
@@ -21,6 +23,8 @@ export class DateRangeFormatterGregorian {
 
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
@@ -30,6 +34,8 @@ export class DateRangeFormatterGregorian {
     static createD(locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null): DateRangeFormatterGregorian;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
@@ -39,6 +45,8 @@ export class DateRangeFormatterGregorian {
     static createDWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null): DateRangeFormatterGregorian;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
@@ -48,6 +56,8 @@ export class DateRangeFormatterGregorian {
     static createMd(locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null): DateRangeFormatterGregorian;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
@@ -57,6 +67,8 @@ export class DateRangeFormatterGregorian {
     static createMdWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null): DateRangeFormatterGregorian;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
@@ -66,6 +78,8 @@ export class DateRangeFormatterGregorian {
     static createYmd(locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateRangeFormatterGregorian;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
@@ -75,6 +89,8 @@ export class DateRangeFormatterGregorian {
     static createYmdWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateRangeFormatterGregorian;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
@@ -84,6 +100,8 @@ export class DateRangeFormatterGregorian {
     static createDe(locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null): DateRangeFormatterGregorian;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
@@ -93,6 +111,8 @@ export class DateRangeFormatterGregorian {
     static createDeWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null): DateRangeFormatterGregorian;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
@@ -102,6 +122,8 @@ export class DateRangeFormatterGregorian {
     static createMde(locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null): DateRangeFormatterGregorian;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
@@ -111,6 +133,8 @@ export class DateRangeFormatterGregorian {
     static createMdeWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null): DateRangeFormatterGregorian;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
@@ -120,6 +144,8 @@ export class DateRangeFormatterGregorian {
     static createYmde(locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateRangeFormatterGregorian;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
@@ -129,6 +155,8 @@ export class DateRangeFormatterGregorian {
     static createYmdeWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateRangeFormatterGregorian;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
@@ -138,6 +166,8 @@ export class DateRangeFormatterGregorian {
     static createE(locale: Locale, length: DateTimeLength | null): DateRangeFormatterGregorian;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
@@ -147,6 +177,8 @@ export class DateRangeFormatterGregorian {
     static createEWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null): DateRangeFormatterGregorian;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
@@ -156,6 +188,8 @@ export class DateRangeFormatterGregorian {
     static createM(locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null): DateRangeFormatterGregorian;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
@@ -165,6 +199,8 @@ export class DateRangeFormatterGregorian {
     static createMWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null): DateRangeFormatterGregorian;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
@@ -174,6 +210,8 @@ export class DateRangeFormatterGregorian {
     static createYm(locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateRangeFormatterGregorian;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
@@ -183,6 +221,8 @@ export class DateRangeFormatterGregorian {
     static createYmWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateRangeFormatterGregorian;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
@@ -192,6 +232,8 @@ export class DateRangeFormatterGregorian {
     static createY(locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateRangeFormatterGregorian;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
@@ -201,6 +243,8 @@ export class DateRangeFormatterGregorian {
     static createYWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateRangeFormatterGregorian;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.format) for more information.
      */
     formatIso(startIsoDate: IsoDate, endIsoDate: IsoDate): string;

--- a/ffi/npm/lib/DateRangeFormatterGregorian.mjs
+++ b/ffi/npm/lib/DateRangeFormatterGregorian.mjs
@@ -14,6 +14,8 @@ const DateRangeFormatterGregorian_box_destroy_registry = new FinalizationRegistr
 });
 
 /**
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
+ *
  * See the [Rust documentation for `FixedCalendarDateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html) for more information.
  */
 export class DateRangeFormatterGregorian {
@@ -46,6 +48,8 @@ export class DateRangeFormatterGregorian {
 
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
@@ -77,6 +81,8 @@ export class DateRangeFormatterGregorian {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
@@ -108,6 +114,8 @@ export class DateRangeFormatterGregorian {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
@@ -139,6 +147,8 @@ export class DateRangeFormatterGregorian {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
@@ -170,6 +180,8 @@ export class DateRangeFormatterGregorian {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
@@ -201,6 +213,8 @@ export class DateRangeFormatterGregorian {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
@@ -232,6 +246,8 @@ export class DateRangeFormatterGregorian {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
@@ -263,6 +279,8 @@ export class DateRangeFormatterGregorian {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
@@ -294,6 +312,8 @@ export class DateRangeFormatterGregorian {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
@@ -325,6 +345,8 @@ export class DateRangeFormatterGregorian {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
@@ -356,6 +378,8 @@ export class DateRangeFormatterGregorian {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
@@ -387,6 +411,8 @@ export class DateRangeFormatterGregorian {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
@@ -418,6 +444,8 @@ export class DateRangeFormatterGregorian {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
@@ -449,6 +477,8 @@ export class DateRangeFormatterGregorian {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
@@ -480,6 +510,8 @@ export class DateRangeFormatterGregorian {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
@@ -511,6 +543,8 @@ export class DateRangeFormatterGregorian {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
@@ -542,6 +576,8 @@ export class DateRangeFormatterGregorian {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
@@ -573,6 +609,8 @@ export class DateRangeFormatterGregorian {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
@@ -604,6 +642,8 @@ export class DateRangeFormatterGregorian {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
@@ -635,6 +675,8 @@ export class DateRangeFormatterGregorian {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
@@ -666,6 +708,8 @@ export class DateRangeFormatterGregorian {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.format) for more information.
      */
     formatIso(startIsoDate, endIsoDate) {

--- a/ffi/npm/lib/DateTimeRangeFormatter.d.ts
+++ b/ffi/npm/lib/DateTimeRangeFormatter.d.ts
@@ -14,6 +14,8 @@ import type { pointer, codepoint } from "./diplomat-runtime.d.ts";
 
 
 /**
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
+ *
  * See the [Rust documentation for `DateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html) for more information.
  */
 export class DateTimeRangeFormatter {
@@ -24,6 +26,8 @@ export class DateTimeRangeFormatter {
 
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
@@ -33,6 +37,8 @@ export class DateTimeRangeFormatter {
     static createDt(locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): DateTimeRangeFormatter;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
@@ -42,6 +48,8 @@ export class DateTimeRangeFormatter {
     static createDtWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): DateTimeRangeFormatter;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
@@ -51,6 +59,8 @@ export class DateTimeRangeFormatter {
     static createMdt(locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): DateTimeRangeFormatter;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
@@ -60,6 +70,8 @@ export class DateTimeRangeFormatter {
     static createMdtWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): DateTimeRangeFormatter;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
@@ -69,6 +81,8 @@ export class DateTimeRangeFormatter {
     static createYmdt(locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateTimeRangeFormatter;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
@@ -78,6 +92,8 @@ export class DateTimeRangeFormatter {
     static createYmdtWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateTimeRangeFormatter;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
@@ -87,6 +103,8 @@ export class DateTimeRangeFormatter {
     static createDet(locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): DateTimeRangeFormatter;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
@@ -96,6 +114,8 @@ export class DateTimeRangeFormatter {
     static createDetWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): DateTimeRangeFormatter;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
@@ -105,6 +125,8 @@ export class DateTimeRangeFormatter {
     static createMdet(locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): DateTimeRangeFormatter;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
@@ -114,6 +136,8 @@ export class DateTimeRangeFormatter {
     static createMdetWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): DateTimeRangeFormatter;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
@@ -123,6 +147,8 @@ export class DateTimeRangeFormatter {
     static createYmdet(locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateTimeRangeFormatter;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
@@ -132,6 +158,8 @@ export class DateTimeRangeFormatter {
     static createYmdetWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateTimeRangeFormatter;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
@@ -141,6 +169,8 @@ export class DateTimeRangeFormatter {
     static createEt(locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): DateTimeRangeFormatter;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
@@ -150,11 +180,15 @@ export class DateTimeRangeFormatter {
     static createEtWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): DateTimeRangeFormatter;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
      */
     formatIso(startIsoDate: IsoDate, startTime: Time, endIsoDate: IsoDate, endTime: Time): string;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
      */
     formatSameCalendar(startDate: Date, startTime: Time, endDate: Date, endTime: Time): string;

--- a/ffi/npm/lib/DateTimeRangeFormatter.mjs
+++ b/ffi/npm/lib/DateTimeRangeFormatter.mjs
@@ -17,6 +17,8 @@ const DateTimeRangeFormatter_box_destroy_registry = new FinalizationRegistry((pt
 });
 
 /**
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
+ *
  * See the [Rust documentation for `DateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html) for more information.
  */
 export class DateTimeRangeFormatter {
@@ -49,6 +51,8 @@ export class DateTimeRangeFormatter {
 
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
@@ -80,6 +84,8 @@ export class DateTimeRangeFormatter {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
@@ -111,6 +117,8 @@ export class DateTimeRangeFormatter {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
@@ -142,6 +150,8 @@ export class DateTimeRangeFormatter {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
@@ -173,6 +183,8 @@ export class DateTimeRangeFormatter {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
@@ -204,6 +216,8 @@ export class DateTimeRangeFormatter {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
@@ -235,6 +249,8 @@ export class DateTimeRangeFormatter {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
@@ -266,6 +282,8 @@ export class DateTimeRangeFormatter {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
@@ -297,6 +315,8 @@ export class DateTimeRangeFormatter {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
@@ -328,6 +348,8 @@ export class DateTimeRangeFormatter {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
@@ -359,6 +381,8 @@ export class DateTimeRangeFormatter {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
@@ -390,6 +414,8 @@ export class DateTimeRangeFormatter {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
@@ -421,6 +447,8 @@ export class DateTimeRangeFormatter {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
@@ -452,6 +480,8 @@ export class DateTimeRangeFormatter {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
@@ -483,6 +513,8 @@ export class DateTimeRangeFormatter {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
      */
     formatIso(startIsoDate, startTime, endIsoDate, endTime) {
@@ -501,6 +533,8 @@ export class DateTimeRangeFormatter {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
      */
     formatSameCalendar(startDate, startTime, endDate, endTime) {

--- a/ffi/npm/lib/DateTimeRangeFormatterGregorian.d.ts
+++ b/ffi/npm/lib/DateTimeRangeFormatterGregorian.d.ts
@@ -13,6 +13,8 @@ import type { pointer, codepoint } from "./diplomat-runtime.d.ts";
 
 
 /**
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
+ *
  * See the [Rust documentation for `FixedCalendarDateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html) for more information.
  */
 export class DateTimeRangeFormatterGregorian {
@@ -23,6 +25,8 @@ export class DateTimeRangeFormatterGregorian {
 
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
@@ -32,6 +36,8 @@ export class DateTimeRangeFormatterGregorian {
     static createDt(locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): DateTimeRangeFormatterGregorian;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
@@ -41,6 +47,8 @@ export class DateTimeRangeFormatterGregorian {
     static createDtWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): DateTimeRangeFormatterGregorian;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
@@ -50,6 +58,8 @@ export class DateTimeRangeFormatterGregorian {
     static createMdt(locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): DateTimeRangeFormatterGregorian;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
@@ -59,6 +69,8 @@ export class DateTimeRangeFormatterGregorian {
     static createMdtWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): DateTimeRangeFormatterGregorian;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
@@ -68,6 +80,8 @@ export class DateTimeRangeFormatterGregorian {
     static createYmdt(locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateTimeRangeFormatterGregorian;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
@@ -77,6 +91,8 @@ export class DateTimeRangeFormatterGregorian {
     static createYmdtWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateTimeRangeFormatterGregorian;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
@@ -86,6 +102,8 @@ export class DateTimeRangeFormatterGregorian {
     static createDet(locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): DateTimeRangeFormatterGregorian;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
@@ -95,6 +113,8 @@ export class DateTimeRangeFormatterGregorian {
     static createDetWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): DateTimeRangeFormatterGregorian;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
@@ -104,6 +124,8 @@ export class DateTimeRangeFormatterGregorian {
     static createMdet(locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): DateTimeRangeFormatterGregorian;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
@@ -113,6 +135,8 @@ export class DateTimeRangeFormatterGregorian {
     static createMdetWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): DateTimeRangeFormatterGregorian;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
@@ -122,6 +146,8 @@ export class DateTimeRangeFormatterGregorian {
     static createYmdet(locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateTimeRangeFormatterGregorian;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
@@ -131,6 +157,8 @@ export class DateTimeRangeFormatterGregorian {
     static createYmdetWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateTimeRangeFormatterGregorian;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
@@ -140,6 +168,8 @@ export class DateTimeRangeFormatterGregorian {
     static createEt(locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): DateTimeRangeFormatterGregorian;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
@@ -149,6 +179,8 @@ export class DateTimeRangeFormatterGregorian {
     static createEtWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): DateTimeRangeFormatterGregorian;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.format) for more information.
      */
     formatIso(startIsoDate: IsoDate, startTime: Time, endIsoDate: IsoDate, endTime: Time): string;

--- a/ffi/npm/lib/DateTimeRangeFormatterGregorian.mjs
+++ b/ffi/npm/lib/DateTimeRangeFormatterGregorian.mjs
@@ -16,6 +16,8 @@ const DateTimeRangeFormatterGregorian_box_destroy_registry = new FinalizationReg
 });
 
 /**
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
+ *
  * See the [Rust documentation for `FixedCalendarDateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html) for more information.
  */
 export class DateTimeRangeFormatterGregorian {
@@ -48,6 +50,8 @@ export class DateTimeRangeFormatterGregorian {
 
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
@@ -79,6 +83,8 @@ export class DateTimeRangeFormatterGregorian {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
@@ -110,6 +116,8 @@ export class DateTimeRangeFormatterGregorian {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
@@ -141,6 +149,8 @@ export class DateTimeRangeFormatterGregorian {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
@@ -172,6 +182,8 @@ export class DateTimeRangeFormatterGregorian {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
@@ -203,6 +215,8 @@ export class DateTimeRangeFormatterGregorian {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
@@ -234,6 +248,8 @@ export class DateTimeRangeFormatterGregorian {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
@@ -265,6 +281,8 @@ export class DateTimeRangeFormatterGregorian {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
@@ -296,6 +314,8 @@ export class DateTimeRangeFormatterGregorian {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
@@ -327,6 +347,8 @@ export class DateTimeRangeFormatterGregorian {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
@@ -358,6 +380,8 @@ export class DateTimeRangeFormatterGregorian {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
@@ -389,6 +413,8 @@ export class DateTimeRangeFormatterGregorian {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
@@ -420,6 +446,8 @@ export class DateTimeRangeFormatterGregorian {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
@@ -451,6 +479,8 @@ export class DateTimeRangeFormatterGregorian {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
@@ -482,6 +512,8 @@ export class DateTimeRangeFormatterGregorian {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.format) for more information.
      */
     formatIso(startIsoDate, startTime, endIsoDate, endTime) {

--- a/ffi/npm/lib/TimeRangeFormatter.d.ts
+++ b/ffi/npm/lib/TimeRangeFormatter.d.ts
@@ -11,6 +11,8 @@ import type { pointer, codepoint } from "./diplomat-runtime.d.ts";
 
 
 /**
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
+ *
  * See the [Rust documentation for `NoCalendarRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html) for more information.
  */
 export class TimeRangeFormatter {
@@ -19,6 +21,8 @@ export class TimeRangeFormatter {
 
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `T`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html) for more information.
@@ -28,11 +32,15 @@ export class TimeRangeFormatter {
     static createWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): TimeRangeFormatter;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html#method.format) for more information.
      */
     format(startTime: Time, endTime: Time): string;
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `T`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html) for more information.

--- a/ffi/npm/lib/TimeRangeFormatter.mjs
+++ b/ffi/npm/lib/TimeRangeFormatter.mjs
@@ -14,6 +14,8 @@ const TimeRangeFormatter_box_destroy_registry = new FinalizationRegistry((ptr) =
 });
 
 /**
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
+ *
  * See the [Rust documentation for `NoCalendarRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html) for more information.
  */
 export class TimeRangeFormatter {
@@ -46,6 +48,8 @@ export class TimeRangeFormatter {
 
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `T`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html) for more information.
@@ -77,6 +81,8 @@ export class TimeRangeFormatter {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `T`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html) for more information.
@@ -108,6 +114,8 @@ export class TimeRangeFormatter {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html#method.format) for more information.
      */
     format(startTime, endTime) {
@@ -126,6 +134,8 @@ export class TimeRangeFormatter {
     }
 
     /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `T`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html) for more information.

--- a/ffi/npm/package.json
+++ b/ffi/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "icu",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "ICU4X JavaScript bindings via WebAssembly",
   "main": "lib/index.mjs",
   "exports": {

--- a/tools/make/codegen/templates/range_formatter.rs.jinja
+++ b/tools/make/codegen/templates/range_formatter.rs.jinja
@@ -40,6 +40,7 @@ pub mod ffi {
         {%- let ffi_type = format!("{}RangeFormatter", {{ flavor.camel() }}) %}
     {%- endif %}
 
+    /// 🚧 This API is unstable and may experience breaking changes outside major releases.
     #[diplomat::opaque]
     #[diplomat::rust_link(icu::datetime::range::{{ formatter_kind.rustlink_range() }}, {{ formatter_kind.rustlink_doctype() }})]
     pub struct {{ ffi_type }}(
@@ -63,6 +64,7 @@ pub mod ffi {
     impl {{ ffi_type }} {
         {%- for variant in variants %}
         {%- for ctor in ConstructorType::VALUES %}
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         {%- decl named_constructor %}
         {%- decl named_constructor_full %}
         {%- if ctor.is_with_provider() %}
@@ -167,6 +169,7 @@ pub mod ffi {
         }
         {% endfor %}
         {%- endfor %}
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::rust_link(icu::datetime::range::{{ formatter_kind.rustlink_range() }}::format, {{ formatter_kind.rustlink_doctype_fn() }})]
         #[diplomat::rust_link(icu::datetime::range::FormattedDateRange, Struct, hidden)]
         #[diplomat::rust_link(icu::datetime::range::FormattedDateRange::to_string, FnInStruct, hidden)]
@@ -209,6 +212,7 @@ pub mod ffi {
             let _infallible = self.0.format(&start_value, &end_value).write_to(write);
         }
         {% if !formatter_kind.is_fixed_calendar %}
+        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::rust_link(icu::datetime::range::{{ formatter_kind.rustlink_range() }}::format, {{ formatter_kind.rustlink_doctype_fn() }})]
         #[diplomat::rust_link(icu::datetime::range::FormattedDateRange, Struct, hidden)]
         #[diplomat::rust_link(icu::datetime::range::FormattedDateRange::to_string, FnInStruct, hidden)]


### PR DESCRIPTION
Looks like we accidentally releases these as stable: https://pub.dev/documentation/icu4x/latest/icu4x/DateRangeFormatter-class.html

## Changelog

N/A