### PR TITLE
Bump diplomat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,14 @@ Several crates have had patch releases in the 2.3 stream:
     - Upate to Diplomat 0.16.1 (unicode-org#8411)
   - (2.3.1) `icu_capi`
     - Add missing docs to properties (unicode-org#8407)
+  - (2.3.3) `icu_capi`
+    - Add missing stability annotations (unicode-org#8462)
   - Dart
     - (2.3.1) Add `Error` and `Exception` to classes/enums which are used as errors and exceptions (https://github.com/rust-diplomat/diplomat/pull/1220) (unicode-org#8411)
+    - (2.3.3) Add missing stability annotations (unicode-org#8462)
   - JavaScript
     - (2.3.1) Add validation to arguments to assure type correctness (https://github.com/rust-diplomat/diplomat/pull/902) (unicode-org#8411)
+    - (2.3.3) Add missing stability annotations (unicode-org#8462)
 - Utils
   - (0.11.5, 0.11.6) `zerovec-derive`
     - (0.11.5) Fix soundness issue around multi element buffer validation in ULE derives (unicode-org#8393)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,14 +21,17 @@ Several crates have had patch releases in the 2.3 stream:
     - Upate to Diplomat 0.16.1 (unicode-org#8411)
   - (2.3.1) `icu_capi`
     - Add missing docs to properties (unicode-org#8407)
-  - (2.3.3) `icu_capi`
+  - (2.3.2) `icu_capi`
     - Add missing stability annotations (unicode-org#8462)
-  - Dart
-    - (2.3.1) Add `Error` and `Exception` to classes/enums which are used as errors and exceptions (https://github.com/rust-diplomat/diplomat/pull/1220) (unicode-org#8411)
-    - (2.3.3) Add missing stability annotations (unicode-org#8462)
-  - JavaScript
-    - (2.3.1) Add validation to arguments to assure type correctness (https://github.com/rust-diplomat/diplomat/pull/902) (unicode-org#8411)
-    - (2.3.3) Add missing stability annotations (unicode-org#8462)
+  - (2.3.1) Dart
+    - Add `Error` and `Exception` to classes/enums which are used as errors and exceptions (https://github.com/rust-diplomat/diplomat/pull/1220) (unicode-org#8411)
+  - (2.3.2) Dart
+    - Cache downloaded pre-built binaries (unicode-org#8426)
+    - Add missing stability annotations (unicode-org#8462)
+  - (2.3.1) NPM
+    - Add validation to arguments to assure type correctness (https://github.com/rust-diplomat/diplomat/pull/902) (unicode-org#8411)
+  - (2.3.2) NPM
+    - Add missing stability annotations (unicode-org#8462)
 - Utils
   - (0.11.5, 0.11.6) `zerovec-derive`
     - (0.11.5) Fix soundness issue around multi element buffer validation in ULE derives (unicode-org#8393)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1410,7 +1410,7 @@ version = "2.3.0"
 
 [[package]]
 name = "icu_capi"
-version = "2.3.3"
+version = "2.3.2"
 dependencies = [
  "diplomat",
  "diplomat-runtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -739,7 +739,7 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8b37a6cea72eb6df5143d3e091d4c34cb0cf4046dd1ddcc082988886fe1f809"
 dependencies = [
- "diplomat_core",
+ "diplomat_core 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2",
  "quote",
  "syn 3.0.3",
@@ -749,7 +749,7 @@ dependencies = [
 name = "diplomat-coverage"
 version = "0.0.0"
 dependencies = [
- "diplomat_core",
+ "diplomat_core 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "elsa",
  "lazy_static",
  "rustdoc-types",
@@ -777,13 +777,12 @@ dependencies = [
 [[package]]
 name = "diplomat-tool"
 version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f71ad0ab8cf95b7179a192b1e07c3a5e8b7e6471e279d05101a12a1e77d8025c"
+source = "git+https://github.com/robertbastian/diplomat?rev=eb8f0dc17e17e25d2ed610fc5a359b3ebeee038e#eb8f0dc17e17e25d2ed610fc5a359b3ebeee038e"
 dependencies = [
  "askama",
  "clap",
  "colored",
- "diplomat_core",
+ "diplomat_core 0.16.1 (git+https://github.com/robertbastian/diplomat?rev=eb8f0dc17e17e25d2ed610fc5a359b3ebeee038e)",
  "heck 0.5.0",
  "indenter",
  "itertools 0.14.0",
@@ -799,6 +798,19 @@ name = "diplomat_core"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b18e806f9ecb92df828d080efe47984ae1193958295d4a84fb8b32c9a1aa1b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "smallvec",
+ "strck",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "diplomat_core"
+version = "0.16.1"
+source = "git+https://github.com/robertbastian/diplomat?rev=eb8f0dc17e17e25d2ed610fc5a359b3ebeee038e#eb8f0dc17e17e25d2ed610fc5a359b3ebeee038e"
 dependencies = [
  "annotate-snippets",
  "either",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1410,7 +1410,7 @@ version = "2.3.0"
 
 [[package]]
 name = "icu_capi"
-version = "2.3.2"
+version = "2.3.3"
 dependencies = [
  "diplomat",
  "diplomat-runtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -777,12 +777,12 @@ dependencies = [
 [[package]]
 name = "diplomat-tool"
 version = "0.16.1"
-source = "git+https://github.com/robertbastian/diplomat?rev=eb8f0dc17e17e25d2ed610fc5a359b3ebeee038e#eb8f0dc17e17e25d2ed610fc5a359b3ebeee038e"
+source = "git+https://github.com/rust-diplomat/diplomat?rev=7f5b1556c4f392f69be99d47c24a7d1dbdddb8e7#7f5b1556c4f392f69be99d47c24a7d1dbdddb8e7"
 dependencies = [
  "askama",
  "clap",
  "colored",
- "diplomat_core 0.16.1 (git+https://github.com/robertbastian/diplomat?rev=eb8f0dc17e17e25d2ed610fc5a359b3ebeee038e)",
+ "diplomat_core 0.16.1 (git+https://github.com/rust-diplomat/diplomat?rev=7f5b1556c4f392f69be99d47c24a7d1dbdddb8e7)",
  "heck 0.5.0",
  "indenter",
  "itertools 0.14.0",
@@ -810,7 +810,7 @@ dependencies = [
 [[package]]
 name = "diplomat_core"
 version = "0.16.1"
-source = "git+https://github.com/robertbastian/diplomat?rev=eb8f0dc17e17e25d2ed610fc5a359b3ebeee038e#eb8f0dc17e17e25d2ed610fc5a359b3ebeee038e"
+source = "git+https://github.com/rust-diplomat/diplomat?rev=7f5b1556c4f392f69be99d47c24a7d1dbdddb8e7#7f5b1556c4f392f69be99d47c24a7d1dbdddb8e7"
 dependencies = [
  "annotate-snippets",
  "either",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -224,7 +224,7 @@ icu_benchmark_macros = { path = "tools/benchmark/macros" }
 # Diplomat must be published preceding a new ICU4X release but may use git versions in between
 diplomat = { version = "0.16.1", default-features = false }
 diplomat_core = { version = "0.16.1", default-features = false }
-diplomat-tool = { git = "https://github.com/robertbastian/diplomat", rev = "eb8f0dc17e17e25d2ed610fc5a359b3ebeee038e" }
+diplomat-tool = { git = "https://github.com/rust-diplomat/diplomat", rev = "7f5b1556c4f392f69be99d47c24a7d1dbdddb8e7" }
 # Range dep for better compatability. We will not have this problem
 # after diplomat-runtime 1.0.0
 # <https://github.com/rust-diplomat/diplomat/issues/958>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -224,7 +224,7 @@ icu_benchmark_macros = { path = "tools/benchmark/macros" }
 # Diplomat must be published preceding a new ICU4X release but may use git versions in between
 diplomat = { version = "0.16.1", default-features = false }
 diplomat_core = { version = "0.16.1", default-features = false }
-diplomat-tool = { version = "0.16.1" }
+diplomat-tool = { git = "https://github.com/robertbastian/diplomat", rev = "eb8f0dc17e17e25d2ed610fc5a359b3ebeee038e" }
 # Range dep for better compatability. We will not have this problem
 # after diplomat-runtime 1.0.0
 # <https://github.com/rust-diplomat/diplomat/issues/958>

--- a/ffi/capi/Cargo.toml
+++ b/ffi/capi/Cargo.toml
@@ -18,7 +18,7 @@ include = [
     "LICENSE",
     "README.md"
 ]
-version = "2.3.2"
+version = "2.3.3"
 
 authors.workspace = true
 edition.workspace = true

--- a/ffi/capi/Cargo.toml
+++ b/ffi/capi/Cargo.toml
@@ -18,7 +18,7 @@ include = [
     "LICENSE",
     "README.md"
 ]
-version = "2.3.3"
+version = "2.3.2"
 
 authors.workspace = true
 edition.workspace = true

--- a/ffi/capi/bindings/cpp/icu4x/Bidi.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/Bidi.d.hpp
@@ -58,7 +58,7 @@ public:
    *
    * See the [Rust documentation for `new_with_data_source`](https://docs.rs/unicode_bidi/0.3.11/unicode_bidi/struct.BidiInfo.html#method.new_with_data_source) for more information.
    */
-  inline std::unique_ptr<icu4x::BidiInfo> for_text(std::string_view text DIPLOMAT_LIFETIME_BOUND, std::optional<uint8_t> default_level) const;
+  inline icu4x::diplomat::maybe_null<std::unique_ptr<icu4x::BidiInfo>> for_text(std::string_view text DIPLOMAT_LIFETIME_BOUND, std::optional<uint8_t> default_level) const;
 
   /**
    * Utility function for producing reorderings given a list of levels

--- a/ffi/capi/bindings/cpp/icu4x/Bidi.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/Bidi.hpp
@@ -55,7 +55,7 @@ inline icu4x::diplomat::result<std::unique_ptr<icu4x::Bidi>, icu4x::DataError> i
     return result.is_ok ? icu4x::diplomat::result<std::unique_ptr<icu4x::Bidi>, icu4x::DataError>(icu4x::diplomat::Ok<std::unique_ptr<icu4x::Bidi>>(std::unique_ptr<icu4x::Bidi>(icu4x::Bidi::FromFFI(result.ok)))) : icu4x::diplomat::result<std::unique_ptr<icu4x::Bidi>, icu4x::DataError>(icu4x::diplomat::Err<icu4x::DataError>(icu4x::DataError::FromFFI(result.err)));
 }
 
-inline std::unique_ptr<icu4x::BidiInfo> icu4x::Bidi::for_text(std::string_view text DIPLOMAT_LIFETIME_BOUND, std::optional<uint8_t> default_level) const {
+inline icu4x::diplomat::maybe_null<std::unique_ptr<icu4x::BidiInfo>> icu4x::Bidi::for_text(std::string_view text DIPLOMAT_LIFETIME_BOUND, std::optional<uint8_t> default_level) const {
     auto result = icu4x::capi::icu4x_Bidi_for_text_utf8_mv1(this->AsFFI(),
         {text.data(), text.size()},
         default_level.has_value() ? (icu4x::diplomat::capi::OptionU8{ { default_level.value() }, true }) : (icu4x::diplomat::capi::OptionU8{ {}, false }));

--- a/ffi/capi/bindings/cpp/icu4x/BidiInfo.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/BidiInfo.d.hpp
@@ -40,7 +40,7 @@ public:
   /**
    * Get the nth paragraph, returning `None` if out of bounds
    */
-  inline std::unique_ptr<icu4x::BidiParagraph> paragraph_at(size_t n) const DIPLOMAT_LIFETIME_BOUND;
+  inline icu4x::diplomat::maybe_null<std::unique_ptr<icu4x::BidiParagraph>> paragraph_at(size_t n) const DIPLOMAT_LIFETIME_BOUND;
 
   /**
    * The number of bytes in this full text

--- a/ffi/capi/bindings/cpp/icu4x/BidiInfo.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/BidiInfo.hpp
@@ -38,7 +38,7 @@ inline size_t icu4x::BidiInfo::paragraph_count() const {
     return result;
 }
 
-inline std::unique_ptr<icu4x::BidiParagraph> icu4x::BidiInfo::paragraph_at(size_t n) const DIPLOMAT_LIFETIME_BOUND {
+inline icu4x::diplomat::maybe_null<std::unique_ptr<icu4x::BidiParagraph>> icu4x::BidiInfo::paragraph_at(size_t n) const DIPLOMAT_LIFETIME_BOUND {
     auto result = icu4x::capi::icu4x_BidiInfo_paragraph_at_mv1(this->AsFFI(),
         n);
     return std::unique_ptr<icu4x::BidiParagraph>(icu4x::BidiParagraph::FromFFI(result));

--- a/ffi/capi/bindings/cpp/icu4x/DateRangeFormatter.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/DateRangeFormatter.d.hpp
@@ -37,246 +37,246 @@ namespace capi {
 
 namespace icu4x {
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `DateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html) for more information.
+ *
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
  */
 class DateRangeFormatter {
 public:
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_d(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_d_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_md(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_md_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_ymd(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_ymd_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_de(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_de_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_mde(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_mde_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_ymde(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_ymde_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_e(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_e_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_m(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_m_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_ym(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_ym_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_y(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_y_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline std::string format_iso(const icu4x::IsoDate& start_iso_date, const icu4x::IsoDate& end_iso_date) const;
   template<typename W>
   inline void format_iso_write(const icu4x::IsoDate& start_iso_date, const icu4x::IsoDate& end_iso_date, W& writeable_output) const;
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline std::string format_same_calendar(const icu4x::Date& start_date, const icu4x::Date& end_date) const;
   template<typename W>

--- a/ffi/capi/bindings/cpp/icu4x/DateRangeFormatterGregorian.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/DateRangeFormatterGregorian.d.hpp
@@ -35,237 +35,237 @@ namespace capi {
 
 namespace icu4x {
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `FixedCalendarDateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html) for more information.
+ *
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
  */
 class DateRangeFormatterGregorian {
 public:
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_d(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_d_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_md(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_md_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_ymd(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_ymd_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_de(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_de_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_mde(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_mde_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_ymde(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_ymde_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_e(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_e_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_m(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_m_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_ym(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_ym_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_y(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_y_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.format) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline std::string format_iso(const icu4x::IsoDate& start_iso_date, const icu4x::IsoDate& end_iso_date) const;
   template<typename W>

--- a/ffi/capi/bindings/cpp/icu4x/DateTimeRangeFormatter.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/DateTimeRangeFormatter.d.hpp
@@ -40,180 +40,180 @@ namespace capi {
 
 namespace icu4x {
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `DateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html) for more information.
+ *
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
  */
 class DateTimeRangeFormatter {
 public:
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_dt(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_dt_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_mdt(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_mdt_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_ymdt(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_ymdt_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_det(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_det_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_mdet(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_mdet_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_ymdet(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_ymdet_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_et(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_et_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline std::string format_iso(const icu4x::IsoDate& start_iso_date, const icu4x::Time& start_time, const icu4x::IsoDate& end_iso_date, const icu4x::Time& end_time) const;
   template<typename W>
   inline void format_iso_write(const icu4x::IsoDate& start_iso_date, const icu4x::Time& start_time, const icu4x::IsoDate& end_iso_date, const icu4x::Time& end_time, W& writeable_output) const;
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline std::string format_same_calendar(const icu4x::Date& start_date, const icu4x::Time& start_time, const icu4x::Date& end_date, const icu4x::Time& end_time) const;
   template<typename W>

--- a/ffi/capi/bindings/cpp/icu4x/DateTimeRangeFormatterGregorian.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/DateTimeRangeFormatterGregorian.d.hpp
@@ -38,171 +38,171 @@ namespace capi {
 
 namespace icu4x {
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `FixedCalendarDateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html) for more information.
+ *
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
  */
 class DateTimeRangeFormatterGregorian {
 public:
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_dt(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_dt_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_mdt(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_mdt_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_ymdt(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_ymdt_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_det(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_det_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_mdet(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_mdet_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_ymdet(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_ymdet_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment, std::optional<icu4x::YearStyle> year_style);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_et(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::DateTimeRangeFormatterGregorian>, icu4x::DateTimeFormatterLoadError> create_et_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.format) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline std::string format_iso(const icu4x::IsoDate& start_iso_date, const icu4x::Time& start_time, const icu4x::IsoDate& end_iso_date, const icu4x::Time& end_time) const;
   template<typename W>

--- a/ffi/capi/bindings/cpp/icu4x/DisplayNamesFallback.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/DisplayNamesFallback.d.hpp
@@ -25,9 +25,9 @@ namespace capi {
 
 namespace icu4x {
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `Fallback`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/enum.Fallback.html) for more information.
+ *
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
  */
 class DisplayNamesFallback {
 public:

--- a/ffi/capi/bindings/cpp/icu4x/DisplayNamesOptionsV1.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/DisplayNamesOptionsV1.d.hpp
@@ -36,9 +36,9 @@ namespace capi {
 
 namespace icu4x {
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `DisplayNamesOptions`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/struct.DisplayNamesOptions.html) for more information.
+ *
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
  */
 struct DisplayNamesOptionsV1 {
     std::optional<icu4x::DisplayNamesStyle> style;

--- a/ffi/capi/bindings/cpp/icu4x/DisplayNamesStyle.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/DisplayNamesStyle.d.hpp
@@ -27,9 +27,9 @@ namespace capi {
 
 namespace icu4x {
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `Style`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/enum.Style.html) for more information.
+ *
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
  */
 class DisplayNamesStyle {
 public:

--- a/ffi/capi/bindings/cpp/icu4x/LanguageDisplay.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/LanguageDisplay.d.hpp
@@ -25,9 +25,9 @@ namespace capi {
 
 namespace icu4x {
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `LanguageDisplay`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/enum.LanguageDisplay.html) for more information.
+ *
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
  */
 class LanguageDisplay {
 public:

--- a/ffi/capi/bindings/cpp/icu4x/LanguageDisplayUnstable.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/LanguageDisplayUnstable.d.hpp
@@ -25,9 +25,9 @@ namespace capi {
 
 namespace icu4x {
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `LanguageDisplay`](https://docs.rs/icu/2.3.1/icu/locale/names/enum.LanguageDisplay.html) for more information.
+ *
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
  */
 class LanguageDisplayUnstable {
 public:

--- a/ffi/capi/bindings/cpp/icu4x/LineSegmenter.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/LineSegmenter.d.hpp
@@ -82,7 +82,7 @@ public:
    *
    * See the [Rust documentation for `new_auto`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.LineSegmenter.html#method.new_auto) for more information.
    */
-  inline static std::unique_ptr<icu4x::LineSegmenter> create_auto_with_options_v2(const icu4x::Locale* content_locale, icu4x::LineBreakOptionsV2 options);
+  inline static std::unique_ptr<icu4x::LineSegmenter> create_auto_with_options_v2(icu4x::diplomat::maybe_null<const icu4x::Locale*> content_locale, icu4x::LineBreakOptionsV2 options);
 
   /**
    * Construct a {@link LineSegmenter} with custom options. It automatically loads the best
@@ -90,7 +90,7 @@ public:
    *
    * See the [Rust documentation for `new_auto`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.LineSegmenter.html#method.new_auto) for more information.
    */
-  inline static icu4x::diplomat::result<std::unique_ptr<icu4x::LineSegmenter>, icu4x::DataError> create_auto_with_options_v2_and_provider(const icu4x::DataProvider& provider, const icu4x::Locale* content_locale, icu4x::LineBreakOptionsV2 options);
+  inline static icu4x::diplomat::result<std::unique_ptr<icu4x::LineSegmenter>, icu4x::DataError> create_auto_with_options_v2_and_provider(const icu4x::DataProvider& provider, icu4x::diplomat::maybe_null<const icu4x::Locale*> content_locale, icu4x::LineBreakOptionsV2 options);
 
   /**
    * Construct a {@link LineSegmenter} with custom options and LSTM payload data for
@@ -98,7 +98,7 @@ public:
    *
    * See the [Rust documentation for `new_lstm`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.LineSegmenter.html#method.new_lstm) for more information.
    */
-  inline static std::unique_ptr<icu4x::LineSegmenter> create_lstm_with_options_v2(const icu4x::Locale* content_locale, icu4x::LineBreakOptionsV2 options);
+  inline static std::unique_ptr<icu4x::LineSegmenter> create_lstm_with_options_v2(icu4x::diplomat::maybe_null<const icu4x::Locale*> content_locale, icu4x::LineBreakOptionsV2 options);
 
   /**
    * Construct a {@link LineSegmenter} with custom options and LSTM payload data for
@@ -106,7 +106,7 @@ public:
    *
    * See the [Rust documentation for `new_lstm`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.LineSegmenter.html#method.new_lstm) for more information.
    */
-  inline static icu4x::diplomat::result<std::unique_ptr<icu4x::LineSegmenter>, icu4x::DataError> create_lstm_with_options_v2_and_provider(const icu4x::DataProvider& provider, const icu4x::Locale* content_locale, icu4x::LineBreakOptionsV2 options);
+  inline static icu4x::diplomat::result<std::unique_ptr<icu4x::LineSegmenter>, icu4x::DataError> create_lstm_with_options_v2_and_provider(const icu4x::DataProvider& provider, icu4x::diplomat::maybe_null<const icu4x::Locale*> content_locale, icu4x::LineBreakOptionsV2 options);
 
   /**
    * Construct a {@link LineSegmenter} with custom options and dictionary payload data for
@@ -114,7 +114,7 @@ public:
    *
    * See the [Rust documentation for `new_dictionary`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.LineSegmenter.html#method.new_dictionary) for more information.
    */
-  inline static std::unique_ptr<icu4x::LineSegmenter> create_dictionary_with_options_v2(const icu4x::Locale* content_locale, icu4x::LineBreakOptionsV2 options);
+  inline static std::unique_ptr<icu4x::LineSegmenter> create_dictionary_with_options_v2(icu4x::diplomat::maybe_null<const icu4x::Locale*> content_locale, icu4x::LineBreakOptionsV2 options);
 
   /**
    * Construct a {@link LineSegmenter} with custom options and dictionary payload data for
@@ -122,7 +122,7 @@ public:
    *
    * See the [Rust documentation for `new_dictionary`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.LineSegmenter.html#method.new_dictionary) for more information.
    */
-  inline static icu4x::diplomat::result<std::unique_ptr<icu4x::LineSegmenter>, icu4x::DataError> create_dictionary_with_options_v2_and_provider(const icu4x::DataProvider& provider, const icu4x::Locale* content_locale, icu4x::LineBreakOptionsV2 options);
+  inline static icu4x::diplomat::result<std::unique_ptr<icu4x::LineSegmenter>, icu4x::DataError> create_dictionary_with_options_v2_and_provider(const icu4x::DataProvider& provider, icu4x::diplomat::maybe_null<const icu4x::Locale*> content_locale, icu4x::LineBreakOptionsV2 options);
 
   /**
    * Construct a {@link LineSegmenter} with custom options and no support for scripts requiring complex context dependent line breaks
@@ -130,7 +130,7 @@ public:
    *
    * See the [Rust documentation for `new_for_non_complex_scripts`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.LineSegmenter.html#method.new_for_non_complex_scripts) for more information.
    */
-  inline static std::unique_ptr<icu4x::LineSegmenter> create_for_non_complex_scripts_with_options_v2(const icu4x::Locale* content_locale, icu4x::LineBreakOptionsV2 options);
+  inline static std::unique_ptr<icu4x::LineSegmenter> create_for_non_complex_scripts_with_options_v2(icu4x::diplomat::maybe_null<const icu4x::Locale*> content_locale, icu4x::LineBreakOptionsV2 options);
 
   /**
    * Construct a {@link LineSegmenter} with custom options and no support for complex languages
@@ -138,7 +138,7 @@ public:
    *
    * See the [Rust documentation for `new_for_non_complex_scripts`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.LineSegmenter.html#method.new_for_non_complex_scripts) for more information.
    */
-  inline static icu4x::diplomat::result<std::unique_ptr<icu4x::LineSegmenter>, icu4x::DataError> create_for_non_complex_scripts_with_options_v2_and_provider(const icu4x::DataProvider& provider, const icu4x::Locale* content_locale, icu4x::LineBreakOptionsV2 options);
+  inline static icu4x::diplomat::result<std::unique_ptr<icu4x::LineSegmenter>, icu4x::DataError> create_for_non_complex_scripts_with_options_v2_and_provider(const icu4x::DataProvider& provider, icu4x::diplomat::maybe_null<const icu4x::Locale*> content_locale, icu4x::LineBreakOptionsV2 options);
 
   /**
    * Segments a string.

--- a/ffi/capi/bindings/cpp/icu4x/LineSegmenter.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/LineSegmenter.hpp
@@ -85,52 +85,52 @@ inline std::unique_ptr<icu4x::LineSegmenter> icu4x::LineSegmenter::create_for_no
     return std::unique_ptr<icu4x::LineSegmenter>(icu4x::LineSegmenter::FromFFI(result));
 }
 
-inline std::unique_ptr<icu4x::LineSegmenter> icu4x::LineSegmenter::create_auto_with_options_v2(const icu4x::Locale* content_locale, icu4x::LineBreakOptionsV2 options) {
+inline std::unique_ptr<icu4x::LineSegmenter> icu4x::LineSegmenter::create_auto_with_options_v2(icu4x::diplomat::maybe_null<const icu4x::Locale*> content_locale, icu4x::LineBreakOptionsV2 options) {
     auto result = icu4x::capi::icu4x_LineSegmenter_create_auto_with_options_v2_mv1(content_locale ? content_locale->AsFFI() : nullptr,
         options.AsFFI());
     return std::unique_ptr<icu4x::LineSegmenter>(icu4x::LineSegmenter::FromFFI(result));
 }
 
-inline icu4x::diplomat::result<std::unique_ptr<icu4x::LineSegmenter>, icu4x::DataError> icu4x::LineSegmenter::create_auto_with_options_v2_and_provider(const icu4x::DataProvider& provider, const icu4x::Locale* content_locale, icu4x::LineBreakOptionsV2 options) {
+inline icu4x::diplomat::result<std::unique_ptr<icu4x::LineSegmenter>, icu4x::DataError> icu4x::LineSegmenter::create_auto_with_options_v2_and_provider(const icu4x::DataProvider& provider, icu4x::diplomat::maybe_null<const icu4x::Locale*> content_locale, icu4x::LineBreakOptionsV2 options) {
     auto result = icu4x::capi::icu4x_LineSegmenter_create_auto_with_options_v2_and_provider_mv1(provider.AsFFI(),
         content_locale ? content_locale->AsFFI() : nullptr,
         options.AsFFI());
     return result.is_ok ? icu4x::diplomat::result<std::unique_ptr<icu4x::LineSegmenter>, icu4x::DataError>(icu4x::diplomat::Ok<std::unique_ptr<icu4x::LineSegmenter>>(std::unique_ptr<icu4x::LineSegmenter>(icu4x::LineSegmenter::FromFFI(result.ok)))) : icu4x::diplomat::result<std::unique_ptr<icu4x::LineSegmenter>, icu4x::DataError>(icu4x::diplomat::Err<icu4x::DataError>(icu4x::DataError::FromFFI(result.err)));
 }
 
-inline std::unique_ptr<icu4x::LineSegmenter> icu4x::LineSegmenter::create_lstm_with_options_v2(const icu4x::Locale* content_locale, icu4x::LineBreakOptionsV2 options) {
+inline std::unique_ptr<icu4x::LineSegmenter> icu4x::LineSegmenter::create_lstm_with_options_v2(icu4x::diplomat::maybe_null<const icu4x::Locale*> content_locale, icu4x::LineBreakOptionsV2 options) {
     auto result = icu4x::capi::icu4x_LineSegmenter_create_lstm_with_options_v2_mv1(content_locale ? content_locale->AsFFI() : nullptr,
         options.AsFFI());
     return std::unique_ptr<icu4x::LineSegmenter>(icu4x::LineSegmenter::FromFFI(result));
 }
 
-inline icu4x::diplomat::result<std::unique_ptr<icu4x::LineSegmenter>, icu4x::DataError> icu4x::LineSegmenter::create_lstm_with_options_v2_and_provider(const icu4x::DataProvider& provider, const icu4x::Locale* content_locale, icu4x::LineBreakOptionsV2 options) {
+inline icu4x::diplomat::result<std::unique_ptr<icu4x::LineSegmenter>, icu4x::DataError> icu4x::LineSegmenter::create_lstm_with_options_v2_and_provider(const icu4x::DataProvider& provider, icu4x::diplomat::maybe_null<const icu4x::Locale*> content_locale, icu4x::LineBreakOptionsV2 options) {
     auto result = icu4x::capi::icu4x_LineSegmenter_create_lstm_with_options_v2_and_provider_mv1(provider.AsFFI(),
         content_locale ? content_locale->AsFFI() : nullptr,
         options.AsFFI());
     return result.is_ok ? icu4x::diplomat::result<std::unique_ptr<icu4x::LineSegmenter>, icu4x::DataError>(icu4x::diplomat::Ok<std::unique_ptr<icu4x::LineSegmenter>>(std::unique_ptr<icu4x::LineSegmenter>(icu4x::LineSegmenter::FromFFI(result.ok)))) : icu4x::diplomat::result<std::unique_ptr<icu4x::LineSegmenter>, icu4x::DataError>(icu4x::diplomat::Err<icu4x::DataError>(icu4x::DataError::FromFFI(result.err)));
 }
 
-inline std::unique_ptr<icu4x::LineSegmenter> icu4x::LineSegmenter::create_dictionary_with_options_v2(const icu4x::Locale* content_locale, icu4x::LineBreakOptionsV2 options) {
+inline std::unique_ptr<icu4x::LineSegmenter> icu4x::LineSegmenter::create_dictionary_with_options_v2(icu4x::diplomat::maybe_null<const icu4x::Locale*> content_locale, icu4x::LineBreakOptionsV2 options) {
     auto result = icu4x::capi::icu4x_LineSegmenter_create_dictionary_with_options_v2_mv1(content_locale ? content_locale->AsFFI() : nullptr,
         options.AsFFI());
     return std::unique_ptr<icu4x::LineSegmenter>(icu4x::LineSegmenter::FromFFI(result));
 }
 
-inline icu4x::diplomat::result<std::unique_ptr<icu4x::LineSegmenter>, icu4x::DataError> icu4x::LineSegmenter::create_dictionary_with_options_v2_and_provider(const icu4x::DataProvider& provider, const icu4x::Locale* content_locale, icu4x::LineBreakOptionsV2 options) {
+inline icu4x::diplomat::result<std::unique_ptr<icu4x::LineSegmenter>, icu4x::DataError> icu4x::LineSegmenter::create_dictionary_with_options_v2_and_provider(const icu4x::DataProvider& provider, icu4x::diplomat::maybe_null<const icu4x::Locale*> content_locale, icu4x::LineBreakOptionsV2 options) {
     auto result = icu4x::capi::icu4x_LineSegmenter_create_dictionary_with_options_v2_and_provider_mv1(provider.AsFFI(),
         content_locale ? content_locale->AsFFI() : nullptr,
         options.AsFFI());
     return result.is_ok ? icu4x::diplomat::result<std::unique_ptr<icu4x::LineSegmenter>, icu4x::DataError>(icu4x::diplomat::Ok<std::unique_ptr<icu4x::LineSegmenter>>(std::unique_ptr<icu4x::LineSegmenter>(icu4x::LineSegmenter::FromFFI(result.ok)))) : icu4x::diplomat::result<std::unique_ptr<icu4x::LineSegmenter>, icu4x::DataError>(icu4x::diplomat::Err<icu4x::DataError>(icu4x::DataError::FromFFI(result.err)));
 }
 
-inline std::unique_ptr<icu4x::LineSegmenter> icu4x::LineSegmenter::create_for_non_complex_scripts_with_options_v2(const icu4x::Locale* content_locale, icu4x::LineBreakOptionsV2 options) {
+inline std::unique_ptr<icu4x::LineSegmenter> icu4x::LineSegmenter::create_for_non_complex_scripts_with_options_v2(icu4x::diplomat::maybe_null<const icu4x::Locale*> content_locale, icu4x::LineBreakOptionsV2 options) {
     auto result = icu4x::capi::icu4x_LineSegmenter_create_for_non_complex_scripts_with_options_v2_mv1(content_locale ? content_locale->AsFFI() : nullptr,
         options.AsFFI());
     return std::unique_ptr<icu4x::LineSegmenter>(icu4x::LineSegmenter::FromFFI(result));
 }
 
-inline icu4x::diplomat::result<std::unique_ptr<icu4x::LineSegmenter>, icu4x::DataError> icu4x::LineSegmenter::create_for_non_complex_scripts_with_options_v2_and_provider(const icu4x::DataProvider& provider, const icu4x::Locale* content_locale, icu4x::LineBreakOptionsV2 options) {
+inline icu4x::diplomat::result<std::unique_ptr<icu4x::LineSegmenter>, icu4x::DataError> icu4x::LineSegmenter::create_for_non_complex_scripts_with_options_v2_and_provider(const icu4x::DataProvider& provider, icu4x::diplomat::maybe_null<const icu4x::Locale*> content_locale, icu4x::LineBreakOptionsV2 options) {
     auto result = icu4x::capi::icu4x_LineSegmenter_create_for_non_complex_scripts_with_options_v2_and_provider_mv1(provider.AsFFI(),
         content_locale ? content_locale->AsFFI() : nullptr,
         options.AsFFI());

--- a/ffi/capi/bindings/cpp/icu4x/LocaleDisplayNamesFormatter.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/LocaleDisplayNamesFormatter.d.hpp
@@ -31,38 +31,37 @@ namespace capi {
 
 namespace icu4x {
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `LocaleDisplayNamesFormatter`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.LocaleDisplayNamesFormatter.html) for more information.
+ *
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
  */
 class LocaleDisplayNamesFormatter {
 public:
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * Creates a new `LocaleDisplayNamesFormatter` from locale data and an options bag using compiled data.
    *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.LocaleDisplayNamesFormatter.html#method.try_new) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::LocaleDisplayNamesFormatter>, icu4x::DataError> create_v1(const icu4x::Locale& locale, icu4x::DisplayNamesOptionsV1 options);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * Creates a new `LocaleDisplayNamesFormatter` from locale data and an options bag using a particular data source.
    *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/struct.LocaleDisplayNamesFormatter.html#method.try_new) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::LocaleDisplayNamesFormatter>, icu4x::DataError> create_v1_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, icu4x::DisplayNamesOptionsV1 options);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * Returns the locale-specific display name of a locale.
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    *
    * See the [Rust documentation for `of`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.LocaleDisplayNamesFormatter.html#method.of) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline std::string of(const icu4x::Locale& locale) const;
   template<typename W>

--- a/ffi/capi/bindings/cpp/icu4x/LocaleFallbackIterator.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/LocaleFallbackIterator.d.hpp
@@ -32,7 +32,7 @@ namespace icu4x {
 class LocaleFallbackIterator {
 public:
 
-  inline std::unique_ptr<icu4x::Locale> next();
+  inline icu4x::diplomat::maybe_null<std::unique_ptr<icu4x::Locale>> next();
 
     inline const icu4x::capi::LocaleFallbackIterator* AsFFI() const;
     inline icu4x::capi::LocaleFallbackIterator* AsFFI();

--- a/ffi/capi/bindings/cpp/icu4x/LocaleFallbackIterator.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/LocaleFallbackIterator.hpp
@@ -27,7 +27,7 @@ namespace capi {
 } // namespace capi
 } // namespace
 
-inline std::unique_ptr<icu4x::Locale> icu4x::LocaleFallbackIterator::next() {
+inline icu4x::diplomat::maybe_null<std::unique_ptr<icu4x::Locale>> icu4x::LocaleFallbackIterator::next() {
     auto result = icu4x::capi::icu4x_LocaleFallbackIterator_next_mv1(this->AsFFI());
     return std::unique_ptr<icu4x::Locale>(icu4x::Locale::FromFFI(result));
 }

--- a/ffi/capi/bindings/cpp/icu4x/LocaleNamesUnstable.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/LocaleNamesUnstable.d.hpp
@@ -29,8 +29,6 @@ namespace capi {
 
 namespace icu4x {
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * This struct holds free functions for loading display names for languages, scripts,
  * regions, and language identifiers.
  *
@@ -41,365 +39,367 @@ namespace icu4x {
  * See the [Rust documentation for `VariantDisplayName`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.VariantDisplayName.html) for more information.
  *
  * See the [Rust documentation for `LanguageIdentifierDisplayName`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html) for more information.
+ *
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
  */
 class LocaleNamesUnstable {
 public:
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_light_with_fallback) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static std::string for_region_light(const icu4x::Locale& locale, std::string_view region);
   template<typename W>
   inline static void for_region_light_write(const icu4x::Locale& locale, std::string_view region, W& writeable_output);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_light_with_fallback) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_region_light_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::string_view region);
   template<typename W>
   inline static icu4x::diplomat::result<std::monostate, icu4x::DataError> for_region_light_with_provider_write(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::string_view region, W& writeable_output);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_tiny_with_fallback) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static std::string for_region_tiny(const icu4x::Locale& locale, std::string_view region);
   template<typename W>
   inline static void for_region_tiny_write(const icu4x::Locale& locale, std::string_view region, W& writeable_output);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_tiny_with_fallback) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_region_tiny_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::string_view region);
   template<typename W>
   inline static icu4x::diplomat::result<std::monostate, icu4x::DataError> for_region_tiny_with_provider_write(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::string_view region, W& writeable_output);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `new_short_tiny_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_short_tiny_with_fallback) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static std::string for_region_short_tiny(const icu4x::Locale& locale, std::string_view region);
   template<typename W>
   inline static void for_region_short_tiny_write(const icu4x::Locale& locale, std::string_view region, W& writeable_output);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `new_short_tiny_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_short_tiny_with_fallback) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_region_short_tiny_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::string_view region);
   template<typename W>
   inline static icu4x::diplomat::result<std::monostate, icu4x::DataError> for_region_short_tiny_with_provider_write(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::string_view region, W& writeable_output);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `new_short_light_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_short_light_with_fallback) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static std::string for_region_short_light(const icu4x::Locale& locale, std::string_view region);
   template<typename W>
   inline static void for_region_short_light_write(const icu4x::Locale& locale, std::string_view region, W& writeable_output);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `new_short_light_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_short_light_with_fallback) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_region_short_light_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::string_view region);
   template<typename W>
   inline static icu4x::diplomat::result<std::monostate, icu4x::DataError> for_region_short_light_with_provider_write(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::string_view region, W& writeable_output);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_light_with_fallback) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static std::string for_script_light(const icu4x::Locale& locale, std::string_view script);
   template<typename W>
   inline static void for_script_light_write(const icu4x::Locale& locale, std::string_view script, W& writeable_output);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_light_with_fallback) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_script_light_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::string_view script);
   template<typename W>
   inline static icu4x::diplomat::result<std::monostate, icu4x::DataError> for_script_light_with_provider_write(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::string_view script, W& writeable_output);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_tiny_with_fallback) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static std::string for_script_tiny(const icu4x::Locale& locale, std::string_view script);
   template<typename W>
   inline static void for_script_tiny_write(const icu4x::Locale& locale, std::string_view script, W& writeable_output);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_tiny_with_fallback) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_script_tiny_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::string_view script);
   template<typename W>
   inline static icu4x::diplomat::result<std::monostate, icu4x::DataError> for_script_tiny_with_provider_write(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::string_view script, W& writeable_output);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_heavy_with_fallback) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static std::string for_script_heavy(const icu4x::Locale& locale, std::string_view script);
   template<typename W>
   inline static void for_script_heavy_write(const icu4x::Locale& locale, std::string_view script, W& writeable_output);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_heavy_with_fallback) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_script_heavy_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::string_view script);
   template<typename W>
   inline static icu4x::diplomat::result<std::monostate, icu4x::DataError> for_script_heavy_with_provider_write(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::string_view script, W& writeable_output);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `new_short_heavy_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_short_heavy_with_fallback) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static std::string for_script_short_heavy(const icu4x::Locale& locale, std::string_view script);
   template<typename W>
   inline static void for_script_short_heavy_write(const icu4x::Locale& locale, std::string_view script, W& writeable_output);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `new_short_heavy_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_short_heavy_with_fallback) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_script_short_heavy_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::string_view script);
   template<typename W>
   inline static icu4x::diplomat::result<std::monostate, icu4x::DataError> for_script_short_heavy_with_provider_write(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::string_view script, W& writeable_output);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.VariantDisplayName.html#method.new_heavy_with_fallback) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static std::string for_variant_heavy(const icu4x::Locale& locale, std::string_view variant);
   template<typename W>
   inline static void for_variant_heavy_write(const icu4x::Locale& locale, std::string_view variant, W& writeable_output);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.VariantDisplayName.html#method.new_heavy_with_fallback) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_variant_heavy_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::string_view variant);
   template<typename W>
   inline static icu4x::diplomat::result<std::monostate, icu4x::DataError> for_variant_heavy_with_provider_write(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::string_view variant, W& writeable_output);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_light) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_language_identifier_light(const icu4x::Locale& locale, const icu4x::Locale& langid, icu4x::LanguageDisplayUnstable language_display);
   template<typename W>
   inline static icu4x::diplomat::result<std::monostate, icu4x::DataError> for_language_identifier_light_write(const icu4x::Locale& locale, const icu4x::Locale& langid, icu4x::LanguageDisplayUnstable language_display, W& writeable_output);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_light) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_language_identifier_light_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::Locale& langid, icu4x::LanguageDisplayUnstable language_display);
   template<typename W>
   inline static icu4x::diplomat::result<std::monostate, icu4x::DataError> for_language_identifier_light_with_provider_write(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::Locale& langid, icu4x::LanguageDisplayUnstable language_display, W& writeable_output);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new_tiny`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_tiny) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_language_identifier_tiny(const icu4x::Locale& locale, const icu4x::Locale& langid, icu4x::LanguageDisplayUnstable language_display);
   template<typename W>
   inline static icu4x::diplomat::result<std::monostate, icu4x::DataError> for_language_identifier_tiny_write(const icu4x::Locale& locale, const icu4x::Locale& langid, icu4x::LanguageDisplayUnstable language_display, W& writeable_output);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new_tiny`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_tiny) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_language_identifier_tiny_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::Locale& langid, icu4x::LanguageDisplayUnstable language_display);
   template<typename W>
   inline static icu4x::diplomat::result<std::monostate, icu4x::DataError> for_language_identifier_tiny_with_provider_write(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::Locale& langid, icu4x::LanguageDisplayUnstable language_display, W& writeable_output);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new_short_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_light) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_language_identifier_short_light(const icu4x::Locale& locale, const icu4x::Locale& langid, icu4x::LanguageDisplayUnstable language_display);
   template<typename W>
   inline static icu4x::diplomat::result<std::monostate, icu4x::DataError> for_language_identifier_short_light_write(const icu4x::Locale& locale, const icu4x::Locale& langid, icu4x::LanguageDisplayUnstable language_display, W& writeable_output);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new_short_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_light) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_language_identifier_short_light_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::Locale& langid, icu4x::LanguageDisplayUnstable language_display);
   template<typename W>
   inline static icu4x::diplomat::result<std::monostate, icu4x::DataError> for_language_identifier_short_light_with_provider_write(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::Locale& langid, icu4x::LanguageDisplayUnstable language_display, W& writeable_output);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new_long_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_long_light) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_language_identifier_long_light(const icu4x::Locale& locale, const icu4x::Locale& langid, icu4x::LanguageDisplayUnstable language_display);
   template<typename W>
   inline static icu4x::diplomat::result<std::monostate, icu4x::DataError> for_language_identifier_long_light_write(const icu4x::Locale& locale, const icu4x::Locale& langid, icu4x::LanguageDisplayUnstable language_display, W& writeable_output);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new_long_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_long_light) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_language_identifier_long_light_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::Locale& langid, icu4x::LanguageDisplayUnstable language_display);
   template<typename W>
   inline static icu4x::diplomat::result<std::monostate, icu4x::DataError> for_language_identifier_long_light_with_provider_write(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::Locale& langid, icu4x::LanguageDisplayUnstable language_display, W& writeable_output);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new_menu_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_menu_light) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_language_identifier_menu_light(const icu4x::Locale& locale, const icu4x::Locale& langid, icu4x::LanguageDisplayUnstable language_display);
   template<typename W>
   inline static icu4x::diplomat::result<std::monostate, icu4x::DataError> for_language_identifier_menu_light_write(const icu4x::Locale& locale, const icu4x::Locale& langid, icu4x::LanguageDisplayUnstable language_display, W& writeable_output);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new_menu_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_menu_light) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_language_identifier_menu_light_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::Locale& langid, icu4x::LanguageDisplayUnstable language_display);
   template<typename W>
   inline static icu4x::diplomat::result<std::monostate, icu4x::DataError> for_language_identifier_menu_light_with_provider_write(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::Locale& langid, icu4x::LanguageDisplayUnstable language_display, W& writeable_output);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new_short_menu_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_menu_light) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_language_identifier_short_menu_light(const icu4x::Locale& locale, const icu4x::Locale& langid, icu4x::LanguageDisplayUnstable language_display);
   template<typename W>
   inline static icu4x::diplomat::result<std::monostate, icu4x::DataError> for_language_identifier_short_menu_light_write(const icu4x::Locale& locale, const icu4x::Locale& langid, icu4x::LanguageDisplayUnstable language_display, W& writeable_output);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new_short_menu_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_menu_light) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_language_identifier_short_menu_light_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::Locale& langid, icu4x::LanguageDisplayUnstable language_display);
   template<typename W>
   inline static icu4x::diplomat::result<std::monostate, icu4x::DataError> for_language_identifier_short_menu_light_with_provider_write(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::Locale& langid, icu4x::LanguageDisplayUnstable language_display, W& writeable_output);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_heavy) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_language_identifier_heavy(const icu4x::Locale& locale, const icu4x::Locale& langid, icu4x::LanguageDisplayUnstable language_display);
   template<typename W>
   inline static icu4x::diplomat::result<std::monostate, icu4x::DataError> for_language_identifier_heavy_write(const icu4x::Locale& locale, const icu4x::Locale& langid, icu4x::LanguageDisplayUnstable language_display, W& writeable_output);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_heavy) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_language_identifier_heavy_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::Locale& langid, icu4x::LanguageDisplayUnstable language_display);
   template<typename W>
   inline static icu4x::diplomat::result<std::monostate, icu4x::DataError> for_language_identifier_heavy_with_provider_write(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::Locale& langid, icu4x::LanguageDisplayUnstable language_display, W& writeable_output);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new_short_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_heavy) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_language_identifier_short_heavy(const icu4x::Locale& locale, const icu4x::Locale& langid, icu4x::LanguageDisplayUnstable language_display);
   template<typename W>
   inline static icu4x::diplomat::result<std::monostate, icu4x::DataError> for_language_identifier_short_heavy_write(const icu4x::Locale& locale, const icu4x::Locale& langid, icu4x::LanguageDisplayUnstable language_display, W& writeable_output);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new_short_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_heavy) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_language_identifier_short_heavy_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::Locale& langid, icu4x::LanguageDisplayUnstable language_display);
   template<typename W>
   inline static icu4x::diplomat::result<std::monostate, icu4x::DataError> for_language_identifier_short_heavy_with_provider_write(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::Locale& langid, icu4x::LanguageDisplayUnstable language_display, W& writeable_output);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new_long_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_long_heavy) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_language_identifier_long_heavy(const icu4x::Locale& locale, const icu4x::Locale& langid, icu4x::LanguageDisplayUnstable language_display);
   template<typename W>
   inline static icu4x::diplomat::result<std::monostate, icu4x::DataError> for_language_identifier_long_heavy_write(const icu4x::Locale& locale, const icu4x::Locale& langid, icu4x::LanguageDisplayUnstable language_display, W& writeable_output);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new_long_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_long_heavy) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_language_identifier_long_heavy_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::Locale& langid, icu4x::LanguageDisplayUnstable language_display);
   template<typename W>
   inline static icu4x::diplomat::result<std::monostate, icu4x::DataError> for_language_identifier_long_heavy_with_provider_write(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::Locale& langid, icu4x::LanguageDisplayUnstable language_display, W& writeable_output);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new_menu_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_menu_heavy) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_language_identifier_menu_heavy(const icu4x::Locale& locale, const icu4x::Locale& langid, icu4x::LanguageDisplayUnstable language_display);
   template<typename W>
   inline static icu4x::diplomat::result<std::monostate, icu4x::DataError> for_language_identifier_menu_heavy_write(const icu4x::Locale& locale, const icu4x::Locale& langid, icu4x::LanguageDisplayUnstable language_display, W& writeable_output);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new_menu_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_menu_heavy) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_language_identifier_menu_heavy_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::Locale& langid, icu4x::LanguageDisplayUnstable language_display);
   template<typename W>
   inline static icu4x::diplomat::result<std::monostate, icu4x::DataError> for_language_identifier_menu_heavy_with_provider_write(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::Locale& langid, icu4x::LanguageDisplayUnstable language_display, W& writeable_output);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new_short_menu_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_menu_heavy) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_language_identifier_short_menu_heavy(const icu4x::Locale& locale, const icu4x::Locale& langid, icu4x::LanguageDisplayUnstable language_display);
   template<typename W>
   inline static icu4x::diplomat::result<std::monostate, icu4x::DataError> for_language_identifier_short_menu_heavy_write(const icu4x::Locale& locale, const icu4x::Locale& langid, icu4x::LanguageDisplayUnstable language_display, W& writeable_output);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new_short_menu_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_menu_heavy) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::string, icu4x::DataError> for_language_identifier_short_menu_heavy_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, const icu4x::Locale& langid, icu4x::LanguageDisplayUnstable language_display);
   template<typename W>

--- a/ffi/capi/bindings/cpp/icu4x/PluralRulesWithRanges.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/PluralRulesWithRanges.d.hpp
@@ -34,6 +34,8 @@ namespace capi {
 namespace icu4x {
 /**
  * See the [Rust documentation for `PluralRulesWithRanges`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRulesWithRanges.html) for more information.
+ *
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
  */
 class PluralRulesWithRanges {
 public:
@@ -42,6 +44,8 @@ public:
    * construct a {@link PluralRulesWithRanges} for the given locale, for cardinal numbers, using compiled data.
    *
    * See the [Rust documentation for `try_new_cardinal`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRulesWithRanges.html#method.try_new_cardinal) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::PluralRulesWithRanges>, icu4x::DataError> create_cardinal(const icu4x::Locale& locale);
 
@@ -49,6 +53,8 @@ public:
    * construct a {@link PluralRulesWithRanges} for the given locale, for cardinal numbers, using a particular data source.
    *
    * See the [Rust documentation for `try_new_cardinal`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRulesWithRanges.html#method.try_new_cardinal) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::PluralRulesWithRanges>, icu4x::DataError> create_cardinal_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale);
 
@@ -56,6 +62,8 @@ public:
    * Construct a {@link PluralRulesWithRanges} for the given locale, for ordinal numbers, using compiled data.
    *
    * See the [Rust documentation for `try_new_ordinal`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRulesWithRanges.html#method.try_new_ordinal) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::PluralRulesWithRanges>, icu4x::DataError> create_ordinal(const icu4x::Locale& locale);
 
@@ -63,6 +71,8 @@ public:
    * Construct a {@link PluralRulesWithRanges} for the given locale, for ordinal numbers, using a particular data source.
    *
    * See the [Rust documentation for `try_new_ordinal`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRulesWithRanges.html#method.try_new_ordinal) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::PluralRulesWithRanges>, icu4x::DataError> create_ordinal_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale);
 
@@ -70,6 +80,8 @@ public:
    * Get the category for a given number represented as operands
    *
    * See the [Rust documentation for `category_for_range`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRulesWithRanges.html#method.category_for_range) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline icu4x::PluralCategory category_for_range(const icu4x::PluralOperands& start, const icu4x::PluralOperands& end) const;
 

--- a/ffi/capi/bindings/cpp/icu4x/RegionDisplayNames.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/RegionDisplayNames.d.hpp
@@ -32,39 +32,39 @@ namespace capi {
 
 namespace icu4x {
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `RegionDisplayNames`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.RegionDisplayNames.html) for more information.
+ *
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
  */
 class RegionDisplayNames {
 public:
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * Creates a new `RegionDisplayNames` from locale data and an options bag using compiled data.
    *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.RegionDisplayNames.html#method.try_new) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::RegionDisplayNames>, icu4x::DataError> create_v1(const icu4x::Locale& locale, icu4x::DisplayNamesOptionsV1 options);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * Creates a new `RegionDisplayNames` from locale data and an options bag using a particular data source.
    *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.RegionDisplayNames.html#method.try_new) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::RegionDisplayNames>, icu4x::DataError> create_v1_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, icu4x::DisplayNamesOptionsV1 options);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * Returns the locale specific display name of a region.
    * Note that the function returns an empty string in case the display name for a given
    * region code is not found.
    *
    * See the [Rust documentation for `of`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.RegionDisplayNames.html#method.of) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline icu4x::diplomat::result<std::string, icu4x::LocaleParseError> of(std::string_view region) const;
   template<typename W>

--- a/ffi/capi/bindings/cpp/icu4x/TimeRangeFormatter.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/TimeRangeFormatter.d.hpp
@@ -35,39 +35,39 @@ namespace capi {
 
 namespace icu4x {
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `NoCalendarRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html) for more information.
+ *
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
  */
 class TimeRangeFormatter {
 public:
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `T`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::TimeRangeFormatter>, icu4x::DateTimeFormatterLoadError> create(const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html#method.try_new) for more information.
    *
    * See the [Rust documentation for `T`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html) for more information.
    *
    * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.for_length)
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<std::unique_ptr<icu4x::TimeRangeFormatter>, icu4x::DateTimeFormatterLoadError> create_with_provider(const icu4x::DataProvider& provider, const icu4x::Locale& locale, std::optional<icu4x::DateTimeLength> length, std::optional<icu4x::TimePrecision> time_precision, std::optional<icu4x::DateTimeAlignment> alignment);
 
   /**
-   * 🚧 This API is unstable and may experience breaking changes outside major releases.
-   *
    * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html#method.format) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline std::string format(const icu4x::Time& start_time, const icu4x::Time& end_time) const;
   template<typename W>

--- a/ffi/capi/bindings/cpp/icu4x/TimeZoneInfo.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/TimeZoneInfo.d.hpp
@@ -56,7 +56,7 @@ public:
    *
    * `variant` is ignored.
    */
-  inline static std::unique_ptr<icu4x::TimeZoneInfo> from_parts(const icu4x::TimeZone& id, const icu4x::UtcOffset* offset, std::optional<icu4x::TimeZoneVariant> _variant);
+  inline static std::unique_ptr<icu4x::TimeZoneInfo> from_parts(const icu4x::TimeZone& id, icu4x::diplomat::maybe_null<const icu4x::UtcOffset*> offset, std::optional<icu4x::TimeZoneVariant> _variant);
 
   /**
    * See the [Rust documentation for `id`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZoneInfo.html#method.id) for more information.
@@ -130,7 +130,7 @@ public:
   /**
    * See the [Rust documentation for `offset`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZoneInfo.html#method.offset) for more information.
    */
-  inline std::unique_ptr<icu4x::UtcOffset> offset() const;
+  inline icu4x::diplomat::maybe_null<std::unique_ptr<icu4x::UtcOffset>> offset() const;
 
   /**
    * See the [Rust documentation for `infer_variant`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZoneInfo.html#method.infer_variant) for more information.

--- a/ffi/capi/bindings/cpp/icu4x/TimeZoneInfo.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/TimeZoneInfo.hpp
@@ -62,7 +62,7 @@ inline std::unique_ptr<icu4x::TimeZoneInfo> icu4x::TimeZoneInfo::utc() {
     return std::unique_ptr<icu4x::TimeZoneInfo>(icu4x::TimeZoneInfo::FromFFI(result));
 }
 
-inline std::unique_ptr<icu4x::TimeZoneInfo> icu4x::TimeZoneInfo::from_parts(const icu4x::TimeZone& id, const icu4x::UtcOffset* offset, std::optional<icu4x::TimeZoneVariant> _variant) {
+inline std::unique_ptr<icu4x::TimeZoneInfo> icu4x::TimeZoneInfo::from_parts(const icu4x::TimeZone& id, icu4x::diplomat::maybe_null<const icu4x::UtcOffset*> offset, std::optional<icu4x::TimeZoneVariant> _variant) {
     auto result = icu4x::capi::icu4x_TimeZoneInfo_from_parts_mv1(id.AsFFI(),
         offset ? offset->AsFFI() : nullptr,
         _variant.has_value() ? (icu4x::capi::TimeZoneVariant_option{ { _variant.value().AsFFI() }, true }) : (icu4x::capi::TimeZoneVariant_option{ {}, false }));
@@ -105,7 +105,7 @@ inline std::unique_ptr<icu4x::TimeZoneInfo> icu4x::TimeZoneInfo::with_variant(ic
     return std::unique_ptr<icu4x::TimeZoneInfo>(icu4x::TimeZoneInfo::FromFFI(result));
 }
 
-inline std::unique_ptr<icu4x::UtcOffset> icu4x::TimeZoneInfo::offset() const {
+inline icu4x::diplomat::maybe_null<std::unique_ptr<icu4x::UtcOffset>> icu4x::TimeZoneInfo::offset() const {
     auto result = icu4x::capi::icu4x_TimeZoneInfo_offset_mv1(this->AsFFI());
     return std::unique_ptr<icu4x::UtcOffset>(icu4x::UtcOffset::FromFFI(result));
 }

--- a/ffi/capi/bindings/cpp/icu4x/TimeZoneIterator.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/TimeZoneIterator.d.hpp
@@ -33,7 +33,7 @@ public:
   /**
    * See the [Rust documentation for `next`](https://docs.rs/icu/2.3.1/icu/time/zone/iana/struct.TimeZoneIter.html#method.next) for more information.
    */
-  inline std::unique_ptr<icu4x::TimeZone> next();
+  inline icu4x::diplomat::maybe_null<std::unique_ptr<icu4x::TimeZone>> next();
 
     inline const icu4x::capi::TimeZoneIterator* AsFFI() const;
     inline icu4x::capi::TimeZoneIterator* AsFFI();

--- a/ffi/capi/bindings/cpp/icu4x/TimeZoneIterator.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/TimeZoneIterator.hpp
@@ -27,7 +27,7 @@ namespace capi {
 } // namespace capi
 } // namespace
 
-inline std::unique_ptr<icu4x::TimeZone> icu4x::TimeZoneIterator::next() {
+inline icu4x::diplomat::maybe_null<std::unique_ptr<icu4x::TimeZone>> icu4x::TimeZoneIterator::next() {
     auto result = icu4x::capi::icu4x_TimeZoneIterator_next_mv1(this->AsFFI());
     return std::unique_ptr<icu4x::TimeZone>(icu4x::TimeZone::FromFFI(result));
 }

--- a/ffi/capi/bindings/cpp/icu4x/VariantOffsets.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/VariantOffsets.d.hpp
@@ -35,7 +35,7 @@ namespace icu4x {
  */
 struct VariantOffsets {
     std::unique_ptr<icu4x::UtcOffset> standard;
-    std::unique_ptr<icu4x::UtcOffset> daylight;
+    icu4x::diplomat::maybe_null<std::unique_ptr<icu4x::UtcOffset>> daylight;
 
     inline icu4x::capi::VariantOffsets AsFFI() const;
     inline static icu4x::VariantOffsets FromFFI(icu4x::capi::VariantOffsets c_struct);

--- a/ffi/capi/bindings/cpp/icu4x/WindowsParser.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/WindowsParser.d.hpp
@@ -57,7 +57,7 @@ public:
   /**
    * See the [Rust documentation for `parse`](https://docs.rs/icu/2.3.1/icu/time/zone/windows/struct.WindowsParserBorrowed.html#method.parse) for more information.
    */
-  inline std::unique_ptr<icu4x::TimeZone> parse(std::string_view value, std::string_view region) const;
+  inline icu4x::diplomat::maybe_null<std::unique_ptr<icu4x::TimeZone>> parse(std::string_view value, std::string_view region) const;
 
     inline const icu4x::capi::WindowsParser* AsFFI() const;
     inline icu4x::capi::WindowsParser* AsFFI();

--- a/ffi/capi/bindings/cpp/icu4x/WindowsParser.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/WindowsParser.hpp
@@ -44,7 +44,7 @@ inline icu4x::diplomat::result<std::unique_ptr<icu4x::WindowsParser>, icu4x::Dat
     return result.is_ok ? icu4x::diplomat::result<std::unique_ptr<icu4x::WindowsParser>, icu4x::DataError>(icu4x::diplomat::Ok<std::unique_ptr<icu4x::WindowsParser>>(std::unique_ptr<icu4x::WindowsParser>(icu4x::WindowsParser::FromFFI(result.ok)))) : icu4x::diplomat::result<std::unique_ptr<icu4x::WindowsParser>, icu4x::DataError>(icu4x::diplomat::Err<icu4x::DataError>(icu4x::DataError::FromFFI(result.err)));
 }
 
-inline std::unique_ptr<icu4x::TimeZone> icu4x::WindowsParser::parse(std::string_view value, std::string_view region) const {
+inline icu4x::diplomat::maybe_null<std::unique_ptr<icu4x::TimeZone>> icu4x::WindowsParser::parse(std::string_view value, std::string_view region) const {
     auto result = icu4x::capi::icu4x_WindowsParser_parse_mv1(this->AsFFI(),
         {value.data(), value.size()},
         {region.data(), region.size()});

--- a/ffi/capi/bindings/cpp/icu4x/ZonedTime.d.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/ZonedTime.d.hpp
@@ -40,6 +40,8 @@ namespace icu4x {
  * An ICU4X `ZonedTime` object capable of containing a ISO-8601 time, and zone.
  *
  * See the [Rust documentation for `ZonedTime`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedTime.html) for more information.
+ *
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
  */
 struct ZonedTime {
     std::unique_ptr<icu4x::Time> time;
@@ -49,6 +51,8 @@ struct ZonedTime {
    * Creates a new {@link ZonedTime} from an IXDTF string.
    *
    * See the [Rust documentation for `try_strict_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedTime.html#method.try_strict_from_str) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<icu4x::ZonedTime, icu4x::Rfc9557ParseError> strict_from_string(std::string_view v, const icu4x::IanaParser& iana_parser);
 
@@ -56,6 +60,8 @@ struct ZonedTime {
    * Creates a new {@link ZonedTime} from a location-only IXDTF string.
    *
    * See the [Rust documentation for `try_location_only_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedTime.html#method.try_location_only_from_str) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<icu4x::ZonedTime, icu4x::Rfc9557ParseError> location_only_from_string(std::string_view v, const icu4x::IanaParser& iana_parser);
 
@@ -63,6 +69,8 @@ struct ZonedTime {
    * Creates a new {@link ZonedTime} from an offset-only IXDTF string.
    *
    * See the [Rust documentation for `try_offset_only_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedTime.html#method.try_offset_only_from_str) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<icu4x::ZonedTime, icu4x::Rfc9557ParseError> offset_only_from_string(std::string_view v);
 
@@ -70,6 +78,8 @@ struct ZonedTime {
    * Creates a new {@link ZonedTime} from an IXDTF string, without requiring the offset.
    *
    * See the [Rust documentation for `try_lenient_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedTime.html#method.try_lenient_from_str) for more information.
+   *
+   * 🚧 This API is unstable and may experience breaking changes outside major releases.
    */
   inline static icu4x::diplomat::result<icu4x::ZonedTime, icu4x::Rfc9557ParseError> lenient_from_string(std::string_view v, const icu4x::IanaParser& iana_parser);
 

--- a/ffi/capi/bindings/cpp/icu4x/diplomat_runtime.hpp
+++ b/ffi/capi/bindings/cpp/icu4x/diplomat_runtime.hpp
@@ -643,6 +643,10 @@ struct next_to_iter_helper {
   next_type _curr;
 };
 
+/// The type may be a nullptr
+template<typename T>
+using maybe_null = T;
+
 } // namespace diplomat
 } // namespace icu4x
 #endif

--- a/ffi/capi/config.toml
+++ b/ffi/capi/config.toml
@@ -3,6 +3,7 @@
 # (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 lib-name = "icu"
+semver_unstable_features = ["unstable", "experimental"]
 
 [demo-gen]
 module-name = "icu"

--- a/ffi/capi/src/date_range_formatter.rs
+++ b/ffi/capi/src/date_range_formatter.rs
@@ -28,7 +28,6 @@ pub mod ffi {
     #[cfg(feature = "buffer_provider")]
     use crate::unstable::provider::ffi::DataProvider;
 
-    /// 🚧 This API is unstable and may experience breaking changes outside major releases.
     #[diplomat::opaque]
     #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter, Struct)]
     pub struct DateRangeFormatter(
@@ -39,7 +38,6 @@ pub mod ffi {
     );
 
     impl DateRangeFormatter {
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "d")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::D, Struct)]
@@ -73,7 +71,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "d_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::D, Struct)]
@@ -109,7 +106,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "md")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::MD, Struct)]
@@ -143,7 +139,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "md_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::MD, Struct)]
@@ -179,7 +174,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "ymd")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::YMD, Struct)]
@@ -217,7 +211,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "ymd_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::YMD, Struct)]
@@ -256,7 +249,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "de")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::DE, Struct)]
@@ -290,7 +282,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "de_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::DE, Struct)]
@@ -326,7 +317,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "mde")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::MDE, Struct)]
@@ -360,7 +350,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "mde_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::MDE, Struct)]
@@ -396,7 +385,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "ymde")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::YMDE, Struct)]
@@ -433,7 +421,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "ymde_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::YMDE, Struct)]
@@ -472,7 +459,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "e")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::E, Struct)]
@@ -504,7 +490,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "e_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::E, Struct)]
@@ -538,7 +523,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "m")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::M, Struct)]
@@ -568,7 +552,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "m_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::M, Struct)]
@@ -600,7 +583,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "ym")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::YM, Struct)]
@@ -633,7 +615,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "ym_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::YM, Struct)]
@@ -668,7 +649,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "y")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Y, Struct)]
@@ -701,7 +681,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "y_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Y, Struct)]
@@ -736,7 +715,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::format, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::range::FormattedDateRange, Struct, hidden)]
         #[diplomat::rust_link(icu::datetime::range::FormattedDateRange::to_string, FnInStruct, hidden)]
@@ -753,7 +731,6 @@ pub mod ffi {
             let _infallible = self.0.format(&start_value, &end_value).write_to(write);
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::format, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::range::FormattedDateRange, Struct, hidden)]
         #[diplomat::rust_link(icu::datetime::range::FormattedDateRange::to_string, FnInStruct, hidden)]
@@ -773,7 +750,6 @@ pub mod ffi {
     }
     
 
-    /// 🚧 This API is unstable and may experience breaking changes outside major releases.
     #[diplomat::opaque]
     #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter, Struct)]
     pub struct DateRangeFormatterGregorian(
@@ -785,7 +761,6 @@ pub mod ffi {
     );
 
     impl DateRangeFormatterGregorian {
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "d")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::D, Struct)]
@@ -819,7 +794,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "d_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::D, Struct)]
@@ -855,7 +829,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "md")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::MD, Struct)]
@@ -889,7 +862,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "md_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::MD, Struct)]
@@ -925,7 +897,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "ymd")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::YMD, Struct)]
@@ -963,7 +934,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "ymd_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::YMD, Struct)]
@@ -1002,7 +972,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "de")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::DE, Struct)]
@@ -1036,7 +1005,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "de_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::DE, Struct)]
@@ -1072,7 +1040,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "mde")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::MDE, Struct)]
@@ -1106,7 +1073,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "mde_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::MDE, Struct)]
@@ -1142,7 +1108,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "ymde")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::YMDE, Struct)]
@@ -1179,7 +1144,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "ymde_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::YMDE, Struct)]
@@ -1218,7 +1182,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "e")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::E, Struct)]
@@ -1250,7 +1213,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "e_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::E, Struct)]
@@ -1284,7 +1246,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "m")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::M, Struct)]
@@ -1314,7 +1275,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "m_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::M, Struct)]
@@ -1346,7 +1306,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "ym")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::YM, Struct)]
@@ -1379,7 +1338,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "ym_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::YM, Struct)]
@@ -1414,7 +1372,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "y")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Y, Struct)]
@@ -1447,7 +1404,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "y_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::Y, Struct)]
@@ -1482,7 +1438,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::format, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::range::FormattedDateRange, Struct, hidden)]
         #[diplomat::rust_link(icu::datetime::range::FormattedDateRange::to_string, FnInStruct, hidden)]

--- a/ffi/capi/src/date_time_range_formatter.rs
+++ b/ffi/capi/src/date_time_range_formatter.rs
@@ -28,7 +28,6 @@ pub mod ffi {
     #[cfg(feature = "buffer_provider")]
     use crate::unstable::provider::ffi::DataProvider;
 
-    /// 🚧 This API is unstable and may experience breaking changes outside major releases.
     #[diplomat::opaque]
     #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter, Struct)]
     pub struct DateTimeRangeFormatter(
@@ -39,7 +38,6 @@ pub mod ffi {
     );
 
     impl DateTimeRangeFormatter {
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "dt")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::DT, Struct)]
@@ -72,7 +70,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "dt_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::DT, Struct)]
@@ -107,7 +104,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "mdt")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::MDT, Struct)]
@@ -140,7 +136,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "mdt_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::MDT, Struct)]
@@ -175,7 +170,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "ymdt")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::YMDT, Struct)]
@@ -212,7 +206,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "ymdt_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::YMDT, Struct)]
@@ -250,7 +243,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "det")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::DET, Struct)]
@@ -283,7 +275,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "det_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::DET, Struct)]
@@ -318,7 +309,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "mdet")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::MDET, Struct)]
@@ -351,7 +341,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "mdet_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::MDET, Struct)]
@@ -386,7 +375,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "ymdet")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::YMDET, Struct)]
@@ -422,7 +410,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "ymdet_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::YMDET, Struct)]
@@ -460,7 +447,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "et")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::ET, Struct)]
@@ -493,7 +479,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "et_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::ET, Struct)]
@@ -528,7 +513,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::format, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::range::FormattedDateRange, Struct, hidden)]
         #[diplomat::rust_link(icu::datetime::range::FormattedDateRange::to_string, FnInStruct, hidden)]
@@ -553,7 +537,6 @@ pub mod ffi {
             let _infallible = self.0.format(&start_value, &end_value).write_to(write);
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::rust_link(icu::datetime::range::DateRangeFormatter::format, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::range::FormattedDateRange, Struct, hidden)]
         #[diplomat::rust_link(icu::datetime::range::FormattedDateRange::to_string, FnInStruct, hidden)]
@@ -581,7 +564,6 @@ pub mod ffi {
     }
     
 
-    /// 🚧 This API is unstable and may experience breaking changes outside major releases.
     #[diplomat::opaque]
     #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter, Struct)]
     pub struct DateTimeRangeFormatterGregorian(
@@ -593,7 +575,6 @@ pub mod ffi {
     );
 
     impl DateTimeRangeFormatterGregorian {
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "dt")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::DT, Struct)]
@@ -626,7 +607,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "dt_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::DT, Struct)]
@@ -661,7 +641,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "mdt")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::MDT, Struct)]
@@ -694,7 +673,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "mdt_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::MDT, Struct)]
@@ -729,7 +707,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "ymdt")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::YMDT, Struct)]
@@ -766,7 +743,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "ymdt_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::YMDT, Struct)]
@@ -804,7 +780,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "det")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::DET, Struct)]
@@ -837,7 +812,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "det_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::DET, Struct)]
@@ -872,7 +846,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "mdet")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::MDET, Struct)]
@@ -905,7 +878,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "mdet_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::MDET, Struct)]
@@ -940,7 +912,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "ymdet")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::YMDET, Struct)]
@@ -976,7 +947,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "ymdet_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::YMDET, Struct)]
@@ -1014,7 +984,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "et")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::ET, Struct)]
@@ -1047,7 +1016,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "et_with_provider")]
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::try_new, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::fieldsets::ET, Struct)]
@@ -1082,7 +1050,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::rust_link(icu::datetime::range::FixedCalendarDateRangeFormatter::format, FnInStruct)]
         #[diplomat::rust_link(icu::datetime::range::FormattedDateRange, Struct, hidden)]
         #[diplomat::rust_link(icu::datetime::range::FormattedDateRange::to_string, FnInStruct, hidden)]

--- a/ffi/capi/src/displaynames.rs
+++ b/ffi/capi/src/displaynames.rs
@@ -17,7 +17,6 @@ pub mod ffi {
 
     use writeable::Writeable;
 
-    /// 🚧 This API is unstable and may experience breaking changes outside major releases.
     #[diplomat::opaque]
     #[diplomat::rust_link(
         icu::experimental::displaynames::multi::LocaleDisplayNamesFormatter,
@@ -27,12 +26,10 @@ pub mod ffi {
         pub icu_experimental::displaynames::multi::LocaleDisplayNamesFormatter,
     );
 
-    /// 🚧 This API is unstable and may experience breaking changes outside major releases.
     #[diplomat::opaque]
     #[diplomat::rust_link(icu::experimental::displaynames::multi::RegionDisplayNames, Struct)]
     pub struct RegionDisplayNames(pub icu_experimental::displaynames::multi::RegionDisplayNames);
 
-    /// 🚧 This API is unstable and may experience breaking changes outside major releases.
     #[diplomat::rust_link(icu::experimental::displaynames::DisplayNamesOptions, Struct)]
     #[diplomat::attr(supports = non_exhaustive_structs, rename = "DisplayNamesOptions")]
     pub struct DisplayNamesOptionsV1 {
@@ -45,7 +42,6 @@ pub mod ffi {
         pub language_display: DiplomatOption<LanguageDisplay>,
     }
 
-    /// 🚧 This API is unstable and may experience breaking changes outside major releases.
     #[diplomat::rust_link(icu::experimental::displaynames::Style, Enum)]
     #[diplomat::enum_convert(icu_experimental::displaynames::Style, needs_wildcard)]
     #[non_exhaustive]
@@ -56,7 +52,6 @@ pub mod ffi {
         Menu,
     }
 
-    /// 🚧 This API is unstable and may experience breaking changes outside major releases.
     #[diplomat::rust_link(icu::experimental::displaynames::Fallback, Enum)]
     #[diplomat::enum_convert(icu_experimental::displaynames::Fallback, needs_wildcard)]
     #[non_exhaustive]
@@ -66,7 +61,6 @@ pub mod ffi {
         None,
     }
 
-    /// 🚧 This API is unstable and may experience breaking changes outside major releases.
     #[diplomat::rust_link(icu::experimental::displaynames::LanguageDisplay, Enum)]
     #[diplomat::enum_convert(icu_experimental::displaynames::LanguageDisplay, needs_wildcard)]
     #[non_exhaustive]
@@ -77,8 +71,6 @@ pub mod ffi {
     }
 
     impl LocaleDisplayNamesFormatter {
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-        ///
         /// Creates a new `LocaleDisplayNamesFormatter` from locale data and an options bag using compiled data.
         #[diplomat::rust_link(
             icu::experimental::displaynames::multi::LocaleDisplayNamesFormatter::try_new,
@@ -102,8 +94,6 @@ pub mod ffi {
             )))
         }
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-        ///
         /// Creates a new `LocaleDisplayNamesFormatter` from locale data and an options bag using a particular data source.
         #[diplomat::rust_link(
             icu::experimental::displaynames::LocaleDisplayNamesFormatter::try_new,
@@ -128,15 +118,11 @@ pub mod ffi {
             )))
         }
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-        ///
         /// Returns the locale-specific display name of a locale.
         #[diplomat::rust_link(
             icu::experimental::displaynames::multi::LocaleDisplayNamesFormatter::of,
             FnInStruct
         )]
-
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         // Unstable, do not generate in demo:
         #[diplomat::attr(demo_gen, disable)]
         pub fn of(&self, locale: &Locale, write: &mut DiplomatWrite) {
@@ -145,8 +131,6 @@ pub mod ffi {
     }
 
     impl RegionDisplayNames {
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-        ///
         /// Creates a new `RegionDisplayNames` from locale data and an options bag using compiled data.
         #[diplomat::rust_link(
             icu::experimental::displaynames::multi::RegionDisplayNames::try_new,
@@ -167,8 +151,6 @@ pub mod ffi {
             )))
         }
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-        ///
         /// Creates a new `RegionDisplayNames` from locale data and an options bag using a particular data source.
         #[diplomat::rust_link(
             icu::experimental::displaynames::multi::RegionDisplayNames::try_new,
@@ -194,8 +176,6 @@ pub mod ffi {
             )))
         }
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-        ///
         /// Returns the locale specific display name of a region.
         /// Note that the function returns an empty string in case the display name for a given
         /// region code is not found.

--- a/ffi/capi/src/locale_names.rs
+++ b/ffi/capi/src/locale_names.rs
@@ -18,7 +18,6 @@ pub mod ffi {
     #[cfg(any(feature = "compiled_data", feature = "buffer_provider"))]
     use writeable::Writeable;
 
-    /// 🚧 This API is unstable and may experience breaking changes outside major releases.
     #[diplomat::rust_link(icu::locale::names::LanguageDisplay, Enum)]
     #[diplomat::enum_convert(icu_locale::names::LanguageDisplay, needs_wildcard)]
     #[non_exhaustive]
@@ -28,7 +27,6 @@ pub mod ffi {
         Standard,
     }
 
-    /// 🚧 This API is unstable and may experience breaking changes outside major releases.
     ///
     /// This struct holds free functions for loading display names for languages, scripts,
     /// regions, and language identifiers.
@@ -42,7 +40,6 @@ pub mod ffi {
     impl LocaleNamesUnstable {
         // --- Region ---
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "compiled_data")]
         #[diplomat::rust_link(
             icu::locale::names::RegionDisplayName::new_light_with_fallback,
@@ -76,7 +73,6 @@ pub mod ffi {
             let _infallible = display_name.write_to(write);
         }
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "buffer_provider")]
         #[diplomat::attr(demo_gen, disable)]
         #[diplomat::rust_link(
@@ -102,7 +98,6 @@ pub mod ffi {
             Ok(())
         }
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "compiled_data")]
         #[diplomat::rust_link(
             icu::locale::names::RegionDisplayName::new_tiny_with_fallback,
@@ -123,7 +118,6 @@ pub mod ffi {
             let _infallible = display_name.write_to(write);
         }
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "buffer_provider")]
         #[diplomat::attr(demo_gen, disable)]
         #[diplomat::rust_link(
@@ -149,7 +143,6 @@ pub mod ffi {
             Ok(())
         }
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "compiled_data")]
         #[diplomat::rust_link(
             icu::locale::names::RegionDisplayName::new_short_tiny_with_fallback,
@@ -170,7 +163,6 @@ pub mod ffi {
             let _infallible = display_name.write_to(write);
         }
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "buffer_provider")]
         #[diplomat::attr(demo_gen, disable)]
         #[diplomat::rust_link(
@@ -196,7 +188,6 @@ pub mod ffi {
             Ok(())
         }
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "compiled_data")]
         #[diplomat::rust_link(
             icu::locale::names::RegionDisplayName::new_short_light_with_fallback,
@@ -217,7 +208,6 @@ pub mod ffi {
             let _infallible = display_name.write_to(write);
         }
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "buffer_provider")]
         #[diplomat::attr(demo_gen, disable)]
         #[diplomat::rust_link(
@@ -245,7 +235,6 @@ pub mod ffi {
 
         // --- Script ---
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "compiled_data")]
         #[diplomat::rust_link(
             icu::locale::names::ScriptDisplayName::new_light_with_fallback,
@@ -279,7 +268,6 @@ pub mod ffi {
             let _infallible = display_name.write_to(write);
         }
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "buffer_provider")]
         #[diplomat::attr(demo_gen, disable)]
         #[diplomat::rust_link(
@@ -305,7 +293,6 @@ pub mod ffi {
             Ok(())
         }
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "compiled_data")]
         #[diplomat::rust_link(
             icu::locale::names::ScriptDisplayName::new_tiny_with_fallback,
@@ -326,7 +313,6 @@ pub mod ffi {
             let _infallible = display_name.write_to(write);
         }
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "buffer_provider")]
         #[diplomat::attr(demo_gen, disable)]
         #[diplomat::rust_link(
@@ -352,7 +338,6 @@ pub mod ffi {
             Ok(())
         }
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "compiled_data")]
         #[diplomat::rust_link(
             icu::locale::names::ScriptDisplayName::new_heavy_with_fallback,
@@ -373,7 +358,6 @@ pub mod ffi {
             let _infallible = display_name.write_to(write);
         }
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "buffer_provider")]
         #[diplomat::attr(demo_gen, disable)]
         #[diplomat::rust_link(
@@ -399,7 +383,6 @@ pub mod ffi {
             Ok(())
         }
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "compiled_data")]
         #[diplomat::rust_link(
             icu::locale::names::ScriptDisplayName::new_short_heavy_with_fallback,
@@ -420,7 +403,6 @@ pub mod ffi {
             let _infallible = display_name.write_to(write);
         }
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "buffer_provider")]
         #[diplomat::attr(demo_gen, disable)]
         #[diplomat::rust_link(
@@ -448,7 +430,6 @@ pub mod ffi {
 
         // --- Variant ---
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "compiled_data")]
         #[diplomat::rust_link(
             icu::locale::names::VariantDisplayName::new_heavy_with_fallback,
@@ -486,7 +467,6 @@ pub mod ffi {
             let _infallible = display_name.write_to(write);
         }
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "buffer_provider")]
         #[diplomat::attr(demo_gen, disable)]
         #[diplomat::rust_link(
@@ -514,7 +494,6 @@ pub mod ffi {
 
         // --- Language Identifier ---
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "compiled_data")]
         #[diplomat::rust_link(
             icu::locale::names::LanguageIdentifierDisplayName::try_new_light,
@@ -568,7 +547,6 @@ pub mod ffi {
             Ok(())
         }
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "buffer_provider")]
         #[diplomat::attr(demo_gen, disable)]
         #[diplomat::rust_link(
@@ -595,7 +573,6 @@ pub mod ffi {
             Ok(())
         }
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "compiled_data")]
         #[diplomat::rust_link(
             icu::locale::names::LanguageIdentifierDisplayName::try_new_tiny,
@@ -619,7 +596,6 @@ pub mod ffi {
             Ok(())
         }
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "buffer_provider")]
         #[diplomat::attr(demo_gen, disable)]
         #[diplomat::rust_link(
@@ -646,7 +622,6 @@ pub mod ffi {
             Ok(())
         }
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "compiled_data")]
         #[diplomat::rust_link(
             icu::locale::names::LanguageIdentifierDisplayName::try_new_short_light,
@@ -671,7 +646,6 @@ pub mod ffi {
             Ok(())
         }
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "buffer_provider")]
         #[diplomat::attr(demo_gen, disable)]
         #[diplomat::rust_link(
@@ -698,7 +672,6 @@ pub mod ffi {
             Ok(())
         }
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "compiled_data")]
         #[diplomat::rust_link(
             icu::locale::names::LanguageIdentifierDisplayName::try_new_long_light,
@@ -723,7 +696,6 @@ pub mod ffi {
             Ok(())
         }
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "buffer_provider")]
         #[diplomat::attr(demo_gen, disable)]
         #[diplomat::rust_link(
@@ -750,7 +722,6 @@ pub mod ffi {
             Ok(())
         }
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "compiled_data")]
         #[diplomat::rust_link(
             icu::locale::names::LanguageIdentifierDisplayName::try_new_menu_light,
@@ -775,7 +746,6 @@ pub mod ffi {
             Ok(())
         }
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "buffer_provider")]
         #[diplomat::attr(demo_gen, disable)]
         #[diplomat::rust_link(
@@ -802,7 +772,6 @@ pub mod ffi {
             Ok(())
         }
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "compiled_data")]
         #[diplomat::rust_link(
             icu::locale::names::LanguageIdentifierDisplayName::try_new_short_menu_light,
@@ -827,7 +796,6 @@ pub mod ffi {
             Ok(())
         }
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "buffer_provider")]
         #[diplomat::attr(demo_gen, disable)]
         #[diplomat::rust_link(
@@ -854,7 +822,6 @@ pub mod ffi {
             Ok(())
         }
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "compiled_data")]
         #[diplomat::rust_link(
             icu::locale::names::LanguageIdentifierDisplayName::try_new_heavy,
@@ -878,7 +845,6 @@ pub mod ffi {
             Ok(())
         }
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "buffer_provider")]
         #[diplomat::attr(demo_gen, disable)]
         #[diplomat::rust_link(
@@ -905,7 +871,6 @@ pub mod ffi {
             Ok(())
         }
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "compiled_data")]
         #[diplomat::rust_link(
             icu::locale::names::LanguageIdentifierDisplayName::try_new_short_heavy,
@@ -930,7 +895,6 @@ pub mod ffi {
             Ok(())
         }
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "buffer_provider")]
         #[diplomat::attr(demo_gen, disable)]
         #[diplomat::rust_link(
@@ -957,7 +921,6 @@ pub mod ffi {
             Ok(())
         }
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "compiled_data")]
         #[diplomat::rust_link(
             icu::locale::names::LanguageIdentifierDisplayName::try_new_long_heavy,
@@ -982,7 +945,6 @@ pub mod ffi {
             Ok(())
         }
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "buffer_provider")]
         #[diplomat::attr(demo_gen, disable)]
         #[diplomat::rust_link(
@@ -1009,7 +971,6 @@ pub mod ffi {
             Ok(())
         }
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "compiled_data")]
         #[diplomat::rust_link(
             icu::locale::names::LanguageIdentifierDisplayName::try_new_menu_heavy,
@@ -1034,7 +995,6 @@ pub mod ffi {
             Ok(())
         }
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "buffer_provider")]
         #[diplomat::attr(demo_gen, disable)]
         #[diplomat::rust_link(
@@ -1061,7 +1021,6 @@ pub mod ffi {
             Ok(())
         }
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "compiled_data")]
         #[diplomat::rust_link(
             icu::locale::names::LanguageIdentifierDisplayName::try_new_short_menu_heavy,
@@ -1086,7 +1045,6 @@ pub mod ffi {
             Ok(())
         }
 
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[cfg(feature = "buffer_provider")]
         #[diplomat::attr(demo_gen, disable)]
         #[diplomat::rust_link(

--- a/ffi/capi/src/time_range_formatter.rs
+++ b/ffi/capi/src/time_range_formatter.rs
@@ -27,7 +27,6 @@ pub mod ffi {
     #[cfg(feature = "buffer_provider")]
     use crate::unstable::provider::ffi::DataProvider;
 
-    /// 🚧 This API is unstable and may experience breaking changes outside major releases.
     #[diplomat::opaque]
     #[diplomat::rust_link(icu::datetime::range::NoCalendarRangeFormatter, Typedef)]
     pub struct TimeRangeFormatter(
@@ -39,7 +38,6 @@ pub mod ffi {
     );
 
     impl TimeRangeFormatter {
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(supports = fallible_constructors, constructor)]
         #[diplomat::rust_link(icu::datetime::range::NoCalendarRangeFormatter::try_new, FnInTypedef)]
         #[diplomat::rust_link(icu::datetime::fieldsets::T, Struct)]
@@ -80,7 +78,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::attr(all(supports = fallible_constructors, supports = named_constructors), named_constructor = "with_provider")]
         #[diplomat::rust_link(icu::datetime::range::NoCalendarRangeFormatter::try_new, FnInTypedef)]
         #[diplomat::rust_link(icu::datetime::fieldsets::T, Struct)]
@@ -122,7 +119,6 @@ pub mod ffi {
             )))
         }
         
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::rust_link(icu::datetime::range::NoCalendarRangeFormatter::format, FnInTypedef)]
         #[diplomat::rust_link(icu::datetime::range::FormattedDateRange, Struct, hidden)]
         #[diplomat::rust_link(icu::datetime::range::FormattedDateRange::to_string, FnInStruct, hidden)]

--- a/ffi/dart/lib/src/bindings/DateRangeFormatter.g.dart
+++ b/ffi/dart/lib/src/bindings/DateRangeFormatter.g.dart
@@ -3,9 +3,8 @@
 
 part of 'lib.g.dart';
 
-/// 🚧 This API is unstable and may experience breaking changes outside major releases.
-///
 /// See the [Rust documentation for `DateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html) for more information.
+@meta.experimental
 final class DateRangeFormatter implements ffi.Finalizable {
   final ffi.Pointer<ffi.Opaque> _ffi;
 
@@ -30,8 +29,6 @@ final class DateRangeFormatter implements ffi.Finalizable {
 
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_DateRangeFormatter_destroy_mv1));
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
@@ -39,6 +36,7 @@ final class DateRangeFormatter implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateRangeFormatter.d(Locale locale, {DateTimeLength? length, DateTimeAlignment? alignment}) {
     final result = _icu4x_DateRangeFormatter_create_d_mv1(locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -47,8 +45,6 @@ final class DateRangeFormatter implements ffi.Finalizable {
     return DateRangeFormatter._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
@@ -56,6 +52,7 @@ final class DateRangeFormatter implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateRangeFormatter.dWithProvider(DataProvider provider, Locale locale, {DateTimeLength? length, DateTimeAlignment? alignment}) {
     final result = _icu4x_DateRangeFormatter_create_d_with_provider_mv1(provider._ffi, locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -64,8 +61,6 @@ final class DateRangeFormatter implements ffi.Finalizable {
     return DateRangeFormatter._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
@@ -73,6 +68,7 @@ final class DateRangeFormatter implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateRangeFormatter.md(Locale locale, {DateTimeLength? length, DateTimeAlignment? alignment}) {
     final result = _icu4x_DateRangeFormatter_create_md_mv1(locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -81,8 +77,6 @@ final class DateRangeFormatter implements ffi.Finalizable {
     return DateRangeFormatter._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
@@ -90,6 +84,7 @@ final class DateRangeFormatter implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateRangeFormatter.mdWithProvider(DataProvider provider, Locale locale, {DateTimeLength? length, DateTimeAlignment? alignment}) {
     final result = _icu4x_DateRangeFormatter_create_md_with_provider_mv1(provider._ffi, locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -98,8 +93,6 @@ final class DateRangeFormatter implements ffi.Finalizable {
     return DateRangeFormatter._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
@@ -107,6 +100,7 @@ final class DateRangeFormatter implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateRangeFormatter.ymd(Locale locale, {DateTimeLength? length, DateTimeAlignment? alignment, YearStyle? yearStyle}) {
     final result = _icu4x_DateRangeFormatter_create_ymd_mv1(locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err(), yearStyle != null ? _ResultInt32Void.ok(yearStyle.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -115,8 +109,6 @@ final class DateRangeFormatter implements ffi.Finalizable {
     return DateRangeFormatter._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
@@ -124,6 +116,7 @@ final class DateRangeFormatter implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateRangeFormatter.ymdWithProvider(DataProvider provider, Locale locale, {DateTimeLength? length, DateTimeAlignment? alignment, YearStyle? yearStyle}) {
     final result = _icu4x_DateRangeFormatter_create_ymd_with_provider_mv1(provider._ffi, locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err(), yearStyle != null ? _ResultInt32Void.ok(yearStyle.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -132,8 +125,6 @@ final class DateRangeFormatter implements ffi.Finalizable {
     return DateRangeFormatter._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
@@ -141,6 +132,7 @@ final class DateRangeFormatter implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateRangeFormatter.de(Locale locale, {DateTimeLength? length, DateTimeAlignment? alignment}) {
     final result = _icu4x_DateRangeFormatter_create_de_mv1(locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -149,8 +141,6 @@ final class DateRangeFormatter implements ffi.Finalizable {
     return DateRangeFormatter._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
@@ -158,6 +148,7 @@ final class DateRangeFormatter implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateRangeFormatter.deWithProvider(DataProvider provider, Locale locale, {DateTimeLength? length, DateTimeAlignment? alignment}) {
     final result = _icu4x_DateRangeFormatter_create_de_with_provider_mv1(provider._ffi, locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -166,8 +157,6 @@ final class DateRangeFormatter implements ffi.Finalizable {
     return DateRangeFormatter._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
@@ -175,6 +164,7 @@ final class DateRangeFormatter implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateRangeFormatter.mde(Locale locale, {DateTimeLength? length, DateTimeAlignment? alignment}) {
     final result = _icu4x_DateRangeFormatter_create_mde_mv1(locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -183,8 +173,6 @@ final class DateRangeFormatter implements ffi.Finalizable {
     return DateRangeFormatter._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
@@ -192,6 +180,7 @@ final class DateRangeFormatter implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateRangeFormatter.mdeWithProvider(DataProvider provider, Locale locale, {DateTimeLength? length, DateTimeAlignment? alignment}) {
     final result = _icu4x_DateRangeFormatter_create_mde_with_provider_mv1(provider._ffi, locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -200,8 +189,6 @@ final class DateRangeFormatter implements ffi.Finalizable {
     return DateRangeFormatter._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
@@ -209,6 +196,7 @@ final class DateRangeFormatter implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateRangeFormatter.ymde(Locale locale, {DateTimeLength? length, DateTimeAlignment? alignment, YearStyle? yearStyle}) {
     final result = _icu4x_DateRangeFormatter_create_ymde_mv1(locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err(), yearStyle != null ? _ResultInt32Void.ok(yearStyle.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -217,8 +205,6 @@ final class DateRangeFormatter implements ffi.Finalizable {
     return DateRangeFormatter._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
@@ -226,6 +212,7 @@ final class DateRangeFormatter implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateRangeFormatter.ymdeWithProvider(DataProvider provider, Locale locale, {DateTimeLength? length, DateTimeAlignment? alignment, YearStyle? yearStyle}) {
     final result = _icu4x_DateRangeFormatter_create_ymde_with_provider_mv1(provider._ffi, locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err(), yearStyle != null ? _ResultInt32Void.ok(yearStyle.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -234,8 +221,6 @@ final class DateRangeFormatter implements ffi.Finalizable {
     return DateRangeFormatter._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
@@ -243,6 +228,7 @@ final class DateRangeFormatter implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateRangeFormatter.e(Locale locale, [DateTimeLength? length]) {
     final result = _icu4x_DateRangeFormatter_create_e_mv1(locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -251,8 +237,6 @@ final class DateRangeFormatter implements ffi.Finalizable {
     return DateRangeFormatter._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
@@ -260,6 +244,7 @@ final class DateRangeFormatter implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateRangeFormatter.eWithProvider(DataProvider provider, Locale locale, [DateTimeLength? length]) {
     final result = _icu4x_DateRangeFormatter_create_e_with_provider_mv1(provider._ffi, locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -268,8 +253,6 @@ final class DateRangeFormatter implements ffi.Finalizable {
     return DateRangeFormatter._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
@@ -277,6 +260,7 @@ final class DateRangeFormatter implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateRangeFormatter.m(Locale locale, {DateTimeLength? length, DateTimeAlignment? alignment}) {
     final result = _icu4x_DateRangeFormatter_create_m_mv1(locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -285,8 +269,6 @@ final class DateRangeFormatter implements ffi.Finalizable {
     return DateRangeFormatter._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
@@ -294,6 +276,7 @@ final class DateRangeFormatter implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateRangeFormatter.mWithProvider(DataProvider provider, Locale locale, {DateTimeLength? length, DateTimeAlignment? alignment}) {
     final result = _icu4x_DateRangeFormatter_create_m_with_provider_mv1(provider._ffi, locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -302,8 +285,6 @@ final class DateRangeFormatter implements ffi.Finalizable {
     return DateRangeFormatter._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
@@ -311,6 +292,7 @@ final class DateRangeFormatter implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateRangeFormatter.ym(Locale locale, {DateTimeLength? length, DateTimeAlignment? alignment, YearStyle? yearStyle}) {
     final result = _icu4x_DateRangeFormatter_create_ym_mv1(locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err(), yearStyle != null ? _ResultInt32Void.ok(yearStyle.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -319,8 +301,6 @@ final class DateRangeFormatter implements ffi.Finalizable {
     return DateRangeFormatter._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
@@ -328,6 +308,7 @@ final class DateRangeFormatter implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateRangeFormatter.ymWithProvider(DataProvider provider, Locale locale, {DateTimeLength? length, DateTimeAlignment? alignment, YearStyle? yearStyle}) {
     final result = _icu4x_DateRangeFormatter_create_ym_with_provider_mv1(provider._ffi, locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err(), yearStyle != null ? _ResultInt32Void.ok(yearStyle.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -336,8 +317,6 @@ final class DateRangeFormatter implements ffi.Finalizable {
     return DateRangeFormatter._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
@@ -345,6 +324,7 @@ final class DateRangeFormatter implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateRangeFormatter.y(Locale locale, {DateTimeLength? length, DateTimeAlignment? alignment, YearStyle? yearStyle}) {
     final result = _icu4x_DateRangeFormatter_create_y_mv1(locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err(), yearStyle != null ? _ResultInt32Void.ok(yearStyle.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -353,8 +333,6 @@ final class DateRangeFormatter implements ffi.Finalizable {
     return DateRangeFormatter._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
@@ -362,6 +340,7 @@ final class DateRangeFormatter implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateRangeFormatter.yWithProvider(DataProvider provider, Locale locale, {DateTimeLength? length, DateTimeAlignment? alignment, YearStyle? yearStyle}) {
     final result = _icu4x_DateRangeFormatter_create_y_with_provider_mv1(provider._ffi, locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err(), yearStyle != null ? _ResultInt32Void.ok(yearStyle.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -370,18 +349,16 @@ final class DateRangeFormatter implements ffi.Finalizable {
     return DateRangeFormatter._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
+  @meta.experimental
   String formatIso(IsoDate startIsoDate, IsoDate endIsoDate) {
     final write = _Write();
     _icu4x_DateRangeFormatter_format_iso_mv1(_ffi, startIsoDate._ffi, endIsoDate._ffi, write._ffi);
     return write.finalize();
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
+  @meta.experimental
   String formatSameCalendar(Date startDate, Date endDate) {
     final write = _Write();
     _icu4x_DateRangeFormatter_format_same_calendar_mv1(_ffi, startDate._ffi, endDate._ffi, write._ffi);

--- a/ffi/dart/lib/src/bindings/DateRangeFormatterGregorian.g.dart
+++ b/ffi/dart/lib/src/bindings/DateRangeFormatterGregorian.g.dart
@@ -3,9 +3,8 @@
 
 part of 'lib.g.dart';
 
-/// 🚧 This API is unstable and may experience breaking changes outside major releases.
-///
 /// See the [Rust documentation for `FixedCalendarDateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html) for more information.
+@meta.experimental
 final class DateRangeFormatterGregorian implements ffi.Finalizable {
   final ffi.Pointer<ffi.Opaque> _ffi;
 
@@ -30,8 +29,6 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
 
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_DateRangeFormatterGregorian_destroy_mv1));
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
@@ -39,6 +36,7 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateRangeFormatterGregorian.d(Locale locale, {DateTimeLength? length, DateTimeAlignment? alignment}) {
     final result = _icu4x_DateRangeFormatterGregorian_create_d_mv1(locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -47,8 +45,6 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
     return DateRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
@@ -56,6 +52,7 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateRangeFormatterGregorian.dWithProvider(DataProvider provider, Locale locale, {DateTimeLength? length, DateTimeAlignment? alignment}) {
     final result = _icu4x_DateRangeFormatterGregorian_create_d_with_provider_mv1(provider._ffi, locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -64,8 +61,6 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
     return DateRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
@@ -73,6 +68,7 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateRangeFormatterGregorian.md(Locale locale, {DateTimeLength? length, DateTimeAlignment? alignment}) {
     final result = _icu4x_DateRangeFormatterGregorian_create_md_mv1(locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -81,8 +77,6 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
     return DateRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
@@ -90,6 +84,7 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateRangeFormatterGregorian.mdWithProvider(DataProvider provider, Locale locale, {DateTimeLength? length, DateTimeAlignment? alignment}) {
     final result = _icu4x_DateRangeFormatterGregorian_create_md_with_provider_mv1(provider._ffi, locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -98,8 +93,6 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
     return DateRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
@@ -107,6 +100,7 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateRangeFormatterGregorian.ymd(Locale locale, {DateTimeLength? length, DateTimeAlignment? alignment, YearStyle? yearStyle}) {
     final result = _icu4x_DateRangeFormatterGregorian_create_ymd_mv1(locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err(), yearStyle != null ? _ResultInt32Void.ok(yearStyle.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -115,8 +109,6 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
     return DateRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
@@ -124,6 +116,7 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateRangeFormatterGregorian.ymdWithProvider(DataProvider provider, Locale locale, {DateTimeLength? length, DateTimeAlignment? alignment, YearStyle? yearStyle}) {
     final result = _icu4x_DateRangeFormatterGregorian_create_ymd_with_provider_mv1(provider._ffi, locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err(), yearStyle != null ? _ResultInt32Void.ok(yearStyle.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -132,8 +125,6 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
     return DateRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
@@ -141,6 +132,7 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateRangeFormatterGregorian.de(Locale locale, {DateTimeLength? length, DateTimeAlignment? alignment}) {
     final result = _icu4x_DateRangeFormatterGregorian_create_de_mv1(locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -149,8 +141,6 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
     return DateRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
@@ -158,6 +148,7 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateRangeFormatterGregorian.deWithProvider(DataProvider provider, Locale locale, {DateTimeLength? length, DateTimeAlignment? alignment}) {
     final result = _icu4x_DateRangeFormatterGregorian_create_de_with_provider_mv1(provider._ffi, locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -166,8 +157,6 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
     return DateRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
@@ -175,6 +164,7 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateRangeFormatterGregorian.mde(Locale locale, {DateTimeLength? length, DateTimeAlignment? alignment}) {
     final result = _icu4x_DateRangeFormatterGregorian_create_mde_mv1(locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -183,8 +173,6 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
     return DateRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
@@ -192,6 +180,7 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateRangeFormatterGregorian.mdeWithProvider(DataProvider provider, Locale locale, {DateTimeLength? length, DateTimeAlignment? alignment}) {
     final result = _icu4x_DateRangeFormatterGregorian_create_mde_with_provider_mv1(provider._ffi, locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -200,8 +189,6 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
     return DateRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
@@ -209,6 +196,7 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateRangeFormatterGregorian.ymde(Locale locale, {DateTimeLength? length, DateTimeAlignment? alignment, YearStyle? yearStyle}) {
     final result = _icu4x_DateRangeFormatterGregorian_create_ymde_mv1(locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err(), yearStyle != null ? _ResultInt32Void.ok(yearStyle.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -217,8 +205,6 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
     return DateRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
@@ -226,6 +212,7 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateRangeFormatterGregorian.ymdeWithProvider(DataProvider provider, Locale locale, {DateTimeLength? length, DateTimeAlignment? alignment, YearStyle? yearStyle}) {
     final result = _icu4x_DateRangeFormatterGregorian_create_ymde_with_provider_mv1(provider._ffi, locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err(), yearStyle != null ? _ResultInt32Void.ok(yearStyle.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -234,8 +221,6 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
     return DateRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
@@ -243,6 +228,7 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateRangeFormatterGregorian.e(Locale locale, [DateTimeLength? length]) {
     final result = _icu4x_DateRangeFormatterGregorian_create_e_mv1(locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -251,8 +237,6 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
     return DateRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
@@ -260,6 +244,7 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateRangeFormatterGregorian.eWithProvider(DataProvider provider, Locale locale, [DateTimeLength? length]) {
     final result = _icu4x_DateRangeFormatterGregorian_create_e_with_provider_mv1(provider._ffi, locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -268,8 +253,6 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
     return DateRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
@@ -277,6 +260,7 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateRangeFormatterGregorian.m(Locale locale, {DateTimeLength? length, DateTimeAlignment? alignment}) {
     final result = _icu4x_DateRangeFormatterGregorian_create_m_mv1(locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -285,8 +269,6 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
     return DateRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
@@ -294,6 +276,7 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateRangeFormatterGregorian.mWithProvider(DataProvider provider, Locale locale, {DateTimeLength? length, DateTimeAlignment? alignment}) {
     final result = _icu4x_DateRangeFormatterGregorian_create_m_with_provider_mv1(provider._ffi, locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -302,8 +285,6 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
     return DateRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
@@ -311,6 +292,7 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateRangeFormatterGregorian.ym(Locale locale, {DateTimeLength? length, DateTimeAlignment? alignment, YearStyle? yearStyle}) {
     final result = _icu4x_DateRangeFormatterGregorian_create_ym_mv1(locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err(), yearStyle != null ? _ResultInt32Void.ok(yearStyle.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -319,8 +301,6 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
     return DateRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
@@ -328,6 +308,7 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateRangeFormatterGregorian.ymWithProvider(DataProvider provider, Locale locale, {DateTimeLength? length, DateTimeAlignment? alignment, YearStyle? yearStyle}) {
     final result = _icu4x_DateRangeFormatterGregorian_create_ym_with_provider_mv1(provider._ffi, locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err(), yearStyle != null ? _ResultInt32Void.ok(yearStyle.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -336,8 +317,6 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
     return DateRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
@@ -345,6 +324,7 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateRangeFormatterGregorian.y(Locale locale, {DateTimeLength? length, DateTimeAlignment? alignment, YearStyle? yearStyle}) {
     final result = _icu4x_DateRangeFormatterGregorian_create_y_mv1(locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err(), yearStyle != null ? _ResultInt32Void.ok(yearStyle.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -353,8 +333,6 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
     return DateRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
@@ -362,6 +340,7 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateRangeFormatterGregorian.yWithProvider(DataProvider provider, Locale locale, {DateTimeLength? length, DateTimeAlignment? alignment, YearStyle? yearStyle}) {
     final result = _icu4x_DateRangeFormatterGregorian_create_y_with_provider_mv1(provider._ffi, locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err(), yearStyle != null ? _ResultInt32Void.ok(yearStyle.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -370,9 +349,8 @@ final class DateRangeFormatterGregorian implements ffi.Finalizable {
     return DateRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.format) for more information.
+  @meta.experimental
   String formatIso(IsoDate startIsoDate, IsoDate endIsoDate) {
     final write = _Write();
     _icu4x_DateRangeFormatterGregorian_format_iso_mv1(_ffi, startIsoDate._ffi, endIsoDate._ffi, write._ffi);

--- a/ffi/dart/lib/src/bindings/DateTimeRangeFormatter.g.dart
+++ b/ffi/dart/lib/src/bindings/DateTimeRangeFormatter.g.dart
@@ -3,9 +3,8 @@
 
 part of 'lib.g.dart';
 
-/// 🚧 This API is unstable and may experience breaking changes outside major releases.
-///
 /// See the [Rust documentation for `DateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html) for more information.
+@meta.experimental
 final class DateTimeRangeFormatter implements ffi.Finalizable {
   final ffi.Pointer<ffi.Opaque> _ffi;
 
@@ -30,8 +29,6 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
 
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_DateTimeRangeFormatter_destroy_mv1));
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
@@ -39,6 +36,7 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateTimeRangeFormatter.dt(Locale locale, {DateTimeLength? length, TimePrecision? timePrecision, DateTimeAlignment? alignment}) {
     final result = _icu4x_DateTimeRangeFormatter_create_dt_mv1(locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), timePrecision != null ? _ResultInt32Void.ok(timePrecision.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -47,8 +45,6 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
     return DateTimeRangeFormatter._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
@@ -56,6 +52,7 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateTimeRangeFormatter.dtWithProvider(DataProvider provider, Locale locale, {DateTimeLength? length, TimePrecision? timePrecision, DateTimeAlignment? alignment}) {
     final result = _icu4x_DateTimeRangeFormatter_create_dt_with_provider_mv1(provider._ffi, locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), timePrecision != null ? _ResultInt32Void.ok(timePrecision.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -64,8 +61,6 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
     return DateTimeRangeFormatter._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
@@ -73,6 +68,7 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateTimeRangeFormatter.mdt(Locale locale, {DateTimeLength? length, TimePrecision? timePrecision, DateTimeAlignment? alignment}) {
     final result = _icu4x_DateTimeRangeFormatter_create_mdt_mv1(locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), timePrecision != null ? _ResultInt32Void.ok(timePrecision.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -81,8 +77,6 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
     return DateTimeRangeFormatter._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
@@ -90,6 +84,7 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateTimeRangeFormatter.mdtWithProvider(DataProvider provider, Locale locale, {DateTimeLength? length, TimePrecision? timePrecision, DateTimeAlignment? alignment}) {
     final result = _icu4x_DateTimeRangeFormatter_create_mdt_with_provider_mv1(provider._ffi, locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), timePrecision != null ? _ResultInt32Void.ok(timePrecision.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -98,8 +93,6 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
     return DateTimeRangeFormatter._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
@@ -107,6 +100,7 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateTimeRangeFormatter.ymdt(Locale locale, {DateTimeLength? length, TimePrecision? timePrecision, DateTimeAlignment? alignment, YearStyle? yearStyle}) {
     final result = _icu4x_DateTimeRangeFormatter_create_ymdt_mv1(locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), timePrecision != null ? _ResultInt32Void.ok(timePrecision.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err(), yearStyle != null ? _ResultInt32Void.ok(yearStyle.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -115,8 +109,6 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
     return DateTimeRangeFormatter._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
@@ -124,6 +116,7 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateTimeRangeFormatter.ymdtWithProvider(DataProvider provider, Locale locale, {DateTimeLength? length, TimePrecision? timePrecision, DateTimeAlignment? alignment, YearStyle? yearStyle}) {
     final result = _icu4x_DateTimeRangeFormatter_create_ymdt_with_provider_mv1(provider._ffi, locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), timePrecision != null ? _ResultInt32Void.ok(timePrecision.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err(), yearStyle != null ? _ResultInt32Void.ok(yearStyle.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -132,8 +125,6 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
     return DateTimeRangeFormatter._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
@@ -141,6 +132,7 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateTimeRangeFormatter.det(Locale locale, {DateTimeLength? length, TimePrecision? timePrecision, DateTimeAlignment? alignment}) {
     final result = _icu4x_DateTimeRangeFormatter_create_det_mv1(locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), timePrecision != null ? _ResultInt32Void.ok(timePrecision.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -149,8 +141,6 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
     return DateTimeRangeFormatter._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
@@ -158,6 +148,7 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateTimeRangeFormatter.detWithProvider(DataProvider provider, Locale locale, {DateTimeLength? length, TimePrecision? timePrecision, DateTimeAlignment? alignment}) {
     final result = _icu4x_DateTimeRangeFormatter_create_det_with_provider_mv1(provider._ffi, locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), timePrecision != null ? _ResultInt32Void.ok(timePrecision.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -166,8 +157,6 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
     return DateTimeRangeFormatter._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
@@ -175,6 +164,7 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateTimeRangeFormatter.mdet(Locale locale, {DateTimeLength? length, TimePrecision? timePrecision, DateTimeAlignment? alignment}) {
     final result = _icu4x_DateTimeRangeFormatter_create_mdet_mv1(locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), timePrecision != null ? _ResultInt32Void.ok(timePrecision.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -183,8 +173,6 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
     return DateTimeRangeFormatter._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
@@ -192,6 +180,7 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateTimeRangeFormatter.mdetWithProvider(DataProvider provider, Locale locale, {DateTimeLength? length, TimePrecision? timePrecision, DateTimeAlignment? alignment}) {
     final result = _icu4x_DateTimeRangeFormatter_create_mdet_with_provider_mv1(provider._ffi, locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), timePrecision != null ? _ResultInt32Void.ok(timePrecision.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -200,8 +189,6 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
     return DateTimeRangeFormatter._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
@@ -209,6 +196,7 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateTimeRangeFormatter.ymdet(Locale locale, {DateTimeLength? length, TimePrecision? timePrecision, DateTimeAlignment? alignment, YearStyle? yearStyle}) {
     final result = _icu4x_DateTimeRangeFormatter_create_ymdet_mv1(locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), timePrecision != null ? _ResultInt32Void.ok(timePrecision.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err(), yearStyle != null ? _ResultInt32Void.ok(yearStyle.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -217,8 +205,6 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
     return DateTimeRangeFormatter._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
@@ -226,6 +212,7 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateTimeRangeFormatter.ymdetWithProvider(DataProvider provider, Locale locale, {DateTimeLength? length, TimePrecision? timePrecision, DateTimeAlignment? alignment, YearStyle? yearStyle}) {
     final result = _icu4x_DateTimeRangeFormatter_create_ymdet_with_provider_mv1(provider._ffi, locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), timePrecision != null ? _ResultInt32Void.ok(timePrecision.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err(), yearStyle != null ? _ResultInt32Void.ok(yearStyle.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -234,8 +221,6 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
     return DateTimeRangeFormatter._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
@@ -243,6 +228,7 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateTimeRangeFormatter.et(Locale locale, {DateTimeLength? length, TimePrecision? timePrecision, DateTimeAlignment? alignment}) {
     final result = _icu4x_DateTimeRangeFormatter_create_et_mv1(locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), timePrecision != null ? _ResultInt32Void.ok(timePrecision.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -251,8 +237,6 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
     return DateTimeRangeFormatter._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
@@ -260,6 +244,7 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateTimeRangeFormatter.etWithProvider(DataProvider provider, Locale locale, {DateTimeLength? length, TimePrecision? timePrecision, DateTimeAlignment? alignment}) {
     final result = _icu4x_DateTimeRangeFormatter_create_et_with_provider_mv1(provider._ffi, locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), timePrecision != null ? _ResultInt32Void.ok(timePrecision.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -268,18 +253,16 @@ final class DateTimeRangeFormatter implements ffi.Finalizable {
     return DateTimeRangeFormatter._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
+  @meta.experimental
   String formatIso(IsoDate startIsoDate, Time startTime, IsoDate endIsoDate, Time endTime) {
     final write = _Write();
     _icu4x_DateTimeRangeFormatter_format_iso_mv1(_ffi, startIsoDate._ffi, startTime._ffi, endIsoDate._ffi, endTime._ffi, write._ffi);
     return write.finalize();
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
+  @meta.experimental
   String formatSameCalendar(Date startDate, Time startTime, Date endDate, Time endTime) {
     final write = _Write();
     _icu4x_DateTimeRangeFormatter_format_same_calendar_mv1(_ffi, startDate._ffi, startTime._ffi, endDate._ffi, endTime._ffi, write._ffi);

--- a/ffi/dart/lib/src/bindings/DateTimeRangeFormatterGregorian.g.dart
+++ b/ffi/dart/lib/src/bindings/DateTimeRangeFormatterGregorian.g.dart
@@ -3,9 +3,8 @@
 
 part of 'lib.g.dart';
 
-/// 🚧 This API is unstable and may experience breaking changes outside major releases.
-///
 /// See the [Rust documentation for `FixedCalendarDateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html) for more information.
+@meta.experimental
 final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
   final ffi.Pointer<ffi.Opaque> _ffi;
 
@@ -30,8 +29,6 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
 
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_DateTimeRangeFormatterGregorian_destroy_mv1));
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
@@ -39,6 +36,7 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateTimeRangeFormatterGregorian.dt(Locale locale, {DateTimeLength? length, TimePrecision? timePrecision, DateTimeAlignment? alignment}) {
     final result = _icu4x_DateTimeRangeFormatterGregorian_create_dt_mv1(locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), timePrecision != null ? _ResultInt32Void.ok(timePrecision.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -47,8 +45,6 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
     return DateTimeRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
@@ -56,6 +52,7 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateTimeRangeFormatterGregorian.dtWithProvider(DataProvider provider, Locale locale, {DateTimeLength? length, TimePrecision? timePrecision, DateTimeAlignment? alignment}) {
     final result = _icu4x_DateTimeRangeFormatterGregorian_create_dt_with_provider_mv1(provider._ffi, locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), timePrecision != null ? _ResultInt32Void.ok(timePrecision.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -64,8 +61,6 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
     return DateTimeRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
@@ -73,6 +68,7 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateTimeRangeFormatterGregorian.mdt(Locale locale, {DateTimeLength? length, TimePrecision? timePrecision, DateTimeAlignment? alignment}) {
     final result = _icu4x_DateTimeRangeFormatterGregorian_create_mdt_mv1(locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), timePrecision != null ? _ResultInt32Void.ok(timePrecision.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -81,8 +77,6 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
     return DateTimeRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
@@ -90,6 +84,7 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateTimeRangeFormatterGregorian.mdtWithProvider(DataProvider provider, Locale locale, {DateTimeLength? length, TimePrecision? timePrecision, DateTimeAlignment? alignment}) {
     final result = _icu4x_DateTimeRangeFormatterGregorian_create_mdt_with_provider_mv1(provider._ffi, locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), timePrecision != null ? _ResultInt32Void.ok(timePrecision.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -98,8 +93,6 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
     return DateTimeRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
@@ -107,6 +100,7 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateTimeRangeFormatterGregorian.ymdt(Locale locale, {DateTimeLength? length, TimePrecision? timePrecision, DateTimeAlignment? alignment, YearStyle? yearStyle}) {
     final result = _icu4x_DateTimeRangeFormatterGregorian_create_ymdt_mv1(locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), timePrecision != null ? _ResultInt32Void.ok(timePrecision.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err(), yearStyle != null ? _ResultInt32Void.ok(yearStyle.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -115,8 +109,6 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
     return DateTimeRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
@@ -124,6 +116,7 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateTimeRangeFormatterGregorian.ymdtWithProvider(DataProvider provider, Locale locale, {DateTimeLength? length, TimePrecision? timePrecision, DateTimeAlignment? alignment, YearStyle? yearStyle}) {
     final result = _icu4x_DateTimeRangeFormatterGregorian_create_ymdt_with_provider_mv1(provider._ffi, locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), timePrecision != null ? _ResultInt32Void.ok(timePrecision.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err(), yearStyle != null ? _ResultInt32Void.ok(yearStyle.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -132,8 +125,6 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
     return DateTimeRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
@@ -141,6 +132,7 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateTimeRangeFormatterGregorian.det(Locale locale, {DateTimeLength? length, TimePrecision? timePrecision, DateTimeAlignment? alignment}) {
     final result = _icu4x_DateTimeRangeFormatterGregorian_create_det_mv1(locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), timePrecision != null ? _ResultInt32Void.ok(timePrecision.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -149,8 +141,6 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
     return DateTimeRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
@@ -158,6 +148,7 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateTimeRangeFormatterGregorian.detWithProvider(DataProvider provider, Locale locale, {DateTimeLength? length, TimePrecision? timePrecision, DateTimeAlignment? alignment}) {
     final result = _icu4x_DateTimeRangeFormatterGregorian_create_det_with_provider_mv1(provider._ffi, locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), timePrecision != null ? _ResultInt32Void.ok(timePrecision.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -166,8 +157,6 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
     return DateTimeRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
@@ -175,6 +164,7 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateTimeRangeFormatterGregorian.mdet(Locale locale, {DateTimeLength? length, TimePrecision? timePrecision, DateTimeAlignment? alignment}) {
     final result = _icu4x_DateTimeRangeFormatterGregorian_create_mdet_mv1(locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), timePrecision != null ? _ResultInt32Void.ok(timePrecision.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -183,8 +173,6 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
     return DateTimeRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
@@ -192,6 +180,7 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateTimeRangeFormatterGregorian.mdetWithProvider(DataProvider provider, Locale locale, {DateTimeLength? length, TimePrecision? timePrecision, DateTimeAlignment? alignment}) {
     final result = _icu4x_DateTimeRangeFormatterGregorian_create_mdet_with_provider_mv1(provider._ffi, locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), timePrecision != null ? _ResultInt32Void.ok(timePrecision.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -200,8 +189,6 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
     return DateTimeRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
@@ -209,6 +196,7 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateTimeRangeFormatterGregorian.ymdet(Locale locale, {DateTimeLength? length, TimePrecision? timePrecision, DateTimeAlignment? alignment, YearStyle? yearStyle}) {
     final result = _icu4x_DateTimeRangeFormatterGregorian_create_ymdet_mv1(locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), timePrecision != null ? _ResultInt32Void.ok(timePrecision.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err(), yearStyle != null ? _ResultInt32Void.ok(yearStyle.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -217,8 +205,6 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
     return DateTimeRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
@@ -226,6 +212,7 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateTimeRangeFormatterGregorian.ymdetWithProvider(DataProvider provider, Locale locale, {DateTimeLength? length, TimePrecision? timePrecision, DateTimeAlignment? alignment, YearStyle? yearStyle}) {
     final result = _icu4x_DateTimeRangeFormatterGregorian_create_ymdet_with_provider_mv1(provider._ffi, locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), timePrecision != null ? _ResultInt32Void.ok(timePrecision.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err(), yearStyle != null ? _ResultInt32Void.ok(yearStyle.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -234,8 +221,6 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
     return DateTimeRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
@@ -243,6 +228,7 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateTimeRangeFormatterGregorian.et(Locale locale, {DateTimeLength? length, TimePrecision? timePrecision, DateTimeAlignment? alignment}) {
     final result = _icu4x_DateTimeRangeFormatterGregorian_create_et_mv1(locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), timePrecision != null ? _ResultInt32Void.ok(timePrecision.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -251,8 +237,6 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
     return DateTimeRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
@@ -260,6 +244,7 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory DateTimeRangeFormatterGregorian.etWithProvider(DataProvider provider, Locale locale, {DateTimeLength? length, TimePrecision? timePrecision, DateTimeAlignment? alignment}) {
     final result = _icu4x_DateTimeRangeFormatterGregorian_create_et_with_provider_mv1(provider._ffi, locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), timePrecision != null ? _ResultInt32Void.ok(timePrecision.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -268,9 +253,8 @@ final class DateTimeRangeFormatterGregorian implements ffi.Finalizable {
     return DateTimeRangeFormatterGregorian._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.format) for more information.
+  @meta.experimental
   String formatIso(IsoDate startIsoDate, Time startTime, IsoDate endIsoDate, Time endTime) {
     final write = _Write();
     _icu4x_DateTimeRangeFormatterGregorian_format_iso_mv1(_ffi, startIsoDate._ffi, startTime._ffi, endIsoDate._ffi, endTime._ffi, write._ffi);

--- a/ffi/dart/lib/src/bindings/DisplayNamesFallback.g.dart
+++ b/ffi/dart/lib/src/bindings/DisplayNamesFallback.g.dart
@@ -3,9 +3,8 @@
 
 part of 'lib.g.dart';
 
-/// 🚧 This API is unstable and may experience breaking changes outside major releases.
-///
 /// See the [Rust documentation for `Fallback`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/enum.Fallback.html) for more information.
+@meta.experimental
 enum DisplayNamesFallback {
   // ignore: public_member_api_docs
   code,

--- a/ffi/dart/lib/src/bindings/DisplayNamesOptions.g.dart
+++ b/ffi/dart/lib/src/bindings/DisplayNamesOptions.g.dart
@@ -9,9 +9,8 @@ final class _DisplayNamesOptionsFfi extends ffi.Struct {
   external _ResultInt32Void languageDisplay;
 }
 
-/// 🚧 This API is unstable and may experience breaking changes outside major releases.
-///
 /// See the [Rust documentation for `DisplayNamesOptions`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/struct.DisplayNamesOptions.html) for more information.
+@meta.experimental
 final class DisplayNamesOptions {
   // ignore: public_member_api_docs
   DisplayNamesStyle? style;

--- a/ffi/dart/lib/src/bindings/DisplayNamesStyle.g.dart
+++ b/ffi/dart/lib/src/bindings/DisplayNamesStyle.g.dart
@@ -3,9 +3,8 @@
 
 part of 'lib.g.dart';
 
-/// 🚧 This API is unstable and may experience breaking changes outside major releases.
-///
 /// See the [Rust documentation for `Style`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/enum.Style.html) for more information.
+@meta.experimental
 enum DisplayNamesStyle {
   // ignore: public_member_api_docs
   narrow,

--- a/ffi/dart/lib/src/bindings/LanguageDisplay.g.dart
+++ b/ffi/dart/lib/src/bindings/LanguageDisplay.g.dart
@@ -3,9 +3,8 @@
 
 part of 'lib.g.dart';
 
-/// 🚧 This API is unstable and may experience breaking changes outside major releases.
-///
 /// See the [Rust documentation for `LanguageDisplay`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/enum.LanguageDisplay.html) for more information.
+@meta.experimental
 enum LanguageDisplay {
   // ignore: public_member_api_docs
   dialect,

--- a/ffi/dart/lib/src/bindings/LanguageDisplayUnstable.g.dart
+++ b/ffi/dart/lib/src/bindings/LanguageDisplayUnstable.g.dart
@@ -3,9 +3,8 @@
 
 part of 'lib.g.dart';
 
-/// 🚧 This API is unstable and may experience breaking changes outside major releases.
-///
 /// See the [Rust documentation for `LanguageDisplay`](https://docs.rs/icu/2.3.1/icu/locale/names/enum.LanguageDisplay.html) for more information.
+@meta.experimental
 enum LanguageDisplayUnstable {
   // ignore: public_member_api_docs
   dialect,

--- a/ffi/dart/lib/src/bindings/LocaleDisplayNamesFormatter.g.dart
+++ b/ffi/dart/lib/src/bindings/LocaleDisplayNamesFormatter.g.dart
@@ -3,9 +3,8 @@
 
 part of 'lib.g.dart';
 
-/// 🚧 This API is unstable and may experience breaking changes outside major releases.
-///
 /// See the [Rust documentation for `LocaleDisplayNamesFormatter`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.LocaleDisplayNamesFormatter.html) for more information.
+@meta.experimental
 final class LocaleDisplayNamesFormatter implements ffi.Finalizable {
   final ffi.Pointer<ffi.Opaque> _ffi;
 
@@ -30,13 +29,12 @@ final class LocaleDisplayNamesFormatter implements ffi.Finalizable {
 
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_LocaleDisplayNamesFormatter_destroy_mv1));
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// Creates a new `LocaleDisplayNamesFormatter` from locale data and an options bag using compiled data.
   ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.LocaleDisplayNamesFormatter.html#method.try_new) for more information.
   ///
   /// Throws [DataError] on failure.
+  @meta.experimental
   factory LocaleDisplayNamesFormatter(Locale locale, DisplayNamesOptions options) {
     final temp = _FinalizedArena();
     final result = _icu4x_LocaleDisplayNamesFormatter_create_v1_mv1(locale._ffi, options._toFfi(temp.arena));
@@ -46,13 +44,12 @@ final class LocaleDisplayNamesFormatter implements ffi.Finalizable {
     return LocaleDisplayNamesFormatter._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// Creates a new `LocaleDisplayNamesFormatter` from locale data and an options bag using a particular data source.
   ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/struct.LocaleDisplayNamesFormatter.html#method.try_new) for more information.
   ///
   /// Throws [DataError] on failure.
+  @meta.experimental
   factory LocaleDisplayNamesFormatter.createWithProvider(DataProvider provider, Locale locale, DisplayNamesOptions options) {
     final temp = _FinalizedArena();
     final result = _icu4x_LocaleDisplayNamesFormatter_create_v1_with_provider_mv1(provider._ffi, locale._ffi, options._toFfi(temp.arena));
@@ -62,12 +59,10 @@ final class LocaleDisplayNamesFormatter implements ffi.Finalizable {
     return LocaleDisplayNamesFormatter._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// Returns the locale-specific display name of a locale.
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
   ///
   /// See the [Rust documentation for `of`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.LocaleDisplayNamesFormatter.html#method.of) for more information.
+  @meta.experimental
   String of(Locale locale) {
     final write = _Write();
     _icu4x_LocaleDisplayNamesFormatter_of_mv1(_ffi, locale._ffi, write._ffi);

--- a/ffi/dart/lib/src/bindings/LocaleNamesUnstable.g.dart
+++ b/ffi/dart/lib/src/bindings/LocaleNamesUnstable.g.dart
@@ -3,8 +3,6 @@
 
 part of 'lib.g.dart';
 
-/// 🚧 This API is unstable and may experience breaking changes outside major releases.
-///
 /// This struct holds free functions for loading display names for languages, scripts,
 /// regions, and language identifiers.
 ///
@@ -15,6 +13,7 @@ part of 'lib.g.dart';
 /// See the [Rust documentation for `VariantDisplayName`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.VariantDisplayName.html) for more information.
 ///
 /// See the [Rust documentation for `LanguageIdentifierDisplayName`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html) for more information.
+@meta.experimental
 final class LocaleNamesUnstable implements ffi.Finalizable {
   final ffi.Pointer<ffi.Opaque> _ffi;
 
@@ -39,9 +38,8 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
 
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_LocaleNamesUnstable_destroy_mv1));
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_light_with_fallback) for more information.
+  @meta.experimental
   static String forRegionLight(Locale locale, String region) {
     final temp = _FinalizedArena();
     final write = _Write();
@@ -49,11 +47,10 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
     return write.finalize();
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_light_with_fallback) for more information.
   ///
   /// Throws [DataError] on failure.
+  @meta.experimental
   static String forRegionLightWithProvider(DataProvider provider, Locale locale, String region) {
     final temp = _FinalizedArena();
     final write = _Write();
@@ -64,9 +61,8 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
     return write.finalize();
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_tiny_with_fallback) for more information.
+  @meta.experimental
   static String forRegionTiny(Locale locale, String region) {
     final temp = _FinalizedArena();
     final write = _Write();
@@ -74,11 +70,10 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
     return write.finalize();
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_tiny_with_fallback) for more information.
   ///
   /// Throws [DataError] on failure.
+  @meta.experimental
   static String forRegionTinyWithProvider(DataProvider provider, Locale locale, String region) {
     final temp = _FinalizedArena();
     final write = _Write();
@@ -89,9 +84,8 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
     return write.finalize();
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `new_short_tiny_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_short_tiny_with_fallback) for more information.
+  @meta.experimental
   static String forRegionShortTiny(Locale locale, String region) {
     final temp = _FinalizedArena();
     final write = _Write();
@@ -99,11 +93,10 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
     return write.finalize();
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `new_short_tiny_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_short_tiny_with_fallback) for more information.
   ///
   /// Throws [DataError] on failure.
+  @meta.experimental
   static String forRegionShortTinyWithProvider(DataProvider provider, Locale locale, String region) {
     final temp = _FinalizedArena();
     final write = _Write();
@@ -114,9 +107,8 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
     return write.finalize();
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `new_short_light_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_short_light_with_fallback) for more information.
+  @meta.experimental
   static String forRegionShortLight(Locale locale, String region) {
     final temp = _FinalizedArena();
     final write = _Write();
@@ -124,11 +116,10 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
     return write.finalize();
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `new_short_light_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_short_light_with_fallback) for more information.
   ///
   /// Throws [DataError] on failure.
+  @meta.experimental
   static String forRegionShortLightWithProvider(DataProvider provider, Locale locale, String region) {
     final temp = _FinalizedArena();
     final write = _Write();
@@ -139,9 +130,8 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
     return write.finalize();
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_light_with_fallback) for more information.
+  @meta.experimental
   static String forScriptLight(Locale locale, String script) {
     final temp = _FinalizedArena();
     final write = _Write();
@@ -149,11 +139,10 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
     return write.finalize();
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_light_with_fallback) for more information.
   ///
   /// Throws [DataError] on failure.
+  @meta.experimental
   static String forScriptLightWithProvider(DataProvider provider, Locale locale, String script) {
     final temp = _FinalizedArena();
     final write = _Write();
@@ -164,9 +153,8 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
     return write.finalize();
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_tiny_with_fallback) for more information.
+  @meta.experimental
   static String forScriptTiny(Locale locale, String script) {
     final temp = _FinalizedArena();
     final write = _Write();
@@ -174,11 +162,10 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
     return write.finalize();
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_tiny_with_fallback) for more information.
   ///
   /// Throws [DataError] on failure.
+  @meta.experimental
   static String forScriptTinyWithProvider(DataProvider provider, Locale locale, String script) {
     final temp = _FinalizedArena();
     final write = _Write();
@@ -189,9 +176,8 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
     return write.finalize();
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_heavy_with_fallback) for more information.
+  @meta.experimental
   static String forScriptHeavy(Locale locale, String script) {
     final temp = _FinalizedArena();
     final write = _Write();
@@ -199,11 +185,10 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
     return write.finalize();
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_heavy_with_fallback) for more information.
   ///
   /// Throws [DataError] on failure.
+  @meta.experimental
   static String forScriptHeavyWithProvider(DataProvider provider, Locale locale, String script) {
     final temp = _FinalizedArena();
     final write = _Write();
@@ -214,9 +199,8 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
     return write.finalize();
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `new_short_heavy_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_short_heavy_with_fallback) for more information.
+  @meta.experimental
   static String forScriptShortHeavy(Locale locale, String script) {
     final temp = _FinalizedArena();
     final write = _Write();
@@ -224,11 +208,10 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
     return write.finalize();
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `new_short_heavy_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_short_heavy_with_fallback) for more information.
   ///
   /// Throws [DataError] on failure.
+  @meta.experimental
   static String forScriptShortHeavyWithProvider(DataProvider provider, Locale locale, String script) {
     final temp = _FinalizedArena();
     final write = _Write();
@@ -239,9 +222,8 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
     return write.finalize();
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.VariantDisplayName.html#method.new_heavy_with_fallback) for more information.
+  @meta.experimental
   static String forVariantHeavy(Locale locale, String variant) {
     final temp = _FinalizedArena();
     final write = _Write();
@@ -249,11 +231,10 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
     return write.finalize();
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.VariantDisplayName.html#method.new_heavy_with_fallback) for more information.
   ///
   /// Throws [DataError] on failure.
+  @meta.experimental
   static String forVariantHeavyWithProvider(DataProvider provider, Locale locale, String variant) {
     final temp = _FinalizedArena();
     final write = _Write();
@@ -264,11 +245,10 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
     return write.finalize();
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_light) for more information.
   ///
   /// Throws [DataError] on failure.
+  @meta.experimental
   static String forLanguageIdentifierLight(Locale locale, Locale langid, LanguageDisplayUnstable languageDisplay) {
     final write = _Write();
     final result = _icu4x_LocaleNamesUnstable_for_language_identifier_light_mv1(locale._ffi, langid._ffi, languageDisplay.index, write._ffi);
@@ -278,11 +258,10 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
     return write.finalize();
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_light) for more information.
   ///
   /// Throws [DataError] on failure.
+  @meta.experimental
   static String forLanguageIdentifierLightWithProvider(DataProvider provider, Locale locale, Locale langid, LanguageDisplayUnstable languageDisplay) {
     final write = _Write();
     final result = _icu4x_LocaleNamesUnstable_for_language_identifier_light_with_provider_mv1(provider._ffi, locale._ffi, langid._ffi, languageDisplay.index, write._ffi);
@@ -292,11 +271,10 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
     return write.finalize();
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new_tiny`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_tiny) for more information.
   ///
   /// Throws [DataError] on failure.
+  @meta.experimental
   static String forLanguageIdentifierTiny(Locale locale, Locale langid, LanguageDisplayUnstable languageDisplay) {
     final write = _Write();
     final result = _icu4x_LocaleNamesUnstable_for_language_identifier_tiny_mv1(locale._ffi, langid._ffi, languageDisplay.index, write._ffi);
@@ -306,11 +284,10 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
     return write.finalize();
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new_tiny`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_tiny) for more information.
   ///
   /// Throws [DataError] on failure.
+  @meta.experimental
   static String forLanguageIdentifierTinyWithProvider(DataProvider provider, Locale locale, Locale langid, LanguageDisplayUnstable languageDisplay) {
     final write = _Write();
     final result = _icu4x_LocaleNamesUnstable_for_language_identifier_tiny_with_provider_mv1(provider._ffi, locale._ffi, langid._ffi, languageDisplay.index, write._ffi);
@@ -320,11 +297,10 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
     return write.finalize();
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new_short_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_light) for more information.
   ///
   /// Throws [DataError] on failure.
+  @meta.experimental
   static String forLanguageIdentifierShortLight(Locale locale, Locale langid, LanguageDisplayUnstable languageDisplay) {
     final write = _Write();
     final result = _icu4x_LocaleNamesUnstable_for_language_identifier_short_light_mv1(locale._ffi, langid._ffi, languageDisplay.index, write._ffi);
@@ -334,11 +310,10 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
     return write.finalize();
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new_short_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_light) for more information.
   ///
   /// Throws [DataError] on failure.
+  @meta.experimental
   static String forLanguageIdentifierShortLightWithProvider(DataProvider provider, Locale locale, Locale langid, LanguageDisplayUnstable languageDisplay) {
     final write = _Write();
     final result = _icu4x_LocaleNamesUnstable_for_language_identifier_short_light_with_provider_mv1(provider._ffi, locale._ffi, langid._ffi, languageDisplay.index, write._ffi);
@@ -348,11 +323,10 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
     return write.finalize();
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new_long_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_long_light) for more information.
   ///
   /// Throws [DataError] on failure.
+  @meta.experimental
   static String forLanguageIdentifierLongLight(Locale locale, Locale langid, LanguageDisplayUnstable languageDisplay) {
     final write = _Write();
     final result = _icu4x_LocaleNamesUnstable_for_language_identifier_long_light_mv1(locale._ffi, langid._ffi, languageDisplay.index, write._ffi);
@@ -362,11 +336,10 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
     return write.finalize();
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new_long_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_long_light) for more information.
   ///
   /// Throws [DataError] on failure.
+  @meta.experimental
   static String forLanguageIdentifierLongLightWithProvider(DataProvider provider, Locale locale, Locale langid, LanguageDisplayUnstable languageDisplay) {
     final write = _Write();
     final result = _icu4x_LocaleNamesUnstable_for_language_identifier_long_light_with_provider_mv1(provider._ffi, locale._ffi, langid._ffi, languageDisplay.index, write._ffi);
@@ -376,11 +349,10 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
     return write.finalize();
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new_menu_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_menu_light) for more information.
   ///
   /// Throws [DataError] on failure.
+  @meta.experimental
   static String forLanguageIdentifierMenuLight(Locale locale, Locale langid, LanguageDisplayUnstable languageDisplay) {
     final write = _Write();
     final result = _icu4x_LocaleNamesUnstable_for_language_identifier_menu_light_mv1(locale._ffi, langid._ffi, languageDisplay.index, write._ffi);
@@ -390,11 +362,10 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
     return write.finalize();
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new_menu_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_menu_light) for more information.
   ///
   /// Throws [DataError] on failure.
+  @meta.experimental
   static String forLanguageIdentifierMenuLightWithProvider(DataProvider provider, Locale locale, Locale langid, LanguageDisplayUnstable languageDisplay) {
     final write = _Write();
     final result = _icu4x_LocaleNamesUnstable_for_language_identifier_menu_light_with_provider_mv1(provider._ffi, locale._ffi, langid._ffi, languageDisplay.index, write._ffi);
@@ -404,11 +375,10 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
     return write.finalize();
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new_short_menu_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_menu_light) for more information.
   ///
   /// Throws [DataError] on failure.
+  @meta.experimental
   static String forLanguageIdentifierShortMenuLight(Locale locale, Locale langid, LanguageDisplayUnstable languageDisplay) {
     final write = _Write();
     final result = _icu4x_LocaleNamesUnstable_for_language_identifier_short_menu_light_mv1(locale._ffi, langid._ffi, languageDisplay.index, write._ffi);
@@ -418,11 +388,10 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
     return write.finalize();
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new_short_menu_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_menu_light) for more information.
   ///
   /// Throws [DataError] on failure.
+  @meta.experimental
   static String forLanguageIdentifierShortMenuLightWithProvider(DataProvider provider, Locale locale, Locale langid, LanguageDisplayUnstable languageDisplay) {
     final write = _Write();
     final result = _icu4x_LocaleNamesUnstable_for_language_identifier_short_menu_light_with_provider_mv1(provider._ffi, locale._ffi, langid._ffi, languageDisplay.index, write._ffi);
@@ -432,11 +401,10 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
     return write.finalize();
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_heavy) for more information.
   ///
   /// Throws [DataError] on failure.
+  @meta.experimental
   static String forLanguageIdentifierHeavy(Locale locale, Locale langid, LanguageDisplayUnstable languageDisplay) {
     final write = _Write();
     final result = _icu4x_LocaleNamesUnstable_for_language_identifier_heavy_mv1(locale._ffi, langid._ffi, languageDisplay.index, write._ffi);
@@ -446,11 +414,10 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
     return write.finalize();
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_heavy) for more information.
   ///
   /// Throws [DataError] on failure.
+  @meta.experimental
   static String forLanguageIdentifierHeavyWithProvider(DataProvider provider, Locale locale, Locale langid, LanguageDisplayUnstable languageDisplay) {
     final write = _Write();
     final result = _icu4x_LocaleNamesUnstable_for_language_identifier_heavy_with_provider_mv1(provider._ffi, locale._ffi, langid._ffi, languageDisplay.index, write._ffi);
@@ -460,11 +427,10 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
     return write.finalize();
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new_short_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_heavy) for more information.
   ///
   /// Throws [DataError] on failure.
+  @meta.experimental
   static String forLanguageIdentifierShortHeavy(Locale locale, Locale langid, LanguageDisplayUnstable languageDisplay) {
     final write = _Write();
     final result = _icu4x_LocaleNamesUnstable_for_language_identifier_short_heavy_mv1(locale._ffi, langid._ffi, languageDisplay.index, write._ffi);
@@ -474,11 +440,10 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
     return write.finalize();
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new_short_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_heavy) for more information.
   ///
   /// Throws [DataError] on failure.
+  @meta.experimental
   static String forLanguageIdentifierShortHeavyWithProvider(DataProvider provider, Locale locale, Locale langid, LanguageDisplayUnstable languageDisplay) {
     final write = _Write();
     final result = _icu4x_LocaleNamesUnstable_for_language_identifier_short_heavy_with_provider_mv1(provider._ffi, locale._ffi, langid._ffi, languageDisplay.index, write._ffi);
@@ -488,11 +453,10 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
     return write.finalize();
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new_long_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_long_heavy) for more information.
   ///
   /// Throws [DataError] on failure.
+  @meta.experimental
   static String forLanguageIdentifierLongHeavy(Locale locale, Locale langid, LanguageDisplayUnstable languageDisplay) {
     final write = _Write();
     final result = _icu4x_LocaleNamesUnstable_for_language_identifier_long_heavy_mv1(locale._ffi, langid._ffi, languageDisplay.index, write._ffi);
@@ -502,11 +466,10 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
     return write.finalize();
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new_long_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_long_heavy) for more information.
   ///
   /// Throws [DataError] on failure.
+  @meta.experimental
   static String forLanguageIdentifierLongHeavyWithProvider(DataProvider provider, Locale locale, Locale langid, LanguageDisplayUnstable languageDisplay) {
     final write = _Write();
     final result = _icu4x_LocaleNamesUnstable_for_language_identifier_long_heavy_with_provider_mv1(provider._ffi, locale._ffi, langid._ffi, languageDisplay.index, write._ffi);
@@ -516,11 +479,10 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
     return write.finalize();
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new_menu_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_menu_heavy) for more information.
   ///
   /// Throws [DataError] on failure.
+  @meta.experimental
   static String forLanguageIdentifierMenuHeavy(Locale locale, Locale langid, LanguageDisplayUnstable languageDisplay) {
     final write = _Write();
     final result = _icu4x_LocaleNamesUnstable_for_language_identifier_menu_heavy_mv1(locale._ffi, langid._ffi, languageDisplay.index, write._ffi);
@@ -530,11 +492,10 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
     return write.finalize();
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new_menu_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_menu_heavy) for more information.
   ///
   /// Throws [DataError] on failure.
+  @meta.experimental
   static String forLanguageIdentifierMenuHeavyWithProvider(DataProvider provider, Locale locale, Locale langid, LanguageDisplayUnstable languageDisplay) {
     final write = _Write();
     final result = _icu4x_LocaleNamesUnstable_for_language_identifier_menu_heavy_with_provider_mv1(provider._ffi, locale._ffi, langid._ffi, languageDisplay.index, write._ffi);
@@ -544,11 +505,10 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
     return write.finalize();
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new_short_menu_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_menu_heavy) for more information.
   ///
   /// Throws [DataError] on failure.
+  @meta.experimental
   static String forLanguageIdentifierShortMenuHeavy(Locale locale, Locale langid, LanguageDisplayUnstable languageDisplay) {
     final write = _Write();
     final result = _icu4x_LocaleNamesUnstable_for_language_identifier_short_menu_heavy_mv1(locale._ffi, langid._ffi, languageDisplay.index, write._ffi);
@@ -558,11 +518,10 @@ final class LocaleNamesUnstable implements ffi.Finalizable {
     return write.finalize();
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new_short_menu_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_menu_heavy) for more information.
   ///
   /// Throws [DataError] on failure.
+  @meta.experimental
   static String forLanguageIdentifierShortMenuHeavyWithProvider(DataProvider provider, Locale locale, Locale langid, LanguageDisplayUnstable languageDisplay) {
     final write = _Write();
     final result = _icu4x_LocaleNamesUnstable_for_language_identifier_short_menu_heavy_with_provider_mv1(provider._ffi, locale._ffi, langid._ffi, languageDisplay.index, write._ffi);

--- a/ffi/dart/lib/src/bindings/PluralRulesWithRanges.g.dart
+++ b/ffi/dart/lib/src/bindings/PluralRulesWithRanges.g.dart
@@ -4,6 +4,7 @@
 part of 'lib.g.dart';
 
 /// See the [Rust documentation for `PluralRulesWithRanges`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRulesWithRanges.html) for more information.
+@meta.experimental
 final class PluralRulesWithRanges implements ffi.Finalizable {
   final ffi.Pointer<ffi.Opaque> _ffi;
 
@@ -33,6 +34,7 @@ final class PluralRulesWithRanges implements ffi.Finalizable {
   /// See the [Rust documentation for `try_new_cardinal`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRulesWithRanges.html#method.try_new_cardinal) for more information.
   ///
   /// Throws [DataError] on failure.
+  @meta.experimental
   factory PluralRulesWithRanges.cardinal(Locale locale) {
     final result = _icu4x_PluralRulesWithRanges_create_cardinal_mv1(locale._ffi);
     if (!result.isOk) {
@@ -46,6 +48,7 @@ final class PluralRulesWithRanges implements ffi.Finalizable {
   /// See the [Rust documentation for `try_new_cardinal`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRulesWithRanges.html#method.try_new_cardinal) for more information.
   ///
   /// Throws [DataError] on failure.
+  @meta.experimental
   factory PluralRulesWithRanges.cardinalWithProvider(DataProvider provider, Locale locale) {
     final result = _icu4x_PluralRulesWithRanges_create_cardinal_with_provider_mv1(provider._ffi, locale._ffi);
     if (!result.isOk) {
@@ -59,6 +62,7 @@ final class PluralRulesWithRanges implements ffi.Finalizable {
   /// See the [Rust documentation for `try_new_ordinal`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRulesWithRanges.html#method.try_new_ordinal) for more information.
   ///
   /// Throws [DataError] on failure.
+  @meta.experimental
   factory PluralRulesWithRanges.ordinal(Locale locale) {
     final result = _icu4x_PluralRulesWithRanges_create_ordinal_mv1(locale._ffi);
     if (!result.isOk) {
@@ -72,6 +76,7 @@ final class PluralRulesWithRanges implements ffi.Finalizable {
   /// See the [Rust documentation for `try_new_ordinal`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRulesWithRanges.html#method.try_new_ordinal) for more information.
   ///
   /// Throws [DataError] on failure.
+  @meta.experimental
   factory PluralRulesWithRanges.ordinalWithProvider(DataProvider provider, Locale locale) {
     final result = _icu4x_PluralRulesWithRanges_create_ordinal_with_provider_mv1(provider._ffi, locale._ffi);
     if (!result.isOk) {
@@ -83,6 +88,7 @@ final class PluralRulesWithRanges implements ffi.Finalizable {
   /// Get the category for a given number represented as operands
   ///
   /// See the [Rust documentation for `category_for_range`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRulesWithRanges.html#method.category_for_range) for more information.
+  @meta.experimental
   PluralCategory categoryForRange(PluralOperands start, PluralOperands end) {
     final result = _icu4x_PluralRulesWithRanges_category_for_range_mv1(_ffi, start._ffi, end._ffi);
     return PluralCategory.values[result];

--- a/ffi/dart/lib/src/bindings/RegionDisplayNames.g.dart
+++ b/ffi/dart/lib/src/bindings/RegionDisplayNames.g.dart
@@ -3,9 +3,8 @@
 
 part of 'lib.g.dart';
 
-/// 🚧 This API is unstable and may experience breaking changes outside major releases.
-///
 /// See the [Rust documentation for `RegionDisplayNames`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.RegionDisplayNames.html) for more information.
+@meta.experimental
 final class RegionDisplayNames implements ffi.Finalizable {
   final ffi.Pointer<ffi.Opaque> _ffi;
 
@@ -30,13 +29,12 @@ final class RegionDisplayNames implements ffi.Finalizable {
 
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_RegionDisplayNames_destroy_mv1));
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// Creates a new `RegionDisplayNames` from locale data and an options bag using compiled data.
   ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.RegionDisplayNames.html#method.try_new) for more information.
   ///
   /// Throws [DataError] on failure.
+  @meta.experimental
   factory RegionDisplayNames(Locale locale, DisplayNamesOptions options) {
     final temp = _FinalizedArena();
     final result = _icu4x_RegionDisplayNames_create_v1_mv1(locale._ffi, options._toFfi(temp.arena));
@@ -46,13 +44,12 @@ final class RegionDisplayNames implements ffi.Finalizable {
     return RegionDisplayNames._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// Creates a new `RegionDisplayNames` from locale data and an options bag using a particular data source.
   ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.RegionDisplayNames.html#method.try_new) for more information.
   ///
   /// Throws [DataError] on failure.
+  @meta.experimental
   factory RegionDisplayNames.createWithProvider(DataProvider provider, Locale locale, DisplayNamesOptions options) {
     final temp = _FinalizedArena();
     final result = _icu4x_RegionDisplayNames_create_v1_with_provider_mv1(provider._ffi, locale._ffi, options._toFfi(temp.arena));
@@ -62,8 +59,6 @@ final class RegionDisplayNames implements ffi.Finalizable {
     return RegionDisplayNames._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// Returns the locale specific display name of a region.
   /// Note that the function returns an empty string in case the display name for a given
   /// region code is not found.
@@ -71,6 +66,7 @@ final class RegionDisplayNames implements ffi.Finalizable {
   /// See the [Rust documentation for `of`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.RegionDisplayNames.html#method.of) for more information.
   ///
   /// Throws [LocaleParseError] on failure.
+  @meta.experimental
   String of(String region) {
     final temp = _FinalizedArena();
     final write = _Write();

--- a/ffi/dart/lib/src/bindings/TimeRangeFormatter.g.dart
+++ b/ffi/dart/lib/src/bindings/TimeRangeFormatter.g.dart
@@ -3,9 +3,8 @@
 
 part of 'lib.g.dart';
 
-/// 🚧 This API is unstable and may experience breaking changes outside major releases.
-///
 /// See the [Rust documentation for `NoCalendarRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html) for more information.
+@meta.experimental
 final class TimeRangeFormatter implements ffi.Finalizable {
   final ffi.Pointer<ffi.Opaque> _ffi;
 
@@ -30,8 +29,6 @@ final class TimeRangeFormatter implements ffi.Finalizable {
 
   static final _finalizer = ffi.NativeFinalizer(ffi.Native.addressOf(_internal_icu4x_TimeRangeFormatter_destroy_mv1));
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `T`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html) for more information.
@@ -39,6 +36,7 @@ final class TimeRangeFormatter implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory TimeRangeFormatter(Locale locale, {DateTimeLength? length, TimePrecision? timePrecision, DateTimeAlignment? alignment}) {
     final result = _icu4x_TimeRangeFormatter_create_mv1(locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), timePrecision != null ? _ResultInt32Void.ok(timePrecision.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -47,8 +45,6 @@ final class TimeRangeFormatter implements ffi.Finalizable {
     return TimeRangeFormatter._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html#method.try_new) for more information.
   ///
   /// See the [Rust documentation for `T`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html) for more information.
@@ -56,6 +52,7 @@ final class TimeRangeFormatter implements ffi.Finalizable {
   /// Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.for_length)
   ///
   /// Throws [DateTimeFormatterLoadError] on failure.
+  @meta.experimental
   factory TimeRangeFormatter.withProvider(DataProvider provider, Locale locale, {DateTimeLength? length, TimePrecision? timePrecision, DateTimeAlignment? alignment}) {
     final result = _icu4x_TimeRangeFormatter_create_with_provider_mv1(provider._ffi, locale._ffi, length != null ? _ResultInt32Void.ok(length.index) : _ResultInt32Void.err(), timePrecision != null ? _ResultInt32Void.ok(timePrecision.index) : _ResultInt32Void.err(), alignment != null ? _ResultInt32Void.ok(alignment.index) : _ResultInt32Void.err());
     if (!result.isOk) {
@@ -64,9 +61,8 @@ final class TimeRangeFormatter implements ffi.Finalizable {
     return TimeRangeFormatter._fromFfi(result.union.ok, []);
   }
 
-  /// 🚧 This API is unstable and may experience breaking changes outside major releases.
-  ///
   /// See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html#method.format) for more information.
+  @meta.experimental
   String format(Time startTime, Time endTime) {
     final write = _Write();
     _icu4x_TimeRangeFormatter_format_mv1(_ffi, startTime._ffi, endTime._ffi, write._ffi);

--- a/ffi/dart/lib/src/bindings/ZonedTime.g.dart
+++ b/ffi/dart/lib/src/bindings/ZonedTime.g.dart
@@ -11,6 +11,7 @@ final class _ZonedTimeFfi extends ffi.Struct {
 /// An ICU4X `ZonedTime` object capable of containing a ISO-8601 time, and zone.
 ///
 /// See the [Rust documentation for `ZonedTime`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedTime.html) for more information.
+@meta.experimental
 final class ZonedTime {
   // ignore: public_member_api_docs
   final Time time;
@@ -40,6 +41,7 @@ final class ZonedTime {
   /// See the [Rust documentation for `try_strict_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedTime.html#method.try_strict_from_str) for more information.
   ///
   /// Throws [Rfc9557ParseError] on failure.
+  @meta.experimental
   factory ZonedTime.strictFromString(String v, IanaParser ianaParser) {
     final temp = _FinalizedArena();
     final result = _icu4x_ZonedTime_strict_from_string_mv1(v._utf8AllocIn(temp.arena), ianaParser._ffi);
@@ -54,6 +56,7 @@ final class ZonedTime {
   /// See the [Rust documentation for `try_location_only_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedTime.html#method.try_location_only_from_str) for more information.
   ///
   /// Throws [Rfc9557ParseError] on failure.
+  @meta.experimental
   factory ZonedTime.locationOnlyFromString(String v, IanaParser ianaParser) {
     final temp = _FinalizedArena();
     final result = _icu4x_ZonedTime_location_only_from_string_mv1(v._utf8AllocIn(temp.arena), ianaParser._ffi);
@@ -68,6 +71,7 @@ final class ZonedTime {
   /// See the [Rust documentation for `try_offset_only_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedTime.html#method.try_offset_only_from_str) for more information.
   ///
   /// Throws [Rfc9557ParseError] on failure.
+  @meta.experimental
   factory ZonedTime.offsetOnlyFromString(String v) {
     final temp = _FinalizedArena();
     final result = _icu4x_ZonedTime_offset_only_from_string_mv1(v._utf8AllocIn(temp.arena));
@@ -82,6 +86,7 @@ final class ZonedTime {
   /// See the [Rust documentation for `try_lenient_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedTime.html#method.try_lenient_from_str) for more information.
   ///
   /// Throws [Rfc9557ParseError] on failure.
+  @meta.experimental
   factory ZonedTime.lenientFromString(String v, IanaParser ianaParser) {
     final temp = _FinalizedArena();
     final result = _icu4x_ZonedTime_lenient_from_string_mv1(v._utf8AllocIn(temp.arena), ianaParser._ffi);

--- a/ffi/dart/pubspec.yaml
+++ b/ffi/dart/pubspec.yaml
@@ -5,7 +5,7 @@
 name: icu4x
 description: > 
   Dart bindings for the Rust `icu` internationalization crate.
-version: 2.3.3
+version: 2.3.2
 repository: https://github.com/unicode-org/icu4x/tree/main/ffi/dart
 issue_tracker: https://github.com/unicode-org/icu4x/issues?q=is%3Aissue%20is%3Aopen%20label%3AU-flutter
 

--- a/ffi/dart/pubspec.yaml
+++ b/ffi/dart/pubspec.yaml
@@ -5,7 +5,7 @@
 name: icu4x
 description: > 
   Dart bindings for the Rust `icu` internationalization crate.
-version: 2.3.2
+version: 2.3.3
 repository: https://github.com/unicode-org/icu4x/tree/main/ffi/dart
 issue_tracker: https://github.com/unicode-org/icu4x/issues?q=is%3Aissue%20is%3Aopen%20label%3AU-flutter
 

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/Bidi.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/Bidi.kt
@@ -16,10 +16,11 @@ internal interface BidiLib: Library {
     fun icu4x_Bidi_level_rtl_mv1(): FFIUint8
     fun icu4x_Bidi_level_ltr_mv1(): FFIUint8
 }
-/** An ICU4X Bidi object, containing loaded bidi data
-*
-*See the [Rust documentation for `BidiClass`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.BidiClass.html) for more information.
-*/
+/**
+ * An ICU4X Bidi object, containing loaded bidi data
+ *
+ * See the [Rust documentation for `BidiClass`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.BidiClass.html) for more information.
+ */
 class Bidi internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -48,8 +49,9 @@ class Bidi internal constructor (
         internal val lib: BidiLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Creates a new [Bidi] from locale data using compiled data.
-        */
+        /**
+         * Creates a new [Bidi] from locale data using compiled data.
+         */
         fun create(): Bidi {
             
             val returnVal = lib.icu4x_Bidi_create_mv1();
@@ -60,8 +62,9 @@ class Bidi internal constructor (
         }
         @JvmStatic
         
-        /** Creates a new [Bidi] from locale data, and a particular data source.
-        */
+        /**
+         * Creates a new [Bidi] from locale data, and a particular data source.
+         */
         fun createWithProvider(provider: DataProvider): Result<Bidi> {
             
             val returnVal = lib.icu4x_Bidi_create_with_provider_mv1(provider.handle);
@@ -77,12 +80,13 @@ class Bidi internal constructor (
         }
         @JvmStatic
         
-        /** Check if a Level returned by `level_at` is an RTL level.
-        *
-        *Invalid levels (numbers greater than 125) will be assumed LTR
-        *
-        *See the [Rust documentation for `is_rtl`](https://docs.rs/unicode_bidi/0.3.11/unicode_bidi/level/struct.Level.html#method.is_rtl) for more information.
-        */
+        /**
+         * Check if a Level returned by `level_at` is an RTL level.
+         *
+         * Invalid levels (numbers greater than 125) will be assumed LTR
+         *
+         * See the [Rust documentation for `is_rtl`](https://docs.rs/unicode_bidi/0.3.11/unicode_bidi/level/struct.Level.html#method.is_rtl) for more information.
+         */
         fun levelIsRtl(level: UByte): Boolean {
             
             val returnVal = lib.icu4x_Bidi_level_is_rtl_mv1(FFIUint8(level));
@@ -90,12 +94,13 @@ class Bidi internal constructor (
         }
         @JvmStatic
         
-        /** Check if a Level returned by `level_at` is an LTR level.
-        *
-        *Invalid levels (numbers greater than 125) will be assumed LTR
-        *
-        *See the [Rust documentation for `is_ltr`](https://docs.rs/unicode_bidi/0.3.11/unicode_bidi/level/struct.Level.html#method.is_ltr) for more information.
-        */
+        /**
+         * Check if a Level returned by `level_at` is an LTR level.
+         *
+         * Invalid levels (numbers greater than 125) will be assumed LTR
+         *
+         * See the [Rust documentation for `is_ltr`](https://docs.rs/unicode_bidi/0.3.11/unicode_bidi/level/struct.Level.html#method.is_ltr) for more information.
+         */
         fun levelIsLtr(level: UByte): Boolean {
             
             val returnVal = lib.icu4x_Bidi_level_is_ltr_mv1(FFIUint8(level));
@@ -103,10 +108,11 @@ class Bidi internal constructor (
         }
         @JvmStatic
         
-        /** Get a basic RTL Level value
-        *
-        *See the [Rust documentation for `rtl`](https://docs.rs/unicode_bidi/0.3.11/unicode_bidi/level/struct.Level.html#method.rtl) for more information.
-        */
+        /**
+         * Get a basic RTL Level value
+         *
+         * See the [Rust documentation for `rtl`](https://docs.rs/unicode_bidi/0.3.11/unicode_bidi/level/struct.Level.html#method.rtl) for more information.
+         */
         fun levelRtl(): UByte {
             
             val returnVal = lib.icu4x_Bidi_level_rtl_mv1();
@@ -114,10 +120,11 @@ class Bidi internal constructor (
         }
         @JvmStatic
         
-        /** Get a simple LTR Level value
-        *
-        *See the [Rust documentation for `ltr`](https://docs.rs/unicode_bidi/0.3.11/unicode_bidi/level/struct.Level.html#method.ltr) for more information.
-        */
+        /**
+         * Get a simple LTR Level value
+         *
+         * See the [Rust documentation for `ltr`](https://docs.rs/unicode_bidi/0.3.11/unicode_bidi/level/struct.Level.html#method.ltr) for more information.
+         */
         fun levelLtr(): UByte {
             
             val returnVal = lib.icu4x_Bidi_level_ltr_mv1();
@@ -125,12 +132,13 @@ class Bidi internal constructor (
         }
     }
     
-    /** Use the data loaded in this object to process a string and calculate bidi information
-    *
-    *Takes in a Level for the default level, if it is an invalid value it will default to LTR
-    *
-    *See the [Rust documentation for `new_with_data_source`](https://docs.rs/unicode_bidi/0.3.11/unicode_bidi/struct.BidiInfo.html#method.new_with_data_source) for more information.
-    */
+    /**
+     * Use the data loaded in this object to process a string and calculate bidi information
+     *
+     * Takes in a Level for the default level, if it is an invalid value it will default to LTR
+     *
+     * See the [Rust documentation for `new_with_data_source`](https://docs.rs/unicode_bidi/0.3.11/unicode_bidi/struct.BidiInfo.html#method.new_with_data_source) for more information.
+     */
     fun for_text(text: String, defaultLevel: UByte?): BidiInfo {
         // This lifetime edge depends on lifetimes: 'text
         val textEdges: MutableList<Any> = mutableListOf();
@@ -143,17 +151,18 @@ class Bidi internal constructor (
         return returnOpaque
     }
     
-    /** Utility function for producing reorderings given a list of levels
-    *
-    *Produces a map saying which visual index maps to which source index.
-    *
-    *The levels array must not have values greater than 126 (this is the
-    *Bidi maximum explicit depth plus one).
-    *Failure to follow this invariant may lead to incorrect results,
-    *but is still safe.
-    *
-    *See the [Rust documentation for `reorder_visual`](https://docs.rs/unicode_bidi/0.3.11/unicode_bidi/struct.BidiInfo.html#method.reorder_visual) for more information.
-    */
+    /**
+     * Utility function for producing reorderings given a list of levels
+     *
+     * Produces a map saying which visual index maps to which source index.
+     *
+     * The levels array must not have values greater than 126 (this is the
+     * Bidi maximum explicit depth plus one).
+     * Failure to follow this invariant may lead to incorrect results,
+     * but is still safe.
+     *
+     * See the [Rust documentation for `reorder_visual`](https://docs.rs/unicode_bidi/0.3.11/unicode_bidi/struct.BidiInfo.html#method.reorder_visual) for more information.
+     */
     fun reorderVisual(levels: UByteArray): ReorderedIndexMap {
         val levelsSliceMemory = PrimitiveArrayTools.borrow(levels)
         

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/BidiClass.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/BidiClass.kt
@@ -14,7 +14,8 @@ internal interface BidiClassLib: Library {
     fun icu4x_BidiClass_from_integer_value_mv1(other: FFIUint8): OptionInt
     fun icu4x_BidiClass_try_from_str_mv1(s: Slice): OptionInt
 }
-/** See the [Rust documentation for `BidiClass`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.BidiClass.html) for more information.
+/**
+ * See the [Rust documentation for `BidiClass`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.BidiClass.html) for more information.
 */
 enum class BidiClass {
     LeftToRight,
@@ -58,8 +59,9 @@ enum class BidiClass {
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.EnumeratedProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.EnumeratedProperty.html#tymethod.for_char) for more information.
+         */
         fun forChar(ch: Int): BidiClass {
             
             val returnVal = lib.icu4x_BidiClass_for_char_mv1(ch);
@@ -67,10 +69,11 @@ enum class BidiClass {
         }
         @JvmStatic
         
-        /** Convert from an integer value from ICU4C or `CodePointMapData`
-        *
-        *See the [Rust documentation for `from_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.BidiClass.html#method.from_icu4c_value) for more information.
-        */
+        /**
+         * Convert from an integer value from ICU4C or `CodePointMapData`
+         *
+         * See the [Rust documentation for `from_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.BidiClass.html#method.from_icu4c_value) for more information.
+         */
         fun fromIntegerValue(other: UByte): BidiClass? {
             
             val returnVal = lib.icu4x_BidiClass_from_integer_value_mv1(FFIUint8(other));
@@ -80,10 +83,11 @@ enum class BidiClass {
         }
         @JvmStatic
         
-        /** Creates a `BidiClass` from a string.
-        *
-        *Short names, long names, and aliases are supported, and matching is case-insensitive.
-        */
+        /**
+         * Creates a `BidiClass` from a string.
+         *
+         * Short names, long names, and aliases are supported, and matching is case-insensitive.
+         */
         fun tryFromStr(s: String): BidiClass? {
             val sSliceMemory = PrimitiveArrayTools.borrowUtf8(s)
             
@@ -98,10 +102,11 @@ enum class BidiClass {
         }
     }
     
-    /** Get the "long" name of this property value (returns empty if property value is unknown)
-    *
-    *See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesLongBorrowed.html#method.get) for more information.
-    */
+    /**
+     * Get the "long" name of this property value (returns empty if property value is unknown)
+     *
+     * See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesLongBorrowed.html#method.get) for more information.
+     */
     fun longName(): String? {
         
         val returnVal = lib.icu4x_BidiClass_long_name_mv1(this.toNative());
@@ -111,10 +116,11 @@ enum class BidiClass {
                                 
     }
     
-    /** Get the "short" name of this property value (returns empty if property value is unknown)
-    *
-    *See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesShortBorrowed.html#method.get) for more information.
-    */
+    /**
+     * Get the "short" name of this property value (returns empty if property value is unknown)
+     *
+     * See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesShortBorrowed.html#method.get) for more information.
+     */
     fun shortName(): String? {
         
         val returnVal = lib.icu4x_BidiClass_short_name_mv1(this.toNative());
@@ -124,10 +130,11 @@ enum class BidiClass {
                                 
     }
     
-    /** Convert to an integer value usable with ICU4C and `CodePointMapData`
-    *
-    *See the [Rust documentation for `to_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.BidiClass.html#method.to_icu4c_value) for more information.
-    */
+    /**
+     * Convert to an integer value usable with ICU4C and `CodePointMapData`
+     *
+     * See the [Rust documentation for `to_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.BidiClass.html#method.to_icu4c_value) for more information.
+     */
     fun toIntegerValue(): UByte {
         
         val returnVal = lib.icu4x_BidiClass_to_integer_value_mv1(this.toNative());

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/BidiDirection.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/BidiDirection.kt
@@ -8,7 +8,8 @@ import com.sun.jna.Structure
 
 internal interface BidiDirectionLib: Library {
 }
-/** See the [Rust documentation for `Direction`](https://docs.rs/unicode_bidi/0.3.11/unicode_bidi/enum.Direction.html) for more information.
+/**
+ * See the [Rust documentation for `Direction`](https://docs.rs/unicode_bidi/0.3.11/unicode_bidi/enum.Direction.html) for more information.
 */
 enum class BidiDirection {
     Ltr,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/BidiInfo.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/BidiInfo.kt
@@ -12,10 +12,11 @@ internal interface BidiInfoLib: Library {
     fun icu4x_BidiInfo_size_mv1(handle: Pointer): FFISizet
     fun icu4x_BidiInfo_level_at_mv1(handle: Pointer, pos: FFISizet): FFIUint8
 }
-/** An object containing bidi information for a given string, produced by `for_text()` on `Bidi`
-*
-*See the [Rust documentation for `BidiInfo`](https://docs.rs/unicode_bidi/0.3.11/unicode_bidi/struct.BidiInfo.html) for more information.
-*/
+/**
+ * An object containing bidi information for a given string, produced by `for_text()` on `Bidi`
+ *
+ * See the [Rust documentation for `BidiInfo`](https://docs.rs/unicode_bidi/0.3.11/unicode_bidi/struct.BidiInfo.html) for more information.
+ */
 class BidiInfo internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -45,16 +46,18 @@ class BidiInfo internal constructor (
         internal val lib: BidiInfoLib = Native.load("icu4x", libClass)
     }
     
-    /** The number of paragraphs contained here
-    */
+    /**
+     * The number of paragraphs contained here
+     */
     fun paragraphCount(): ULong {
         
         val returnVal = lib.icu4x_BidiInfo_paragraph_count_mv1(handle);
         return (returnVal.toULong())
     }
     
-    /** Get the nth paragraph, returning `None` if out of bounds
-    */
+    /**
+     * Get the nth paragraph, returning `None` if out of bounds
+     */
     fun paragraphAt(n: ULong): BidiParagraph? {
         // This lifetime edge depends on lifetimes: 'text
         val textEdges: MutableList<Any> = mutableListOf(this);
@@ -66,20 +69,22 @@ class BidiInfo internal constructor (
         return returnOpaque
     }
     
-    /** The number of bytes in this full text
-    */
+    /**
+     * The number of bytes in this full text
+     */
     fun size(): ULong {
         
         val returnVal = lib.icu4x_BidiInfo_size_mv1(handle);
         return (returnVal.toULong())
     }
     
-    /** Get the BIDI level at a particular byte index in the full text.
-    *This integer is conceptually a `unicode_bidi::Level`,
-    *and can be further inspected using the static methods on Bidi.
-    *
-    *Returns 0 (equivalent to `Level::ltr()`) on error
-    */
+    /**
+     * Get the BIDI level at a particular byte index in the full text.
+     * This integer is conceptually a `unicode_bidi::Level`,
+     * and can be further inspected using the static methods on Bidi.
+     *
+     * Returns 0 (equivalent to `Level::ltr()`) on error
+     */
     fun levelAt(pos: ULong): UByte {
         
         val returnVal = lib.icu4x_BidiInfo_level_at_mv1(handle, FFISizet(pos));

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/BidiMirroringGlyph.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/BidiMirroringGlyph.kt
@@ -11,16 +11,19 @@ internal interface BidiMirroringGlyphLib: Library {
 }
 
 internal class BidiMirroringGlyphNative: Structure(), Structure.ByValue {
-    /** The mirroring glyph
-    */
+    /**
+     * The mirroring glyph
+     */
     @JvmField
     internal var mirroringGlyph: OptionInt = OptionInt.none();
-    /** Whether the glyph is mirrored
-    */
+    /**
+     * Whether the glyph is mirrored
+     */
     @JvmField
     internal var mirrored: Byte = 0;
-    /** The paired bracket type
-    */
+    /**
+     * The paired bracket type
+     */
     @JvmField
     internal var pairedBracketType: Int = BidiPairedBracketType.default().toNative();
 
@@ -71,8 +74,9 @@ internal class OptionBidiMirroringGlyphNative constructor(): Structure(), Struct
 
 }
 
-/** See the [Rust documentation for `BidiMirroringGlyph`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.BidiMirroringGlyph.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `BidiMirroringGlyph`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.BidiMirroringGlyph.html) for more information.
+ */
 class BidiMirroringGlyph (var mirroringGlyph: Int?, var mirrored: Boolean, var pairedBracketType: BidiPairedBracketType) {
     companion object {
 
@@ -90,8 +94,9 @@ class BidiMirroringGlyph (var mirroringGlyph: Int?, var mirrored: Boolean, var p
 
         @JvmStatic
         
-        /** See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.EnumeratedProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.EnumeratedProperty.html#tymethod.for_char) for more information.
+         */
         fun forChar(ch: Int): BidiMirroringGlyph {
             
             val returnVal = lib.icu4x_BidiMirroringGlyph_for_char_mv1(ch);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/BidiPairedBracketType.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/BidiPairedBracketType.kt
@@ -8,7 +8,8 @@ import com.sun.jna.Structure
 
 internal interface BidiPairedBracketTypeLib: Library {
 }
-/** See the [Rust documentation for `BidiPairedBracketType`](https://docs.rs/icu/2.3.1/icu/properties/props/enum.BidiPairedBracketType.html) for more information.
+/**
+ * See the [Rust documentation for `BidiPairedBracketType`](https://docs.rs/icu/2.3.1/icu/properties/props/enum.BidiPairedBracketType.html) for more information.
 */
 enum class BidiPairedBracketType {
     Open,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/BidiParagraph.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/BidiParagraph.kt
@@ -15,8 +15,9 @@ internal interface BidiParagraphLib: Library {
     fun icu4x_BidiParagraph_reorder_line_mv1(handle: Pointer, rangeStart: FFISizet, rangeEnd: FFISizet, write: Pointer): OptionUnit
     fun icu4x_BidiParagraph_level_at_mv1(handle: Pointer, pos: FFISizet): FFIUint8
 }
-/** Bidi information for a single processed paragraph
-*/
+/**
+ * Bidi information for a single processed paragraph
+ */
 class BidiParagraph internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -46,59 +47,65 @@ class BidiParagraph internal constructor (
         internal val lib: BidiParagraphLib = Native.load("icu4x", libClass)
     }
     
-    /** Given a paragraph index `n` within the surrounding text, this sets this
-    *object to the paragraph at that index. Returns nothing when out of bounds.
-    *
-    *This is equivalent to calling `paragraph_at()` on `BidiInfo` but doesn't
-    *create a new object
-    */
+    /**
+     * Given a paragraph index `n` within the surrounding text, this sets this
+     * object to the paragraph at that index. Returns nothing when out of bounds.
+     *
+     * This is equivalent to calling `paragraph_at()` on `BidiInfo` but doesn't
+     * create a new object
+     */
     fun setParagraphInText(n: ULong): Boolean {
         
         val returnVal = lib.icu4x_BidiParagraph_set_paragraph_in_text_mv1(handle, FFISizet(n));
         return (returnVal > 0)
     }
     
-    /** The primary direction of this paragraph
-    *
-    *See the [Rust documentation for `level_at`](https://docs.rs/unicode_bidi/0.3.11/unicode_bidi/struct.Paragraph.html#method.level_at) for more information.
-    */
+    /**
+     * The primary direction of this paragraph
+     *
+     * See the [Rust documentation for `level_at`](https://docs.rs/unicode_bidi/0.3.11/unicode_bidi/struct.Paragraph.html#method.level_at) for more information.
+     */
     fun direction(): BidiDirection {
         
         val returnVal = lib.icu4x_BidiParagraph_direction_mv1(handle);
         return (BidiDirection.fromNative(returnVal))
     }
     
-    /** The number of bytes in this paragraph
-    *
-    *See the [Rust documentation for `len`](https://docs.rs/unicode_bidi/0.3.11/unicode_bidi/struct.ParagraphInfo.html#method.len) for more information.
-    */
+    /**
+     * The number of bytes in this paragraph
+     *
+     * See the [Rust documentation for `len`](https://docs.rs/unicode_bidi/0.3.11/unicode_bidi/struct.ParagraphInfo.html#method.len) for more information.
+     */
     fun size(): ULong {
         
         val returnVal = lib.icu4x_BidiParagraph_size_mv1(handle);
         return (returnVal.toULong())
     }
     
-    /** The start index of this paragraph within the source text
-    */
+    /**
+     * The start index of this paragraph within the source text
+     */
     fun rangeStart(): ULong {
         
         val returnVal = lib.icu4x_BidiParagraph_range_start_mv1(handle);
         return (returnVal.toULong())
     }
     
-    /** The end index of this paragraph within the source text
-    */
+    /**
+     * The end index of this paragraph within the source text
+     */
     fun rangeEnd(): ULong {
         
         val returnVal = lib.icu4x_BidiParagraph_range_end_mv1(handle);
         return (returnVal.toULong())
     }
     
-    /** Reorder a line based on display order. The ranges are specified relative to the source text and must be contained
-    *within this paragraph's range.
-    *
-    *See the [Rust documentation for `level_at`](https://docs.rs/unicode_bidi/0.3.11/unicode_bidi/struct.Paragraph.html#method.level_at) for more information.
-    */
+    /**
+     * Reorder a line based on display order. The ranges are specified relative to the source text and must be contained
+     * within this paragraph's range.
+     *
+     * See the [Rust documentation for `level_at`](https://docs.rs/unicode_bidi/0.3.11/unicode_bidi/struct.Paragraph.html#method.level_at) for more information.
+     */
     fun reorderLine(rangeStart: ULong, rangeEnd: ULong): String? {
         val write = DW.lib.diplomat_buffer_write_create(0)
         val returnVal = lib.icu4x_BidiParagraph_reorder_line_mv1(handle, FFISizet(rangeStart), FFISizet(rangeEnd), write);
@@ -110,14 +117,15 @@ class BidiParagraph internal constructor (
                                 
     }
     
-    /** Get the BIDI level at a particular byte index in this paragraph.
-    *This integer is conceptually a `unicode_bidi::Level`,
-    *and can be further inspected using the static methods on Bidi.
-    *
-    *Returns 0 (equivalent to `Level::ltr()`) on error
-    *
-    *See the [Rust documentation for `level_at`](https://docs.rs/unicode_bidi/0.3.11/unicode_bidi/struct.Paragraph.html#method.level_at) for more information.
-    */
+    /**
+     * Get the BIDI level at a particular byte index in this paragraph.
+     * This integer is conceptually a `unicode_bidi::Level`,
+     * and can be further inspected using the static methods on Bidi.
+     *
+     * Returns 0 (equivalent to `Level::ltr()`) on error
+     *
+     * See the [Rust documentation for `level_at`](https://docs.rs/unicode_bidi/0.3.11/unicode_bidi/struct.Paragraph.html#method.level_at) for more information.
+     */
     fun levelAt(pos: ULong): UByte {
         
         val returnVal = lib.icu4x_BidiParagraph_level_at_mv1(handle, FFISizet(pos));

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/Block.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/Block.kt
@@ -14,7 +14,8 @@ internal interface BlockLib: Library {
     fun icu4x_Block_from_integer_value_mv1(other: FFIUint16): OptionInt
     fun icu4x_Block_try_from_str_mv1(s: Slice): OptionInt
 }
-/** See the [Rust documentation for `Block`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Block.html) for more information.
+/**
+ * See the [Rust documentation for `Block`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Block.html) for more information.
 */
 enum class Block {
     NoBlock,
@@ -389,8 +390,9 @@ enum class Block {
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.EnumeratedProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.EnumeratedProperty.html#tymethod.for_char) for more information.
+         */
         fun forChar(ch: Int): Block {
             
             val returnVal = lib.icu4x_Block_for_char_mv1(ch);
@@ -398,10 +400,11 @@ enum class Block {
         }
         @JvmStatic
         
-        /** Convert from an integer value from ICU4C or `CodePointMapData`
-        *
-        *See the [Rust documentation for `from_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Block.html#method.from_icu4c_value) for more information.
-        */
+        /**
+         * Convert from an integer value from ICU4C or `CodePointMapData`
+         *
+         * See the [Rust documentation for `from_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Block.html#method.from_icu4c_value) for more information.
+         */
         fun fromIntegerValue(other: UShort): Block? {
             
             val returnVal = lib.icu4x_Block_from_integer_value_mv1(FFIUint16(other));
@@ -411,10 +414,11 @@ enum class Block {
         }
         @JvmStatic
         
-        /** Creates a `Block` from a string.
-        *
-        *Short names, long names, and aliases are supported, and matching is case-insensitive.
-        */
+        /**
+         * Creates a `Block` from a string.
+         *
+         * Short names, long names, and aliases are supported, and matching is case-insensitive.
+         */
         fun tryFromStr(s: String): Block? {
             val sSliceMemory = PrimitiveArrayTools.borrowUtf8(s)
             
@@ -429,10 +433,11 @@ enum class Block {
         }
     }
     
-    /** Get the "long" name of this property value (returns empty if property value is unknown)
-    *
-    *See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesLongBorrowed.html#method.get) for more information.
-    */
+    /**
+     * Get the "long" name of this property value (returns empty if property value is unknown)
+     *
+     * See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesLongBorrowed.html#method.get) for more information.
+     */
     fun longName(): String? {
         
         val returnVal = lib.icu4x_Block_long_name_mv1(this.toNative());
@@ -442,10 +447,11 @@ enum class Block {
                                 
     }
     
-    /** Get the "short" name of this property value (returns empty if property value is unknown)
-    *
-    *See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesShortBorrowed.html#method.get) for more information.
-    */
+    /**
+     * Get the "short" name of this property value (returns empty if property value is unknown)
+     *
+     * See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesShortBorrowed.html#method.get) for more information.
+     */
     fun shortName(): String? {
         
         val returnVal = lib.icu4x_Block_short_name_mv1(this.toNative());
@@ -455,10 +461,11 @@ enum class Block {
                                 
     }
     
-    /** Convert to an integer value usable with ICU4C and `CodePointMapData`
-    *
-    *See the [Rust documentation for `to_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Block.html#method.to_icu4c_value) for more information.
-    */
+    /**
+     * Convert to an integer value usable with ICU4C and `CodePointMapData`
+     *
+     * See the [Rust documentation for `to_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Block.html#method.to_icu4c_value) for more information.
+     */
     fun toIntegerValue(): UShort {
         
         val returnVal = lib.icu4x_Block_to_integer_value_mv1(this.toNative());

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/Calendar.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/Calendar.kt
@@ -11,8 +11,9 @@ internal interface CalendarLib: Library {
     fun icu4x_Calendar_create_with_provider_mv1(provider: Pointer, kind: Int): ResultPointerInt
     fun icu4x_Calendar_kind_mv1(handle: Pointer): Int
 }
-/** See the [Rust documentation for `AnyCalendar`](https://docs.rs/icu/2.3.1/icu/calendar/enum.AnyCalendar.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `AnyCalendar`](https://docs.rs/icu/2.3.1/icu/calendar/enum.AnyCalendar.html) for more information.
+ */
 class Calendar internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -41,10 +42,11 @@ class Calendar internal constructor (
         internal val lib: CalendarLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Creates a new [Calendar] for the specified kind, using compiled data.
-        *
-        *See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/calendar/enum.AnyCalendar.html#method.new) for more information.
-        */
+        /**
+         * Creates a new [Calendar] for the specified kind, using compiled data.
+         *
+         * See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/calendar/enum.AnyCalendar.html#method.new) for more information.
+         */
         fun create(kind: CalendarKind): Calendar {
             
             val returnVal = lib.icu4x_Calendar_create_mv1(kind.toNative());
@@ -55,10 +57,11 @@ class Calendar internal constructor (
         }
         @JvmStatic
         
-        /** Creates a new [Calendar] for the specified kind, using a particular data source.
-        *
-        *See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/calendar/enum.AnyCalendar.html#method.new) for more information.
-        */
+        /**
+         * Creates a new [Calendar] for the specified kind, using a particular data source.
+         *
+         * See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/calendar/enum.AnyCalendar.html#method.new) for more information.
+         */
         fun createWithProvider(provider: DataProvider, kind: CalendarKind): Result<Calendar> {
             
             val returnVal = lib.icu4x_Calendar_create_with_provider_mv1(provider.handle, kind.toNative());
@@ -74,10 +77,11 @@ class Calendar internal constructor (
         }
     }
     
-    /** Returns the kind of this calendar
-    *
-    *See the [Rust documentation for `kind`](https://docs.rs/icu/2.3.1/icu/calendar/enum.AnyCalendar.html#method.kind) for more information.
-    */
+    /**
+     * Returns the kind of this calendar
+     *
+     * See the [Rust documentation for `kind`](https://docs.rs/icu/2.3.1/icu/calendar/enum.AnyCalendar.html#method.kind) for more information.
+     */
     fun kind(): CalendarKind {
         
         val returnVal = lib.icu4x_Calendar_kind_mv1(handle);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CalendarDateAddError.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CalendarDateAddError.kt
@@ -8,7 +8,8 @@ import com.sun.jna.Structure
 
 internal interface CalendarDateAddErrorLib: Library {
 }
-/** Additional information: [1](https://docs.rs/icu/2.3.1/icu/calendar/error/enum.DateAddError.html)
+/**
+ * Additional information: [1](https://docs.rs/icu/2.3.1/icu/calendar/error/enum.DateAddError.html)
 */
 enum class CalendarDateAddError {
     Unknown,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CalendarDateFromFieldsError.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CalendarDateFromFieldsError.kt
@@ -8,7 +8,8 @@ import com.sun.jna.Structure
 
 internal interface CalendarDateFromFieldsErrorLib: Library {
 }
-/** Additional information: [1](https://docs.rs/icu/2.3.1/icu/calendar/error/enum.DateFromFieldsError.html)
+/**
+ * Additional information: [1](https://docs.rs/icu/2.3.1/icu/calendar/error/enum.DateFromFieldsError.html)
 */
 enum class CalendarDateFromFieldsError(val inner: Int) {
     Unknown(0),

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CalendarError.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CalendarError.kt
@@ -8,7 +8,8 @@ import com.sun.jna.Structure
 
 internal interface CalendarErrorLib: Library {
 }
-/** Additional information: [1](https://docs.rs/icu/2.3.1/icu/calendar/struct.RangeError.html), [2](https://docs.rs/icu/2.3.1/icu/calendar/enum.DateError.html), [3](https://docs.rs/icu/2.3.1/icu/calendar/error/enum.MonthCodeParseError.html), [4](https://docs.rs/icu/2.3.1/icu/calendar/error/enum.DateNewError.html)
+/**
+ * Additional information: [1](https://docs.rs/icu/2.3.1/icu/calendar/struct.RangeError.html), [2](https://docs.rs/icu/2.3.1/icu/calendar/enum.DateError.html), [3](https://docs.rs/icu/2.3.1/icu/calendar/error/enum.MonthCodeParseError.html), [4](https://docs.rs/icu/2.3.1/icu/calendar/error/enum.DateNewError.html)
 */
 enum class CalendarError {
     Unknown,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CalendarKind.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CalendarKind.kt
@@ -9,9 +9,10 @@ import com.sun.jna.Structure
 internal interface CalendarKindLib: Library {
     fun icu4x_CalendarKind_create_mv1(locale: Pointer): Int
 }
-/** The various calendar types currently supported by [Calendar]
-*
-*See the [Rust documentation for `AnyCalendarKind`](https://docs.rs/icu/2.3.1/icu/calendar/enum.AnyCalendarKind.html) for more information.
+/**
+ * The various calendar types currently supported by [Calendar]
+ *
+ * See the [Rust documentation for `AnyCalendarKind`](https://docs.rs/icu/2.3.1/icu/calendar/enum.AnyCalendarKind.html) for more information.
 */
 enum class CalendarKind(val inner: Int) {
     Iso(0),
@@ -72,10 +73,11 @@ enum class CalendarKind(val inner: Int) {
         }
         @JvmStatic
         
-        /** Creates a new [CalendarKind] for the specified locale, using compiled data.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/calendar/enum.AnyCalendarKind.html#method.try_new) for more information.
-        */
+        /**
+         * Creates a new [CalendarKind] for the specified locale, using compiled data.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/calendar/enum.AnyCalendarKind.html#method.try_new) for more information.
+         */
         fun create(locale: Locale): CalendarKind {
             
             val returnVal = lib.icu4x_CalendarKind_create_mv1(locale.handle);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CalendarMismatchedCalendarError.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CalendarMismatchedCalendarError.kt
@@ -6,8 +6,9 @@ import com.sun.jna.Native
 import com.sun.jna.Pointer
 import com.sun.jna.Structure
 
-/** Additional information: [1](https://docs.rs/icu/2.3.1/icu/calendar/error/struct.MismatchedCalendarError.html)
-*/
+/**
+ * Additional information: [1](https://docs.rs/icu/2.3.1/icu/calendar/error/struct.MismatchedCalendarError.html)
+ */
 class CalendarMismatchedCalendarError (): Exception("Rust error result for CalendarMismatchedCalendarError") {
     companion object {
 

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CanonicalCombiningClass.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CanonicalCombiningClass.kt
@@ -14,7 +14,8 @@ internal interface CanonicalCombiningClassLib: Library {
     fun icu4x_CanonicalCombiningClass_from_integer_value_mv1(other: FFIUint8): OptionInt
     fun icu4x_CanonicalCombiningClass_try_from_str_mv1(s: Slice): OptionInt
 }
-/** See the [Rust documentation for `CanonicalCombiningClass`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.CanonicalCombiningClass.html) for more information.
+/**
+ * See the [Rust documentation for `CanonicalCombiningClass`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.CanonicalCombiningClass.html) for more information.
 */
 enum class CanonicalCombiningClass(val inner: Int) {
     NotReordered(0),
@@ -153,8 +154,9 @@ enum class CanonicalCombiningClass(val inner: Int) {
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.EnumeratedProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.EnumeratedProperty.html#tymethod.for_char) for more information.
+         */
         fun forChar(ch: Int): CanonicalCombiningClass {
             
             val returnVal = lib.icu4x_CanonicalCombiningClass_for_char_mv1(ch);
@@ -162,10 +164,11 @@ enum class CanonicalCombiningClass(val inner: Int) {
         }
         @JvmStatic
         
-        /** Convert from an integer value from ICU4C or `CodePointMapData`
-        *
-        *See the [Rust documentation for `from_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.CanonicalCombiningClass.html#method.from_icu4c_value) for more information.
-        */
+        /**
+         * Convert from an integer value from ICU4C or `CodePointMapData`
+         *
+         * See the [Rust documentation for `from_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.CanonicalCombiningClass.html#method.from_icu4c_value) for more information.
+         */
         fun fromIntegerValue(other: UByte): CanonicalCombiningClass? {
             
             val returnVal = lib.icu4x_CanonicalCombiningClass_from_integer_value_mv1(FFIUint8(other));
@@ -175,10 +178,11 @@ enum class CanonicalCombiningClass(val inner: Int) {
         }
         @JvmStatic
         
-        /** Creates a `CanonicalCombiningClass` from a string.
-        *
-        *Short names, long names, and aliases are supported, and matching is case-insensitive.
-        */
+        /**
+         * Creates a `CanonicalCombiningClass` from a string.
+         *
+         * Short names, long names, and aliases are supported, and matching is case-insensitive.
+         */
         fun tryFromStr(s: String): CanonicalCombiningClass? {
             val sSliceMemory = PrimitiveArrayTools.borrowUtf8(s)
             
@@ -193,10 +197,11 @@ enum class CanonicalCombiningClass(val inner: Int) {
         }
     }
     
-    /** Get the "long" name of this property value (returns empty if property value is unknown)
-    *
-    *See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesLongBorrowed.html#method.get) for more information.
-    */
+    /**
+     * Get the "long" name of this property value (returns empty if property value is unknown)
+     *
+     * See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesLongBorrowed.html#method.get) for more information.
+     */
     fun longName(): String? {
         
         val returnVal = lib.icu4x_CanonicalCombiningClass_long_name_mv1(this.toNative());
@@ -206,10 +211,11 @@ enum class CanonicalCombiningClass(val inner: Int) {
                                 
     }
     
-    /** Get the "short" name of this property value (returns empty if property value is unknown)
-    *
-    *See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesShortBorrowed.html#method.get) for more information.
-    */
+    /**
+     * Get the "short" name of this property value (returns empty if property value is unknown)
+     *
+     * See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesShortBorrowed.html#method.get) for more information.
+     */
     fun shortName(): String? {
         
         val returnVal = lib.icu4x_CanonicalCombiningClass_short_name_mv1(this.toNative());
@@ -219,10 +225,11 @@ enum class CanonicalCombiningClass(val inner: Int) {
                                 
     }
     
-    /** Convert to an integer value usable with ICU4C and `CodePointMapData`
-    *
-    *See the [Rust documentation for `to_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.CanonicalCombiningClass.html#method.to_icu4c_value) for more information.
-    */
+    /**
+     * Convert to an integer value usable with ICU4C and `CodePointMapData`
+     *
+     * See the [Rust documentation for `to_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.CanonicalCombiningClass.html#method.to_icu4c_value) for more information.
+     */
     fun toIntegerValue(): UByte {
         
         val returnVal = lib.icu4x_CanonicalCombiningClass_to_integer_value_mv1(this.toNative());

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CanonicalCombiningClassMap.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CanonicalCombiningClassMap.kt
@@ -11,10 +11,11 @@ internal interface CanonicalCombiningClassMapLib: Library {
     fun icu4x_CanonicalCombiningClassMap_create_with_provider_mv1(provider: Pointer): ResultPointerInt
     fun icu4x_CanonicalCombiningClassMap_get_mv1(handle: Pointer, ch: Int): FFIUint8
 }
-/** Lookup of the `Canonical_Combining_Class` Unicode property
-*
-*See the [Rust documentation for `CanonicalCombiningClassMap`](https://docs.rs/icu/2.3.1/icu/normalizer/properties/struct.CanonicalCombiningClassMap.html) for more information.
-*/
+/**
+ * Lookup of the `Canonical_Combining_Class` Unicode property
+ *
+ * See the [Rust documentation for `CanonicalCombiningClassMap`](https://docs.rs/icu/2.3.1/icu/normalizer/properties/struct.CanonicalCombiningClassMap.html) for more information.
+ */
 class CanonicalCombiningClassMap internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -43,10 +44,11 @@ class CanonicalCombiningClassMap internal constructor (
         internal val lib: CanonicalCombiningClassMapLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Construct a new `CanonicalCombiningClassMap` instance for NFC using compiled data.
-        *
-        *See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/normalizer/properties/struct.CanonicalCombiningClassMap.html#method.new) for more information.
-        */
+        /**
+         * Construct a new `CanonicalCombiningClassMap` instance for NFC using compiled data.
+         *
+         * See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/normalizer/properties/struct.CanonicalCombiningClassMap.html#method.new) for more information.
+         */
         fun create(): CanonicalCombiningClassMap {
             
             val returnVal = lib.icu4x_CanonicalCombiningClassMap_create_mv1();
@@ -57,10 +59,11 @@ class CanonicalCombiningClassMap internal constructor (
         }
         @JvmStatic
         
-        /** Construct a new `CanonicalCombiningClassMap` instance for NFC using a particular data source.
-        *
-        *See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/normalizer/properties/struct.CanonicalCombiningClassMap.html#method.new) for more information.
-        */
+        /**
+         * Construct a new `CanonicalCombiningClassMap` instance for NFC using a particular data source.
+         *
+         * See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/normalizer/properties/struct.CanonicalCombiningClassMap.html#method.new) for more information.
+         */
         fun createWithProvider(provider: DataProvider): Result<CanonicalCombiningClassMap> {
             
             val returnVal = lib.icu4x_CanonicalCombiningClassMap_create_with_provider_mv1(provider.handle);
@@ -76,10 +79,11 @@ class CanonicalCombiningClassMap internal constructor (
         }
     }
     
-    /** See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/normalizer/properties/struct.CanonicalCombiningClassMapBorrowed.html#method.get) for more information.
-    *
-    *Additional information: [1](https://docs.rs/icu/2.3.1/icu/properties/props/struct.CanonicalCombiningClass.html)
-    */
+    /**
+     * See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/normalizer/properties/struct.CanonicalCombiningClassMapBorrowed.html#method.get) for more information.
+     *
+     * Additional information: [1](https://docs.rs/icu/2.3.1/icu/properties/props/struct.CanonicalCombiningClass.html)
+     */
     fun get(ch: Int): UByte {
         
         val returnVal = lib.icu4x_CanonicalCombiningClassMap_get_mv1(handle, ch);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CanonicalComposition.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CanonicalComposition.kt
@@ -11,12 +11,13 @@ internal interface CanonicalCompositionLib: Library {
     fun icu4x_CanonicalComposition_create_with_provider_mv1(provider: Pointer): ResultPointerInt
     fun icu4x_CanonicalComposition_compose_mv1(handle: Pointer, starter: Int, second: Int): Int
 }
-/** The raw canonical composition operation.
-*
-*Callers should generally use `ComposingNormalizer` unless they specifically need raw composition operations
-*
-*See the [Rust documentation for `CanonicalComposition`](https://docs.rs/icu/2.3.1/icu/normalizer/properties/struct.CanonicalComposition.html) for more information.
-*/
+/**
+ * The raw canonical composition operation.
+ *
+ * Callers should generally use `ComposingNormalizer` unless they specifically need raw composition operations
+ *
+ * See the [Rust documentation for `CanonicalComposition`](https://docs.rs/icu/2.3.1/icu/normalizer/properties/struct.CanonicalComposition.html) for more information.
+ */
 class CanonicalComposition internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -45,10 +46,11 @@ class CanonicalComposition internal constructor (
         internal val lib: CanonicalCompositionLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Construct a new `CanonicalComposition` instance for NFC using compiled data.
-        *
-        *See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/normalizer/properties/struct.CanonicalComposition.html#method.new) for more information.
-        */
+        /**
+         * Construct a new `CanonicalComposition` instance for NFC using compiled data.
+         *
+         * See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/normalizer/properties/struct.CanonicalComposition.html#method.new) for more information.
+         */
         fun create(): CanonicalComposition {
             
             val returnVal = lib.icu4x_CanonicalComposition_create_mv1();
@@ -59,10 +61,11 @@ class CanonicalComposition internal constructor (
         }
         @JvmStatic
         
-        /** Construct a new `CanonicalComposition` instance for NFC using a particular data source.
-        *
-        *See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/normalizer/properties/struct.CanonicalComposition.html#method.new) for more information.
-        */
+        /**
+         * Construct a new `CanonicalComposition` instance for NFC using a particular data source.
+         *
+         * See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/normalizer/properties/struct.CanonicalComposition.html#method.new) for more information.
+         */
         fun createWithProvider(provider: DataProvider): Result<CanonicalComposition> {
             
             val returnVal = lib.icu4x_CanonicalComposition_create_with_provider_mv1(provider.handle);
@@ -78,11 +81,12 @@ class CanonicalComposition internal constructor (
         }
     }
     
-    /** Performs canonical composition (including Hangul) on a pair of characters
-    *or returns NUL if these characters don’t compose. Composition exclusions are taken into account.
-    *
-    *See the [Rust documentation for `compose`](https://docs.rs/icu/2.3.1/icu/normalizer/properties/struct.CanonicalCompositionBorrowed.html#method.compose) for more information.
-    */
+    /**
+     * Performs canonical composition (including Hangul) on a pair of characters
+     * or returns NUL if these characters don’t compose. Composition exclusions are taken into account.
+     *
+     * See the [Rust documentation for `compose`](https://docs.rs/icu/2.3.1/icu/normalizer/properties/struct.CanonicalCompositionBorrowed.html#method.compose) for more information.
+     */
     fun compose(starter: Int, second: Int): Int {
         
         val returnVal = lib.icu4x_CanonicalComposition_compose_mv1(handle, starter, second);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CanonicalDecomposition.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CanonicalDecomposition.kt
@@ -11,12 +11,13 @@ internal interface CanonicalDecompositionLib: Library {
     fun icu4x_CanonicalDecomposition_create_with_provider_mv1(provider: Pointer): ResultPointerInt
     fun icu4x_CanonicalDecomposition_decompose_mv1(handle: Pointer, c: Int): DecomposedNative
 }
-/** The raw (non-recursive) canonical decomposition operation.
-*
-*Callers should generally use `DecomposingNormalizer` unless they specifically need raw composition operations
-*
-*See the [Rust documentation for `CanonicalDecomposition`](https://docs.rs/icu/2.3.1/icu/normalizer/properties/struct.CanonicalDecomposition.html) for more information.
-*/
+/**
+ * The raw (non-recursive) canonical decomposition operation.
+ *
+ * Callers should generally use `DecomposingNormalizer` unless they specifically need raw composition operations
+ *
+ * See the [Rust documentation for `CanonicalDecomposition`](https://docs.rs/icu/2.3.1/icu/normalizer/properties/struct.CanonicalDecomposition.html) for more information.
+ */
 class CanonicalDecomposition internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -45,10 +46,11 @@ class CanonicalDecomposition internal constructor (
         internal val lib: CanonicalDecompositionLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Construct a new `CanonicalDecomposition` instance for NFC using compiled data.
-        *
-        *See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/normalizer/properties/struct.CanonicalDecomposition.html#method.new) for more information.
-        */
+        /**
+         * Construct a new `CanonicalDecomposition` instance for NFC using compiled data.
+         *
+         * See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/normalizer/properties/struct.CanonicalDecomposition.html#method.new) for more information.
+         */
         fun create(): CanonicalDecomposition {
             
             val returnVal = lib.icu4x_CanonicalDecomposition_create_mv1();
@@ -59,10 +61,11 @@ class CanonicalDecomposition internal constructor (
         }
         @JvmStatic
         
-        /** Construct a new `CanonicalDecomposition` instance for NFC using a particular data source.
-        *
-        *See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/normalizer/properties/struct.CanonicalDecomposition.html#method.new) for more information.
-        */
+        /**
+         * Construct a new `CanonicalDecomposition` instance for NFC using a particular data source.
+         *
+         * See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/normalizer/properties/struct.CanonicalDecomposition.html#method.new) for more information.
+         */
         fun createWithProvider(provider: DataProvider): Result<CanonicalDecomposition> {
             
             val returnVal = lib.icu4x_CanonicalDecomposition_create_with_provider_mv1(provider.handle);
@@ -78,10 +81,11 @@ class CanonicalDecomposition internal constructor (
         }
     }
     
-    /** Performs non-recursive canonical decomposition (including for Hangul).
-    *
-    *See the [Rust documentation for `decompose`](https://docs.rs/icu/2.3.1/icu/normalizer/properties/struct.CanonicalDecompositionBorrowed.html#method.decompose) for more information.
-    */
+    /**
+     * Performs non-recursive canonical decomposition (including for Hangul).
+     *
+     * See the [Rust documentation for `decompose`](https://docs.rs/icu/2.3.1/icu/normalizer/properties/struct.CanonicalDecompositionBorrowed.html#method.decompose) for more information.
+     */
     fun decompose(c: Int): Decomposed {
         
         val returnVal = lib.icu4x_CanonicalDecomposition_decompose_mv1(handle, c);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CaseMapCloser.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CaseMapCloser.kt
@@ -12,8 +12,9 @@ internal interface CaseMapCloserLib: Library {
     fun icu4x_CaseMapCloser_add_case_closure_to_mv1(handle: Pointer, c: Int, builder: Pointer): Unit
     fun icu4x_CaseMapCloser_add_string_case_closure_to_mv1(handle: Pointer, s: Slice, builder: Pointer): Byte
 }
-/** See the [Rust documentation for `CaseMapCloser`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapCloser.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `CaseMapCloser`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapCloser.html) for more information.
+ */
 class CaseMapCloser internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -42,10 +43,11 @@ class CaseMapCloser internal constructor (
         internal val lib: CaseMapCloserLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Construct a new `CaseMapCloser` instance using compiled data.
-        *
-        *See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapCloser.html#method.new) for more information.
-        */
+        /**
+         * Construct a new `CaseMapCloser` instance using compiled data.
+         *
+         * See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapCloser.html#method.new) for more information.
+         */
         fun create(): Result<CaseMapCloser> {
             
             val returnVal = lib.icu4x_CaseMapCloser_create_mv1();
@@ -61,10 +63,11 @@ class CaseMapCloser internal constructor (
         }
         @JvmStatic
         
-        /** Construct a new `CaseMapCloser` instance using a particular data source.
-        *
-        *See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapCloser.html#method.new) for more information.
-        */
+        /**
+         * Construct a new `CaseMapCloser` instance using a particular data source.
+         *
+         * See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapCloser.html#method.new) for more information.
+         */
         fun createWithProvider(provider: DataProvider): Result<CaseMapCloser> {
             
             val returnVal = lib.icu4x_CaseMapCloser_create_with_provider_mv1(provider.handle);
@@ -80,24 +83,26 @@ class CaseMapCloser internal constructor (
         }
     }
     
-    /** Adds all simple case mappings and the full case folding for `c` to `builder`.
-    *Also adds special case closure mappings.
-    *
-    *See the [Rust documentation for `add_case_closure_to`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapCloserBorrowed.html#method.add_case_closure_to) for more information.
-    */
+    /**
+     * Adds all simple case mappings and the full case folding for `c` to `builder`.
+     * Also adds special case closure mappings.
+     *
+     * See the [Rust documentation for `add_case_closure_to`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapCloserBorrowed.html#method.add_case_closure_to) for more information.
+     */
     fun addCaseClosureTo(c: Int, builder: CodePointSetBuilder): Unit {
         
         val returnVal = lib.icu4x_CaseMapCloser_add_case_closure_to_mv1(handle, c, builder.handle /* note this is a mutable reference. Think carefully about using, especially concurrently */);
         
     }
     
-    /** Finds all characters and strings which may casemap to `s` as their full case folding string
-    *and adds them to the set.
-    *
-    *Returns true if the string was found
-    *
-    *See the [Rust documentation for `add_string_case_closure_to`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapCloserBorrowed.html#method.add_string_case_closure_to) for more information.
-    */
+    /**
+     * Finds all characters and strings which may casemap to `s` as their full case folding string
+     * and adds them to the set.
+     *
+     * Returns true if the string was found
+     *
+     * See the [Rust documentation for `add_string_case_closure_to`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapCloserBorrowed.html#method.add_string_case_closure_to) for more information.
+     */
     fun addStringCaseClosureTo(s: String, builder: CodePointSetBuilder): Boolean {
         val sSliceMemory = PrimitiveArrayTools.borrowUtf8(s)
         

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CaseMapper.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CaseMapper.kt
@@ -29,8 +29,9 @@ internal interface CaseMapperLib: Library {
     fun icu4x_CaseMapper_simple_fold_turkic_mv1(handle: Pointer, ch: Int): Int
     fun icu4x_CaseMapper_simple_fold_turkic_with_compiled_data_mv1(ch: Int): Int
 }
-/** See the [Rust documentation for `CaseMapper`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapper.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `CaseMapper`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapper.html) for more information.
+ */
 class CaseMapper internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -59,10 +60,11 @@ class CaseMapper internal constructor (
         internal val lib: CaseMapperLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Construct a new `CaseMapper` instance using compiled data.
-        *
-        *See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapper.html#method.new) for more information.
-        */
+        /**
+         * Construct a new `CaseMapper` instance using compiled data.
+         *
+         * See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapper.html#method.new) for more information.
+         */
         fun create(): CaseMapper {
             
             val returnVal = lib.icu4x_CaseMapper_create_mv1();
@@ -73,10 +75,11 @@ class CaseMapper internal constructor (
         }
         @JvmStatic
         
-        /** Construct a new `CaseMapper` instance using a particular data source.
-        *
-        *See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapper.html#method.new) for more information.
-        */
+        /**
+         * Construct a new `CaseMapper` instance using a particular data source.
+         *
+         * See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapper.html#method.new) for more information.
+         */
         fun createWithProvider(provider: DataProvider): Result<CaseMapper> {
             
             val returnVal = lib.icu4x_CaseMapper_create_with_provider_mv1(provider.handle);
@@ -92,10 +95,11 @@ class CaseMapper internal constructor (
         }
         @JvmStatic
         
-        /** Returns the full lowercase mapping of the given string, using compiled data (avoids having to allocate a `CaseMapper` object)
-        *
-        *See the [Rust documentation for `lowercase`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapperBorrowed.html#method.lowercase) for more information.
-        */
+        /**
+         * Returns the full lowercase mapping of the given string, using compiled data (avoids having to allocate a `CaseMapper` object)
+         *
+         * See the [Rust documentation for `lowercase`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapperBorrowed.html#method.lowercase) for more information.
+         */
         fun lowercaseWithCompiledData(s: String, locale: Locale): String {
             val sSliceMemory = PrimitiveArrayTools.borrowUtf8(s)
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -110,10 +114,11 @@ class CaseMapper internal constructor (
         }
         @JvmStatic
         
-        /** Returns the full uppercase mapping of the given string, using compiled data (avoids having to allocate a `CaseMapper` object)
-        *
-        *See the [Rust documentation for `uppercase`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapperBorrowed.html#method.uppercase) for more information.
-        */
+        /**
+         * Returns the full uppercase mapping of the given string, using compiled data (avoids having to allocate a `CaseMapper` object)
+         *
+         * See the [Rust documentation for `uppercase`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapperBorrowed.html#method.uppercase) for more information.
+         */
         fun uppercaseWithCompiledData(s: String, locale: Locale): String {
             val sSliceMemory = PrimitiveArrayTools.borrowUtf8(s)
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -128,15 +133,16 @@ class CaseMapper internal constructor (
         }
         @JvmStatic
         
-        /** Returns the full titlecase mapping of the given string, performing head adjustment without
-        *loading additional data, using compiled data (avoids having to allocate a `CaseMapper` object).
-        *
-        *(if head adjustment is enabled in the options)
-        *
-        *The `v1` refers to the version of the options struct, which may change as we add more options
-        *
-        *See the [Rust documentation for `titlecase_segment_with_only_case_data_to_string`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapperBorrowed.html#method.titlecase_segment_with_only_case_data_to_string) for more information.
-        */
+        /**
+         * Returns the full titlecase mapping of the given string, performing head adjustment without
+         * loading additional data, using compiled data (avoids having to allocate a `CaseMapper` object).
+         *
+         * (if head adjustment is enabled in the options)
+         *
+         * The `v1` refers to the version of the options struct, which may change as we add more options
+         *
+         * See the [Rust documentation for `titlecase_segment_with_only_case_data_to_string`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapperBorrowed.html#method.titlecase_segment_with_only_case_data_to_string) for more information.
+         */
         fun titlecase_segment_with_only_case_compiled_data(s: String, locale: Locale, options: TitlecaseOptions): String {
             val sSliceMemory = PrimitiveArrayTools.borrowUtf8(s)
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -151,10 +157,11 @@ class CaseMapper internal constructor (
         }
         @JvmStatic
         
-        /** Returns the simple lowercase mapping of the given character, using compiled data (avoids having to allocate a `CaseMapper` object)
-        *
-        *See the [Rust documentation for `simple_lowercase`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapperBorrowed.html#method.simple_lowercase) for more information.
-        */
+        /**
+         * Returns the simple lowercase mapping of the given character, using compiled data (avoids having to allocate a `CaseMapper` object)
+         *
+         * See the [Rust documentation for `simple_lowercase`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapperBorrowed.html#method.simple_lowercase) for more information.
+         */
         fun simpleLowercaseWithCompiledData(ch: Int): Int {
             
             val returnVal = lib.icu4x_CaseMapper_simple_lowercase_with_compiled_data_mv1(ch);
@@ -162,10 +169,11 @@ class CaseMapper internal constructor (
         }
         @JvmStatic
         
-        /** Returns the simple uppercase mapping of the given character, using compiled data (avoids having to allocate a `CaseMapper` object)
-        *
-        *See the [Rust documentation for `simple_uppercase`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapperBorrowed.html#method.simple_uppercase) for more information.
-        */
+        /**
+         * Returns the simple uppercase mapping of the given character, using compiled data (avoids having to allocate a `CaseMapper` object)
+         *
+         * See the [Rust documentation for `simple_uppercase`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapperBorrowed.html#method.simple_uppercase) for more information.
+         */
         fun simpleUppercaseWithCompiledData(ch: Int): Int {
             
             val returnVal = lib.icu4x_CaseMapper_simple_uppercase_with_compiled_data_mv1(ch);
@@ -173,10 +181,11 @@ class CaseMapper internal constructor (
         }
         @JvmStatic
         
-        /** Returns the simple titlecase mapping of the given character, using compiled data (avoids having to allocate a `CaseMapper` object)
-        *
-        *See the [Rust documentation for `simple_titlecase`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapperBorrowed.html#method.simple_titlecase) for more information.
-        */
+        /**
+         * Returns the simple titlecase mapping of the given character, using compiled data (avoids having to allocate a `CaseMapper` object)
+         *
+         * See the [Rust documentation for `simple_titlecase`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapperBorrowed.html#method.simple_titlecase) for more information.
+         */
         fun simpleTitlecaseWithCompiledData(ch: Int): Int {
             
             val returnVal = lib.icu4x_CaseMapper_simple_titlecase_with_compiled_data_mv1(ch);
@@ -184,10 +193,11 @@ class CaseMapper internal constructor (
         }
         @JvmStatic
         
-        /** Returns the simple casefolding of the given character, using compiled data (avoids having to allocate a `CaseMapper` object)
-        *
-        *See the [Rust documentation for `simple_fold`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapperBorrowed.html#method.simple_fold) for more information.
-        */
+        /**
+         * Returns the simple casefolding of the given character, using compiled data (avoids having to allocate a `CaseMapper` object)
+         *
+         * See the [Rust documentation for `simple_fold`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapperBorrowed.html#method.simple_fold) for more information.
+         */
         fun simpleFoldWithCompiledData(ch: Int): Int {
             
             val returnVal = lib.icu4x_CaseMapper_simple_fold_with_compiled_data_mv1(ch);
@@ -195,10 +205,11 @@ class CaseMapper internal constructor (
         }
         @JvmStatic
         
-        /** Returns the simple Turkic casefolding of the given character, using compiled data (avoids having to allocate a `CaseMapper` object)
-        *
-        *See the [Rust documentation for `simple_fold_turkic`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapperBorrowed.html#method.simple_fold_turkic) for more information.
-        */
+        /**
+         * Returns the simple Turkic casefolding of the given character, using compiled data (avoids having to allocate a `CaseMapper` object)
+         *
+         * See the [Rust documentation for `simple_fold_turkic`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapperBorrowed.html#method.simple_fold_turkic) for more information.
+         */
         fun simpleFoldTurkicWithCompiledData(ch: Int): Int {
             
             val returnVal = lib.icu4x_CaseMapper_simple_fold_turkic_with_compiled_data_mv1(ch);
@@ -206,10 +217,11 @@ class CaseMapper internal constructor (
         }
     }
     
-    /** Returns the full lowercase mapping of the given string
-    *
-    *See the [Rust documentation for `lowercase`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapperBorrowed.html#method.lowercase) for more information.
-    */
+    /**
+     * Returns the full lowercase mapping of the given string
+     *
+     * See the [Rust documentation for `lowercase`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapperBorrowed.html#method.lowercase) for more information.
+     */
     fun lowercase(s: String, locale: Locale): String {
         val sSliceMemory = PrimitiveArrayTools.borrowUtf8(s)
         val write = DW.lib.diplomat_buffer_write_create(0)
@@ -223,10 +235,11 @@ class CaseMapper internal constructor (
         }
     }
     
-    /** Returns the full uppercase mapping of the given string
-    *
-    *See the [Rust documentation for `uppercase`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapperBorrowed.html#method.uppercase) for more information.
-    */
+    /**
+     * Returns the full uppercase mapping of the given string
+     *
+     * See the [Rust documentation for `uppercase`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapperBorrowed.html#method.uppercase) for more information.
+     */
     fun uppercase(s: String, locale: Locale): String {
         val sSliceMemory = PrimitiveArrayTools.borrowUtf8(s)
         val write = DW.lib.diplomat_buffer_write_create(0)
@@ -240,14 +253,15 @@ class CaseMapper internal constructor (
         }
     }
     
-    /** Returns the full titlecase mapping of the given string, performing head adjustment without
-    *loading additional data.
-    *(if head adjustment is enabled in the options)
-    *
-    *The `v1` refers to the version of the options struct, which may change as we add more options
-    *
-    *See the [Rust documentation for `titlecase_segment_with_only_case_data`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapperBorrowed.html#method.titlecase_segment_with_only_case_data) for more information.
-    */
+    /**
+     * Returns the full titlecase mapping of the given string, performing head adjustment without
+     * loading additional data.
+     * (if head adjustment is enabled in the options)
+     *
+     * The `v1` refers to the version of the options struct, which may change as we add more options
+     *
+     * See the [Rust documentation for `titlecase_segment_with_only_case_data`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapperBorrowed.html#method.titlecase_segment_with_only_case_data) for more information.
+     */
     fun titlecase_segment_with_only_case_data(s: String, locale: Locale, options: TitlecaseOptions): String {
         val sSliceMemory = PrimitiveArrayTools.borrowUtf8(s)
         val write = DW.lib.diplomat_buffer_write_create(0)
@@ -261,10 +275,11 @@ class CaseMapper internal constructor (
         }
     }
     
-    /** Case-folds the characters in the given string
-    *
-    *See the [Rust documentation for `fold`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapperBorrowed.html#method.fold) for more information.
-    */
+    /**
+     * Case-folds the characters in the given string
+     *
+     * See the [Rust documentation for `fold`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapperBorrowed.html#method.fold) for more information.
+     */
     fun fold(s: String): String {
         val sSliceMemory = PrimitiveArrayTools.borrowUtf8(s)
         val write = DW.lib.diplomat_buffer_write_create(0)
@@ -278,11 +293,12 @@ class CaseMapper internal constructor (
         }
     }
     
-    /** Case-folds the characters in the given string
-    *using Turkic (T) mappings for dotted/dotless I.
-    *
-    *See the [Rust documentation for `fold_turkic`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapperBorrowed.html#method.fold_turkic) for more information.
-    */
+    /**
+     * Case-folds the characters in the given string
+     * using Turkic (T) mappings for dotted/dotless I.
+     *
+     * See the [Rust documentation for `fold_turkic`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapperBorrowed.html#method.fold_turkic) for more information.
+     */
     fun foldTurkic(s: String): String {
         val sSliceMemory = PrimitiveArrayTools.borrowUtf8(s)
         val write = DW.lib.diplomat_buffer_write_create(0)
@@ -296,88 +312,94 @@ class CaseMapper internal constructor (
         }
     }
     
-    /** Adds all simple case mappings and the full case folding for `c` to `builder`.
-    *Also adds special case closure mappings.
-    *
-    *In other words, this adds all characters that this casemaps to, as
-    *well as all characters that may casemap to this one.
-    *
-    *Note that since `CodePointSetBuilder` does not contain strings, this will
-    *ignore string mappings.
-    *
-    *Identical to the similarly named method on `CaseMapCloser`, use that if you
-    *plan on using string case closure mappings too.
-    *
-    *See the [Rust documentation for `add_case_closure_to`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapperBorrowed.html#method.add_case_closure_to) for more information.
-    */
+    /**
+     * Adds all simple case mappings and the full case folding for `c` to `builder`.
+     * Also adds special case closure mappings.
+     *
+     * In other words, this adds all characters that this casemaps to, as
+     * well as all characters that may casemap to this one.
+     *
+     * Note that since `CodePointSetBuilder` does not contain strings, this will
+     * ignore string mappings.
+     *
+     * Identical to the similarly named method on `CaseMapCloser`, use that if you
+     * plan on using string case closure mappings too.
+     *
+     * See the [Rust documentation for `add_case_closure_to`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapperBorrowed.html#method.add_case_closure_to) for more information.
+     */
     fun addCaseClosureTo(c: Int, builder: CodePointSetBuilder): Unit {
         
         val returnVal = lib.icu4x_CaseMapper_add_case_closure_to_mv1(handle, c, builder.handle /* note this is a mutable reference. Think carefully about using, especially concurrently */);
         
     }
     
-    /** Returns the simple lowercase mapping of the given character.
-    *
-    *This function only implements simple and common mappings.
-    *Full mappings, which can map one char to a string, are not included.
-    *For full mappings, use `CaseMapperBorrowed::lowercase`.
-    *
-    *See the [Rust documentation for `simple_lowercase`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapperBorrowed.html#method.simple_lowercase) for more information.
-    */
+    /**
+     * Returns the simple lowercase mapping of the given character.
+     *
+     * This function only implements simple and common mappings.
+     * Full mappings, which can map one char to a string, are not included.
+     * For full mappings, use `CaseMapperBorrowed::lowercase`.
+     *
+     * See the [Rust documentation for `simple_lowercase`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapperBorrowed.html#method.simple_lowercase) for more information.
+     */
     fun simpleLowercase(ch: Int): Int {
         
         val returnVal = lib.icu4x_CaseMapper_simple_lowercase_mv1(handle, ch);
         return (returnVal)
     }
     
-    /** Returns the simple uppercase mapping of the given character.
-    *
-    *This function only implements simple and common mappings.
-    *Full mappings, which can map one char to a string, are not included.
-    *For full mappings, use `CaseMapperBorrowed::uppercase`.
-    *
-    *See the [Rust documentation for `simple_uppercase`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapperBorrowed.html#method.simple_uppercase) for more information.
-    */
+    /**
+     * Returns the simple uppercase mapping of the given character.
+     *
+     * This function only implements simple and common mappings.
+     * Full mappings, which can map one char to a string, are not included.
+     * For full mappings, use `CaseMapperBorrowed::uppercase`.
+     *
+     * See the [Rust documentation for `simple_uppercase`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapperBorrowed.html#method.simple_uppercase) for more information.
+     */
     fun simpleUppercase(ch: Int): Int {
         
         val returnVal = lib.icu4x_CaseMapper_simple_uppercase_mv1(handle, ch);
         return (returnVal)
     }
     
-    /** Returns the simple titlecase mapping of the given character.
-    *
-    *This function only implements simple and common mappings.
-    *Full mappings, which can map one char to a string, are not included.
-    *For full mappings, use `CaseMapperBorrowed::titlecase_segment`.
-    *
-    *See the [Rust documentation for `simple_titlecase`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapperBorrowed.html#method.simple_titlecase) for more information.
-    */
+    /**
+     * Returns the simple titlecase mapping of the given character.
+     *
+     * This function only implements simple and common mappings.
+     * Full mappings, which can map one char to a string, are not included.
+     * For full mappings, use `CaseMapperBorrowed::titlecase_segment`.
+     *
+     * See the [Rust documentation for `simple_titlecase`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapperBorrowed.html#method.simple_titlecase) for more information.
+     */
     fun simpleTitlecase(ch: Int): Int {
         
         val returnVal = lib.icu4x_CaseMapper_simple_titlecase_mv1(handle, ch);
         return (returnVal)
     }
     
-    /** Returns the simple casefolding of the given character.
-    *
-    *This function only implements simple folding.
-    *For full folding, use `CaseMapperBorrowed::fold`.
-    *
-    *See the [Rust documentation for `simple_fold`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapperBorrowed.html#method.simple_fold) for more information.
-    */
+    /**
+     * Returns the simple casefolding of the given character.
+     *
+     * This function only implements simple folding.
+     * For full folding, use `CaseMapperBorrowed::fold`.
+     *
+     * See the [Rust documentation for `simple_fold`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapperBorrowed.html#method.simple_fold) for more information.
+     */
     fun simpleFold(ch: Int): Int {
         
         val returnVal = lib.icu4x_CaseMapper_simple_fold_mv1(handle, ch);
         return (returnVal)
     }
     
-    /** Returns the simple casefolding of the given character in the Turkic locale.
-    *
-    *This function only implements simple folding.
-    *For full folding, use `CaseMapperBorrowed::fold_turkic`.
-    *
-    *See the [Rust documentation for `simple_fold_turkic`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapperBorrowed.html#method.simple_fold_turkic) for more information.
-    */
+    /**
+     * Returns the simple casefolding of the given character in the Turkic locale.
+     *
+     * This function only implements simple folding.
+     * For full folding, use `CaseMapperBorrowed::fold_turkic`.
+     *
+     * See the [Rust documentation for `simple_fold_turkic`](https://docs.rs/icu/2.3.1/icu/casemap/struct.CaseMapperBorrowed.html#method.simple_fold_turkic) for more information.
+     */
     fun simpleFoldTurkic(ch: Int): Int {
         
         val returnVal = lib.icu4x_CaseMapper_simple_fold_turkic_mv1(handle, ch);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CodePointMapData16.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CodePointMapData16.kt
@@ -16,16 +16,17 @@ internal interface CodePointMapData16Lib: Library {
     fun icu4x_CodePointMapData16_create_script_mv1(): Pointer
     fun icu4x_CodePointMapData16_create_script_with_provider_mv1(provider: Pointer): ResultPointerInt
 }
-/** An ICU4X Unicode Map Property object, capable of querying whether a code point (key) to obtain the Unicode property value, for a specific Unicode property.
-*
-*For properties whose values fit into 16 bits.
-*
-*See the [Rust documentation for `properties`](https://docs.rs/icu/2.3.1/icu/properties/index.html) for more information.
-*
-*See the [Rust documentation for `CodePointMapData`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointMapData.html) for more information.
-*
-*See the [Rust documentation for `CodePointMapDataBorrowed`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointMapDataBorrowed.html) for more information.
-*/
+/**
+ * An ICU4X Unicode Map Property object, capable of querying whether a code point (key) to obtain the Unicode property value, for a specific Unicode property.
+ *
+ * For properties whose values fit into 16 bits.
+ *
+ * See the [Rust documentation for `properties`](https://docs.rs/icu/2.3.1/icu/properties/index.html) for more information.
+ *
+ * See the [Rust documentation for `CodePointMapData`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointMapData.html) for more information.
+ *
+ * See the [Rust documentation for `CodePointMapDataBorrowed`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointMapDataBorrowed.html) for more information.
+ */
 class CodePointMapData16 internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -54,10 +55,11 @@ class CodePointMapData16 internal constructor (
         internal val lib: CodePointMapData16Lib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Create a map for the `Block` property, using compiled data.
-        *
-        *See the [Rust documentation for `Block`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Block.html) for more information.
-        */
+        /**
+         * Create a map for the `Block` property, using compiled data.
+         *
+         * See the [Rust documentation for `Block`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Block.html) for more information.
+         */
         fun createBlock(): CodePointMapData16 {
             
             val returnVal = lib.icu4x_CodePointMapData16_create_block_mv1();
@@ -68,10 +70,11 @@ class CodePointMapData16 internal constructor (
         }
         @JvmStatic
         
-        /** Create a map for the `Block` property, using a particular data source.
-        *
-        *See the [Rust documentation for `Block`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Block.html) for more information.
-        */
+        /**
+         * Create a map for the `Block` property, using a particular data source.
+         *
+         * See the [Rust documentation for `Block`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Block.html) for more information.
+         */
         fun createBlockWithProvider(provider: DataProvider): Result<CodePointMapData16> {
             
             val returnVal = lib.icu4x_CodePointMapData16_create_block_with_provider_mv1(provider.handle);
@@ -87,10 +90,11 @@ class CodePointMapData16 internal constructor (
         }
         @JvmStatic
         
-        /** Create a map for the `Script` property, using compiled data.
-        *
-        *See the [Rust documentation for `Script`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Script.html) for more information.
-        */
+        /**
+         * Create a map for the `Script` property, using compiled data.
+         *
+         * See the [Rust documentation for `Script`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Script.html) for more information.
+         */
         fun createScript(): CodePointMapData16 {
             
             val returnVal = lib.icu4x_CodePointMapData16_create_script_mv1();
@@ -101,10 +105,11 @@ class CodePointMapData16 internal constructor (
         }
         @JvmStatic
         
-        /** Create a map for the `Script` property, using a particular data source.
-        *
-        *See the [Rust documentation for `Script`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Script.html) for more information.
-        */
+        /**
+         * Create a map for the `Script` property, using a particular data source.
+         *
+         * See the [Rust documentation for `Script`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Script.html) for more information.
+         */
         fun createScriptWithProvider(provider: DataProvider): Result<CodePointMapData16> {
             
             val returnVal = lib.icu4x_CodePointMapData16_create_script_with_provider_mv1(provider.handle);
@@ -120,20 +125,22 @@ class CodePointMapData16 internal constructor (
         }
     }
     
-    /** Gets the value for a code point.
-    *
-    *See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointMapDataBorrowed.html#method.get) for more information.
-    */
+    /**
+     * Gets the value for a code point.
+     *
+     * See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointMapDataBorrowed.html#method.get) for more information.
+     */
     fun get(cp: Int): UShort {
         
         val returnVal = lib.icu4x_CodePointMapData16_get_mv1(handle, cp);
         return (returnVal.toUShort())
     }
     
-    /** Produces an iterator over ranges of code points that map to `value`
-    *
-    *See the [Rust documentation for `iter_ranges_for_value`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointMapDataBorrowed.html#method.iter_ranges_for_value) for more information.
-    */
+    /**
+     * Produces an iterator over ranges of code points that map to `value`
+     *
+     * See the [Rust documentation for `iter_ranges_for_value`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointMapDataBorrowed.html#method.iter_ranges_for_value) for more information.
+     */
     fun iterRangesForValue(value: UShort): CodePointRangeIterator {
         // This lifetime edge depends on lifetimes: 'a
         val aEdges: MutableList<Any> = mutableListOf(this);
@@ -145,10 +152,11 @@ class CodePointMapData16 internal constructor (
         return returnOpaque
     }
     
-    /** Produces an iterator over ranges of code points that do not map to `value`
-    *
-    *See the [Rust documentation for `iter_ranges_for_value_complemented`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointMapDataBorrowed.html#method.iter_ranges_for_value_complemented) for more information.
-    */
+    /**
+     * Produces an iterator over ranges of code points that do not map to `value`
+     *
+     * See the [Rust documentation for `iter_ranges_for_value_complemented`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointMapDataBorrowed.html#method.iter_ranges_for_value_complemented) for more information.
+     */
     fun iterRangesForValueComplemented(value: UShort): CodePointRangeIterator {
         // This lifetime edge depends on lifetimes: 'a
         val aEdges: MutableList<Any> = mutableListOf(this);
@@ -160,10 +168,11 @@ class CodePointMapData16 internal constructor (
         return returnOpaque
     }
     
-    /** Gets a [CodePointSetData] representing all entries in this map that map to the given value
-    *
-    *See the [Rust documentation for `get_set_for_value`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointMapDataBorrowed.html#method.get_set_for_value) for more information.
-    */
+    /**
+     * Gets a [CodePointSetData] representing all entries in this map that map to the given value
+     *
+     * See the [Rust documentation for `get_set_for_value`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointMapDataBorrowed.html#method.get_set_for_value) for more information.
+     */
     fun getSetForValue(value: UShort): CodePointSetData {
         
         val returnVal = lib.icu4x_CodePointMapData16_get_set_for_value_mv1(handle, FFIUint16(value));

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CodePointMapData8.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CodePointMapData8.kt
@@ -43,16 +43,17 @@ internal interface CodePointMapData8Lib: Library {
     fun icu4x_CodePointMapData8_create_word_break_mv1(): Pointer
     fun icu4x_CodePointMapData8_create_word_break_with_provider_mv1(provider: Pointer): ResultPointerInt
 }
-/** An ICU4X Unicode Map Property object, capable of querying whether a code point (key) to obtain the Unicode property value, for a specific Unicode property.
-*
-*For properties whose values fit into 8 bits.
-*
-*See the [Rust documentation for `properties`](https://docs.rs/icu/2.3.1/icu/properties/index.html) for more information.
-*
-*See the [Rust documentation for `CodePointMapData`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointMapData.html) for more information.
-*
-*See the [Rust documentation for `CodePointMapDataBorrowed`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointMapDataBorrowed.html) for more information.
-*/
+/**
+ * An ICU4X Unicode Map Property object, capable of querying whether a code point (key) to obtain the Unicode property value, for a specific Unicode property.
+ *
+ * For properties whose values fit into 8 bits.
+ *
+ * See the [Rust documentation for `properties`](https://docs.rs/icu/2.3.1/icu/properties/index.html) for more information.
+ *
+ * See the [Rust documentation for `CodePointMapData`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointMapData.html) for more information.
+ *
+ * See the [Rust documentation for `CodePointMapDataBorrowed`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointMapDataBorrowed.html) for more information.
+ */
 class CodePointMapData8 internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -81,10 +82,11 @@ class CodePointMapData8 internal constructor (
         internal val lib: CodePointMapData8Lib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Create a map for the `BidiClass` property, using compiled data.
-        *
-        *See the [Rust documentation for `BidiClass`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.BidiClass.html) for more information.
-        */
+        /**
+         * Create a map for the `BidiClass` property, using compiled data.
+         *
+         * See the [Rust documentation for `BidiClass`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.BidiClass.html) for more information.
+         */
         fun createBidiClass(): CodePointMapData8 {
             
             val returnVal = lib.icu4x_CodePointMapData8_create_bidi_class_mv1();
@@ -95,10 +97,11 @@ class CodePointMapData8 internal constructor (
         }
         @JvmStatic
         
-        /** Create a map for the `BidiClass` property, using a particular data source.
-        *
-        *See the [Rust documentation for `BidiClass`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.BidiClass.html) for more information.
-        */
+        /**
+         * Create a map for the `BidiClass` property, using a particular data source.
+         *
+         * See the [Rust documentation for `BidiClass`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.BidiClass.html) for more information.
+         */
         fun createBidiClassWithProvider(provider: DataProvider): Result<CodePointMapData8> {
             
             val returnVal = lib.icu4x_CodePointMapData8_create_bidi_class_with_provider_mv1(provider.handle);
@@ -114,10 +117,11 @@ class CodePointMapData8 internal constructor (
         }
         @JvmStatic
         
-        /** Create a map for the `CanonicalCombiningClass` property, using compiled data.
-        *
-        *See the [Rust documentation for `CanonicalCombiningClass`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.CanonicalCombiningClass.html) for more information.
-        */
+        /**
+         * Create a map for the `CanonicalCombiningClass` property, using compiled data.
+         *
+         * See the [Rust documentation for `CanonicalCombiningClass`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.CanonicalCombiningClass.html) for more information.
+         */
         fun createCanonicalCombiningClass(): CodePointMapData8 {
             
             val returnVal = lib.icu4x_CodePointMapData8_create_canonical_combining_class_mv1();
@@ -128,10 +132,11 @@ class CodePointMapData8 internal constructor (
         }
         @JvmStatic
         
-        /** Create a map for the `CanonicalCombiningClass` property, using a particular data source.
-        *
-        *See the [Rust documentation for `CanonicalCombiningClass`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.CanonicalCombiningClass.html) for more information.
-        */
+        /**
+         * Create a map for the `CanonicalCombiningClass` property, using a particular data source.
+         *
+         * See the [Rust documentation for `CanonicalCombiningClass`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.CanonicalCombiningClass.html) for more information.
+         */
         fun createCanonicalCombiningClassWithProvider(provider: DataProvider): Result<CodePointMapData8> {
             
             val returnVal = lib.icu4x_CodePointMapData8_create_canonical_combining_class_with_provider_mv1(provider.handle);
@@ -147,10 +152,11 @@ class CodePointMapData8 internal constructor (
         }
         @JvmStatic
         
-        /** Create a map for the `EastAsianWidth` property, using compiled data.
-        *
-        *See the [Rust documentation for `EastAsianWidth`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.EastAsianWidth.html) for more information.
-        */
+        /**
+         * Create a map for the `EastAsianWidth` property, using compiled data.
+         *
+         * See the [Rust documentation for `EastAsianWidth`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.EastAsianWidth.html) for more information.
+         */
         fun createEastAsianWidth(): CodePointMapData8 {
             
             val returnVal = lib.icu4x_CodePointMapData8_create_east_asian_width_mv1();
@@ -161,10 +167,11 @@ class CodePointMapData8 internal constructor (
         }
         @JvmStatic
         
-        /** Create a map for the `EastAsianWidth` property, using a particular data source.
-        *
-        *See the [Rust documentation for `EastAsianWidth`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.EastAsianWidth.html) for more information.
-        */
+        /**
+         * Create a map for the `EastAsianWidth` property, using a particular data source.
+         *
+         * See the [Rust documentation for `EastAsianWidth`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.EastAsianWidth.html) for more information.
+         */
         fun createEastAsianWidthWithProvider(provider: DataProvider): Result<CodePointMapData8> {
             
             val returnVal = lib.icu4x_CodePointMapData8_create_east_asian_width_with_provider_mv1(provider.handle);
@@ -180,10 +187,11 @@ class CodePointMapData8 internal constructor (
         }
         @JvmStatic
         
-        /** Create a map for the `GeneralCategory` property, using compiled data.
-        *
-        *See the [Rust documentation for `GeneralCategory`](https://docs.rs/icu/2.3.1/icu/properties/props/enum.GeneralCategory.html) for more information.
-        */
+        /**
+         * Create a map for the `GeneralCategory` property, using compiled data.
+         *
+         * See the [Rust documentation for `GeneralCategory`](https://docs.rs/icu/2.3.1/icu/properties/props/enum.GeneralCategory.html) for more information.
+         */
         fun createGeneralCategory(): CodePointMapData8 {
             
             val returnVal = lib.icu4x_CodePointMapData8_create_general_category_mv1();
@@ -194,10 +202,11 @@ class CodePointMapData8 internal constructor (
         }
         @JvmStatic
         
-        /** Create a map for the `GeneralCategory` property, using a particular data source.
-        *
-        *See the [Rust documentation for `GeneralCategory`](https://docs.rs/icu/2.3.1/icu/properties/props/enum.GeneralCategory.html) for more information.
-        */
+        /**
+         * Create a map for the `GeneralCategory` property, using a particular data source.
+         *
+         * See the [Rust documentation for `GeneralCategory`](https://docs.rs/icu/2.3.1/icu/properties/props/enum.GeneralCategory.html) for more information.
+         */
         fun createGeneralCategoryWithProvider(provider: DataProvider): Result<CodePointMapData8> {
             
             val returnVal = lib.icu4x_CodePointMapData8_create_general_category_with_provider_mv1(provider.handle);
@@ -213,10 +222,11 @@ class CodePointMapData8 internal constructor (
         }
         @JvmStatic
         
-        /** Create a map for the `GraphemeClusterBreak` property, using compiled data.
-        *
-        *See the [Rust documentation for `GraphemeClusterBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GraphemeClusterBreak.html) for more information.
-        */
+        /**
+         * Create a map for the `GraphemeClusterBreak` property, using compiled data.
+         *
+         * See the [Rust documentation for `GraphemeClusterBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GraphemeClusterBreak.html) for more information.
+         */
         fun createGraphemeClusterBreak(): CodePointMapData8 {
             
             val returnVal = lib.icu4x_CodePointMapData8_create_grapheme_cluster_break_mv1();
@@ -227,10 +237,11 @@ class CodePointMapData8 internal constructor (
         }
         @JvmStatic
         
-        /** Create a map for the `GraphemeClusterBreak` property, using a particular data source.
-        *
-        *See the [Rust documentation for `GraphemeClusterBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GraphemeClusterBreak.html) for more information.
-        */
+        /**
+         * Create a map for the `GraphemeClusterBreak` property, using a particular data source.
+         *
+         * See the [Rust documentation for `GraphemeClusterBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GraphemeClusterBreak.html) for more information.
+         */
         fun createGraphemeClusterBreakWithProvider(provider: DataProvider): Result<CodePointMapData8> {
             
             val returnVal = lib.icu4x_CodePointMapData8_create_grapheme_cluster_break_with_provider_mv1(provider.handle);
@@ -246,10 +257,11 @@ class CodePointMapData8 internal constructor (
         }
         @JvmStatic
         
-        /** Create a map for the `HangulSyllableType` property, using compiled data.
-        *
-        *See the [Rust documentation for `HangulSyllableType`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.HangulSyllableType.html) for more information.
-        */
+        /**
+         * Create a map for the `HangulSyllableType` property, using compiled data.
+         *
+         * See the [Rust documentation for `HangulSyllableType`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.HangulSyllableType.html) for more information.
+         */
         fun createHangulSyllableType(): CodePointMapData8 {
             
             val returnVal = lib.icu4x_CodePointMapData8_create_hangul_syllable_type_mv1();
@@ -260,10 +272,11 @@ class CodePointMapData8 internal constructor (
         }
         @JvmStatic
         
-        /** Create a map for the `HangulSyllableType` property, using a particular data source.
-        *
-        *See the [Rust documentation for `HangulSyllableType`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.HangulSyllableType.html) for more information.
-        */
+        /**
+         * Create a map for the `HangulSyllableType` property, using a particular data source.
+         *
+         * See the [Rust documentation for `HangulSyllableType`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.HangulSyllableType.html) for more information.
+         */
         fun createHangulSyllableTypeWithProvider(provider: DataProvider): Result<CodePointMapData8> {
             
             val returnVal = lib.icu4x_CodePointMapData8_create_hangul_syllable_type_with_provider_mv1(provider.handle);
@@ -279,10 +292,11 @@ class CodePointMapData8 internal constructor (
         }
         @JvmStatic
         
-        /** Create a map for the `IndicConjunctBreak` property, using compiled data.
-        *
-        *See the [Rust documentation for `IndicConjunctBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IndicConjunctBreak.html) for more information.
-        */
+        /**
+         * Create a map for the `IndicConjunctBreak` property, using compiled data.
+         *
+         * See the [Rust documentation for `IndicConjunctBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IndicConjunctBreak.html) for more information.
+         */
         fun createIndicConjunctBreak(): CodePointMapData8 {
             
             val returnVal = lib.icu4x_CodePointMapData8_create_indic_conjunct_break_mv1();
@@ -293,10 +307,11 @@ class CodePointMapData8 internal constructor (
         }
         @JvmStatic
         
-        /** Create a map for the `IndicConjunctBreak` property, using a particular data source.
-        *
-        *See the [Rust documentation for `IndicConjunctBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IndicConjunctBreak.html) for more information.
-        */
+        /**
+         * Create a map for the `IndicConjunctBreak` property, using a particular data source.
+         *
+         * See the [Rust documentation for `IndicConjunctBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IndicConjunctBreak.html) for more information.
+         */
         fun createIndicConjunctBreakWithProvider(provider: DataProvider): Result<CodePointMapData8> {
             
             val returnVal = lib.icu4x_CodePointMapData8_create_indic_conjunct_break_with_provider_mv1(provider.handle);
@@ -312,10 +327,11 @@ class CodePointMapData8 internal constructor (
         }
         @JvmStatic
         
-        /** Create a map for the `IndicSyllabicCategory` property, using compiled data.
-        *
-        *See the [Rust documentation for `IndicSyllabicCategory`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IndicSyllabicCategory.html) for more information.
-        */
+        /**
+         * Create a map for the `IndicSyllabicCategory` property, using compiled data.
+         *
+         * See the [Rust documentation for `IndicSyllabicCategory`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IndicSyllabicCategory.html) for more information.
+         */
         fun createIndicSyllabicCategory(): CodePointMapData8 {
             
             val returnVal = lib.icu4x_CodePointMapData8_create_indic_syllabic_category_mv1();
@@ -326,10 +342,11 @@ class CodePointMapData8 internal constructor (
         }
         @JvmStatic
         
-        /** Create a map for the `IndicSyllabicCategory` property, using a particular data source.
-        *
-        *See the [Rust documentation for `IndicSyllabicCategory`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IndicSyllabicCategory.html) for more information.
-        */
+        /**
+         * Create a map for the `IndicSyllabicCategory` property, using a particular data source.
+         *
+         * See the [Rust documentation for `IndicSyllabicCategory`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IndicSyllabicCategory.html) for more information.
+         */
         fun createIndicSyllabicCategoryWithProvider(provider: DataProvider): Result<CodePointMapData8> {
             
             val returnVal = lib.icu4x_CodePointMapData8_create_indic_syllabic_category_with_provider_mv1(provider.handle);
@@ -345,10 +362,11 @@ class CodePointMapData8 internal constructor (
         }
         @JvmStatic
         
-        /** Create a map for the `JoiningGroup` property, using compiled data.
-        *
-        *See the [Rust documentation for `JoiningGroup`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.JoiningGroup.html) for more information.
-        */
+        /**
+         * Create a map for the `JoiningGroup` property, using compiled data.
+         *
+         * See the [Rust documentation for `JoiningGroup`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.JoiningGroup.html) for more information.
+         */
         fun createJoiningGroup(): CodePointMapData8 {
             
             val returnVal = lib.icu4x_CodePointMapData8_create_joining_group_mv1();
@@ -359,10 +377,11 @@ class CodePointMapData8 internal constructor (
         }
         @JvmStatic
         
-        /** Create a map for the `JoiningGroup` property, using a particular data source.
-        *
-        *See the [Rust documentation for `JoiningGroup`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.JoiningGroup.html) for more information.
-        */
+        /**
+         * Create a map for the `JoiningGroup` property, using a particular data source.
+         *
+         * See the [Rust documentation for `JoiningGroup`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.JoiningGroup.html) for more information.
+         */
         fun createJoiningGroupWithProvider(provider: DataProvider): Result<CodePointMapData8> {
             
             val returnVal = lib.icu4x_CodePointMapData8_create_joining_group_with_provider_mv1(provider.handle);
@@ -378,10 +397,11 @@ class CodePointMapData8 internal constructor (
         }
         @JvmStatic
         
-        /** Create a map for the `JoiningType` property, using compiled data.
-        *
-        *See the [Rust documentation for `JoiningType`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.JoiningType.html) for more information.
-        */
+        /**
+         * Create a map for the `JoiningType` property, using compiled data.
+         *
+         * See the [Rust documentation for `JoiningType`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.JoiningType.html) for more information.
+         */
         fun createJoiningType(): CodePointMapData8 {
             
             val returnVal = lib.icu4x_CodePointMapData8_create_joining_type_mv1();
@@ -392,10 +412,11 @@ class CodePointMapData8 internal constructor (
         }
         @JvmStatic
         
-        /** Create a map for the `JoiningType` property, using a particular data source.
-        *
-        *See the [Rust documentation for `JoiningType`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.JoiningType.html) for more information.
-        */
+        /**
+         * Create a map for the `JoiningType` property, using a particular data source.
+         *
+         * See the [Rust documentation for `JoiningType`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.JoiningType.html) for more information.
+         */
         fun createJoiningTypeWithProvider(provider: DataProvider): Result<CodePointMapData8> {
             
             val returnVal = lib.icu4x_CodePointMapData8_create_joining_type_with_provider_mv1(provider.handle);
@@ -411,10 +432,11 @@ class CodePointMapData8 internal constructor (
         }
         @JvmStatic
         
-        /** Create a map for the `LineBreak` property, using compiled data.
-        *
-        *See the [Rust documentation for `LineBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.LineBreak.html) for more information.
-        */
+        /**
+         * Create a map for the `LineBreak` property, using compiled data.
+         *
+         * See the [Rust documentation for `LineBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.LineBreak.html) for more information.
+         */
         fun createLineBreak(): CodePointMapData8 {
             
             val returnVal = lib.icu4x_CodePointMapData8_create_line_break_mv1();
@@ -425,10 +447,11 @@ class CodePointMapData8 internal constructor (
         }
         @JvmStatic
         
-        /** Create a map for the `LineBreak` property, using a particular data source.
-        *
-        *See the [Rust documentation for `LineBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.LineBreak.html) for more information.
-        */
+        /**
+         * Create a map for the `LineBreak` property, using a particular data source.
+         *
+         * See the [Rust documentation for `LineBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.LineBreak.html) for more information.
+         */
         fun createLineBreakWithProvider(provider: DataProvider): Result<CodePointMapData8> {
             
             val returnVal = lib.icu4x_CodePointMapData8_create_line_break_with_provider_mv1(provider.handle);
@@ -444,10 +467,11 @@ class CodePointMapData8 internal constructor (
         }
         @JvmStatic
         
-        /** Create a map for the `NumericType` property, using compiled data.
-        *
-        *See the [Rust documentation for `NumericType`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.NumericType.html) for more information.
-        */
+        /**
+         * Create a map for the `NumericType` property, using compiled data.
+         *
+         * See the [Rust documentation for `NumericType`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.NumericType.html) for more information.
+         */
         fun createNumericType(): CodePointMapData8 {
             
             val returnVal = lib.icu4x_CodePointMapData8_create_numeric_type_mv1();
@@ -458,10 +482,11 @@ class CodePointMapData8 internal constructor (
         }
         @JvmStatic
         
-        /** Create a map for the `NumericType` property, using a particular data source.
-        *
-        *See the [Rust documentation for `NumericType`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.NumericType.html) for more information.
-        */
+        /**
+         * Create a map for the `NumericType` property, using a particular data source.
+         *
+         * See the [Rust documentation for `NumericType`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.NumericType.html) for more information.
+         */
         fun createNumericTypeWithProvider(provider: DataProvider): Result<CodePointMapData8> {
             
             val returnVal = lib.icu4x_CodePointMapData8_create_numeric_type_with_provider_mv1(provider.handle);
@@ -477,10 +502,11 @@ class CodePointMapData8 internal constructor (
         }
         @JvmStatic
         
-        /** Create a map for the `SentenceBreak` property, using compiled data.
-        *
-        *See the [Rust documentation for `SentenceBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.SentenceBreak.html) for more information.
-        */
+        /**
+         * Create a map for the `SentenceBreak` property, using compiled data.
+         *
+         * See the [Rust documentation for `SentenceBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.SentenceBreak.html) for more information.
+         */
         fun createSentenceBreak(): CodePointMapData8 {
             
             val returnVal = lib.icu4x_CodePointMapData8_create_sentence_break_mv1();
@@ -491,10 +517,11 @@ class CodePointMapData8 internal constructor (
         }
         @JvmStatic
         
-        /** Create a map for the `SentenceBreak` property, using a particular data source.
-        *
-        *See the [Rust documentation for `SentenceBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.SentenceBreak.html) for more information.
-        */
+        /**
+         * Create a map for the `SentenceBreak` property, using a particular data source.
+         *
+         * See the [Rust documentation for `SentenceBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.SentenceBreak.html) for more information.
+         */
         fun createSentenceBreakWithProvider(provider: DataProvider): Result<CodePointMapData8> {
             
             val returnVal = lib.icu4x_CodePointMapData8_create_sentence_break_with_provider_mv1(provider.handle);
@@ -510,10 +537,11 @@ class CodePointMapData8 internal constructor (
         }
         @JvmStatic
         
-        /** Create a map for the `VerticalOrientation` property, using compiled data.
-        *
-        *See the [Rust documentation for `VerticalOrientation`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.VerticalOrientation.html) for more information.
-        */
+        /**
+         * Create a map for the `VerticalOrientation` property, using compiled data.
+         *
+         * See the [Rust documentation for `VerticalOrientation`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.VerticalOrientation.html) for more information.
+         */
         fun createVerticalOrientation(): CodePointMapData8 {
             
             val returnVal = lib.icu4x_CodePointMapData8_create_vertical_orientation_mv1();
@@ -524,10 +552,11 @@ class CodePointMapData8 internal constructor (
         }
         @JvmStatic
         
-        /** Create a map for the `VerticalOrientation` property, using a particular data source.
-        *
-        *See the [Rust documentation for `VerticalOrientation`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.VerticalOrientation.html) for more information.
-        */
+        /**
+         * Create a map for the `VerticalOrientation` property, using a particular data source.
+         *
+         * See the [Rust documentation for `VerticalOrientation`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.VerticalOrientation.html) for more information.
+         */
         fun createVerticalOrientationWithProvider(provider: DataProvider): Result<CodePointMapData8> {
             
             val returnVal = lib.icu4x_CodePointMapData8_create_vertical_orientation_with_provider_mv1(provider.handle);
@@ -543,10 +572,11 @@ class CodePointMapData8 internal constructor (
         }
         @JvmStatic
         
-        /** Create a map for the `WordBreak` property, using compiled data.
-        *
-        *See the [Rust documentation for `WordBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.WordBreak.html) for more information.
-        */
+        /**
+         * Create a map for the `WordBreak` property, using compiled data.
+         *
+         * See the [Rust documentation for `WordBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.WordBreak.html) for more information.
+         */
         fun createWordBreak(): CodePointMapData8 {
             
             val returnVal = lib.icu4x_CodePointMapData8_create_word_break_mv1();
@@ -557,10 +587,11 @@ class CodePointMapData8 internal constructor (
         }
         @JvmStatic
         
-        /** Create a map for the `WordBreak` property, using a particular data source.
-        *
-        *See the [Rust documentation for `WordBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.WordBreak.html) for more information.
-        */
+        /**
+         * Create a map for the `WordBreak` property, using a particular data source.
+         *
+         * See the [Rust documentation for `WordBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.WordBreak.html) for more information.
+         */
         fun createWordBreakWithProvider(provider: DataProvider): Result<CodePointMapData8> {
             
             val returnVal = lib.icu4x_CodePointMapData8_create_word_break_with_provider_mv1(provider.handle);
@@ -576,20 +607,22 @@ class CodePointMapData8 internal constructor (
         }
     }
     
-    /** Gets the value for a code point.
-    *
-    *See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointMapDataBorrowed.html#method.get) for more information.
-    */
+    /**
+     * Gets the value for a code point.
+     *
+     * See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointMapDataBorrowed.html#method.get) for more information.
+     */
     fun get(cp: Int): UByte {
         
         val returnVal = lib.icu4x_CodePointMapData8_get_mv1(handle, cp);
         return (returnVal.toUByte())
     }
     
-    /** Produces an iterator over ranges of code points that map to `value`
-    *
-    *See the [Rust documentation for `iter_ranges_for_value`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointMapDataBorrowed.html#method.iter_ranges_for_value) for more information.
-    */
+    /**
+     * Produces an iterator over ranges of code points that map to `value`
+     *
+     * See the [Rust documentation for `iter_ranges_for_value`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointMapDataBorrowed.html#method.iter_ranges_for_value) for more information.
+     */
     fun iterRangesForValue(value: UByte): CodePointRangeIterator {
         // This lifetime edge depends on lifetimes: 'a
         val aEdges: MutableList<Any> = mutableListOf(this);
@@ -601,10 +634,11 @@ class CodePointMapData8 internal constructor (
         return returnOpaque
     }
     
-    /** Produces an iterator over ranges of code points that do not map to `value`
-    *
-    *See the [Rust documentation for `iter_ranges_for_value_complemented`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointMapDataBorrowed.html#method.iter_ranges_for_value_complemented) for more information.
-    */
+    /**
+     * Produces an iterator over ranges of code points that do not map to `value`
+     *
+     * See the [Rust documentation for `iter_ranges_for_value_complemented`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointMapDataBorrowed.html#method.iter_ranges_for_value_complemented) for more information.
+     */
     fun iterRangesForValueComplemented(value: UByte): CodePointRangeIterator {
         // This lifetime edge depends on lifetimes: 'a
         val aEdges: MutableList<Any> = mutableListOf(this);
@@ -616,17 +650,18 @@ class CodePointMapData8 internal constructor (
         return returnOpaque
     }
     
-    /** Given a mask value (the nth bit marks property value = n), produce an iterator over ranges of code points
-    *whose property values are contained in the mask.
-    *
-    *The main mask property supported is that for `General_Category`, which can be obtained via `general_category_to_mask()` or
-    *by using `GeneralCategoryNameToMaskMapper`
-    *
-    *Should only be used on maps for properties with values less than 32 (like `General_Category`),
-    *other maps will have unpredictable results
-    *
-    *See the [Rust documentation for `iter_ranges_for_group`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointMapDataBorrowed.html#method.iter_ranges_for_group) for more information.
-    */
+    /**
+     * Given a mask value (the nth bit marks property value = n), produce an iterator over ranges of code points
+     * whose property values are contained in the mask.
+     *
+     * The main mask property supported is that for `General_Category`, which can be obtained via `general_category_to_mask()` or
+     * by using `GeneralCategoryNameToMaskMapper`
+     *
+     * Should only be used on maps for properties with values less than 32 (like `General_Category`),
+     * other maps will have unpredictable results
+     *
+     * See the [Rust documentation for `iter_ranges_for_group`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointMapDataBorrowed.html#method.iter_ranges_for_group) for more information.
+     */
     fun iterRangesForGroup(group: GeneralCategoryGroup): CodePointRangeIterator {
         // This lifetime edge depends on lifetimes: 'a
         val aEdges: MutableList<Any> = mutableListOf(this);
@@ -638,10 +673,11 @@ class CodePointMapData8 internal constructor (
         return returnOpaque
     }
     
-    /** Gets a [CodePointSetData] representing all entries in this map that map to the given value
-    *
-    *See the [Rust documentation for `get_set_for_value`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointMapDataBorrowed.html#method.get_set_for_value) for more information.
-    */
+    /**
+     * Gets a [CodePointSetData] representing all entries in this map that map to the given value
+     *
+     * See the [Rust documentation for `get_set_for_value`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointMapDataBorrowed.html#method.get_set_for_value) for more information.
+     */
     fun getSetForValue(value: UByte): CodePointSetData {
         
         val returnVal = lib.icu4x_CodePointMapData8_get_set_for_value_mv1(handle, FFIUint8(value));

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CodePointRangeIterator.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CodePointRangeIterator.kt
@@ -9,9 +9,10 @@ internal interface CodePointRangeIteratorLib: Library {
     fun icu4x_CodePointRangeIterator_destroy_mv1(handle: Pointer)
     fun icu4x_CodePointRangeIterator_next_mv1(handle: Pointer): CodePointRangeIteratorResultNative
 }
-/** An iterator over code point ranges, produced by `CodePointSetData` or
-*one of the `CodePointMapData` types
-*/
+/**
+ * An iterator over code point ranges, produced by `CodePointSetData` or
+ * one of the `CodePointMapData` types
+ */
 class CodePointRangeIterator internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -41,10 +42,11 @@ class CodePointRangeIterator internal constructor (
         internal val lib: CodePointRangeIteratorLib = Native.load("icu4x", libClass)
     }
     
-    /** Advance the iterator by one and return the next range.
-    *
-    *If the iterator is out of items, `done` will be true
-    */
+    /**
+     * Advance the iterator by one and return the next range.
+     *
+     * If the iterator is out of items, `done` will be true
+     */
     fun next(): CodePointRangeIteratorResult {
         
         val returnVal = lib.icu4x_CodePointRangeIterator_next_mv1(handle);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CodePointRangeIteratorResult.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CodePointRangeIteratorResult.kt
@@ -64,14 +64,15 @@ internal class OptionCodePointRangeIteratorResultNative constructor(): Structure
 
 }
 
-/** Result of a single iteration of [CodePointRangeIterator].
-*Logically can be considered to be an `Option<RangeInclusive<DiplomatChar>>`,
-*
-*`start` and `end` represent an inclusive range of code points `[start, end]`,
-*and `done` will be true if the iterator has already finished. The last contentful
-*iteration will NOT produce a range `done=true`, in other words `start` and `end` are useful
-*values if and only if `done=false`.
-*/
+/**
+ * Result of a single iteration of [CodePointRangeIterator].
+ * Logically can be considered to be an `Option<RangeInclusive<DiplomatChar>>`,
+ *
+ * `start` and `end` represent an inclusive range of code points `[start, end]`,
+ * and `done` will be true if the iterator has already finished. The last contentful
+ * iteration will NOT produce a range `done=true`, in other words `start` and `end` are useful
+ * values if and only if `done=false`.
+ */
 class CodePointRangeIteratorResult (var start: Int, var end: Int, var done: Boolean) {
     companion object {
 

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CodePointSetBuilder.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CodePointSetBuilder.kt
@@ -24,8 +24,9 @@ internal interface CodePointSetBuilderLib: Library {
     fun icu4x_CodePointSetBuilder_complement_inclusive_range_mv1(handle: Pointer, start: Int, end: Int): Unit
     fun icu4x_CodePointSetBuilder_complement_set_mv1(handle: Pointer, data: Pointer): Unit
 }
-/** See the [Rust documentation for `CodePointInversionListBuilder`](https://docs.rs/icu/2.3.1/icu/collections/codepointinvlist/struct.CodePointInversionListBuilder.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `CodePointInversionListBuilder`](https://docs.rs/icu/2.3.1/icu/collections/codepointinvlist/struct.CodePointInversionListBuilder.html) for more information.
+ */
 class CodePointSetBuilder internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -54,10 +55,11 @@ class CodePointSetBuilder internal constructor (
         internal val lib: CodePointSetBuilderLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Make a new set builder containing nothing
-        *
-        *See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/collections/codepointinvlist/struct.CodePointInversionListBuilder.html#method.new) for more information.
-        */
+        /**
+         * Make a new set builder containing nothing
+         *
+         * See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/collections/codepointinvlist/struct.CodePointInversionListBuilder.html#method.new) for more information.
+         */
         fun create(): CodePointSetBuilder {
             
             val returnVal = lib.icu4x_CodePointSetBuilder_create_mv1();
@@ -68,12 +70,13 @@ class CodePointSetBuilder internal constructor (
         }
     }
     
-    /** Build this into a set
-    *
-    *This object is repopulated with an empty builder
-    *
-    *See the [Rust documentation for `build`](https://docs.rs/icu/2.3.1/icu/collections/codepointinvlist/struct.CodePointInversionListBuilder.html#method.build) for more information.
-    */
+    /**
+     * Build this into a set
+     *
+     * This object is repopulated with an empty builder
+     *
+     * See the [Rust documentation for `build`](https://docs.rs/icu/2.3.1/icu/collections/codepointinvlist/struct.CodePointInversionListBuilder.html#method.build) for more information.
+     */
     fun build(): CodePointSetData {
         
         val returnVal = lib.icu4x_CodePointSetBuilder_build_mv1(handle);
@@ -83,148 +86,162 @@ class CodePointSetBuilder internal constructor (
         return returnOpaque
     }
     
-    /** Complements this set
-    *
-    *(Elements in this set are removed and vice versa)
-    *
-    *See the [Rust documentation for `complement`](https://docs.rs/icu/2.3.1/icu/collections/codepointinvlist/struct.CodePointInversionListBuilder.html#method.complement) for more information.
-    */
+    /**
+     * Complements this set
+     *
+     * (Elements in this set are removed and vice versa)
+     *
+     * See the [Rust documentation for `complement`](https://docs.rs/icu/2.3.1/icu/collections/codepointinvlist/struct.CodePointInversionListBuilder.html#method.complement) for more information.
+     */
     fun complement(): Unit {
         
         val returnVal = lib.icu4x_CodePointSetBuilder_complement_mv1(handle);
         
     }
     
-    /** Returns whether this set is empty
-    *
-    *See the [Rust documentation for `is_empty`](https://docs.rs/icu/2.3.1/icu/collections/codepointinvlist/struct.CodePointInversionListBuilder.html#method.is_empty) for more information.
-    */
+    /**
+     * Returns whether this set is empty
+     *
+     * See the [Rust documentation for `is_empty`](https://docs.rs/icu/2.3.1/icu/collections/codepointinvlist/struct.CodePointInversionListBuilder.html#method.is_empty) for more information.
+     */
     fun isEmpty(): Boolean {
         
         val returnVal = lib.icu4x_CodePointSetBuilder_is_empty_mv1(handle);
         return (returnVal > 0)
     }
     
-    /** Add a single character to the set
-    *
-    *See the [Rust documentation for `add_char`](https://docs.rs/icu/2.3.1/icu/collections/codepointinvlist/struct.CodePointInversionListBuilder.html#method.add_char) for more information.
-    */
+    /**
+     * Add a single character to the set
+     *
+     * See the [Rust documentation for `add_char`](https://docs.rs/icu/2.3.1/icu/collections/codepointinvlist/struct.CodePointInversionListBuilder.html#method.add_char) for more information.
+     */
     fun addChar(ch: Int): Unit {
         
         val returnVal = lib.icu4x_CodePointSetBuilder_add_char_mv1(handle, ch);
         
     }
     
-    /** Add an inclusive range of characters to the set
-    *
-    *See the [Rust documentation for `add_range`](https://docs.rs/icu/2.3.1/icu/collections/codepointinvlist/struct.CodePointInversionListBuilder.html#method.add_range) for more information.
-    */
+    /**
+     * Add an inclusive range of characters to the set
+     *
+     * See the [Rust documentation for `add_range`](https://docs.rs/icu/2.3.1/icu/collections/codepointinvlist/struct.CodePointInversionListBuilder.html#method.add_range) for more information.
+     */
     fun addInclusiveRange(start: Int, end: Int): Unit {
         
         val returnVal = lib.icu4x_CodePointSetBuilder_add_inclusive_range_mv1(handle, start, end);
         
     }
     
-    /** Add all elements that belong to the provided set to the set
-    *
-    *See the [Rust documentation for `add_set`](https://docs.rs/icu/2.3.1/icu/collections/codepointinvlist/struct.CodePointInversionListBuilder.html#method.add_set) for more information.
-    */
+    /**
+     * Add all elements that belong to the provided set to the set
+     *
+     * See the [Rust documentation for `add_set`](https://docs.rs/icu/2.3.1/icu/collections/codepointinvlist/struct.CodePointInversionListBuilder.html#method.add_set) for more information.
+     */
     fun addSet(data: CodePointSetData): Unit {
         
         val returnVal = lib.icu4x_CodePointSetBuilder_add_set_mv1(handle, data.handle);
         
     }
     
-    /** Remove a single character to the set
-    *
-    *See the [Rust documentation for `remove_char`](https://docs.rs/icu/2.3.1/icu/collections/codepointinvlist/struct.CodePointInversionListBuilder.html#method.remove_char) for more information.
-    */
+    /**
+     * Remove a single character to the set
+     *
+     * See the [Rust documentation for `remove_char`](https://docs.rs/icu/2.3.1/icu/collections/codepointinvlist/struct.CodePointInversionListBuilder.html#method.remove_char) for more information.
+     */
     fun removeChar(ch: Int): Unit {
         
         val returnVal = lib.icu4x_CodePointSetBuilder_remove_char_mv1(handle, ch);
         
     }
     
-    /** Remove an inclusive range of characters from the set
-    *
-    *See the [Rust documentation for `remove_range`](https://docs.rs/icu/2.3.1/icu/collections/codepointinvlist/struct.CodePointInversionListBuilder.html#method.remove_range) for more information.
-    */
+    /**
+     * Remove an inclusive range of characters from the set
+     *
+     * See the [Rust documentation for `remove_range`](https://docs.rs/icu/2.3.1/icu/collections/codepointinvlist/struct.CodePointInversionListBuilder.html#method.remove_range) for more information.
+     */
     fun removeInclusiveRange(start: Int, end: Int): Unit {
         
         val returnVal = lib.icu4x_CodePointSetBuilder_remove_inclusive_range_mv1(handle, start, end);
         
     }
     
-    /** Remove all elements that belong to the provided set from the set
-    *
-    *See the [Rust documentation for `remove_set`](https://docs.rs/icu/2.3.1/icu/collections/codepointinvlist/struct.CodePointInversionListBuilder.html#method.remove_set) for more information.
-    */
+    /**
+     * Remove all elements that belong to the provided set from the set
+     *
+     * See the [Rust documentation for `remove_set`](https://docs.rs/icu/2.3.1/icu/collections/codepointinvlist/struct.CodePointInversionListBuilder.html#method.remove_set) for more information.
+     */
     fun removeSet(data: CodePointSetData): Unit {
         
         val returnVal = lib.icu4x_CodePointSetBuilder_remove_set_mv1(handle, data.handle);
         
     }
     
-    /** Removes all elements from the set except a single character
-    *
-    *See the [Rust documentation for `retain_char`](https://docs.rs/icu/2.3.1/icu/collections/codepointinvlist/struct.CodePointInversionListBuilder.html#method.retain_char) for more information.
-    */
+    /**
+     * Removes all elements from the set except a single character
+     *
+     * See the [Rust documentation for `retain_char`](https://docs.rs/icu/2.3.1/icu/collections/codepointinvlist/struct.CodePointInversionListBuilder.html#method.retain_char) for more information.
+     */
     fun retainChar(ch: Int): Unit {
         
         val returnVal = lib.icu4x_CodePointSetBuilder_retain_char_mv1(handle, ch);
         
     }
     
-    /** Removes all elements from the set except an inclusive range of characters f
-    *
-    *See the [Rust documentation for `retain_range`](https://docs.rs/icu/2.3.1/icu/collections/codepointinvlist/struct.CodePointInversionListBuilder.html#method.retain_range) for more information.
-    */
+    /**
+     * Removes all elements from the set except an inclusive range of characters f
+     *
+     * See the [Rust documentation for `retain_range`](https://docs.rs/icu/2.3.1/icu/collections/codepointinvlist/struct.CodePointInversionListBuilder.html#method.retain_range) for more information.
+     */
     fun retainInclusiveRange(start: Int, end: Int): Unit {
         
         val returnVal = lib.icu4x_CodePointSetBuilder_retain_inclusive_range_mv1(handle, start, end);
         
     }
     
-    /** Removes all elements from the set except all elements in the provided set
-    *
-    *See the [Rust documentation for `retain_set`](https://docs.rs/icu/2.3.1/icu/collections/codepointinvlist/struct.CodePointInversionListBuilder.html#method.retain_set) for more information.
-    */
+    /**
+     * Removes all elements from the set except all elements in the provided set
+     *
+     * See the [Rust documentation for `retain_set`](https://docs.rs/icu/2.3.1/icu/collections/codepointinvlist/struct.CodePointInversionListBuilder.html#method.retain_set) for more information.
+     */
     fun retainSet(data: CodePointSetData): Unit {
         
         val returnVal = lib.icu4x_CodePointSetBuilder_retain_set_mv1(handle, data.handle);
         
     }
     
-    /** Complement a single character to the set
-    *
-    *(Characters which are in this set are removed and vice versa)
-    *
-    *See the [Rust documentation for `complement_char`](https://docs.rs/icu/2.3.1/icu/collections/codepointinvlist/struct.CodePointInversionListBuilder.html#method.complement_char) for more information.
-    */
+    /**
+     * Complement a single character to the set
+     *
+     * (Characters which are in this set are removed and vice versa)
+     *
+     * See the [Rust documentation for `complement_char`](https://docs.rs/icu/2.3.1/icu/collections/codepointinvlist/struct.CodePointInversionListBuilder.html#method.complement_char) for more information.
+     */
     fun complementChar(ch: Int): Unit {
         
         val returnVal = lib.icu4x_CodePointSetBuilder_complement_char_mv1(handle, ch);
         
     }
     
-    /** Complement an inclusive range of characters from the set
-    *
-    *(Characters which are in this set are removed and vice versa)
-    *
-    *See the [Rust documentation for `complement_range`](https://docs.rs/icu/2.3.1/icu/collections/codepointinvlist/struct.CodePointInversionListBuilder.html#method.complement_range) for more information.
-    */
+    /**
+     * Complement an inclusive range of characters from the set
+     *
+     * (Characters which are in this set are removed and vice versa)
+     *
+     * See the [Rust documentation for `complement_range`](https://docs.rs/icu/2.3.1/icu/collections/codepointinvlist/struct.CodePointInversionListBuilder.html#method.complement_range) for more information.
+     */
     fun complementInclusiveRange(start: Int, end: Int): Unit {
         
         val returnVal = lib.icu4x_CodePointSetBuilder_complement_inclusive_range_mv1(handle, start, end);
         
     }
     
-    /** Complement all elements that belong to the provided set from the set
-    *
-    *(Characters which are in this set are removed and vice versa)
-    *
-    *See the [Rust documentation for `complement_set`](https://docs.rs/icu/2.3.1/icu/collections/codepointinvlist/struct.CodePointInversionListBuilder.html#method.complement_set) for more information.
-    */
+    /**
+     * Complement all elements that belong to the provided set from the set
+     *
+     * (Characters which are in this set are removed and vice versa)
+     *
+     * See the [Rust documentation for `complement_set`](https://docs.rs/icu/2.3.1/icu/collections/codepointinvlist/struct.CodePointInversionListBuilder.html#method.complement_set) for more information.
+     */
     fun complementSet(data: CodePointSetData): Unit {
         
         val returnVal = lib.icu4x_CodePointSetBuilder_complement_set_mv1(handle, data.handle);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CodePointSetData.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CodePointSetData.kt
@@ -222,14 +222,15 @@ internal interface CodePointSetDataLib: Library {
     fun icu4x_CodePointSetData_create_for_ecma262_mv1(propertyName: Slice): ResultPointerInt
     fun icu4x_CodePointSetData_create_for_ecma262_with_provider_mv1(provider: Pointer, propertyName: Slice): ResultPointerInt
 }
-/** An ICU4X Unicode Set Property object, capable of querying whether a code point is contained in a set based on a Unicode property.
-*
-*See the [Rust documentation for `properties`](https://docs.rs/icu/2.3.1/icu/properties/index.html) for more information.
-*
-*See the [Rust documentation for `CodePointSetData`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointSetData.html) for more information.
-*
-*See the [Rust documentation for `CodePointSetDataBorrowed`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointSetDataBorrowed.html) for more information.
-*/
+/**
+ * An ICU4X Unicode Set Property object, capable of querying whether a code point is contained in a set based on a Unicode property.
+ *
+ * See the [Rust documentation for `properties`](https://docs.rs/icu/2.3.1/icu/properties/index.html) for more information.
+ *
+ * See the [Rust documentation for `CodePointSetData`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointSetData.html) for more information.
+ *
+ * See the [Rust documentation for `CodePointSetDataBorrowed`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointSetDataBorrowed.html) for more information.
+ */
 class CodePointSetData internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -258,13 +259,14 @@ class CodePointSetData internal constructor (
         internal val lib: CodePointSetDataLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Produces a set for obtaining General Category Group values
-        *which is a mask with the same format as the `U_GC_XX_MASK` mask in ICU4C, using compiled data.
-        *
-        *See the [Rust documentation for `GeneralCategoryGroup`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategoryGroup.html) for more information.
-        *
-        *See the [Rust documentation for `get_set_for_value_group`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointMapDataBorrowed.html#method.get_set_for_value_group) for more information.
-        */
+        /**
+         * Produces a set for obtaining General Category Group values
+         * which is a mask with the same format as the `U_GC_XX_MASK` mask in ICU4C, using compiled data.
+         *
+         * See the [Rust documentation for `GeneralCategoryGroup`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategoryGroup.html) for more information.
+         *
+         * See the [Rust documentation for `get_set_for_value_group`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointMapDataBorrowed.html#method.get_set_for_value_group) for more information.
+         */
         fun createGeneralCategoryGroup(group: GeneralCategoryGroup): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_general_category_group_mv1(group.toNative());
@@ -275,13 +277,14 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Produces a set for obtaining General Category Group values
-        *which is a mask with the same format as the `U_GC_XX_MASK` mask in ICU4C, using a provided data source.
-        *
-        *See the [Rust documentation for `GeneralCategoryGroup`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategoryGroup.html) for more information.
-        *
-        *See the [Rust documentation for `get_set_for_value_group`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointMapDataBorrowed.html#method.get_set_for_value_group) for more information.
-        */
+        /**
+         * Produces a set for obtaining General Category Group values
+         * which is a mask with the same format as the `U_GC_XX_MASK` mask in ICU4C, using a provided data source.
+         *
+         * See the [Rust documentation for `GeneralCategoryGroup`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategoryGroup.html) for more information.
+         *
+         * See the [Rust documentation for `get_set_for_value_group`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointMapDataBorrowed.html#method.get_set_for_value_group) for more information.
+         */
         fun createGeneralCategoryGroupWithProvider(provider: DataProvider, group: UInt): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_general_category_group_with_provider_mv1(provider.handle, FFIUint32(group));
@@ -297,10 +300,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Ascii_Hex_Digit` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Ascii_Hex_Digit` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun asciiHexDigitForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_ascii_hex_digit_for_char_mv1(ch);
@@ -308,10 +312,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Ascii_Hex_Digit` property, using compiled data.
-        *
-        *See the [Rust documentation for `AsciiHexDigit`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.AsciiHexDigit.html) for more information.
-        */
+        /**
+         * Create a set for the `Ascii_Hex_Digit` property, using compiled data.
+         *
+         * See the [Rust documentation for `AsciiHexDigit`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.AsciiHexDigit.html) for more information.
+         */
         fun createAsciiHexDigit(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_ascii_hex_digit_mv1();
@@ -322,10 +327,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Ascii_Hex_Digit` property, using a particular data source.
-        *
-        *See the [Rust documentation for `AsciiHexDigit`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.AsciiHexDigit.html) for more information.
-        */
+        /**
+         * Create a set for the `Ascii_Hex_Digit` property, using a particular data source.
+         *
+         * See the [Rust documentation for `AsciiHexDigit`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.AsciiHexDigit.html) for more information.
+         */
         fun createAsciiHexDigitWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_ascii_hex_digit_with_provider_mv1(provider.handle);
@@ -341,10 +347,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Alnum` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Alnum` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun alnumForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_alnum_for_char_mv1(ch);
@@ -352,10 +359,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Alnum` property, using compiled data.
-        *
-        *See the [Rust documentation for `Alnum`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Alnum.html) for more information.
-        */
+        /**
+         * Create a set for the `Alnum` property, using compiled data.
+         *
+         * See the [Rust documentation for `Alnum`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Alnum.html) for more information.
+         */
         fun createAlnum(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_alnum_mv1();
@@ -366,10 +374,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Alnum` property, using a particular data source.
-        *
-        *See the [Rust documentation for `Alnum`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Alnum.html) for more information.
-        */
+        /**
+         * Create a set for the `Alnum` property, using a particular data source.
+         *
+         * See the [Rust documentation for `Alnum`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Alnum.html) for more information.
+         */
         fun createAlnumWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_alnum_with_provider_mv1(provider.handle);
@@ -385,10 +394,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Alphabetic` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Alphabetic` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun alphabeticForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_alphabetic_for_char_mv1(ch);
@@ -396,10 +406,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Alphabetic` property, using compiled data.
-        *
-        *See the [Rust documentation for `Alphabetic`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Alphabetic.html) for more information.
-        */
+        /**
+         * Create a set for the `Alphabetic` property, using compiled data.
+         *
+         * See the [Rust documentation for `Alphabetic`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Alphabetic.html) for more information.
+         */
         fun createAlphabetic(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_alphabetic_mv1();
@@ -410,10 +421,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Alphabetic` property, using a particular data source.
-        *
-        *See the [Rust documentation for `Alphabetic`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Alphabetic.html) for more information.
-        */
+        /**
+         * Create a set for the `Alphabetic` property, using a particular data source.
+         *
+         * See the [Rust documentation for `Alphabetic`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Alphabetic.html) for more information.
+         */
         fun createAlphabeticWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_alphabetic_with_provider_mv1(provider.handle);
@@ -429,10 +441,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Bidi_Control` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Bidi_Control` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun bidiControlForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_bidi_control_for_char_mv1(ch);
@@ -440,10 +453,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Bidi_Control` property, using compiled data.
-        *
-        *See the [Rust documentation for `BidiControl`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.BidiControl.html) for more information.
-        */
+        /**
+         * Create a set for the `Bidi_Control` property, using compiled data.
+         *
+         * See the [Rust documentation for `BidiControl`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.BidiControl.html) for more information.
+         */
         fun createBidiControl(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_bidi_control_mv1();
@@ -454,10 +468,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Bidi_Control` property, using a particular data source.
-        *
-        *See the [Rust documentation for `BidiControl`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.BidiControl.html) for more information.
-        */
+        /**
+         * Create a set for the `Bidi_Control` property, using a particular data source.
+         *
+         * See the [Rust documentation for `BidiControl`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.BidiControl.html) for more information.
+         */
         fun createBidiControlWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_bidi_control_with_provider_mv1(provider.handle);
@@ -473,10 +488,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Bidi_Mirrored` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Bidi_Mirrored` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun bidiMirroredForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_bidi_mirrored_for_char_mv1(ch);
@@ -484,10 +500,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Bidi_Mirrored` property, using compiled data.
-        *
-        *See the [Rust documentation for `BidiMirrored`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.BidiMirrored.html) for more information.
-        */
+        /**
+         * Create a set for the `Bidi_Mirrored` property, using compiled data.
+         *
+         * See the [Rust documentation for `BidiMirrored`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.BidiMirrored.html) for more information.
+         */
         fun createBidiMirrored(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_bidi_mirrored_mv1();
@@ -498,10 +515,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Bidi_Mirrored` property, using a particular data source.
-        *
-        *See the [Rust documentation for `BidiMirrored`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.BidiMirrored.html) for more information.
-        */
+        /**
+         * Create a set for the `Bidi_Mirrored` property, using a particular data source.
+         *
+         * See the [Rust documentation for `BidiMirrored`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.BidiMirrored.html) for more information.
+         */
         fun createBidiMirroredWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_bidi_mirrored_with_provider_mv1(provider.handle);
@@ -517,10 +535,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Blank` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Blank` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun blankForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_blank_for_char_mv1(ch);
@@ -528,10 +547,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Blank` property, using compiled data.
-        *
-        *See the [Rust documentation for `Blank`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Blank.html) for more information.
-        */
+        /**
+         * Create a set for the `Blank` property, using compiled data.
+         *
+         * See the [Rust documentation for `Blank`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Blank.html) for more information.
+         */
         fun createBlank(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_blank_mv1();
@@ -542,10 +562,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Blank` property, using a particular data source.
-        *
-        *See the [Rust documentation for `Blank`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Blank.html) for more information.
-        */
+        /**
+         * Create a set for the `Blank` property, using a particular data source.
+         *
+         * See the [Rust documentation for `Blank`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Blank.html) for more information.
+         */
         fun createBlankWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_blank_with_provider_mv1(provider.handle);
@@ -561,10 +582,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Cased` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Cased` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun casedForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_cased_for_char_mv1(ch);
@@ -572,10 +594,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Cased` property, using compiled data.
-        *
-        *See the [Rust documentation for `Cased`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Cased.html) for more information.
-        */
+        /**
+         * Create a set for the `Cased` property, using compiled data.
+         *
+         * See the [Rust documentation for `Cased`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Cased.html) for more information.
+         */
         fun createCased(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_cased_mv1();
@@ -586,10 +609,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Cased` property, using a particular data source.
-        *
-        *See the [Rust documentation for `Cased`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Cased.html) for more information.
-        */
+        /**
+         * Create a set for the `Cased` property, using a particular data source.
+         *
+         * See the [Rust documentation for `Cased`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Cased.html) for more information.
+         */
         fun createCasedWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_cased_with_provider_mv1(provider.handle);
@@ -605,10 +629,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Case_Ignorable` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Case_Ignorable` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun caseIgnorableForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_case_ignorable_for_char_mv1(ch);
@@ -616,10 +641,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Case_Ignorable` property, using compiled data.
-        *
-        *See the [Rust documentation for `CaseIgnorable`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.CaseIgnorable.html) for more information.
-        */
+        /**
+         * Create a set for the `Case_Ignorable` property, using compiled data.
+         *
+         * See the [Rust documentation for `CaseIgnorable`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.CaseIgnorable.html) for more information.
+         */
         fun createCaseIgnorable(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_case_ignorable_mv1();
@@ -630,10 +656,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Case_Ignorable` property, using a particular data source.
-        *
-        *See the [Rust documentation for `CaseIgnorable`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.CaseIgnorable.html) for more information.
-        */
+        /**
+         * Create a set for the `Case_Ignorable` property, using a particular data source.
+         *
+         * See the [Rust documentation for `CaseIgnorable`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.CaseIgnorable.html) for more information.
+         */
         fun createCaseIgnorableWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_case_ignorable_with_provider_mv1(provider.handle);
@@ -649,10 +676,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Full_Composition_Exclusion` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Full_Composition_Exclusion` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun fullCompositionExclusionForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_full_composition_exclusion_for_char_mv1(ch);
@@ -660,10 +688,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Full_Composition_Exclusion` property, using compiled data.
-        *
-        *See the [Rust documentation for `FullCompositionExclusion`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.FullCompositionExclusion.html) for more information.
-        */
+        /**
+         * Create a set for the `Full_Composition_Exclusion` property, using compiled data.
+         *
+         * See the [Rust documentation for `FullCompositionExclusion`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.FullCompositionExclusion.html) for more information.
+         */
         fun createFullCompositionExclusion(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_full_composition_exclusion_mv1();
@@ -674,10 +703,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Full_Composition_Exclusion` property, using a particular data source.
-        *
-        *See the [Rust documentation for `FullCompositionExclusion`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.FullCompositionExclusion.html) for more information.
-        */
+        /**
+         * Create a set for the `Full_Composition_Exclusion` property, using a particular data source.
+         *
+         * See the [Rust documentation for `FullCompositionExclusion`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.FullCompositionExclusion.html) for more information.
+         */
         fun createFullCompositionExclusionWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_full_composition_exclusion_with_provider_mv1(provider.handle);
@@ -693,10 +723,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Changes_When_Casefolded` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Changes_When_Casefolded` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun changesWhenCasefoldedForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_changes_when_casefolded_for_char_mv1(ch);
@@ -704,10 +735,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Changes_When_Casefolded` property, using compiled data.
-        *
-        *See the [Rust documentation for `ChangesWhenCasefolded`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.ChangesWhenCasefolded.html) for more information.
-        */
+        /**
+         * Create a set for the `Changes_When_Casefolded` property, using compiled data.
+         *
+         * See the [Rust documentation for `ChangesWhenCasefolded`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.ChangesWhenCasefolded.html) for more information.
+         */
         fun createChangesWhenCasefolded(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_changes_when_casefolded_mv1();
@@ -718,10 +750,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Changes_When_Casefolded` property, using a particular data source.
-        *
-        *See the [Rust documentation for `ChangesWhenCasefolded`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.ChangesWhenCasefolded.html) for more information.
-        */
+        /**
+         * Create a set for the `Changes_When_Casefolded` property, using a particular data source.
+         *
+         * See the [Rust documentation for `ChangesWhenCasefolded`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.ChangesWhenCasefolded.html) for more information.
+         */
         fun createChangesWhenCasefoldedWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_changes_when_casefolded_with_provider_mv1(provider.handle);
@@ -737,10 +770,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Changes_When_Casemapped` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Changes_When_Casemapped` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun changesWhenCasemappedForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_changes_when_casemapped_for_char_mv1(ch);
@@ -748,10 +782,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Changes_When_Casemapped` property, using compiled data.
-        *
-        *See the [Rust documentation for `ChangesWhenCasemapped`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.ChangesWhenCasemapped.html) for more information.
-        */
+        /**
+         * Create a set for the `Changes_When_Casemapped` property, using compiled data.
+         *
+         * See the [Rust documentation for `ChangesWhenCasemapped`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.ChangesWhenCasemapped.html) for more information.
+         */
         fun createChangesWhenCasemapped(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_changes_when_casemapped_mv1();
@@ -762,10 +797,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Changes_When_Casemapped` property, using a particular data source.
-        *
-        *See the [Rust documentation for `ChangesWhenCasemapped`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.ChangesWhenCasemapped.html) for more information.
-        */
+        /**
+         * Create a set for the `Changes_When_Casemapped` property, using a particular data source.
+         *
+         * See the [Rust documentation for `ChangesWhenCasemapped`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.ChangesWhenCasemapped.html) for more information.
+         */
         fun createChangesWhenCasemappedWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_changes_when_casemapped_with_provider_mv1(provider.handle);
@@ -781,10 +817,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Changes_When_Nfkc_Casefolded` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Changes_When_Nfkc_Casefolded` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun changesWhenNfkcCasefoldedForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_changes_when_nfkc_casefolded_for_char_mv1(ch);
@@ -792,10 +829,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Changes_When_Nfkc_Casefolded` property, using compiled data.
-        *
-        *See the [Rust documentation for `ChangesWhenNfkcCasefolded`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.ChangesWhenNfkcCasefolded.html) for more information.
-        */
+        /**
+         * Create a set for the `Changes_When_Nfkc_Casefolded` property, using compiled data.
+         *
+         * See the [Rust documentation for `ChangesWhenNfkcCasefolded`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.ChangesWhenNfkcCasefolded.html) for more information.
+         */
         fun createChangesWhenNfkcCasefolded(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_changes_when_nfkc_casefolded_mv1();
@@ -806,10 +844,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Changes_When_Nfkc_Casefolded` property, using a particular data source.
-        *
-        *See the [Rust documentation for `ChangesWhenNfkcCasefolded`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.ChangesWhenNfkcCasefolded.html) for more information.
-        */
+        /**
+         * Create a set for the `Changes_When_Nfkc_Casefolded` property, using a particular data source.
+         *
+         * See the [Rust documentation for `ChangesWhenNfkcCasefolded`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.ChangesWhenNfkcCasefolded.html) for more information.
+         */
         fun createChangesWhenNfkcCasefoldedWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_changes_when_nfkc_casefolded_with_provider_mv1(provider.handle);
@@ -825,10 +864,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Changes_When_Lowercased` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Changes_When_Lowercased` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun changesWhenLowercasedForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_changes_when_lowercased_for_char_mv1(ch);
@@ -836,10 +876,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Changes_When_Lowercased` property, using compiled data.
-        *
-        *See the [Rust documentation for `ChangesWhenLowercased`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.ChangesWhenLowercased.html) for more information.
-        */
+        /**
+         * Create a set for the `Changes_When_Lowercased` property, using compiled data.
+         *
+         * See the [Rust documentation for `ChangesWhenLowercased`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.ChangesWhenLowercased.html) for more information.
+         */
         fun createChangesWhenLowercased(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_changes_when_lowercased_mv1();
@@ -850,10 +891,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Changes_When_Lowercased` property, using a particular data source.
-        *
-        *See the [Rust documentation for `ChangesWhenLowercased`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.ChangesWhenLowercased.html) for more information.
-        */
+        /**
+         * Create a set for the `Changes_When_Lowercased` property, using a particular data source.
+         *
+         * See the [Rust documentation for `ChangesWhenLowercased`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.ChangesWhenLowercased.html) for more information.
+         */
         fun createChangesWhenLowercasedWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_changes_when_lowercased_with_provider_mv1(provider.handle);
@@ -869,10 +911,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Changes_When_Titlecased` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Changes_When_Titlecased` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun changesWhenTitlecasedForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_changes_when_titlecased_for_char_mv1(ch);
@@ -880,10 +923,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Changes_When_Titlecased` property, using compiled data.
-        *
-        *See the [Rust documentation for `ChangesWhenTitlecased`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.ChangesWhenTitlecased.html) for more information.
-        */
+        /**
+         * Create a set for the `Changes_When_Titlecased` property, using compiled data.
+         *
+         * See the [Rust documentation for `ChangesWhenTitlecased`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.ChangesWhenTitlecased.html) for more information.
+         */
         fun createChangesWhenTitlecased(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_changes_when_titlecased_mv1();
@@ -894,10 +938,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Changes_When_Titlecased` property, using a particular data source.
-        *
-        *See the [Rust documentation for `ChangesWhenTitlecased`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.ChangesWhenTitlecased.html) for more information.
-        */
+        /**
+         * Create a set for the `Changes_When_Titlecased` property, using a particular data source.
+         *
+         * See the [Rust documentation for `ChangesWhenTitlecased`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.ChangesWhenTitlecased.html) for more information.
+         */
         fun createChangesWhenTitlecasedWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_changes_when_titlecased_with_provider_mv1(provider.handle);
@@ -913,10 +958,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Changes_When_Uppercased` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Changes_When_Uppercased` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun changesWhenUppercasedForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_changes_when_uppercased_for_char_mv1(ch);
@@ -924,10 +970,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Changes_When_Uppercased` property, using compiled data.
-        *
-        *See the [Rust documentation for `ChangesWhenUppercased`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.ChangesWhenUppercased.html) for more information.
-        */
+        /**
+         * Create a set for the `Changes_When_Uppercased` property, using compiled data.
+         *
+         * See the [Rust documentation for `ChangesWhenUppercased`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.ChangesWhenUppercased.html) for more information.
+         */
         fun createChangesWhenUppercased(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_changes_when_uppercased_mv1();
@@ -938,10 +985,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Changes_When_Uppercased` property, using a particular data source.
-        *
-        *See the [Rust documentation for `ChangesWhenUppercased`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.ChangesWhenUppercased.html) for more information.
-        */
+        /**
+         * Create a set for the `Changes_When_Uppercased` property, using a particular data source.
+         *
+         * See the [Rust documentation for `ChangesWhenUppercased`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.ChangesWhenUppercased.html) for more information.
+         */
         fun createChangesWhenUppercasedWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_changes_when_uppercased_with_provider_mv1(provider.handle);
@@ -957,10 +1005,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Dash` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Dash` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun dashForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_dash_for_char_mv1(ch);
@@ -968,10 +1017,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Dash` property, using compiled data.
-        *
-        *See the [Rust documentation for `Dash`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Dash.html) for more information.
-        */
+        /**
+         * Create a set for the `Dash` property, using compiled data.
+         *
+         * See the [Rust documentation for `Dash`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Dash.html) for more information.
+         */
         fun createDash(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_dash_mv1();
@@ -982,10 +1032,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Dash` property, using a particular data source.
-        *
-        *See the [Rust documentation for `Dash`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Dash.html) for more information.
-        */
+        /**
+         * Create a set for the `Dash` property, using a particular data source.
+         *
+         * See the [Rust documentation for `Dash`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Dash.html) for more information.
+         */
         fun createDashWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_dash_with_provider_mv1(provider.handle);
@@ -1001,10 +1052,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Deprecated` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Deprecated` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun deprecatedForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_deprecated_for_char_mv1(ch);
@@ -1012,10 +1064,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Deprecated` property, using compiled data.
-        *
-        *See the [Rust documentation for `Deprecated`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Deprecated.html) for more information.
-        */
+        /**
+         * Create a set for the `Deprecated` property, using compiled data.
+         *
+         * See the [Rust documentation for `Deprecated`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Deprecated.html) for more information.
+         */
         fun createDeprecated(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_deprecated_mv1();
@@ -1026,10 +1079,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Deprecated` property, using a particular data source.
-        *
-        *See the [Rust documentation for `Deprecated`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Deprecated.html) for more information.
-        */
+        /**
+         * Create a set for the `Deprecated` property, using a particular data source.
+         *
+         * See the [Rust documentation for `Deprecated`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Deprecated.html) for more information.
+         */
         fun createDeprecatedWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_deprecated_with_provider_mv1(provider.handle);
@@ -1045,10 +1099,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Default_Ignorable_Code_Point` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Default_Ignorable_Code_Point` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun defaultIgnorableCodePointForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_default_ignorable_code_point_for_char_mv1(ch);
@@ -1056,10 +1111,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Default_Ignorable_Code_Point` property, using compiled data.
-        *
-        *See the [Rust documentation for `DefaultIgnorableCodePoint`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.DefaultIgnorableCodePoint.html) for more information.
-        */
+        /**
+         * Create a set for the `Default_Ignorable_Code_Point` property, using compiled data.
+         *
+         * See the [Rust documentation for `DefaultIgnorableCodePoint`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.DefaultIgnorableCodePoint.html) for more information.
+         */
         fun createDefaultIgnorableCodePoint(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_default_ignorable_code_point_mv1();
@@ -1070,10 +1126,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Default_Ignorable_Code_Point` property, using a particular data source.
-        *
-        *See the [Rust documentation for `DefaultIgnorableCodePoint`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.DefaultIgnorableCodePoint.html) for more information.
-        */
+        /**
+         * Create a set for the `Default_Ignorable_Code_Point` property, using a particular data source.
+         *
+         * See the [Rust documentation for `DefaultIgnorableCodePoint`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.DefaultIgnorableCodePoint.html) for more information.
+         */
         fun createDefaultIgnorableCodePointWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_default_ignorable_code_point_with_provider_mv1(provider.handle);
@@ -1089,10 +1146,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Diacritic` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Diacritic` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun diacriticForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_diacritic_for_char_mv1(ch);
@@ -1100,10 +1158,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Diacritic` property, using compiled data.
-        *
-        *See the [Rust documentation for `Diacritic`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Diacritic.html) for more information.
-        */
+        /**
+         * Create a set for the `Diacritic` property, using compiled data.
+         *
+         * See the [Rust documentation for `Diacritic`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Diacritic.html) for more information.
+         */
         fun createDiacritic(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_diacritic_mv1();
@@ -1114,10 +1173,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Diacritic` property, using a particular data source.
-        *
-        *See the [Rust documentation for `Diacritic`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Diacritic.html) for more information.
-        */
+        /**
+         * Create a set for the `Diacritic` property, using a particular data source.
+         *
+         * See the [Rust documentation for `Diacritic`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Diacritic.html) for more information.
+         */
         fun createDiacriticWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_diacritic_with_provider_mv1(provider.handle);
@@ -1133,10 +1193,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Emoji_Modifier_Base` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Emoji_Modifier_Base` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun emojiModifierBaseForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_emoji_modifier_base_for_char_mv1(ch);
@@ -1144,10 +1205,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Emoji_Modifier_Base` property, using compiled data.
-        *
-        *See the [Rust documentation for `EmojiModifierBase`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.EmojiModifierBase.html) for more information.
-        */
+        /**
+         * Create a set for the `Emoji_Modifier_Base` property, using compiled data.
+         *
+         * See the [Rust documentation for `EmojiModifierBase`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.EmojiModifierBase.html) for more information.
+         */
         fun createEmojiModifierBase(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_emoji_modifier_base_mv1();
@@ -1158,10 +1220,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Emoji_Modifier_Base` property, using a particular data source.
-        *
-        *See the [Rust documentation for `EmojiModifierBase`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.EmojiModifierBase.html) for more information.
-        */
+        /**
+         * Create a set for the `Emoji_Modifier_Base` property, using a particular data source.
+         *
+         * See the [Rust documentation for `EmojiModifierBase`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.EmojiModifierBase.html) for more information.
+         */
         fun createEmojiModifierBaseWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_emoji_modifier_base_with_provider_mv1(provider.handle);
@@ -1177,10 +1240,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Emoji_Component` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Emoji_Component` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun emojiComponentForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_emoji_component_for_char_mv1(ch);
@@ -1188,10 +1252,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Emoji_Component` property, using compiled data.
-        *
-        *See the [Rust documentation for `EmojiComponent`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.EmojiComponent.html) for more information.
-        */
+        /**
+         * Create a set for the `Emoji_Component` property, using compiled data.
+         *
+         * See the [Rust documentation for `EmojiComponent`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.EmojiComponent.html) for more information.
+         */
         fun createEmojiComponent(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_emoji_component_mv1();
@@ -1202,10 +1267,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Emoji_Component` property, using a particular data source.
-        *
-        *See the [Rust documentation for `EmojiComponent`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.EmojiComponent.html) for more information.
-        */
+        /**
+         * Create a set for the `Emoji_Component` property, using a particular data source.
+         *
+         * See the [Rust documentation for `EmojiComponent`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.EmojiComponent.html) for more information.
+         */
         fun createEmojiComponentWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_emoji_component_with_provider_mv1(provider.handle);
@@ -1221,10 +1287,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Emoji_Modifier` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Emoji_Modifier` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun emojiModifierForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_emoji_modifier_for_char_mv1(ch);
@@ -1232,10 +1299,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Emoji_Modifier` property, using compiled data.
-        *
-        *See the [Rust documentation for `EmojiModifier`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.EmojiModifier.html) for more information.
-        */
+        /**
+         * Create a set for the `Emoji_Modifier` property, using compiled data.
+         *
+         * See the [Rust documentation for `EmojiModifier`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.EmojiModifier.html) for more information.
+         */
         fun createEmojiModifier(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_emoji_modifier_mv1();
@@ -1246,10 +1314,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Emoji_Modifier` property, using a particular data source.
-        *
-        *See the [Rust documentation for `EmojiModifier`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.EmojiModifier.html) for more information.
-        */
+        /**
+         * Create a set for the `Emoji_Modifier` property, using a particular data source.
+         *
+         * See the [Rust documentation for `EmojiModifier`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.EmojiModifier.html) for more information.
+         */
         fun createEmojiModifierWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_emoji_modifier_with_provider_mv1(provider.handle);
@@ -1265,10 +1334,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Emoji` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Emoji` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun emojiForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_emoji_for_char_mv1(ch);
@@ -1276,10 +1346,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Emoji` property, using compiled data.
-        *
-        *See the [Rust documentation for `Emoji`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Emoji.html) for more information.
-        */
+        /**
+         * Create a set for the `Emoji` property, using compiled data.
+         *
+         * See the [Rust documentation for `Emoji`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Emoji.html) for more information.
+         */
         fun createEmoji(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_emoji_mv1();
@@ -1290,10 +1361,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Emoji` property, using a particular data source.
-        *
-        *See the [Rust documentation for `Emoji`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Emoji.html) for more information.
-        */
+        /**
+         * Create a set for the `Emoji` property, using a particular data source.
+         *
+         * See the [Rust documentation for `Emoji`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Emoji.html) for more information.
+         */
         fun createEmojiWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_emoji_with_provider_mv1(provider.handle);
@@ -1309,10 +1381,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Emoji_Presentation` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Emoji_Presentation` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun emojiPresentationForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_emoji_presentation_for_char_mv1(ch);
@@ -1320,10 +1393,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Emoji_Presentation` property, using compiled data.
-        *
-        *See the [Rust documentation for `EmojiPresentation`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.EmojiPresentation.html) for more information.
-        */
+        /**
+         * Create a set for the `Emoji_Presentation` property, using compiled data.
+         *
+         * See the [Rust documentation for `EmojiPresentation`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.EmojiPresentation.html) for more information.
+         */
         fun createEmojiPresentation(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_emoji_presentation_mv1();
@@ -1334,10 +1408,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Emoji_Presentation` property, using a particular data source.
-        *
-        *See the [Rust documentation for `EmojiPresentation`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.EmojiPresentation.html) for more information.
-        */
+        /**
+         * Create a set for the `Emoji_Presentation` property, using a particular data source.
+         *
+         * See the [Rust documentation for `EmojiPresentation`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.EmojiPresentation.html) for more information.
+         */
         fun createEmojiPresentationWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_emoji_presentation_with_provider_mv1(provider.handle);
@@ -1353,10 +1428,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Extender` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Extender` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun extenderForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_extender_for_char_mv1(ch);
@@ -1364,10 +1440,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Extender` property, using compiled data.
-        *
-        *See the [Rust documentation for `Extender`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Extender.html) for more information.
-        */
+        /**
+         * Create a set for the `Extender` property, using compiled data.
+         *
+         * See the [Rust documentation for `Extender`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Extender.html) for more information.
+         */
         fun createExtender(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_extender_mv1();
@@ -1378,10 +1455,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Extender` property, using a particular data source.
-        *
-        *See the [Rust documentation for `Extender`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Extender.html) for more information.
-        */
+        /**
+         * Create a set for the `Extender` property, using a particular data source.
+         *
+         * See the [Rust documentation for `Extender`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Extender.html) for more information.
+         */
         fun createExtenderWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_extender_with_provider_mv1(provider.handle);
@@ -1397,10 +1475,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Extended_Pictographic` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Extended_Pictographic` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun extendedPictographicForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_extended_pictographic_for_char_mv1(ch);
@@ -1408,10 +1487,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Extended_Pictographic` property, using compiled data.
-        *
-        *See the [Rust documentation for `ExtendedPictographic`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.ExtendedPictographic.html) for more information.
-        */
+        /**
+         * Create a set for the `Extended_Pictographic` property, using compiled data.
+         *
+         * See the [Rust documentation for `ExtendedPictographic`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.ExtendedPictographic.html) for more information.
+         */
         fun createExtendedPictographic(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_extended_pictographic_mv1();
@@ -1422,10 +1502,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Extended_Pictographic` property, using a particular data source.
-        *
-        *See the [Rust documentation for `ExtendedPictographic`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.ExtendedPictographic.html) for more information.
-        */
+        /**
+         * Create a set for the `Extended_Pictographic` property, using a particular data source.
+         *
+         * See the [Rust documentation for `ExtendedPictographic`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.ExtendedPictographic.html) for more information.
+         */
         fun createExtendedPictographicWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_extended_pictographic_with_provider_mv1(provider.handle);
@@ -1441,10 +1522,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Graph` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Graph` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun graphForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_graph_for_char_mv1(ch);
@@ -1452,10 +1534,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Graph` property, using compiled data.
-        *
-        *See the [Rust documentation for `Graph`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Graph.html) for more information.
-        */
+        /**
+         * Create a set for the `Graph` property, using compiled data.
+         *
+         * See the [Rust documentation for `Graph`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Graph.html) for more information.
+         */
         fun createGraph(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_graph_mv1();
@@ -1466,10 +1549,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Graph` property, using a particular data source.
-        *
-        *See the [Rust documentation for `Graph`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Graph.html) for more information.
-        */
+        /**
+         * Create a set for the `Graph` property, using a particular data source.
+         *
+         * See the [Rust documentation for `Graph`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Graph.html) for more information.
+         */
         fun createGraphWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_graph_with_provider_mv1(provider.handle);
@@ -1485,10 +1569,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Grapheme_Base` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Grapheme_Base` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun graphemeBaseForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_grapheme_base_for_char_mv1(ch);
@@ -1496,10 +1581,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Grapheme_Base` property, using compiled data.
-        *
-        *See the [Rust documentation for `GraphemeBase`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GraphemeBase.html) for more information.
-        */
+        /**
+         * Create a set for the `Grapheme_Base` property, using compiled data.
+         *
+         * See the [Rust documentation for `GraphemeBase`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GraphemeBase.html) for more information.
+         */
         fun createGraphemeBase(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_grapheme_base_mv1();
@@ -1510,10 +1596,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Grapheme_Base` property, using a particular data source.
-        *
-        *See the [Rust documentation for `GraphemeBase`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GraphemeBase.html) for more information.
-        */
+        /**
+         * Create a set for the `Grapheme_Base` property, using a particular data source.
+         *
+         * See the [Rust documentation for `GraphemeBase`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GraphemeBase.html) for more information.
+         */
         fun createGraphemeBaseWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_grapheme_base_with_provider_mv1(provider.handle);
@@ -1529,10 +1616,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Grapheme_Extend` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Grapheme_Extend` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun graphemeExtendForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_grapheme_extend_for_char_mv1(ch);
@@ -1540,10 +1628,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Grapheme_Extend` property, using compiled data.
-        *
-        *See the [Rust documentation for `GraphemeExtend`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GraphemeExtend.html) for more information.
-        */
+        /**
+         * Create a set for the `Grapheme_Extend` property, using compiled data.
+         *
+         * See the [Rust documentation for `GraphemeExtend`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GraphemeExtend.html) for more information.
+         */
         fun createGraphemeExtend(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_grapheme_extend_mv1();
@@ -1554,10 +1643,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Grapheme_Extend` property, using a particular data source.
-        *
-        *See the [Rust documentation for `GraphemeExtend`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GraphemeExtend.html) for more information.
-        */
+        /**
+         * Create a set for the `Grapheme_Extend` property, using a particular data source.
+         *
+         * See the [Rust documentation for `GraphemeExtend`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GraphemeExtend.html) for more information.
+         */
         fun createGraphemeExtendWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_grapheme_extend_with_provider_mv1(provider.handle);
@@ -1573,10 +1663,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Grapheme_Link` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Grapheme_Link` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun graphemeLinkForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_grapheme_link_for_char_mv1(ch);
@@ -1584,10 +1675,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Grapheme_Link` property, using compiled data.
-        *
-        *See the [Rust documentation for `GraphemeLink`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GraphemeLink.html) for more information.
-        */
+        /**
+         * Create a set for the `Grapheme_Link` property, using compiled data.
+         *
+         * See the [Rust documentation for `GraphemeLink`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GraphemeLink.html) for more information.
+         */
         fun createGraphemeLink(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_grapheme_link_mv1();
@@ -1598,10 +1690,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Grapheme_Link` property, using a particular data source.
-        *
-        *See the [Rust documentation for `GraphemeLink`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GraphemeLink.html) for more information.
-        */
+        /**
+         * Create a set for the `Grapheme_Link` property, using a particular data source.
+         *
+         * See the [Rust documentation for `GraphemeLink`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GraphemeLink.html) for more information.
+         */
         fun createGraphemeLinkWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_grapheme_link_with_provider_mv1(provider.handle);
@@ -1617,10 +1710,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Hex_Digit` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Hex_Digit` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun hexDigitForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_hex_digit_for_char_mv1(ch);
@@ -1628,10 +1722,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Hex_Digit` property, using compiled data.
-        *
-        *See the [Rust documentation for `HexDigit`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.HexDigit.html) for more information.
-        */
+        /**
+         * Create a set for the `Hex_Digit` property, using compiled data.
+         *
+         * See the [Rust documentation for `HexDigit`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.HexDigit.html) for more information.
+         */
         fun createHexDigit(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_hex_digit_mv1();
@@ -1642,10 +1737,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Hex_Digit` property, using a particular data source.
-        *
-        *See the [Rust documentation for `HexDigit`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.HexDigit.html) for more information.
-        */
+        /**
+         * Create a set for the `Hex_Digit` property, using a particular data source.
+         *
+         * See the [Rust documentation for `HexDigit`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.HexDigit.html) for more information.
+         */
         fun createHexDigitWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_hex_digit_with_provider_mv1(provider.handle);
@@ -1661,10 +1757,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Hyphen` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Hyphen` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun hyphenForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_hyphen_for_char_mv1(ch);
@@ -1672,10 +1769,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Hyphen` property, using compiled data.
-        *
-        *See the [Rust documentation for `Hyphen`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Hyphen.html) for more information.
-        */
+        /**
+         * Create a set for the `Hyphen` property, using compiled data.
+         *
+         * See the [Rust documentation for `Hyphen`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Hyphen.html) for more information.
+         */
         fun createHyphen(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_hyphen_mv1();
@@ -1686,10 +1784,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Hyphen` property, using a particular data source.
-        *
-        *See the [Rust documentation for `Hyphen`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Hyphen.html) for more information.
-        */
+        /**
+         * Create a set for the `Hyphen` property, using a particular data source.
+         *
+         * See the [Rust documentation for `Hyphen`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Hyphen.html) for more information.
+         */
         fun createHyphenWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_hyphen_with_provider_mv1(provider.handle);
@@ -1705,10 +1804,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `ID_Compat_Math_Continue` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `ID_Compat_Math_Continue` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun idCompatMathContinueForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_id_compat_math_continue_for_char_mv1(ch);
@@ -1716,10 +1816,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `ID_Compat_Math_Continue` property, using compiled data.
-        *
-        *See the [Rust documentation for `IdCompatMathContinue`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IdCompatMathContinue.html) for more information.
-        */
+        /**
+         * Create a set for the `ID_Compat_Math_Continue` property, using compiled data.
+         *
+         * See the [Rust documentation for `IdCompatMathContinue`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IdCompatMathContinue.html) for more information.
+         */
         fun createIdCompatMathContinue(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_id_compat_math_continue_mv1();
@@ -1730,10 +1831,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `ID_Compat_Math_Continue` property, using a particular data source.
-        *
-        *See the [Rust documentation for `IdCompatMathContinue`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IdCompatMathContinue.html) for more information.
-        */
+        /**
+         * Create a set for the `ID_Compat_Math_Continue` property, using a particular data source.
+         *
+         * See the [Rust documentation for `IdCompatMathContinue`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IdCompatMathContinue.html) for more information.
+         */
         fun createIdCompatMathContinueWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_id_compat_math_continue_with_provider_mv1(provider.handle);
@@ -1749,10 +1851,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `ID_Compat_Math_Start` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `ID_Compat_Math_Start` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun idCompatMathStartForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_id_compat_math_start_for_char_mv1(ch);
@@ -1760,10 +1863,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `ID_Compat_Math_Start` property, using compiled data.
-        *
-        *See the [Rust documentation for `IdCompatMathStart`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IdCompatMathStart.html) for more information.
-        */
+        /**
+         * Create a set for the `ID_Compat_Math_Start` property, using compiled data.
+         *
+         * See the [Rust documentation for `IdCompatMathStart`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IdCompatMathStart.html) for more information.
+         */
         fun createIdCompatMathStart(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_id_compat_math_start_mv1();
@@ -1774,10 +1878,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `ID_Compat_Math_Start` property, using a particular data source.
-        *
-        *See the [Rust documentation for `IdCompatMathStart`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IdCompatMathStart.html) for more information.
-        */
+        /**
+         * Create a set for the `ID_Compat_Math_Start` property, using a particular data source.
+         *
+         * See the [Rust documentation for `IdCompatMathStart`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IdCompatMathStart.html) for more information.
+         */
         fun createIdCompatMathStartWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_id_compat_math_start_with_provider_mv1(provider.handle);
@@ -1793,10 +1898,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Id_Continue` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Id_Continue` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun idContinueForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_id_continue_for_char_mv1(ch);
@@ -1804,10 +1910,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Id_Continue` property, using compiled data.
-        *
-        *See the [Rust documentation for `IdContinue`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IdContinue.html) for more information.
-        */
+        /**
+         * Create a set for the `Id_Continue` property, using compiled data.
+         *
+         * See the [Rust documentation for `IdContinue`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IdContinue.html) for more information.
+         */
         fun createIdContinue(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_id_continue_mv1();
@@ -1818,10 +1925,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Id_Continue` property, using a particular data source.
-        *
-        *See the [Rust documentation for `IdContinue`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IdContinue.html) for more information.
-        */
+        /**
+         * Create a set for the `Id_Continue` property, using a particular data source.
+         *
+         * See the [Rust documentation for `IdContinue`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IdContinue.html) for more information.
+         */
         fun createIdContinueWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_id_continue_with_provider_mv1(provider.handle);
@@ -1837,10 +1945,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Ideographic` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Ideographic` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun ideographicForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_ideographic_for_char_mv1(ch);
@@ -1848,10 +1957,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Ideographic` property, using compiled data.
-        *
-        *See the [Rust documentation for `Ideographic`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Ideographic.html) for more information.
-        */
+        /**
+         * Create a set for the `Ideographic` property, using compiled data.
+         *
+         * See the [Rust documentation for `Ideographic`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Ideographic.html) for more information.
+         */
         fun createIdeographic(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_ideographic_mv1();
@@ -1862,10 +1972,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Ideographic` property, using a particular data source.
-        *
-        *See the [Rust documentation for `Ideographic`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Ideographic.html) for more information.
-        */
+        /**
+         * Create a set for the `Ideographic` property, using a particular data source.
+         *
+         * See the [Rust documentation for `Ideographic`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Ideographic.html) for more information.
+         */
         fun createIdeographicWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_ideographic_with_provider_mv1(provider.handle);
@@ -1881,10 +1992,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Id_Start` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Id_Start` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun idStartForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_id_start_for_char_mv1(ch);
@@ -1892,10 +2004,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Id_Start` property, using compiled data.
-        *
-        *See the [Rust documentation for `IdStart`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IdStart.html) for more information.
-        */
+        /**
+         * Create a set for the `Id_Start` property, using compiled data.
+         *
+         * See the [Rust documentation for `IdStart`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IdStart.html) for more information.
+         */
         fun createIdStart(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_id_start_mv1();
@@ -1906,10 +2019,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Id_Start` property, using a particular data source.
-        *
-        *See the [Rust documentation for `IdStart`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IdStart.html) for more information.
-        */
+        /**
+         * Create a set for the `Id_Start` property, using a particular data source.
+         *
+         * See the [Rust documentation for `IdStart`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IdStart.html) for more information.
+         */
         fun createIdStartWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_id_start_with_provider_mv1(provider.handle);
@@ -1925,10 +2039,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Ids_Binary_Operator` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Ids_Binary_Operator` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun idsBinaryOperatorForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_ids_binary_operator_for_char_mv1(ch);
@@ -1936,10 +2051,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Ids_Binary_Operator` property, using compiled data.
-        *
-        *See the [Rust documentation for `IdsBinaryOperator`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IdsBinaryOperator.html) for more information.
-        */
+        /**
+         * Create a set for the `Ids_Binary_Operator` property, using compiled data.
+         *
+         * See the [Rust documentation for `IdsBinaryOperator`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IdsBinaryOperator.html) for more information.
+         */
         fun createIdsBinaryOperator(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_ids_binary_operator_mv1();
@@ -1950,10 +2066,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Ids_Binary_Operator` property, using a particular data source.
-        *
-        *See the [Rust documentation for `IdsBinaryOperator`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IdsBinaryOperator.html) for more information.
-        */
+        /**
+         * Create a set for the `Ids_Binary_Operator` property, using a particular data source.
+         *
+         * See the [Rust documentation for `IdsBinaryOperator`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IdsBinaryOperator.html) for more information.
+         */
         fun createIdsBinaryOperatorWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_ids_binary_operator_with_provider_mv1(provider.handle);
@@ -1969,10 +2086,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Ids_Trinary_Operator` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Ids_Trinary_Operator` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun idsTrinaryOperatorForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_ids_trinary_operator_for_char_mv1(ch);
@@ -1980,10 +2098,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Ids_Trinary_Operator` property, using compiled data.
-        *
-        *See the [Rust documentation for `IdsTrinaryOperator`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IdsTrinaryOperator.html) for more information.
-        */
+        /**
+         * Create a set for the `Ids_Trinary_Operator` property, using compiled data.
+         *
+         * See the [Rust documentation for `IdsTrinaryOperator`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IdsTrinaryOperator.html) for more information.
+         */
         fun createIdsTrinaryOperator(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_ids_trinary_operator_mv1();
@@ -1994,10 +2113,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Ids_Trinary_Operator` property, using a particular data source.
-        *
-        *See the [Rust documentation for `IdsTrinaryOperator`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IdsTrinaryOperator.html) for more information.
-        */
+        /**
+         * Create a set for the `Ids_Trinary_Operator` property, using a particular data source.
+         *
+         * See the [Rust documentation for `IdsTrinaryOperator`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IdsTrinaryOperator.html) for more information.
+         */
         fun createIdsTrinaryOperatorWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_ids_trinary_operator_with_provider_mv1(provider.handle);
@@ -2013,10 +2133,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Ids_Unary_Operator` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Ids_Unary_Operator` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun idsUnaryOperatorForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_ids_unary_operator_for_char_mv1(ch);
@@ -2024,10 +2145,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Ids_Unary_Operator` property, using compiled data.
-        *
-        *See the [Rust documentation for `IdsUnaryOperator`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IdsUnaryOperator.html) for more information.
-        */
+        /**
+         * Create a set for the `Ids_Unary_Operator` property, using compiled data.
+         *
+         * See the [Rust documentation for `IdsUnaryOperator`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IdsUnaryOperator.html) for more information.
+         */
         fun createIdsUnaryOperator(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_ids_unary_operator_mv1();
@@ -2038,10 +2160,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Ids_Unary_Operator` property, using a particular data source.
-        *
-        *See the [Rust documentation for `IdsUnaryOperator`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IdsUnaryOperator.html) for more information.
-        */
+        /**
+         * Create a set for the `Ids_Unary_Operator` property, using a particular data source.
+         *
+         * See the [Rust documentation for `IdsUnaryOperator`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IdsUnaryOperator.html) for more information.
+         */
         fun createIdsUnaryOperatorWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_ids_unary_operator_with_provider_mv1(provider.handle);
@@ -2057,10 +2180,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Join_Control` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Join_Control` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun joinControlForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_join_control_for_char_mv1(ch);
@@ -2068,10 +2192,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Join_Control` property, using compiled data.
-        *
-        *See the [Rust documentation for `JoinControl`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.JoinControl.html) for more information.
-        */
+        /**
+         * Create a set for the `Join_Control` property, using compiled data.
+         *
+         * See the [Rust documentation for `JoinControl`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.JoinControl.html) for more information.
+         */
         fun createJoinControl(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_join_control_mv1();
@@ -2082,10 +2207,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Join_Control` property, using a particular data source.
-        *
-        *See the [Rust documentation for `JoinControl`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.JoinControl.html) for more information.
-        */
+        /**
+         * Create a set for the `Join_Control` property, using a particular data source.
+         *
+         * See the [Rust documentation for `JoinControl`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.JoinControl.html) for more information.
+         */
         fun createJoinControlWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_join_control_with_provider_mv1(provider.handle);
@@ -2101,10 +2227,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Logical_Order_Exception` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Logical_Order_Exception` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun logicalOrderExceptionForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_logical_order_exception_for_char_mv1(ch);
@@ -2112,10 +2239,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Logical_Order_Exception` property, using compiled data.
-        *
-        *See the [Rust documentation for `LogicalOrderException`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.LogicalOrderException.html) for more information.
-        */
+        /**
+         * Create a set for the `Logical_Order_Exception` property, using compiled data.
+         *
+         * See the [Rust documentation for `LogicalOrderException`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.LogicalOrderException.html) for more information.
+         */
         fun createLogicalOrderException(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_logical_order_exception_mv1();
@@ -2126,10 +2254,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Logical_Order_Exception` property, using a particular data source.
-        *
-        *See the [Rust documentation for `LogicalOrderException`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.LogicalOrderException.html) for more information.
-        */
+        /**
+         * Create a set for the `Logical_Order_Exception` property, using a particular data source.
+         *
+         * See the [Rust documentation for `LogicalOrderException`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.LogicalOrderException.html) for more information.
+         */
         fun createLogicalOrderExceptionWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_logical_order_exception_with_provider_mv1(provider.handle);
@@ -2145,10 +2274,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Lowercase` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Lowercase` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun lowercaseForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_lowercase_for_char_mv1(ch);
@@ -2156,10 +2286,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Lowercase` property, using compiled data.
-        *
-        *See the [Rust documentation for `Lowercase`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Lowercase.html) for more information.
-        */
+        /**
+         * Create a set for the `Lowercase` property, using compiled data.
+         *
+         * See the [Rust documentation for `Lowercase`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Lowercase.html) for more information.
+         */
         fun createLowercase(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_lowercase_mv1();
@@ -2170,10 +2301,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Lowercase` property, using a particular data source.
-        *
-        *See the [Rust documentation for `Lowercase`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Lowercase.html) for more information.
-        */
+        /**
+         * Create a set for the `Lowercase` property, using a particular data source.
+         *
+         * See the [Rust documentation for `Lowercase`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Lowercase.html) for more information.
+         */
         fun createLowercaseWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_lowercase_with_provider_mv1(provider.handle);
@@ -2189,10 +2321,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Math` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Math` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun mathForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_math_for_char_mv1(ch);
@@ -2200,10 +2333,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Math` property, using compiled data.
-        *
-        *See the [Rust documentation for `Math`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Math.html) for more information.
-        */
+        /**
+         * Create a set for the `Math` property, using compiled data.
+         *
+         * See the [Rust documentation for `Math`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Math.html) for more information.
+         */
         fun createMath(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_math_mv1();
@@ -2214,10 +2348,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Math` property, using a particular data source.
-        *
-        *See the [Rust documentation for `Math`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Math.html) for more information.
-        */
+        /**
+         * Create a set for the `Math` property, using a particular data source.
+         *
+         * See the [Rust documentation for `Math`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Math.html) for more information.
+         */
         fun createMathWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_math_with_provider_mv1(provider.handle);
@@ -2233,10 +2368,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Modifier_Combining_mark` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Modifier_Combining_mark` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun modifierCombiningMarkForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_modifier_combining_mark_for_char_mv1(ch);
@@ -2244,10 +2380,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Modifier_Combining_mark` property, using compiled data.
-        *
-        *See the [Rust documentation for `ModifierCombiningMark`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.ModifierCombiningMark.html) for more information.
-        */
+        /**
+         * Create a set for the `Modifier_Combining_mark` property, using compiled data.
+         *
+         * See the [Rust documentation for `ModifierCombiningMark`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.ModifierCombiningMark.html) for more information.
+         */
         fun createModifierCombiningMark(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_modifier_combining_mark_mv1();
@@ -2258,10 +2395,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Modifier_Combining_mark` property, using a particular data source.
-        *
-        *See the [Rust documentation for `ModifierCombiningMark`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.ModifierCombiningMark.html) for more information.
-        */
+        /**
+         * Create a set for the `Modifier_Combining_mark` property, using a particular data source.
+         *
+         * See the [Rust documentation for `ModifierCombiningMark`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.ModifierCombiningMark.html) for more information.
+         */
         fun createModifierCombiningMarkWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_modifier_combining_mark_with_provider_mv1(provider.handle);
@@ -2277,10 +2415,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Noncharacter_Code_Point` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Noncharacter_Code_Point` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun noncharacterCodePointForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_noncharacter_code_point_for_char_mv1(ch);
@@ -2288,10 +2427,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Noncharacter_Code_Point` property, using compiled data.
-        *
-        *See the [Rust documentation for `NoncharacterCodePoint`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.NoncharacterCodePoint.html) for more information.
-        */
+        /**
+         * Create a set for the `Noncharacter_Code_Point` property, using compiled data.
+         *
+         * See the [Rust documentation for `NoncharacterCodePoint`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.NoncharacterCodePoint.html) for more information.
+         */
         fun createNoncharacterCodePoint(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_noncharacter_code_point_mv1();
@@ -2302,10 +2442,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Noncharacter_Code_Point` property, using a particular data source.
-        *
-        *See the [Rust documentation for `NoncharacterCodePoint`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.NoncharacterCodePoint.html) for more information.
-        */
+        /**
+         * Create a set for the `Noncharacter_Code_Point` property, using a particular data source.
+         *
+         * See the [Rust documentation for `NoncharacterCodePoint`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.NoncharacterCodePoint.html) for more information.
+         */
         fun createNoncharacterCodePointWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_noncharacter_code_point_with_provider_mv1(provider.handle);
@@ -2321,10 +2462,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Nfc_Inert` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Nfc_Inert` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun nfcInertForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_nfc_inert_for_char_mv1(ch);
@@ -2332,10 +2474,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Nfc_Inert` property, using compiled data.
-        *
-        *See the [Rust documentation for `NfcInert`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.NfcInert.html) for more information.
-        */
+        /**
+         * Create a set for the `Nfc_Inert` property, using compiled data.
+         *
+         * See the [Rust documentation for `NfcInert`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.NfcInert.html) for more information.
+         */
         fun createNfcInert(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_nfc_inert_mv1();
@@ -2346,10 +2489,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Nfc_Inert` property, using a particular data source.
-        *
-        *See the [Rust documentation for `NfcInert`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.NfcInert.html) for more information.
-        */
+        /**
+         * Create a set for the `Nfc_Inert` property, using a particular data source.
+         *
+         * See the [Rust documentation for `NfcInert`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.NfcInert.html) for more information.
+         */
         fun createNfcInertWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_nfc_inert_with_provider_mv1(provider.handle);
@@ -2365,10 +2509,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Nfd_Inert` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Nfd_Inert` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun nfdInertForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_nfd_inert_for_char_mv1(ch);
@@ -2376,10 +2521,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Nfd_Inert` property, using compiled data.
-        *
-        *See the [Rust documentation for `NfdInert`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.NfdInert.html) for more information.
-        */
+        /**
+         * Create a set for the `Nfd_Inert` property, using compiled data.
+         *
+         * See the [Rust documentation for `NfdInert`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.NfdInert.html) for more information.
+         */
         fun createNfdInert(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_nfd_inert_mv1();
@@ -2390,10 +2536,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Nfd_Inert` property, using a particular data source.
-        *
-        *See the [Rust documentation for `NfdInert`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.NfdInert.html) for more information.
-        */
+        /**
+         * Create a set for the `Nfd_Inert` property, using a particular data source.
+         *
+         * See the [Rust documentation for `NfdInert`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.NfdInert.html) for more information.
+         */
         fun createNfdInertWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_nfd_inert_with_provider_mv1(provider.handle);
@@ -2409,10 +2556,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Nfkc_Inert` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Nfkc_Inert` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun nfkcInertForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_nfkc_inert_for_char_mv1(ch);
@@ -2420,10 +2568,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Nfkc_Inert` property, using compiled data.
-        *
-        *See the [Rust documentation for `NfkcInert`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.NfkcInert.html) for more information.
-        */
+        /**
+         * Create a set for the `Nfkc_Inert` property, using compiled data.
+         *
+         * See the [Rust documentation for `NfkcInert`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.NfkcInert.html) for more information.
+         */
         fun createNfkcInert(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_nfkc_inert_mv1();
@@ -2434,10 +2583,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Nfkc_Inert` property, using a particular data source.
-        *
-        *See the [Rust documentation for `NfkcInert`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.NfkcInert.html) for more information.
-        */
+        /**
+         * Create a set for the `Nfkc_Inert` property, using a particular data source.
+         *
+         * See the [Rust documentation for `NfkcInert`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.NfkcInert.html) for more information.
+         */
         fun createNfkcInertWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_nfkc_inert_with_provider_mv1(provider.handle);
@@ -2453,10 +2603,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Nfkd_Inert` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Nfkd_Inert` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun nfkdInertForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_nfkd_inert_for_char_mv1(ch);
@@ -2464,10 +2615,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Nfkd_Inert` property, using compiled data.
-        *
-        *See the [Rust documentation for `NfkdInert`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.NfkdInert.html) for more information.
-        */
+        /**
+         * Create a set for the `Nfkd_Inert` property, using compiled data.
+         *
+         * See the [Rust documentation for `NfkdInert`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.NfkdInert.html) for more information.
+         */
         fun createNfkdInert(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_nfkd_inert_mv1();
@@ -2478,10 +2630,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Nfkd_Inert` property, using a particular data source.
-        *
-        *See the [Rust documentation for `NfkdInert`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.NfkdInert.html) for more information.
-        */
+        /**
+         * Create a set for the `Nfkd_Inert` property, using a particular data source.
+         *
+         * See the [Rust documentation for `NfkdInert`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.NfkdInert.html) for more information.
+         */
         fun createNfkdInertWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_nfkd_inert_with_provider_mv1(provider.handle);
@@ -2497,10 +2650,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Pattern_Syntax` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Pattern_Syntax` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun patternSyntaxForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_pattern_syntax_for_char_mv1(ch);
@@ -2508,10 +2662,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Pattern_Syntax` property, using compiled data.
-        *
-        *See the [Rust documentation for `PatternSyntax`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.PatternSyntax.html) for more information.
-        */
+        /**
+         * Create a set for the `Pattern_Syntax` property, using compiled data.
+         *
+         * See the [Rust documentation for `PatternSyntax`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.PatternSyntax.html) for more information.
+         */
         fun createPatternSyntax(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_pattern_syntax_mv1();
@@ -2522,10 +2677,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Pattern_Syntax` property, using a particular data source.
-        *
-        *See the [Rust documentation for `PatternSyntax`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.PatternSyntax.html) for more information.
-        */
+        /**
+         * Create a set for the `Pattern_Syntax` property, using a particular data source.
+         *
+         * See the [Rust documentation for `PatternSyntax`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.PatternSyntax.html) for more information.
+         */
         fun createPatternSyntaxWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_pattern_syntax_with_provider_mv1(provider.handle);
@@ -2541,10 +2697,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Pattern_White_Space` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Pattern_White_Space` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun patternWhiteSpaceForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_pattern_white_space_for_char_mv1(ch);
@@ -2552,10 +2709,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Pattern_White_Space` property, using compiled data.
-        *
-        *See the [Rust documentation for `PatternWhiteSpace`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.PatternWhiteSpace.html) for more information.
-        */
+        /**
+         * Create a set for the `Pattern_White_Space` property, using compiled data.
+         *
+         * See the [Rust documentation for `PatternWhiteSpace`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.PatternWhiteSpace.html) for more information.
+         */
         fun createPatternWhiteSpace(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_pattern_white_space_mv1();
@@ -2566,10 +2724,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Pattern_White_Space` property, using a particular data source.
-        *
-        *See the [Rust documentation for `PatternWhiteSpace`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.PatternWhiteSpace.html) for more information.
-        */
+        /**
+         * Create a set for the `Pattern_White_Space` property, using a particular data source.
+         *
+         * See the [Rust documentation for `PatternWhiteSpace`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.PatternWhiteSpace.html) for more information.
+         */
         fun createPatternWhiteSpaceWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_pattern_white_space_with_provider_mv1(provider.handle);
@@ -2585,10 +2744,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Prepended_Concatenation_Mark` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Prepended_Concatenation_Mark` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun prependedConcatenationMarkForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_prepended_concatenation_mark_for_char_mv1(ch);
@@ -2596,10 +2756,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Prepended_Concatenation_Mark` property, using compiled data.
-        *
-        *See the [Rust documentation for `PrependedConcatenationMark`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.PrependedConcatenationMark.html) for more information.
-        */
+        /**
+         * Create a set for the `Prepended_Concatenation_Mark` property, using compiled data.
+         *
+         * See the [Rust documentation for `PrependedConcatenationMark`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.PrependedConcatenationMark.html) for more information.
+         */
         fun createPrependedConcatenationMark(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_prepended_concatenation_mark_mv1();
@@ -2610,10 +2771,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Prepended_Concatenation_Mark` property, using a particular data source.
-        *
-        *See the [Rust documentation for `PrependedConcatenationMark`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.PrependedConcatenationMark.html) for more information.
-        */
+        /**
+         * Create a set for the `Prepended_Concatenation_Mark` property, using a particular data source.
+         *
+         * See the [Rust documentation for `PrependedConcatenationMark`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.PrependedConcatenationMark.html) for more information.
+         */
         fun createPrependedConcatenationMarkWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_prepended_concatenation_mark_with_provider_mv1(provider.handle);
@@ -2629,10 +2791,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Print` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Print` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun printForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_print_for_char_mv1(ch);
@@ -2640,10 +2803,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Print` property, using compiled data.
-        *
-        *See the [Rust documentation for `Print`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Print.html) for more information.
-        */
+        /**
+         * Create a set for the `Print` property, using compiled data.
+         *
+         * See the [Rust documentation for `Print`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Print.html) for more information.
+         */
         fun createPrint(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_print_mv1();
@@ -2654,10 +2818,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Print` property, using a particular data source.
-        *
-        *See the [Rust documentation for `Print`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Print.html) for more information.
-        */
+        /**
+         * Create a set for the `Print` property, using a particular data source.
+         *
+         * See the [Rust documentation for `Print`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Print.html) for more information.
+         */
         fun createPrintWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_print_with_provider_mv1(provider.handle);
@@ -2673,10 +2838,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Quotation_Mark` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Quotation_Mark` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun quotationMarkForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_quotation_mark_for_char_mv1(ch);
@@ -2684,10 +2850,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Quotation_Mark` property, using compiled data.
-        *
-        *See the [Rust documentation for `QuotationMark`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.QuotationMark.html) for more information.
-        */
+        /**
+         * Create a set for the `Quotation_Mark` property, using compiled data.
+         *
+         * See the [Rust documentation for `QuotationMark`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.QuotationMark.html) for more information.
+         */
         fun createQuotationMark(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_quotation_mark_mv1();
@@ -2698,10 +2865,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Quotation_Mark` property, using a particular data source.
-        *
-        *See the [Rust documentation for `QuotationMark`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.QuotationMark.html) for more information.
-        */
+        /**
+         * Create a set for the `Quotation_Mark` property, using a particular data source.
+         *
+         * See the [Rust documentation for `QuotationMark`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.QuotationMark.html) for more information.
+         */
         fun createQuotationMarkWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_quotation_mark_with_provider_mv1(provider.handle);
@@ -2717,10 +2885,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Radical` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Radical` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun radicalForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_radical_for_char_mv1(ch);
@@ -2728,10 +2897,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Radical` property, using compiled data.
-        *
-        *See the [Rust documentation for `Radical`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Radical.html) for more information.
-        */
+        /**
+         * Create a set for the `Radical` property, using compiled data.
+         *
+         * See the [Rust documentation for `Radical`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Radical.html) for more information.
+         */
         fun createRadical(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_radical_mv1();
@@ -2742,10 +2912,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Radical` property, using a particular data source.
-        *
-        *See the [Rust documentation for `Radical`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Radical.html) for more information.
-        */
+        /**
+         * Create a set for the `Radical` property, using a particular data source.
+         *
+         * See the [Rust documentation for `Radical`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Radical.html) for more information.
+         */
         fun createRadicalWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_radical_with_provider_mv1(provider.handle);
@@ -2761,10 +2932,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Regional_Indicator` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Regional_Indicator` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun regionalIndicatorForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_regional_indicator_for_char_mv1(ch);
@@ -2772,10 +2944,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Regional_Indicator` property, using compiled data.
-        *
-        *See the [Rust documentation for `RegionalIndicator`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.RegionalIndicator.html) for more information.
-        */
+        /**
+         * Create a set for the `Regional_Indicator` property, using compiled data.
+         *
+         * See the [Rust documentation for `RegionalIndicator`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.RegionalIndicator.html) for more information.
+         */
         fun createRegionalIndicator(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_regional_indicator_mv1();
@@ -2786,10 +2959,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Regional_Indicator` property, using a particular data source.
-        *
-        *See the [Rust documentation for `RegionalIndicator`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.RegionalIndicator.html) for more information.
-        */
+        /**
+         * Create a set for the `Regional_Indicator` property, using a particular data source.
+         *
+         * See the [Rust documentation for `RegionalIndicator`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.RegionalIndicator.html) for more information.
+         */
         fun createRegionalIndicatorWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_regional_indicator_with_provider_mv1(provider.handle);
@@ -2805,10 +2979,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Soft_Dotted` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Soft_Dotted` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun softDottedForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_soft_dotted_for_char_mv1(ch);
@@ -2816,10 +2991,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Soft_Dotted` property, using compiled data.
-        *
-        *See the [Rust documentation for `SoftDotted`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.SoftDotted.html) for more information.
-        */
+        /**
+         * Create a set for the `Soft_Dotted` property, using compiled data.
+         *
+         * See the [Rust documentation for `SoftDotted`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.SoftDotted.html) for more information.
+         */
         fun createSoftDotted(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_soft_dotted_mv1();
@@ -2830,10 +3006,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Soft_Dotted` property, using a particular data source.
-        *
-        *See the [Rust documentation for `SoftDotted`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.SoftDotted.html) for more information.
-        */
+        /**
+         * Create a set for the `Soft_Dotted` property, using a particular data source.
+         *
+         * See the [Rust documentation for `SoftDotted`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.SoftDotted.html) for more information.
+         */
         fun createSoftDottedWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_soft_dotted_with_provider_mv1(provider.handle);
@@ -2849,10 +3026,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Segment_Starter` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Segment_Starter` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun segmentStarterForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_segment_starter_for_char_mv1(ch);
@@ -2860,10 +3038,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Segment_Starter` property, using compiled data.
-        *
-        *See the [Rust documentation for `SegmentStarter`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.SegmentStarter.html) for more information.
-        */
+        /**
+         * Create a set for the `Segment_Starter` property, using compiled data.
+         *
+         * See the [Rust documentation for `SegmentStarter`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.SegmentStarter.html) for more information.
+         */
         fun createSegmentStarter(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_segment_starter_mv1();
@@ -2874,10 +3053,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Segment_Starter` property, using a particular data source.
-        *
-        *See the [Rust documentation for `SegmentStarter`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.SegmentStarter.html) for more information.
-        */
+        /**
+         * Create a set for the `Segment_Starter` property, using a particular data source.
+         *
+         * See the [Rust documentation for `SegmentStarter`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.SegmentStarter.html) for more information.
+         */
         fun createSegmentStarterWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_segment_starter_with_provider_mv1(provider.handle);
@@ -2893,10 +3073,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Case_Sensitive` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Case_Sensitive` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun caseSensitiveForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_case_sensitive_for_char_mv1(ch);
@@ -2904,10 +3085,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Case_Sensitive` property, using compiled data.
-        *
-        *See the [Rust documentation for `CaseSensitive`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.CaseSensitive.html) for more information.
-        */
+        /**
+         * Create a set for the `Case_Sensitive` property, using compiled data.
+         *
+         * See the [Rust documentation for `CaseSensitive`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.CaseSensitive.html) for more information.
+         */
         fun createCaseSensitive(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_case_sensitive_mv1();
@@ -2918,10 +3100,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Case_Sensitive` property, using a particular data source.
-        *
-        *See the [Rust documentation for `CaseSensitive`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.CaseSensitive.html) for more information.
-        */
+        /**
+         * Create a set for the `Case_Sensitive` property, using a particular data source.
+         *
+         * See the [Rust documentation for `CaseSensitive`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.CaseSensitive.html) for more information.
+         */
         fun createCaseSensitiveWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_case_sensitive_with_provider_mv1(provider.handle);
@@ -2937,10 +3120,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Sentence_Terminal` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Sentence_Terminal` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun sentenceTerminalForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_sentence_terminal_for_char_mv1(ch);
@@ -2948,10 +3132,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Sentence_Terminal` property, using compiled data.
-        *
-        *See the [Rust documentation for `SentenceTerminal`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.SentenceTerminal.html) for more information.
-        */
+        /**
+         * Create a set for the `Sentence_Terminal` property, using compiled data.
+         *
+         * See the [Rust documentation for `SentenceTerminal`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.SentenceTerminal.html) for more information.
+         */
         fun createSentenceTerminal(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_sentence_terminal_mv1();
@@ -2962,10 +3147,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Sentence_Terminal` property, using a particular data source.
-        *
-        *See the [Rust documentation for `SentenceTerminal`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.SentenceTerminal.html) for more information.
-        */
+        /**
+         * Create a set for the `Sentence_Terminal` property, using a particular data source.
+         *
+         * See the [Rust documentation for `SentenceTerminal`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.SentenceTerminal.html) for more information.
+         */
         fun createSentenceTerminalWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_sentence_terminal_with_provider_mv1(provider.handle);
@@ -2981,10 +3167,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Terminal_Punctuation` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Terminal_Punctuation` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun terminalPunctuationForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_terminal_punctuation_for_char_mv1(ch);
@@ -2992,10 +3179,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Terminal_Punctuation` property, using compiled data.
-        *
-        *See the [Rust documentation for `TerminalPunctuation`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.TerminalPunctuation.html) for more information.
-        */
+        /**
+         * Create a set for the `Terminal_Punctuation` property, using compiled data.
+         *
+         * See the [Rust documentation for `TerminalPunctuation`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.TerminalPunctuation.html) for more information.
+         */
         fun createTerminalPunctuation(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_terminal_punctuation_mv1();
@@ -3006,10 +3194,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Terminal_Punctuation` property, using a particular data source.
-        *
-        *See the [Rust documentation for `TerminalPunctuation`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.TerminalPunctuation.html) for more information.
-        */
+        /**
+         * Create a set for the `Terminal_Punctuation` property, using a particular data source.
+         *
+         * See the [Rust documentation for `TerminalPunctuation`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.TerminalPunctuation.html) for more information.
+         */
         fun createTerminalPunctuationWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_terminal_punctuation_with_provider_mv1(provider.handle);
@@ -3025,10 +3214,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Unified_Ideograph` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Unified_Ideograph` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun unifiedIdeographForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_unified_ideograph_for_char_mv1(ch);
@@ -3036,10 +3226,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Unified_Ideograph` property, using compiled data.
-        *
-        *See the [Rust documentation for `UnifiedIdeograph`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.UnifiedIdeograph.html) for more information.
-        */
+        /**
+         * Create a set for the `Unified_Ideograph` property, using compiled data.
+         *
+         * See the [Rust documentation for `UnifiedIdeograph`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.UnifiedIdeograph.html) for more information.
+         */
         fun createUnifiedIdeograph(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_unified_ideograph_mv1();
@@ -3050,10 +3241,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Unified_Ideograph` property, using a particular data source.
-        *
-        *See the [Rust documentation for `UnifiedIdeograph`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.UnifiedIdeograph.html) for more information.
-        */
+        /**
+         * Create a set for the `Unified_Ideograph` property, using a particular data source.
+         *
+         * See the [Rust documentation for `UnifiedIdeograph`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.UnifiedIdeograph.html) for more information.
+         */
         fun createUnifiedIdeographWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_unified_ideograph_with_provider_mv1(provider.handle);
@@ -3069,10 +3261,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Uppercase` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Uppercase` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun uppercaseForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_uppercase_for_char_mv1(ch);
@@ -3080,10 +3273,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Uppercase` property, using compiled data.
-        *
-        *See the [Rust documentation for `Uppercase`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Uppercase.html) for more information.
-        */
+        /**
+         * Create a set for the `Uppercase` property, using compiled data.
+         *
+         * See the [Rust documentation for `Uppercase`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Uppercase.html) for more information.
+         */
         fun createUppercase(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_uppercase_mv1();
@@ -3094,10 +3288,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Uppercase` property, using a particular data source.
-        *
-        *See the [Rust documentation for `Uppercase`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Uppercase.html) for more information.
-        */
+        /**
+         * Create a set for the `Uppercase` property, using a particular data source.
+         *
+         * See the [Rust documentation for `Uppercase`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Uppercase.html) for more information.
+         */
         fun createUppercaseWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_uppercase_with_provider_mv1(provider.handle);
@@ -3113,10 +3308,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Variation_Selector` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Variation_Selector` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun variationSelectorForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_variation_selector_for_char_mv1(ch);
@@ -3124,10 +3320,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Variation_Selector` property, using compiled data.
-        *
-        *See the [Rust documentation for `VariationSelector`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.VariationSelector.html) for more information.
-        */
+        /**
+         * Create a set for the `Variation_Selector` property, using compiled data.
+         *
+         * See the [Rust documentation for `VariationSelector`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.VariationSelector.html) for more information.
+         */
         fun createVariationSelector(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_variation_selector_mv1();
@@ -3138,10 +3335,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Variation_Selector` property, using a particular data source.
-        *
-        *See the [Rust documentation for `VariationSelector`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.VariationSelector.html) for more information.
-        */
+        /**
+         * Create a set for the `Variation_Selector` property, using a particular data source.
+         *
+         * See the [Rust documentation for `VariationSelector`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.VariationSelector.html) for more information.
+         */
         fun createVariationSelectorWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_variation_selector_with_provider_mv1(provider.handle);
@@ -3157,10 +3355,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `White_Space` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `White_Space` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun whiteSpaceForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_white_space_for_char_mv1(ch);
@@ -3168,10 +3367,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `White_Space` property, using compiled data.
-        *
-        *See the [Rust documentation for `WhiteSpace`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.WhiteSpace.html) for more information.
-        */
+        /**
+         * Create a set for the `White_Space` property, using compiled data.
+         *
+         * See the [Rust documentation for `WhiteSpace`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.WhiteSpace.html) for more information.
+         */
         fun createWhiteSpace(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_white_space_mv1();
@@ -3182,10 +3382,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `White_Space` property, using a particular data source.
-        *
-        *See the [Rust documentation for `WhiteSpace`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.WhiteSpace.html) for more information.
-        */
+        /**
+         * Create a set for the `White_Space` property, using a particular data source.
+         *
+         * See the [Rust documentation for `WhiteSpace`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.WhiteSpace.html) for more information.
+         */
         fun createWhiteSpaceWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_white_space_with_provider_mv1(provider.handle);
@@ -3201,10 +3402,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Xdigit` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Xdigit` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun xdigitForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_xdigit_for_char_mv1(ch);
@@ -3212,10 +3414,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Xdigit` property, using compiled data.
-        *
-        *See the [Rust documentation for `Xdigit`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Xdigit.html) for more information.
-        */
+        /**
+         * Create a set for the `Xdigit` property, using compiled data.
+         *
+         * See the [Rust documentation for `Xdigit`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Xdigit.html) for more information.
+         */
         fun createXdigit(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_xdigit_mv1();
@@ -3226,10 +3429,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Xdigit` property, using a particular data source.
-        *
-        *See the [Rust documentation for `Xdigit`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Xdigit.html) for more information.
-        */
+        /**
+         * Create a set for the `Xdigit` property, using a particular data source.
+         *
+         * See the [Rust documentation for `Xdigit`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Xdigit.html) for more information.
+         */
         fun createXdigitWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_xdigit_with_provider_mv1(provider.handle);
@@ -3245,10 +3449,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Xid_Continue` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Xid_Continue` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun xidContinueForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_xid_continue_for_char_mv1(ch);
@@ -3256,10 +3461,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Xid_Continue` property, using compiled data.
-        *
-        *See the [Rust documentation for `XidContinue`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.XidContinue.html) for more information.
-        */
+        /**
+         * Create a set for the `Xid_Continue` property, using compiled data.
+         *
+         * See the [Rust documentation for `XidContinue`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.XidContinue.html) for more information.
+         */
         fun createXidContinue(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_xid_continue_mv1();
@@ -3270,10 +3476,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Xid_Continue` property, using a particular data source.
-        *
-        *See the [Rust documentation for `XidContinue`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.XidContinue.html) for more information.
-        */
+        /**
+         * Create a set for the `Xid_Continue` property, using a particular data source.
+         *
+         * See the [Rust documentation for `XidContinue`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.XidContinue.html) for more information.
+         */
         fun createXidContinueWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_xid_continue_with_provider_mv1(provider.handle);
@@ -3289,10 +3496,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Xid_Start` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Xid_Start` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.BinaryProperty.html#tymethod.for_char) for more information.
+         */
         fun xidStartForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_CodePointSetData_xid_start_for_char_mv1(ch);
@@ -3300,10 +3508,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Xid_Start` property, using compiled data.
-        *
-        *See the [Rust documentation for `XidStart`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.XidStart.html) for more information.
-        */
+        /**
+         * Create a set for the `Xid_Start` property, using compiled data.
+         *
+         * See the [Rust documentation for `XidStart`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.XidStart.html) for more information.
+         */
         fun createXidStart(): CodePointSetData {
             
             val returnVal = lib.icu4x_CodePointSetData_create_xid_start_mv1();
@@ -3314,10 +3523,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a set for the `Xid_Start` property, using a particular data source.
-        *
-        *See the [Rust documentation for `XidStart`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.XidStart.html) for more information.
-        */
+        /**
+         * Create a set for the `Xid_Start` property, using a particular data source.
+         *
+         * See the [Rust documentation for `XidStart`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.XidStart.html) for more information.
+         */
         fun createXidStartWithProvider(provider: DataProvider): Result<CodePointSetData> {
             
             val returnVal = lib.icu4x_CodePointSetData_create_xid_start_with_provider_mv1(provider.handle);
@@ -3333,10 +3543,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** [ecma]: https://tc39.es/ecma262/#table-binary-unicode-properties
-        *
-        *See the [Rust documentation for `new_for_ecma262`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointSetData.html#method.new_for_ecma262) for more information.
-        */
+        /**
+         * [ecma]: https://tc39.es/ecma262/#table-binary-unicode-properties
+         *
+         * See the [Rust documentation for `new_for_ecma262`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointSetData.html#method.new_for_ecma262) for more information.
+         */
         fun createForEcma262(propertyName: String): Result<CodePointSetData> {
             val propertyNameSliceMemory = PrimitiveArrayTools.borrowUtf8(propertyName)
             
@@ -3357,10 +3568,11 @@ class CodePointSetData internal constructor (
         }
         @JvmStatic
         
-        /** [ecma]: https://tc39.es/ecma262/#table-binary-unicode-properties
-        *
-        *See the [Rust documentation for `new_for_ecma262`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointSetData.html#method.new_for_ecma262) for more information.
-        */
+        /**
+         * [ecma]: https://tc39.es/ecma262/#table-binary-unicode-properties
+         *
+         * See the [Rust documentation for `new_for_ecma262`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointSetData.html#method.new_for_ecma262) for more information.
+         */
         fun createForEcma262WithProvider(provider: DataProvider, propertyName: String): Result<CodePointSetData> {
             val propertyNameSliceMemory = PrimitiveArrayTools.borrowUtf8(propertyName)
             
@@ -3381,20 +3593,22 @@ class CodePointSetData internal constructor (
         }
     }
     
-    /** Checks whether the code point is in the set.
-    *
-    *See the [Rust documentation for `contains`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointSetDataBorrowed.html#method.contains) for more information.
-    */
+    /**
+     * Checks whether the code point is in the set.
+     *
+     * See the [Rust documentation for `contains`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointSetDataBorrowed.html#method.contains) for more information.
+     */
     fun contains(cp: Int): Boolean {
         
         val returnVal = lib.icu4x_CodePointSetData_contains_mv1(handle, cp);
         return (returnVal > 0)
     }
     
-    /** Produces an iterator over ranges of code points contained in this set
-    *
-    *See the [Rust documentation for `iter_ranges`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointSetDataBorrowed.html#method.iter_ranges) for more information.
-    */
+    /**
+     * Produces an iterator over ranges of code points contained in this set
+     *
+     * See the [Rust documentation for `iter_ranges`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointSetDataBorrowed.html#method.iter_ranges) for more information.
+     */
     fun iterRanges(): CodePointRangeIterator {
         // This lifetime edge depends on lifetimes: 'a
         val aEdges: MutableList<Any> = mutableListOf(this);
@@ -3406,10 +3620,11 @@ class CodePointSetData internal constructor (
         return returnOpaque
     }
     
-    /** Produces an iterator over ranges of code points not contained in this set
-    *
-    *See the [Rust documentation for `iter_ranges_complemented`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointSetDataBorrowed.html#method.iter_ranges_complemented) for more information.
-    */
+    /**
+     * Produces an iterator over ranges of code points not contained in this set
+     *
+     * See the [Rust documentation for `iter_ranges_complemented`](https://docs.rs/icu/2.3.1/icu/properties/struct.CodePointSetDataBorrowed.html#method.iter_ranges_complemented) for more information.
+     */
     fun iterRangesComplemented(): CodePointRangeIterator {
         // This lifetime edge depends on lifetimes: 'a
         val aEdges: MutableList<Any> = mutableListOf(this);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/Collator.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/Collator.kt
@@ -12,8 +12,9 @@ internal interface CollatorLib: Library {
     fun icu4x_Collator_compare_utf16_mv1(handle: Pointer, left: Slice, right: Slice): Byte
     fun icu4x_Collator_resolved_options_v1_mv1(handle: Pointer): CollatorResolvedOptionsNative
 }
-/** See the [Rust documentation for `Collator`](https://docs.rs/icu/2.3.1/icu/collator/struct.Collator.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `Collator`](https://docs.rs/icu/2.3.1/icu/collator/struct.Collator.html) for more information.
+ */
 class Collator internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -42,10 +43,11 @@ class Collator internal constructor (
         internal val lib: CollatorLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Construct a new Collator instance using compiled data.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/collator/struct.Collator.html#method.try_new) for more information.
-        */
+        /**
+         * Construct a new Collator instance using compiled data.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/collator/struct.Collator.html#method.try_new) for more information.
+         */
         fun create(locale: Locale, options: CollatorOptions): Result<Collator> {
             
             val returnVal = lib.icu4x_Collator_create_v1_mv1(locale.handle, options.toNative());
@@ -61,10 +63,11 @@ class Collator internal constructor (
         }
         @JvmStatic
         
-        /** Construct a new Collator instance using a particular data source.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/collator/struct.Collator.html#method.try_new) for more information.
-        */
+        /**
+         * Construct a new Collator instance using a particular data source.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/collator/struct.Collator.html#method.try_new) for more information.
+         */
         fun create_with_provider(provider: DataProvider, locale: Locale, options: CollatorOptions): Result<Collator> {
             
             val returnVal = lib.icu4x_Collator_create_v1_with_provider_mv1(provider.handle, locale.handle, options.toNative());
@@ -80,13 +83,14 @@ class Collator internal constructor (
         }
     }
     
-    /** Compare two strings.
-    *
-    *Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
-    *to the WHATWG Encoding Standard.
-    *
-    *See the [Rust documentation for `compare_utf16`](https://docs.rs/icu/2.3.1/icu/collator/struct.CollatorBorrowed.html#method.compare_utf16) for more information.
-    */
+    /**
+     * Compare two strings.
+     *
+     * Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
+     * to the WHATWG Encoding Standard.
+     *
+     * See the [Rust documentation for `compare_utf16`](https://docs.rs/icu/2.3.1/icu/collator/struct.CollatorBorrowed.html#method.compare_utf16) for more information.
+     */
     fun compare(left: String, right: String): Byte {
         val leftSliceMemory = PrimitiveArrayTools.borrowUtf16(left)
         val rightSliceMemory = PrimitiveArrayTools.borrowUtf16(right)
@@ -100,12 +104,13 @@ class Collator internal constructor (
         }
     }
     
-    /** The resolved options showing how the default options, the requested options,
-    *and the options from locale data were combined. None of the struct fields
-    *will have `Auto` as the value.
-    *
-    *See the [Rust documentation for `resolved_options`](https://docs.rs/icu/2.3.1/icu/collator/struct.CollatorBorrowed.html#method.resolved_options) for more information.
-    */
+    /**
+     * The resolved options showing how the default options, the requested options,
+     * and the options from locale data were combined. None of the struct fields
+     * will have `Auto` as the value.
+     *
+     * See the [Rust documentation for `resolved_options`](https://docs.rs/icu/2.3.1/icu/collator/struct.CollatorBorrowed.html#method.resolved_options) for more information.
+     */
     fun resolved_options(): CollatorResolvedOptions {
         
         val returnVal = lib.icu4x_Collator_resolved_options_v1_mv1(handle);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CollatorAlternateHandling.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CollatorAlternateHandling.kt
@@ -8,7 +8,8 @@ import com.sun.jna.Structure
 
 internal interface CollatorAlternateHandlingLib: Library {
 }
-/** See the [Rust documentation for `AlternateHandling`](https://docs.rs/icu/2.3.1/icu/collator/options/enum.AlternateHandling.html) for more information.
+/**
+ * See the [Rust documentation for `AlternateHandling`](https://docs.rs/icu/2.3.1/icu/collator/options/enum.AlternateHandling.html) for more information.
 */
 enum class CollatorAlternateHandling {
     NonIgnorable,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CollatorCaseFirst.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CollatorCaseFirst.kt
@@ -8,7 +8,8 @@ import com.sun.jna.Structure
 
 internal interface CollatorCaseFirstLib: Library {
 }
-/** See the [Rust documentation for `CollationCaseFirst`](https://docs.rs/icu/2.3.1/icu/collator/preferences/enum.CollationCaseFirst.html) for more information.
+/**
+ * See the [Rust documentation for `CollationCaseFirst`](https://docs.rs/icu/2.3.1/icu/collator/preferences/enum.CollationCaseFirst.html) for more information.
 */
 enum class CollatorCaseFirst {
     Off,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CollatorCaseLevel.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CollatorCaseLevel.kt
@@ -8,7 +8,8 @@ import com.sun.jna.Structure
 
 internal interface CollatorCaseLevelLib: Library {
 }
-/** See the [Rust documentation for `CaseLevel`](https://docs.rs/icu/2.3.1/icu/collator/options/enum.CaseLevel.html) for more information.
+/**
+ * See the [Rust documentation for `CaseLevel`](https://docs.rs/icu/2.3.1/icu/collator/options/enum.CaseLevel.html) for more information.
 */
 enum class CollatorCaseLevel {
     Off,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CollatorMaxVariable.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CollatorMaxVariable.kt
@@ -8,7 +8,8 @@ import com.sun.jna.Structure
 
 internal interface CollatorMaxVariableLib: Library {
 }
-/** See the [Rust documentation for `MaxVariable`](https://docs.rs/icu/2.3.1/icu/collator/options/enum.MaxVariable.html) for more information.
+/**
+ * See the [Rust documentation for `MaxVariable`](https://docs.rs/icu/2.3.1/icu/collator/options/enum.MaxVariable.html) for more information.
 */
 enum class CollatorMaxVariable {
     Space,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CollatorNumericOrdering.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CollatorNumericOrdering.kt
@@ -8,7 +8,8 @@ import com.sun.jna.Structure
 
 internal interface CollatorNumericOrderingLib: Library {
 }
-/** See the [Rust documentation for `CollationNumericOrdering`](https://docs.rs/icu/2.3.1/icu/collator/preferences/enum.CollationNumericOrdering.html) for more information.
+/**
+ * See the [Rust documentation for `CollationNumericOrdering`](https://docs.rs/icu/2.3.1/icu/collator/preferences/enum.CollationNumericOrdering.html) for more information.
 */
 enum class CollatorNumericOrdering {
     Off,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CollatorOptions.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CollatorOptions.kt
@@ -66,8 +66,9 @@ internal class OptionCollatorOptionsNative constructor(): Structure(), Structure
 
 }
 
-/** See the [Rust documentation for `CollatorOptions`](https://docs.rs/icu/2.3.1/icu/collator/options/struct.CollatorOptions.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `CollatorOptions`](https://docs.rs/icu/2.3.1/icu/collator/options/struct.CollatorOptions.html) for more information.
+ */
 class CollatorOptions (var strength: CollatorStrength?, var alternateHandling: CollatorAlternateHandling?, var maxVariable: CollatorMaxVariable?, var caseLevel: CollatorCaseLevel?) {
     companion object {
 

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CollatorResolvedOptions.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CollatorResolvedOptions.kt
@@ -70,8 +70,9 @@ internal class OptionCollatorResolvedOptionsNative constructor(): Structure(), S
 
 }
 
-/** See the [Rust documentation for `ResolvedCollatorOptions`](https://docs.rs/icu/2.3.1/icu/collator/options/struct.ResolvedCollatorOptions.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `ResolvedCollatorOptions`](https://docs.rs/icu/2.3.1/icu/collator/options/struct.ResolvedCollatorOptions.html) for more information.
+ */
 class CollatorResolvedOptions (var strength: CollatorStrength, var alternateHandling: CollatorAlternateHandling, var caseFirst: CollatorCaseFirst, var maxVariable: CollatorMaxVariable, var caseLevel: CollatorCaseLevel, var numeric: CollatorNumericOrdering) {
     companion object {
 

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CollatorStrength.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/CollatorStrength.kt
@@ -8,7 +8,8 @@ import com.sun.jna.Structure
 
 internal interface CollatorStrengthLib: Library {
 }
-/** See the [Rust documentation for `Strength`](https://docs.rs/icu/2.3.1/icu/collator/options/enum.Strength.html) for more information.
+/**
+ * See the [Rust documentation for `Strength`](https://docs.rs/icu/2.3.1/icu/collator/options/enum.Strength.html) for more information.
 */
 enum class CollatorStrength {
     Primary,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/ComposingNormalizer.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/ComposingNormalizer.kt
@@ -15,8 +15,9 @@ internal interface ComposingNormalizerLib: Library {
     fun icu4x_ComposingNormalizer_is_normalized_utf16_mv1(handle: Pointer, s: Slice): Byte
     fun icu4x_ComposingNormalizer_is_normalized_utf16_up_to_mv1(handle: Pointer, s: Slice): FFISizet
 }
-/** See the [Rust documentation for `ComposingNormalizer`](https://docs.rs/icu/2.3.1/icu/normalizer/struct.ComposingNormalizer.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `ComposingNormalizer`](https://docs.rs/icu/2.3.1/icu/normalizer/struct.ComposingNormalizer.html) for more information.
+ */
 class ComposingNormalizer internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -45,10 +46,11 @@ class ComposingNormalizer internal constructor (
         internal val lib: ComposingNormalizerLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Construct a new `ComposingNormalizer` instance for NFC using compiled data.
-        *
-        *See the [Rust documentation for `new_nfc`](https://docs.rs/icu/2.3.1/icu/normalizer/struct.ComposingNormalizer.html#method.new_nfc) for more information.
-        */
+        /**
+         * Construct a new `ComposingNormalizer` instance for NFC using compiled data.
+         *
+         * See the [Rust documentation for `new_nfc`](https://docs.rs/icu/2.3.1/icu/normalizer/struct.ComposingNormalizer.html#method.new_nfc) for more information.
+         */
         fun createNfc(): ComposingNormalizer {
             
             val returnVal = lib.icu4x_ComposingNormalizer_create_nfc_mv1();
@@ -59,10 +61,11 @@ class ComposingNormalizer internal constructor (
         }
         @JvmStatic
         
-        /** Construct a new `ComposingNormalizer` instance for NFC using a particular data source.
-        *
-        *See the [Rust documentation for `new_nfc`](https://docs.rs/icu/2.3.1/icu/normalizer/struct.ComposingNormalizer.html#method.new_nfc) for more information.
-        */
+        /**
+         * Construct a new `ComposingNormalizer` instance for NFC using a particular data source.
+         *
+         * See the [Rust documentation for `new_nfc`](https://docs.rs/icu/2.3.1/icu/normalizer/struct.ComposingNormalizer.html#method.new_nfc) for more information.
+         */
         fun createNfcWithProvider(provider: DataProvider): Result<ComposingNormalizer> {
             
             val returnVal = lib.icu4x_ComposingNormalizer_create_nfc_with_provider_mv1(provider.handle);
@@ -78,10 +81,11 @@ class ComposingNormalizer internal constructor (
         }
         @JvmStatic
         
-        /** Construct a new `ComposingNormalizer` instance for NFKC using compiled data.
-        *
-        *See the [Rust documentation for `new_nfkc`](https://docs.rs/icu/2.3.1/icu/normalizer/struct.ComposingNormalizer.html#method.new_nfkc) for more information.
-        */
+        /**
+         * Construct a new `ComposingNormalizer` instance for NFKC using compiled data.
+         *
+         * See the [Rust documentation for `new_nfkc`](https://docs.rs/icu/2.3.1/icu/normalizer/struct.ComposingNormalizer.html#method.new_nfkc) for more information.
+         */
         fun createNfkc(): ComposingNormalizer {
             
             val returnVal = lib.icu4x_ComposingNormalizer_create_nfkc_mv1();
@@ -92,10 +96,11 @@ class ComposingNormalizer internal constructor (
         }
         @JvmStatic
         
-        /** Construct a new `ComposingNormalizer` instance for NFKC using a particular data source.
-        *
-        *See the [Rust documentation for `new_nfkc`](https://docs.rs/icu/2.3.1/icu/normalizer/struct.ComposingNormalizer.html#method.new_nfkc) for more information.
-        */
+        /**
+         * Construct a new `ComposingNormalizer` instance for NFKC using a particular data source.
+         *
+         * See the [Rust documentation for `new_nfkc`](https://docs.rs/icu/2.3.1/icu/normalizer/struct.ComposingNormalizer.html#method.new_nfkc) for more information.
+         */
         fun createNfkcWithProvider(provider: DataProvider): Result<ComposingNormalizer> {
             
             val returnVal = lib.icu4x_ComposingNormalizer_create_nfkc_with_provider_mv1(provider.handle);
@@ -111,13 +116,14 @@ class ComposingNormalizer internal constructor (
         }
     }
     
-    /** Normalize a string
-    *
-    *Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
-    *to the WHATWG Encoding Standard.
-    *
-    *See the [Rust documentation for `normalize_utf8`](https://docs.rs/icu/2.3.1/icu/normalizer/struct.ComposingNormalizerBorrowed.html#method.normalize_utf8) for more information.
-    */
+    /**
+     * Normalize a string
+     *
+     * Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
+     * to the WHATWG Encoding Standard.
+     *
+     * See the [Rust documentation for `normalize_utf8`](https://docs.rs/icu/2.3.1/icu/normalizer/struct.ComposingNormalizerBorrowed.html#method.normalize_utf8) for more information.
+     */
     fun normalize(s: String): String {
         val sSliceMemory = PrimitiveArrayTools.borrowUtf8(s)
         val write = DW.lib.diplomat_buffer_write_create(0)
@@ -131,13 +137,14 @@ class ComposingNormalizer internal constructor (
         }
     }
     
-    /** Check if a string is normalized
-    *
-    *Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
-    *to the WHATWG Encoding Standard.
-    *
-    *See the [Rust documentation for `is_normalized_utf16`](https://docs.rs/icu/2.3.1/icu/normalizer/struct.ComposingNormalizerBorrowed.html#method.is_normalized_utf16) for more information.
-    */
+    /**
+     * Check if a string is normalized
+     *
+     * Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
+     * to the WHATWG Encoding Standard.
+     *
+     * See the [Rust documentation for `is_normalized_utf16`](https://docs.rs/icu/2.3.1/icu/normalizer/struct.ComposingNormalizerBorrowed.html#method.is_normalized_utf16) for more information.
+     */
     fun is_normalized(s: String): Boolean {
         val sSliceMemory = PrimitiveArrayTools.borrowUtf16(s)
         
@@ -149,10 +156,11 @@ class ComposingNormalizer internal constructor (
         }
     }
     
-    /** Return the index a slice of potentially-invalid UTF-16 is normalized up to
-    *
-    *See the [Rust documentation for `split_normalized_utf16`](https://docs.rs/icu/2.3.1/icu/normalizer/struct.ComposingNormalizerBorrowed.html#method.split_normalized_utf16) for more information.
-    */
+    /**
+     * Return the index a slice of potentially-invalid UTF-16 is normalized up to
+     *
+     * See the [Rust documentation for `split_normalized_utf16`](https://docs.rs/icu/2.3.1/icu/normalizer/struct.ComposingNormalizerBorrowed.html#method.split_normalized_utf16) for more information.
+     */
     fun is_normalized_up_to(s: String): ULong {
         val sSliceMemory = PrimitiveArrayTools.borrowUtf16(s)
         

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DataError.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DataError.kt
@@ -8,7 +8,8 @@ import com.sun.jna.Structure
 
 internal interface DataErrorLib: Library {
 }
-/** Additional information: [1](https://docs.rs/icu_provider/2.3.0/icu_provider/struct.DataError.html), [2](https://docs.rs/icu_provider/2.3.0/icu_provider/enum.DataErrorKind.html)
+/**
+ * Additional information: [1](https://docs.rs/icu_provider/2.3.0/icu_provider/struct.DataError.html), [2](https://docs.rs/icu_provider/2.3.0/icu_provider/enum.DataErrorKind.html)
 */
 enum class DataError {
     Unknown,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DataProvider.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DataProvider.kt
@@ -13,15 +13,16 @@ internal interface DataProviderLib: Library {
     fun icu4x_DataProvider_fork_by_locale_mv1(handle: Pointer, other: Pointer): ResultUnitInt
     fun icu4x_DataProvider_enable_locale_fallback_with_mv1(handle: Pointer, fallbacker: Pointer): ResultUnitInt
 }
-/** An ICU4X data provider, capable of loading ICU4X data keys from some source.
-*
-*Currently the only source supported is loading from "blob" formatted data from a bytes buffer or the file system.
-*
-*If you wish to use ICU4X's builtin "compiled data", use the version of the constructors that do not have `_with_provider`
-*in their names.
-*
-*See the [Rust documentation for `icu_provider`](https://docs.rs/icu_provider/2.3.0/icu_provider/index.html) for more information.
-*/
+/**
+ * An ICU4X data provider, capable of loading ICU4X data keys from some source.
+ *
+ * Currently the only source supported is loading from "blob" formatted data from a bytes buffer or the file system.
+ *
+ * If you wish to use ICU4X's builtin "compiled data", use the version of the constructors that do not have `_with_provider`
+ * in their names.
+ *
+ * See the [Rust documentation for `icu_provider`](https://docs.rs/icu_provider/2.3.0/icu_provider/index.html) for more information.
+ */
 class DataProvider internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -50,12 +51,13 @@ class DataProvider internal constructor (
         internal val lib: DataProviderLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Constructs an `FsDataProvider` and returns it as an [DataProvider].
-        *Requires the `provider_fs` Cargo feature.
-        *Not supported in WASM.
-        *
-        *See the [Rust documentation for `FsDataProvider`](https://docs.rs/icu_provider_fs/2.3.0/icu_provider_fs/struct.FsDataProvider.html) for more information.
-        */
+        /**
+         * Constructs an `FsDataProvider` and returns it as an [DataProvider].
+         * Requires the `provider_fs` Cargo feature.
+         * Not supported in WASM.
+         *
+         * See the [Rust documentation for `FsDataProvider`](https://docs.rs/icu_provider_fs/2.3.0/icu_provider_fs/struct.FsDataProvider.html) for more information.
+         */
         fun fromFs(path: String): Result<DataProvider> {
             val pathSliceMemory = PrimitiveArrayTools.borrowUtf8(path)
             
@@ -76,10 +78,11 @@ class DataProvider internal constructor (
         }
         @JvmStatic
         
-        /** Constructs a `BlobDataProvider` and returns it as an [DataProvider].
-        *
-        *See the [Rust documentation for `try_new_from_static_blob`](https://docs.rs/icu_provider_blob/2.3.0/icu_provider_blob/struct.BlobDataProvider.html#method.try_new_from_static_blob) for more information.
-        */
+        /**
+         * Constructs a `BlobDataProvider` and returns it as an [DataProvider].
+         *
+         * See the [Rust documentation for `try_new_from_static_blob`](https://docs.rs/icu_provider_blob/2.3.0/icu_provider_blob/struct.BlobDataProvider.html#method.try_new_from_static_blob) for more information.
+         */
         fun fromByteSlice(blob: ByteArray): Result<DataProvider> {
             val blobSliceMemory = PrimitiveArrayTools.borrow(blob).leakStatic()
             
@@ -96,13 +99,14 @@ class DataProvider internal constructor (
         }
     }
     
-    /** Creates a provider that tries the current provider and then, if the current provider
-    *doesn't support the data key, another provider `other`.
-    *
-    *This takes ownership of the `other` provider, leaving an empty provider in its place.
-    *
-    *See the [Rust documentation for `ForkByMarkerProvider`](https://docs.rs/icu_provider_adapters/2.3.0/icu_provider_adapters/fork/type.ForkByMarkerProvider.html) for more information.
-    */
+    /**
+     * Creates a provider that tries the current provider and then, if the current provider
+     * doesn't support the data key, another provider `other`.
+     *
+     * This takes ownership of the `other` provider, leaving an empty provider in its place.
+     *
+     * See the [Rust documentation for `ForkByMarkerProvider`](https://docs.rs/icu_provider_adapters/2.3.0/icu_provider_adapters/fork/type.ForkByMarkerProvider.html) for more information.
+     */
     fun forkByMarker(other: DataProvider): Result<Unit> {
         
         val returnVal = lib.icu4x_DataProvider_fork_by_marker_mv1(handle, other.handle /* note this is a mutable reference. Think carefully about using, especially concurrently */);
@@ -114,10 +118,11 @@ class DataProvider internal constructor (
         }
     }
     
-    /** Same as `fork_by_key` but forks by locale instead of key.
-    *
-    *See the [Rust documentation for `IdentifierNotFoundPredicate`](https://docs.rs/icu_provider_adapters/2.3.0/icu_provider_adapters/fork/predicates/struct.IdentifierNotFoundPredicate.html) for more information.
-    */
+    /**
+     * Same as `fork_by_key` but forks by locale instead of key.
+     *
+     * See the [Rust documentation for `IdentifierNotFoundPredicate`](https://docs.rs/icu_provider_adapters/2.3.0/icu_provider_adapters/fork/predicates/struct.IdentifierNotFoundPredicate.html) for more information.
+     */
     fun forkByLocale(other: DataProvider): Result<Unit> {
         
         val returnVal = lib.icu4x_DataProvider_fork_by_locale_mv1(handle, other.handle /* note this is a mutable reference. Think carefully about using, especially concurrently */);
@@ -129,10 +134,11 @@ class DataProvider internal constructor (
         }
     }
     
-    /** See the [Rust documentation for `new`](https://docs.rs/icu_provider_adapters/2.3.0/icu_provider_adapters/fallback/struct.LocaleFallbackProvider.html#method.new) for more information.
-    *
-    *Additional information: [1](https://docs.rs/icu_provider_adapters/2.3.0/icu_provider_adapters/fallback/struct.LocaleFallbackProvider.html)
-    */
+    /**
+     * See the [Rust documentation for `new`](https://docs.rs/icu_provider_adapters/2.3.0/icu_provider_adapters/fallback/struct.LocaleFallbackProvider.html#method.new) for more information.
+     *
+     * Additional information: [1](https://docs.rs/icu_provider_adapters/2.3.0/icu_provider_adapters/fallback/struct.LocaleFallbackProvider.html)
+     */
     fun enableLocaleFallbackWith(fallbacker: LocaleFallbacker): Result<Unit> {
         
         val returnVal = lib.icu4x_DataProvider_enable_locale_fallback_with_mv1(handle, fallbacker.handle);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/Date.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/Date.kt
@@ -34,10 +34,11 @@ internal interface DateLib: Library {
     fun icu4x_Date_try_add_with_options_mv1(handle: Pointer, duration: DateDurationNative, options: DateAddOptionsNative): ResultPointerInt
     fun icu4x_Date_try_until_with_options_mv1(handle: Pointer, other: Pointer, options: DateDifferenceOptionsNative): ResultDateDurationNativeCalendarMismatchedCalendarErrorNative
 }
-/** An ICU4X Date object capable of containing a date for any calendar.
-*
-*See the [Rust documentation for `Date`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html) for more information.
-*/
+/**
+ * An ICU4X Date object capable of containing a date for any calendar.
+ *
+ * See the [Rust documentation for `Date`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html) for more information.
+ */
 class Date internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -66,11 +67,12 @@ class Date internal constructor (
         internal val lib: DateLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Creates a new [Date] representing the ISO date
-        *given but in a given calendar
-        *
-        *See the [Rust documentation for `new_from_iso`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.new_from_iso) for more information.
-        */
+        /**
+         * Creates a new [Date] representing the ISO date
+         * given but in a given calendar
+         *
+         * See the [Rust documentation for `new_from_iso`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.new_from_iso) for more information.
+         */
         fun fromIsoInCalendar(isoYear: Int, isoMonth: UByte, isoDay: UByte, calendar: Calendar): Result<Date> {
             
             val returnVal = lib.icu4x_Date_from_iso_in_calendar_mv1(isoYear, FFIUint8(isoMonth), FFIUint8(isoDay), calendar.handle);
@@ -86,10 +88,11 @@ class Date internal constructor (
         }
         @JvmStatic
         
-        /** Creates a new [Date] from the given fields, which are interpreted in the given calendar system.
-        *
-        *See the [Rust documentation for `try_from_fields`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.try_from_fields) for more information.
-        */
+        /**
+         * Creates a new [Date] from the given fields, which are interpreted in the given calendar system.
+         *
+         * See the [Rust documentation for `try_from_fields`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.try_from_fields) for more information.
+         */
         fun fromFieldsInCalendar(fields: DateFields, options: DateFromFieldsOptions, calendar: Calendar): Result<Date> {
             val temporaryEdgeArena: MutableList<Any> = mutableListOf()
             
@@ -106,14 +109,15 @@ class Date internal constructor (
         }
         @JvmStatic
         
-        /** Creates a new [Date] from the given codes, which are interpreted in the given calendar system
-        *
-        *An empty era code will treat the year as an extended year
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `try_from_str`](https://docs.rs/icu/2.3.1/icu/calendar/types/struct.Month.html#method.try_from_str) for more information.
-        */
+        /**
+         * Creates a new [Date] from the given codes, which are interpreted in the given calendar system
+         *
+         * An empty era code will treat the year as an extended year
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `try_from_str`](https://docs.rs/icu/2.3.1/icu/calendar/types/struct.Month.html#method.try_from_str) for more information.
+         */
         fun fromCodesInCalendar(eraCode: String, year: Int, monthCode: String, day: UByte, calendar: Calendar): Result<Date> {
             val eraCodeSliceMemory = PrimitiveArrayTools.borrowUtf8(eraCode)
             val monthCodeSliceMemory = PrimitiveArrayTools.borrowUtf8(monthCode)
@@ -136,10 +140,11 @@ class Date internal constructor (
         }
         @JvmStatic
         
-        /** Creates a new [Date] from the given Rata Die
-        *
-        *See the [Rust documentation for `from_rata_die`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.from_rata_die) for more information.
-        */
+        /**
+         * Creates a new [Date] from the given Rata Die
+         *
+         * See the [Rust documentation for `from_rata_die`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.from_rata_die) for more information.
+         */
         fun fromRataDie(rd: Long, calendar: Calendar): Result<Date> {
             
             val returnVal = lib.icu4x_Date_from_rata_die_mv1(rd, calendar.handle);
@@ -155,10 +160,11 @@ class Date internal constructor (
         }
         @JvmStatic
         
-        /** Creates a new [Date] from an IXDTF string.
-        *
-        *See the [Rust documentation for `try_from_str`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.try_from_str) for more information.
-        */
+        /**
+         * Creates a new [Date] from an IXDTF string.
+         *
+         * See the [Rust documentation for `try_from_str`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.try_from_str) for more information.
+         */
         fun fromString(v: String, calendar: Calendar): Result<Date> {
             val vSliceMemory = PrimitiveArrayTools.borrowUtf8(v)
             
@@ -179,10 +185,11 @@ class Date internal constructor (
         }
     }
     
-    /** Convert this date to one in a different calendar
-    *
-    *See the [Rust documentation for `to_calendar`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.to_calendar) for more information.
-    */
+    /**
+     * Convert this date to one in a different calendar
+     *
+     * See the [Rust documentation for `to_calendar`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.to_calendar) for more information.
+     */
     fun toCalendar(calendar: Calendar): Date {
         
         val returnVal = lib.icu4x_Date_to_calendar_mv1(handle, calendar.handle);
@@ -192,10 +199,11 @@ class Date internal constructor (
         return returnOpaque
     }
     
-    /** Converts this date to ISO
-    *
-    *See the [Rust documentation for `to_iso`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.to_iso) for more information.
-    */
+    /**
+     * Converts this date to ISO
+     *
+     * See the [Rust documentation for `to_iso`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.to_iso) for more information.
+     */
     fun toIso(): IsoDate {
         
         val returnVal = lib.icu4x_Date_to_iso_mv1(handle);
@@ -205,84 +213,91 @@ class Date internal constructor (
         return returnOpaque
     }
     
-    /** Returns this date's Rata Die
-    *
-    *See the [Rust documentation for `to_rata_die`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.to_rata_die) for more information.
-    */
+    /**
+     * Returns this date's Rata Die
+     *
+     * See the [Rust documentation for `to_rata_die`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.to_rata_die) for more information.
+     */
     fun toRataDie(): Long {
         
         val returnVal = lib.icu4x_Date_to_rata_die_mv1(handle);
         return (returnVal)
     }
     
-    /** Returns the 1-indexed day in the year for this date
-    *
-    *See the [Rust documentation for `day_of_year`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.day_of_year) for more information.
-    */
+    /**
+     * Returns the 1-indexed day in the year for this date
+     *
+     * See the [Rust documentation for `day_of_year`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.day_of_year) for more information.
+     */
     fun dayOfYear(): UShort {
         
         val returnVal = lib.icu4x_Date_day_of_year_mv1(handle);
         return (returnVal.toUShort())
     }
     
-    /** Returns the 1-indexed day in the month for this date
-    *
-    *See the [Rust documentation for `day_of_month`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.day_of_month) for more information.
-    */
+    /**
+     * Returns the 1-indexed day in the month for this date
+     *
+     * See the [Rust documentation for `day_of_month`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.day_of_month) for more information.
+     */
     fun dayOfMonth(): UByte {
         
         val returnVal = lib.icu4x_Date_day_of_month_mv1(handle);
         return (returnVal.toUByte())
     }
     
-    /** Returns the day in the week for this day
-    *
-    *This is *not* the day of the week, an ordinal number that is locale
-    *dependent.
-    *
-    *See the [Rust documentation for `day_of_week`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.day_of_week) for more information.
-    */
+    /**
+     * Returns the day in the week for this day
+     *
+     * This is *not* the day of the week, an ordinal number that is locale
+     * dependent.
+     *
+     * See the [Rust documentation for `day_of_week`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.day_of_week) for more information.
+     */
     fun dayOfWeek(): Weekday {
         
         val returnVal = lib.icu4x_Date_day_of_week_mv1(handle);
         return (Weekday.fromNative(returnVal))
     }
     
-    /** Returns the day in the week for this day
-    *
-    *See the [Rust documentation for `weekday`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.weekday) for more information.
-    */
+    /**
+     * Returns the day in the week for this day
+     *
+     * See the [Rust documentation for `weekday`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.weekday) for more information.
+     */
     fun weekday(): Weekday {
         
         val returnVal = lib.icu4x_Date_weekday_mv1(handle);
         return (Weekday.fromNative(returnVal))
     }
     
-    /** Returns 1-indexed number of the month of this date in its year
-    *
-    *Note that for lunar calendars this may not lead to the same month
-    *having the same ordinal month across years; use `month_code` if you care
-    *about month identity.
-    *
-    *See the [Rust documentation for `month`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.month) for more information.
-    *
-    *See the [Rust documentation for `ordinal`](https://docs.rs/icu/2.3.1/icu/calendar/types/struct.MonthInfo.html#structfield.ordinal) for more information.
-    */
+    /**
+     * Returns 1-indexed number of the month of this date in its year
+     *
+     * Note that for lunar calendars this may not lead to the same month
+     * having the same ordinal month across years; use `month_code` if you care
+     * about month identity.
+     *
+     * See the [Rust documentation for `month`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.month) for more information.
+     *
+     * See the [Rust documentation for `ordinal`](https://docs.rs/icu/2.3.1/icu/calendar/types/struct.MonthInfo.html#structfield.ordinal) for more information.
+     */
     fun ordinalMonth(): UByte {
         
         val returnVal = lib.icu4x_Date_ordinal_month_mv1(handle);
         return (returnVal.toUByte())
     }
     
-    /** Returns the month code for this date. Typically something
-    *like "M01", "M02", but can be more complicated for lunar calendars.
-    *
-    *See the [Rust documentation for `code`](https://docs.rs/icu/2.3.1/icu/calendar/types/struct.Month.html#method.code) for more information.
-    *
-    *See the [Rust documentation for `standard_code`](https://docs.rs/icu/2.3.1/icu/calendar/types/struct.MonthInfo.html#structfield.standard_code) for more information.
-    *
-    *Additional information: [1](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.month)
-    */
+    /**
+     * Returns the month code for this date. Typically something
+     * like "M01", "M02", but can be more complicated for lunar calendars.
+     *
+     * See the [Rust documentation for `code`](https://docs.rs/icu/2.3.1/icu/calendar/types/struct.Month.html#method.code) for more information.
+     *
+     * See the [Rust documentation for `standard_code`](https://docs.rs/icu/2.3.1/icu/calendar/types/struct.MonthInfo.html#structfield.standard_code) for more information.
+     *
+     * Additional information: [1](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.month)
+     */
     fun monthCode(): String {
         val write = DW.lib.diplomat_buffer_write_create(0)
         val returnVal = lib.icu4x_Date_month_code_mv1(handle, write);
@@ -291,60 +306,65 @@ class Date internal constructor (
         return returnString
     }
     
-    /** Returns the month number of this month.
-    *
-    *See the [Rust documentation for `number`](https://docs.rs/icu/2.3.1/icu/calendar/types/struct.Month.html#method.number) for more information.
-    */
+    /**
+     * Returns the month number of this month.
+     *
+     * See the [Rust documentation for `number`](https://docs.rs/icu/2.3.1/icu/calendar/types/struct.Month.html#method.number) for more information.
+     */
     fun monthNumber(): UByte {
         
         val returnVal = lib.icu4x_Date_month_number_mv1(handle);
         return (returnVal.toUByte())
     }
     
-    /** Returns whether the month is a leap month.
-    *
-    *See the [Rust documentation for `is_leap`](https://docs.rs/icu/2.3.1/icu/calendar/types/struct.Month.html#method.is_leap) for more information.
-    */
+    /**
+     * Returns whether the month is a leap month.
+     *
+     * See the [Rust documentation for `is_leap`](https://docs.rs/icu/2.3.1/icu/calendar/types/struct.Month.html#method.is_leap) for more information.
+     */
     fun monthIsLeap(): Boolean {
         
         val returnVal = lib.icu4x_Date_month_is_leap_mv1(handle);
         return (returnVal > 0)
     }
     
-    /** Returns the year number in the current era for this date
-    *
-    *For calendars without an era, returns the related ISO year.
-    *
-    *See the [Rust documentation for `era_year_or_related_iso`](https://docs.rs/icu/2.3.1/icu/calendar/types/enum.YearInfo.html#method.era_year_or_related_iso) for more information.
-    *
-    *Additional information: [1](https://docs.rs/icu/2.3.1/icu/calendar/types/struct.EraYear.html#structfield.year), [2](https://docs.rs/icu/2.3.1/icu/calendar/types/struct.CyclicYear.html#structfield.related_iso), [3](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.year)
-    */
+    /**
+     * Returns the year number in the current era for this date
+     *
+     * For calendars without an era, returns the related ISO year.
+     *
+     * See the [Rust documentation for `era_year_or_related_iso`](https://docs.rs/icu/2.3.1/icu/calendar/types/enum.YearInfo.html#method.era_year_or_related_iso) for more information.
+     *
+     * Additional information: [1](https://docs.rs/icu/2.3.1/icu/calendar/types/struct.EraYear.html#structfield.year), [2](https://docs.rs/icu/2.3.1/icu/calendar/types/struct.CyclicYear.html#structfield.related_iso), [3](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.year)
+     */
     fun eraYearOrRelatedIso(): Int {
         
         val returnVal = lib.icu4x_Date_era_year_or_related_iso_mv1(handle);
         return (returnVal)
     }
     
-    /** Returns the extended year, which can be used for
-    *
-    *This year number can be used when you need a simple numeric representation
-    *of the year, and can be meaningfully compared with extended years from other
-    *eras or used in arithmetic.
-    *
-    *See the [Rust documentation for `extended_year`](https://docs.rs/icu/2.3.1/icu/calendar/types/enum.YearInfo.html#method.extended_year) for more information.
-    */
+    /**
+     * Returns the extended year, which can be used for
+     *
+     * This year number can be used when you need a simple numeric representation
+     * of the year, and can be meaningfully compared with extended years from other
+     * eras or used in arithmetic.
+     *
+     * See the [Rust documentation for `extended_year`](https://docs.rs/icu/2.3.1/icu/calendar/types/enum.YearInfo.html#method.extended_year) for more information.
+     */
     fun extendedYear(): Int {
         
         val returnVal = lib.icu4x_Date_extended_year_mv1(handle);
         return (returnVal)
     }
     
-    /** Returns the era for this date, or an empty string
-    *
-    *See the [Rust documentation for `era`](https://docs.rs/icu/2.3.1/icu/calendar/types/struct.EraYear.html#structfield.era) for more information.
-    *
-    *Additional information: [1](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.year)
-    */
+    /**
+     * Returns the era for this date, or an empty string
+     *
+     * See the [Rust documentation for `era`](https://docs.rs/icu/2.3.1/icu/calendar/types/struct.EraYear.html#structfield.era) for more information.
+     *
+     * Additional information: [1](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.year)
+     */
     fun era(): String {
         val write = DW.lib.diplomat_buffer_write_create(0)
         val returnVal = lib.icu4x_Date_era_mv1(handle, write);
@@ -353,50 +373,55 @@ class Date internal constructor (
         return returnString
     }
     
-    /** Returns the number of months in the year represented by this date
-    *
-    *See the [Rust documentation for `months_in_year`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.months_in_year) for more information.
-    */
+    /**
+     * Returns the number of months in the year represented by this date
+     *
+     * See the [Rust documentation for `months_in_year`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.months_in_year) for more information.
+     */
     fun monthsInYear(): UByte {
         
         val returnVal = lib.icu4x_Date_months_in_year_mv1(handle);
         return (returnVal.toUByte())
     }
     
-    /** Returns the number of days in the month represented by this date
-    *
-    *See the [Rust documentation for `days_in_month`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.days_in_month) for more information.
-    */
+    /**
+     * Returns the number of days in the month represented by this date
+     *
+     * See the [Rust documentation for `days_in_month`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.days_in_month) for more information.
+     */
     fun daysInMonth(): UByte {
         
         val returnVal = lib.icu4x_Date_days_in_month_mv1(handle);
         return (returnVal.toUByte())
     }
     
-    /** Returns the number of days in the year represented by this date
-    *
-    *See the [Rust documentation for `days_in_year`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.days_in_year) for more information.
-    */
+    /**
+     * Returns the number of days in the year represented by this date
+     *
+     * See the [Rust documentation for `days_in_year`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.days_in_year) for more information.
+     */
     fun daysInYear(): UShort {
         
         val returnVal = lib.icu4x_Date_days_in_year_mv1(handle);
         return (returnVal.toUShort())
     }
     
-    /** Returns if the year is a leap year for this date
-    *
-    *See the [Rust documentation for `is_in_leap_year`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.is_in_leap_year) for more information.
-    */
+    /**
+     * Returns if the year is a leap year for this date
+     *
+     * See the [Rust documentation for `is_in_leap_year`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.is_in_leap_year) for more information.
+     */
     fun isInLeapYear(): Boolean {
         
         val returnVal = lib.icu4x_Date_is_in_leap_year_mv1(handle);
         return (returnVal > 0)
     }
     
-    /** Returns the [Calendar] object backing this date
-    *
-    *See the [Rust documentation for `calendar`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.calendar) for more information.
-    */
+    /**
+     * Returns the [Calendar] object backing this date
+     *
+     * See the [Rust documentation for `calendar`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.calendar) for more information.
+     */
     fun calendar(): Calendar {
         
         val returnVal = lib.icu4x_Date_calendar_mv1(handle);
@@ -406,10 +431,11 @@ class Date internal constructor (
         return returnOpaque
     }
     
-    /** Returns a new [Date] with the given duration added to it.
-    *
-    *See the [Rust documentation for `try_added_with_options`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.try_added_with_options) for more information.
-    */
+    /**
+     * Returns a new [Date] with the given duration added to it.
+     *
+     * See the [Rust documentation for `try_added_with_options`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.try_added_with_options) for more information.
+     */
     fun tryAddWithOptions(duration: DateDuration, options: DateAddOptions): Result<Date> {
         
         val returnVal = lib.icu4x_Date_try_add_with_options_mv1(handle, duration.toNative(), options.toNative());
@@ -424,10 +450,11 @@ class Date internal constructor (
         }
     }
     
-    /** Calculating the duration between `other - self`
-    *
-    *See the [Rust documentation for `try_until_with_options`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.try_until_with_options) for more information.
-    */
+    /**
+     * Calculating the duration between `other - self`
+     *
+     * See the [Rust documentation for `try_until_with_options`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.try_until_with_options) for more information.
+     */
     fun tryUntilWithOptions(other: Date, options: DateDifferenceOptions): Result<DateDuration> {
         
         val returnVal = lib.icu4x_Date_try_until_with_options_mv1(handle, other.handle, options.toNative());

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateAddOptions.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateAddOptions.kt
@@ -60,8 +60,9 @@ internal class OptionDateAddOptionsNative constructor(): Structure(), Structure.
 
 }
 
-/** See the [Rust documentation for `DateAddOptions`](https://docs.rs/icu/2.3.1/icu/calendar/options/struct.DateAddOptions.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `DateAddOptions`](https://docs.rs/icu/2.3.1/icu/calendar/options/struct.DateAddOptions.html) for more information.
+ */
 class DateAddOptions (var overflow: DateOverflow?) {
     companion object {
 

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateDifferenceOptions.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateDifferenceOptions.kt
@@ -60,8 +60,9 @@ internal class OptionDateDifferenceOptionsNative constructor(): Structure(), Str
 
 }
 
-/** See the [Rust documentation for `DateDifferenceOptions`](https://docs.rs/icu/2.3.1/icu/calendar/options/struct.DateDifferenceOptions.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `DateDifferenceOptions`](https://docs.rs/icu/2.3.1/icu/calendar/options/struct.DateDifferenceOptions.html) for more information.
+ */
 class DateDifferenceOptions (var largestUnit: DateDurationUnit?) {
     companion object {
 

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateDuration.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateDuration.kt
@@ -73,8 +73,9 @@ internal class OptionDateDurationNative constructor(): Structure(), Structure.By
 
 }
 
-/** See the [Rust documentation for `DateDuration`](https://docs.rs/icu/2.3.1/icu/calendar/types/struct.DateDuration.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `DateDuration`](https://docs.rs/icu/2.3.1/icu/calendar/types/struct.DateDuration.html) for more information.
+ */
 class DateDuration (var isNegative: Boolean, var years: UInt, var months: UInt, var weeks: UInt, var days: UInt) {
     companion object {
 
@@ -94,10 +95,11 @@ class DateDuration (var isNegative: Boolean, var years: UInt, var months: UInt, 
 
         @JvmStatic
         
-        /** Creates a new [DateDuration] from an ISO 8601 string.
-        *
-        *See the [Rust documentation for `try_from_str`](https://docs.rs/icu/2.3.1/icu/calendar/types/struct.DateDuration.html#method.try_from_str) for more information.
-        */
+        /**
+         * Creates a new [DateDuration] from an ISO 8601 string.
+         *
+         * See the [Rust documentation for `try_from_str`](https://docs.rs/icu/2.3.1/icu/calendar/types/struct.DateDuration.html#method.try_from_str) for more information.
+         */
         fun fromString(v: String): Result<DateDuration> {
             val vSliceMemory = PrimitiveArrayTools.borrowUtf8(v)
             
@@ -116,10 +118,11 @@ class DateDuration (var isNegative: Boolean, var years: UInt, var months: UInt, 
         }
         @JvmStatic
         
-        /** Returns a new [DateDuration] representing a number of years.
-        *
-        *See the [Rust documentation for `for_years`](https://docs.rs/icu/2.3.1/icu/calendar/types/struct.DateDuration.html#method.for_years) for more information.
-        */
+        /**
+         * Returns a new [DateDuration] representing a number of years.
+         *
+         * See the [Rust documentation for `for_years`](https://docs.rs/icu/2.3.1/icu/calendar/types/struct.DateDuration.html#method.for_years) for more information.
+         */
         fun forYears(years: Int): DateDuration {
             
             val returnVal = lib.icu4x_DateDuration_for_years_mv1(years);
@@ -128,10 +131,11 @@ class DateDuration (var isNegative: Boolean, var years: UInt, var months: UInt, 
         }
         @JvmStatic
         
-        /** Returns a new [DateDuration] representing a number of months.
-        *
-        *See the [Rust documentation for `for_months`](https://docs.rs/icu/2.3.1/icu/calendar/types/struct.DateDuration.html#method.for_months) for more information.
-        */
+        /**
+         * Returns a new [DateDuration] representing a number of months.
+         *
+         * See the [Rust documentation for `for_months`](https://docs.rs/icu/2.3.1/icu/calendar/types/struct.DateDuration.html#method.for_months) for more information.
+         */
         fun forMonths(months: Int): DateDuration {
             
             val returnVal = lib.icu4x_DateDuration_for_months_mv1(months);
@@ -140,10 +144,11 @@ class DateDuration (var isNegative: Boolean, var years: UInt, var months: UInt, 
         }
         @JvmStatic
         
-        /** Returns a new [DateDuration] representing a number of weeks.
-        *
-        *See the [Rust documentation for `for_weeks`](https://docs.rs/icu/2.3.1/icu/calendar/types/struct.DateDuration.html#method.for_weeks) for more information.
-        */
+        /**
+         * Returns a new [DateDuration] representing a number of weeks.
+         *
+         * See the [Rust documentation for `for_weeks`](https://docs.rs/icu/2.3.1/icu/calendar/types/struct.DateDuration.html#method.for_weeks) for more information.
+         */
         fun forWeeks(weeks: Int): DateDuration {
             
             val returnVal = lib.icu4x_DateDuration_for_weeks_mv1(weeks);
@@ -152,10 +157,11 @@ class DateDuration (var isNegative: Boolean, var years: UInt, var months: UInt, 
         }
         @JvmStatic
         
-        /** Returns a new [DateDuration] representing a number of days.
-        *
-        *See the [Rust documentation for `for_days`](https://docs.rs/icu/2.3.1/icu/calendar/types/struct.DateDuration.html#method.for_days) for more information.
-        */
+        /**
+         * Returns a new [DateDuration] representing a number of days.
+         *
+         * See the [Rust documentation for `for_days`](https://docs.rs/icu/2.3.1/icu/calendar/types/struct.DateDuration.html#method.for_days) for more information.
+         */
         fun forDays(days: Int): DateDuration {
             
             val returnVal = lib.icu4x_DateDuration_for_days_mv1(days);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateDurationParseError.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateDurationParseError.kt
@@ -8,7 +8,8 @@ import com.sun.jna.Structure
 
 internal interface DateDurationParseErrorLib: Library {
 }
-/** Additional information: [1](https://docs.rs/icu/2.3.1/icu/calendar/error/enum.DateDurationParseError.html)
+/**
+ * Additional information: [1](https://docs.rs/icu/2.3.1/icu/calendar/error/enum.DateDurationParseError.html)
 */
 enum class DateDurationParseError {
     InvalidStructure,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateDurationUnit.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateDurationUnit.kt
@@ -8,7 +8,8 @@ import com.sun.jna.Structure
 
 internal interface DateDurationUnitLib: Library {
 }
-/** See the [Rust documentation for `DateDurationUnit`](https://docs.rs/icu/2.3.1/icu/calendar/options/enum.DateDurationUnit.html) for more information.
+/**
+ * See the [Rust documentation for `DateDurationUnit`](https://docs.rs/icu/2.3.1/icu/calendar/options/enum.DateDurationUnit.html) for more information.
 */
 enum class DateDurationUnit {
     Years,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateFields.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateFields.kt
@@ -70,8 +70,9 @@ internal class OptionDateFieldsNative constructor(): Structure(), Structure.ByVa
 
 }
 
-/** See the [Rust documentation for `DateFields`](https://docs.rs/icu/2.3.1/icu/calendar/types/struct.DateFields.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `DateFields`](https://docs.rs/icu/2.3.1/icu/calendar/types/struct.DateFields.html) for more information.
+ */
 class DateFields (var era: String?, var eraYear: Int?, var extendedYear: Int?, var monthCode: String?, var ordinalMonth: UByte?, var day: UByte?) {
     companion object {
 

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateFormatter.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateFormatter.kt
@@ -30,8 +30,9 @@ internal interface DateFormatterLib: Library {
     fun icu4x_DateFormatter_format_iso_mv1(handle: Pointer, isoDate: Pointer, write: Pointer): Unit
     fun icu4x_DateFormatter_format_same_calendar_mv1(handle: Pointer, date: Pointer, write: Pointer): ResultUnitDateTimeMismatchedCalendarErrorNative
 }
-/** See the [Rust documentation for `DateTimeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `DateTimeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html) for more information.
+ */
 class DateFormatter internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -60,12 +61,13 @@ class DateFormatter internal constructor (
         internal val lib: DateFormatterLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.for_length)
+         */
         fun createD(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateFormatter> {
             
             val returnVal = lib.icu4x_DateFormatter_create_d_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -81,12 +83,13 @@ class DateFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.for_length)
+         */
         fun createDWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateFormatter> {
             
             val returnVal = lib.icu4x_DateFormatter_create_d_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -102,12 +105,13 @@ class DateFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.for_length)
+         */
         fun createMd(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateFormatter> {
             
             val returnVal = lib.icu4x_DateFormatter_create_md_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -123,12 +127,13 @@ class DateFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.for_length)
+         */
         fun createMdWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateFormatter> {
             
             val returnVal = lib.icu4x_DateFormatter_create_md_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -144,12 +149,13 @@ class DateFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.for_length)
+         */
         fun createYmd(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateFormatter> {
             
             val returnVal = lib.icu4x_DateFormatter_create_ymd_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -165,12 +171,13 @@ class DateFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.for_length)
+         */
         fun createYmdWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateFormatter> {
             
             val returnVal = lib.icu4x_DateFormatter_create_ymd_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -186,12 +193,13 @@ class DateFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.for_length)
+         */
         fun createDe(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateFormatter> {
             
             val returnVal = lib.icu4x_DateFormatter_create_de_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -207,12 +215,13 @@ class DateFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.for_length)
+         */
         fun createDeWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateFormatter> {
             
             val returnVal = lib.icu4x_DateFormatter_create_de_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -228,12 +237,13 @@ class DateFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.for_length)
+         */
         fun createMde(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateFormatter> {
             
             val returnVal = lib.icu4x_DateFormatter_create_mde_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -249,12 +259,13 @@ class DateFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.for_length)
+         */
         fun createMdeWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateFormatter> {
             
             val returnVal = lib.icu4x_DateFormatter_create_mde_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -270,12 +281,13 @@ class DateFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.for_length)
+         */
         fun createYmde(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateFormatter> {
             
             val returnVal = lib.icu4x_DateFormatter_create_ymde_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -291,12 +303,13 @@ class DateFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.for_length)
+         */
         fun createYmdeWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateFormatter> {
             
             val returnVal = lib.icu4x_DateFormatter_create_ymde_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -312,12 +325,13 @@ class DateFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html#method.for_length)
+         */
         fun createE(locale: Locale, length: DateTimeLength?): Result<DateFormatter> {
             
             val returnVal = lib.icu4x_DateFormatter_create_e_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -333,12 +347,13 @@ class DateFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html#method.for_length)
+         */
         fun createEWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?): Result<DateFormatter> {
             
             val returnVal = lib.icu4x_DateFormatter_create_e_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -354,12 +369,13 @@ class DateFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.for_length)
+         */
         fun createM(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateFormatter> {
             
             val returnVal = lib.icu4x_DateFormatter_create_m_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -375,12 +391,13 @@ class DateFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.for_length)
+         */
         fun createMWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateFormatter> {
             
             val returnVal = lib.icu4x_DateFormatter_create_m_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -396,12 +413,13 @@ class DateFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.for_length)
+         */
         fun createYm(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateFormatter> {
             
             val returnVal = lib.icu4x_DateFormatter_create_ym_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -417,12 +435,13 @@ class DateFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.for_length)
+         */
         fun createYmWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateFormatter> {
             
             val returnVal = lib.icu4x_DateFormatter_create_ym_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -438,12 +457,13 @@ class DateFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.for_length)
+         */
         fun createY(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateFormatter> {
             
             val returnVal = lib.icu4x_DateFormatter_create_y_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -459,12 +479,13 @@ class DateFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.for_length)
+         */
         fun createYWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateFormatter> {
             
             val returnVal = lib.icu4x_DateFormatter_create_y_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -480,8 +501,9 @@ class DateFormatter internal constructor (
         }
     }
     
-    /** See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.format) for more information.
-    */
+    /**
+     * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.format) for more information.
+     */
     fun formatIso(isoDate: IsoDate): String {
         val write = DW.lib.diplomat_buffer_write_create(0)
         val returnVal = lib.icu4x_DateFormatter_format_iso_mv1(handle, isoDate.handle, write);
@@ -490,8 +512,9 @@ class DateFormatter internal constructor (
         return returnString
     }
     
-    /** See the [Rust documentation for `format_same_calendar`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.format_same_calendar) for more information.
-    */
+    /**
+     * See the [Rust documentation for `format_same_calendar`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.format_same_calendar) for more information.
+     */
     fun formatSameCalendar(date: Date): Result<String> {
         val write = DW.lib.diplomat_buffer_write_create(0)
         val returnVal = lib.icu4x_DateFormatter_format_same_calendar_mv1(handle, date.handle, write);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateFormatterGregorian.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateFormatterGregorian.kt
@@ -29,8 +29,9 @@ internal interface DateFormatterGregorianLib: Library {
     fun icu4x_DateFormatterGregorian_create_y_with_provider_mv1(provider: Pointer, locale: Pointer, length: OptionInt, alignment: OptionInt, yearStyle: OptionInt): ResultPointerInt
     fun icu4x_DateFormatterGregorian_format_iso_mv1(handle: Pointer, isoDate: Pointer, write: Pointer): Unit
 }
-/** See the [Rust documentation for `FixedCalendarDateTimeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `FixedCalendarDateTimeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html) for more information.
+ */
 class DateFormatterGregorian internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -59,12 +60,13 @@ class DateFormatterGregorian internal constructor (
         internal val lib: DateFormatterGregorianLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.for_length)
+         */
         fun createD(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateFormatterGregorian_create_d_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -80,12 +82,13 @@ class DateFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.for_length)
+         */
         fun createDWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateFormatterGregorian_create_d_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -101,12 +104,13 @@ class DateFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.for_length)
+         */
         fun createMd(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateFormatterGregorian_create_md_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -122,12 +126,13 @@ class DateFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.for_length)
+         */
         fun createMdWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateFormatterGregorian_create_md_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -143,12 +148,13 @@ class DateFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.for_length)
+         */
         fun createYmd(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateFormatterGregorian_create_ymd_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -164,12 +170,13 @@ class DateFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.for_length)
+         */
         fun createYmdWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateFormatterGregorian_create_ymd_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -185,12 +192,13 @@ class DateFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.for_length)
+         */
         fun createDe(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateFormatterGregorian_create_de_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -206,12 +214,13 @@ class DateFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.for_length)
+         */
         fun createDeWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateFormatterGregorian_create_de_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -227,12 +236,13 @@ class DateFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.for_length)
+         */
         fun createMde(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateFormatterGregorian_create_mde_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -248,12 +258,13 @@ class DateFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.for_length)
+         */
         fun createMdeWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateFormatterGregorian_create_mde_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -269,12 +280,13 @@ class DateFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.for_length)
+         */
         fun createYmde(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateFormatterGregorian_create_ymde_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -290,12 +302,13 @@ class DateFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.for_length)
+         */
         fun createYmdeWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateFormatterGregorian_create_ymde_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -311,12 +324,13 @@ class DateFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html#method.for_length)
+         */
         fun createE(locale: Locale, length: DateTimeLength?): Result<DateFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateFormatterGregorian_create_e_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -332,12 +346,13 @@ class DateFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html#method.for_length)
+         */
         fun createEWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?): Result<DateFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateFormatterGregorian_create_e_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -353,12 +368,13 @@ class DateFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.for_length)
+         */
         fun createM(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateFormatterGregorian_create_m_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -374,12 +390,13 @@ class DateFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.for_length)
+         */
         fun createMWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateFormatterGregorian_create_m_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -395,12 +412,13 @@ class DateFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.for_length)
+         */
         fun createYm(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateFormatterGregorian_create_ym_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -416,12 +434,13 @@ class DateFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.for_length)
+         */
         fun createYmWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateFormatterGregorian_create_ym_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -437,12 +456,13 @@ class DateFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.for_length)
+         */
         fun createY(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateFormatterGregorian_create_y_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -458,12 +478,13 @@ class DateFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.for_length)
+         */
         fun createYWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateFormatterGregorian_create_y_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -479,8 +500,9 @@ class DateFormatterGregorian internal constructor (
         }
     }
     
-    /** See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.format) for more information.
-    */
+    /**
+     * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.format) for more information.
+     */
     fun formatIso(isoDate: IsoDate): String {
         val write = DW.lib.diplomat_buffer_write_create(0)
         val returnVal = lib.icu4x_DateFormatterGregorian_format_iso_mv1(handle, isoDate.handle, write);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateFromFieldsOptions.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateFromFieldsOptions.kt
@@ -62,8 +62,9 @@ internal class OptionDateFromFieldsOptionsNative constructor(): Structure(), Str
 
 }
 
-/** See the [Rust documentation for `DateFromFieldsOptions`](https://docs.rs/icu/2.3.1/icu/calendar/options/struct.DateFromFieldsOptions.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `DateFromFieldsOptions`](https://docs.rs/icu/2.3.1/icu/calendar/options/struct.DateFromFieldsOptions.html) for more information.
+ */
 class DateFromFieldsOptions (var overflow: DateOverflow?, var missingFieldsStrategy: DateMissingFieldsStrategy?) {
     companion object {
 

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateMissingFieldsStrategy.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateMissingFieldsStrategy.kt
@@ -8,7 +8,8 @@ import com.sun.jna.Structure
 
 internal interface DateMissingFieldsStrategyLib: Library {
 }
-/** See the [Rust documentation for `MissingFieldsStrategy`](https://docs.rs/icu/2.3.1/icu/calendar/options/enum.MissingFieldsStrategy.html) for more information.
+/**
+ * See the [Rust documentation for `MissingFieldsStrategy`](https://docs.rs/icu/2.3.1/icu/calendar/options/enum.MissingFieldsStrategy.html) for more information.
 */
 enum class DateMissingFieldsStrategy {
     Reject,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateOverflow.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateOverflow.kt
@@ -8,7 +8,8 @@ import com.sun.jna.Structure
 
 internal interface DateOverflowLib: Library {
 }
-/** See the [Rust documentation for `Overflow`](https://docs.rs/icu/2.3.1/icu/calendar/options/enum.Overflow.html) for more information.
+/**
+ * See the [Rust documentation for `Overflow`](https://docs.rs/icu/2.3.1/icu/calendar/options/enum.Overflow.html) for more information.
 */
 enum class DateOverflow {
     Constrain,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateRangeFormatter.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateRangeFormatter.kt
@@ -31,9 +31,9 @@ internal interface DateRangeFormatterLib: Library {
     fun icu4x_DateRangeFormatter_format_same_calendar_mv1(handle: Pointer, startDate: Pointer, endDate: Pointer, write: Pointer): Unit
 }
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `DateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html) for more information.
+ *
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
  */
 class DateRangeFormatter internal constructor (
     internal val handle: Pointer,
@@ -64,13 +64,13 @@ class DateRangeFormatter internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createD(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateRangeFormatter> {
             
@@ -88,13 +88,13 @@ class DateRangeFormatter internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createDWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateRangeFormatter> {
             
@@ -112,13 +112,13 @@ class DateRangeFormatter internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createMd(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateRangeFormatter> {
             
@@ -136,13 +136,13 @@ class DateRangeFormatter internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createMdWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateRangeFormatter> {
             
@@ -160,13 +160,13 @@ class DateRangeFormatter internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createYmd(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateRangeFormatter> {
             
@@ -184,13 +184,13 @@ class DateRangeFormatter internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createYmdWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateRangeFormatter> {
             
@@ -208,13 +208,13 @@ class DateRangeFormatter internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createDe(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateRangeFormatter> {
             
@@ -232,13 +232,13 @@ class DateRangeFormatter internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createDeWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateRangeFormatter> {
             
@@ -256,13 +256,13 @@ class DateRangeFormatter internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createMde(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateRangeFormatter> {
             
@@ -280,13 +280,13 @@ class DateRangeFormatter internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createMdeWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateRangeFormatter> {
             
@@ -304,13 +304,13 @@ class DateRangeFormatter internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createYmde(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateRangeFormatter> {
             
@@ -328,13 +328,13 @@ class DateRangeFormatter internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createYmdeWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateRangeFormatter> {
             
@@ -352,13 +352,13 @@ class DateRangeFormatter internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createE(locale: Locale, length: DateTimeLength?): Result<DateRangeFormatter> {
             
@@ -376,13 +376,13 @@ class DateRangeFormatter internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createEWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?): Result<DateRangeFormatter> {
             
@@ -400,13 +400,13 @@ class DateRangeFormatter internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createM(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateRangeFormatter> {
             
@@ -424,13 +424,13 @@ class DateRangeFormatter internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createMWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateRangeFormatter> {
             
@@ -448,13 +448,13 @@ class DateRangeFormatter internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createYm(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateRangeFormatter> {
             
@@ -472,13 +472,13 @@ class DateRangeFormatter internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createYmWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateRangeFormatter> {
             
@@ -496,13 +496,13 @@ class DateRangeFormatter internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createY(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateRangeFormatter> {
             
@@ -520,13 +520,13 @@ class DateRangeFormatter internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createYWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateRangeFormatter> {
             
@@ -544,9 +544,9 @@ class DateRangeFormatter internal constructor (
     }
     
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
+     *
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
      */
     fun formatIso(startIsoDate: IsoDate, endIsoDate: IsoDate): String {
         val write = DW.lib.diplomat_buffer_write_create(0)
@@ -557,9 +557,9 @@ class DateRangeFormatter internal constructor (
     }
     
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
+     *
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
      */
     fun formatSameCalendar(startDate: Date, endDate: Date): String {
         val write = DW.lib.diplomat_buffer_write_create(0)

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateRangeFormatter.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateRangeFormatter.kt
@@ -30,10 +30,11 @@ internal interface DateRangeFormatterLib: Library {
     fun icu4x_DateRangeFormatter_format_iso_mv1(handle: Pointer, startIsoDate: Pointer, endIsoDate: Pointer, write: Pointer): Unit
     fun icu4x_DateRangeFormatter_format_same_calendar_mv1(handle: Pointer, startDate: Pointer, endDate: Pointer, write: Pointer): Unit
 }
-/** 🚧 This API is unstable and may experience breaking changes outside major releases.
-*
-*See the [Rust documentation for `DateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html) for more information.
-*/
+/**
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
+ *
+ * See the [Rust documentation for `DateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html) for more information.
+ */
 class DateRangeFormatter internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -62,14 +63,15 @@ class DateRangeFormatter internal constructor (
         internal val lib: DateRangeFormatterLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.for_length)
+         */
         fun createD(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateRangeFormatter> {
             
             val returnVal = lib.icu4x_DateRangeFormatter_create_d_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -85,14 +87,15 @@ class DateRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.for_length)
+         */
         fun createDWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateRangeFormatter> {
             
             val returnVal = lib.icu4x_DateRangeFormatter_create_d_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -108,14 +111,15 @@ class DateRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.for_length)
+         */
         fun createMd(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateRangeFormatter> {
             
             val returnVal = lib.icu4x_DateRangeFormatter_create_md_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -131,14 +135,15 @@ class DateRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.for_length)
+         */
         fun createMdWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateRangeFormatter> {
             
             val returnVal = lib.icu4x_DateRangeFormatter_create_md_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -154,14 +159,15 @@ class DateRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.for_length)
+         */
         fun createYmd(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateRangeFormatter> {
             
             val returnVal = lib.icu4x_DateRangeFormatter_create_ymd_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -177,14 +183,15 @@ class DateRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.for_length)
+         */
         fun createYmdWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateRangeFormatter> {
             
             val returnVal = lib.icu4x_DateRangeFormatter_create_ymd_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -200,14 +207,15 @@ class DateRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.for_length)
+         */
         fun createDe(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateRangeFormatter> {
             
             val returnVal = lib.icu4x_DateRangeFormatter_create_de_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -223,14 +231,15 @@ class DateRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.for_length)
+         */
         fun createDeWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateRangeFormatter> {
             
             val returnVal = lib.icu4x_DateRangeFormatter_create_de_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -246,14 +255,15 @@ class DateRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.for_length)
+         */
         fun createMde(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateRangeFormatter> {
             
             val returnVal = lib.icu4x_DateRangeFormatter_create_mde_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -269,14 +279,15 @@ class DateRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.for_length)
+         */
         fun createMdeWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateRangeFormatter> {
             
             val returnVal = lib.icu4x_DateRangeFormatter_create_mde_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -292,14 +303,15 @@ class DateRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.for_length)
+         */
         fun createYmde(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateRangeFormatter> {
             
             val returnVal = lib.icu4x_DateRangeFormatter_create_ymde_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -315,14 +327,15 @@ class DateRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.for_length)
+         */
         fun createYmdeWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateRangeFormatter> {
             
             val returnVal = lib.icu4x_DateRangeFormatter_create_ymde_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -338,14 +351,15 @@ class DateRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html#method.for_length)
+         */
         fun createE(locale: Locale, length: DateTimeLength?): Result<DateRangeFormatter> {
             
             val returnVal = lib.icu4x_DateRangeFormatter_create_e_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -361,14 +375,15 @@ class DateRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html#method.for_length)
+         */
         fun createEWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?): Result<DateRangeFormatter> {
             
             val returnVal = lib.icu4x_DateRangeFormatter_create_e_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -384,14 +399,15 @@ class DateRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.for_length)
+         */
         fun createM(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateRangeFormatter> {
             
             val returnVal = lib.icu4x_DateRangeFormatter_create_m_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -407,14 +423,15 @@ class DateRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.for_length)
+         */
         fun createMWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateRangeFormatter> {
             
             val returnVal = lib.icu4x_DateRangeFormatter_create_m_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -430,14 +447,15 @@ class DateRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.for_length)
+         */
         fun createYm(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateRangeFormatter> {
             
             val returnVal = lib.icu4x_DateRangeFormatter_create_ym_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -453,14 +471,15 @@ class DateRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.for_length)
+         */
         fun createYmWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateRangeFormatter> {
             
             val returnVal = lib.icu4x_DateRangeFormatter_create_ym_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -476,14 +495,15 @@ class DateRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.for_length)
+         */
         fun createY(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateRangeFormatter> {
             
             val returnVal = lib.icu4x_DateRangeFormatter_create_y_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -499,14 +519,15 @@ class DateRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.for_length)
+         */
         fun createYWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateRangeFormatter> {
             
             val returnVal = lib.icu4x_DateRangeFormatter_create_y_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -522,10 +543,11 @@ class DateRangeFormatter internal constructor (
         }
     }
     
-    /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-    *
-    *See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
-    */
+    /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
+     * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
+     */
     fun formatIso(startIsoDate: IsoDate, endIsoDate: IsoDate): String {
         val write = DW.lib.diplomat_buffer_write_create(0)
         val returnVal = lib.icu4x_DateRangeFormatter_format_iso_mv1(handle, startIsoDate.handle, endIsoDate.handle, write);
@@ -534,10 +556,11 @@ class DateRangeFormatter internal constructor (
         return returnString
     }
     
-    /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-    *
-    *See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
-    */
+    /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
+     * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
+     */
     fun formatSameCalendar(startDate: Date, endDate: Date): String {
         val write = DW.lib.diplomat_buffer_write_create(0)
         val returnVal = lib.icu4x_DateRangeFormatter_format_same_calendar_mv1(handle, startDate.handle, endDate.handle, write);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateRangeFormatterGregorian.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateRangeFormatterGregorian.kt
@@ -30,9 +30,9 @@ internal interface DateRangeFormatterGregorianLib: Library {
     fun icu4x_DateRangeFormatterGregorian_format_iso_mv1(handle: Pointer, startIsoDate: Pointer, endIsoDate: Pointer, write: Pointer): Unit
 }
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `FixedCalendarDateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html) for more information.
+ *
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
  */
 class DateRangeFormatterGregorian internal constructor (
     internal val handle: Pointer,
@@ -63,13 +63,13 @@ class DateRangeFormatterGregorian internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createD(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateRangeFormatterGregorian> {
             
@@ -87,13 +87,13 @@ class DateRangeFormatterGregorian internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createDWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateRangeFormatterGregorian> {
             
@@ -111,13 +111,13 @@ class DateRangeFormatterGregorian internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createMd(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateRangeFormatterGregorian> {
             
@@ -135,13 +135,13 @@ class DateRangeFormatterGregorian internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createMdWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateRangeFormatterGregorian> {
             
@@ -159,13 +159,13 @@ class DateRangeFormatterGregorian internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createYmd(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateRangeFormatterGregorian> {
             
@@ -183,13 +183,13 @@ class DateRangeFormatterGregorian internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createYmdWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateRangeFormatterGregorian> {
             
@@ -207,13 +207,13 @@ class DateRangeFormatterGregorian internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createDe(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateRangeFormatterGregorian> {
             
@@ -231,13 +231,13 @@ class DateRangeFormatterGregorian internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createDeWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateRangeFormatterGregorian> {
             
@@ -255,13 +255,13 @@ class DateRangeFormatterGregorian internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createMde(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateRangeFormatterGregorian> {
             
@@ -279,13 +279,13 @@ class DateRangeFormatterGregorian internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createMdeWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateRangeFormatterGregorian> {
             
@@ -303,13 +303,13 @@ class DateRangeFormatterGregorian internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createYmde(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateRangeFormatterGregorian> {
             
@@ -327,13 +327,13 @@ class DateRangeFormatterGregorian internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createYmdeWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateRangeFormatterGregorian> {
             
@@ -351,13 +351,13 @@ class DateRangeFormatterGregorian internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createE(locale: Locale, length: DateTimeLength?): Result<DateRangeFormatterGregorian> {
             
@@ -375,13 +375,13 @@ class DateRangeFormatterGregorian internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createEWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?): Result<DateRangeFormatterGregorian> {
             
@@ -399,13 +399,13 @@ class DateRangeFormatterGregorian internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createM(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateRangeFormatterGregorian> {
             
@@ -423,13 +423,13 @@ class DateRangeFormatterGregorian internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createMWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateRangeFormatterGregorian> {
             
@@ -447,13 +447,13 @@ class DateRangeFormatterGregorian internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createYm(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateRangeFormatterGregorian> {
             
@@ -471,13 +471,13 @@ class DateRangeFormatterGregorian internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createYmWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateRangeFormatterGregorian> {
             
@@ -495,13 +495,13 @@ class DateRangeFormatterGregorian internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createY(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateRangeFormatterGregorian> {
             
@@ -519,13 +519,13 @@ class DateRangeFormatterGregorian internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createYWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateRangeFormatterGregorian> {
             
@@ -543,9 +543,9 @@ class DateRangeFormatterGregorian internal constructor (
     }
     
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.format) for more information.
+     *
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
      */
     fun formatIso(startIsoDate: IsoDate, endIsoDate: IsoDate): String {
         val write = DW.lib.diplomat_buffer_write_create(0)

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateRangeFormatterGregorian.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateRangeFormatterGregorian.kt
@@ -29,10 +29,11 @@ internal interface DateRangeFormatterGregorianLib: Library {
     fun icu4x_DateRangeFormatterGregorian_create_y_with_provider_mv1(provider: Pointer, locale: Pointer, length: OptionInt, alignment: OptionInt, yearStyle: OptionInt): ResultPointerInt
     fun icu4x_DateRangeFormatterGregorian_format_iso_mv1(handle: Pointer, startIsoDate: Pointer, endIsoDate: Pointer, write: Pointer): Unit
 }
-/** 🚧 This API is unstable and may experience breaking changes outside major releases.
-*
-*See the [Rust documentation for `FixedCalendarDateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html) for more information.
-*/
+/**
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
+ *
+ * See the [Rust documentation for `FixedCalendarDateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html) for more information.
+ */
 class DateRangeFormatterGregorian internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -61,14 +62,15 @@ class DateRangeFormatterGregorian internal constructor (
         internal val lib: DateRangeFormatterGregorianLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.for_length)
+         */
         fun createD(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateRangeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateRangeFormatterGregorian_create_d_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -84,14 +86,15 @@ class DateRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.for_length)
+         */
         fun createDWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateRangeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateRangeFormatterGregorian_create_d_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -107,14 +110,15 @@ class DateRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.for_length)
+         */
         fun createMd(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateRangeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateRangeFormatterGregorian_create_md_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -130,14 +134,15 @@ class DateRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.for_length)
+         */
         fun createMdWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateRangeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateRangeFormatterGregorian_create_md_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -153,14 +158,15 @@ class DateRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.for_length)
+         */
         fun createYmd(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateRangeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateRangeFormatterGregorian_create_ymd_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -176,14 +182,15 @@ class DateRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.for_length)
+         */
         fun createYmdWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateRangeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateRangeFormatterGregorian_create_ymd_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -199,14 +206,15 @@ class DateRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.for_length)
+         */
         fun createDe(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateRangeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateRangeFormatterGregorian_create_de_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -222,14 +230,15 @@ class DateRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.for_length)
+         */
         fun createDeWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateRangeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateRangeFormatterGregorian_create_de_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -245,14 +254,15 @@ class DateRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.for_length)
+         */
         fun createMde(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateRangeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateRangeFormatterGregorian_create_mde_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -268,14 +278,15 @@ class DateRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.for_length)
+         */
         fun createMdeWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateRangeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateRangeFormatterGregorian_create_mde_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -291,14 +302,15 @@ class DateRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.for_length)
+         */
         fun createYmde(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateRangeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateRangeFormatterGregorian_create_ymde_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -314,14 +326,15 @@ class DateRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.for_length)
+         */
         fun createYmdeWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateRangeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateRangeFormatterGregorian_create_ymde_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -337,14 +350,15 @@ class DateRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html#method.for_length)
+         */
         fun createE(locale: Locale, length: DateTimeLength?): Result<DateRangeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateRangeFormatterGregorian_create_e_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -360,14 +374,15 @@ class DateRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html#method.for_length)
+         */
         fun createEWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?): Result<DateRangeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateRangeFormatterGregorian_create_e_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -383,14 +398,15 @@ class DateRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.for_length)
+         */
         fun createM(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateRangeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateRangeFormatterGregorian_create_m_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -406,14 +422,15 @@ class DateRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.for_length)
+         */
         fun createMWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?): Result<DateRangeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateRangeFormatterGregorian_create_m_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -429,14 +446,15 @@ class DateRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.for_length)
+         */
         fun createYm(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateRangeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateRangeFormatterGregorian_create_ym_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -452,14 +470,15 @@ class DateRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.for_length)
+         */
         fun createYmWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateRangeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateRangeFormatterGregorian_create_ym_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -475,14 +494,15 @@ class DateRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.for_length)
+         */
         fun createY(locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateRangeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateRangeFormatterGregorian_create_y_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -498,14 +518,15 @@ class DateRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.for_length)
+         */
         fun createYWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateRangeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateRangeFormatterGregorian_create_y_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -521,10 +542,11 @@ class DateRangeFormatterGregorian internal constructor (
         }
     }
     
-    /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-    *
-    *See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.format) for more information.
-    */
+    /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
+     * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.format) for more information.
+     */
     fun formatIso(startIsoDate: IsoDate, endIsoDate: IsoDate): String {
         val write = DW.lib.diplomat_buffer_write_create(0)
         val returnVal = lib.icu4x_DateRangeFormatterGregorian_format_iso_mv1(handle, startIsoDate.handle, endIsoDate.handle, write);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateTime.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateTime.kt
@@ -63,10 +63,11 @@ internal class OptionDateTimeNative constructor(): Structure(), Structure.ByValu
 
 }
 
-/** An ICU4X `DateTime` object capable of containing a date and time for any calendar.
-*
-*See the [Rust documentation for `DateTime`](https://docs.rs/icu/2.3.1/icu/time/struct.DateTime.html) for more information.
-*/
+/**
+ * An ICU4X `DateTime` object capable of containing a date and time for any calendar.
+ *
+ * See the [Rust documentation for `DateTime`](https://docs.rs/icu/2.3.1/icu/time/struct.DateTime.html) for more information.
+ */
 class DateTime (var date: Date, var time: Time) {
     companion object {
 
@@ -83,10 +84,11 @@ class DateTime (var date: Date, var time: Time) {
 
         @JvmStatic
         
-        /** Creates a new [DateTime] from an IXDTF string.
-        *
-        *See the [Rust documentation for `try_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.DateTime.html#method.try_from_str) for more information.
-        */
+        /**
+         * Creates a new [DateTime] from an IXDTF string.
+         *
+         * See the [Rust documentation for `try_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.DateTime.html#method.try_from_str) for more information.
+         */
         fun fromString(v: String, calendar: Calendar): Result<DateTime> {
             val vSliceMemory = PrimitiveArrayTools.borrowUtf8(v)
             

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateTimeAlignment.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateTimeAlignment.kt
@@ -8,7 +8,8 @@ import com.sun.jna.Structure
 
 internal interface DateTimeAlignmentLib: Library {
 }
-/** See the [Rust documentation for `Alignment`](https://docs.rs/icu/2.3.1/icu/datetime/options/enum.Alignment.html) for more information.
+/**
+ * See the [Rust documentation for `Alignment`](https://docs.rs/icu/2.3.1/icu/datetime/options/enum.Alignment.html) for more information.
 */
 enum class DateTimeAlignment {
     Auto,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateTimeFormatter.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateTimeFormatter.kt
@@ -24,8 +24,9 @@ internal interface DateTimeFormatterLib: Library {
     fun icu4x_DateTimeFormatter_format_iso_mv1(handle: Pointer, isoDate: Pointer, time: Pointer, write: Pointer): Unit
     fun icu4x_DateTimeFormatter_format_same_calendar_mv1(handle: Pointer, date: Pointer, time: Pointer, write: Pointer): ResultUnitDateTimeMismatchedCalendarErrorNative
 }
-/** See the [Rust documentation for `DateTimeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `DateTimeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html) for more information.
+ */
 class DateTimeFormatter internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -54,12 +55,13 @@ class DateTimeFormatter internal constructor (
         internal val lib: DateTimeFormatterLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.for_length)
+         */
         fun createDt(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeFormatter> {
             
             val returnVal = lib.icu4x_DateTimeFormatter_create_dt_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -75,12 +77,13 @@ class DateTimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.for_length)
+         */
         fun createDtWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeFormatter> {
             
             val returnVal = lib.icu4x_DateTimeFormatter_create_dt_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -96,12 +99,13 @@ class DateTimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.for_length)
+         */
         fun createMdt(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeFormatter> {
             
             val returnVal = lib.icu4x_DateTimeFormatter_create_mdt_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -117,12 +121,13 @@ class DateTimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.for_length)
+         */
         fun createMdtWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeFormatter> {
             
             val returnVal = lib.icu4x_DateTimeFormatter_create_mdt_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -138,12 +143,13 @@ class DateTimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.for_length)
+         */
         fun createYmdt(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateTimeFormatter> {
             
             val returnVal = lib.icu4x_DateTimeFormatter_create_ymdt_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -159,12 +165,13 @@ class DateTimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.for_length)
+         */
         fun createYmdtWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateTimeFormatter> {
             
             val returnVal = lib.icu4x_DateTimeFormatter_create_ymdt_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -180,12 +187,13 @@ class DateTimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.for_length)
+         */
         fun createDet(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeFormatter> {
             
             val returnVal = lib.icu4x_DateTimeFormatter_create_det_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -201,12 +209,13 @@ class DateTimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.for_length)
+         */
         fun createDetWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeFormatter> {
             
             val returnVal = lib.icu4x_DateTimeFormatter_create_det_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -222,12 +231,13 @@ class DateTimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.for_length)
+         */
         fun createMdet(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeFormatter> {
             
             val returnVal = lib.icu4x_DateTimeFormatter_create_mdet_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -243,12 +253,13 @@ class DateTimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.for_length)
+         */
         fun createMdetWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeFormatter> {
             
             val returnVal = lib.icu4x_DateTimeFormatter_create_mdet_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -264,12 +275,13 @@ class DateTimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.for_length)
+         */
         fun createYmdet(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateTimeFormatter> {
             
             val returnVal = lib.icu4x_DateTimeFormatter_create_ymdet_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -285,12 +297,13 @@ class DateTimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.for_length)
+         */
         fun createYmdetWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateTimeFormatter> {
             
             val returnVal = lib.icu4x_DateTimeFormatter_create_ymdet_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -306,12 +319,13 @@ class DateTimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.for_length)
+         */
         fun createEt(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeFormatter> {
             
             val returnVal = lib.icu4x_DateTimeFormatter_create_et_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -327,12 +341,13 @@ class DateTimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.for_length)
+         */
         fun createEtWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeFormatter> {
             
             val returnVal = lib.icu4x_DateTimeFormatter_create_et_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -348,8 +363,9 @@ class DateTimeFormatter internal constructor (
         }
     }
     
-    /** See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.format) for more information.
-    */
+    /**
+     * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.format) for more information.
+     */
     fun formatIso(isoDate: IsoDate, time: Time): String {
         val write = DW.lib.diplomat_buffer_write_create(0)
         val returnVal = lib.icu4x_DateTimeFormatter_format_iso_mv1(handle, isoDate.handle, time.handle, write);
@@ -358,8 +374,9 @@ class DateTimeFormatter internal constructor (
         return returnString
     }
     
-    /** See the [Rust documentation for `format_same_calendar`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.format_same_calendar) for more information.
-    */
+    /**
+     * See the [Rust documentation for `format_same_calendar`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.format_same_calendar) for more information.
+     */
     fun formatSameCalendar(date: Date, time: Time): Result<String> {
         val write = DW.lib.diplomat_buffer_write_create(0)
         val returnVal = lib.icu4x_DateTimeFormatter_format_same_calendar_mv1(handle, date.handle, time.handle, write);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateTimeFormatterGregorian.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateTimeFormatterGregorian.kt
@@ -23,8 +23,9 @@ internal interface DateTimeFormatterGregorianLib: Library {
     fun icu4x_DateTimeFormatterGregorian_create_et_with_provider_mv1(provider: Pointer, locale: Pointer, length: OptionInt, timePrecision: OptionInt, alignment: OptionInt): ResultPointerInt
     fun icu4x_DateTimeFormatterGregorian_format_iso_mv1(handle: Pointer, isoDate: Pointer, time: Pointer, write: Pointer): Unit
 }
-/** See the [Rust documentation for `FixedCalendarDateTimeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `FixedCalendarDateTimeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html) for more information.
+ */
 class DateTimeFormatterGregorian internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -53,12 +54,13 @@ class DateTimeFormatterGregorian internal constructor (
         internal val lib: DateTimeFormatterGregorianLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.for_length)
+         */
         fun createDt(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateTimeFormatterGregorian_create_dt_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -74,12 +76,13 @@ class DateTimeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.for_length)
+         */
         fun createDtWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateTimeFormatterGregorian_create_dt_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -95,12 +98,13 @@ class DateTimeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.for_length)
+         */
         fun createMdt(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateTimeFormatterGregorian_create_mdt_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -116,12 +120,13 @@ class DateTimeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.for_length)
+         */
         fun createMdtWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateTimeFormatterGregorian_create_mdt_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -137,12 +142,13 @@ class DateTimeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.for_length)
+         */
         fun createYmdt(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateTimeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateTimeFormatterGregorian_create_ymdt_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -158,12 +164,13 @@ class DateTimeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.for_length)
+         */
         fun createYmdtWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateTimeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateTimeFormatterGregorian_create_ymdt_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -179,12 +186,13 @@ class DateTimeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.for_length)
+         */
         fun createDet(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateTimeFormatterGregorian_create_det_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -200,12 +208,13 @@ class DateTimeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.for_length)
+         */
         fun createDetWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateTimeFormatterGregorian_create_det_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -221,12 +230,13 @@ class DateTimeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.for_length)
+         */
         fun createMdet(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateTimeFormatterGregorian_create_mdet_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -242,12 +252,13 @@ class DateTimeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.for_length)
+         */
         fun createMdetWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateTimeFormatterGregorian_create_mdet_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -263,12 +274,13 @@ class DateTimeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.for_length)
+         */
         fun createYmdet(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateTimeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateTimeFormatterGregorian_create_ymdet_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -284,12 +296,13 @@ class DateTimeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.for_length)
+         */
         fun createYmdetWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateTimeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateTimeFormatterGregorian_create_ymdet_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -305,12 +318,13 @@ class DateTimeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.for_length)
+         */
         fun createEt(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateTimeFormatterGregorian_create_et_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -326,12 +340,13 @@ class DateTimeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.for_length)
+         */
         fun createEtWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateTimeFormatterGregorian_create_et_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -347,8 +362,9 @@ class DateTimeFormatterGregorian internal constructor (
         }
     }
     
-    /** See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.format) for more information.
-    */
+    /**
+     * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.format) for more information.
+     */
     fun formatIso(isoDate: IsoDate, time: Time): String {
         val write = DW.lib.diplomat_buffer_write_create(0)
         val returnVal = lib.icu4x_DateTimeFormatterGregorian_format_iso_mv1(handle, isoDate.handle, time.handle, write);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateTimeFormatterLoadError.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateTimeFormatterLoadError.kt
@@ -8,7 +8,8 @@ import com.sun.jna.Structure
 
 internal interface DateTimeFormatterLoadErrorLib: Library {
 }
-/** Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/enum.DateTimeFormatterLoadError.html), [2](https://docs.rs/icu/2.3.1/icu/datetime/pattern/enum.PatternLoadError.html), [3](https://docs.rs/icu_provider/2.3.0/icu_provider/struct.DataError.html), [4](https://docs.rs/icu_provider/2.3.0/icu_provider/enum.DataErrorKind.html)
+/**
+ * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/enum.DateTimeFormatterLoadError.html), [2](https://docs.rs/icu/2.3.1/icu/datetime/pattern/enum.PatternLoadError.html), [3](https://docs.rs/icu_provider/2.3.0/icu_provider/struct.DataError.html), [4](https://docs.rs/icu_provider/2.3.0/icu_provider/enum.DataErrorKind.html)
 */
 enum class DateTimeFormatterLoadError(val inner: Int) {
     Unknown(0),

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateTimeLength.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateTimeLength.kt
@@ -8,7 +8,8 @@ import com.sun.jna.Structure
 
 internal interface DateTimeLengthLib: Library {
 }
-/** See the [Rust documentation for `Length`](https://docs.rs/icu/2.3.1/icu/datetime/options/enum.Length.html) for more information.
+/**
+ * See the [Rust documentation for `Length`](https://docs.rs/icu/2.3.1/icu/datetime/options/enum.Length.html) for more information.
 */
 enum class DateTimeLength {
     Long,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateTimeMismatchedCalendarError.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateTimeMismatchedCalendarError.kt
@@ -62,8 +62,9 @@ internal class OptionDateTimeMismatchedCalendarErrorNative constructor(): Struct
 
 }
 
-/** See the [Rust documentation for `MismatchedCalendarError`](https://docs.rs/icu/2.3.1/icu/datetime/struct.MismatchedCalendarError.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `MismatchedCalendarError`](https://docs.rs/icu/2.3.1/icu/datetime/struct.MismatchedCalendarError.html) for more information.
+ */
 class DateTimeMismatchedCalendarError (var thisKind: CalendarKind, var dateKind: CalendarKind?): Exception("Rust error result for DateTimeMismatchedCalendarError") {
     companion object {
 

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateTimeRangeFormatter.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateTimeRangeFormatter.kt
@@ -24,10 +24,11 @@ internal interface DateTimeRangeFormatterLib: Library {
     fun icu4x_DateTimeRangeFormatter_format_iso_mv1(handle: Pointer, startIsoDate: Pointer, startTime: Pointer, endIsoDate: Pointer, endTime: Pointer, write: Pointer): Unit
     fun icu4x_DateTimeRangeFormatter_format_same_calendar_mv1(handle: Pointer, startDate: Pointer, startTime: Pointer, endDate: Pointer, endTime: Pointer, write: Pointer): Unit
 }
-/** 🚧 This API is unstable and may experience breaking changes outside major releases.
-*
-*See the [Rust documentation for `DateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html) for more information.
-*/
+/**
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
+ *
+ * See the [Rust documentation for `DateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html) for more information.
+ */
 class DateTimeRangeFormatter internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -56,14 +57,15 @@ class DateTimeRangeFormatter internal constructor (
         internal val lib: DateTimeRangeFormatterLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.for_length)
+         */
         fun createDt(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeRangeFormatter> {
             
             val returnVal = lib.icu4x_DateTimeRangeFormatter_create_dt_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -79,14 +81,15 @@ class DateTimeRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.for_length)
+         */
         fun createDtWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeRangeFormatter> {
             
             val returnVal = lib.icu4x_DateTimeRangeFormatter_create_dt_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -102,14 +105,15 @@ class DateTimeRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.for_length)
+         */
         fun createMdt(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeRangeFormatter> {
             
             val returnVal = lib.icu4x_DateTimeRangeFormatter_create_mdt_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -125,14 +129,15 @@ class DateTimeRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.for_length)
+         */
         fun createMdtWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeRangeFormatter> {
             
             val returnVal = lib.icu4x_DateTimeRangeFormatter_create_mdt_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -148,14 +153,15 @@ class DateTimeRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.for_length)
+         */
         fun createYmdt(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateTimeRangeFormatter> {
             
             val returnVal = lib.icu4x_DateTimeRangeFormatter_create_ymdt_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -171,14 +177,15 @@ class DateTimeRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.for_length)
+         */
         fun createYmdtWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateTimeRangeFormatter> {
             
             val returnVal = lib.icu4x_DateTimeRangeFormatter_create_ymdt_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -194,14 +201,15 @@ class DateTimeRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.for_length)
+         */
         fun createDet(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeRangeFormatter> {
             
             val returnVal = lib.icu4x_DateTimeRangeFormatter_create_det_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -217,14 +225,15 @@ class DateTimeRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.for_length)
+         */
         fun createDetWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeRangeFormatter> {
             
             val returnVal = lib.icu4x_DateTimeRangeFormatter_create_det_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -240,14 +249,15 @@ class DateTimeRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.for_length)
+         */
         fun createMdet(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeRangeFormatter> {
             
             val returnVal = lib.icu4x_DateTimeRangeFormatter_create_mdet_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -263,14 +273,15 @@ class DateTimeRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.for_length)
+         */
         fun createMdetWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeRangeFormatter> {
             
             val returnVal = lib.icu4x_DateTimeRangeFormatter_create_mdet_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -286,14 +297,15 @@ class DateTimeRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.for_length)
+         */
         fun createYmdet(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateTimeRangeFormatter> {
             
             val returnVal = lib.icu4x_DateTimeRangeFormatter_create_ymdet_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -309,14 +321,15 @@ class DateTimeRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.for_length)
+         */
         fun createYmdetWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateTimeRangeFormatter> {
             
             val returnVal = lib.icu4x_DateTimeRangeFormatter_create_ymdet_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -332,14 +345,15 @@ class DateTimeRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.for_length)
+         */
         fun createEt(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeRangeFormatter> {
             
             val returnVal = lib.icu4x_DateTimeRangeFormatter_create_et_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -355,14 +369,15 @@ class DateTimeRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.for_length)
+         */
         fun createEtWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeRangeFormatter> {
             
             val returnVal = lib.icu4x_DateTimeRangeFormatter_create_et_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -378,10 +393,11 @@ class DateTimeRangeFormatter internal constructor (
         }
     }
     
-    /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-    *
-    *See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
-    */
+    /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
+     * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
+     */
     fun formatIso(startIsoDate: IsoDate, startTime: Time, endIsoDate: IsoDate, endTime: Time): String {
         val write = DW.lib.diplomat_buffer_write_create(0)
         val returnVal = lib.icu4x_DateTimeRangeFormatter_format_iso_mv1(handle, startIsoDate.handle, startTime.handle, endIsoDate.handle, endTime.handle, write);
@@ -390,10 +406,11 @@ class DateTimeRangeFormatter internal constructor (
         return returnString
     }
     
-    /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-    *
-    *See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
-    */
+    /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
+     * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
+     */
     fun formatSameCalendar(startDate: Date, startTime: Time, endDate: Date, endTime: Time): String {
         val write = DW.lib.diplomat_buffer_write_create(0)
         val returnVal = lib.icu4x_DateTimeRangeFormatter_format_same_calendar_mv1(handle, startDate.handle, startTime.handle, endDate.handle, endTime.handle, write);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateTimeRangeFormatter.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateTimeRangeFormatter.kt
@@ -25,9 +25,9 @@ internal interface DateTimeRangeFormatterLib: Library {
     fun icu4x_DateTimeRangeFormatter_format_same_calendar_mv1(handle: Pointer, startDate: Pointer, startTime: Pointer, endDate: Pointer, endTime: Pointer, write: Pointer): Unit
 }
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `DateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html) for more information.
+ *
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
  */
 class DateTimeRangeFormatter internal constructor (
     internal val handle: Pointer,
@@ -58,13 +58,13 @@ class DateTimeRangeFormatter internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createDt(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeRangeFormatter> {
             
@@ -82,13 +82,13 @@ class DateTimeRangeFormatter internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createDtWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeRangeFormatter> {
             
@@ -106,13 +106,13 @@ class DateTimeRangeFormatter internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createMdt(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeRangeFormatter> {
             
@@ -130,13 +130,13 @@ class DateTimeRangeFormatter internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createMdtWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeRangeFormatter> {
             
@@ -154,13 +154,13 @@ class DateTimeRangeFormatter internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createYmdt(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateTimeRangeFormatter> {
             
@@ -178,13 +178,13 @@ class DateTimeRangeFormatter internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createYmdtWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateTimeRangeFormatter> {
             
@@ -202,13 +202,13 @@ class DateTimeRangeFormatter internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createDet(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeRangeFormatter> {
             
@@ -226,13 +226,13 @@ class DateTimeRangeFormatter internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createDetWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeRangeFormatter> {
             
@@ -250,13 +250,13 @@ class DateTimeRangeFormatter internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createMdet(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeRangeFormatter> {
             
@@ -274,13 +274,13 @@ class DateTimeRangeFormatter internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createMdetWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeRangeFormatter> {
             
@@ -298,13 +298,13 @@ class DateTimeRangeFormatter internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createYmdet(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateTimeRangeFormatter> {
             
@@ -322,13 +322,13 @@ class DateTimeRangeFormatter internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createYmdetWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateTimeRangeFormatter> {
             
@@ -346,13 +346,13 @@ class DateTimeRangeFormatter internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createEt(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeRangeFormatter> {
             
@@ -370,13 +370,13 @@ class DateTimeRangeFormatter internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createEtWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeRangeFormatter> {
             
@@ -394,9 +394,9 @@ class DateTimeRangeFormatter internal constructor (
     }
     
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
+     *
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
      */
     fun formatIso(startIsoDate: IsoDate, startTime: Time, endIsoDate: IsoDate, endTime: Time): String {
         val write = DW.lib.diplomat_buffer_write_create(0)
@@ -407,9 +407,9 @@ class DateTimeRangeFormatter internal constructor (
     }
     
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
+     *
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
      */
     fun formatSameCalendar(startDate: Date, startTime: Time, endDate: Date, endTime: Time): String {
         val write = DW.lib.diplomat_buffer_write_create(0)

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateTimeRangeFormatterGregorian.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateTimeRangeFormatterGregorian.kt
@@ -23,10 +23,11 @@ internal interface DateTimeRangeFormatterGregorianLib: Library {
     fun icu4x_DateTimeRangeFormatterGregorian_create_et_with_provider_mv1(provider: Pointer, locale: Pointer, length: OptionInt, timePrecision: OptionInt, alignment: OptionInt): ResultPointerInt
     fun icu4x_DateTimeRangeFormatterGregorian_format_iso_mv1(handle: Pointer, startIsoDate: Pointer, startTime: Pointer, endIsoDate: Pointer, endTime: Pointer, write: Pointer): Unit
 }
-/** 🚧 This API is unstable and may experience breaking changes outside major releases.
-*
-*See the [Rust documentation for `FixedCalendarDateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html) for more information.
-*/
+/**
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
+ *
+ * See the [Rust documentation for `FixedCalendarDateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html) for more information.
+ */
 class DateTimeRangeFormatterGregorian internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -55,14 +56,15 @@ class DateTimeRangeFormatterGregorian internal constructor (
         internal val lib: DateTimeRangeFormatterGregorianLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.for_length)
+         */
         fun createDt(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeRangeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateTimeRangeFormatterGregorian_create_dt_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -78,14 +80,15 @@ class DateTimeRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.for_length)
+         */
         fun createDtWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeRangeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateTimeRangeFormatterGregorian_create_dt_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -101,14 +104,15 @@ class DateTimeRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.for_length)
+         */
         fun createMdt(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeRangeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateTimeRangeFormatterGregorian_create_mdt_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -124,14 +128,15 @@ class DateTimeRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.for_length)
+         */
         fun createMdtWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeRangeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateTimeRangeFormatterGregorian_create_mdt_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -147,14 +152,15 @@ class DateTimeRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.for_length)
+         */
         fun createYmdt(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateTimeRangeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateTimeRangeFormatterGregorian_create_ymdt_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -170,14 +176,15 @@ class DateTimeRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.for_length)
+         */
         fun createYmdtWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateTimeRangeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateTimeRangeFormatterGregorian_create_ymdt_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -193,14 +200,15 @@ class DateTimeRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.for_length)
+         */
         fun createDet(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeRangeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateTimeRangeFormatterGregorian_create_det_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -216,14 +224,15 @@ class DateTimeRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.for_length)
+         */
         fun createDetWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeRangeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateTimeRangeFormatterGregorian_create_det_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -239,14 +248,15 @@ class DateTimeRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.for_length)
+         */
         fun createMdet(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeRangeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateTimeRangeFormatterGregorian_create_mdet_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -262,14 +272,15 @@ class DateTimeRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.for_length)
+         */
         fun createMdetWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeRangeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateTimeRangeFormatterGregorian_create_mdet_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -285,14 +296,15 @@ class DateTimeRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.for_length)
+         */
         fun createYmdet(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateTimeRangeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateTimeRangeFormatterGregorian_create_ymdet_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -308,14 +320,15 @@ class DateTimeRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.for_length)
+         */
         fun createYmdetWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateTimeRangeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateTimeRangeFormatterGregorian_create_ymdet_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), yearStyle?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -331,14 +344,15 @@ class DateTimeRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.for_length)
+         */
         fun createEt(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeRangeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateTimeRangeFormatterGregorian_create_et_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -354,14 +368,15 @@ class DateTimeRangeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.for_length)
+         */
         fun createEtWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeRangeFormatterGregorian> {
             
             val returnVal = lib.icu4x_DateTimeRangeFormatterGregorian_create_et_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -377,10 +392,11 @@ class DateTimeRangeFormatterGregorian internal constructor (
         }
     }
     
-    /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-    *
-    *See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.format) for more information.
-    */
+    /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
+     * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.format) for more information.
+     */
     fun formatIso(startIsoDate: IsoDate, startTime: Time, endIsoDate: IsoDate, endTime: Time): String {
         val write = DW.lib.diplomat_buffer_write_create(0)
         val returnVal = lib.icu4x_DateTimeRangeFormatterGregorian_format_iso_mv1(handle, startIsoDate.handle, startTime.handle, endIsoDate.handle, endTime.handle, write);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateTimeRangeFormatterGregorian.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateTimeRangeFormatterGregorian.kt
@@ -24,9 +24,9 @@ internal interface DateTimeRangeFormatterGregorianLib: Library {
     fun icu4x_DateTimeRangeFormatterGregorian_format_iso_mv1(handle: Pointer, startIsoDate: Pointer, startTime: Pointer, endIsoDate: Pointer, endTime: Pointer, write: Pointer): Unit
 }
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `FixedCalendarDateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html) for more information.
+ *
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
  */
 class DateTimeRangeFormatterGregorian internal constructor (
     internal val handle: Pointer,
@@ -57,13 +57,13 @@ class DateTimeRangeFormatterGregorian internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createDt(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeRangeFormatterGregorian> {
             
@@ -81,13 +81,13 @@ class DateTimeRangeFormatterGregorian internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createDtWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeRangeFormatterGregorian> {
             
@@ -105,13 +105,13 @@ class DateTimeRangeFormatterGregorian internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createMdt(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeRangeFormatterGregorian> {
             
@@ -129,13 +129,13 @@ class DateTimeRangeFormatterGregorian internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createMdtWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeRangeFormatterGregorian> {
             
@@ -153,13 +153,13 @@ class DateTimeRangeFormatterGregorian internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createYmdt(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateTimeRangeFormatterGregorian> {
             
@@ -177,13 +177,13 @@ class DateTimeRangeFormatterGregorian internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createYmdtWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateTimeRangeFormatterGregorian> {
             
@@ -201,13 +201,13 @@ class DateTimeRangeFormatterGregorian internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createDet(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeRangeFormatterGregorian> {
             
@@ -225,13 +225,13 @@ class DateTimeRangeFormatterGregorian internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createDetWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeRangeFormatterGregorian> {
             
@@ -249,13 +249,13 @@ class DateTimeRangeFormatterGregorian internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createMdet(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeRangeFormatterGregorian> {
             
@@ -273,13 +273,13 @@ class DateTimeRangeFormatterGregorian internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createMdetWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeRangeFormatterGregorian> {
             
@@ -297,13 +297,13 @@ class DateTimeRangeFormatterGregorian internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createYmdet(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateTimeRangeFormatterGregorian> {
             
@@ -321,13 +321,13 @@ class DateTimeRangeFormatterGregorian internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createYmdetWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?, yearStyle: YearStyle?): Result<DateTimeRangeFormatterGregorian> {
             
@@ -345,13 +345,13 @@ class DateTimeRangeFormatterGregorian internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createEt(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeRangeFormatterGregorian> {
             
@@ -369,13 +369,13 @@ class DateTimeRangeFormatterGregorian internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createEtWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<DateTimeRangeFormatterGregorian> {
             
@@ -393,9 +393,9 @@ class DateTimeRangeFormatterGregorian internal constructor (
     }
     
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.format) for more information.
+     *
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
      */
     fun formatIso(startIsoDate: IsoDate, startTime: Time, endIsoDate: IsoDate, endTime: Time): String {
         val write = DW.lib.diplomat_buffer_write_create(0)

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateTimeWriteError.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DateTimeWriteError.kt
@@ -8,11 +8,12 @@ import com.sun.jna.Structure
 
 internal interface DateTimeWriteErrorLib: Library {
 }
-/** An error when formatting a datetime.
-*
-*Currently never returned by any API.
-*
-*Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/unchecked/enum.FormattedDateTimeUncheckedError.html)
+/**
+ * An error when formatting a datetime.
+ *
+ * Currently never returned by any API.
+ *
+ * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/unchecked/enum.FormattedDateTimeUncheckedError.html)
 */
 enum class DateTimeWriteError {
     Unknown,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/Decimal.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/Decimal.kt
@@ -42,8 +42,9 @@ internal interface DecimalLib: Library {
     fun icu4x_Decimal_concatenate_end_mv1(handle: Pointer, other: Pointer): ResultUnitUnit
     fun icu4x_Decimal_to_string_mv1(handle: Pointer, write: Pointer): Unit
 }
-/** See the [Rust documentation for `Decimal`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `Decimal`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html) for more information.
+ */
 class Decimal internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -72,10 +73,11 @@ class Decimal internal constructor (
         internal val lib: DecimalLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Construct an [Decimal] from an integer.
-        *
-        *See the [Rust documentation for `Decimal`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html) for more information.
-        */
+        /**
+         * Construct an [Decimal] from an integer.
+         *
+         * See the [Rust documentation for `Decimal`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html) for more information.
+         */
         fun from(v: Int): Decimal {
             
             val returnVal = lib.icu4x_Decimal_from_int32_mv1(v);
@@ -86,10 +88,11 @@ class Decimal internal constructor (
         }
         @JvmStatic
         
-        /** Construct an [Decimal] from an integer.
-        *
-        *See the [Rust documentation for `Decimal`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html) for more information.
-        */
+        /**
+         * Construct an [Decimal] from an integer.
+         *
+         * See the [Rust documentation for `Decimal`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html) for more information.
+         */
         fun from(v: UInt): Decimal {
             
             val returnVal = lib.icu4x_Decimal_from_uint32_mv1(FFIUint32(v));
@@ -100,10 +103,11 @@ class Decimal internal constructor (
         }
         @JvmStatic
         
-        /** Construct an [Decimal] from an integer.
-        *
-        *See the [Rust documentation for `Decimal`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html) for more information.
-        */
+        /**
+         * Construct an [Decimal] from an integer.
+         *
+         * See the [Rust documentation for `Decimal`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html) for more information.
+         */
         fun from(v: Long): Decimal {
             
             val returnVal = lib.icu4x_Decimal_from_int64_mv1(v);
@@ -114,10 +118,11 @@ class Decimal internal constructor (
         }
         @JvmStatic
         
-        /** Construct an [Decimal] from an integer.
-        *
-        *See the [Rust documentation for `Decimal`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html) for more information.
-        */
+        /**
+         * Construct an [Decimal] from an integer.
+         *
+         * See the [Rust documentation for `Decimal`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html) for more information.
+         */
         fun from(v: ULong): Decimal {
             
             val returnVal = lib.icu4x_Decimal_from_uint64_mv1(FFIUint64(v));
@@ -128,12 +133,13 @@ class Decimal internal constructor (
         }
         @JvmStatic
         
-        /** Construct an [Decimal] from an integer-valued float
-        *
-        *See the [Rust documentation for `try_from_f64`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.try_from_f64) for more information.
-        *
-        *See the [Rust documentation for `FloatPrecision`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/enum.FloatPrecision.html) for more information.
-        */
+        /**
+         * Construct an [Decimal] from an integer-valued float
+         *
+         * See the [Rust documentation for `try_from_f64`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.try_from_f64) for more information.
+         *
+         * See the [Rust documentation for `FloatPrecision`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/enum.FloatPrecision.html) for more information.
+         */
         fun fromDoubleWithIntegerPrecision(f: Double): Result<Decimal> {
             
             val returnVal = lib.icu4x_Decimal_from_double_with_integer_precision_mv1(f);
@@ -149,12 +155,13 @@ class Decimal internal constructor (
         }
         @JvmStatic
         
-        /** Construct an [Decimal] from an float, with a given power of 10 for the lower magnitude
-        *
-        *See the [Rust documentation for `try_from_f64`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.try_from_f64) for more information.
-        *
-        *See the [Rust documentation for `FloatPrecision`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/enum.FloatPrecision.html) for more information.
-        */
+        /**
+         * Construct an [Decimal] from an float, with a given power of 10 for the lower magnitude
+         *
+         * See the [Rust documentation for `try_from_f64`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.try_from_f64) for more information.
+         *
+         * See the [Rust documentation for `FloatPrecision`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/enum.FloatPrecision.html) for more information.
+         */
         fun fromDoubleWithLowerMagnitude(f: Double, magnitude: Short): Result<Decimal> {
             
             val returnVal = lib.icu4x_Decimal_from_double_with_lower_magnitude_mv1(f, magnitude);
@@ -170,12 +177,13 @@ class Decimal internal constructor (
         }
         @JvmStatic
         
-        /** Construct an [Decimal] from an float, for a given number of significant digits
-        *
-        *See the [Rust documentation for `try_from_f64`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.try_from_f64) for more information.
-        *
-        *See the [Rust documentation for `FloatPrecision`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/enum.FloatPrecision.html) for more information.
-        */
+        /**
+         * Construct an [Decimal] from an float, for a given number of significant digits
+         *
+         * See the [Rust documentation for `try_from_f64`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.try_from_f64) for more information.
+         *
+         * See the [Rust documentation for `FloatPrecision`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/enum.FloatPrecision.html) for more information.
+         */
         fun fromDoubleWithSignificantDigits(f: Double, digits: UByte): Result<Decimal> {
             
             val returnVal = lib.icu4x_Decimal_from_double_with_significant_digits_mv1(f, FFIUint8(digits));
@@ -191,13 +199,14 @@ class Decimal internal constructor (
         }
         @JvmStatic
         
-        /** Construct an [Decimal] from an float, with enough digits to recover
-        *the original floating point in IEEE 754 without needing trailing zeros
-        *
-        *See the [Rust documentation for `try_from_f64`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.try_from_f64) for more information.
-        *
-        *See the [Rust documentation for `FloatPrecision`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/enum.FloatPrecision.html) for more information.
-        */
+        /**
+         * Construct an [Decimal] from an float, with enough digits to recover
+         * the original floating point in IEEE 754 without needing trailing zeros
+         *
+         * See the [Rust documentation for `try_from_f64`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.try_from_f64) for more information.
+         *
+         * See the [Rust documentation for `FloatPrecision`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/enum.FloatPrecision.html) for more information.
+         */
         fun fromDoubleWithRoundTripPrecision(f: Double): Result<Decimal> {
             
             val returnVal = lib.icu4x_Decimal_from_double_with_round_trip_precision_mv1(f);
@@ -213,10 +222,11 @@ class Decimal internal constructor (
         }
         @JvmStatic
         
-        /** Construct an [Decimal] from a string.
-        *
-        *See the [Rust documentation for `try_from_str`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.try_from_str) for more information.
-        */
+        /**
+         * Construct an [Decimal] from a string.
+         *
+         * See the [Rust documentation for `try_from_str`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.try_from_str) for more information.
+         */
         fun fromString(v: String): Result<Decimal> {
             val vSliceMemory = PrimitiveArrayTools.borrowUtf8(v)
             
@@ -237,214 +247,238 @@ class Decimal internal constructor (
         }
     }
     
-    /** See the [Rust documentation for `digit_at`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.digit_at) for more information.
-    */
+    /**
+     * See the [Rust documentation for `digit_at`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.digit_at) for more information.
+     */
     fun digitAt(magnitude: Short): UByte {
         
         val returnVal = lib.icu4x_Decimal_digit_at_mv1(handle, magnitude);
         return (returnVal.toUByte())
     }
     
-    /** See the [Rust documentation for `magnitude_range`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.magnitude_range) for more information.
-    */
+    /**
+     * See the [Rust documentation for `magnitude_range`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.magnitude_range) for more information.
+     */
     fun magnitudeStart(): Short {
         
         val returnVal = lib.icu4x_Decimal_magnitude_start_mv1(handle);
         return (returnVal)
     }
     
-    /** See the [Rust documentation for `magnitude_range`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.magnitude_range) for more information.
-    */
+    /**
+     * See the [Rust documentation for `magnitude_range`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.magnitude_range) for more information.
+     */
     fun magnitudeEnd(): Short {
         
         val returnVal = lib.icu4x_Decimal_magnitude_end_mv1(handle);
         return (returnVal)
     }
     
-    /** See the [Rust documentation for `nonzero_magnitude_start`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.nonzero_magnitude_start) for more information.
-    */
+    /**
+     * See the [Rust documentation for `nonzero_magnitude_start`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.nonzero_magnitude_start) for more information.
+     */
     fun nonzeroMagnitudeStart(): Short {
         
         val returnVal = lib.icu4x_Decimal_nonzero_magnitude_start_mv1(handle);
         return (returnVal)
     }
     
-    /** See the [Rust documentation for `nonzero_magnitude_end`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.nonzero_magnitude_end) for more information.
-    */
+    /**
+     * See the [Rust documentation for `nonzero_magnitude_end`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.nonzero_magnitude_end) for more information.
+     */
     fun nonzeroMagnitudeEnd(): Short {
         
         val returnVal = lib.icu4x_Decimal_nonzero_magnitude_end_mv1(handle);
         return (returnVal)
     }
     
-    /** See the [Rust documentation for `is_zero`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.is_zero) for more information.
-    */
+    /**
+     * See the [Rust documentation for `is_zero`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.is_zero) for more information.
+     */
     fun isZero(): Boolean {
         
         val returnVal = lib.icu4x_Decimal_is_zero_mv1(handle);
         return (returnVal > 0)
     }
     
-    /** Multiply the [Decimal] by a given power of ten.
-    *
-    *See the [Rust documentation for `multiply_pow10`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.multiply_pow10) for more information.
-    */
+    /**
+     * Multiply the [Decimal] by a given power of ten.
+     *
+     * See the [Rust documentation for `multiply_pow10`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.multiply_pow10) for more information.
+     */
     fun multiplyPow10(power: Short): Unit {
         
         val returnVal = lib.icu4x_Decimal_multiply_pow10_mv1(handle, power);
         
     }
     
-    /** See the [Rust documentation for `sign`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.sign) for more information.
-    */
+    /**
+     * See the [Rust documentation for `sign`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.sign) for more information.
+     */
     fun sign(): DecimalSign {
         
         val returnVal = lib.icu4x_Decimal_sign_mv1(handle);
         return (DecimalSign.fromNative(returnVal))
     }
     
-    /** Set the sign of the [Decimal].
-    *
-    *See the [Rust documentation for `set_sign`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.set_sign) for more information.
-    */
+    /**
+     * Set the sign of the [Decimal].
+     *
+     * See the [Rust documentation for `set_sign`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.set_sign) for more information.
+     */
     fun setSign(sign: DecimalSign): Unit {
         
         val returnVal = lib.icu4x_Decimal_set_sign_mv1(handle, sign.toNative());
         
     }
     
-    /** See the [Rust documentation for `apply_sign_display`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.apply_sign_display) for more information.
-    */
+    /**
+     * See the [Rust documentation for `apply_sign_display`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.apply_sign_display) for more information.
+     */
     fun applySignDisplay(signDisplay: DecimalSignDisplay): Unit {
         
         val returnVal = lib.icu4x_Decimal_apply_sign_display_mv1(handle, signDisplay.toNative());
         
     }
     
-    /** See the [Rust documentation for `trim_start`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.trim_start) for more information.
-    */
+    /**
+     * See the [Rust documentation for `trim_start`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.trim_start) for more information.
+     */
     fun trimStart(): Unit {
         
         val returnVal = lib.icu4x_Decimal_trim_start_mv1(handle);
         
     }
     
-    /** See the [Rust documentation for `trim_end`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.trim_end) for more information.
-    */
+    /**
+     * See the [Rust documentation for `trim_end`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.trim_end) for more information.
+     */
     fun trimEnd(): Unit {
         
         val returnVal = lib.icu4x_Decimal_trim_end_mv1(handle);
         
     }
     
-    /** See the [Rust documentation for `trim_end_if_integer`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.trim_end_if_integer) for more information.
-    */
+    /**
+     * See the [Rust documentation for `trim_end_if_integer`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.trim_end_if_integer) for more information.
+     */
     fun trimEndIfInteger(): Unit {
         
         val returnVal = lib.icu4x_Decimal_trim_end_if_integer_mv1(handle);
         
     }
     
-    /** Zero-pad the [Decimal] on the left to a particular position
-    *
-    *See the [Rust documentation for `pad_start`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.pad_start) for more information.
-    */
+    /**
+     * Zero-pad the [Decimal] on the left to a particular position
+     *
+     * See the [Rust documentation for `pad_start`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.pad_start) for more information.
+     */
     fun padStart(position: Short): Unit {
         
         val returnVal = lib.icu4x_Decimal_pad_start_mv1(handle, position);
         
     }
     
-    /** Zero-pad the [Decimal] on the right to a particular position
-    *
-    *See the [Rust documentation for `pad_end`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.pad_end) for more information.
-    */
+    /**
+     * Zero-pad the [Decimal] on the right to a particular position
+     *
+     * See the [Rust documentation for `pad_end`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.pad_end) for more information.
+     */
     fun padEnd(position: Short): Unit {
         
         val returnVal = lib.icu4x_Decimal_pad_end_mv1(handle, position);
         
     }
     
-    /** Truncate the [Decimal] on the left to a particular position, deleting digits if necessary. This is useful for, e.g. abbreviating years
-    *("2022" -> "22")
-    *
-    *See the [Rust documentation for `set_max_position`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.set_max_position) for more information.
-    */
+    /**
+     * Truncate the [Decimal] on the left to a particular position, deleting digits if necessary. This is useful for, e.g. abbreviating years
+     * ("2022" -> "22")
+     *
+     * See the [Rust documentation for `set_max_position`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.set_max_position) for more information.
+     */
     fun setMaxPosition(position: Short): Unit {
         
         val returnVal = lib.icu4x_Decimal_set_max_position_mv1(handle, position);
         
     }
     
-    /** Round the number at a particular digit position.
-    *
-    *This uses half to even rounding, which resolves ties by selecting the nearest
-    *even integer to the original value.
-    *
-    *See the [Rust documentation for `round`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.round) for more information.
-    */
+    /**
+     * Round the number at a particular digit position.
+     *
+     * This uses half to even rounding, which resolves ties by selecting the nearest
+     * even integer to the original value.
+     *
+     * See the [Rust documentation for `round`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.round) for more information.
+     */
     fun round(position: Short): Unit {
         
         val returnVal = lib.icu4x_Decimal_round_mv1(handle, position);
         
     }
     
-    /** See the [Rust documentation for `ceil`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.ceil) for more information.
-    */
+    /**
+     * See the [Rust documentation for `ceil`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.ceil) for more information.
+     */
     fun ceil(position: Short): Unit {
         
         val returnVal = lib.icu4x_Decimal_ceil_mv1(handle, position);
         
     }
     
-    /** See the [Rust documentation for `expand`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.expand) for more information.
-    */
+    /**
+     * See the [Rust documentation for `expand`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.expand) for more information.
+     */
     fun expand(position: Short): Unit {
         
         val returnVal = lib.icu4x_Decimal_expand_mv1(handle, position);
         
     }
     
-    /** See the [Rust documentation for `floor`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.floor) for more information.
-    */
+    /**
+     * See the [Rust documentation for `floor`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.floor) for more information.
+     */
     fun floor(position: Short): Unit {
         
         val returnVal = lib.icu4x_Decimal_floor_mv1(handle, position);
         
     }
     
-    /** See the [Rust documentation for `trunc`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.trunc) for more information.
-    */
+    /**
+     * See the [Rust documentation for `trunc`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.trunc) for more information.
+     */
     fun trunc(position: Short): Unit {
         
         val returnVal = lib.icu4x_Decimal_trunc_mv1(handle, position);
         
     }
     
-    /** See the [Rust documentation for `round_with_mode`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.round_with_mode) for more information.
-    */
+    /**
+     * See the [Rust documentation for `round_with_mode`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.round_with_mode) for more information.
+     */
     fun roundWithMode(position: Short, mode: DecimalSignedRoundingMode): Unit {
         
         val returnVal = lib.icu4x_Decimal_round_with_mode_mv1(handle, position, mode.toNative());
         
     }
     
-    /** See the [Rust documentation for `round_with_mode_and_increment`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.round_with_mode_and_increment) for more information.
-    */
+    /**
+     * See the [Rust documentation for `round_with_mode_and_increment`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.round_with_mode_and_increment) for more information.
+     */
     fun roundWithModeAndIncrement(position: Short, mode: DecimalSignedRoundingMode, increment: DecimalRoundingIncrement): Unit {
         
         val returnVal = lib.icu4x_Decimal_round_with_mode_and_increment_mv1(handle, position, mode.toNative(), increment.toNative());
         
     }
     
-    /** Concatenates `other` to the end of `self`.
-    *
-    *If successful, `other` will be set to 0 and a successful status is returned.
-    *
-    *If not successful, `other` will be unchanged and an error is returned.
-    *
-    *See the [Rust documentation for `concatenate_end`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.concatenate_end) for more information.
-    */
+    /**
+     * Concatenates `other` to the end of `self`.
+     *
+     * If successful, `other` will be set to 0 and a successful status is returned.
+     *
+     * If not successful, `other` will be unchanged and an error is returned.
+     *
+     * See the [Rust documentation for `concatenate_end`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.concatenate_end) for more information.
+     */
     fun concatenateEnd(other: Decimal): Result<Unit> {
         
         val returnVal = lib.icu4x_Decimal_concatenate_end_mv1(handle, other.handle /* note this is a mutable reference. Think carefully about using, especially concurrently */);
@@ -456,10 +490,11 @@ class Decimal internal constructor (
         }
     }
     
-    /** Format the [Decimal] as a string.
-    *
-    *See the [Rust documentation for `write_to`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.write_to) for more information.
-    */
+    /**
+     * Format the [Decimal] as a string.
+     *
+     * See the [Rust documentation for `write_to`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/type.Decimal.html#method.write_to) for more information.
+     */
     override fun toString(): String {
         val write = DW.lib.diplomat_buffer_write_create(0)
         val returnVal = lib.icu4x_Decimal_to_string_mv1(handle, write);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DecimalFormatter.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DecimalFormatter.kt
@@ -12,10 +12,11 @@ internal interface DecimalFormatterLib: Library {
     fun icu4x_DecimalFormatter_create_with_manual_data_mv1(plusSignPrefix: Slice, plusSignSuffix: Slice, minusSignPrefix: Slice, minusSignSuffix: Slice, decimalSeparator: Slice, groupingSeparator: Slice, primaryGroupSize: FFIUint8, secondaryGroupSize: FFIUint8, minGroupSize: FFIUint8, digits: Slice, groupingStrategy: OptionInt): ResultPointerInt
     fun icu4x_DecimalFormatter_format_mv1(handle: Pointer, value: Pointer, write: Pointer): Unit
 }
-/** An ICU4X Decimal Format object, capable of formatting a [Decimal] as a string.
-*
-*See the [Rust documentation for `DecimalFormatter`](https://docs.rs/icu/2.3.1/icu/decimal/struct.DecimalFormatter.html) for more information.
-*/
+/**
+ * An ICU4X Decimal Format object, capable of formatting a [Decimal] as a string.
+ *
+ * See the [Rust documentation for `DecimalFormatter`](https://docs.rs/icu/2.3.1/icu/decimal/struct.DecimalFormatter.html) for more information.
+ */
 class DecimalFormatter internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -44,10 +45,11 @@ class DecimalFormatter internal constructor (
         internal val lib: DecimalFormatterLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Creates a new [DecimalFormatter], using compiled data
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/decimal/struct.DecimalFormatter.html#method.try_new) for more information.
-        */
+        /**
+         * Creates a new [DecimalFormatter], using compiled data
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/decimal/struct.DecimalFormatter.html#method.try_new) for more information.
+         */
         fun createWithGroupingStrategy(locale: Locale, groupingStrategy: DecimalGroupingStrategy?): Result<DecimalFormatter> {
             
             val returnVal = lib.icu4x_DecimalFormatter_create_with_grouping_strategy_mv1(locale.handle, groupingStrategy?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -63,10 +65,11 @@ class DecimalFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a new [DecimalFormatter], using a particular data source.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/decimal/struct.DecimalFormatter.html#method.try_new) for more information.
-        */
+        /**
+         * Creates a new [DecimalFormatter], using a particular data source.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/decimal/struct.DecimalFormatter.html#method.try_new) for more information.
+         */
         fun createWithGroupingStrategyAndProvider(provider: DataProvider, locale: Locale, groupingStrategy: DecimalGroupingStrategy?): Result<DecimalFormatter> {
             
             val returnVal = lib.icu4x_DecimalFormatter_create_with_grouping_strategy_and_provider_mv1(provider.handle, locale.handle, groupingStrategy?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -82,10 +85,11 @@ class DecimalFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a new [DecimalFormatter] from preconstructed locale data.
-        *
-        *See the [Rust documentation for `DecimalSymbolsV1`](https://docs.rs/icu/2.3.1/icu/decimal/provider/struct.DecimalSymbolsV1.html) for more information.
-        */
+        /**
+         * Creates a new [DecimalFormatter] from preconstructed locale data.
+         *
+         * See the [Rust documentation for `DecimalSymbolsV1`](https://docs.rs/icu/2.3.1/icu/decimal/provider/struct.DecimalSymbolsV1.html) for more information.
+         */
         fun createWithManualData(plusSignPrefix: String, plusSignSuffix: String, minusSignPrefix: String, minusSignSuffix: String, decimalSeparator: String, groupingSeparator: String, primaryGroupSize: UByte, secondaryGroupSize: UByte, minGroupSize: UByte, digits: IntArray, groupingStrategy: DecimalGroupingStrategy?): Result<DecimalFormatter> {
             val plusSignPrefixSliceMemory = PrimitiveArrayTools.borrowUtf8(plusSignPrefix)
             val plusSignSuffixSliceMemory = PrimitiveArrayTools.borrowUtf8(plusSignSuffix)
@@ -118,10 +122,11 @@ class DecimalFormatter internal constructor (
         }
     }
     
-    /** Formats a [Decimal] to a string.
-    *
-    *See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/decimal/struct.DecimalFormatter.html#method.format) for more information.
-    */
+    /**
+     * Formats a [Decimal] to a string.
+     *
+     * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/decimal/struct.DecimalFormatter.html#method.format) for more information.
+     */
     fun format(value: Decimal): String {
         val write = DW.lib.diplomat_buffer_write_create(0)
         val returnVal = lib.icu4x_DecimalFormatter_format_mv1(handle, value.handle, write);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DecimalGroupingStrategy.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DecimalGroupingStrategy.kt
@@ -8,7 +8,8 @@ import com.sun.jna.Structure
 
 internal interface DecimalGroupingStrategyLib: Library {
 }
-/** See the [Rust documentation for `GroupingStrategy`](https://docs.rs/icu/2.3.1/icu/decimal/options/enum.GroupingStrategy.html) for more information.
+/**
+ * See the [Rust documentation for `GroupingStrategy`](https://docs.rs/icu/2.3.1/icu/decimal/options/enum.GroupingStrategy.html) for more information.
 */
 enum class DecimalGroupingStrategy {
     Auto,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DecimalLimitError.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DecimalLimitError.kt
@@ -6,8 +6,9 @@ import com.sun.jna.Native
 import com.sun.jna.Pointer
 import com.sun.jna.Structure
 
-/** Additional information: [1](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/struct.LimitError.html)
-*/
+/**
+ * Additional information: [1](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/struct.LimitError.html)
+ */
 class DecimalLimitError (): Exception("Rust error result for DecimalLimitError") {
     companion object {
 

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DecimalParseError.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DecimalParseError.kt
@@ -8,7 +8,8 @@ import com.sun.jna.Structure
 
 internal interface DecimalParseErrorLib: Library {
 }
-/** Additional information: [1](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/enum.ParseError.html)
+/**
+ * Additional information: [1](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/enum.ParseError.html)
 */
 enum class DecimalParseError {
     Unknown,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DecimalRoundingIncrement.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DecimalRoundingIncrement.kt
@@ -8,9 +8,10 @@ import com.sun.jna.Structure
 
 internal interface DecimalRoundingIncrementLib: Library {
 }
-/** Increment used in a rounding operation.
-*
-*See the [Rust documentation for `RoundingIncrement`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/enum.RoundingIncrement.html) for more information.
+/**
+ * Increment used in a rounding operation.
+ *
+ * See the [Rust documentation for `RoundingIncrement`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/enum.RoundingIncrement.html) for more information.
 */
 enum class DecimalRoundingIncrement {
     MultiplesOf1,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DecimalSign.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DecimalSign.kt
@@ -8,9 +8,10 @@ import com.sun.jna.Structure
 
 internal interface DecimalSignLib: Library {
 }
-/** The sign of a Decimal, as shown in formatting.
-*
-*See the [Rust documentation for `Sign`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/enum.Sign.html) for more information.
+/**
+ * The sign of a Decimal, as shown in formatting.
+ *
+ * See the [Rust documentation for `Sign`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/enum.Sign.html) for more information.
 */
 enum class DecimalSign {
     None,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DecimalSignDisplay.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DecimalSignDisplay.kt
@@ -8,9 +8,10 @@ import com.sun.jna.Structure
 
 internal interface DecimalSignDisplayLib: Library {
 }
-/** ECMA-402 compatible sign display preference.
-*
-*See the [Rust documentation for `SignDisplay`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/enum.SignDisplay.html) for more information.
+/**
+ * ECMA-402 compatible sign display preference.
+ *
+ * See the [Rust documentation for `SignDisplay`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/enum.SignDisplay.html) for more information.
 */
 enum class DecimalSignDisplay {
     Auto,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DecimalSignedRoundingMode.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DecimalSignedRoundingMode.kt
@@ -8,9 +8,10 @@ import com.sun.jna.Structure
 
 internal interface DecimalSignedRoundingModeLib: Library {
 }
-/** Mode used in a rounding operation for signed numbers.
-*
-*See the [Rust documentation for `SignedRoundingMode`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/enum.SignedRoundingMode.html) for more information.
+/**
+ * Mode used in a rounding operation for signed numbers.
+ *
+ * See the [Rust documentation for `SignedRoundingMode`](https://docs.rs/fixed_decimal/0.7.2/fixed_decimal/enum.SignedRoundingMode.html) for more information.
 */
 enum class DecimalSignedRoundingMode {
     Expand,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/Decomposed.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/Decomposed.kt
@@ -62,12 +62,13 @@ internal class OptionDecomposedNative constructor(): Structure(), Structure.ByVa
 
 }
 
-/** The outcome of non-recursive canonical decomposition of a character.
-*`second` will be NUL when the decomposition expands to a single character
-*(which may or may not be the original one)
-*
-*See the [Rust documentation for `Decomposed`](https://docs.rs/icu/2.3.1/icu/normalizer/properties/enum.Decomposed.html) for more information.
-*/
+/**
+ * The outcome of non-recursive canonical decomposition of a character.
+ * `second` will be NUL when the decomposition expands to a single character
+ * (which may or may not be the original one)
+ *
+ * See the [Rust documentation for `Decomposed`](https://docs.rs/icu/2.3.1/icu/normalizer/properties/enum.Decomposed.html) for more information.
+ */
 class Decomposed (var first: Int, var second: Int) {
     companion object {
 

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DecomposingNormalizer.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DecomposingNormalizer.kt
@@ -15,8 +15,9 @@ internal interface DecomposingNormalizerLib: Library {
     fun icu4x_DecomposingNormalizer_is_normalized_utf16_mv1(handle: Pointer, s: Slice): Byte
     fun icu4x_DecomposingNormalizer_is_normalized_utf16_up_to_mv1(handle: Pointer, s: Slice): FFISizet
 }
-/** See the [Rust documentation for `DecomposingNormalizer`](https://docs.rs/icu/2.3.1/icu/normalizer/struct.DecomposingNormalizer.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `DecomposingNormalizer`](https://docs.rs/icu/2.3.1/icu/normalizer/struct.DecomposingNormalizer.html) for more information.
+ */
 class DecomposingNormalizer internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -45,10 +46,11 @@ class DecomposingNormalizer internal constructor (
         internal val lib: DecomposingNormalizerLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Construct a new `DecomposingNormalizer` instance for NFD using compiled data.
-        *
-        *See the [Rust documentation for `new_nfd`](https://docs.rs/icu/2.3.1/icu/normalizer/struct.DecomposingNormalizer.html#method.new_nfd) for more information.
-        */
+        /**
+         * Construct a new `DecomposingNormalizer` instance for NFD using compiled data.
+         *
+         * See the [Rust documentation for `new_nfd`](https://docs.rs/icu/2.3.1/icu/normalizer/struct.DecomposingNormalizer.html#method.new_nfd) for more information.
+         */
         fun createNfd(): DecomposingNormalizer {
             
             val returnVal = lib.icu4x_DecomposingNormalizer_create_nfd_mv1();
@@ -59,10 +61,11 @@ class DecomposingNormalizer internal constructor (
         }
         @JvmStatic
         
-        /** Construct a new `DecomposingNormalizer` instance for NFD using a particular data source.
-        *
-        *See the [Rust documentation for `new_nfd`](https://docs.rs/icu/2.3.1/icu/normalizer/struct.DecomposingNormalizer.html#method.new_nfd) for more information.
-        */
+        /**
+         * Construct a new `DecomposingNormalizer` instance for NFD using a particular data source.
+         *
+         * See the [Rust documentation for `new_nfd`](https://docs.rs/icu/2.3.1/icu/normalizer/struct.DecomposingNormalizer.html#method.new_nfd) for more information.
+         */
         fun createNfdWithProvider(provider: DataProvider): Result<DecomposingNormalizer> {
             
             val returnVal = lib.icu4x_DecomposingNormalizer_create_nfd_with_provider_mv1(provider.handle);
@@ -78,10 +81,11 @@ class DecomposingNormalizer internal constructor (
         }
         @JvmStatic
         
-        /** Construct a new `DecomposingNormalizer` instance for NFKD using compiled data.
-        *
-        *See the [Rust documentation for `new_nfkd`](https://docs.rs/icu/2.3.1/icu/normalizer/struct.DecomposingNormalizer.html#method.new_nfkd) for more information.
-        */
+        /**
+         * Construct a new `DecomposingNormalizer` instance for NFKD using compiled data.
+         *
+         * See the [Rust documentation for `new_nfkd`](https://docs.rs/icu/2.3.1/icu/normalizer/struct.DecomposingNormalizer.html#method.new_nfkd) for more information.
+         */
         fun createNfkd(): DecomposingNormalizer {
             
             val returnVal = lib.icu4x_DecomposingNormalizer_create_nfkd_mv1();
@@ -92,10 +96,11 @@ class DecomposingNormalizer internal constructor (
         }
         @JvmStatic
         
-        /** Construct a new `DecomposingNormalizer` instance for NFKD using a particular data source.
-        *
-        *See the [Rust documentation for `new_nfkd`](https://docs.rs/icu/2.3.1/icu/normalizer/struct.DecomposingNormalizer.html#method.new_nfkd) for more information.
-        */
+        /**
+         * Construct a new `DecomposingNormalizer` instance for NFKD using a particular data source.
+         *
+         * See the [Rust documentation for `new_nfkd`](https://docs.rs/icu/2.3.1/icu/normalizer/struct.DecomposingNormalizer.html#method.new_nfkd) for more information.
+         */
         fun createNfkdWithProvider(provider: DataProvider): Result<DecomposingNormalizer> {
             
             val returnVal = lib.icu4x_DecomposingNormalizer_create_nfkd_with_provider_mv1(provider.handle);
@@ -111,13 +116,14 @@ class DecomposingNormalizer internal constructor (
         }
     }
     
-    /** Normalize a string
-    *
-    *Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
-    *to the WHATWG Encoding Standard.
-    *
-    *See the [Rust documentation for `normalize_utf8`](https://docs.rs/icu/2.3.1/icu/normalizer/struct.DecomposingNormalizerBorrowed.html#method.normalize_utf8) for more information.
-    */
+    /**
+     * Normalize a string
+     *
+     * Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
+     * to the WHATWG Encoding Standard.
+     *
+     * See the [Rust documentation for `normalize_utf8`](https://docs.rs/icu/2.3.1/icu/normalizer/struct.DecomposingNormalizerBorrowed.html#method.normalize_utf8) for more information.
+     */
     fun normalize(s: String): String {
         val sSliceMemory = PrimitiveArrayTools.borrowUtf8(s)
         val write = DW.lib.diplomat_buffer_write_create(0)
@@ -131,13 +137,14 @@ class DecomposingNormalizer internal constructor (
         }
     }
     
-    /** Check if a string is normalized
-    *
-    *Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
-    *to the WHATWG Encoding Standard.
-    *
-    *See the [Rust documentation for `is_normalized_utf16`](https://docs.rs/icu/2.3.1/icu/normalizer/struct.DecomposingNormalizerBorrowed.html#method.is_normalized_utf16) for more information.
-    */
+    /**
+     * Check if a string is normalized
+     *
+     * Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
+     * to the WHATWG Encoding Standard.
+     *
+     * See the [Rust documentation for `is_normalized_utf16`](https://docs.rs/icu/2.3.1/icu/normalizer/struct.DecomposingNormalizerBorrowed.html#method.is_normalized_utf16) for more information.
+     */
     fun is_normalized(s: String): Boolean {
         val sSliceMemory = PrimitiveArrayTools.borrowUtf16(s)
         
@@ -149,10 +156,11 @@ class DecomposingNormalizer internal constructor (
         }
     }
     
-    /** Return the index a slice of potentially-invalid UTF-16 is normalized up to
-    *
-    *See the [Rust documentation for `split_normalized_utf16`](https://docs.rs/icu/2.3.1/icu/normalizer/struct.DecomposingNormalizerBorrowed.html#method.split_normalized_utf16) for more information.
-    */
+    /**
+     * Return the index a slice of potentially-invalid UTF-16 is normalized up to
+     *
+     * See the [Rust documentation for `split_normalized_utf16`](https://docs.rs/icu/2.3.1/icu/normalizer/struct.DecomposingNormalizerBorrowed.html#method.split_normalized_utf16) for more information.
+     */
     fun is_normalized_up_to(s: String): ULong {
         val sSliceMemory = PrimitiveArrayTools.borrowUtf16(s)
         

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DisplayNamesFallback.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DisplayNamesFallback.kt
@@ -8,9 +8,10 @@ import com.sun.jna.Structure
 
 internal interface DisplayNamesFallbackLib: Library {
 }
-/** 🚧 This API is unstable and may experience breaking changes outside major releases.
-*
-*See the [Rust documentation for `Fallback`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/enum.Fallback.html) for more information.
+/**
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
+ *
+ * See the [Rust documentation for `Fallback`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/enum.Fallback.html) for more information.
 */
 enum class DisplayNamesFallback {
     Code,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DisplayNamesFallback.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DisplayNamesFallback.kt
@@ -9,9 +9,9 @@ import com.sun.jna.Structure
 internal interface DisplayNamesFallbackLib: Library {
 }
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `Fallback`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/enum.Fallback.html) for more information.
+ *
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
 */
 enum class DisplayNamesFallback {
     Code,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DisplayNamesOptions.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DisplayNamesOptions.kt
@@ -75,9 +75,9 @@ internal class OptionDisplayNamesOptionsNative constructor(): Structure(), Struc
 }
 
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `DisplayNamesOptions`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/struct.DisplayNamesOptions.html) for more information.
+ *
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
  */
 class DisplayNamesOptions (var style: DisplayNamesStyle?, var fallback: DisplayNamesFallback?, var languageDisplay: LanguageDisplay?) {
     companion object {

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DisplayNamesOptions.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DisplayNamesOptions.kt
@@ -10,17 +10,20 @@ internal interface DisplayNamesOptionsLib: Library {
 }
 
 internal class DisplayNamesOptionsNative: Structure(), Structure.ByValue {
-    /** The optional formatting style to use for display name.
-    */
+    /**
+     * The optional formatting style to use for display name.
+     */
     @JvmField
     internal var style: OptionInt = OptionInt.none();
-    /** The fallback return when the system does not have the
-*requested display name, defaults to "code".
-    */
+    /**
+     * The fallback return when the system does not have the
+     * requested display name, defaults to "code".
+     */
     @JvmField
     internal var fallback: OptionInt = OptionInt.none();
-    /** The language display kind, defaults to "dialect".
-    */
+    /**
+     * The language display kind, defaults to "dialect".
+     */
     @JvmField
     internal var languageDisplay: OptionInt = OptionInt.none();
 
@@ -71,10 +74,11 @@ internal class OptionDisplayNamesOptionsNative constructor(): Structure(), Struc
 
 }
 
-/** 🚧 This API is unstable and may experience breaking changes outside major releases.
-*
-*See the [Rust documentation for `DisplayNamesOptions`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/struct.DisplayNamesOptions.html) for more information.
-*/
+/**
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
+ *
+ * See the [Rust documentation for `DisplayNamesOptions`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/struct.DisplayNamesOptions.html) for more information.
+ */
 class DisplayNamesOptions (var style: DisplayNamesStyle?, var fallback: DisplayNamesFallback?, var languageDisplay: LanguageDisplay?) {
     companion object {
 

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DisplayNamesStyle.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DisplayNamesStyle.kt
@@ -9,9 +9,9 @@ import com.sun.jna.Structure
 internal interface DisplayNamesStyleLib: Library {
 }
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `Style`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/enum.Style.html) for more information.
+ *
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
 */
 enum class DisplayNamesStyle {
     Narrow,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DisplayNamesStyle.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/DisplayNamesStyle.kt
@@ -8,9 +8,10 @@ import com.sun.jna.Structure
 
 internal interface DisplayNamesStyleLib: Library {
 }
-/** 🚧 This API is unstable and may experience breaking changes outside major releases.
-*
-*See the [Rust documentation for `Style`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/enum.Style.html) for more information.
+/**
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
+ *
+ * See the [Rust documentation for `Style`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/enum.Style.html) for more information.
 */
 enum class DisplayNamesStyle {
     Narrow,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/EastAsianWidth.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/EastAsianWidth.kt
@@ -14,7 +14,8 @@ internal interface EastAsianWidthLib: Library {
     fun icu4x_EastAsianWidth_from_integer_value_mv1(other: FFIUint8): OptionInt
     fun icu4x_EastAsianWidth_try_from_str_mv1(s: Slice): OptionInt
 }
-/** See the [Rust documentation for `EastAsianWidth`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.EastAsianWidth.html) for more information.
+/**
+ * See the [Rust documentation for `EastAsianWidth`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.EastAsianWidth.html) for more information.
 */
 enum class EastAsianWidth {
     Neutral,
@@ -41,8 +42,9 @@ enum class EastAsianWidth {
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.EnumeratedProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.EnumeratedProperty.html#tymethod.for_char) for more information.
+         */
         fun forChar(ch: Int): EastAsianWidth {
             
             val returnVal = lib.icu4x_EastAsianWidth_for_char_mv1(ch);
@@ -50,10 +52,11 @@ enum class EastAsianWidth {
         }
         @JvmStatic
         
-        /** Convert from an integer value from ICU4C or `CodePointMapData`
-        *
-        *See the [Rust documentation for `from_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.EastAsianWidth.html#method.from_icu4c_value) for more information.
-        */
+        /**
+         * Convert from an integer value from ICU4C or `CodePointMapData`
+         *
+         * See the [Rust documentation for `from_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.EastAsianWidth.html#method.from_icu4c_value) for more information.
+         */
         fun fromIntegerValue(other: UByte): EastAsianWidth? {
             
             val returnVal = lib.icu4x_EastAsianWidth_from_integer_value_mv1(FFIUint8(other));
@@ -63,10 +66,11 @@ enum class EastAsianWidth {
         }
         @JvmStatic
         
-        /** Creates a `EastAsianWidth` from a string.
-        *
-        *Short names, long names, and aliases are supported, and matching is case-insensitive.
-        */
+        /**
+         * Creates a `EastAsianWidth` from a string.
+         *
+         * Short names, long names, and aliases are supported, and matching is case-insensitive.
+         */
         fun tryFromStr(s: String): EastAsianWidth? {
             val sSliceMemory = PrimitiveArrayTools.borrowUtf8(s)
             
@@ -81,10 +85,11 @@ enum class EastAsianWidth {
         }
     }
     
-    /** Get the "long" name of this property value (returns empty if property value is unknown)
-    *
-    *See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesLongBorrowed.html#method.get) for more information.
-    */
+    /**
+     * Get the "long" name of this property value (returns empty if property value is unknown)
+     *
+     * See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesLongBorrowed.html#method.get) for more information.
+     */
     fun longName(): String? {
         
         val returnVal = lib.icu4x_EastAsianWidth_long_name_mv1(this.toNative());
@@ -94,10 +99,11 @@ enum class EastAsianWidth {
                                 
     }
     
-    /** Get the "short" name of this property value (returns empty if property value is unknown)
-    *
-    *See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesShortBorrowed.html#method.get) for more information.
-    */
+    /**
+     * Get the "short" name of this property value (returns empty if property value is unknown)
+     *
+     * See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesShortBorrowed.html#method.get) for more information.
+     */
     fun shortName(): String? {
         
         val returnVal = lib.icu4x_EastAsianWidth_short_name_mv1(this.toNative());
@@ -107,10 +113,11 @@ enum class EastAsianWidth {
                                 
     }
     
-    /** Convert to an integer value usable with ICU4C and `CodePointMapData`
-    *
-    *See the [Rust documentation for `to_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.EastAsianWidth.html#method.to_icu4c_value) for more information.
-    */
+    /**
+     * Convert to an integer value usable with ICU4C and `CodePointMapData`
+     *
+     * See the [Rust documentation for `to_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.EastAsianWidth.html#method.to_icu4c_value) for more information.
+     */
     fun toIntegerValue(): UByte {
         
         val returnVal = lib.icu4x_EastAsianWidth_to_integer_value_mv1(this.toNative());

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/EmojiSetData.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/EmojiSetData.kt
@@ -14,16 +14,17 @@ internal interface EmojiSetDataLib: Library {
     fun icu4x_EmojiSetData_basic_emoji_for_char_mv1(ch: Int): Byte
     fun icu4x_EmojiSetData_basic_emoji_for_str_mv1(s: Slice): Byte
 }
-/** An ICU4X Unicode Set Property object, capable of querying whether a code point is contained in a set based on a Unicode property.
-*
-*See the [Rust documentation for `properties`](https://docs.rs/icu/2.3.1/icu/properties/index.html) for more information.
-*
-*See the [Rust documentation for `EmojiSetData`](https://docs.rs/icu/2.3.1/icu/properties/struct.EmojiSetData.html) for more information.
-*
-*See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/properties/struct.EmojiSetData.html#method.new) for more information.
-*
-*See the [Rust documentation for `EmojiSetDataBorrowed`](https://docs.rs/icu/2.3.1/icu/properties/struct.EmojiSetDataBorrowed.html) for more information.
-*/
+/**
+ * An ICU4X Unicode Set Property object, capable of querying whether a code point is contained in a set based on a Unicode property.
+ *
+ * See the [Rust documentation for `properties`](https://docs.rs/icu/2.3.1/icu/properties/index.html) for more information.
+ *
+ * See the [Rust documentation for `EmojiSetData`](https://docs.rs/icu/2.3.1/icu/properties/struct.EmojiSetData.html) for more information.
+ *
+ * See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/properties/struct.EmojiSetData.html#method.new) for more information.
+ *
+ * See the [Rust documentation for `EmojiSetDataBorrowed`](https://docs.rs/icu/2.3.1/icu/properties/struct.EmojiSetDataBorrowed.html) for more information.
+ */
 class EmojiSetData internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -52,10 +53,11 @@ class EmojiSetData internal constructor (
         internal val lib: EmojiSetDataLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Create a map for the `Basic_Emoji` property, using compiled data.
-        *
-        *See the [Rust documentation for `BasicEmoji`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.BasicEmoji.html) for more information.
-        */
+        /**
+         * Create a map for the `Basic_Emoji` property, using compiled data.
+         *
+         * See the [Rust documentation for `BasicEmoji`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.BasicEmoji.html) for more information.
+         */
         fun createBasic(): EmojiSetData {
             
             val returnVal = lib.icu4x_EmojiSetData_create_basic_mv1();
@@ -66,10 +68,11 @@ class EmojiSetData internal constructor (
         }
         @JvmStatic
         
-        /** Create a map for the `Basic_Emoji` property, using a particular data source.
-        *
-        *See the [Rust documentation for `BasicEmoji`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.BasicEmoji.html) for more information.
-        */
+        /**
+         * Create a map for the `Basic_Emoji` property, using a particular data source.
+         *
+         * See the [Rust documentation for `BasicEmoji`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.BasicEmoji.html) for more information.
+         */
         fun createBasicWithProvider(provider: DataProvider): Result<EmojiSetData> {
             
             val returnVal = lib.icu4x_EmojiSetData_create_basic_with_provider_mv1(provider.handle);
@@ -85,10 +88,11 @@ class EmojiSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Basic_Emoji` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.EmojiSet.html#tymethod.for_char) for more information.
-        */
+        /**
+         * Get the `Basic_Emoji` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.EmojiSet.html#tymethod.for_char) for more information.
+         */
         fun basicEmojiForChar(ch: Int): Boolean {
             
             val returnVal = lib.icu4x_EmojiSetData_basic_emoji_for_char_mv1(ch);
@@ -96,10 +100,11 @@ class EmojiSetData internal constructor (
         }
         @JvmStatic
         
-        /** Get the `Basic_Emoji` value for a given character, using compiled data
-        *
-        *See the [Rust documentation for `for_str`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.EmojiSet.html#tymethod.for_str) for more information.
-        */
+        /**
+         * Get the `Basic_Emoji` value for a given character, using compiled data
+         *
+         * See the [Rust documentation for `for_str`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.EmojiSet.html#tymethod.for_str) for more information.
+         */
         fun basicEmojiForStr(s: String): Boolean {
             val sSliceMemory = PrimitiveArrayTools.borrowUtf8(s)
             
@@ -112,10 +117,11 @@ class EmojiSetData internal constructor (
         }
     }
     
-    /** Checks whether the string is in the set.
-    *
-    *See the [Rust documentation for `contains_str`](https://docs.rs/icu/2.3.1/icu/properties/struct.EmojiSetDataBorrowed.html#method.contains_str) for more information.
-    */
+    /**
+     * Checks whether the string is in the set.
+     *
+     * See the [Rust documentation for `contains_str`](https://docs.rs/icu/2.3.1/icu/properties/struct.EmojiSetDataBorrowed.html#method.contains_str) for more information.
+     */
     fun contains(s: String): Boolean {
         val sSliceMemory = PrimitiveArrayTools.borrowUtf8(s)
         
@@ -127,10 +133,11 @@ class EmojiSetData internal constructor (
         }
     }
     
-    /** Checks whether the code point is in the set.
-    *
-    *See the [Rust documentation for `contains`](https://docs.rs/icu/2.3.1/icu/properties/struct.EmojiSetDataBorrowed.html#method.contains) for more information.
-    */
+    /**
+     * Checks whether the code point is in the set.
+     *
+     * See the [Rust documentation for `contains`](https://docs.rs/icu/2.3.1/icu/properties/struct.EmojiSetDataBorrowed.html#method.contains) for more information.
+     */
     fun contains(cp: Int): Boolean {
         
         val returnVal = lib.icu4x_EmojiSetData_contains_mv1(handle, cp);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/ExemplarCharacters.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/ExemplarCharacters.kt
@@ -20,14 +20,15 @@ internal interface ExemplarCharactersLib: Library {
     fun icu4x_ExemplarCharacters_create_index_mv1(locale: Pointer): ResultPointerInt
     fun icu4x_ExemplarCharacters_create_index_with_provider_mv1(provider: Pointer, locale: Pointer): ResultPointerInt
 }
-/** A set of "exemplar characters" for a given locale.
-*
-*See the [Rust documentation for `locale`](https://docs.rs/icu/2.3.1/icu/locale/index.html) for more information.
-*
-*See the [Rust documentation for `ExemplarCharacters`](https://docs.rs/icu/2.3.1/icu/locale/exemplar_chars/struct.ExemplarCharacters.html) for more information.
-*
-*See the [Rust documentation for `ExemplarCharactersBorrowed`](https://docs.rs/icu/2.3.1/icu/locale/exemplar_chars/struct.ExemplarCharactersBorrowed.html) for more information.
-*/
+/**
+ * A set of "exemplar characters" for a given locale.
+ *
+ * See the [Rust documentation for `locale`](https://docs.rs/icu/2.3.1/icu/locale/index.html) for more information.
+ *
+ * See the [Rust documentation for `ExemplarCharacters`](https://docs.rs/icu/2.3.1/icu/locale/exemplar_chars/struct.ExemplarCharacters.html) for more information.
+ *
+ * See the [Rust documentation for `ExemplarCharactersBorrowed`](https://docs.rs/icu/2.3.1/icu/locale/exemplar_chars/struct.ExemplarCharactersBorrowed.html) for more information.
+ */
 class ExemplarCharacters internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -56,10 +57,11 @@ class ExemplarCharacters internal constructor (
         internal val lib: ExemplarCharactersLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Create an [ExemplarCharacters] for the "main" set of exemplar characters for a given locale, using compiled data.
-        *
-        *See the [Rust documentation for `try_new_main`](https://docs.rs/icu/2.3.1/icu/locale/exemplar_chars/struct.ExemplarCharacters.html#method.try_new_main) for more information.
-        */
+        /**
+         * Create an [ExemplarCharacters] for the "main" set of exemplar characters for a given locale, using compiled data.
+         *
+         * See the [Rust documentation for `try_new_main`](https://docs.rs/icu/2.3.1/icu/locale/exemplar_chars/struct.ExemplarCharacters.html#method.try_new_main) for more information.
+         */
         fun createMain(locale: Locale): Result<ExemplarCharacters> {
             
             val returnVal = lib.icu4x_ExemplarCharacters_create_main_mv1(locale.handle);
@@ -75,10 +77,11 @@ class ExemplarCharacters internal constructor (
         }
         @JvmStatic
         
-        /** Create an [ExemplarCharacters] for the "main" set of exemplar characters for a given locale, using a particular data source
-        *
-        *See the [Rust documentation for `try_new_main`](https://docs.rs/icu/2.3.1/icu/locale/exemplar_chars/struct.ExemplarCharacters.html#method.try_new_main) for more information.
-        */
+        /**
+         * Create an [ExemplarCharacters] for the "main" set of exemplar characters for a given locale, using a particular data source
+         *
+         * See the [Rust documentation for `try_new_main`](https://docs.rs/icu/2.3.1/icu/locale/exemplar_chars/struct.ExemplarCharacters.html#method.try_new_main) for more information.
+         */
         fun createMainWithProvider(provider: DataProvider, locale: Locale): Result<ExemplarCharacters> {
             
             val returnVal = lib.icu4x_ExemplarCharacters_create_main_with_provider_mv1(provider.handle, locale.handle);
@@ -94,10 +97,11 @@ class ExemplarCharacters internal constructor (
         }
         @JvmStatic
         
-        /** Create an [ExemplarCharacters] for the "auxiliary" set of exemplar characters for a given locale, using compiled data.
-        *
-        *See the [Rust documentation for `try_new_auxiliary`](https://docs.rs/icu/2.3.1/icu/locale/exemplar_chars/struct.ExemplarCharacters.html#method.try_new_auxiliary) for more information.
-        */
+        /**
+         * Create an [ExemplarCharacters] for the "auxiliary" set of exemplar characters for a given locale, using compiled data.
+         *
+         * See the [Rust documentation for `try_new_auxiliary`](https://docs.rs/icu/2.3.1/icu/locale/exemplar_chars/struct.ExemplarCharacters.html#method.try_new_auxiliary) for more information.
+         */
         fun createAuxiliary(locale: Locale): Result<ExemplarCharacters> {
             
             val returnVal = lib.icu4x_ExemplarCharacters_create_auxiliary_mv1(locale.handle);
@@ -113,10 +117,11 @@ class ExemplarCharacters internal constructor (
         }
         @JvmStatic
         
-        /** Create an [ExemplarCharacters] for the "auxiliary" set of exemplar characters for a given locale, using compiled data.
-        *
-        *See the [Rust documentation for `try_new_auxiliary`](https://docs.rs/icu/2.3.1/icu/locale/exemplar_chars/struct.ExemplarCharacters.html#method.try_new_auxiliary) for more information.
-        */
+        /**
+         * Create an [ExemplarCharacters] for the "auxiliary" set of exemplar characters for a given locale, using compiled data.
+         *
+         * See the [Rust documentation for `try_new_auxiliary`](https://docs.rs/icu/2.3.1/icu/locale/exemplar_chars/struct.ExemplarCharacters.html#method.try_new_auxiliary) for more information.
+         */
         fun createAuxiliaryWithProvider(provider: DataProvider, locale: Locale): Result<ExemplarCharacters> {
             
             val returnVal = lib.icu4x_ExemplarCharacters_create_auxiliary_with_provider_mv1(provider.handle, locale.handle);
@@ -132,10 +137,11 @@ class ExemplarCharacters internal constructor (
         }
         @JvmStatic
         
-        /** Create an [ExemplarCharacters] for the "punctuation" set of exemplar characters for a given locale, using compiled data.
-        *
-        *See the [Rust documentation for `try_new_punctuation`](https://docs.rs/icu/2.3.1/icu/locale/exemplar_chars/struct.ExemplarCharacters.html#method.try_new_punctuation) for more information.
-        */
+        /**
+         * Create an [ExemplarCharacters] for the "punctuation" set of exemplar characters for a given locale, using compiled data.
+         *
+         * See the [Rust documentation for `try_new_punctuation`](https://docs.rs/icu/2.3.1/icu/locale/exemplar_chars/struct.ExemplarCharacters.html#method.try_new_punctuation) for more information.
+         */
         fun createPunctuation(locale: Locale): Result<ExemplarCharacters> {
             
             val returnVal = lib.icu4x_ExemplarCharacters_create_punctuation_mv1(locale.handle);
@@ -151,10 +157,11 @@ class ExemplarCharacters internal constructor (
         }
         @JvmStatic
         
-        /** Create an [ExemplarCharacters] for the "punctuation" set of exemplar characters for a given locale, using compiled data.
-        *
-        *See the [Rust documentation for `try_new_punctuation`](https://docs.rs/icu/2.3.1/icu/locale/exemplar_chars/struct.ExemplarCharacters.html#method.try_new_punctuation) for more information.
-        */
+        /**
+         * Create an [ExemplarCharacters] for the "punctuation" set of exemplar characters for a given locale, using compiled data.
+         *
+         * See the [Rust documentation for `try_new_punctuation`](https://docs.rs/icu/2.3.1/icu/locale/exemplar_chars/struct.ExemplarCharacters.html#method.try_new_punctuation) for more information.
+         */
         fun createPunctuationWithProvider(provider: DataProvider, locale: Locale): Result<ExemplarCharacters> {
             
             val returnVal = lib.icu4x_ExemplarCharacters_create_punctuation_with_provider_mv1(provider.handle, locale.handle);
@@ -170,10 +177,11 @@ class ExemplarCharacters internal constructor (
         }
         @JvmStatic
         
-        /** Create an [ExemplarCharacters] for the "numbers" set of exemplar characters for a given locale, using compiled data.
-        *
-        *See the [Rust documentation for `try_new_numbers`](https://docs.rs/icu/2.3.1/icu/locale/exemplar_chars/struct.ExemplarCharacters.html#method.try_new_numbers) for more information.
-        */
+        /**
+         * Create an [ExemplarCharacters] for the "numbers" set of exemplar characters for a given locale, using compiled data.
+         *
+         * See the [Rust documentation for `try_new_numbers`](https://docs.rs/icu/2.3.1/icu/locale/exemplar_chars/struct.ExemplarCharacters.html#method.try_new_numbers) for more information.
+         */
         fun createNumbers(locale: Locale): Result<ExemplarCharacters> {
             
             val returnVal = lib.icu4x_ExemplarCharacters_create_numbers_mv1(locale.handle);
@@ -189,10 +197,11 @@ class ExemplarCharacters internal constructor (
         }
         @JvmStatic
         
-        /** Create an [ExemplarCharacters] for the "numbers" set of exemplar characters for a given locale, using compiled data.
-        *
-        *See the [Rust documentation for `try_new_numbers`](https://docs.rs/icu/2.3.1/icu/locale/exemplar_chars/struct.ExemplarCharacters.html#method.try_new_numbers) for more information.
-        */
+        /**
+         * Create an [ExemplarCharacters] for the "numbers" set of exemplar characters for a given locale, using compiled data.
+         *
+         * See the [Rust documentation for `try_new_numbers`](https://docs.rs/icu/2.3.1/icu/locale/exemplar_chars/struct.ExemplarCharacters.html#method.try_new_numbers) for more information.
+         */
         fun createNumbersWithProvider(provider: DataProvider, locale: Locale): Result<ExemplarCharacters> {
             
             val returnVal = lib.icu4x_ExemplarCharacters_create_numbers_with_provider_mv1(provider.handle, locale.handle);
@@ -208,10 +217,11 @@ class ExemplarCharacters internal constructor (
         }
         @JvmStatic
         
-        /** Create an [ExemplarCharacters] for the "index" set of exemplar characters for a given locale, using compiled data.
-        *
-        *See the [Rust documentation for `try_new_index`](https://docs.rs/icu/2.3.1/icu/locale/exemplar_chars/struct.ExemplarCharacters.html#method.try_new_index) for more information.
-        */
+        /**
+         * Create an [ExemplarCharacters] for the "index" set of exemplar characters for a given locale, using compiled data.
+         *
+         * See the [Rust documentation for `try_new_index`](https://docs.rs/icu/2.3.1/icu/locale/exemplar_chars/struct.ExemplarCharacters.html#method.try_new_index) for more information.
+         */
         fun createIndex(locale: Locale): Result<ExemplarCharacters> {
             
             val returnVal = lib.icu4x_ExemplarCharacters_create_index_mv1(locale.handle);
@@ -227,10 +237,11 @@ class ExemplarCharacters internal constructor (
         }
         @JvmStatic
         
-        /** Create an [ExemplarCharacters] for the "index" set of exemplar characters for a given locale, using compiled data.
-        *
-        *See the [Rust documentation for `try_new_index`](https://docs.rs/icu/2.3.1/icu/locale/exemplar_chars/struct.ExemplarCharacters.html#method.try_new_index) for more information.
-        */
+        /**
+         * Create an [ExemplarCharacters] for the "index" set of exemplar characters for a given locale, using compiled data.
+         *
+         * See the [Rust documentation for `try_new_index`](https://docs.rs/icu/2.3.1/icu/locale/exemplar_chars/struct.ExemplarCharacters.html#method.try_new_index) for more information.
+         */
         fun createIndexWithProvider(provider: DataProvider, locale: Locale): Result<ExemplarCharacters> {
             
             val returnVal = lib.icu4x_ExemplarCharacters_create_index_with_provider_mv1(provider.handle, locale.handle);
@@ -246,10 +257,11 @@ class ExemplarCharacters internal constructor (
         }
     }
     
-    /** Checks whether the string is in the set.
-    *
-    *See the [Rust documentation for `contains_str`](https://docs.rs/icu/2.3.1/icu/collections/codepointinvliststringlist/struct.CodePointInversionListAndStringList.html#method.contains_str) for more information.
-    */
+    /**
+     * Checks whether the string is in the set.
+     *
+     * See the [Rust documentation for `contains_str`](https://docs.rs/icu/2.3.1/icu/collections/codepointinvliststringlist/struct.CodePointInversionListAndStringList.html#method.contains_str) for more information.
+     */
     fun contains(s: String): Boolean {
         val sSliceMemory = PrimitiveArrayTools.borrowUtf8(s)
         
@@ -261,10 +273,11 @@ class ExemplarCharacters internal constructor (
         }
     }
     
-    /** Checks whether the code point is in the set.
-    *
-    *See the [Rust documentation for `contains`](https://docs.rs/icu/2.3.1/icu/collections/codepointinvliststringlist/struct.CodePointInversionListAndStringList.html#method.contains) for more information.
-    */
+    /**
+     * Checks whether the code point is in the set.
+     *
+     * See the [Rust documentation for `contains`](https://docs.rs/icu/2.3.1/icu/collections/codepointinvliststringlist/struct.CodePointInversionListAndStringList.html#method.contains) for more information.
+     */
     fun contains(cp: Int): Boolean {
         
         val returnVal = lib.icu4x_ExemplarCharacters_contains_mv1(handle, cp);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/GeneralCategory.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/GeneralCategory.kt
@@ -15,7 +15,8 @@ internal interface GeneralCategoryLib: Library {
     fun icu4x_GeneralCategory_try_from_str_mv1(s: Slice): OptionInt
     fun icu4x_GeneralCategory_to_group_mv1(inner: Int): GeneralCategoryGroupNative
 }
-/** See the [Rust documentation for `GeneralCategory`](https://docs.rs/icu/2.3.1/icu/properties/props/enum.GeneralCategory.html) for more information.
+/**
+ * See the [Rust documentation for `GeneralCategory`](https://docs.rs/icu/2.3.1/icu/properties/props/enum.GeneralCategory.html) for more information.
 */
 enum class GeneralCategory {
     Unassigned,
@@ -66,8 +67,9 @@ enum class GeneralCategory {
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.EnumeratedProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.EnumeratedProperty.html#tymethod.for_char) for more information.
+         */
         fun forChar(ch: Int): GeneralCategory {
             
             val returnVal = lib.icu4x_GeneralCategory_for_char_mv1(ch);
@@ -75,10 +77,11 @@ enum class GeneralCategory {
         }
         @JvmStatic
         
-        /** Convert from an integer value from ICU4C or `CodePointMapData`
-        *
-        *See the [Rust documentation for `from_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategory.html#method.from_icu4c_value) for more information.
-        */
+        /**
+         * Convert from an integer value from ICU4C or `CodePointMapData`
+         *
+         * See the [Rust documentation for `from_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategory.html#method.from_icu4c_value) for more information.
+         */
         fun fromIntegerValue(other: UByte): GeneralCategory? {
             
             val returnVal = lib.icu4x_GeneralCategory_from_integer_value_mv1(FFIUint8(other));
@@ -88,10 +91,11 @@ enum class GeneralCategory {
         }
         @JvmStatic
         
-        /** Creates a `GeneralCategory` from a string.
-        *
-        *Short names, long names, and aliases are supported, and matching is case-insensitive.
-        */
+        /**
+         * Creates a `GeneralCategory` from a string.
+         *
+         * Short names, long names, and aliases are supported, and matching is case-insensitive.
+         */
         fun tryFromStr(s: String): GeneralCategory? {
             val sSliceMemory = PrimitiveArrayTools.borrowUtf8(s)
             
@@ -106,10 +110,11 @@ enum class GeneralCategory {
         }
     }
     
-    /** Get the "long" name of this property value (returns empty if property value is unknown)
-    *
-    *See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesLongBorrowed.html#method.get) for more information.
-    */
+    /**
+     * Get the "long" name of this property value (returns empty if property value is unknown)
+     *
+     * See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesLongBorrowed.html#method.get) for more information.
+     */
     fun longName(): String? {
         
         val returnVal = lib.icu4x_GeneralCategory_long_name_mv1(this.toNative());
@@ -119,10 +124,11 @@ enum class GeneralCategory {
                                 
     }
     
-    /** Get the "short" name of this property value (returns empty if property value is unknown)
-    *
-    *See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesShortBorrowed.html#method.get) for more information.
-    */
+    /**
+     * Get the "short" name of this property value (returns empty if property value is unknown)
+     *
+     * See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesShortBorrowed.html#method.get) for more information.
+     */
     fun shortName(): String? {
         
         val returnVal = lib.icu4x_GeneralCategory_short_name_mv1(this.toNative());
@@ -132,20 +138,22 @@ enum class GeneralCategory {
                                 
     }
     
-    /** Convert to an integer value usable with ICU4C and `CodePointMapData`
-    *
-    *See the [Rust documentation for `to_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategory.html#method.to_icu4c_value) for more information.
-    */
+    /**
+     * Convert to an integer value usable with ICU4C and `CodePointMapData`
+     *
+     * See the [Rust documentation for `to_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategory.html#method.to_icu4c_value) for more information.
+     */
     fun toIntegerValue(): UByte {
         
         val returnVal = lib.icu4x_GeneralCategory_to_integer_value_mv1(this.toNative());
         return (returnVal.toUByte())
     }
     
-    /** Produces a `GeneralCategoryGroup` mask that can represent a group of general categories
-    *
-    *See the [Rust documentation for `GeneralCategoryGroup`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategoryGroup.html) for more information.
-    */
+    /**
+     * Produces a `GeneralCategoryGroup` mask that can represent a group of general categories
+     *
+     * See the [Rust documentation for `GeneralCategoryGroup`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategoryGroup.html) for more information.
+     */
     fun toGroup(): GeneralCategoryGroup {
         
         val returnVal = lib.icu4x_GeneralCategory_to_group_mv1(this.toNative());

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/GeneralCategoryGroup.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/GeneralCategoryGroup.kt
@@ -74,10 +74,11 @@ internal class OptionGeneralCategoryGroupNative constructor(): Structure(), Stru
 
 }
 
-/** A mask that is capable of representing groups of `General_Category` values.
-*
-*See the [Rust documentation for `GeneralCategoryGroup`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategoryGroup.html) for more information.
-*/
+/**
+ * A mask that is capable of representing groups of `General_Category` values.
+ *
+ * See the [Rust documentation for `GeneralCategoryGroup`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategoryGroup.html) for more information.
+ */
 class GeneralCategoryGroup (var mask: UInt) {
     companion object {
 
@@ -93,8 +94,9 @@ class GeneralCategoryGroup (var mask: UInt) {
 
         @JvmStatic
         
-        /** See the [Rust documentation for `all`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategoryGroup.html#method.all) for more information.
-        */
+        /**
+         * See the [Rust documentation for `all`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategoryGroup.html#method.all) for more information.
+         */
         fun all(): GeneralCategoryGroup {
             
             val returnVal = lib.icu4x_GeneralCategoryGroup_all_mv1();
@@ -103,8 +105,9 @@ class GeneralCategoryGroup (var mask: UInt) {
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `empty`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategoryGroup.html#method.empty) for more information.
-        */
+        /**
+         * See the [Rust documentation for `empty`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategoryGroup.html#method.empty) for more information.
+         */
         fun empty(): GeneralCategoryGroup {
             
             val returnVal = lib.icu4x_GeneralCategoryGroup_empty_mv1();
@@ -113,8 +116,9 @@ class GeneralCategoryGroup (var mask: UInt) {
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `CasedLetter`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategoryGroup.html#associatedconstant.CasedLetter) for more information.
-        */
+        /**
+         * See the [Rust documentation for `CasedLetter`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategoryGroup.html#associatedconstant.CasedLetter) for more information.
+         */
         fun casedLetter(): GeneralCategoryGroup {
             
             val returnVal = lib.icu4x_GeneralCategoryGroup_cased_letter_mv1();
@@ -123,8 +127,9 @@ class GeneralCategoryGroup (var mask: UInt) {
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `Letter`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategoryGroup.html#associatedconstant.Letter) for more information.
-        */
+        /**
+         * See the [Rust documentation for `Letter`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategoryGroup.html#associatedconstant.Letter) for more information.
+         */
         fun letter(): GeneralCategoryGroup {
             
             val returnVal = lib.icu4x_GeneralCategoryGroup_letter_mv1();
@@ -133,8 +138,9 @@ class GeneralCategoryGroup (var mask: UInt) {
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `Mark`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategoryGroup.html#associatedconstant.Mark) for more information.
-        */
+        /**
+         * See the [Rust documentation for `Mark`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategoryGroup.html#associatedconstant.Mark) for more information.
+         */
         fun mark(): GeneralCategoryGroup {
             
             val returnVal = lib.icu4x_GeneralCategoryGroup_mark_mv1();
@@ -143,8 +149,9 @@ class GeneralCategoryGroup (var mask: UInt) {
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `Number`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategoryGroup.html#associatedconstant.Number) for more information.
-        */
+        /**
+         * See the [Rust documentation for `Number`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategoryGroup.html#associatedconstant.Number) for more information.
+         */
         fun number(): GeneralCategoryGroup {
             
             val returnVal = lib.icu4x_GeneralCategoryGroup_number_mv1();
@@ -153,8 +160,9 @@ class GeneralCategoryGroup (var mask: UInt) {
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `Other`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategoryGroup.html#associatedconstant.Other) for more information.
-        */
+        /**
+         * See the [Rust documentation for `Other`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategoryGroup.html#associatedconstant.Other) for more information.
+         */
         fun separator(): GeneralCategoryGroup {
             
             val returnVal = lib.icu4x_GeneralCategoryGroup_separator_mv1();
@@ -163,8 +171,9 @@ class GeneralCategoryGroup (var mask: UInt) {
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `Letter`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategoryGroup.html#associatedconstant.Letter) for more information.
-        */
+        /**
+         * See the [Rust documentation for `Letter`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategoryGroup.html#associatedconstant.Letter) for more information.
+         */
         fun other(): GeneralCategoryGroup {
             
             val returnVal = lib.icu4x_GeneralCategoryGroup_other_mv1();
@@ -173,8 +182,9 @@ class GeneralCategoryGroup (var mask: UInt) {
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `Punctuation`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategoryGroup.html#associatedconstant.Punctuation) for more information.
-        */
+        /**
+         * See the [Rust documentation for `Punctuation`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategoryGroup.html#associatedconstant.Punctuation) for more information.
+         */
         fun punctuation(): GeneralCategoryGroup {
             
             val returnVal = lib.icu4x_GeneralCategoryGroup_punctuation_mv1();
@@ -183,8 +193,9 @@ class GeneralCategoryGroup (var mask: UInt) {
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `Symbol`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategoryGroup.html#associatedconstant.Symbol) for more information.
-        */
+        /**
+         * See the [Rust documentation for `Symbol`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategoryGroup.html#associatedconstant.Symbol) for more information.
+         */
         fun symbol(): GeneralCategoryGroup {
             
             val returnVal = lib.icu4x_GeneralCategoryGroup_symbol_mv1();
@@ -199,16 +210,18 @@ class GeneralCategoryGroup (var mask: UInt) {
     }
 
     
-    /** See the [Rust documentation for `contains`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategoryGroup.html#method.contains) for more information.
-    */
+    /**
+     * See the [Rust documentation for `contains`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategoryGroup.html#method.contains) for more information.
+     */
     fun contains(val_: GeneralCategory): Boolean {
         
         val returnVal = lib.icu4x_GeneralCategoryGroup_contains_mv1(this.toNative(), val_.toNative());
         return (returnVal > 0)
     }
     
-    /** See the [Rust documentation for `complement`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategoryGroup.html#method.complement) for more information.
-    */
+    /**
+     * See the [Rust documentation for `complement`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategoryGroup.html#method.complement) for more information.
+     */
     fun complement(): GeneralCategoryGroup {
         
         val returnVal = lib.icu4x_GeneralCategoryGroup_complement_mv1(this.toNative());
@@ -216,8 +229,9 @@ class GeneralCategoryGroup (var mask: UInt) {
         return returnStruct
     }
     
-    /** See the [Rust documentation for `union`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategoryGroup.html#method.union) for more information.
-    */
+    /**
+     * See the [Rust documentation for `union`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategoryGroup.html#method.union) for more information.
+     */
     fun union(other: GeneralCategoryGroup): GeneralCategoryGroup {
         
         val returnVal = lib.icu4x_GeneralCategoryGroup_union_mv1(this.toNative(), other.toNative());
@@ -225,8 +239,9 @@ class GeneralCategoryGroup (var mask: UInt) {
         return returnStruct
     }
     
-    /** See the [Rust documentation for `intersection`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategoryGroup.html#method.intersection) for more information.
-    */
+    /**
+     * See the [Rust documentation for `intersection`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategoryGroup.html#method.intersection) for more information.
+     */
     fun intersection(other: GeneralCategoryGroup): GeneralCategoryGroup {
         
         val returnVal = lib.icu4x_GeneralCategoryGroup_intersection_mv1(this.toNative(), other.toNative());

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/GeneralCategoryNameToGroupMapper.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/GeneralCategoryNameToGroupMapper.kt
@@ -12,12 +12,13 @@ internal interface GeneralCategoryNameToGroupMapperLib: Library {
     fun icu4x_GeneralCategoryNameToGroupMapper_create_mv1(): Pointer
     fun icu4x_GeneralCategoryNameToGroupMapper_create_with_provider_mv1(provider: Pointer): ResultPointerInt
 }
-/** A type capable of looking up General Category Group values from a string name.
-*
-*See the [Rust documentation for `PropertyParser`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyParser.html) for more information.
-*
-*See the [Rust documentation for `GeneralCategory`](https://docs.rs/icu/2.3.1/icu/properties/props/enum.GeneralCategory.html) for more information.
-*/
+/**
+ * A type capable of looking up General Category Group values from a string name.
+ *
+ * See the [Rust documentation for `PropertyParser`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyParser.html) for more information.
+ *
+ * See the [Rust documentation for `GeneralCategory`](https://docs.rs/icu/2.3.1/icu/properties/props/enum.GeneralCategory.html) for more information.
+ */
 class GeneralCategoryNameToGroupMapper internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -46,10 +47,11 @@ class GeneralCategoryNameToGroupMapper internal constructor (
         internal val lib: GeneralCategoryNameToGroupMapperLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Create a name-to-mask mapper for the `General_Category` property, using compiled data.
-        *
-        *See the [Rust documentation for `GeneralCategoryGroup`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategoryGroup.html) for more information.
-        */
+        /**
+         * Create a name-to-mask mapper for the `General_Category` property, using compiled data.
+         *
+         * See the [Rust documentation for `GeneralCategoryGroup`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategoryGroup.html) for more information.
+         */
         fun create(): GeneralCategoryNameToGroupMapper {
             
             val returnVal = lib.icu4x_GeneralCategoryNameToGroupMapper_create_mv1();
@@ -60,10 +62,11 @@ class GeneralCategoryNameToGroupMapper internal constructor (
         }
         @JvmStatic
         
-        /** Create a name-to-mask mapper for the `General_Category` property, using a particular data source.
-        *
-        *See the [Rust documentation for `GeneralCategoryGroup`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategoryGroup.html) for more information.
-        */
+        /**
+         * Create a name-to-mask mapper for the `General_Category` property, using a particular data source.
+         *
+         * See the [Rust documentation for `GeneralCategoryGroup`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GeneralCategoryGroup.html) for more information.
+         */
         fun createWithProvider(provider: DataProvider): Result<GeneralCategoryNameToGroupMapper> {
             
             val returnVal = lib.icu4x_GeneralCategoryNameToGroupMapper_create_with_provider_mv1(provider.handle);
@@ -79,12 +82,13 @@ class GeneralCategoryNameToGroupMapper internal constructor (
         }
     }
     
-    /** Get the mask value matching the given name, using strict matching
-    *
-    *Returns 0 if the name is unknown for this property
-    *
-    *See the [Rust documentation for `get_strict`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyParserBorrowed.html#method.get_strict) for more information.
-    */
+    /**
+     * Get the mask value matching the given name, using strict matching
+     *
+     * Returns 0 if the name is unknown for this property
+     *
+     * See the [Rust documentation for `get_strict`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyParserBorrowed.html#method.get_strict) for more information.
+     */
     fun getStrict(name: String): GeneralCategoryGroup {
         val nameSliceMemory = PrimitiveArrayTools.borrowUtf8(name)
         
@@ -97,12 +101,13 @@ class GeneralCategoryNameToGroupMapper internal constructor (
         }
     }
     
-    /** Get the mask value matching the given name, using loose matching
-    *
-    *Returns 0 if the name is unknown for this property
-    *
-    *See the [Rust documentation for `get_loose`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyParserBorrowed.html#method.get_loose) for more information.
-    */
+    /**
+     * Get the mask value matching the given name, using loose matching
+     *
+     * Returns 0 if the name is unknown for this property
+     *
+     * See the [Rust documentation for `get_loose`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyParserBorrowed.html#method.get_loose) for more information.
+     */
     fun getLoose(name: String): GeneralCategoryGroup {
         val nameSliceMemory = PrimitiveArrayTools.borrowUtf8(name)
         

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/GraphemeClusterBreak.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/GraphemeClusterBreak.kt
@@ -14,7 +14,8 @@ internal interface GraphemeClusterBreakLib: Library {
     fun icu4x_GraphemeClusterBreak_from_integer_value_mv1(other: FFIUint8): OptionInt
     fun icu4x_GraphemeClusterBreak_try_from_str_mv1(s: Slice): OptionInt
 }
-/** See the [Rust documentation for `GraphemeClusterBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GraphemeClusterBreak.html) for more information.
+/**
+ * See the [Rust documentation for `GraphemeClusterBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GraphemeClusterBreak.html) for more information.
 */
 enum class GraphemeClusterBreak {
     Other,
@@ -53,8 +54,9 @@ enum class GraphemeClusterBreak {
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.EnumeratedProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.EnumeratedProperty.html#tymethod.for_char) for more information.
+         */
         fun forChar(ch: Int): GraphemeClusterBreak {
             
             val returnVal = lib.icu4x_GraphemeClusterBreak_for_char_mv1(ch);
@@ -62,10 +64,11 @@ enum class GraphemeClusterBreak {
         }
         @JvmStatic
         
-        /** Convert from an integer value from ICU4C or `CodePointMapData`
-        *
-        *See the [Rust documentation for `from_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GraphemeClusterBreak.html#method.from_icu4c_value) for more information.
-        */
+        /**
+         * Convert from an integer value from ICU4C or `CodePointMapData`
+         *
+         * See the [Rust documentation for `from_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GraphemeClusterBreak.html#method.from_icu4c_value) for more information.
+         */
         fun fromIntegerValue(other: UByte): GraphemeClusterBreak? {
             
             val returnVal = lib.icu4x_GraphemeClusterBreak_from_integer_value_mv1(FFIUint8(other));
@@ -75,10 +78,11 @@ enum class GraphemeClusterBreak {
         }
         @JvmStatic
         
-        /** Creates a `GraphemeClusterBreak` from a string.
-        *
-        *Short names, long names, and aliases are supported, and matching is case-insensitive.
-        */
+        /**
+         * Creates a `GraphemeClusterBreak` from a string.
+         *
+         * Short names, long names, and aliases are supported, and matching is case-insensitive.
+         */
         fun tryFromStr(s: String): GraphemeClusterBreak? {
             val sSliceMemory = PrimitiveArrayTools.borrowUtf8(s)
             
@@ -93,10 +97,11 @@ enum class GraphemeClusterBreak {
         }
     }
     
-    /** Get the "long" name of this property value (returns empty if property value is unknown)
-    *
-    *See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesLongBorrowed.html#method.get) for more information.
-    */
+    /**
+     * Get the "long" name of this property value (returns empty if property value is unknown)
+     *
+     * See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesLongBorrowed.html#method.get) for more information.
+     */
     fun longName(): String? {
         
         val returnVal = lib.icu4x_GraphemeClusterBreak_long_name_mv1(this.toNative());
@@ -106,10 +111,11 @@ enum class GraphemeClusterBreak {
                                 
     }
     
-    /** Get the "short" name of this property value (returns empty if property value is unknown)
-    *
-    *See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesShortBorrowed.html#method.get) for more information.
-    */
+    /**
+     * Get the "short" name of this property value (returns empty if property value is unknown)
+     *
+     * See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesShortBorrowed.html#method.get) for more information.
+     */
     fun shortName(): String? {
         
         val returnVal = lib.icu4x_GraphemeClusterBreak_short_name_mv1(this.toNative());
@@ -119,10 +125,11 @@ enum class GraphemeClusterBreak {
                                 
     }
     
-    /** Convert to an integer value usable with ICU4C and `CodePointMapData`
-    *
-    *See the [Rust documentation for `to_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GraphemeClusterBreak.html#method.to_icu4c_value) for more information.
-    */
+    /**
+     * Convert to an integer value usable with ICU4C and `CodePointMapData`
+     *
+     * See the [Rust documentation for `to_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GraphemeClusterBreak.html#method.to_icu4c_value) for more information.
+     */
     fun toIntegerValue(): UByte {
         
         val returnVal = lib.icu4x_GraphemeClusterBreak_to_integer_value_mv1(this.toNative());

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/GraphemeClusterBreakIteratorLatin1.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/GraphemeClusterBreakIteratorLatin1.kt
@@ -9,8 +9,9 @@ internal interface GraphemeClusterBreakIteratorLatin1Lib: Library {
     fun icu4x_GraphemeClusterBreakIteratorLatin1_destroy_mv1(handle: Pointer)
     fun icu4x_GraphemeClusterBreakIteratorLatin1_next_mv1(handle: Pointer): Int
 }
-/** See the [Rust documentation for `GraphemeClusterBreakIterator`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.GraphemeClusterBreakIterator.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `GraphemeClusterBreakIterator`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.GraphemeClusterBreakIterator.html) for more information.
+ */
 class GraphemeClusterBreakIteratorLatin1 internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -40,11 +41,12 @@ class GraphemeClusterBreakIteratorLatin1 internal constructor (
         internal val lib: GraphemeClusterBreakIteratorLatin1Lib = Native.load("icu4x", libClass)
     }
     
-    /** Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
-    *out of range of a 32-bit signed integer.
-    *
-    *See the [Rust documentation for `next`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.GraphemeClusterBreakIterator.html#method.next) for more information.
-    */
+    /**
+     * Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
+     * out of range of a 32-bit signed integer.
+     *
+     * See the [Rust documentation for `next`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.GraphemeClusterBreakIterator.html#method.next) for more information.
+     */
     fun next(): Int {
         
         val returnVal = lib.icu4x_GraphemeClusterBreakIteratorLatin1_next_mv1(handle);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/GraphemeClusterBreakIteratorUtf16.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/GraphemeClusterBreakIteratorUtf16.kt
@@ -9,8 +9,9 @@ internal interface GraphemeClusterBreakIteratorUtf16Lib: Library {
     fun icu4x_GraphemeClusterBreakIteratorUtf16_destroy_mv1(handle: Pointer)
     fun icu4x_GraphemeClusterBreakIteratorUtf16_next_mv1(handle: Pointer): Int
 }
-/** See the [Rust documentation for `GraphemeClusterBreakIterator`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.GraphemeClusterBreakIterator.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `GraphemeClusterBreakIterator`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.GraphemeClusterBreakIterator.html) for more information.
+ */
 class GraphemeClusterBreakIteratorUtf16 internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -40,11 +41,12 @@ class GraphemeClusterBreakIteratorUtf16 internal constructor (
         internal val lib: GraphemeClusterBreakIteratorUtf16Lib = Native.load("icu4x", libClass)
     }
     
-    /** Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
-    *out of range of a 32-bit signed integer.
-    *
-    *See the [Rust documentation for `next`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.GraphemeClusterBreakIterator.html#method.next) for more information.
-    */
+    /**
+     * Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
+     * out of range of a 32-bit signed integer.
+     *
+     * See the [Rust documentation for `next`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.GraphemeClusterBreakIterator.html#method.next) for more information.
+     */
     fun next(): Int {
         
         val returnVal = lib.icu4x_GraphemeClusterBreakIteratorUtf16_next_mv1(handle);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/GraphemeClusterBreakIteratorUtf8.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/GraphemeClusterBreakIteratorUtf8.kt
@@ -9,8 +9,9 @@ internal interface GraphemeClusterBreakIteratorUtf8Lib: Library {
     fun icu4x_GraphemeClusterBreakIteratorUtf8_destroy_mv1(handle: Pointer)
     fun icu4x_GraphemeClusterBreakIteratorUtf8_next_mv1(handle: Pointer): Int
 }
-/** See the [Rust documentation for `GraphemeClusterBreakIterator`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.GraphemeClusterBreakIterator.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `GraphemeClusterBreakIterator`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.GraphemeClusterBreakIterator.html) for more information.
+ */
 class GraphemeClusterBreakIteratorUtf8 internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -40,11 +41,12 @@ class GraphemeClusterBreakIteratorUtf8 internal constructor (
         internal val lib: GraphemeClusterBreakIteratorUtf8Lib = Native.load("icu4x", libClass)
     }
     
-    /** Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
-    *out of range of a 32-bit signed integer.
-    *
-    *See the [Rust documentation for `next`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.GraphemeClusterBreakIterator.html#method.next) for more information.
-    */
+    /**
+     * Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
+     * out of range of a 32-bit signed integer.
+     *
+     * See the [Rust documentation for `next`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.GraphemeClusterBreakIterator.html#method.next) for more information.
+     */
     fun next(): Int {
         
         val returnVal = lib.icu4x_GraphemeClusterBreakIteratorUtf8_next_mv1(handle);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/GraphemeClusterSegmenter.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/GraphemeClusterSegmenter.kt
@@ -11,11 +11,12 @@ internal interface GraphemeClusterSegmenterLib: Library {
     fun icu4x_GraphemeClusterSegmenter_create_with_provider_mv1(provider: Pointer): ResultPointerInt
     fun icu4x_GraphemeClusterSegmenter_segment_utf16_mv1(handle: Pointer, input: Slice): Pointer
 }
-/** An ICU4X grapheme-cluster-break segmenter, capable of finding grapheme cluster breakpoints
-*in strings.
-*
-*See the [Rust documentation for `GraphemeClusterSegmenter`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.GraphemeClusterSegmenter.html) for more information.
-*/
+/**
+ * An ICU4X grapheme-cluster-break segmenter, capable of finding grapheme cluster breakpoints
+ * in strings.
+ *
+ * See the [Rust documentation for `GraphemeClusterSegmenter`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.GraphemeClusterSegmenter.html) for more information.
+ */
 class GraphemeClusterSegmenter internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -44,10 +45,11 @@ class GraphemeClusterSegmenter internal constructor (
         internal val lib: GraphemeClusterSegmenterLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Construct an [GraphemeClusterSegmenter] using compiled data.
-        *
-        *See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.GraphemeClusterSegmenter.html#method.new) for more information.
-        */
+        /**
+         * Construct an [GraphemeClusterSegmenter] using compiled data.
+         *
+         * See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.GraphemeClusterSegmenter.html#method.new) for more information.
+         */
         fun create(): GraphemeClusterSegmenter {
             
             val returnVal = lib.icu4x_GraphemeClusterSegmenter_create_mv1();
@@ -58,10 +60,11 @@ class GraphemeClusterSegmenter internal constructor (
         }
         @JvmStatic
         
-        /** Construct an [GraphemeClusterSegmenter].
-        *
-        *See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.GraphemeClusterSegmenter.html#method.new) for more information.
-        */
+        /**
+         * Construct an [GraphemeClusterSegmenter].
+         *
+         * See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.GraphemeClusterSegmenter.html#method.new) for more information.
+         */
         fun createWithProvider(provider: DataProvider): Result<GraphemeClusterSegmenter> {
             
             val returnVal = lib.icu4x_GraphemeClusterSegmenter_create_with_provider_mv1(provider.handle);
@@ -77,13 +80,14 @@ class GraphemeClusterSegmenter internal constructor (
         }
     }
     
-    /** Segments a string.
-    *
-    *Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
-    *to the WHATWG Encoding Standard.
-    *
-    *See the [Rust documentation for `segment_utf16`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.GraphemeClusterSegmenterBorrowed.html#method.segment_utf16) for more information.
-    */
+    /**
+     * Segments a string.
+     *
+     * Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
+     * to the WHATWG Encoding Standard.
+     *
+     * See the [Rust documentation for `segment_utf16`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.GraphemeClusterSegmenterBorrowed.html#method.segment_utf16) for more information.
+     */
     fun segment(input: String): GraphemeClusterBreakIteratorUtf16 {
         // This lifetime edge depends on lifetimes: 'a
         val aEdges: MutableList<Any> = mutableListOf(this);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/HangulSyllableType.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/HangulSyllableType.kt
@@ -14,7 +14,8 @@ internal interface HangulSyllableTypeLib: Library {
     fun icu4x_HangulSyllableType_from_integer_value_mv1(other: FFIUint8): OptionInt
     fun icu4x_HangulSyllableType_try_from_str_mv1(s: Slice): OptionInt
 }
-/** See the [Rust documentation for `HangulSyllableType`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.HangulSyllableType.html) for more information.
+/**
+ * See the [Rust documentation for `HangulSyllableType`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.HangulSyllableType.html) for more information.
 */
 enum class HangulSyllableType {
     NotApplicable,
@@ -41,8 +42,9 @@ enum class HangulSyllableType {
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.EnumeratedProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.EnumeratedProperty.html#tymethod.for_char) for more information.
+         */
         fun forChar(ch: Int): HangulSyllableType {
             
             val returnVal = lib.icu4x_HangulSyllableType_for_char_mv1(ch);
@@ -50,10 +52,11 @@ enum class HangulSyllableType {
         }
         @JvmStatic
         
-        /** Convert from an integer value from ICU4C or `CodePointMapData`
-        *
-        *See the [Rust documentation for `from_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.HangulSyllableType.html#method.from_icu4c_value) for more information.
-        */
+        /**
+         * Convert from an integer value from ICU4C or `CodePointMapData`
+         *
+         * See the [Rust documentation for `from_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.HangulSyllableType.html#method.from_icu4c_value) for more information.
+         */
         fun fromIntegerValue(other: UByte): HangulSyllableType? {
             
             val returnVal = lib.icu4x_HangulSyllableType_from_integer_value_mv1(FFIUint8(other));
@@ -63,10 +66,11 @@ enum class HangulSyllableType {
         }
         @JvmStatic
         
-        /** Creates a `HangulSyllableType` from a string.
-        *
-        *Short names, long names, and aliases are supported, and matching is case-insensitive.
-        */
+        /**
+         * Creates a `HangulSyllableType` from a string.
+         *
+         * Short names, long names, and aliases are supported, and matching is case-insensitive.
+         */
         fun tryFromStr(s: String): HangulSyllableType? {
             val sSliceMemory = PrimitiveArrayTools.borrowUtf8(s)
             
@@ -81,10 +85,11 @@ enum class HangulSyllableType {
         }
     }
     
-    /** Get the "long" name of this property value (returns empty if property value is unknown)
-    *
-    *See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesLongBorrowed.html#method.get) for more information.
-    */
+    /**
+     * Get the "long" name of this property value (returns empty if property value is unknown)
+     *
+     * See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesLongBorrowed.html#method.get) for more information.
+     */
     fun longName(): String? {
         
         val returnVal = lib.icu4x_HangulSyllableType_long_name_mv1(this.toNative());
@@ -94,10 +99,11 @@ enum class HangulSyllableType {
                                 
     }
     
-    /** Get the "short" name of this property value (returns empty if property value is unknown)
-    *
-    *See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesShortBorrowed.html#method.get) for more information.
-    */
+    /**
+     * Get the "short" name of this property value (returns empty if property value is unknown)
+     *
+     * See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesShortBorrowed.html#method.get) for more information.
+     */
     fun shortName(): String? {
         
         val returnVal = lib.icu4x_HangulSyllableType_short_name_mv1(this.toNative());
@@ -107,10 +113,11 @@ enum class HangulSyllableType {
                                 
     }
     
-    /** Convert to an integer value usable with ICU4C and `CodePointMapData`
-    *
-    *See the [Rust documentation for `to_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.HangulSyllableType.html#method.to_icu4c_value) for more information.
-    */
+    /**
+     * Convert to an integer value usable with ICU4C and `CodePointMapData`
+     *
+     * See the [Rust documentation for `to_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.HangulSyllableType.html#method.to_icu4c_value) for more information.
+     */
     fun toIntegerValue(): UByte {
         
         val returnVal = lib.icu4x_HangulSyllableType_to_integer_value_mv1(this.toNative());

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/IanaParser.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/IanaParser.kt
@@ -12,13 +12,14 @@ internal interface IanaParserLib: Library {
     fun icu4x_IanaParser_parse_mv1(handle: Pointer, value: Slice): Pointer
     fun icu4x_IanaParser_iter_mv1(handle: Pointer): Pointer
 }
-/** A mapper between IANA time zone identifiers and BCP-47 time zone identifiers.
-*
-*This mapper supports two-way mapping, but it is optimized for the case of IANA to BCP-47.
-*It also supports normalizing and canonicalizing the IANA strings.
-*
-*See the [Rust documentation for `IanaParser`](https://docs.rs/icu/2.3.1/icu/time/zone/iana/struct.IanaParser.html) for more information.
-*/
+/**
+ * A mapper between IANA time zone identifiers and BCP-47 time zone identifiers.
+ *
+ * This mapper supports two-way mapping, but it is optimized for the case of IANA to BCP-47.
+ * It also supports normalizing and canonicalizing the IANA strings.
+ *
+ * See the [Rust documentation for `IanaParser`](https://docs.rs/icu/2.3.1/icu/time/zone/iana/struct.IanaParser.html) for more information.
+ */
 class IanaParser internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -47,10 +48,11 @@ class IanaParser internal constructor (
         internal val lib: IanaParserLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Create a new [IanaParser] using compiled data
-        *
-        *See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/time/zone/iana/struct.IanaParser.html#method.new) for more information.
-        */
+        /**
+         * Create a new [IanaParser] using compiled data
+         *
+         * See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/time/zone/iana/struct.IanaParser.html#method.new) for more information.
+         */
         fun create(): IanaParser {
             
             val returnVal = lib.icu4x_IanaParser_create_mv1();
@@ -61,10 +63,11 @@ class IanaParser internal constructor (
         }
         @JvmStatic
         
-        /** Create a new [IanaParser] using a particular data source
-        *
-        *See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/time/zone/iana/struct.IanaParser.html#method.new) for more information.
-        */
+        /**
+         * Create a new [IanaParser] using a particular data source
+         *
+         * See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/time/zone/iana/struct.IanaParser.html#method.new) for more information.
+         */
         fun createWithProvider(provider: DataProvider): Result<IanaParser> {
             
             val returnVal = lib.icu4x_IanaParser_create_with_provider_mv1(provider.handle);
@@ -80,8 +83,9 @@ class IanaParser internal constructor (
         }
     }
     
-    /** See the [Rust documentation for `parse`](https://docs.rs/icu/2.3.1/icu/time/zone/iana/struct.IanaParserBorrowed.html#method.parse) for more information.
-    */
+    /**
+     * See the [Rust documentation for `parse`](https://docs.rs/icu/2.3.1/icu/time/zone/iana/struct.IanaParserBorrowed.html#method.parse) for more information.
+     */
     fun parse(value: String): TimeZone {
         val valueSliceMemory = PrimitiveArrayTools.borrowUtf8(value)
         
@@ -96,8 +100,9 @@ class IanaParser internal constructor (
         }
     }
     
-    /** See the [Rust documentation for `iter`](https://docs.rs/icu/2.3.1/icu/time/zone/iana/struct.IanaParserBorrowed.html#method.iter) for more information.
-    */
+    /**
+     * See the [Rust documentation for `iter`](https://docs.rs/icu/2.3.1/icu/time/zone/iana/struct.IanaParserBorrowed.html#method.iter) for more information.
+     */
     fun iter(): TimeZoneIterator {
         // This lifetime edge depends on lifetimes: 'a
         val aEdges: MutableList<Any> = mutableListOf(this);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/IanaParserExtended.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/IanaParserExtended.kt
@@ -13,13 +13,14 @@ internal interface IanaParserExtendedLib: Library {
     fun icu4x_IanaParserExtended_iter_mv1(handle: Pointer): Pointer
     fun icu4x_IanaParserExtended_iter_all_mv1(handle: Pointer): Pointer
 }
-/** A mapper between IANA time zone identifiers and BCP-47 time zone identifiers.
-*
-*This mapper supports two-way mapping, but it is optimized for the case of IANA to BCP-47.
-*It also supports normalizing and canonicalizing the IANA strings.
-*
-*See the [Rust documentation for `IanaParserExtended`](https://docs.rs/icu/2.3.1/icu/time/zone/iana/struct.IanaParserExtended.html) for more information.
-*/
+/**
+ * A mapper between IANA time zone identifiers and BCP-47 time zone identifiers.
+ *
+ * This mapper supports two-way mapping, but it is optimized for the case of IANA to BCP-47.
+ * It also supports normalizing and canonicalizing the IANA strings.
+ *
+ * See the [Rust documentation for `IanaParserExtended`](https://docs.rs/icu/2.3.1/icu/time/zone/iana/struct.IanaParserExtended.html) for more information.
+ */
 class IanaParserExtended internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -48,10 +49,11 @@ class IanaParserExtended internal constructor (
         internal val lib: IanaParserExtendedLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Create a new [IanaParserExtended] using compiled data
-        *
-        *See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/time/zone/iana/struct.IanaParserExtended.html#method.new) for more information.
-        */
+        /**
+         * Create a new [IanaParserExtended] using compiled data
+         *
+         * See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/time/zone/iana/struct.IanaParserExtended.html#method.new) for more information.
+         */
         fun create(): IanaParserExtended {
             
             val returnVal = lib.icu4x_IanaParserExtended_create_mv1();
@@ -62,10 +64,11 @@ class IanaParserExtended internal constructor (
         }
         @JvmStatic
         
-        /** Create a new [IanaParserExtended] using a particular data source
-        *
-        *See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/time/zone/iana/struct.IanaParserExtended.html#method.new) for more information.
-        */
+        /**
+         * Create a new [IanaParserExtended] using a particular data source
+         *
+         * See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/time/zone/iana/struct.IanaParserExtended.html#method.new) for more information.
+         */
         fun createWithProvider(provider: DataProvider): Result<IanaParserExtended> {
             
             val returnVal = lib.icu4x_IanaParserExtended_create_with_provider_mv1(provider.handle);
@@ -81,8 +84,9 @@ class IanaParserExtended internal constructor (
         }
     }
     
-    /** See the [Rust documentation for `parse`](https://docs.rs/icu/2.3.1/icu/time/zone/iana/struct.IanaParserExtendedBorrowed.html#method.parse) for more information.
-    */
+    /**
+     * See the [Rust documentation for `parse`](https://docs.rs/icu/2.3.1/icu/time/zone/iana/struct.IanaParserExtendedBorrowed.html#method.parse) for more information.
+     */
     fun parse(value: String): TimeZoneAndCanonicalAndNormalized {
         // This lifetime edge depends on lifetimes: 'a
         val aEdges: MutableList<Any> = mutableListOf(this);
@@ -97,8 +101,9 @@ class IanaParserExtended internal constructor (
         }
     }
     
-    /** See the [Rust documentation for `iter`](https://docs.rs/icu/2.3.1/icu/time/zone/iana/struct.IanaParserExtendedBorrowed.html#method.iter) for more information.
-    */
+    /**
+     * See the [Rust documentation for `iter`](https://docs.rs/icu/2.3.1/icu/time/zone/iana/struct.IanaParserExtendedBorrowed.html#method.iter) for more information.
+     */
     fun iter(): TimeZoneAndCanonicalIterator {
         // This lifetime edge depends on lifetimes: 'a
         val aEdges: MutableList<Any> = mutableListOf(this);
@@ -110,8 +115,9 @@ class IanaParserExtended internal constructor (
         return returnOpaque
     }
     
-    /** See the [Rust documentation for `iter_all`](https://docs.rs/icu/2.3.1/icu/time/zone/iana/struct.IanaParserExtendedBorrowed.html#method.iter_all) for more information.
-    */
+    /**
+     * See the [Rust documentation for `iter_all`](https://docs.rs/icu/2.3.1/icu/time/zone/iana/struct.IanaParserExtendedBorrowed.html#method.iter_all) for more information.
+     */
     fun iterAll(): TimeZoneAndCanonicalAndNormalizedIterator {
         // This lifetime edge depends on lifetimes: 'a
         val aEdges: MutableList<Any> = mutableListOf(this);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/IndicConjunctBreak.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/IndicConjunctBreak.kt
@@ -14,7 +14,8 @@ internal interface IndicConjunctBreakLib: Library {
     fun icu4x_IndicConjunctBreak_from_integer_value_mv1(other: FFIUint8): OptionInt
     fun icu4x_IndicConjunctBreak_try_from_str_mv1(s: Slice): OptionInt
 }
-/** See the [Rust documentation for `IndicConjunctBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IndicConjunctBreak.html) for more information.
+/**
+ * See the [Rust documentation for `IndicConjunctBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IndicConjunctBreak.html) for more information.
 */
 enum class IndicConjunctBreak {
     None,
@@ -39,8 +40,9 @@ enum class IndicConjunctBreak {
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.EnumeratedProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.EnumeratedProperty.html#tymethod.for_char) for more information.
+         */
         fun forChar(ch: Int): IndicConjunctBreak {
             
             val returnVal = lib.icu4x_IndicConjunctBreak_for_char_mv1(ch);
@@ -48,10 +50,11 @@ enum class IndicConjunctBreak {
         }
         @JvmStatic
         
-        /** Convert from an integer value from ICU4C or `CodePointMapData`
-        *
-        *See the [Rust documentation for `from_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IndicConjunctBreak.html#method.from_icu4c_value) for more information.
-        */
+        /**
+         * Convert from an integer value from ICU4C or `CodePointMapData`
+         *
+         * See the [Rust documentation for `from_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IndicConjunctBreak.html#method.from_icu4c_value) for more information.
+         */
         fun fromIntegerValue(other: UByte): IndicConjunctBreak? {
             
             val returnVal = lib.icu4x_IndicConjunctBreak_from_integer_value_mv1(FFIUint8(other));
@@ -61,10 +64,11 @@ enum class IndicConjunctBreak {
         }
         @JvmStatic
         
-        /** Creates a `IndicConjunctBreak` from a string.
-        *
-        *Short names, long names, and aliases are supported, and matching is case-insensitive.
-        */
+        /**
+         * Creates a `IndicConjunctBreak` from a string.
+         *
+         * Short names, long names, and aliases are supported, and matching is case-insensitive.
+         */
         fun tryFromStr(s: String): IndicConjunctBreak? {
             val sSliceMemory = PrimitiveArrayTools.borrowUtf8(s)
             
@@ -79,10 +83,11 @@ enum class IndicConjunctBreak {
         }
     }
     
-    /** Get the "long" name of this property value (returns empty if property value is unknown)
-    *
-    *See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesLongBorrowed.html#method.get) for more information.
-    */
+    /**
+     * Get the "long" name of this property value (returns empty if property value is unknown)
+     *
+     * See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesLongBorrowed.html#method.get) for more information.
+     */
     fun longName(): String? {
         
         val returnVal = lib.icu4x_IndicConjunctBreak_long_name_mv1(this.toNative());
@@ -92,10 +97,11 @@ enum class IndicConjunctBreak {
                                 
     }
     
-    /** Get the "short" name of this property value (returns empty if property value is unknown)
-    *
-    *See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesShortBorrowed.html#method.get) for more information.
-    */
+    /**
+     * Get the "short" name of this property value (returns empty if property value is unknown)
+     *
+     * See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesShortBorrowed.html#method.get) for more information.
+     */
     fun shortName(): String? {
         
         val returnVal = lib.icu4x_IndicConjunctBreak_short_name_mv1(this.toNative());
@@ -105,10 +111,11 @@ enum class IndicConjunctBreak {
                                 
     }
     
-    /** Convert to an integer value usable with ICU4C and `CodePointMapData`
-    *
-    *See the [Rust documentation for `to_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IndicConjunctBreak.html#method.to_icu4c_value) for more information.
-    */
+    /**
+     * Convert to an integer value usable with ICU4C and `CodePointMapData`
+     *
+     * See the [Rust documentation for `to_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IndicConjunctBreak.html#method.to_icu4c_value) for more information.
+     */
     fun toIntegerValue(): UByte {
         
         val returnVal = lib.icu4x_IndicConjunctBreak_to_integer_value_mv1(this.toNative());

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/IndicSyllabicCategory.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/IndicSyllabicCategory.kt
@@ -14,7 +14,8 @@ internal interface IndicSyllabicCategoryLib: Library {
     fun icu4x_IndicSyllabicCategory_from_integer_value_mv1(other: FFIUint8): OptionInt
     fun icu4x_IndicSyllabicCategory_try_from_str_mv1(s: Slice): OptionInt
 }
-/** See the [Rust documentation for `IndicSyllabicCategory`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IndicSyllabicCategory.html) for more information.
+/**
+ * See the [Rust documentation for `IndicSyllabicCategory`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IndicSyllabicCategory.html) for more information.
 */
 enum class IndicSyllabicCategory {
     Other,
@@ -72,8 +73,9 @@ enum class IndicSyllabicCategory {
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.EnumeratedProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.EnumeratedProperty.html#tymethod.for_char) for more information.
+         */
         fun forChar(ch: Int): IndicSyllabicCategory {
             
             val returnVal = lib.icu4x_IndicSyllabicCategory_for_char_mv1(ch);
@@ -81,10 +83,11 @@ enum class IndicSyllabicCategory {
         }
         @JvmStatic
         
-        /** Convert from an integer value from ICU4C or `CodePointMapData`
-        *
-        *See the [Rust documentation for `from_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IndicSyllabicCategory.html#method.from_icu4c_value) for more information.
-        */
+        /**
+         * Convert from an integer value from ICU4C or `CodePointMapData`
+         *
+         * See the [Rust documentation for `from_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IndicSyllabicCategory.html#method.from_icu4c_value) for more information.
+         */
         fun fromIntegerValue(other: UByte): IndicSyllabicCategory? {
             
             val returnVal = lib.icu4x_IndicSyllabicCategory_from_integer_value_mv1(FFIUint8(other));
@@ -94,10 +97,11 @@ enum class IndicSyllabicCategory {
         }
         @JvmStatic
         
-        /** Creates a `IndicSyllabicCategory` from a string.
-        *
-        *Short names, long names, and aliases are supported, and matching is case-insensitive.
-        */
+        /**
+         * Creates a `IndicSyllabicCategory` from a string.
+         *
+         * Short names, long names, and aliases are supported, and matching is case-insensitive.
+         */
         fun tryFromStr(s: String): IndicSyllabicCategory? {
             val sSliceMemory = PrimitiveArrayTools.borrowUtf8(s)
             
@@ -112,10 +116,11 @@ enum class IndicSyllabicCategory {
         }
     }
     
-    /** Get the "long" name of this property value (returns empty if property value is unknown)
-    *
-    *See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesLongBorrowed.html#method.get) for more information.
-    */
+    /**
+     * Get the "long" name of this property value (returns empty if property value is unknown)
+     *
+     * See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesLongBorrowed.html#method.get) for more information.
+     */
     fun longName(): String? {
         
         val returnVal = lib.icu4x_IndicSyllabicCategory_long_name_mv1(this.toNative());
@@ -125,10 +130,11 @@ enum class IndicSyllabicCategory {
                                 
     }
     
-    /** Get the "short" name of this property value (returns empty if property value is unknown)
-    *
-    *See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesShortBorrowed.html#method.get) for more information.
-    */
+    /**
+     * Get the "short" name of this property value (returns empty if property value is unknown)
+     *
+     * See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesShortBorrowed.html#method.get) for more information.
+     */
     fun shortName(): String? {
         
         val returnVal = lib.icu4x_IndicSyllabicCategory_short_name_mv1(this.toNative());
@@ -138,10 +144,11 @@ enum class IndicSyllabicCategory {
                                 
     }
     
-    /** Convert to an integer value usable with ICU4C and `CodePointMapData`
-    *
-    *See the [Rust documentation for `to_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IndicSyllabicCategory.html#method.to_icu4c_value) for more information.
-    */
+    /**
+     * Convert to an integer value usable with ICU4C and `CodePointMapData`
+     *
+     * See the [Rust documentation for `to_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IndicSyllabicCategory.html#method.to_icu4c_value) for more information.
+     */
     fun toIntegerValue(): UByte {
         
         val returnVal = lib.icu4x_IndicSyllabicCategory_to_integer_value_mv1(this.toNative());

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/IsoDate.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/IsoDate.kt
@@ -27,10 +27,11 @@ internal interface IsoDateLib: Library {
     fun icu4x_IsoDate_try_add_with_options_mv1(handle: Pointer, duration: DateDurationNative, options: DateAddOptionsNative): ResultPointerInt
     fun icu4x_IsoDate_until_with_options_mv1(handle: Pointer, other: Pointer, options: DateDifferenceOptionsNative): DateDurationNative
 }
-/** An ICU4X Date object capable of containing a ISO-8601 date
-*
-*See the [Rust documentation for `Date`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html) for more information.
-*/
+/**
+ * An ICU4X Date object capable of containing a ISO-8601 date
+ *
+ * See the [Rust documentation for `Date`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html) for more information.
+ */
 class IsoDate internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -59,10 +60,11 @@ class IsoDate internal constructor (
         internal val lib: IsoDateLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Creates a new [IsoDate] from the specified date.
-        *
-        *See the [Rust documentation for `try_new_iso`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.try_new_iso) for more information.
-        */
+        /**
+         * Creates a new [IsoDate] from the specified date.
+         *
+         * See the [Rust documentation for `try_new_iso`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.try_new_iso) for more information.
+         */
         fun create(year: Int, month: UByte, day: UByte): Result<IsoDate> {
             
             val returnVal = lib.icu4x_IsoDate_create_mv1(year, FFIUint8(month), FFIUint8(day));
@@ -78,10 +80,11 @@ class IsoDate internal constructor (
         }
         @JvmStatic
         
-        /** Creates a new [IsoDate] from the given Rata Die
-        *
-        *See the [Rust documentation for `from_rata_die`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.from_rata_die) for more information.
-        */
+        /**
+         * Creates a new [IsoDate] from the given Rata Die
+         *
+         * See the [Rust documentation for `from_rata_die`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.from_rata_die) for more information.
+         */
         fun fromRataDie(rd: Long): IsoDate {
             
             val returnVal = lib.icu4x_IsoDate_from_rata_die_mv1(rd);
@@ -92,10 +95,11 @@ class IsoDate internal constructor (
         }
         @JvmStatic
         
-        /** Creates a new [IsoDate] from an IXDTF string.
-        *
-        *See the [Rust documentation for `try_from_str`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.try_from_str) for more information.
-        */
+        /**
+         * Creates a new [IsoDate] from an IXDTF string.
+         *
+         * See the [Rust documentation for `try_from_str`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.try_from_str) for more information.
+         */
         fun fromString(v: String): Result<IsoDate> {
             val vSliceMemory = PrimitiveArrayTools.borrowUtf8(v)
             
@@ -116,10 +120,11 @@ class IsoDate internal constructor (
         }
     }
     
-    /** Convert this date to one in a different calendar
-    *
-    *See the [Rust documentation for `to_calendar`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.to_calendar) for more information.
-    */
+    /**
+     * Convert this date to one in a different calendar
+     *
+     * See the [Rust documentation for `to_calendar`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.to_calendar) for more information.
+     */
     fun toCalendar(calendar: Calendar): Date {
         
         val returnVal = lib.icu4x_IsoDate_to_calendar_mv1(handle, calendar.handle);
@@ -129,8 +134,9 @@ class IsoDate internal constructor (
         return returnOpaque
     }
     
-    /** See the [Rust documentation for `to_any`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.to_any) for more information.
-    */
+    /**
+     * See the [Rust documentation for `to_any`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.to_any) for more information.
+     */
     fun toAny(): Date {
         
         val returnVal = lib.icu4x_IsoDate_to_any_mv1(handle);
@@ -140,63 +146,69 @@ class IsoDate internal constructor (
         return returnOpaque
     }
     
-    /** Returns this date's Rata Die
-    *
-    *See the [Rust documentation for `to_rata_die`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.to_rata_die) for more information.
-    */
+    /**
+     * Returns this date's Rata Die
+     *
+     * See the [Rust documentation for `to_rata_die`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.to_rata_die) for more information.
+     */
     fun toRataDie(): Long {
         
         val returnVal = lib.icu4x_IsoDate_to_rata_die_mv1(handle);
         return (returnVal)
     }
     
-    /** Returns the 1-indexed day in the year for this date
-    *
-    *See the [Rust documentation for `day_of_year`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.day_of_year) for more information.
-    */
+    /**
+     * Returns the 1-indexed day in the year for this date
+     *
+     * See the [Rust documentation for `day_of_year`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.day_of_year) for more information.
+     */
     fun dayOfYear(): UShort {
         
         val returnVal = lib.icu4x_IsoDate_day_of_year_mv1(handle);
         return (returnVal.toUShort())
     }
     
-    /** Returns the 1-indexed day in the month for this date
-    *
-    *See the [Rust documentation for `day_of_month`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.day_of_month) for more information.
-    */
+    /**
+     * Returns the 1-indexed day in the month for this date
+     *
+     * See the [Rust documentation for `day_of_month`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.day_of_month) for more information.
+     */
     fun dayOfMonth(): UByte {
         
         val returnVal = lib.icu4x_IsoDate_day_of_month_mv1(handle);
         return (returnVal.toUByte())
     }
     
-    /** Returns the day in the week for this day
-    *
-    *This is *not* the day of the week, an ordinal number that is locale
-    *dependent.
-    *
-    *See the [Rust documentation for `day_of_week`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.day_of_week) for more information.
-    */
+    /**
+     * Returns the day in the week for this day
+     *
+     * This is *not* the day of the week, an ordinal number that is locale
+     * dependent.
+     *
+     * See the [Rust documentation for `day_of_week`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.day_of_week) for more information.
+     */
     fun dayOfWeek(): Weekday {
         
         val returnVal = lib.icu4x_IsoDate_day_of_week_mv1(handle);
         return (Weekday.fromNative(returnVal))
     }
     
-    /** Returns the day in the week for this day
-    *
-    *See the [Rust documentation for `weekday`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.weekday) for more information.
-    */
+    /**
+     * Returns the day in the week for this day
+     *
+     * See the [Rust documentation for `weekday`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.weekday) for more information.
+     */
     fun weekday(): Weekday {
         
         val returnVal = lib.icu4x_IsoDate_weekday_mv1(handle);
         return (Weekday.fromNative(returnVal))
     }
     
-    /** Returns the week number in this year, using week data
-    *
-    *See the [Rust documentation for `week_of_year`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.week_of_year) for more information.
-    */
+    /**
+     * Returns the week number in this year, using week data
+     *
+     * See the [Rust documentation for `week_of_year`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.week_of_year) for more information.
+     */
     fun weekOfYear(): IsoWeekOfYear {
         
         val returnVal = lib.icu4x_IsoDate_week_of_year_mv1(handle);
@@ -204,74 +216,81 @@ class IsoDate internal constructor (
         return returnStruct
     }
     
-    /** Returns 1-indexed number of the month of this date in its year
-    *
-    *See the [Rust documentation for `ordinal`](https://docs.rs/icu/2.3.1/icu/calendar/types/struct.MonthInfo.html#structfield.ordinal) for more information.
-    *
-    *Additional information: [1](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.month)
-    */
+    /**
+     * Returns 1-indexed number of the month of this date in its year
+     *
+     * See the [Rust documentation for `ordinal`](https://docs.rs/icu/2.3.1/icu/calendar/types/struct.MonthInfo.html#structfield.ordinal) for more information.
+     *
+     * Additional information: [1](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.month)
+     */
     fun month(): UByte {
         
         val returnVal = lib.icu4x_IsoDate_month_mv1(handle);
         return (returnVal.toUByte())
     }
     
-    /** Returns the year number in the current era for this date
-    *
-    *For calendars without an era, returns the extended year
-    *
-    *See the [Rust documentation for `extended_year`](https://docs.rs/icu/2.3.1/icu/calendar/types/enum.YearInfo.html#method.extended_year) for more information.
-    */
+    /**
+     * Returns the year number in the current era for this date
+     *
+     * For calendars without an era, returns the extended year
+     *
+     * See the [Rust documentation for `extended_year`](https://docs.rs/icu/2.3.1/icu/calendar/types/enum.YearInfo.html#method.extended_year) for more information.
+     */
     fun year(): Int {
         
         val returnVal = lib.icu4x_IsoDate_year_mv1(handle);
         return (returnVal)
     }
     
-    /** Returns if the year is a leap year for this date
-    *
-    *See the [Rust documentation for `is_in_leap_year`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.is_in_leap_year) for more information.
-    */
+    /**
+     * Returns if the year is a leap year for this date
+     *
+     * See the [Rust documentation for `is_in_leap_year`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.is_in_leap_year) for more information.
+     */
     fun isInLeapYear(): Boolean {
         
         val returnVal = lib.icu4x_IsoDate_is_in_leap_year_mv1(handle);
         return (returnVal > 0)
     }
     
-    /** Returns the number of months in the year represented by this date
-    *
-    *See the [Rust documentation for `months_in_year`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.months_in_year) for more information.
-    */
+    /**
+     * Returns the number of months in the year represented by this date
+     *
+     * See the [Rust documentation for `months_in_year`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.months_in_year) for more information.
+     */
     fun monthsInYear(): UByte {
         
         val returnVal = lib.icu4x_IsoDate_months_in_year_mv1(handle);
         return (returnVal.toUByte())
     }
     
-    /** Returns the number of days in the month represented by this date
-    *
-    *See the [Rust documentation for `days_in_month`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.days_in_month) for more information.
-    */
+    /**
+     * Returns the number of days in the month represented by this date
+     *
+     * See the [Rust documentation for `days_in_month`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.days_in_month) for more information.
+     */
     fun daysInMonth(): UByte {
         
         val returnVal = lib.icu4x_IsoDate_days_in_month_mv1(handle);
         return (returnVal.toUByte())
     }
     
-    /** Returns the number of days in the year represented by this date
-    *
-    *See the [Rust documentation for `days_in_year`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.days_in_year) for more information.
-    */
+    /**
+     * Returns the number of days in the year represented by this date
+     *
+     * See the [Rust documentation for `days_in_year`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.days_in_year) for more information.
+     */
     fun daysInYear(): UShort {
         
         val returnVal = lib.icu4x_IsoDate_days_in_year_mv1(handle);
         return (returnVal.toUShort())
     }
     
-    /** Returns a new [IsoDate] with the given duration added to it.
-    *
-    *See the [Rust documentation for `try_added_with_options`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.try_added_with_options) for more information.
-    */
+    /**
+     * Returns a new [IsoDate] with the given duration added to it.
+     *
+     * See the [Rust documentation for `try_added_with_options`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.try_added_with_options) for more information.
+     */
     fun tryAddWithOptions(duration: DateDuration, options: DateAddOptions): Result<IsoDate> {
         
         val returnVal = lib.icu4x_IsoDate_try_add_with_options_mv1(handle, duration.toNative(), options.toNative());
@@ -286,10 +305,11 @@ class IsoDate internal constructor (
         }
     }
     
-    /** Calculating the duration between `other - self`
-    *
-    *See the [Rust documentation for `try_until_with_options`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.try_until_with_options) for more information.
-    */
+    /**
+     * Calculating the duration between `other - self`
+     *
+     * See the [Rust documentation for `try_until_with_options`](https://docs.rs/icu/2.3.1/icu/calendar/struct.Date.html#method.try_until_with_options) for more information.
+     */
     fun untilWithOptions(other: IsoDate, options: DateDifferenceOptions): DateDuration {
         
         val returnVal = lib.icu4x_IsoDate_until_with_options_mv1(handle, other.handle, options.toNative());

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/IsoDateTime.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/IsoDateTime.kt
@@ -63,10 +63,11 @@ internal class OptionIsoDateTimeNative constructor(): Structure(), Structure.ByV
 
 }
 
-/** An ICU4X `DateTime` object capable of containing a ISO-8601 date and time.
-*
-*See the [Rust documentation for `DateTime`](https://docs.rs/icu/2.3.1/icu/time/struct.DateTime.html) for more information.
-*/
+/**
+ * An ICU4X `DateTime` object capable of containing a ISO-8601 date and time.
+ *
+ * See the [Rust documentation for `DateTime`](https://docs.rs/icu/2.3.1/icu/time/struct.DateTime.html) for more information.
+ */
 class IsoDateTime (var date: IsoDate, var time: Time) {
     companion object {
 
@@ -83,10 +84,11 @@ class IsoDateTime (var date: IsoDate, var time: Time) {
 
         @JvmStatic
         
-        /** Creates a new [IsoDateTime] from an IXDTF string.
-        *
-        *See the [Rust documentation for `try_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.DateTime.html#method.try_from_str) for more information.
-        */
+        /**
+         * Creates a new [IsoDateTime] from an IXDTF string.
+         *
+         * See the [Rust documentation for `try_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.DateTime.html#method.try_from_str) for more information.
+         */
         fun fromString(v: String): Result<IsoDateTime> {
             val vSliceMemory = PrimitiveArrayTools.borrowUtf8(v)
             

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/IsoWeekOfYear.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/IsoWeekOfYear.kt
@@ -62,8 +62,9 @@ internal class OptionIsoWeekOfYearNative constructor(): Structure(), Structure.B
 
 }
 
-/** See the [Rust documentation for `IsoWeekOfYear`](https://docs.rs/icu/2.3.1/icu/calendar/types/struct.IsoWeekOfYear.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `IsoWeekOfYear`](https://docs.rs/icu/2.3.1/icu/calendar/types/struct.IsoWeekOfYear.html) for more information.
+ */
 class IsoWeekOfYear (var weekNumber: UByte, var isoYear: Int) {
     companion object {
 

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/JoiningGroup.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/JoiningGroup.kt
@@ -14,7 +14,8 @@ internal interface JoiningGroupLib: Library {
     fun icu4x_JoiningGroup_from_integer_value_mv1(other: FFIUint8): OptionInt
     fun icu4x_JoiningGroup_try_from_str_mv1(s: Slice): OptionInt
 }
-/** See the [Rust documentation for `JoiningGroup`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.JoiningGroup.html) for more information.
+/**
+ * See the [Rust documentation for `JoiningGroup`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.JoiningGroup.html) for more information.
 */
 enum class JoiningGroup {
     NoJoiningGroup,
@@ -151,8 +152,9 @@ enum class JoiningGroup {
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.EnumeratedProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.EnumeratedProperty.html#tymethod.for_char) for more information.
+         */
         fun forChar(ch: Int): JoiningGroup {
             
             val returnVal = lib.icu4x_JoiningGroup_for_char_mv1(ch);
@@ -160,10 +162,11 @@ enum class JoiningGroup {
         }
         @JvmStatic
         
-        /** Convert from an integer value from ICU4C or `CodePointMapData`
-        *
-        *See the [Rust documentation for `from_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.JoiningGroup.html#method.from_icu4c_value) for more information.
-        */
+        /**
+         * Convert from an integer value from ICU4C or `CodePointMapData`
+         *
+         * See the [Rust documentation for `from_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.JoiningGroup.html#method.from_icu4c_value) for more information.
+         */
         fun fromIntegerValue(other: UByte): JoiningGroup? {
             
             val returnVal = lib.icu4x_JoiningGroup_from_integer_value_mv1(FFIUint8(other));
@@ -173,10 +176,11 @@ enum class JoiningGroup {
         }
         @JvmStatic
         
-        /** Creates a `JoiningGroup` from a string.
-        *
-        *Short names, long names, and aliases are supported, and matching is case-insensitive.
-        */
+        /**
+         * Creates a `JoiningGroup` from a string.
+         *
+         * Short names, long names, and aliases are supported, and matching is case-insensitive.
+         */
         fun tryFromStr(s: String): JoiningGroup? {
             val sSliceMemory = PrimitiveArrayTools.borrowUtf8(s)
             
@@ -191,10 +195,11 @@ enum class JoiningGroup {
         }
     }
     
-    /** Get the "long" name of this property value (returns empty if property value is unknown)
-    *
-    *See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesLongBorrowed.html#method.get) for more information.
-    */
+    /**
+     * Get the "long" name of this property value (returns empty if property value is unknown)
+     *
+     * See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesLongBorrowed.html#method.get) for more information.
+     */
     fun longName(): String? {
         
         val returnVal = lib.icu4x_JoiningGroup_long_name_mv1(this.toNative());
@@ -204,10 +209,11 @@ enum class JoiningGroup {
                                 
     }
     
-    /** Get the "short" name of this property value (returns empty if property value is unknown)
-    *
-    *See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesShortBorrowed.html#method.get) for more information.
-    */
+    /**
+     * Get the "short" name of this property value (returns empty if property value is unknown)
+     *
+     * See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesShortBorrowed.html#method.get) for more information.
+     */
     fun shortName(): String? {
         
         val returnVal = lib.icu4x_JoiningGroup_short_name_mv1(this.toNative());
@@ -217,10 +223,11 @@ enum class JoiningGroup {
                                 
     }
     
-    /** Convert to an integer value usable with ICU4C and `CodePointMapData`
-    *
-    *See the [Rust documentation for `to_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.JoiningGroup.html#method.to_icu4c_value) for more information.
-    */
+    /**
+     * Convert to an integer value usable with ICU4C and `CodePointMapData`
+     *
+     * See the [Rust documentation for `to_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.JoiningGroup.html#method.to_icu4c_value) for more information.
+     */
     fun toIntegerValue(): UByte {
         
         val returnVal = lib.icu4x_JoiningGroup_to_integer_value_mv1(this.toNative());

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/JoiningType.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/JoiningType.kt
@@ -14,7 +14,8 @@ internal interface JoiningTypeLib: Library {
     fun icu4x_JoiningType_from_integer_value_mv1(other: FFIUint8): OptionInt
     fun icu4x_JoiningType_try_from_str_mv1(s: Slice): OptionInt
 }
-/** See the [Rust documentation for `JoiningType`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.JoiningType.html) for more information.
+/**
+ * See the [Rust documentation for `JoiningType`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.JoiningType.html) for more information.
 */
 enum class JoiningType {
     NonJoining,
@@ -41,8 +42,9 @@ enum class JoiningType {
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.EnumeratedProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.EnumeratedProperty.html#tymethod.for_char) for more information.
+         */
         fun forChar(ch: Int): JoiningType {
             
             val returnVal = lib.icu4x_JoiningType_for_char_mv1(ch);
@@ -50,10 +52,11 @@ enum class JoiningType {
         }
         @JvmStatic
         
-        /** Convert from an integer value from ICU4C or `CodePointMapData`
-        *
-        *See the [Rust documentation for `from_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.JoiningType.html#method.from_icu4c_value) for more information.
-        */
+        /**
+         * Convert from an integer value from ICU4C or `CodePointMapData`
+         *
+         * See the [Rust documentation for `from_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.JoiningType.html#method.from_icu4c_value) for more information.
+         */
         fun fromIntegerValue(other: UByte): JoiningType? {
             
             val returnVal = lib.icu4x_JoiningType_from_integer_value_mv1(FFIUint8(other));
@@ -63,10 +66,11 @@ enum class JoiningType {
         }
         @JvmStatic
         
-        /** Creates a `JoiningType` from a string.
-        *
-        *Short names, long names, and aliases are supported, and matching is case-insensitive.
-        */
+        /**
+         * Creates a `JoiningType` from a string.
+         *
+         * Short names, long names, and aliases are supported, and matching is case-insensitive.
+         */
         fun tryFromStr(s: String): JoiningType? {
             val sSliceMemory = PrimitiveArrayTools.borrowUtf8(s)
             
@@ -81,10 +85,11 @@ enum class JoiningType {
         }
     }
     
-    /** Get the "long" name of this property value (returns empty if property value is unknown)
-    *
-    *See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesLongBorrowed.html#method.get) for more information.
-    */
+    /**
+     * Get the "long" name of this property value (returns empty if property value is unknown)
+     *
+     * See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesLongBorrowed.html#method.get) for more information.
+     */
     fun longName(): String? {
         
         val returnVal = lib.icu4x_JoiningType_long_name_mv1(this.toNative());
@@ -94,10 +99,11 @@ enum class JoiningType {
                                 
     }
     
-    /** Get the "short" name of this property value (returns empty if property value is unknown)
-    *
-    *See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesShortBorrowed.html#method.get) for more information.
-    */
+    /**
+     * Get the "short" name of this property value (returns empty if property value is unknown)
+     *
+     * See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesShortBorrowed.html#method.get) for more information.
+     */
     fun shortName(): String? {
         
         val returnVal = lib.icu4x_JoiningType_short_name_mv1(this.toNative());
@@ -107,10 +113,11 @@ enum class JoiningType {
                                 
     }
     
-    /** Convert to an integer value usable with ICU4C and `CodePointMapData`
-    *
-    *See the [Rust documentation for `to_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.JoiningType.html#method.to_icu4c_value) for more information.
-    */
+    /**
+     * Convert to an integer value usable with ICU4C and `CodePointMapData`
+     *
+     * See the [Rust documentation for `to_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.JoiningType.html#method.to_icu4c_value) for more information.
+     */
     fun toIntegerValue(): UByte {
         
         val returnVal = lib.icu4x_JoiningType_to_integer_value_mv1(this.toNative());

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LanguageDisplay.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LanguageDisplay.kt
@@ -9,9 +9,9 @@ import com.sun.jna.Structure
 internal interface LanguageDisplayLib: Library {
 }
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `LanguageDisplay`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/enum.LanguageDisplay.html) for more information.
+ *
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
 */
 enum class LanguageDisplay {
     Dialect,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LanguageDisplay.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LanguageDisplay.kt
@@ -8,9 +8,10 @@ import com.sun.jna.Structure
 
 internal interface LanguageDisplayLib: Library {
 }
-/** 🚧 This API is unstable and may experience breaking changes outside major releases.
-*
-*See the [Rust documentation for `LanguageDisplay`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/enum.LanguageDisplay.html) for more information.
+/**
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
+ *
+ * See the [Rust documentation for `LanguageDisplay`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/enum.LanguageDisplay.html) for more information.
 */
 enum class LanguageDisplay {
     Dialect,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LanguageDisplayUnstable.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LanguageDisplayUnstable.kt
@@ -8,9 +8,10 @@ import com.sun.jna.Structure
 
 internal interface LanguageDisplayUnstableLib: Library {
 }
-/** 🚧 This API is unstable and may experience breaking changes outside major releases.
-*
-*See the [Rust documentation for `LanguageDisplay`](https://docs.rs/icu/2.3.1/icu/locale/names/enum.LanguageDisplay.html) for more information.
+/**
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
+ *
+ * See the [Rust documentation for `LanguageDisplay`](https://docs.rs/icu/2.3.1/icu/locale/names/enum.LanguageDisplay.html) for more information.
 */
 enum class LanguageDisplayUnstable {
     Dialect,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LanguageDisplayUnstable.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LanguageDisplayUnstable.kt
@@ -9,9 +9,9 @@ import com.sun.jna.Structure
 internal interface LanguageDisplayUnstableLib: Library {
 }
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `LanguageDisplay`](https://docs.rs/icu/2.3.1/icu/locale/names/enum.LanguageDisplay.html) for more information.
+ *
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
 */
 enum class LanguageDisplayUnstable {
     Dialect,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LeadingAdjustment.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LeadingAdjustment.kt
@@ -8,7 +8,8 @@ import com.sun.jna.Structure
 
 internal interface LeadingAdjustmentLib: Library {
 }
-/** See the [Rust documentation for `LeadingAdjustment`](https://docs.rs/icu/2.3.1/icu/casemap/options/enum.LeadingAdjustment.html) for more information.
+/**
+ * See the [Rust documentation for `LeadingAdjustment`](https://docs.rs/icu/2.3.1/icu/casemap/options/enum.LeadingAdjustment.html) for more information.
 */
 enum class LeadingAdjustment {
     Auto,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LineBreak.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LineBreak.kt
@@ -14,7 +14,8 @@ internal interface LineBreakLib: Library {
     fun icu4x_LineBreak_from_integer_value_mv1(other: FFIUint8): OptionInt
     fun icu4x_LineBreak_try_from_str_mv1(s: Slice): OptionInt
 }
-/** See the [Rust documentation for `LineBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.LineBreak.html) for more information.
+/**
+ * See the [Rust documentation for `LineBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.LineBreak.html) for more information.
 */
 enum class LineBreak {
     Unknown,
@@ -84,8 +85,9 @@ enum class LineBreak {
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.EnumeratedProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.EnumeratedProperty.html#tymethod.for_char) for more information.
+         */
         fun forChar(ch: Int): LineBreak {
             
             val returnVal = lib.icu4x_LineBreak_for_char_mv1(ch);
@@ -93,10 +95,11 @@ enum class LineBreak {
         }
         @JvmStatic
         
-        /** Convert from an integer value from ICU4C or `CodePointMapData`
-        *
-        *See the [Rust documentation for `from_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.LineBreak.html#method.from_icu4c_value) for more information.
-        */
+        /**
+         * Convert from an integer value from ICU4C or `CodePointMapData`
+         *
+         * See the [Rust documentation for `from_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.LineBreak.html#method.from_icu4c_value) for more information.
+         */
         fun fromIntegerValue(other: UByte): LineBreak? {
             
             val returnVal = lib.icu4x_LineBreak_from_integer_value_mv1(FFIUint8(other));
@@ -106,10 +109,11 @@ enum class LineBreak {
         }
         @JvmStatic
         
-        /** Creates a `LineBreak` from a string.
-        *
-        *Short names, long names, and aliases are supported, and matching is case-insensitive.
-        */
+        /**
+         * Creates a `LineBreak` from a string.
+         *
+         * Short names, long names, and aliases are supported, and matching is case-insensitive.
+         */
         fun tryFromStr(s: String): LineBreak? {
             val sSliceMemory = PrimitiveArrayTools.borrowUtf8(s)
             
@@ -124,10 +128,11 @@ enum class LineBreak {
         }
     }
     
-    /** Get the "long" name of this property value (returns empty if property value is unknown)
-    *
-    *See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesLongBorrowed.html#method.get) for more information.
-    */
+    /**
+     * Get the "long" name of this property value (returns empty if property value is unknown)
+     *
+     * See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesLongBorrowed.html#method.get) for more information.
+     */
     fun longName(): String? {
         
         val returnVal = lib.icu4x_LineBreak_long_name_mv1(this.toNative());
@@ -137,10 +142,11 @@ enum class LineBreak {
                                 
     }
     
-    /** Get the "short" name of this property value (returns empty if property value is unknown)
-    *
-    *See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesShortBorrowed.html#method.get) for more information.
-    */
+    /**
+     * Get the "short" name of this property value (returns empty if property value is unknown)
+     *
+     * See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesShortBorrowed.html#method.get) for more information.
+     */
     fun shortName(): String? {
         
         val returnVal = lib.icu4x_LineBreak_short_name_mv1(this.toNative());
@@ -150,10 +156,11 @@ enum class LineBreak {
                                 
     }
     
-    /** Convert to an integer value usable with ICU4C and `CodePointMapData`
-    *
-    *See the [Rust documentation for `to_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.LineBreak.html#method.to_icu4c_value) for more information.
-    */
+    /**
+     * Convert to an integer value usable with ICU4C and `CodePointMapData`
+     *
+     * See the [Rust documentation for `to_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.LineBreak.html#method.to_icu4c_value) for more information.
+     */
     fun toIntegerValue(): UByte {
         
         val returnVal = lib.icu4x_LineBreak_to_integer_value_mv1(this.toNative());

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LineBreakIteratorLatin1.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LineBreakIteratorLatin1.kt
@@ -9,8 +9,9 @@ internal interface LineBreakIteratorLatin1Lib: Library {
     fun icu4x_LineBreakIteratorLatin1_destroy_mv1(handle: Pointer)
     fun icu4x_LineBreakIteratorLatin1_next_mv1(handle: Pointer): Int
 }
-/** See the [Rust documentation for `LineBreakIterator`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.LineBreakIterator.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `LineBreakIterator`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.LineBreakIterator.html) for more information.
+ */
 class LineBreakIteratorLatin1 internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -40,11 +41,12 @@ class LineBreakIteratorLatin1 internal constructor (
         internal val lib: LineBreakIteratorLatin1Lib = Native.load("icu4x", libClass)
     }
     
-    /** Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
-    *out of range of a 32-bit signed integer.
-    *
-    *See the [Rust documentation for `next`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.LineBreakIterator.html#method.next) for more information.
-    */
+    /**
+     * Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
+     * out of range of a 32-bit signed integer.
+     *
+     * See the [Rust documentation for `next`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.LineBreakIterator.html#method.next) for more information.
+     */
     fun next(): Int {
         
         val returnVal = lib.icu4x_LineBreakIteratorLatin1_next_mv1(handle);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LineBreakIteratorUtf16.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LineBreakIteratorUtf16.kt
@@ -9,8 +9,9 @@ internal interface LineBreakIteratorUtf16Lib: Library {
     fun icu4x_LineBreakIteratorUtf16_destroy_mv1(handle: Pointer)
     fun icu4x_LineBreakIteratorUtf16_next_mv1(handle: Pointer): Int
 }
-/** See the [Rust documentation for `LineBreakIterator`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.LineBreakIterator.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `LineBreakIterator`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.LineBreakIterator.html) for more information.
+ */
 class LineBreakIteratorUtf16 internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -40,11 +41,12 @@ class LineBreakIteratorUtf16 internal constructor (
         internal val lib: LineBreakIteratorUtf16Lib = Native.load("icu4x", libClass)
     }
     
-    /** Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
-    *out of range of a 32-bit signed integer.
-    *
-    *See the [Rust documentation for `next`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.LineBreakIterator.html#method.next) for more information.
-    */
+    /**
+     * Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
+     * out of range of a 32-bit signed integer.
+     *
+     * See the [Rust documentation for `next`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.LineBreakIterator.html#method.next) for more information.
+     */
     fun next(): Int {
         
         val returnVal = lib.icu4x_LineBreakIteratorUtf16_next_mv1(handle);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LineBreakIteratorUtf8.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LineBreakIteratorUtf8.kt
@@ -9,8 +9,9 @@ internal interface LineBreakIteratorUtf8Lib: Library {
     fun icu4x_LineBreakIteratorUtf8_destroy_mv1(handle: Pointer)
     fun icu4x_LineBreakIteratorUtf8_next_mv1(handle: Pointer): Int
 }
-/** See the [Rust documentation for `LineBreakIterator`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.LineBreakIterator.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `LineBreakIterator`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.LineBreakIterator.html) for more information.
+ */
 class LineBreakIteratorUtf8 internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -40,11 +41,12 @@ class LineBreakIteratorUtf8 internal constructor (
         internal val lib: LineBreakIteratorUtf8Lib = Native.load("icu4x", libClass)
     }
     
-    /** Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
-    *out of range of a 32-bit signed integer.
-    *
-    *See the [Rust documentation for `next`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.LineBreakIterator.html#method.next) for more information.
-    */
+    /**
+     * Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
+     * out of range of a 32-bit signed integer.
+     *
+     * See the [Rust documentation for `next`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.LineBreakIterator.html#method.next) for more information.
+     */
     fun next(): Int {
         
         val returnVal = lib.icu4x_LineBreakIteratorUtf8_next_mv1(handle);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LineBreakOptions.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LineBreakOptions.kt
@@ -62,8 +62,9 @@ internal class OptionLineBreakOptionsNative constructor(): Structure(), Structur
 
 }
 
-/** See the [Rust documentation for `LineBreakOptions`](https://docs.rs/icu/2.3.1/icu/segmenter/options/struct.LineBreakOptions.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `LineBreakOptions`](https://docs.rs/icu/2.3.1/icu/segmenter/options/struct.LineBreakOptions.html) for more information.
+ */
 class LineBreakOptions (var strictness: LineBreakStrictness?, var wordOption: LineBreakWordOption?) {
     companion object {
 

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LineBreakStrictness.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LineBreakStrictness.kt
@@ -8,7 +8,8 @@ import com.sun.jna.Structure
 
 internal interface LineBreakStrictnessLib: Library {
 }
-/** See the [Rust documentation for `LineBreakStrictness`](https://docs.rs/icu/2.3.1/icu/segmenter/options/enum.LineBreakStrictness.html) for more information.
+/**
+ * See the [Rust documentation for `LineBreakStrictness`](https://docs.rs/icu/2.3.1/icu/segmenter/options/enum.LineBreakStrictness.html) for more information.
 */
 enum class LineBreakStrictness {
     Loose,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LineBreakWordOption.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LineBreakWordOption.kt
@@ -8,7 +8,8 @@ import com.sun.jna.Structure
 
 internal interface LineBreakWordOptionLib: Library {
 }
-/** See the [Rust documentation for `LineBreakWordOption`](https://docs.rs/icu/2.3.1/icu/segmenter/options/enum.LineBreakWordOption.html) for more information.
+/**
+ * See the [Rust documentation for `LineBreakWordOption`](https://docs.rs/icu/2.3.1/icu/segmenter/options/enum.LineBreakWordOption.html) for more information.
 */
 enum class LineBreakWordOption {
     Normal,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LineSegmenter.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LineSegmenter.kt
@@ -21,10 +21,11 @@ internal interface LineSegmenterLib: Library {
     fun icu4x_LineSegmenter_create_for_non_complex_scripts_with_options_v2_and_provider_mv1(provider: Pointer, contentLocale: Pointer?, options: LineBreakOptionsNative): ResultPointerInt
     fun icu4x_LineSegmenter_segment_utf16_mv1(handle: Pointer, input: Slice): Pointer
 }
-/** An ICU4X line-break segmenter, capable of finding breakpoints in strings.
-*
-*See the [Rust documentation for `LineSegmenter`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.LineSegmenter.html) for more information.
-*/
+/**
+ * An ICU4X line-break segmenter, capable of finding breakpoints in strings.
+ *
+ * See the [Rust documentation for `LineSegmenter`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.LineSegmenter.html) for more information.
+ */
 class LineSegmenter internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -53,11 +54,12 @@ class LineSegmenter internal constructor (
         internal val lib: LineSegmenterLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Construct a [LineSegmenter] with default options (no locale-based tailoring) using compiled data. It automatically loads the best
-        *available payload data for Burmese, Khmer, Lao, and Thai.
-        *
-        *See the [Rust documentation for `new_auto`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.LineSegmenter.html#method.new_auto) for more information.
-        */
+        /**
+         * Construct a [LineSegmenter] with default options (no locale-based tailoring) using compiled data. It automatically loads the best
+         * available payload data for Burmese, Khmer, Lao, and Thai.
+         *
+         * See the [Rust documentation for `new_auto`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.LineSegmenter.html#method.new_auto) for more information.
+         */
         fun createAuto(): LineSegmenter {
             
             val returnVal = lib.icu4x_LineSegmenter_create_auto_mv1();
@@ -68,11 +70,12 @@ class LineSegmenter internal constructor (
         }
         @JvmStatic
         
-        /** Construct a [LineSegmenter] with default options (no locale-based tailoring) and LSTM payload data for
-        *Burmese, Khmer, Lao, and Thai, using compiled data.
-        *
-        *See the [Rust documentation for `new_lstm`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.LineSegmenter.html#method.new_lstm) for more information.
-        */
+        /**
+         * Construct a [LineSegmenter] with default options (no locale-based tailoring) and LSTM payload data for
+         * Burmese, Khmer, Lao, and Thai, using compiled data.
+         *
+         * See the [Rust documentation for `new_lstm`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.LineSegmenter.html#method.new_lstm) for more information.
+         */
         fun createLstm(): LineSegmenter {
             
             val returnVal = lib.icu4x_LineSegmenter_create_lstm_mv1();
@@ -83,11 +86,12 @@ class LineSegmenter internal constructor (
         }
         @JvmStatic
         
-        /** Construct a [LineSegmenter] with default options (no locale-based tailoring) and dictionary payload data for
-        *Burmese, Khmer, Lao, and Thai, using compiled data
-        *
-        *See the [Rust documentation for `new_dictionary`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.LineSegmenter.html#method.new_dictionary) for more information.
-        */
+        /**
+         * Construct a [LineSegmenter] with default options (no locale-based tailoring) and dictionary payload data for
+         * Burmese, Khmer, Lao, and Thai, using compiled data
+         *
+         * See the [Rust documentation for `new_dictionary`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.LineSegmenter.html#method.new_dictionary) for more information.
+         */
         fun createDictionary(): LineSegmenter {
             
             val returnVal = lib.icu4x_LineSegmenter_create_dictionary_mv1();
@@ -98,11 +102,12 @@ class LineSegmenter internal constructor (
         }
         @JvmStatic
         
-        /** Construct a [LineSegmenter] with default options (no locale-based tailoring) and no support for scripts requiring complex context dependent line breaks
-        *(Burmese, Khmer, Lao, and Thai), using compiled data
-        *
-        *See the [Rust documentation for `new_for_non_complex_scripts`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.LineSegmenter.html#method.new_for_non_complex_scripts) for more information.
-        */
+        /**
+         * Construct a [LineSegmenter] with default options (no locale-based tailoring) and no support for scripts requiring complex context dependent line breaks
+         * (Burmese, Khmer, Lao, and Thai), using compiled data
+         *
+         * See the [Rust documentation for `new_for_non_complex_scripts`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.LineSegmenter.html#method.new_for_non_complex_scripts) for more information.
+         */
         fun createForNonComplexScripts(): LineSegmenter {
             
             val returnVal = lib.icu4x_LineSegmenter_create_for_non_complex_scripts_mv1();
@@ -113,11 +118,12 @@ class LineSegmenter internal constructor (
         }
         @JvmStatic
         
-        /** Construct a [LineSegmenter] with custom options using compiled data. It automatically loads the best
-        *available payload data for Burmese, Khmer, Lao, and Thai.
-        *
-        *See the [Rust documentation for `new_auto`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.LineSegmenter.html#method.new_auto) for more information.
-        */
+        /**
+         * Construct a [LineSegmenter] with custom options using compiled data. It automatically loads the best
+         * available payload data for Burmese, Khmer, Lao, and Thai.
+         *
+         * See the [Rust documentation for `new_auto`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.LineSegmenter.html#method.new_auto) for more information.
+         */
         fun auto_with_options(contentLocale: Locale?, options: LineBreakOptions): LineSegmenter {
             
             val returnVal = lib.icu4x_LineSegmenter_create_auto_with_options_v2_mv1(contentLocale?.handle, options.toNative());
@@ -128,11 +134,12 @@ class LineSegmenter internal constructor (
         }
         @JvmStatic
         
-        /** Construct a [LineSegmenter] with custom options. It automatically loads the best
-        *available payload data for Burmese, Khmer, Lao, and Thai, using a particular data source.
-        *
-        *See the [Rust documentation for `new_auto`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.LineSegmenter.html#method.new_auto) for more information.
-        */
+        /**
+         * Construct a [LineSegmenter] with custom options. It automatically loads the best
+         * available payload data for Burmese, Khmer, Lao, and Thai, using a particular data source.
+         *
+         * See the [Rust documentation for `new_auto`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.LineSegmenter.html#method.new_auto) for more information.
+         */
         fun auto_with_options_and_provider(provider: DataProvider, contentLocale: Locale?, options: LineBreakOptions): Result<LineSegmenter> {
             
             val returnVal = lib.icu4x_LineSegmenter_create_auto_with_options_v2_and_provider_mv1(provider.handle, contentLocale?.handle, options.toNative());
@@ -148,11 +155,12 @@ class LineSegmenter internal constructor (
         }
         @JvmStatic
         
-        /** Construct a [LineSegmenter] with custom options and LSTM payload data for
-        *Burmese, Khmer, Lao, and Thai, using compiled data.
-        *
-        *See the [Rust documentation for `new_lstm`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.LineSegmenter.html#method.new_lstm) for more information.
-        */
+        /**
+         * Construct a [LineSegmenter] with custom options and LSTM payload data for
+         * Burmese, Khmer, Lao, and Thai, using compiled data.
+         *
+         * See the [Rust documentation for `new_lstm`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.LineSegmenter.html#method.new_lstm) for more information.
+         */
         fun lstm_with_options(contentLocale: Locale?, options: LineBreakOptions): LineSegmenter {
             
             val returnVal = lib.icu4x_LineSegmenter_create_lstm_with_options_v2_mv1(contentLocale?.handle, options.toNative());
@@ -163,11 +171,12 @@ class LineSegmenter internal constructor (
         }
         @JvmStatic
         
-        /** Construct a [LineSegmenter] with custom options and LSTM payload data for
-        *Burmese, Khmer, Lao, and Thai, using a particular data source.
-        *
-        *See the [Rust documentation for `new_lstm`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.LineSegmenter.html#method.new_lstm) for more information.
-        */
+        /**
+         * Construct a [LineSegmenter] with custom options and LSTM payload data for
+         * Burmese, Khmer, Lao, and Thai, using a particular data source.
+         *
+         * See the [Rust documentation for `new_lstm`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.LineSegmenter.html#method.new_lstm) for more information.
+         */
         fun lstm_with_options_and_provider(provider: DataProvider, contentLocale: Locale?, options: LineBreakOptions): Result<LineSegmenter> {
             
             val returnVal = lib.icu4x_LineSegmenter_create_lstm_with_options_v2_and_provider_mv1(provider.handle, contentLocale?.handle, options.toNative());
@@ -183,11 +192,12 @@ class LineSegmenter internal constructor (
         }
         @JvmStatic
         
-        /** Construct a [LineSegmenter] with custom options and dictionary payload data for
-        *Burmese, Khmer, Lao, and Thai, using compiled data.
-        *
-        *See the [Rust documentation for `new_dictionary`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.LineSegmenter.html#method.new_dictionary) for more information.
-        */
+        /**
+         * Construct a [LineSegmenter] with custom options and dictionary payload data for
+         * Burmese, Khmer, Lao, and Thai, using compiled data.
+         *
+         * See the [Rust documentation for `new_dictionary`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.LineSegmenter.html#method.new_dictionary) for more information.
+         */
         fun dictionary_with_options(contentLocale: Locale?, options: LineBreakOptions): LineSegmenter {
             
             val returnVal = lib.icu4x_LineSegmenter_create_dictionary_with_options_v2_mv1(contentLocale?.handle, options.toNative());
@@ -198,11 +208,12 @@ class LineSegmenter internal constructor (
         }
         @JvmStatic
         
-        /** Construct a [LineSegmenter] with custom options and dictionary payload data for
-        *Burmese, Khmer, Lao, and Thai, using a particular data source.
-        *
-        *See the [Rust documentation for `new_dictionary`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.LineSegmenter.html#method.new_dictionary) for more information.
-        */
+        /**
+         * Construct a [LineSegmenter] with custom options and dictionary payload data for
+         * Burmese, Khmer, Lao, and Thai, using a particular data source.
+         *
+         * See the [Rust documentation for `new_dictionary`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.LineSegmenter.html#method.new_dictionary) for more information.
+         */
         fun dictionary_with_options_and_provider(provider: DataProvider, contentLocale: Locale?, options: LineBreakOptions): Result<LineSegmenter> {
             
             val returnVal = lib.icu4x_LineSegmenter_create_dictionary_with_options_v2_and_provider_mv1(provider.handle, contentLocale?.handle, options.toNative());
@@ -218,11 +229,12 @@ class LineSegmenter internal constructor (
         }
         @JvmStatic
         
-        /** Construct a [LineSegmenter] with custom options and no support for scripts requiring complex context dependent line breaks
-        *(Burmese, Khmer, Lao, and Thai), using compiled data.
-        *
-        *See the [Rust documentation for `new_for_non_complex_scripts`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.LineSegmenter.html#method.new_for_non_complex_scripts) for more information.
-        */
+        /**
+         * Construct a [LineSegmenter] with custom options and no support for scripts requiring complex context dependent line breaks
+         * (Burmese, Khmer, Lao, and Thai), using compiled data.
+         *
+         * See the [Rust documentation for `new_for_non_complex_scripts`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.LineSegmenter.html#method.new_for_non_complex_scripts) for more information.
+         */
         fun for_non_complex_scripts_with_options(contentLocale: Locale?, options: LineBreakOptions): LineSegmenter {
             
             val returnVal = lib.icu4x_LineSegmenter_create_for_non_complex_scripts_with_options_v2_mv1(contentLocale?.handle, options.toNative());
@@ -233,11 +245,12 @@ class LineSegmenter internal constructor (
         }
         @JvmStatic
         
-        /** Construct a [LineSegmenter] with custom options and no support for complex languages
-        *(Burmese, Khmer, Lao, and Thai), using a particular data source.
-        *
-        *See the [Rust documentation for `new_for_non_complex_scripts`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.LineSegmenter.html#method.new_for_non_complex_scripts) for more information.
-        */
+        /**
+         * Construct a [LineSegmenter] with custom options and no support for complex languages
+         * (Burmese, Khmer, Lao, and Thai), using a particular data source.
+         *
+         * See the [Rust documentation for `new_for_non_complex_scripts`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.LineSegmenter.html#method.new_for_non_complex_scripts) for more information.
+         */
         fun for_non_complex_scripts_with_options_and_provider(provider: DataProvider, contentLocale: Locale?, options: LineBreakOptions): Result<LineSegmenter> {
             
             val returnVal = lib.icu4x_LineSegmenter_create_for_non_complex_scripts_with_options_v2_and_provider_mv1(provider.handle, contentLocale?.handle, options.toNative());
@@ -253,13 +266,14 @@ class LineSegmenter internal constructor (
         }
     }
     
-    /** Segments a string.
-    *
-    *Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
-    *to the WHATWG Encoding Standard.
-    *
-    *See the [Rust documentation for `segment_utf16`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.LineSegmenterBorrowed.html#method.segment_utf16) for more information.
-    */
+    /**
+     * Segments a string.
+     *
+     * Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
+     * to the WHATWG Encoding Standard.
+     *
+     * See the [Rust documentation for `segment_utf16`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.LineSegmenterBorrowed.html#method.segment_utf16) for more information.
+     */
     fun segment(input: String): LineBreakIteratorUtf16 {
         // This lifetime edge depends on lifetimes: 'a
         val aEdges: MutableList<Any> = mutableListOf(this);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/ListFormatter.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/ListFormatter.kt
@@ -15,8 +15,9 @@ internal interface ListFormatterLib: Library {
     fun icu4x_ListFormatter_create_unit_with_length_and_provider_mv1(provider: Pointer, locale: Pointer, length: Int): ResultPointerInt
     fun icu4x_ListFormatter_format_utf16_mv1(handle: Pointer, list: Slice, write: Pointer): Unit
 }
-/** See the [Rust documentation for `ListFormatter`](https://docs.rs/icu/2.3.1/icu/list/struct.ListFormatter.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `ListFormatter`](https://docs.rs/icu/2.3.1/icu/list/struct.ListFormatter.html) for more information.
+ */
 class ListFormatter internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -45,10 +46,11 @@ class ListFormatter internal constructor (
         internal val lib: ListFormatterLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Construct a new `ListFormatter` instance for And patterns from compiled data.
-        *
-        *See the [Rust documentation for `try_new_and`](https://docs.rs/icu/2.3.1/icu/list/struct.ListFormatter.html#method.try_new_and) for more information.
-        */
+        /**
+         * Construct a new `ListFormatter` instance for And patterns from compiled data.
+         *
+         * See the [Rust documentation for `try_new_and`](https://docs.rs/icu/2.3.1/icu/list/struct.ListFormatter.html#method.try_new_and) for more information.
+         */
         fun createAndWithLength(locale: Locale, length: ListLength): Result<ListFormatter> {
             
             val returnVal = lib.icu4x_ListFormatter_create_and_with_length_mv1(locale.handle, length.toNative());
@@ -64,10 +66,11 @@ class ListFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Construct a new `ListFormatter` instance for And patterns
-        *
-        *See the [Rust documentation for `try_new_and`](https://docs.rs/icu/2.3.1/icu/list/struct.ListFormatter.html#method.try_new_and) for more information.
-        */
+        /**
+         * Construct a new `ListFormatter` instance for And patterns
+         *
+         * See the [Rust documentation for `try_new_and`](https://docs.rs/icu/2.3.1/icu/list/struct.ListFormatter.html#method.try_new_and) for more information.
+         */
         fun createAndWithLengthAndProvider(provider: DataProvider, locale: Locale, length: ListLength): Result<ListFormatter> {
             
             val returnVal = lib.icu4x_ListFormatter_create_and_with_length_and_provider_mv1(provider.handle, locale.handle, length.toNative());
@@ -83,10 +86,11 @@ class ListFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Construct a new `ListFormatter` instance for And patterns from compiled data.
-        *
-        *See the [Rust documentation for `try_new_or`](https://docs.rs/icu/2.3.1/icu/list/struct.ListFormatter.html#method.try_new_or) for more information.
-        */
+        /**
+         * Construct a new `ListFormatter` instance for And patterns from compiled data.
+         *
+         * See the [Rust documentation for `try_new_or`](https://docs.rs/icu/2.3.1/icu/list/struct.ListFormatter.html#method.try_new_or) for more information.
+         */
         fun createOrWithLength(locale: Locale, length: ListLength): Result<ListFormatter> {
             
             val returnVal = lib.icu4x_ListFormatter_create_or_with_length_mv1(locale.handle, length.toNative());
@@ -102,10 +106,11 @@ class ListFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Construct a new `ListFormatter` instance for And patterns
-        *
-        *See the [Rust documentation for `try_new_or`](https://docs.rs/icu/2.3.1/icu/list/struct.ListFormatter.html#method.try_new_or) for more information.
-        */
+        /**
+         * Construct a new `ListFormatter` instance for And patterns
+         *
+         * See the [Rust documentation for `try_new_or`](https://docs.rs/icu/2.3.1/icu/list/struct.ListFormatter.html#method.try_new_or) for more information.
+         */
         fun createOrWithLengthAndProvider(provider: DataProvider, locale: Locale, length: ListLength): Result<ListFormatter> {
             
             val returnVal = lib.icu4x_ListFormatter_create_or_with_length_and_provider_mv1(provider.handle, locale.handle, length.toNative());
@@ -121,10 +126,11 @@ class ListFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Construct a new `ListFormatter` instance for And patterns from compiled data.
-        *
-        *See the [Rust documentation for `try_new_unit`](https://docs.rs/icu/2.3.1/icu/list/struct.ListFormatter.html#method.try_new_unit) for more information.
-        */
+        /**
+         * Construct a new `ListFormatter` instance for And patterns from compiled data.
+         *
+         * See the [Rust documentation for `try_new_unit`](https://docs.rs/icu/2.3.1/icu/list/struct.ListFormatter.html#method.try_new_unit) for more information.
+         */
         fun createUnitWithLength(locale: Locale, length: ListLength): Result<ListFormatter> {
             
             val returnVal = lib.icu4x_ListFormatter_create_unit_with_length_mv1(locale.handle, length.toNative());
@@ -140,10 +146,11 @@ class ListFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Construct a new `ListFormatter` instance for And patterns
-        *
-        *See the [Rust documentation for `try_new_unit`](https://docs.rs/icu/2.3.1/icu/list/struct.ListFormatter.html#method.try_new_unit) for more information.
-        */
+        /**
+         * Construct a new `ListFormatter` instance for And patterns
+         *
+         * See the [Rust documentation for `try_new_unit`](https://docs.rs/icu/2.3.1/icu/list/struct.ListFormatter.html#method.try_new_unit) for more information.
+         */
         fun createUnitWithLengthAndProvider(provider: DataProvider, locale: Locale, length: ListLength): Result<ListFormatter> {
             
             val returnVal = lib.icu4x_ListFormatter_create_unit_with_length_and_provider_mv1(provider.handle, locale.handle, length.toNative());
@@ -159,8 +166,9 @@ class ListFormatter internal constructor (
         }
     }
     
-    /** See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/list/struct.ListFormatter.html#method.format) for more information.
-    */
+    /**
+     * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/list/struct.ListFormatter.html#method.format) for more information.
+     */
     fun format(list: Array<String>): String {
         val listSliceMemory = PrimitiveArrayTools.borrowUtf16s(list)
         val write = DW.lib.diplomat_buffer_write_create(0)

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/ListLength.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/ListLength.kt
@@ -8,7 +8,8 @@ import com.sun.jna.Structure
 
 internal interface ListLengthLib: Library {
 }
-/** See the [Rust documentation for `ListLength`](https://docs.rs/icu/2.3.1/icu/list/options/enum.ListLength.html) for more information.
+/**
+ * See the [Rust documentation for `ListLength`](https://docs.rs/icu/2.3.1/icu/list/options/enum.ListLength.html) for more information.
 */
 enum class ListLength {
     Wide,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/Locale.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/Locale.kt
@@ -32,10 +32,11 @@ internal interface LocaleLib: Library {
     fun icu4x_Locale_compare_to_string_mv1(handle: Pointer, other: Slice): Byte
     fun icu4x_Locale_compare_to_mv1(handle: Pointer, other: Pointer): Byte
 }
-/** An ICU4X Locale, capable of representing strings like `"en-US"`.
-*
-*See the [Rust documentation for `Locale`](https://docs.rs/icu/2.3.1/icu/locale/struct.Locale.html) for more information.
-*/
+/**
+ * An ICU4X Locale, capable of representing strings like `"en-US"`.
+ *
+ * See the [Rust documentation for `Locale`](https://docs.rs/icu/2.3.1/icu/locale/struct.Locale.html) for more information.
+ */
 class Locale internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -64,14 +65,15 @@ class Locale internal constructor (
         internal val lib: LocaleLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Construct an [Locale] from an locale identifier.
-        *
-        *This will run the complete locale parsing algorithm. If code size and
-        *performance are critical and the locale is of a known shape (such as
-        *`aa-BB`) use `create_und`, `set_language`, `set_script`, and `set_region`.
-        *
-        *See the [Rust documentation for `try_from_str`](https://docs.rs/icu/2.3.1/icu/locale/struct.Locale.html#method.try_from_str) for more information.
-        */
+        /**
+         * Construct an [Locale] from an locale identifier.
+         *
+         * This will run the complete locale parsing algorithm. If code size and
+         * performance are critical and the locale is of a known shape (such as
+         * `aa-BB`) use `create_und`, `set_language`, `set_script`, and `set_region`.
+         *
+         * See the [Rust documentation for `try_from_str`](https://docs.rs/icu/2.3.1/icu/locale/struct.Locale.html#method.try_from_str) for more information.
+         */
         fun fromString(name: String): Result<Locale> {
             val nameSliceMemory = PrimitiveArrayTools.borrowUtf8(name)
             
@@ -92,10 +94,11 @@ class Locale internal constructor (
         }
         @JvmStatic
         
-        /** Construct a unknown [Locale] "und".
-        *
-        *See the [Rust documentation for `UNKNOWN`](https://docs.rs/icu/2.3.1/icu/locale/struct.Locale.html#associatedconstant.UNKNOWN) for more information.
-        */
+        /**
+         * Construct a unknown [Locale] "und".
+         *
+         * See the [Rust documentation for `UNKNOWN`](https://docs.rs/icu/2.3.1/icu/locale/struct.Locale.html#associatedconstant.UNKNOWN) for more information.
+         */
         fun unknown(): Locale {
             
             val returnVal = lib.icu4x_Locale_unknown_mv1();
@@ -106,10 +109,11 @@ class Locale internal constructor (
         }
         @JvmStatic
         
-        /** Normalizes a locale string.
-        *
-        *See the [Rust documentation for `normalize`](https://docs.rs/icu/2.3.1/icu/locale/struct.Locale.html#method.normalize) for more information.
-        */
+        /**
+         * Normalizes a locale string.
+         *
+         * See the [Rust documentation for `normalize`](https://docs.rs/icu/2.3.1/icu/locale/struct.Locale.html#method.normalize) for more information.
+         */
         fun normalize(s: String): Result<String> {
             val sSliceMemory = PrimitiveArrayTools.borrowUtf8(s)
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -129,10 +133,11 @@ class Locale internal constructor (
         }
     }
     
-    /** Clones the [Locale].
-    *
-    *See the [Rust documentation for `Locale`](https://docs.rs/icu/2.3.1/icu/locale/struct.Locale.html) for more information.
-    */
+    /**
+     * Clones the [Locale].
+     *
+     * See the [Rust documentation for `Locale`](https://docs.rs/icu/2.3.1/icu/locale/struct.Locale.html) for more information.
+     */
     fun clone(): Locale {
         
         val returnVal = lib.icu4x_Locale_clone_mv1(handle);
@@ -142,11 +147,12 @@ class Locale internal constructor (
         return returnOpaque
     }
     
-    /** Returns a string representation of the `LanguageIdentifier` part of
-    *[Locale].
-    *
-    *See the [Rust documentation for `id`](https://docs.rs/icu/2.3.1/icu/locale/struct.Locale.html#structfield.id) for more information.
-    */
+    /**
+     * Returns a string representation of the `LanguageIdentifier` part of
+     * [Locale].
+     *
+     * See the [Rust documentation for `id`](https://docs.rs/icu/2.3.1/icu/locale/struct.Locale.html#structfield.id) for more information.
+     */
     fun basename(): String {
         val write = DW.lib.diplomat_buffer_write_create(0)
         val returnVal = lib.icu4x_Locale_basename_mv1(handle, write);
@@ -155,10 +161,11 @@ class Locale internal constructor (
         return returnString
     }
     
-    /** Returns a string representation of the unicode extension.
-    *
-    *See the [Rust documentation for `extensions`](https://docs.rs/icu/2.3.1/icu/locale/struct.Locale.html#structfield.extensions) for more information.
-    */
+    /**
+     * Returns a string representation of the unicode extension.
+     *
+     * See the [Rust documentation for `extensions`](https://docs.rs/icu/2.3.1/icu/locale/struct.Locale.html#structfield.extensions) for more information.
+     */
     fun getUnicodeExtension(s: String): String? {
         val sSliceMemory = PrimitiveArrayTools.borrowUtf8(s)
         val write = DW.lib.diplomat_buffer_write_create(0)
@@ -175,10 +182,11 @@ class Locale internal constructor (
         }
     }
     
-    /** Set a Unicode extension.
-    *
-    *See the [Rust documentation for `extensions`](https://docs.rs/icu/2.3.1/icu/locale/struct.Locale.html#structfield.extensions) for more information.
-    */
+    /**
+     * Set a Unicode extension.
+     *
+     * See the [Rust documentation for `extensions`](https://docs.rs/icu/2.3.1/icu/locale/struct.Locale.html#structfield.extensions) for more information.
+     */
     fun setUnicodeExtension(k: String, v: String): Unit? {
         val kSliceMemory = PrimitiveArrayTools.borrowUtf8(k)
         val vSliceMemory = PrimitiveArrayTools.borrowUtf8(v)
@@ -192,10 +200,11 @@ class Locale internal constructor (
         }
     }
     
-    /** Returns a string representation of [Locale] language.
-    *
-    *See the [Rust documentation for `id`](https://docs.rs/icu/2.3.1/icu/locale/struct.Locale.html#structfield.id) for more information.
-    */
+    /**
+     * Returns a string representation of [Locale] language.
+     *
+     * See the [Rust documentation for `id`](https://docs.rs/icu/2.3.1/icu/locale/struct.Locale.html#structfield.id) for more information.
+     */
     fun language(): String {
         val write = DW.lib.diplomat_buffer_write_create(0)
         val returnVal = lib.icu4x_Locale_language_mv1(handle, write);
@@ -204,10 +213,11 @@ class Locale internal constructor (
         return returnString
     }
     
-    /** Set the language part of the [Locale].
-    *
-    *See the [Rust documentation for `try_from_str`](https://docs.rs/icu/2.3.1/icu/locale/struct.Locale.html#method.try_from_str) for more information.
-    */
+    /**
+     * Set the language part of the [Locale].
+     *
+     * See the [Rust documentation for `try_from_str`](https://docs.rs/icu/2.3.1/icu/locale/struct.Locale.html#method.try_from_str) for more information.
+     */
     fun setLanguage(s: String): Result<Unit> {
         val sSliceMemory = PrimitiveArrayTools.borrowUtf8(s)
         
@@ -224,10 +234,11 @@ class Locale internal constructor (
         }
     }
     
-    /** Returns a string representation of [Locale] region.
-    *
-    *See the [Rust documentation for `id`](https://docs.rs/icu/2.3.1/icu/locale/struct.Locale.html#structfield.id) for more information.
-    */
+    /**
+     * Returns a string representation of [Locale] region.
+     *
+     * See the [Rust documentation for `id`](https://docs.rs/icu/2.3.1/icu/locale/struct.Locale.html#structfield.id) for more information.
+     */
     fun region(): String? {
         val write = DW.lib.diplomat_buffer_write_create(0)
         val returnVal = lib.icu4x_Locale_region_mv1(handle, write);
@@ -239,10 +250,11 @@ class Locale internal constructor (
                                 
     }
     
-    /** Set the region part of the [Locale].
-    *
-    *See the [Rust documentation for `try_from_str`](https://docs.rs/icu/2.3.1/icu/locale/struct.Locale.html#method.try_from_str) for more information.
-    */
+    /**
+     * Set the region part of the [Locale].
+     *
+     * See the [Rust documentation for `try_from_str`](https://docs.rs/icu/2.3.1/icu/locale/struct.Locale.html#method.try_from_str) for more information.
+     */
     fun setRegion(s: String): Result<Unit> {
         val sSliceMemory = PrimitiveArrayTools.borrowUtf8(s)
         
@@ -259,10 +271,11 @@ class Locale internal constructor (
         }
     }
     
-    /** Returns a string representation of [Locale] script.
-    *
-    *See the [Rust documentation for `id`](https://docs.rs/icu/2.3.1/icu/locale/struct.Locale.html#structfield.id) for more information.
-    */
+    /**
+     * Returns a string representation of [Locale] script.
+     *
+     * See the [Rust documentation for `id`](https://docs.rs/icu/2.3.1/icu/locale/struct.Locale.html#structfield.id) for more information.
+     */
     fun script(): String? {
         val write = DW.lib.diplomat_buffer_write_create(0)
         val returnVal = lib.icu4x_Locale_script_mv1(handle, write);
@@ -274,10 +287,11 @@ class Locale internal constructor (
                                 
     }
     
-    /** Set the script part of the [Locale]. Pass an empty string to remove the script.
-    *
-    *See the [Rust documentation for `try_from_str`](https://docs.rs/icu/2.3.1/icu/locale/struct.Locale.html#method.try_from_str) for more information.
-    */
+    /**
+     * Set the script part of the [Locale]. Pass an empty string to remove the script.
+     *
+     * See the [Rust documentation for `try_from_str`](https://docs.rs/icu/2.3.1/icu/locale/struct.Locale.html#method.try_from_str) for more information.
+     */
     fun setScript(s: String): Result<Unit> {
         val sSliceMemory = PrimitiveArrayTools.borrowUtf8(s)
         
@@ -294,10 +308,11 @@ class Locale internal constructor (
         }
     }
     
-    /** Returns a string representation of the [Locale] variants.
-    *
-    *See the [Rust documentation for `Variants`](https://docs.rs/icu/2.3.1/icu/locale/struct.Variants.html) for more information.
-    */
+    /**
+     * Returns a string representation of the [Locale] variants.
+     *
+     * See the [Rust documentation for `Variants`](https://docs.rs/icu/2.3.1/icu/locale/struct.Variants.html) for more information.
+     */
     fun variants(): String {
         val write = DW.lib.diplomat_buffer_write_create(0)
         val returnVal = lib.icu4x_Locale_variants_mv1(handle, write);
@@ -306,20 +321,22 @@ class Locale internal constructor (
         return returnString
     }
     
-    /** Returns the number of variants in this [Locale].
-    *
-    *See the [Rust documentation for `Variants`](https://docs.rs/icu/2.3.1/icu/locale/struct.Variants.html) for more information.
-    */
+    /**
+     * Returns the number of variants in this [Locale].
+     *
+     * See the [Rust documentation for `Variants`](https://docs.rs/icu/2.3.1/icu/locale/struct.Variants.html) for more information.
+     */
     fun variantCount(): ULong {
         
         val returnVal = lib.icu4x_Locale_variant_count_mv1(handle);
         return (returnVal.toULong())
     }
     
-    /** Returns the variant at the given index, or nothing if the index is out of bounds.
-    *
-    *See the [Rust documentation for `Variants`](https://docs.rs/icu/2.3.1/icu/locale/struct.Variants.html) for more information.
-    */
+    /**
+     * Returns the variant at the given index, or nothing if the index is out of bounds.
+     *
+     * See the [Rust documentation for `Variants`](https://docs.rs/icu/2.3.1/icu/locale/struct.Variants.html) for more information.
+     */
     fun variantAt(index: ULong): String? {
         val write = DW.lib.diplomat_buffer_write_create(0)
         val returnVal = lib.icu4x_Locale_variant_at_mv1(handle, FFISizet(index), write);
@@ -331,10 +348,11 @@ class Locale internal constructor (
                                 
     }
     
-    /** Returns whether the [Locale] has a specific variant.
-    *
-    *See the [Rust documentation for `Variants`](https://docs.rs/icu/2.3.1/icu/locale/struct.Variants.html) for more information.
-    */
+    /**
+     * Returns whether the [Locale] has a specific variant.
+     *
+     * See the [Rust documentation for `Variants`](https://docs.rs/icu/2.3.1/icu/locale/struct.Variants.html) for more information.
+     */
     fun hasVariant(s: String): Boolean {
         val sSliceMemory = PrimitiveArrayTools.borrowUtf8(s)
         
@@ -346,13 +364,14 @@ class Locale internal constructor (
         }
     }
     
-    /** Adds a variant to the [Locale].
-    *
-    *Returns an error if the variant string is invalid.
-    *Returns `true` if the variant was added, `false` if already present.
-    *
-    *See the [Rust documentation for `push`](https://docs.rs/icu/2.3.1/icu/locale/struct.Variants.html#method.push) for more information.
-    */
+    /**
+     * Adds a variant to the [Locale].
+     *
+     * Returns an error if the variant string is invalid.
+     * Returns `true` if the variant was added, `false` if already present.
+     *
+     * See the [Rust documentation for `push`](https://docs.rs/icu/2.3.1/icu/locale/struct.Variants.html#method.push) for more information.
+     */
     fun addVariant(s: String): Result<Boolean> {
         val sSliceMemory = PrimitiveArrayTools.borrowUtf8(s)
         
@@ -369,13 +388,14 @@ class Locale internal constructor (
         }
     }
     
-    /** Removes a variant from the [Locale].
-    *
-    *Returns `true` if the variant was removed, `false` if not present.
-    *Returns `false` for invalid variant strings (they cannot exist in the locale).
-    *
-    *See the [Rust documentation for `remove`](https://docs.rs/icu/2.3.1/icu/locale/struct.Variants.html#method.remove) for more information.
-    */
+    /**
+     * Removes a variant from the [Locale].
+     *
+     * Returns `true` if the variant was removed, `false` if not present.
+     * Returns `false` for invalid variant strings (they cannot exist in the locale).
+     *
+     * See the [Rust documentation for `remove`](https://docs.rs/icu/2.3.1/icu/locale/struct.Variants.html#method.remove) for more information.
+     */
     fun removeVariant(s: String): Boolean {
         val sSliceMemory = PrimitiveArrayTools.borrowUtf8(s)
         
@@ -387,20 +407,22 @@ class Locale internal constructor (
         }
     }
     
-    /** Clears all variants from the [Locale].
-    *
-    *See the [Rust documentation for `clear`](https://docs.rs/icu/2.3.1/icu/locale/struct.Variants.html#method.clear) for more information.
-    */
+    /**
+     * Clears all variants from the [Locale].
+     *
+     * See the [Rust documentation for `clear`](https://docs.rs/icu/2.3.1/icu/locale/struct.Variants.html#method.clear) for more information.
+     */
     fun clearVariants(): Unit {
         
         val returnVal = lib.icu4x_Locale_clear_variants_mv1(handle);
         
     }
     
-    /** Returns a string representation of [Locale].
-    *
-    *See the [Rust documentation for `write_to`](https://docs.rs/icu/2.3.1/icu/locale/struct.Locale.html#method.write_to) for more information.
-    */
+    /**
+     * Returns a string representation of [Locale].
+     *
+     * See the [Rust documentation for `write_to`](https://docs.rs/icu/2.3.1/icu/locale/struct.Locale.html#method.write_to) for more information.
+     */
     override fun toString(): String {
         val write = DW.lib.diplomat_buffer_write_create(0)
         val returnVal = lib.icu4x_Locale_to_string_mv1(handle, write);
@@ -409,8 +431,9 @@ class Locale internal constructor (
         return returnString
     }
     
-    /** See the [Rust documentation for `normalizing_eq`](https://docs.rs/icu/2.3.1/icu/locale/struct.Locale.html#method.normalizing_eq) for more information.
-    */
+    /**
+     * See the [Rust documentation for `normalizing_eq`](https://docs.rs/icu/2.3.1/icu/locale/struct.Locale.html#method.normalizing_eq) for more information.
+     */
     fun normalizingEq(other: String): Boolean {
         val otherSliceMemory = PrimitiveArrayTools.borrowUtf8(other)
         
@@ -422,8 +445,9 @@ class Locale internal constructor (
         }
     }
     
-    /** See the [Rust documentation for `strict_cmp`](https://docs.rs/icu/2.3.1/icu/locale/struct.Locale.html#method.strict_cmp) for more information.
-    */
+    /**
+     * See the [Rust documentation for `strict_cmp`](https://docs.rs/icu/2.3.1/icu/locale/struct.Locale.html#method.strict_cmp) for more information.
+     */
     fun compareToString(other: String): Byte {
         val otherSliceMemory = PrimitiveArrayTools.borrowUtf8(other)
         
@@ -435,8 +459,9 @@ class Locale internal constructor (
         }
     }
     
-    /** See the [Rust documentation for `total_cmp`](https://docs.rs/icu/2.3.1/icu/locale/struct.Locale.html#method.total_cmp) for more information.
-    */
+    /**
+     * See the [Rust documentation for `total_cmp`](https://docs.rs/icu/2.3.1/icu/locale/struct.Locale.html#method.total_cmp) for more information.
+     */
     fun compareTo(other: Locale): Byte {
         
         val returnVal = lib.icu4x_Locale_compare_to_mv1(handle, other.handle);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LocaleCanonicalizer.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LocaleCanonicalizer.kt
@@ -13,10 +13,11 @@ internal interface LocaleCanonicalizerLib: Library {
     fun icu4x_LocaleCanonicalizer_create_extended_with_provider_mv1(provider: Pointer): ResultPointerInt
     fun icu4x_LocaleCanonicalizer_canonicalize_mv1(handle: Pointer, locale: Pointer): Int
 }
-/** A locale canonicalizer.
-*
-*See the [Rust documentation for `LocaleCanonicalizer`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleCanonicalizer.html) for more information.
-*/
+/**
+ * A locale canonicalizer.
+ *
+ * See the [Rust documentation for `LocaleCanonicalizer`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleCanonicalizer.html) for more information.
+ */
 class LocaleCanonicalizer internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -45,10 +46,11 @@ class LocaleCanonicalizer internal constructor (
         internal val lib: LocaleCanonicalizerLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Create a new [LocaleCanonicalizer] using compiled data.
-        *
-        *See the [Rust documentation for `new_common`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleCanonicalizer.html#method.new_common) for more information.
-        */
+        /**
+         * Create a new [LocaleCanonicalizer] using compiled data.
+         *
+         * See the [Rust documentation for `new_common`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleCanonicalizer.html#method.new_common) for more information.
+         */
         fun createCommon(): LocaleCanonicalizer {
             
             val returnVal = lib.icu4x_LocaleCanonicalizer_create_common_mv1();
@@ -59,10 +61,11 @@ class LocaleCanonicalizer internal constructor (
         }
         @JvmStatic
         
-        /** Create a new [LocaleCanonicalizer].
-        *
-        *See the [Rust documentation for `new_common`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleCanonicalizer.html#method.new_common) for more information.
-        */
+        /**
+         * Create a new [LocaleCanonicalizer].
+         *
+         * See the [Rust documentation for `new_common`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleCanonicalizer.html#method.new_common) for more information.
+         */
         fun createCommonWithProvider(provider: DataProvider): Result<LocaleCanonicalizer> {
             
             val returnVal = lib.icu4x_LocaleCanonicalizer_create_common_with_provider_mv1(provider.handle);
@@ -78,10 +81,11 @@ class LocaleCanonicalizer internal constructor (
         }
         @JvmStatic
         
-        /** Create a new [LocaleCanonicalizer] with extended data using compiled data.
-        *
-        *See the [Rust documentation for `new_extended`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleCanonicalizer.html#method.new_extended) for more information.
-        */
+        /**
+         * Create a new [LocaleCanonicalizer] with extended data using compiled data.
+         *
+         * See the [Rust documentation for `new_extended`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleCanonicalizer.html#method.new_extended) for more information.
+         */
         fun createExtended(): LocaleCanonicalizer {
             
             val returnVal = lib.icu4x_LocaleCanonicalizer_create_extended_mv1();
@@ -92,10 +96,11 @@ class LocaleCanonicalizer internal constructor (
         }
         @JvmStatic
         
-        /** Create a new [LocaleCanonicalizer] with extended data.
-        *
-        *See the [Rust documentation for `new_extended`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleCanonicalizer.html#method.new_extended) for more information.
-        */
+        /**
+         * Create a new [LocaleCanonicalizer] with extended data.
+         *
+         * See the [Rust documentation for `new_extended`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleCanonicalizer.html#method.new_extended) for more information.
+         */
         fun createExtendedWithProvider(provider: DataProvider): Result<LocaleCanonicalizer> {
             
             val returnVal = lib.icu4x_LocaleCanonicalizer_create_extended_with_provider_mv1(provider.handle);
@@ -111,8 +116,9 @@ class LocaleCanonicalizer internal constructor (
         }
     }
     
-    /** See the [Rust documentation for `canonicalize`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleCanonicalizer.html#method.canonicalize) for more information.
-    */
+    /**
+     * See the [Rust documentation for `canonicalize`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleCanonicalizer.html#method.canonicalize) for more information.
+     */
     fun canonicalize(locale: Locale): TransformResult {
         
         val returnVal = lib.icu4x_LocaleCanonicalizer_canonicalize_mv1(handle, locale.handle /* note this is a mutable reference. Think carefully about using, especially concurrently */);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LocaleDirection.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LocaleDirection.kt
@@ -8,7 +8,8 @@ import com.sun.jna.Structure
 
 internal interface LocaleDirectionLib: Library {
 }
-/** See the [Rust documentation for `Direction`](https://docs.rs/icu/2.3.1/icu/locale/enum.Direction.html) for more information.
+/**
+ * See the [Rust documentation for `Direction`](https://docs.rs/icu/2.3.1/icu/locale/enum.Direction.html) for more information.
 */
 enum class LocaleDirection {
     LeftToRight,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LocaleDirectionality.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LocaleDirectionality.kt
@@ -15,8 +15,9 @@ internal interface LocaleDirectionalityLib: Library {
     fun icu4x_LocaleDirectionality_is_left_to_right_mv1(handle: Pointer, locale: Pointer): Byte
     fun icu4x_LocaleDirectionality_is_right_to_left_mv1(handle: Pointer, locale: Pointer): Byte
 }
-/** See the [Rust documentation for `LocaleDirectionality`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleDirectionality.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `LocaleDirectionality`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleDirectionality.html) for more information.
+ */
 class LocaleDirectionality internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -45,10 +46,11 @@ class LocaleDirectionality internal constructor (
         internal val lib: LocaleDirectionalityLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Construct a new `LocaleDirectionality` instance using compiled data.
-        *
-        *See the [Rust documentation for `new_common`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleDirectionality.html#method.new_common) for more information.
-        */
+        /**
+         * Construct a new `LocaleDirectionality` instance using compiled data.
+         *
+         * See the [Rust documentation for `new_common`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleDirectionality.html#method.new_common) for more information.
+         */
         fun createCommon(): LocaleDirectionality {
             
             val returnVal = lib.icu4x_LocaleDirectionality_create_common_mv1();
@@ -59,10 +61,11 @@ class LocaleDirectionality internal constructor (
         }
         @JvmStatic
         
-        /** Construct a new `LocaleDirectionality` instance using a particular data source.
-        *
-        *See the [Rust documentation for `new_common`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleDirectionality.html#method.new_common) for more information.
-        */
+        /**
+         * Construct a new `LocaleDirectionality` instance using a particular data source.
+         *
+         * See the [Rust documentation for `new_common`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleDirectionality.html#method.new_common) for more information.
+         */
         fun createCommonWithProvider(provider: DataProvider): Result<LocaleDirectionality> {
             
             val returnVal = lib.icu4x_LocaleDirectionality_create_common_with_provider_mv1(provider.handle);
@@ -78,10 +81,11 @@ class LocaleDirectionality internal constructor (
         }
         @JvmStatic
         
-        /** Construct a new `LocaleDirectionality` instance using compiled data.
-        *
-        *See the [Rust documentation for `new_extended`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleDirectionality.html#method.new_extended) for more information.
-        */
+        /**
+         * Construct a new `LocaleDirectionality` instance using compiled data.
+         *
+         * See the [Rust documentation for `new_extended`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleDirectionality.html#method.new_extended) for more information.
+         */
         fun createExtended(): LocaleDirectionality {
             
             val returnVal = lib.icu4x_LocaleDirectionality_create_extended_mv1();
@@ -92,10 +96,11 @@ class LocaleDirectionality internal constructor (
         }
         @JvmStatic
         
-        /** Construct a new `LocaleDirectionality` instance using a particular data source.
-        *
-        *See the [Rust documentation for `new_extended`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleDirectionality.html#method.new_extended) for more information.
-        */
+        /**
+         * Construct a new `LocaleDirectionality` instance using a particular data source.
+         *
+         * See the [Rust documentation for `new_extended`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleDirectionality.html#method.new_extended) for more information.
+         */
         fun createExtendedWithProvider(provider: DataProvider): Result<LocaleDirectionality> {
             
             val returnVal = lib.icu4x_LocaleDirectionality_create_extended_with_provider_mv1(provider.handle);
@@ -111,24 +116,27 @@ class LocaleDirectionality internal constructor (
         }
     }
     
-    /** See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleDirectionality.html#method.get) for more information.
-    */
+    /**
+     * See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleDirectionality.html#method.get) for more information.
+     */
     fun get(locale: Locale): LocaleDirection {
         
         val returnVal = lib.icu4x_LocaleDirectionality_get_mv1(handle, locale.handle);
         return (LocaleDirection.fromNative(returnVal))
     }
     
-    /** See the [Rust documentation for `is_left_to_right`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleDirectionality.html#method.is_left_to_right) for more information.
-    */
+    /**
+     * See the [Rust documentation for `is_left_to_right`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleDirectionality.html#method.is_left_to_right) for more information.
+     */
     fun isLeftToRight(locale: Locale): Boolean {
         
         val returnVal = lib.icu4x_LocaleDirectionality_is_left_to_right_mv1(handle, locale.handle);
         return (returnVal > 0)
     }
     
-    /** See the [Rust documentation for `is_right_to_left`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleDirectionality.html#method.is_right_to_left) for more information.
-    */
+    /**
+     * See the [Rust documentation for `is_right_to_left`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleDirectionality.html#method.is_right_to_left) for more information.
+     */
     fun isRightToLeft(locale: Locale): Boolean {
         
         val returnVal = lib.icu4x_LocaleDirectionality_is_right_to_left_mv1(handle, locale.handle);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LocaleDisplayNamesFormatter.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LocaleDisplayNamesFormatter.kt
@@ -11,10 +11,11 @@ internal interface LocaleDisplayNamesFormatterLib: Library {
     fun icu4x_LocaleDisplayNamesFormatter_create_v1_with_provider_mv1(provider: Pointer, locale: Pointer, options: DisplayNamesOptionsNative): ResultPointerInt
     fun icu4x_LocaleDisplayNamesFormatter_of_mv1(handle: Pointer, locale: Pointer, write: Pointer): Unit
 }
-/** 🚧 This API is unstable and may experience breaking changes outside major releases.
-*
-*See the [Rust documentation for `LocaleDisplayNamesFormatter`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.LocaleDisplayNamesFormatter.html) for more information.
-*/
+/**
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
+ *
+ * See the [Rust documentation for `LocaleDisplayNamesFormatter`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.LocaleDisplayNamesFormatter.html) for more information.
+ */
 class LocaleDisplayNamesFormatter internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -43,12 +44,13 @@ class LocaleDisplayNamesFormatter internal constructor (
         internal val lib: LocaleDisplayNamesFormatterLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *Creates a new `LocaleDisplayNamesFormatter` from locale data and an options bag using compiled data.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.LocaleDisplayNamesFormatter.html#method.try_new) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * Creates a new `LocaleDisplayNamesFormatter` from locale data and an options bag using compiled data.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.LocaleDisplayNamesFormatter.html#method.try_new) for more information.
+         */
         fun create(locale: Locale, options: DisplayNamesOptions): Result<LocaleDisplayNamesFormatter> {
             
             val returnVal = lib.icu4x_LocaleDisplayNamesFormatter_create_v1_mv1(locale.handle, options.toNative());
@@ -64,12 +66,13 @@ class LocaleDisplayNamesFormatter internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *Creates a new `LocaleDisplayNamesFormatter` from locale data and an options bag using a particular data source.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/struct.LocaleDisplayNamesFormatter.html#method.try_new) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * Creates a new `LocaleDisplayNamesFormatter` from locale data and an options bag using a particular data source.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/struct.LocaleDisplayNamesFormatter.html#method.try_new) for more information.
+         */
         fun create_with_provider(provider: DataProvider, locale: Locale, options: DisplayNamesOptions): Result<LocaleDisplayNamesFormatter> {
             
             val returnVal = lib.icu4x_LocaleDisplayNamesFormatter_create_v1_with_provider_mv1(provider.handle, locale.handle, options.toNative());
@@ -85,13 +88,14 @@ class LocaleDisplayNamesFormatter internal constructor (
         }
     }
     
-    /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-    *
-    *Returns the locale-specific display name of a locale.
-    *🚧 This API is unstable and may experience breaking changes outside major releases.
-    *
-    *See the [Rust documentation for `of`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.LocaleDisplayNamesFormatter.html#method.of) for more information.
-    */
+    /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
+     * Returns the locale-specific display name of a locale.
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
+     * See the [Rust documentation for `of`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.LocaleDisplayNamesFormatter.html#method.of) for more information.
+     */
     fun of(locale: Locale): String {
         val write = DW.lib.diplomat_buffer_write_create(0)
         val returnVal = lib.icu4x_LocaleDisplayNamesFormatter_of_mv1(handle, locale.handle, write);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LocaleDisplayNamesFormatter.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LocaleDisplayNamesFormatter.kt
@@ -12,9 +12,9 @@ internal interface LocaleDisplayNamesFormatterLib: Library {
     fun icu4x_LocaleDisplayNamesFormatter_of_mv1(handle: Pointer, locale: Pointer, write: Pointer): Unit
 }
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `LocaleDisplayNamesFormatter`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.LocaleDisplayNamesFormatter.html) for more information.
+ *
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
  */
 class LocaleDisplayNamesFormatter internal constructor (
     internal val handle: Pointer,
@@ -45,11 +45,11 @@ class LocaleDisplayNamesFormatter internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * Creates a new `LocaleDisplayNamesFormatter` from locale data and an options bag using compiled data.
          *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.LocaleDisplayNamesFormatter.html#method.try_new) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun create(locale: Locale, options: DisplayNamesOptions): Result<LocaleDisplayNamesFormatter> {
             
@@ -67,11 +67,11 @@ class LocaleDisplayNamesFormatter internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * Creates a new `LocaleDisplayNamesFormatter` from locale data and an options bag using a particular data source.
          *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/struct.LocaleDisplayNamesFormatter.html#method.try_new) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun create_with_provider(provider: DataProvider, locale: Locale, options: DisplayNamesOptions): Result<LocaleDisplayNamesFormatter> {
             
@@ -89,12 +89,11 @@ class LocaleDisplayNamesFormatter internal constructor (
     }
     
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * Returns the locale-specific display name of a locale.
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
      * See the [Rust documentation for `of`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.LocaleDisplayNamesFormatter.html#method.of) for more information.
+     *
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
      */
     fun of(locale: Locale): String {
         val write = DW.lib.diplomat_buffer_write_create(0)

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LocaleExpander.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LocaleExpander.kt
@@ -15,10 +15,11 @@ internal interface LocaleExpanderLib: Library {
     fun icu4x_LocaleExpander_minimize_mv1(handle: Pointer, locale: Pointer): Int
     fun icu4x_LocaleExpander_minimize_favor_script_mv1(handle: Pointer, locale: Pointer): Int
 }
-/** A locale expander.
-*
-*See the [Rust documentation for `LocaleExpander`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleExpander.html) for more information.
-*/
+/**
+ * A locale expander.
+ *
+ * See the [Rust documentation for `LocaleExpander`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleExpander.html) for more information.
+ */
 class LocaleExpander internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -47,10 +48,11 @@ class LocaleExpander internal constructor (
         internal val lib: LocaleExpanderLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Create a new [LocaleExpander] using compiled data.
-        *
-        *See the [Rust documentation for `new_common`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleExpander.html#method.new_common) for more information.
-        */
+        /**
+         * Create a new [LocaleExpander] using compiled data.
+         *
+         * See the [Rust documentation for `new_common`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleExpander.html#method.new_common) for more information.
+         */
         fun createCommon(): LocaleExpander {
             
             val returnVal = lib.icu4x_LocaleExpander_create_common_mv1();
@@ -61,10 +63,11 @@ class LocaleExpander internal constructor (
         }
         @JvmStatic
         
-        /** Create a new [LocaleExpander] using a `new_common` data source.
-        *
-        *See the [Rust documentation for `new_common`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleExpander.html#method.new_common) for more information.
-        */
+        /**
+         * Create a new [LocaleExpander] using a `new_common` data source.
+         *
+         * See the [Rust documentation for `new_common`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleExpander.html#method.new_common) for more information.
+         */
         fun createCommonWithProvider(provider: DataProvider): Result<LocaleExpander> {
             
             val returnVal = lib.icu4x_LocaleExpander_create_common_with_provider_mv1(provider.handle);
@@ -80,10 +83,11 @@ class LocaleExpander internal constructor (
         }
         @JvmStatic
         
-        /** Create a new [LocaleExpander] with extended data using compiled data.
-        *
-        *See the [Rust documentation for `new_extended`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleExpander.html#method.new_extended) for more information.
-        */
+        /**
+         * Create a new [LocaleExpander] with extended data using compiled data.
+         *
+         * See the [Rust documentation for `new_extended`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleExpander.html#method.new_extended) for more information.
+         */
         fun createExtended(): LocaleExpander {
             
             val returnVal = lib.icu4x_LocaleExpander_create_extended_mv1();
@@ -94,10 +98,11 @@ class LocaleExpander internal constructor (
         }
         @JvmStatic
         
-        /** Create a new [LocaleExpander] with extended data using a particular data source.
-        *
-        *See the [Rust documentation for `new_extended`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleExpander.html#method.new_extended) for more information.
-        */
+        /**
+         * Create a new [LocaleExpander] with extended data using a particular data source.
+         *
+         * See the [Rust documentation for `new_extended`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleExpander.html#method.new_extended) for more information.
+         */
         fun createExtendedWithProvider(provider: DataProvider): Result<LocaleExpander> {
             
             val returnVal = lib.icu4x_LocaleExpander_create_extended_with_provider_mv1(provider.handle);
@@ -113,24 +118,27 @@ class LocaleExpander internal constructor (
         }
     }
     
-    /** See the [Rust documentation for `maximize`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleExpander.html#method.maximize) for more information.
-    */
+    /**
+     * See the [Rust documentation for `maximize`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleExpander.html#method.maximize) for more information.
+     */
     fun maximize(locale: Locale): TransformResult {
         
         val returnVal = lib.icu4x_LocaleExpander_maximize_mv1(handle, locale.handle /* note this is a mutable reference. Think carefully about using, especially concurrently */);
         return (TransformResult.fromNative(returnVal))
     }
     
-    /** See the [Rust documentation for `minimize`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleExpander.html#method.minimize) for more information.
-    */
+    /**
+     * See the [Rust documentation for `minimize`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleExpander.html#method.minimize) for more information.
+     */
     fun minimize(locale: Locale): TransformResult {
         
         val returnVal = lib.icu4x_LocaleExpander_minimize_mv1(handle, locale.handle /* note this is a mutable reference. Think carefully about using, especially concurrently */);
         return (TransformResult.fromNative(returnVal))
     }
     
-    /** See the [Rust documentation for `minimize_favor_script`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleExpander.html#method.minimize_favor_script) for more information.
-    */
+    /**
+     * See the [Rust documentation for `minimize_favor_script`](https://docs.rs/icu/2.3.1/icu/locale/struct.LocaleExpander.html#method.minimize_favor_script) for more information.
+     */
     fun minimizeFavorScript(locale: Locale): TransformResult {
         
         val returnVal = lib.icu4x_LocaleExpander_minimize_favor_script_mv1(handle, locale.handle /* note this is a mutable reference. Think carefully about using, especially concurrently */);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LocaleFallbackConfig.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LocaleFallbackConfig.kt
@@ -10,8 +10,9 @@ internal interface LocaleFallbackConfigLib: Library {
 }
 
 internal class LocaleFallbackConfigNative: Structure(), Structure.ByValue {
-    /** Choice of priority mode.
-    */
+    /**
+     * Choice of priority mode.
+     */
     @JvmField
     internal var priority: Int = LocaleFallbackPriority.default().toNative();
 
@@ -62,10 +63,11 @@ internal class OptionLocaleFallbackConfigNative constructor(): Structure(), Stru
 
 }
 
-/** Collection of configurations for the ICU4X fallback algorithm.
-*
-*See the [Rust documentation for `LocaleFallbackConfig`](https://docs.rs/icu/2.3.1/icu/locale/fallback/struct.LocaleFallbackConfig.html) for more information.
-*/
+/**
+ * Collection of configurations for the ICU4X fallback algorithm.
+ *
+ * See the [Rust documentation for `LocaleFallbackConfig`](https://docs.rs/icu/2.3.1/icu/locale/fallback/struct.LocaleFallbackConfig.html) for more information.
+ */
 class LocaleFallbackConfig (var priority: LocaleFallbackPriority) {
     companion object {
 

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LocaleFallbackIterator.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LocaleFallbackIterator.kt
@@ -10,10 +10,11 @@ internal interface LocaleFallbackIteratorLib: Library {
     fun icu4x_LocaleFallbackIterator_next_mv1(handle: Pointer): Pointer?
 }
 typealias LocaleFallbackIteratorIteratorItem = Locale?
-/** An iterator over the locale under fallback.
-*
-*See the [Rust documentation for `LocaleFallbackIterator`](https://docs.rs/icu/2.3.1/icu/locale/fallback/struct.LocaleFallbackIterator.html) for more information.
-*/
+/**
+ * An iterator over the locale under fallback.
+ *
+ * See the [Rust documentation for `LocaleFallbackIterator`](https://docs.rs/icu/2.3.1/icu/locale/fallback/struct.LocaleFallbackIterator.html) for more information.
+ */
 class LocaleFallbackIterator internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LocaleFallbackPriority.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LocaleFallbackPriority.kt
@@ -8,9 +8,10 @@ import com.sun.jna.Structure
 
 internal interface LocaleFallbackPriorityLib: Library {
 }
-/** Priority mode for the ICU4X fallback algorithm.
-*
-*See the [Rust documentation for `LocaleFallbackPriority`](https://docs.rs/icu/2.3.1/icu/locale/fallback/enum.LocaleFallbackPriority.html) for more information.
+/**
+ * Priority mode for the ICU4X fallback algorithm.
+ *
+ * See the [Rust documentation for `LocaleFallbackPriority`](https://docs.rs/icu/2.3.1/icu/locale/fallback/enum.LocaleFallbackPriority.html) for more information.
 */
 enum class LocaleFallbackPriority {
     Language,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LocaleFallbacker.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LocaleFallbacker.kt
@@ -12,10 +12,11 @@ internal interface LocaleFallbackerLib: Library {
     fun icu4x_LocaleFallbacker_without_data_mv1(): Pointer
     fun icu4x_LocaleFallbacker_for_config_mv1(handle: Pointer, config: LocaleFallbackConfigNative): Pointer
 }
-/** An object that runs the ICU4X locale fallback algorithm.
-*
-*See the [Rust documentation for `LocaleFallbacker`](https://docs.rs/icu/2.3.1/icu/locale/fallback/struct.LocaleFallbacker.html) for more information.
-*/
+/**
+ * An object that runs the ICU4X locale fallback algorithm.
+ *
+ * See the [Rust documentation for `LocaleFallbacker`](https://docs.rs/icu/2.3.1/icu/locale/fallback/struct.LocaleFallbacker.html) for more information.
+ */
 class LocaleFallbacker internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -44,10 +45,11 @@ class LocaleFallbacker internal constructor (
         internal val lib: LocaleFallbackerLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Creates a new `LocaleFallbacker` from compiled data.
-        *
-        *See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/locale/fallback/struct.LocaleFallbacker.html#method.new) for more information.
-        */
+        /**
+         * Creates a new `LocaleFallbacker` from compiled data.
+         *
+         * See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/locale/fallback/struct.LocaleFallbacker.html#method.new) for more information.
+         */
         fun create(): LocaleFallbacker {
             
             val returnVal = lib.icu4x_LocaleFallbacker_create_mv1();
@@ -58,10 +60,11 @@ class LocaleFallbacker internal constructor (
         }
         @JvmStatic
         
-        /** Creates a new `LocaleFallbacker` from a data provider.
-        *
-        *See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/locale/fallback/struct.LocaleFallbacker.html#method.new) for more information.
-        */
+        /**
+         * Creates a new `LocaleFallbacker` from a data provider.
+         *
+         * See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/locale/fallback/struct.LocaleFallbacker.html#method.new) for more information.
+         */
         fun createWithProvider(provider: DataProvider): Result<LocaleFallbacker> {
             
             val returnVal = lib.icu4x_LocaleFallbacker_create_with_provider_mv1(provider.handle);
@@ -77,10 +80,11 @@ class LocaleFallbacker internal constructor (
         }
         @JvmStatic
         
-        /** Creates a new `LocaleFallbacker` without data for limited functionality.
-        *
-        *See the [Rust documentation for `new_without_data`](https://docs.rs/icu/2.3.1/icu/locale/fallback/struct.LocaleFallbacker.html#method.new_without_data) for more information.
-        */
+        /**
+         * Creates a new `LocaleFallbacker` without data for limited functionality.
+         *
+         * See the [Rust documentation for `new_without_data`](https://docs.rs/icu/2.3.1/icu/locale/fallback/struct.LocaleFallbacker.html#method.new_without_data) for more information.
+         */
         fun withoutData(): LocaleFallbacker {
             
             val returnVal = lib.icu4x_LocaleFallbacker_without_data_mv1();
@@ -91,10 +95,11 @@ class LocaleFallbacker internal constructor (
         }
     }
     
-    /** Associates this `LocaleFallbacker` with configuration options.
-    *
-    *See the [Rust documentation for `for_config`](https://docs.rs/icu/2.3.1/icu/locale/fallback/struct.LocaleFallbacker.html#method.for_config) for more information.
-    */
+    /**
+     * Associates this `LocaleFallbacker` with configuration options.
+     *
+     * See the [Rust documentation for `for_config`](https://docs.rs/icu/2.3.1/icu/locale/fallback/struct.LocaleFallbacker.html#method.for_config) for more information.
+     */
     fun forConfig(config: LocaleFallbackConfig): LocaleFallbackerWithConfig {
         // This lifetime edge depends on lifetimes: 'a
         val aEdges: MutableList<Any> = mutableListOf(this);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LocaleFallbackerWithConfig.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LocaleFallbackerWithConfig.kt
@@ -10,10 +10,11 @@ internal interface LocaleFallbackerWithConfigLib: Library {
     fun icu4x_LocaleFallbackerWithConfig_config_mv1(handle: Pointer): LocaleFallbackConfigNative
     fun icu4x_LocaleFallbackerWithConfig_fallback_for_locale_mv1(handle: Pointer, locale: Pointer): Pointer
 }
-/** An object that runs the ICU4X locale fallback algorithm with specific configurations.
-*
-*See the [Rust documentation for `LocaleFallbackerWithConfig`](https://docs.rs/icu/2.3.1/icu/locale/fallback/struct.LocaleFallbackerWithConfig.html) for more information.
-*/
+/**
+ * An object that runs the ICU4X locale fallback algorithm with specific configurations.
+ *
+ * See the [Rust documentation for `LocaleFallbackerWithConfig`](https://docs.rs/icu/2.3.1/icu/locale/fallback/struct.LocaleFallbackerWithConfig.html) for more information.
+ */
 class LocaleFallbackerWithConfig internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -43,10 +44,11 @@ class LocaleFallbackerWithConfig internal constructor (
         internal val lib: LocaleFallbackerWithConfigLib = Native.load("icu4x", libClass)
     }
     
-    /** Returns the associated config.
-    *
-    *See the [Rust documentation for `config`](https://docs.rs/icu/2.3.1/icu/locale/fallback/struct.LocaleFallbackerWithConfig.html#method.config) for more information.
-    */
+    /**
+     * Returns the associated config.
+     *
+     * See the [Rust documentation for `config`](https://docs.rs/icu/2.3.1/icu/locale/fallback/struct.LocaleFallbackerWithConfig.html#method.config) for more information.
+     */
     fun config(): LocaleFallbackConfig {
         
         val returnVal = lib.icu4x_LocaleFallbackerWithConfig_config_mv1(handle);
@@ -54,10 +56,11 @@ class LocaleFallbackerWithConfig internal constructor (
         return returnStruct
     }
     
-    /** Creates an iterator from a locale with each step of fallback.
-    *
-    *See the [Rust documentation for `fallback_for`](https://docs.rs/icu/2.3.1/icu/locale/fallback/struct.LocaleFallbacker.html#method.fallback_for) for more information.
-    */
+    /**
+     * Creates an iterator from a locale with each step of fallback.
+     *
+     * See the [Rust documentation for `fallback_for`](https://docs.rs/icu/2.3.1/icu/locale/fallback/struct.LocaleFallbacker.html#method.fallback_for) for more information.
+     */
     fun fallbackForLocale(locale: Locale): LocaleFallbackIterator {
         // This lifetime edge depends on lifetimes: 'a, 'b
         val aEdges: MutableList<Any> = mutableListOf(this);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LocaleNamesUnstable.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LocaleNamesUnstable.kt
@@ -48,19 +48,20 @@ internal interface LocaleNamesUnstableLib: Library {
     fun icu4x_LocaleNamesUnstable_for_language_identifier_short_menu_heavy_mv1(locale: Pointer, langid: Pointer, languageDisplay: Int, write: Pointer): ResultUnitInt
     fun icu4x_LocaleNamesUnstable_for_language_identifier_short_menu_heavy_with_provider_mv1(provider: Pointer, locale: Pointer, langid: Pointer, languageDisplay: Int, write: Pointer): ResultUnitInt
 }
-/** 🚧 This API is unstable and may experience breaking changes outside major releases.
-*
-*This struct holds free functions for loading display names for languages, scripts,
-*regions, and language identifiers.
-*
-*See the [Rust documentation for `RegionDisplayName`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html) for more information.
-*
-*See the [Rust documentation for `ScriptDisplayName`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html) for more information.
-*
-*See the [Rust documentation for `VariantDisplayName`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.VariantDisplayName.html) for more information.
-*
-*See the [Rust documentation for `LanguageIdentifierDisplayName`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html) for more information.
-*/
+/**
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
+ *
+ * This struct holds free functions for loading display names for languages, scripts,
+ * regions, and language identifiers.
+ *
+ * See the [Rust documentation for `RegionDisplayName`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html) for more information.
+ *
+ * See the [Rust documentation for `ScriptDisplayName`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html) for more information.
+ *
+ * See the [Rust documentation for `VariantDisplayName`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.VariantDisplayName.html) for more information.
+ *
+ * See the [Rust documentation for `LanguageIdentifierDisplayName`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html) for more information.
+ */
 class LocaleNamesUnstable internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -89,10 +90,11 @@ class LocaleNamesUnstable internal constructor (
         internal val lib: LocaleNamesUnstableLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_light_with_fallback) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_light_with_fallback) for more information.
+         */
         fun forRegionLight(locale: Locale, region: String): String {
             val regionSliceMemory = PrimitiveArrayTools.borrowUtf8(region)
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -107,10 +109,11 @@ class LocaleNamesUnstable internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_light_with_fallback) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_light_with_fallback) for more information.
+         */
         fun forRegionLightWithProvider(provider: DataProvider, locale: Locale, region: String): Result<String> {
             val regionSliceMemory = PrimitiveArrayTools.borrowUtf8(region)
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -130,10 +133,11 @@ class LocaleNamesUnstable internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_tiny_with_fallback) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_tiny_with_fallback) for more information.
+         */
         fun forRegionTiny(locale: Locale, region: String): String {
             val regionSliceMemory = PrimitiveArrayTools.borrowUtf8(region)
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -148,10 +152,11 @@ class LocaleNamesUnstable internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_tiny_with_fallback) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_tiny_with_fallback) for more information.
+         */
         fun forRegionTinyWithProvider(provider: DataProvider, locale: Locale, region: String): Result<String> {
             val regionSliceMemory = PrimitiveArrayTools.borrowUtf8(region)
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -171,10 +176,11 @@ class LocaleNamesUnstable internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `new_short_tiny_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_short_tiny_with_fallback) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `new_short_tiny_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_short_tiny_with_fallback) for more information.
+         */
         fun forRegionShortTiny(locale: Locale, region: String): String {
             val regionSliceMemory = PrimitiveArrayTools.borrowUtf8(region)
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -189,10 +195,11 @@ class LocaleNamesUnstable internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `new_short_tiny_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_short_tiny_with_fallback) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `new_short_tiny_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_short_tiny_with_fallback) for more information.
+         */
         fun forRegionShortTinyWithProvider(provider: DataProvider, locale: Locale, region: String): Result<String> {
             val regionSliceMemory = PrimitiveArrayTools.borrowUtf8(region)
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -212,10 +219,11 @@ class LocaleNamesUnstable internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `new_short_light_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_short_light_with_fallback) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `new_short_light_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_short_light_with_fallback) for more information.
+         */
         fun forRegionShortLight(locale: Locale, region: String): String {
             val regionSliceMemory = PrimitiveArrayTools.borrowUtf8(region)
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -230,10 +238,11 @@ class LocaleNamesUnstable internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `new_short_light_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_short_light_with_fallback) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `new_short_light_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_short_light_with_fallback) for more information.
+         */
         fun forRegionShortLightWithProvider(provider: DataProvider, locale: Locale, region: String): Result<String> {
             val regionSliceMemory = PrimitiveArrayTools.borrowUtf8(region)
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -253,10 +262,11 @@ class LocaleNamesUnstable internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_light_with_fallback) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_light_with_fallback) for more information.
+         */
         fun forScriptLight(locale: Locale, script: String): String {
             val scriptSliceMemory = PrimitiveArrayTools.borrowUtf8(script)
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -271,10 +281,11 @@ class LocaleNamesUnstable internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_light_with_fallback) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_light_with_fallback) for more information.
+         */
         fun forScriptLightWithProvider(provider: DataProvider, locale: Locale, script: String): Result<String> {
             val scriptSliceMemory = PrimitiveArrayTools.borrowUtf8(script)
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -294,10 +305,11 @@ class LocaleNamesUnstable internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_tiny_with_fallback) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_tiny_with_fallback) for more information.
+         */
         fun forScriptTiny(locale: Locale, script: String): String {
             val scriptSliceMemory = PrimitiveArrayTools.borrowUtf8(script)
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -312,10 +324,11 @@ class LocaleNamesUnstable internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_tiny_with_fallback) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_tiny_with_fallback) for more information.
+         */
         fun forScriptTinyWithProvider(provider: DataProvider, locale: Locale, script: String): Result<String> {
             val scriptSliceMemory = PrimitiveArrayTools.borrowUtf8(script)
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -335,10 +348,11 @@ class LocaleNamesUnstable internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_heavy_with_fallback) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_heavy_with_fallback) for more information.
+         */
         fun forScriptHeavy(locale: Locale, script: String): String {
             val scriptSliceMemory = PrimitiveArrayTools.borrowUtf8(script)
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -353,10 +367,11 @@ class LocaleNamesUnstable internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_heavy_with_fallback) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_heavy_with_fallback) for more information.
+         */
         fun forScriptHeavyWithProvider(provider: DataProvider, locale: Locale, script: String): Result<String> {
             val scriptSliceMemory = PrimitiveArrayTools.borrowUtf8(script)
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -376,10 +391,11 @@ class LocaleNamesUnstable internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `new_short_heavy_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_short_heavy_with_fallback) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `new_short_heavy_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_short_heavy_with_fallback) for more information.
+         */
         fun forScriptShortHeavy(locale: Locale, script: String): String {
             val scriptSliceMemory = PrimitiveArrayTools.borrowUtf8(script)
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -394,10 +410,11 @@ class LocaleNamesUnstable internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `new_short_heavy_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_short_heavy_with_fallback) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `new_short_heavy_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_short_heavy_with_fallback) for more information.
+         */
         fun forScriptShortHeavyWithProvider(provider: DataProvider, locale: Locale, script: String): Result<String> {
             val scriptSliceMemory = PrimitiveArrayTools.borrowUtf8(script)
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -417,10 +434,11 @@ class LocaleNamesUnstable internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.VariantDisplayName.html#method.new_heavy_with_fallback) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.VariantDisplayName.html#method.new_heavy_with_fallback) for more information.
+         */
         fun forVariantHeavy(locale: Locale, variant: String): String {
             val variantSliceMemory = PrimitiveArrayTools.borrowUtf8(variant)
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -435,10 +453,11 @@ class LocaleNamesUnstable internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.VariantDisplayName.html#method.new_heavy_with_fallback) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.VariantDisplayName.html#method.new_heavy_with_fallback) for more information.
+         */
         fun forVariantHeavyWithProvider(provider: DataProvider, locale: Locale, variant: String): Result<String> {
             val variantSliceMemory = PrimitiveArrayTools.borrowUtf8(variant)
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -458,10 +477,11 @@ class LocaleNamesUnstable internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_light) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_light) for more information.
+         */
         fun forLanguageIdentifierLight(locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)
             val returnVal = lib.icu4x_LocaleNamesUnstable_for_language_identifier_light_mv1(locale.handle, langid.handle, languageDisplay.toNative(), write);
@@ -476,10 +496,11 @@ class LocaleNamesUnstable internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_light) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_light) for more information.
+         */
         fun forLanguageIdentifierLightWithProvider(provider: DataProvider, locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)
             val returnVal = lib.icu4x_LocaleNamesUnstable_for_language_identifier_light_with_provider_mv1(provider.handle, locale.handle, langid.handle, languageDisplay.toNative(), write);
@@ -494,10 +515,11 @@ class LocaleNamesUnstable internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new_tiny`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_tiny) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new_tiny`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_tiny) for more information.
+         */
         fun forLanguageIdentifierTiny(locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)
             val returnVal = lib.icu4x_LocaleNamesUnstable_for_language_identifier_tiny_mv1(locale.handle, langid.handle, languageDisplay.toNative(), write);
@@ -512,10 +534,11 @@ class LocaleNamesUnstable internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new_tiny`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_tiny) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new_tiny`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_tiny) for more information.
+         */
         fun forLanguageIdentifierTinyWithProvider(provider: DataProvider, locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)
             val returnVal = lib.icu4x_LocaleNamesUnstable_for_language_identifier_tiny_with_provider_mv1(provider.handle, locale.handle, langid.handle, languageDisplay.toNative(), write);
@@ -530,10 +553,11 @@ class LocaleNamesUnstable internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new_short_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_light) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new_short_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_light) for more information.
+         */
         fun forLanguageIdentifierShortLight(locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)
             val returnVal = lib.icu4x_LocaleNamesUnstable_for_language_identifier_short_light_mv1(locale.handle, langid.handle, languageDisplay.toNative(), write);
@@ -548,10 +572,11 @@ class LocaleNamesUnstable internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new_short_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_light) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new_short_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_light) for more information.
+         */
         fun forLanguageIdentifierShortLightWithProvider(provider: DataProvider, locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)
             val returnVal = lib.icu4x_LocaleNamesUnstable_for_language_identifier_short_light_with_provider_mv1(provider.handle, locale.handle, langid.handle, languageDisplay.toNative(), write);
@@ -566,10 +591,11 @@ class LocaleNamesUnstable internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new_long_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_long_light) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new_long_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_long_light) for more information.
+         */
         fun forLanguageIdentifierLongLight(locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)
             val returnVal = lib.icu4x_LocaleNamesUnstable_for_language_identifier_long_light_mv1(locale.handle, langid.handle, languageDisplay.toNative(), write);
@@ -584,10 +610,11 @@ class LocaleNamesUnstable internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new_long_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_long_light) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new_long_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_long_light) for more information.
+         */
         fun forLanguageIdentifierLongLightWithProvider(provider: DataProvider, locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)
             val returnVal = lib.icu4x_LocaleNamesUnstable_for_language_identifier_long_light_with_provider_mv1(provider.handle, locale.handle, langid.handle, languageDisplay.toNative(), write);
@@ -602,10 +629,11 @@ class LocaleNamesUnstable internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new_menu_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_menu_light) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new_menu_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_menu_light) for more information.
+         */
         fun forLanguageIdentifierMenuLight(locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)
             val returnVal = lib.icu4x_LocaleNamesUnstable_for_language_identifier_menu_light_mv1(locale.handle, langid.handle, languageDisplay.toNative(), write);
@@ -620,10 +648,11 @@ class LocaleNamesUnstable internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new_menu_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_menu_light) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new_menu_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_menu_light) for more information.
+         */
         fun forLanguageIdentifierMenuLightWithProvider(provider: DataProvider, locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)
             val returnVal = lib.icu4x_LocaleNamesUnstable_for_language_identifier_menu_light_with_provider_mv1(provider.handle, locale.handle, langid.handle, languageDisplay.toNative(), write);
@@ -638,10 +667,11 @@ class LocaleNamesUnstable internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new_short_menu_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_menu_light) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new_short_menu_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_menu_light) for more information.
+         */
         fun forLanguageIdentifierShortMenuLight(locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)
             val returnVal = lib.icu4x_LocaleNamesUnstable_for_language_identifier_short_menu_light_mv1(locale.handle, langid.handle, languageDisplay.toNative(), write);
@@ -656,10 +686,11 @@ class LocaleNamesUnstable internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new_short_menu_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_menu_light) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new_short_menu_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_menu_light) for more information.
+         */
         fun forLanguageIdentifierShortMenuLightWithProvider(provider: DataProvider, locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)
             val returnVal = lib.icu4x_LocaleNamesUnstable_for_language_identifier_short_menu_light_with_provider_mv1(provider.handle, locale.handle, langid.handle, languageDisplay.toNative(), write);
@@ -674,10 +705,11 @@ class LocaleNamesUnstable internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_heavy) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_heavy) for more information.
+         */
         fun forLanguageIdentifierHeavy(locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)
             val returnVal = lib.icu4x_LocaleNamesUnstable_for_language_identifier_heavy_mv1(locale.handle, langid.handle, languageDisplay.toNative(), write);
@@ -692,10 +724,11 @@ class LocaleNamesUnstable internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_heavy) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_heavy) for more information.
+         */
         fun forLanguageIdentifierHeavyWithProvider(provider: DataProvider, locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)
             val returnVal = lib.icu4x_LocaleNamesUnstable_for_language_identifier_heavy_with_provider_mv1(provider.handle, locale.handle, langid.handle, languageDisplay.toNative(), write);
@@ -710,10 +743,11 @@ class LocaleNamesUnstable internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new_short_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_heavy) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new_short_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_heavy) for more information.
+         */
         fun forLanguageIdentifierShortHeavy(locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)
             val returnVal = lib.icu4x_LocaleNamesUnstable_for_language_identifier_short_heavy_mv1(locale.handle, langid.handle, languageDisplay.toNative(), write);
@@ -728,10 +762,11 @@ class LocaleNamesUnstable internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new_short_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_heavy) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new_short_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_heavy) for more information.
+         */
         fun forLanguageIdentifierShortHeavyWithProvider(provider: DataProvider, locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)
             val returnVal = lib.icu4x_LocaleNamesUnstable_for_language_identifier_short_heavy_with_provider_mv1(provider.handle, locale.handle, langid.handle, languageDisplay.toNative(), write);
@@ -746,10 +781,11 @@ class LocaleNamesUnstable internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new_long_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_long_heavy) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new_long_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_long_heavy) for more information.
+         */
         fun forLanguageIdentifierLongHeavy(locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)
             val returnVal = lib.icu4x_LocaleNamesUnstable_for_language_identifier_long_heavy_mv1(locale.handle, langid.handle, languageDisplay.toNative(), write);
@@ -764,10 +800,11 @@ class LocaleNamesUnstable internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new_long_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_long_heavy) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new_long_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_long_heavy) for more information.
+         */
         fun forLanguageIdentifierLongHeavyWithProvider(provider: DataProvider, locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)
             val returnVal = lib.icu4x_LocaleNamesUnstable_for_language_identifier_long_heavy_with_provider_mv1(provider.handle, locale.handle, langid.handle, languageDisplay.toNative(), write);
@@ -782,10 +819,11 @@ class LocaleNamesUnstable internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new_menu_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_menu_heavy) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new_menu_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_menu_heavy) for more information.
+         */
         fun forLanguageIdentifierMenuHeavy(locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)
             val returnVal = lib.icu4x_LocaleNamesUnstable_for_language_identifier_menu_heavy_mv1(locale.handle, langid.handle, languageDisplay.toNative(), write);
@@ -800,10 +838,11 @@ class LocaleNamesUnstable internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new_menu_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_menu_heavy) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new_menu_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_menu_heavy) for more information.
+         */
         fun forLanguageIdentifierMenuHeavyWithProvider(provider: DataProvider, locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)
             val returnVal = lib.icu4x_LocaleNamesUnstable_for_language_identifier_menu_heavy_with_provider_mv1(provider.handle, locale.handle, langid.handle, languageDisplay.toNative(), write);
@@ -818,10 +857,11 @@ class LocaleNamesUnstable internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new_short_menu_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_menu_heavy) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new_short_menu_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_menu_heavy) for more information.
+         */
         fun forLanguageIdentifierShortMenuHeavy(locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)
             val returnVal = lib.icu4x_LocaleNamesUnstable_for_language_identifier_short_menu_heavy_mv1(locale.handle, langid.handle, languageDisplay.toNative(), write);
@@ -836,10 +876,11 @@ class LocaleNamesUnstable internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new_short_menu_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_menu_heavy) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new_short_menu_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_menu_heavy) for more information.
+         */
         fun forLanguageIdentifierShortMenuHeavyWithProvider(provider: DataProvider, locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)
             val returnVal = lib.icu4x_LocaleNamesUnstable_for_language_identifier_short_menu_heavy_with_provider_mv1(provider.handle, locale.handle, langid.handle, languageDisplay.toNative(), write);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LocaleNamesUnstable.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LocaleNamesUnstable.kt
@@ -49,8 +49,6 @@ internal interface LocaleNamesUnstableLib: Library {
     fun icu4x_LocaleNamesUnstable_for_language_identifier_short_menu_heavy_with_provider_mv1(provider: Pointer, locale: Pointer, langid: Pointer, languageDisplay: Int, write: Pointer): ResultUnitInt
 }
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * This struct holds free functions for loading display names for languages, scripts,
  * regions, and language identifiers.
  *
@@ -61,6 +59,8 @@ internal interface LocaleNamesUnstableLib: Library {
  * See the [Rust documentation for `VariantDisplayName`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.VariantDisplayName.html) for more information.
  *
  * See the [Rust documentation for `LanguageIdentifierDisplayName`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html) for more information.
+ *
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
  */
 class LocaleNamesUnstable internal constructor (
     internal val handle: Pointer,
@@ -91,9 +91,9 @@ class LocaleNamesUnstable internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_light_with_fallback) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun forRegionLight(locale: Locale, region: String): String {
             val regionSliceMemory = PrimitiveArrayTools.borrowUtf8(region)
@@ -110,9 +110,9 @@ class LocaleNamesUnstable internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_light_with_fallback) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun forRegionLightWithProvider(provider: DataProvider, locale: Locale, region: String): Result<String> {
             val regionSliceMemory = PrimitiveArrayTools.borrowUtf8(region)
@@ -134,9 +134,9 @@ class LocaleNamesUnstable internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_tiny_with_fallback) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun forRegionTiny(locale: Locale, region: String): String {
             val regionSliceMemory = PrimitiveArrayTools.borrowUtf8(region)
@@ -153,9 +153,9 @@ class LocaleNamesUnstable internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_tiny_with_fallback) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun forRegionTinyWithProvider(provider: DataProvider, locale: Locale, region: String): Result<String> {
             val regionSliceMemory = PrimitiveArrayTools.borrowUtf8(region)
@@ -177,9 +177,9 @@ class LocaleNamesUnstable internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `new_short_tiny_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_short_tiny_with_fallback) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun forRegionShortTiny(locale: Locale, region: String): String {
             val regionSliceMemory = PrimitiveArrayTools.borrowUtf8(region)
@@ -196,9 +196,9 @@ class LocaleNamesUnstable internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `new_short_tiny_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_short_tiny_with_fallback) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun forRegionShortTinyWithProvider(provider: DataProvider, locale: Locale, region: String): Result<String> {
             val regionSliceMemory = PrimitiveArrayTools.borrowUtf8(region)
@@ -220,9 +220,9 @@ class LocaleNamesUnstable internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `new_short_light_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_short_light_with_fallback) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun forRegionShortLight(locale: Locale, region: String): String {
             val regionSliceMemory = PrimitiveArrayTools.borrowUtf8(region)
@@ -239,9 +239,9 @@ class LocaleNamesUnstable internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `new_short_light_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_short_light_with_fallback) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun forRegionShortLightWithProvider(provider: DataProvider, locale: Locale, region: String): Result<String> {
             val regionSliceMemory = PrimitiveArrayTools.borrowUtf8(region)
@@ -263,9 +263,9 @@ class LocaleNamesUnstable internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_light_with_fallback) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun forScriptLight(locale: Locale, script: String): String {
             val scriptSliceMemory = PrimitiveArrayTools.borrowUtf8(script)
@@ -282,9 +282,9 @@ class LocaleNamesUnstable internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_light_with_fallback) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun forScriptLightWithProvider(provider: DataProvider, locale: Locale, script: String): Result<String> {
             val scriptSliceMemory = PrimitiveArrayTools.borrowUtf8(script)
@@ -306,9 +306,9 @@ class LocaleNamesUnstable internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_tiny_with_fallback) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun forScriptTiny(locale: Locale, script: String): String {
             val scriptSliceMemory = PrimitiveArrayTools.borrowUtf8(script)
@@ -325,9 +325,9 @@ class LocaleNamesUnstable internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_tiny_with_fallback) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun forScriptTinyWithProvider(provider: DataProvider, locale: Locale, script: String): Result<String> {
             val scriptSliceMemory = PrimitiveArrayTools.borrowUtf8(script)
@@ -349,9 +349,9 @@ class LocaleNamesUnstable internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_heavy_with_fallback) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun forScriptHeavy(locale: Locale, script: String): String {
             val scriptSliceMemory = PrimitiveArrayTools.borrowUtf8(script)
@@ -368,9 +368,9 @@ class LocaleNamesUnstable internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_heavy_with_fallback) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun forScriptHeavyWithProvider(provider: DataProvider, locale: Locale, script: String): Result<String> {
             val scriptSliceMemory = PrimitiveArrayTools.borrowUtf8(script)
@@ -392,9 +392,9 @@ class LocaleNamesUnstable internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `new_short_heavy_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_short_heavy_with_fallback) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun forScriptShortHeavy(locale: Locale, script: String): String {
             val scriptSliceMemory = PrimitiveArrayTools.borrowUtf8(script)
@@ -411,9 +411,9 @@ class LocaleNamesUnstable internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `new_short_heavy_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_short_heavy_with_fallback) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun forScriptShortHeavyWithProvider(provider: DataProvider, locale: Locale, script: String): Result<String> {
             val scriptSliceMemory = PrimitiveArrayTools.borrowUtf8(script)
@@ -435,9 +435,9 @@ class LocaleNamesUnstable internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.VariantDisplayName.html#method.new_heavy_with_fallback) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun forVariantHeavy(locale: Locale, variant: String): String {
             val variantSliceMemory = PrimitiveArrayTools.borrowUtf8(variant)
@@ -454,9 +454,9 @@ class LocaleNamesUnstable internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.VariantDisplayName.html#method.new_heavy_with_fallback) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun forVariantHeavyWithProvider(provider: DataProvider, locale: Locale, variant: String): Result<String> {
             val variantSliceMemory = PrimitiveArrayTools.borrowUtf8(variant)
@@ -478,9 +478,9 @@ class LocaleNamesUnstable internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_light) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun forLanguageIdentifierLight(locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -497,9 +497,9 @@ class LocaleNamesUnstable internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_light) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun forLanguageIdentifierLightWithProvider(provider: DataProvider, locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -516,9 +516,9 @@ class LocaleNamesUnstable internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new_tiny`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_tiny) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun forLanguageIdentifierTiny(locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -535,9 +535,9 @@ class LocaleNamesUnstable internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new_tiny`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_tiny) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun forLanguageIdentifierTinyWithProvider(provider: DataProvider, locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -554,9 +554,9 @@ class LocaleNamesUnstable internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new_short_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_light) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun forLanguageIdentifierShortLight(locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -573,9 +573,9 @@ class LocaleNamesUnstable internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new_short_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_light) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun forLanguageIdentifierShortLightWithProvider(provider: DataProvider, locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -592,9 +592,9 @@ class LocaleNamesUnstable internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new_long_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_long_light) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun forLanguageIdentifierLongLight(locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -611,9 +611,9 @@ class LocaleNamesUnstable internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new_long_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_long_light) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun forLanguageIdentifierLongLightWithProvider(provider: DataProvider, locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -630,9 +630,9 @@ class LocaleNamesUnstable internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new_menu_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_menu_light) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun forLanguageIdentifierMenuLight(locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -649,9 +649,9 @@ class LocaleNamesUnstable internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new_menu_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_menu_light) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun forLanguageIdentifierMenuLightWithProvider(provider: DataProvider, locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -668,9 +668,9 @@ class LocaleNamesUnstable internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new_short_menu_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_menu_light) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun forLanguageIdentifierShortMenuLight(locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -687,9 +687,9 @@ class LocaleNamesUnstable internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new_short_menu_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_menu_light) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun forLanguageIdentifierShortMenuLightWithProvider(provider: DataProvider, locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -706,9 +706,9 @@ class LocaleNamesUnstable internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_heavy) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun forLanguageIdentifierHeavy(locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -725,9 +725,9 @@ class LocaleNamesUnstable internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_heavy) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun forLanguageIdentifierHeavyWithProvider(provider: DataProvider, locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -744,9 +744,9 @@ class LocaleNamesUnstable internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new_short_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_heavy) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun forLanguageIdentifierShortHeavy(locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -763,9 +763,9 @@ class LocaleNamesUnstable internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new_short_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_heavy) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun forLanguageIdentifierShortHeavyWithProvider(provider: DataProvider, locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -782,9 +782,9 @@ class LocaleNamesUnstable internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new_long_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_long_heavy) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun forLanguageIdentifierLongHeavy(locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -801,9 +801,9 @@ class LocaleNamesUnstable internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new_long_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_long_heavy) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun forLanguageIdentifierLongHeavyWithProvider(provider: DataProvider, locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -820,9 +820,9 @@ class LocaleNamesUnstable internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new_menu_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_menu_heavy) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun forLanguageIdentifierMenuHeavy(locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -839,9 +839,9 @@ class LocaleNamesUnstable internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new_menu_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_menu_heavy) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun forLanguageIdentifierMenuHeavyWithProvider(provider: DataProvider, locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -858,9 +858,9 @@ class LocaleNamesUnstable internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new_short_menu_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_menu_heavy) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun forLanguageIdentifierShortMenuHeavy(locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -877,9 +877,9 @@ class LocaleNamesUnstable internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new_short_menu_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_menu_heavy) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun forLanguageIdentifierShortMenuHeavyWithProvider(provider: DataProvider, locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): Result<String> {
             val write = DW.lib.diplomat_buffer_write_create(0)

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LocaleParseError.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/LocaleParseError.kt
@@ -8,7 +8,8 @@ import com.sun.jna.Structure
 
 internal interface LocaleParseErrorLib: Library {
 }
-/** Additional information: [1](https://docs.rs/icu/2.3.1/icu/locale/enum.ParseError.html)
+/**
+ * Additional information: [1](https://docs.rs/icu/2.3.1/icu/locale/enum.ParseError.html)
 */
 enum class LocaleParseError {
     Unknown,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/Logger.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/Logger.kt
@@ -9,8 +9,9 @@ internal interface LoggerLib: Library {
     fun icu4x_Logger_destroy_mv1(handle: Pointer)
     fun icu4x_Logger_init_simple_logger_mv1(): Byte
 }
-/** An object allowing control over the logging used
-*/
+/**
+ * An object allowing control over the logging used
+ */
 class Logger internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -39,12 +40,13 @@ class Logger internal constructor (
         internal val lib: LoggerLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Initialize the logger using `simple_logger`
-        *
-        *Requires the `simple_logger` Cargo feature.
-        *
-        *Returns `false` if there was already a logger set.
-        */
+        /**
+         * Initialize the logger using `simple_logger`
+         *
+         * Requires the `simple_logger` Cargo feature.
+         *
+         * Returns `false` if there was already a logger set.
+         */
         fun initSimpleLogger(): Boolean {
             
             val returnVal = lib.icu4x_Logger_init_simple_logger_mv1();

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/NumericType.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/NumericType.kt
@@ -14,7 +14,8 @@ internal interface NumericTypeLib: Library {
     fun icu4x_NumericType_from_integer_value_mv1(other: FFIUint8): OptionInt
     fun icu4x_NumericType_try_from_str_mv1(s: Slice): OptionInt
 }
-/** See the [Rust documentation for `NumericType`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.NumericType.html) for more information.
+/**
+ * See the [Rust documentation for `NumericType`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.NumericType.html) for more information.
 */
 enum class NumericType {
     None,
@@ -39,8 +40,9 @@ enum class NumericType {
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.EnumeratedProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.EnumeratedProperty.html#tymethod.for_char) for more information.
+         */
         fun forChar(ch: Int): NumericType {
             
             val returnVal = lib.icu4x_NumericType_for_char_mv1(ch);
@@ -48,10 +50,11 @@ enum class NumericType {
         }
         @JvmStatic
         
-        /** Convert from an integer value from ICU4C or `CodePointMapData`
-        *
-        *See the [Rust documentation for `from_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.NumericType.html#method.from_icu4c_value) for more information.
-        */
+        /**
+         * Convert from an integer value from ICU4C or `CodePointMapData`
+         *
+         * See the [Rust documentation for `from_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.NumericType.html#method.from_icu4c_value) for more information.
+         */
         fun fromIntegerValue(other: UByte): NumericType? {
             
             val returnVal = lib.icu4x_NumericType_from_integer_value_mv1(FFIUint8(other));
@@ -61,10 +64,11 @@ enum class NumericType {
         }
         @JvmStatic
         
-        /** Creates a `NumericType` from a string.
-        *
-        *Short names, long names, and aliases are supported, and matching is case-insensitive.
-        */
+        /**
+         * Creates a `NumericType` from a string.
+         *
+         * Short names, long names, and aliases are supported, and matching is case-insensitive.
+         */
         fun tryFromStr(s: String): NumericType? {
             val sSliceMemory = PrimitiveArrayTools.borrowUtf8(s)
             
@@ -79,10 +83,11 @@ enum class NumericType {
         }
     }
     
-    /** Get the "long" name of this property value (returns empty if property value is unknown)
-    *
-    *See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesLongBorrowed.html#method.get) for more information.
-    */
+    /**
+     * Get the "long" name of this property value (returns empty if property value is unknown)
+     *
+     * See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesLongBorrowed.html#method.get) for more information.
+     */
     fun longName(): String? {
         
         val returnVal = lib.icu4x_NumericType_long_name_mv1(this.toNative());
@@ -92,10 +97,11 @@ enum class NumericType {
                                 
     }
     
-    /** Get the "short" name of this property value (returns empty if property value is unknown)
-    *
-    *See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesShortBorrowed.html#method.get) for more information.
-    */
+    /**
+     * Get the "short" name of this property value (returns empty if property value is unknown)
+     *
+     * See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesShortBorrowed.html#method.get) for more information.
+     */
     fun shortName(): String? {
         
         val returnVal = lib.icu4x_NumericType_short_name_mv1(this.toNative());
@@ -105,10 +111,11 @@ enum class NumericType {
                                 
     }
     
-    /** Convert to an integer value usable with ICU4C and `CodePointMapData`
-    *
-    *See the [Rust documentation for `to_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.NumericType.html#method.to_icu4c_value) for more information.
-    */
+    /**
+     * Convert to an integer value usable with ICU4C and `CodePointMapData`
+     *
+     * See the [Rust documentation for `to_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.NumericType.html#method.to_icu4c_value) for more information.
+     */
     fun toIntegerValue(): UByte {
         
         val returnVal = lib.icu4x_NumericType_to_integer_value_mv1(this.toNative());

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/PluralCategories.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/PluralCategories.kt
@@ -70,8 +70,9 @@ internal class OptionPluralCategoriesNative constructor(): Structure(), Structur
 
 }
 
-/** See the [Rust documentation for `categories`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRules.html#method.categories) for more information.
-*/
+/**
+ * See the [Rust documentation for `categories`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRules.html#method.categories) for more information.
+ */
 class PluralCategories (var zero: Boolean, var one: Boolean, var two: Boolean, var few: Boolean, var many: Boolean, var other: Boolean) {
     companion object {
 

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/PluralCategory.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/PluralCategory.kt
@@ -9,7 +9,8 @@ import com.sun.jna.Structure
 internal interface PluralCategoryLib: Library {
     fun icu4x_PluralCategory_get_for_cldr_string_mv1(s: Slice): OptionInt
 }
-/** See the [Rust documentation for `PluralCategory`](https://docs.rs/icu/2.3.1/icu/plurals/enum.PluralCategory.html) for more information.
+/**
+ * See the [Rust documentation for `PluralCategory`](https://docs.rs/icu/2.3.1/icu/plurals/enum.PluralCategory.html) for more information.
 */
 enum class PluralCategory {
     Zero,
@@ -36,13 +37,14 @@ enum class PluralCategory {
         }
         @JvmStatic
         
-        /** Construct from a string in the format
-        *[specified in TR35](https://unicode.org/reports/tr35/tr35-numbers.html#Language_Plural_Rules)
-        *
-        *See the [Rust documentation for `get_for_cldr_string`](https://docs.rs/icu/2.3.1/icu/plurals/enum.PluralCategory.html#method.get_for_cldr_string) for more information.
-        *
-        *See the [Rust documentation for `get_for_cldr_bytes`](https://docs.rs/icu/2.3.1/icu/plurals/enum.PluralCategory.html#method.get_for_cldr_bytes) for more information.
-        */
+        /**
+         * Construct from a string in the format
+         * [specified in TR35](https://unicode.org/reports/tr35/tr35-numbers.html#Language_Plural_Rules)
+         *
+         * See the [Rust documentation for `get_for_cldr_string`](https://docs.rs/icu/2.3.1/icu/plurals/enum.PluralCategory.html#method.get_for_cldr_string) for more information.
+         *
+         * See the [Rust documentation for `get_for_cldr_bytes`](https://docs.rs/icu/2.3.1/icu/plurals/enum.PluralCategory.html#method.get_for_cldr_bytes) for more information.
+         */
         fun getForCldrString(s: String): PluralCategory? {
             val sSliceMemory = PrimitiveArrayTools.borrowUtf8(s)
             

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/PluralOperands.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/PluralOperands.kt
@@ -11,8 +11,9 @@ internal interface PluralOperandsLib: Library {
     fun icu4x_PluralOperands_from_int64_mv1(i: Long): Pointer
     fun icu4x_PluralOperands_from_fixed_decimal_mv1(x: Pointer): Pointer
 }
-/** See the [Rust documentation for `PluralOperands`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralOperands.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `PluralOperands`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralOperands.html) for more information.
+ */
 class PluralOperands internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -41,10 +42,11 @@ class PluralOperands internal constructor (
         internal val lib: PluralOperandsLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Construct for a given string representing a number
-        *
-        *See the [Rust documentation for `from_str`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralOperands.html#method.from_str) for more information.
-        */
+        /**
+         * Construct for a given string representing a number
+         *
+         * See the [Rust documentation for `from_str`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralOperands.html#method.from_str) for more information.
+         */
         fun fromString(s: String): Result<PluralOperands> {
             val sSliceMemory = PrimitiveArrayTools.borrowUtf8(s)
             
@@ -65,8 +67,9 @@ class PluralOperands internal constructor (
         }
         @JvmStatic
         
-        /** Construct for a given integer
-        */
+        /**
+         * Construct for a given integer
+         */
         fun from(i: Long): PluralOperands {
             
             val returnVal = lib.icu4x_PluralOperands_from_int64_mv1(i);
@@ -77,10 +80,11 @@ class PluralOperands internal constructor (
         }
         @JvmStatic
         
-        /** Construct from a `FixedDecimal`
-        *
-        *Retains at most 18 digits each from the integer and fraction parts.
-        */
+        /**
+         * Construct from a `FixedDecimal`
+         *
+         * Retains at most 18 digits each from the integer and fraction parts.
+         */
         fun fromFixedDecimal(x: Decimal): PluralOperands {
             
             val returnVal = lib.icu4x_PluralOperands_from_fixed_decimal_mv1(x.handle);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/PluralRules.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/PluralRules.kt
@@ -14,8 +14,9 @@ internal interface PluralRulesLib: Library {
     fun icu4x_PluralRules_category_for_mv1(handle: Pointer, op: Pointer): Int
     fun icu4x_PluralRules_categories_mv1(handle: Pointer): PluralCategoriesNative
 }
-/** See the [Rust documentation for `PluralRules`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRules.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `PluralRules`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRules.html) for more information.
+ */
 class PluralRules internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -44,10 +45,11 @@ class PluralRules internal constructor (
         internal val lib: PluralRulesLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Construct an [PluralRules] for the given locale, for cardinal numbers, using compiled data.
-        *
-        *See the [Rust documentation for `try_new_cardinal`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRules.html#method.try_new_cardinal) for more information.
-        */
+        /**
+         * Construct an [PluralRules] for the given locale, for cardinal numbers, using compiled data.
+         *
+         * See the [Rust documentation for `try_new_cardinal`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRules.html#method.try_new_cardinal) for more information.
+         */
         fun createCardinal(locale: Locale): Result<PluralRules> {
             
             val returnVal = lib.icu4x_PluralRules_create_cardinal_mv1(locale.handle);
@@ -63,10 +65,11 @@ class PluralRules internal constructor (
         }
         @JvmStatic
         
-        /** Construct an [PluralRules] for the given locale, for cardinal numbers, using a particular data source.
-        *
-        *See the [Rust documentation for `try_new_cardinal`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRules.html#method.try_new_cardinal) for more information.
-        */
+        /**
+         * Construct an [PluralRules] for the given locale, for cardinal numbers, using a particular data source.
+         *
+         * See the [Rust documentation for `try_new_cardinal`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRules.html#method.try_new_cardinal) for more information.
+         */
         fun createCardinalWithProvider(provider: DataProvider, locale: Locale): Result<PluralRules> {
             
             val returnVal = lib.icu4x_PluralRules_create_cardinal_with_provider_mv1(provider.handle, locale.handle);
@@ -82,10 +85,11 @@ class PluralRules internal constructor (
         }
         @JvmStatic
         
-        /** Construct an [PluralRules] for the given locale, for ordinal numbers, using compiled data.
-        *
-        *See the [Rust documentation for `try_new_ordinal`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRules.html#method.try_new_ordinal) for more information.
-        */
+        /**
+         * Construct an [PluralRules] for the given locale, for ordinal numbers, using compiled data.
+         *
+         * See the [Rust documentation for `try_new_ordinal`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRules.html#method.try_new_ordinal) for more information.
+         */
         fun createOrdinal(locale: Locale): Result<PluralRules> {
             
             val returnVal = lib.icu4x_PluralRules_create_ordinal_mv1(locale.handle);
@@ -101,10 +105,11 @@ class PluralRules internal constructor (
         }
         @JvmStatic
         
-        /** Construct an [PluralRules] for the given locale, for ordinal numbers, using a particular data source.
-        *
-        *See the [Rust documentation for `try_new_ordinal`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRules.html#method.try_new_ordinal) for more information.
-        */
+        /**
+         * Construct an [PluralRules] for the given locale, for ordinal numbers, using a particular data source.
+         *
+         * See the [Rust documentation for `try_new_ordinal`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRules.html#method.try_new_ordinal) for more information.
+         */
         fun createOrdinalWithProvider(provider: DataProvider, locale: Locale): Result<PluralRules> {
             
             val returnVal = lib.icu4x_PluralRules_create_ordinal_with_provider_mv1(provider.handle, locale.handle);
@@ -120,20 +125,22 @@ class PluralRules internal constructor (
         }
     }
     
-    /** Get the category for a given number represented as operands
-    *
-    *See the [Rust documentation for `category_for`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRules.html#method.category_for) for more information.
-    */
+    /**
+     * Get the category for a given number represented as operands
+     *
+     * See the [Rust documentation for `category_for`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRules.html#method.category_for) for more information.
+     */
     fun categoryFor(op: PluralOperands): PluralCategory {
         
         val returnVal = lib.icu4x_PluralRules_category_for_mv1(handle, op.handle);
         return (PluralCategory.fromNative(returnVal))
     }
     
-    /** Get all of the categories needed in the current locale
-    *
-    *See the [Rust documentation for `categories`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRules.html#method.categories) for more information.
-    */
+    /**
+     * Get all of the categories needed in the current locale
+     *
+     * See the [Rust documentation for `categories`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRules.html#method.categories) for more information.
+     */
     fun categories(): PluralCategories {
         
         val returnVal = lib.icu4x_PluralRules_categories_mv1(handle);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/PluralRulesWithRanges.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/PluralRulesWithRanges.kt
@@ -13,8 +13,9 @@ internal interface PluralRulesWithRangesLib: Library {
     fun icu4x_PluralRulesWithRanges_create_ordinal_with_provider_mv1(provider: Pointer, locale: Pointer): ResultPointerInt
     fun icu4x_PluralRulesWithRanges_category_for_range_mv1(handle: Pointer, start: Pointer, end: Pointer): Int
 }
-/** See the [Rust documentation for `PluralRulesWithRanges`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRulesWithRanges.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `PluralRulesWithRanges`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRulesWithRanges.html) for more information.
+ */
 class PluralRulesWithRanges internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -43,10 +44,11 @@ class PluralRulesWithRanges internal constructor (
         internal val lib: PluralRulesWithRangesLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** construct a [PluralRulesWithRanges] for the given locale, for cardinal numbers, using compiled data.
-        *
-        *See the [Rust documentation for `try_new_cardinal`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRulesWithRanges.html#method.try_new_cardinal) for more information.
-        */
+        /**
+         * construct a [PluralRulesWithRanges] for the given locale, for cardinal numbers, using compiled data.
+         *
+         * See the [Rust documentation for `try_new_cardinal`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRulesWithRanges.html#method.try_new_cardinal) for more information.
+         */
         fun createCardinal(locale: Locale): Result<PluralRulesWithRanges> {
             
             val returnVal = lib.icu4x_PluralRulesWithRanges_create_cardinal_mv1(locale.handle);
@@ -62,10 +64,11 @@ class PluralRulesWithRanges internal constructor (
         }
         @JvmStatic
         
-        /** construct a [PluralRulesWithRanges] for the given locale, for cardinal numbers, using a particular data source.
-        *
-        *See the [Rust documentation for `try_new_cardinal`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRulesWithRanges.html#method.try_new_cardinal) for more information.
-        */
+        /**
+         * construct a [PluralRulesWithRanges] for the given locale, for cardinal numbers, using a particular data source.
+         *
+         * See the [Rust documentation for `try_new_cardinal`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRulesWithRanges.html#method.try_new_cardinal) for more information.
+         */
         fun createCardinalWithProvider(provider: DataProvider, locale: Locale): Result<PluralRulesWithRanges> {
             
             val returnVal = lib.icu4x_PluralRulesWithRanges_create_cardinal_with_provider_mv1(provider.handle, locale.handle);
@@ -81,10 +84,11 @@ class PluralRulesWithRanges internal constructor (
         }
         @JvmStatic
         
-        /** Construct a [PluralRulesWithRanges] for the given locale, for ordinal numbers, using compiled data.
-        *
-        *See the [Rust documentation for `try_new_ordinal`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRulesWithRanges.html#method.try_new_ordinal) for more information.
-        */
+        /**
+         * Construct a [PluralRulesWithRanges] for the given locale, for ordinal numbers, using compiled data.
+         *
+         * See the [Rust documentation for `try_new_ordinal`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRulesWithRanges.html#method.try_new_ordinal) for more information.
+         */
         fun createOrdinal(locale: Locale): Result<PluralRulesWithRanges> {
             
             val returnVal = lib.icu4x_PluralRulesWithRanges_create_ordinal_mv1(locale.handle);
@@ -100,10 +104,11 @@ class PluralRulesWithRanges internal constructor (
         }
         @JvmStatic
         
-        /** Construct a [PluralRulesWithRanges] for the given locale, for ordinal numbers, using a particular data source.
-        *
-        *See the [Rust documentation for `try_new_ordinal`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRulesWithRanges.html#method.try_new_ordinal) for more information.
-        */
+        /**
+         * Construct a [PluralRulesWithRanges] for the given locale, for ordinal numbers, using a particular data source.
+         *
+         * See the [Rust documentation for `try_new_ordinal`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRulesWithRanges.html#method.try_new_ordinal) for more information.
+         */
         fun createOrdinalWithProvider(provider: DataProvider, locale: Locale): Result<PluralRulesWithRanges> {
             
             val returnVal = lib.icu4x_PluralRulesWithRanges_create_ordinal_with_provider_mv1(provider.handle, locale.handle);
@@ -119,10 +124,11 @@ class PluralRulesWithRanges internal constructor (
         }
     }
     
-    /** Get the category for a given number represented as operands
-    *
-    *See the [Rust documentation for `category_for_range`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRulesWithRanges.html#method.category_for_range) for more information.
-    */
+    /**
+     * Get the category for a given number represented as operands
+     *
+     * See the [Rust documentation for `category_for_range`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRulesWithRanges.html#method.category_for_range) for more information.
+     */
     fun categoryForRange(start: PluralOperands, end: PluralOperands): PluralCategory {
         
         val returnVal = lib.icu4x_PluralRulesWithRanges_category_for_range_mv1(handle, start.handle, end.handle);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/PluralRulesWithRanges.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/PluralRulesWithRanges.kt
@@ -15,6 +15,8 @@ internal interface PluralRulesWithRangesLib: Library {
 }
 /**
  * See the [Rust documentation for `PluralRulesWithRanges`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRulesWithRanges.html) for more information.
+ *
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
  */
 class PluralRulesWithRanges internal constructor (
     internal val handle: Pointer,
@@ -48,6 +50,8 @@ class PluralRulesWithRanges internal constructor (
          * construct a [PluralRulesWithRanges] for the given locale, for cardinal numbers, using compiled data.
          *
          * See the [Rust documentation for `try_new_cardinal`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRulesWithRanges.html#method.try_new_cardinal) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createCardinal(locale: Locale): Result<PluralRulesWithRanges> {
             
@@ -68,6 +72,8 @@ class PluralRulesWithRanges internal constructor (
          * construct a [PluralRulesWithRanges] for the given locale, for cardinal numbers, using a particular data source.
          *
          * See the [Rust documentation for `try_new_cardinal`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRulesWithRanges.html#method.try_new_cardinal) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createCardinalWithProvider(provider: DataProvider, locale: Locale): Result<PluralRulesWithRanges> {
             
@@ -88,6 +94,8 @@ class PluralRulesWithRanges internal constructor (
          * Construct a [PluralRulesWithRanges] for the given locale, for ordinal numbers, using compiled data.
          *
          * See the [Rust documentation for `try_new_ordinal`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRulesWithRanges.html#method.try_new_ordinal) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createOrdinal(locale: Locale): Result<PluralRulesWithRanges> {
             
@@ -108,6 +116,8 @@ class PluralRulesWithRanges internal constructor (
          * Construct a [PluralRulesWithRanges] for the given locale, for ordinal numbers, using a particular data source.
          *
          * See the [Rust documentation for `try_new_ordinal`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRulesWithRanges.html#method.try_new_ordinal) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createOrdinalWithProvider(provider: DataProvider, locale: Locale): Result<PluralRulesWithRanges> {
             
@@ -128,6 +138,8 @@ class PluralRulesWithRanges internal constructor (
      * Get the category for a given number represented as operands
      *
      * See the [Rust documentation for `category_for_range`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRulesWithRanges.html#method.category_for_range) for more information.
+     *
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
      */
     fun categoryForRange(start: PluralOperands, end: PluralOperands): PluralCategory {
         

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/PropertyValueNameToEnumMapper.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/PropertyValueNameToEnumMapper.kt
@@ -44,14 +44,15 @@ internal interface PropertyValueNameToEnumMapperLib: Library {
     fun icu4x_PropertyValueNameToEnumMapper_create_word_break_mv1(): Pointer
     fun icu4x_PropertyValueNameToEnumMapper_create_word_break_with_provider_mv1(provider: Pointer): ResultPointerInt
 }
-/** A type capable of looking up a property value from a string name.
-*
-*See the [Rust documentation for `PropertyParser`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyParser.html) for more information.
-*
-*See the [Rust documentation for `PropertyParserBorrowed`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyParserBorrowed.html) for more information.
-*
-*See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyParser.html#method.new) for more information.
-*/
+/**
+ * A type capable of looking up a property value from a string name.
+ *
+ * See the [Rust documentation for `PropertyParser`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyParser.html) for more information.
+ *
+ * See the [Rust documentation for `PropertyParserBorrowed`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyParserBorrowed.html) for more information.
+ *
+ * See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyParser.html#method.new) for more information.
+ */
 class PropertyValueNameToEnumMapper internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -80,10 +81,11 @@ class PropertyValueNameToEnumMapper internal constructor (
         internal val lib: PropertyValueNameToEnumMapperLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Create a name-to-enum mapper for the `BidiClass` property, using compiled data.
-        *
-        *See the [Rust documentation for `BidiClass`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.BidiClass.html) for more information.
-        */
+        /**
+         * Create a name-to-enum mapper for the `BidiClass` property, using compiled data.
+         *
+         * See the [Rust documentation for `BidiClass`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.BidiClass.html) for more information.
+         */
         fun createBidiClass(): PropertyValueNameToEnumMapper {
             
             val returnVal = lib.icu4x_PropertyValueNameToEnumMapper_create_bidi_class_mv1();
@@ -94,10 +96,11 @@ class PropertyValueNameToEnumMapper internal constructor (
         }
         @JvmStatic
         
-        /** Create a name-to-enum mapper for the `BidiClass` property, using a particular data source.
-        *
-        *See the [Rust documentation for `BidiClass`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.BidiClass.html) for more information.
-        */
+        /**
+         * Create a name-to-enum mapper for the `BidiClass` property, using a particular data source.
+         *
+         * See the [Rust documentation for `BidiClass`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.BidiClass.html) for more information.
+         */
         fun createBidiClassWithProvider(provider: DataProvider): Result<PropertyValueNameToEnumMapper> {
             
             val returnVal = lib.icu4x_PropertyValueNameToEnumMapper_create_bidi_class_with_provider_mv1(provider.handle);
@@ -113,10 +116,11 @@ class PropertyValueNameToEnumMapper internal constructor (
         }
         @JvmStatic
         
-        /** Create a name-to-enum mapper for the `Block` property, using compiled data.
-        *
-        *See the [Rust documentation for `Block`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Block.html) for more information.
-        */
+        /**
+         * Create a name-to-enum mapper for the `Block` property, using compiled data.
+         *
+         * See the [Rust documentation for `Block`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Block.html) for more information.
+         */
         fun createBlock(): PropertyValueNameToEnumMapper {
             
             val returnVal = lib.icu4x_PropertyValueNameToEnumMapper_create_block_mv1();
@@ -127,10 +131,11 @@ class PropertyValueNameToEnumMapper internal constructor (
         }
         @JvmStatic
         
-        /** Create a name-to-enum mapper for the `Block` property, using a particular data source.
-        *
-        *See the [Rust documentation for `Block`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Block.html) for more information.
-        */
+        /**
+         * Create a name-to-enum mapper for the `Block` property, using a particular data source.
+         *
+         * See the [Rust documentation for `Block`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Block.html) for more information.
+         */
         fun createBlockWithProvider(provider: DataProvider): Result<PropertyValueNameToEnumMapper> {
             
             val returnVal = lib.icu4x_PropertyValueNameToEnumMapper_create_block_with_provider_mv1(provider.handle);
@@ -146,10 +151,11 @@ class PropertyValueNameToEnumMapper internal constructor (
         }
         @JvmStatic
         
-        /** Create a name-to-enum mapper for the `CanonicalCombiningClass` property, using compiled data.
-        *
-        *See the [Rust documentation for `CanonicalCombiningClass`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.CanonicalCombiningClass.html) for more information.
-        */
+        /**
+         * Create a name-to-enum mapper for the `CanonicalCombiningClass` property, using compiled data.
+         *
+         * See the [Rust documentation for `CanonicalCombiningClass`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.CanonicalCombiningClass.html) for more information.
+         */
         fun createCanonicalCombiningClass(): PropertyValueNameToEnumMapper {
             
             val returnVal = lib.icu4x_PropertyValueNameToEnumMapper_create_canonical_combining_class_mv1();
@@ -160,10 +166,11 @@ class PropertyValueNameToEnumMapper internal constructor (
         }
         @JvmStatic
         
-        /** Create a name-to-enum mapper for the `CanonicalCombiningClass` property, using a particular data source.
-        *
-        *See the [Rust documentation for `CanonicalCombiningClass`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.CanonicalCombiningClass.html) for more information.
-        */
+        /**
+         * Create a name-to-enum mapper for the `CanonicalCombiningClass` property, using a particular data source.
+         *
+         * See the [Rust documentation for `CanonicalCombiningClass`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.CanonicalCombiningClass.html) for more information.
+         */
         fun createCanonicalCombiningClassWithProvider(provider: DataProvider): Result<PropertyValueNameToEnumMapper> {
             
             val returnVal = lib.icu4x_PropertyValueNameToEnumMapper_create_canonical_combining_class_with_provider_mv1(provider.handle);
@@ -179,10 +186,11 @@ class PropertyValueNameToEnumMapper internal constructor (
         }
         @JvmStatic
         
-        /** Create a name-to-enum mapper for the `EastAsianWidth` property, using compiled data.
-        *
-        *See the [Rust documentation for `EastAsianWidth`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.EastAsianWidth.html) for more information.
-        */
+        /**
+         * Create a name-to-enum mapper for the `EastAsianWidth` property, using compiled data.
+         *
+         * See the [Rust documentation for `EastAsianWidth`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.EastAsianWidth.html) for more information.
+         */
         fun createEastAsianWidth(): PropertyValueNameToEnumMapper {
             
             val returnVal = lib.icu4x_PropertyValueNameToEnumMapper_create_east_asian_width_mv1();
@@ -193,10 +201,11 @@ class PropertyValueNameToEnumMapper internal constructor (
         }
         @JvmStatic
         
-        /** Create a name-to-enum mapper for the `EastAsianWidth` property, using a particular data source.
-        *
-        *See the [Rust documentation for `EastAsianWidth`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.EastAsianWidth.html) for more information.
-        */
+        /**
+         * Create a name-to-enum mapper for the `EastAsianWidth` property, using a particular data source.
+         *
+         * See the [Rust documentation for `EastAsianWidth`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.EastAsianWidth.html) for more information.
+         */
         fun createEastAsianWidthWithProvider(provider: DataProvider): Result<PropertyValueNameToEnumMapper> {
             
             val returnVal = lib.icu4x_PropertyValueNameToEnumMapper_create_east_asian_width_with_provider_mv1(provider.handle);
@@ -212,10 +221,11 @@ class PropertyValueNameToEnumMapper internal constructor (
         }
         @JvmStatic
         
-        /** Create a name-to-enum mapper for the `GeneralCategory` property, using compiled data.
-        *
-        *See the [Rust documentation for `GeneralCategory`](https://docs.rs/icu/2.3.1/icu/properties/props/enum.GeneralCategory.html) for more information.
-        */
+        /**
+         * Create a name-to-enum mapper for the `GeneralCategory` property, using compiled data.
+         *
+         * See the [Rust documentation for `GeneralCategory`](https://docs.rs/icu/2.3.1/icu/properties/props/enum.GeneralCategory.html) for more information.
+         */
         fun createGeneralCategory(): PropertyValueNameToEnumMapper {
             
             val returnVal = lib.icu4x_PropertyValueNameToEnumMapper_create_general_category_mv1();
@@ -226,10 +236,11 @@ class PropertyValueNameToEnumMapper internal constructor (
         }
         @JvmStatic
         
-        /** Create a name-to-enum mapper for the `GeneralCategory` property, using a particular data source.
-        *
-        *See the [Rust documentation for `GeneralCategory`](https://docs.rs/icu/2.3.1/icu/properties/props/enum.GeneralCategory.html) for more information.
-        */
+        /**
+         * Create a name-to-enum mapper for the `GeneralCategory` property, using a particular data source.
+         *
+         * See the [Rust documentation for `GeneralCategory`](https://docs.rs/icu/2.3.1/icu/properties/props/enum.GeneralCategory.html) for more information.
+         */
         fun createGeneralCategoryWithProvider(provider: DataProvider): Result<PropertyValueNameToEnumMapper> {
             
             val returnVal = lib.icu4x_PropertyValueNameToEnumMapper_create_general_category_with_provider_mv1(provider.handle);
@@ -245,10 +256,11 @@ class PropertyValueNameToEnumMapper internal constructor (
         }
         @JvmStatic
         
-        /** Create a name-to-enum mapper for the `GraphemeClusterBreak` property, using compiled data.
-        *
-        *See the [Rust documentation for `GraphemeClusterBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GraphemeClusterBreak.html) for more information.
-        */
+        /**
+         * Create a name-to-enum mapper for the `GraphemeClusterBreak` property, using compiled data.
+         *
+         * See the [Rust documentation for `GraphemeClusterBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GraphemeClusterBreak.html) for more information.
+         */
         fun createGraphemeClusterBreak(): PropertyValueNameToEnumMapper {
             
             val returnVal = lib.icu4x_PropertyValueNameToEnumMapper_create_grapheme_cluster_break_mv1();
@@ -259,10 +271,11 @@ class PropertyValueNameToEnumMapper internal constructor (
         }
         @JvmStatic
         
-        /** Create a name-to-enum mapper for the `GraphemeClusterBreak` property, using a particular data source.
-        *
-        *See the [Rust documentation for `GraphemeClusterBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GraphemeClusterBreak.html) for more information.
-        */
+        /**
+         * Create a name-to-enum mapper for the `GraphemeClusterBreak` property, using a particular data source.
+         *
+         * See the [Rust documentation for `GraphemeClusterBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.GraphemeClusterBreak.html) for more information.
+         */
         fun createGraphemeClusterBreakWithProvider(provider: DataProvider): Result<PropertyValueNameToEnumMapper> {
             
             val returnVal = lib.icu4x_PropertyValueNameToEnumMapper_create_grapheme_cluster_break_with_provider_mv1(provider.handle);
@@ -278,10 +291,11 @@ class PropertyValueNameToEnumMapper internal constructor (
         }
         @JvmStatic
         
-        /** Create a name-to-enum mapper for the `HangulSyllableType` property, using compiled data.
-        *
-        *See the [Rust documentation for `HangulSyllableType`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.HangulSyllableType.html) for more information.
-        */
+        /**
+         * Create a name-to-enum mapper for the `HangulSyllableType` property, using compiled data.
+         *
+         * See the [Rust documentation for `HangulSyllableType`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.HangulSyllableType.html) for more information.
+         */
         fun createHangulSyllableType(): PropertyValueNameToEnumMapper {
             
             val returnVal = lib.icu4x_PropertyValueNameToEnumMapper_create_hangul_syllable_type_mv1();
@@ -292,10 +306,11 @@ class PropertyValueNameToEnumMapper internal constructor (
         }
         @JvmStatic
         
-        /** Create a name-to-enum mapper for the `HangulSyllableType` property, using a particular data source.
-        *
-        *See the [Rust documentation for `HangulSyllableType`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.HangulSyllableType.html) for more information.
-        */
+        /**
+         * Create a name-to-enum mapper for the `HangulSyllableType` property, using a particular data source.
+         *
+         * See the [Rust documentation for `HangulSyllableType`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.HangulSyllableType.html) for more information.
+         */
         fun createHangulSyllableTypeWithProvider(provider: DataProvider): Result<PropertyValueNameToEnumMapper> {
             
             val returnVal = lib.icu4x_PropertyValueNameToEnumMapper_create_hangul_syllable_type_with_provider_mv1(provider.handle);
@@ -311,10 +326,11 @@ class PropertyValueNameToEnumMapper internal constructor (
         }
         @JvmStatic
         
-        /** Create a name-to-enum mapper for the `IndicConjunctBreak` property, using compiled data.
-        *
-        *See the [Rust documentation for `IndicConjunctBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IndicConjunctBreak.html) for more information.
-        */
+        /**
+         * Create a name-to-enum mapper for the `IndicConjunctBreak` property, using compiled data.
+         *
+         * See the [Rust documentation for `IndicConjunctBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IndicConjunctBreak.html) for more information.
+         */
         fun createIndicConjunctBreak(): PropertyValueNameToEnumMapper {
             
             val returnVal = lib.icu4x_PropertyValueNameToEnumMapper_create_indic_conjunct_break_mv1();
@@ -325,10 +341,11 @@ class PropertyValueNameToEnumMapper internal constructor (
         }
         @JvmStatic
         
-        /** Create a name-to-enum mapper for the `IndicConjunctBreak` property, using a particular data source.
-        *
-        *See the [Rust documentation for `IndicConjunctBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IndicConjunctBreak.html) for more information.
-        */
+        /**
+         * Create a name-to-enum mapper for the `IndicConjunctBreak` property, using a particular data source.
+         *
+         * See the [Rust documentation for `IndicConjunctBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IndicConjunctBreak.html) for more information.
+         */
         fun createIndicConjunctBreakWithProvider(provider: DataProvider): Result<PropertyValueNameToEnumMapper> {
             
             val returnVal = lib.icu4x_PropertyValueNameToEnumMapper_create_indic_conjunct_break_with_provider_mv1(provider.handle);
@@ -344,10 +361,11 @@ class PropertyValueNameToEnumMapper internal constructor (
         }
         @JvmStatic
         
-        /** Create a name-to-enum mapper for the `IndicSyllabicCategory` property, using compiled data.
-        *
-        *See the [Rust documentation for `IndicSyllabicCategory`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IndicSyllabicCategory.html) for more information.
-        */
+        /**
+         * Create a name-to-enum mapper for the `IndicSyllabicCategory` property, using compiled data.
+         *
+         * See the [Rust documentation for `IndicSyllabicCategory`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IndicSyllabicCategory.html) for more information.
+         */
         fun createIndicSyllabicCategory(): PropertyValueNameToEnumMapper {
             
             val returnVal = lib.icu4x_PropertyValueNameToEnumMapper_create_indic_syllabic_category_mv1();
@@ -358,10 +376,11 @@ class PropertyValueNameToEnumMapper internal constructor (
         }
         @JvmStatic
         
-        /** Create a name-to-enum mapper for the `IndicSyllabicCategory` property, using a particular data source.
-        *
-        *See the [Rust documentation for `IndicSyllabicCategory`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IndicSyllabicCategory.html) for more information.
-        */
+        /**
+         * Create a name-to-enum mapper for the `IndicSyllabicCategory` property, using a particular data source.
+         *
+         * See the [Rust documentation for `IndicSyllabicCategory`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.IndicSyllabicCategory.html) for more information.
+         */
         fun createIndicSyllabicCategoryWithProvider(provider: DataProvider): Result<PropertyValueNameToEnumMapper> {
             
             val returnVal = lib.icu4x_PropertyValueNameToEnumMapper_create_indic_syllabic_category_with_provider_mv1(provider.handle);
@@ -377,10 +396,11 @@ class PropertyValueNameToEnumMapper internal constructor (
         }
         @JvmStatic
         
-        /** Create a name-to-enum mapper for the `JoiningGroup` property, using compiled data.
-        *
-        *See the [Rust documentation for `JoiningGroup`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.JoiningGroup.html) for more information.
-        */
+        /**
+         * Create a name-to-enum mapper for the `JoiningGroup` property, using compiled data.
+         *
+         * See the [Rust documentation for `JoiningGroup`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.JoiningGroup.html) for more information.
+         */
         fun createJoiningGroup(): PropertyValueNameToEnumMapper {
             
             val returnVal = lib.icu4x_PropertyValueNameToEnumMapper_create_joining_group_mv1();
@@ -391,10 +411,11 @@ class PropertyValueNameToEnumMapper internal constructor (
         }
         @JvmStatic
         
-        /** Create a name-to-enum mapper for the `JoiningGroup` property, using a particular data source.
-        *
-        *See the [Rust documentation for `JoiningGroup`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.JoiningGroup.html) for more information.
-        */
+        /**
+         * Create a name-to-enum mapper for the `JoiningGroup` property, using a particular data source.
+         *
+         * See the [Rust documentation for `JoiningGroup`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.JoiningGroup.html) for more information.
+         */
         fun createJoiningGroupWithProvider(provider: DataProvider): Result<PropertyValueNameToEnumMapper> {
             
             val returnVal = lib.icu4x_PropertyValueNameToEnumMapper_create_joining_group_with_provider_mv1(provider.handle);
@@ -410,10 +431,11 @@ class PropertyValueNameToEnumMapper internal constructor (
         }
         @JvmStatic
         
-        /** Create a name-to-enum mapper for the `JoiningType` property, using compiled data.
-        *
-        *See the [Rust documentation for `JoiningType`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.JoiningType.html) for more information.
-        */
+        /**
+         * Create a name-to-enum mapper for the `JoiningType` property, using compiled data.
+         *
+         * See the [Rust documentation for `JoiningType`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.JoiningType.html) for more information.
+         */
         fun createJoiningType(): PropertyValueNameToEnumMapper {
             
             val returnVal = lib.icu4x_PropertyValueNameToEnumMapper_create_joining_type_mv1();
@@ -424,10 +446,11 @@ class PropertyValueNameToEnumMapper internal constructor (
         }
         @JvmStatic
         
-        /** Create a name-to-enum mapper for the `JoiningType` property, using a particular data source.
-        *
-        *See the [Rust documentation for `JoiningType`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.JoiningType.html) for more information.
-        */
+        /**
+         * Create a name-to-enum mapper for the `JoiningType` property, using a particular data source.
+         *
+         * See the [Rust documentation for `JoiningType`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.JoiningType.html) for more information.
+         */
         fun createJoiningTypeWithProvider(provider: DataProvider): Result<PropertyValueNameToEnumMapper> {
             
             val returnVal = lib.icu4x_PropertyValueNameToEnumMapper_create_joining_type_with_provider_mv1(provider.handle);
@@ -443,10 +466,11 @@ class PropertyValueNameToEnumMapper internal constructor (
         }
         @JvmStatic
         
-        /** Create a name-to-enum mapper for the `LineBreak` property, using compiled data.
-        *
-        *See the [Rust documentation for `LineBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.LineBreak.html) for more information.
-        */
+        /**
+         * Create a name-to-enum mapper for the `LineBreak` property, using compiled data.
+         *
+         * See the [Rust documentation for `LineBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.LineBreak.html) for more information.
+         */
         fun createLineBreak(): PropertyValueNameToEnumMapper {
             
             val returnVal = lib.icu4x_PropertyValueNameToEnumMapper_create_line_break_mv1();
@@ -457,10 +481,11 @@ class PropertyValueNameToEnumMapper internal constructor (
         }
         @JvmStatic
         
-        /** Create a name-to-enum mapper for the `LineBreak` property, using a particular data source.
-        *
-        *See the [Rust documentation for `LineBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.LineBreak.html) for more information.
-        */
+        /**
+         * Create a name-to-enum mapper for the `LineBreak` property, using a particular data source.
+         *
+         * See the [Rust documentation for `LineBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.LineBreak.html) for more information.
+         */
         fun createLineBreakWithProvider(provider: DataProvider): Result<PropertyValueNameToEnumMapper> {
             
             val returnVal = lib.icu4x_PropertyValueNameToEnumMapper_create_line_break_with_provider_mv1(provider.handle);
@@ -476,10 +501,11 @@ class PropertyValueNameToEnumMapper internal constructor (
         }
         @JvmStatic
         
-        /** Create a name-to-enum mapper for the `NumericType` property, using compiled data.
-        *
-        *See the [Rust documentation for `NumericType`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.NumericType.html) for more information.
-        */
+        /**
+         * Create a name-to-enum mapper for the `NumericType` property, using compiled data.
+         *
+         * See the [Rust documentation for `NumericType`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.NumericType.html) for more information.
+         */
         fun createNumericType(): PropertyValueNameToEnumMapper {
             
             val returnVal = lib.icu4x_PropertyValueNameToEnumMapper_create_numeric_type_mv1();
@@ -490,10 +516,11 @@ class PropertyValueNameToEnumMapper internal constructor (
         }
         @JvmStatic
         
-        /** Create a name-to-enum mapper for the `NumericType` property, using a particular data source.
-        *
-        *See the [Rust documentation for `NumericType`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.NumericType.html) for more information.
-        */
+        /**
+         * Create a name-to-enum mapper for the `NumericType` property, using a particular data source.
+         *
+         * See the [Rust documentation for `NumericType`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.NumericType.html) for more information.
+         */
         fun createNumericTypeWithProvider(provider: DataProvider): Result<PropertyValueNameToEnumMapper> {
             
             val returnVal = lib.icu4x_PropertyValueNameToEnumMapper_create_numeric_type_with_provider_mv1(provider.handle);
@@ -509,10 +536,11 @@ class PropertyValueNameToEnumMapper internal constructor (
         }
         @JvmStatic
         
-        /** Create a name-to-enum mapper for the `Script` property, using compiled data.
-        *
-        *See the [Rust documentation for `Script`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Script.html) for more information.
-        */
+        /**
+         * Create a name-to-enum mapper for the `Script` property, using compiled data.
+         *
+         * See the [Rust documentation for `Script`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Script.html) for more information.
+         */
         fun createScript(): PropertyValueNameToEnumMapper {
             
             val returnVal = lib.icu4x_PropertyValueNameToEnumMapper_create_script_mv1();
@@ -523,10 +551,11 @@ class PropertyValueNameToEnumMapper internal constructor (
         }
         @JvmStatic
         
-        /** Create a name-to-enum mapper for the `Script` property, using a particular data source.
-        *
-        *See the [Rust documentation for `Script`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Script.html) for more information.
-        */
+        /**
+         * Create a name-to-enum mapper for the `Script` property, using a particular data source.
+         *
+         * See the [Rust documentation for `Script`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Script.html) for more information.
+         */
         fun createScriptWithProvider(provider: DataProvider): Result<PropertyValueNameToEnumMapper> {
             
             val returnVal = lib.icu4x_PropertyValueNameToEnumMapper_create_script_with_provider_mv1(provider.handle);
@@ -542,10 +571,11 @@ class PropertyValueNameToEnumMapper internal constructor (
         }
         @JvmStatic
         
-        /** Create a name-to-enum mapper for the `SentenceBreak` property, using compiled data.
-        *
-        *See the [Rust documentation for `SentenceBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.SentenceBreak.html) for more information.
-        */
+        /**
+         * Create a name-to-enum mapper for the `SentenceBreak` property, using compiled data.
+         *
+         * See the [Rust documentation for `SentenceBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.SentenceBreak.html) for more information.
+         */
         fun createSentenceBreak(): PropertyValueNameToEnumMapper {
             
             val returnVal = lib.icu4x_PropertyValueNameToEnumMapper_create_sentence_break_mv1();
@@ -556,10 +586,11 @@ class PropertyValueNameToEnumMapper internal constructor (
         }
         @JvmStatic
         
-        /** Create a name-to-enum mapper for the `SentenceBreak` property, using a particular data source.
-        *
-        *See the [Rust documentation for `SentenceBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.SentenceBreak.html) for more information.
-        */
+        /**
+         * Create a name-to-enum mapper for the `SentenceBreak` property, using a particular data source.
+         *
+         * See the [Rust documentation for `SentenceBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.SentenceBreak.html) for more information.
+         */
         fun createSentenceBreakWithProvider(provider: DataProvider): Result<PropertyValueNameToEnumMapper> {
             
             val returnVal = lib.icu4x_PropertyValueNameToEnumMapper_create_sentence_break_with_provider_mv1(provider.handle);
@@ -575,10 +606,11 @@ class PropertyValueNameToEnumMapper internal constructor (
         }
         @JvmStatic
         
-        /** Create a name-to-enum mapper for the `VerticalOrientation` property, using compiled data.
-        *
-        *See the [Rust documentation for `VerticalOrientation`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.VerticalOrientation.html) for more information.
-        */
+        /**
+         * Create a name-to-enum mapper for the `VerticalOrientation` property, using compiled data.
+         *
+         * See the [Rust documentation for `VerticalOrientation`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.VerticalOrientation.html) for more information.
+         */
         fun createVerticalOrientation(): PropertyValueNameToEnumMapper {
             
             val returnVal = lib.icu4x_PropertyValueNameToEnumMapper_create_vertical_orientation_mv1();
@@ -589,10 +621,11 @@ class PropertyValueNameToEnumMapper internal constructor (
         }
         @JvmStatic
         
-        /** Create a name-to-enum mapper for the `VerticalOrientation` property, using a particular data source.
-        *
-        *See the [Rust documentation for `VerticalOrientation`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.VerticalOrientation.html) for more information.
-        */
+        /**
+         * Create a name-to-enum mapper for the `VerticalOrientation` property, using a particular data source.
+         *
+         * See the [Rust documentation for `VerticalOrientation`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.VerticalOrientation.html) for more information.
+         */
         fun createVerticalOrientationWithProvider(provider: DataProvider): Result<PropertyValueNameToEnumMapper> {
             
             val returnVal = lib.icu4x_PropertyValueNameToEnumMapper_create_vertical_orientation_with_provider_mv1(provider.handle);
@@ -608,10 +641,11 @@ class PropertyValueNameToEnumMapper internal constructor (
         }
         @JvmStatic
         
-        /** Create a name-to-enum mapper for the `WordBreak` property, using compiled data.
-        *
-        *See the [Rust documentation for `WordBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.WordBreak.html) for more information.
-        */
+        /**
+         * Create a name-to-enum mapper for the `WordBreak` property, using compiled data.
+         *
+         * See the [Rust documentation for `WordBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.WordBreak.html) for more information.
+         */
         fun createWordBreak(): PropertyValueNameToEnumMapper {
             
             val returnVal = lib.icu4x_PropertyValueNameToEnumMapper_create_word_break_mv1();
@@ -622,10 +656,11 @@ class PropertyValueNameToEnumMapper internal constructor (
         }
         @JvmStatic
         
-        /** Create a name-to-enum mapper for the `WordBreak` property, using a particular data source.
-        *
-        *See the [Rust documentation for `WordBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.WordBreak.html) for more information.
-        */
+        /**
+         * Create a name-to-enum mapper for the `WordBreak` property, using a particular data source.
+         *
+         * See the [Rust documentation for `WordBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.WordBreak.html) for more information.
+         */
         fun createWordBreakWithProvider(provider: DataProvider): Result<PropertyValueNameToEnumMapper> {
             
             val returnVal = lib.icu4x_PropertyValueNameToEnumMapper_create_word_break_with_provider_mv1(provider.handle);
@@ -641,12 +676,13 @@ class PropertyValueNameToEnumMapper internal constructor (
         }
     }
     
-    /** Get the property value matching the given name, using strict matching
-    *
-    *Returns -1 if the name is unknown for this property
-    *
-    *See the [Rust documentation for `get_strict`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyParserBorrowed.html#method.get_strict) for more information.
-    */
+    /**
+     * Get the property value matching the given name, using strict matching
+     *
+     * Returns -1 if the name is unknown for this property
+     *
+     * See the [Rust documentation for `get_strict`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyParserBorrowed.html#method.get_strict) for more information.
+     */
     fun getStrict(name: String): Short {
         val nameSliceMemory = PrimitiveArrayTools.borrowUtf8(name)
         
@@ -658,12 +694,13 @@ class PropertyValueNameToEnumMapper internal constructor (
         }
     }
     
-    /** Get the property value matching the given name, using loose matching
-    *
-    *Returns -1 if the name is unknown for this property
-    *
-    *See the [Rust documentation for `get_loose`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyParserBorrowed.html#method.get_loose) for more information.
-    */
+    /**
+     * Get the property value matching the given name, using loose matching
+     *
+     * Returns -1 if the name is unknown for this property
+     *
+     * See the [Rust documentation for `get_loose`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyParserBorrowed.html#method.get_loose) for more information.
+     */
     fun getLoose(name: String): Short {
         val nameSliceMemory = PrimitiveArrayTools.borrowUtf8(name)
         

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/RegionDisplayNames.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/RegionDisplayNames.kt
@@ -11,10 +11,11 @@ internal interface RegionDisplayNamesLib: Library {
     fun icu4x_RegionDisplayNames_create_v1_with_provider_mv1(provider: Pointer, locale: Pointer, options: DisplayNamesOptionsNative): ResultPointerInt
     fun icu4x_RegionDisplayNames_of_mv1(handle: Pointer, region: Slice, write: Pointer): ResultUnitInt
 }
-/** 🚧 This API is unstable and may experience breaking changes outside major releases.
-*
-*See the [Rust documentation for `RegionDisplayNames`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.RegionDisplayNames.html) for more information.
-*/
+/**
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
+ *
+ * See the [Rust documentation for `RegionDisplayNames`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.RegionDisplayNames.html) for more information.
+ */
 class RegionDisplayNames internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -43,12 +44,13 @@ class RegionDisplayNames internal constructor (
         internal val lib: RegionDisplayNamesLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *Creates a new `RegionDisplayNames` from locale data and an options bag using compiled data.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.RegionDisplayNames.html#method.try_new) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * Creates a new `RegionDisplayNames` from locale data and an options bag using compiled data.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.RegionDisplayNames.html#method.try_new) for more information.
+         */
         fun create(locale: Locale, options: DisplayNamesOptions): Result<RegionDisplayNames> {
             
             val returnVal = lib.icu4x_RegionDisplayNames_create_v1_mv1(locale.handle, options.toNative());
@@ -64,12 +66,13 @@ class RegionDisplayNames internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *Creates a new `RegionDisplayNames` from locale data and an options bag using a particular data source.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.RegionDisplayNames.html#method.try_new) for more information.
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * Creates a new `RegionDisplayNames` from locale data and an options bag using a particular data source.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.RegionDisplayNames.html#method.try_new) for more information.
+         */
         fun create_with_provider(provider: DataProvider, locale: Locale, options: DisplayNamesOptions): Result<RegionDisplayNames> {
             
             val returnVal = lib.icu4x_RegionDisplayNames_create_v1_with_provider_mv1(provider.handle, locale.handle, options.toNative());
@@ -85,14 +88,15 @@ class RegionDisplayNames internal constructor (
         }
     }
     
-    /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-    *
-    *Returns the locale specific display name of a region.
-    *Note that the function returns an empty string in case the display name for a given
-    *region code is not found.
-    *
-    *See the [Rust documentation for `of`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.RegionDisplayNames.html#method.of) for more information.
-    */
+    /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
+     * Returns the locale specific display name of a region.
+     * Note that the function returns an empty string in case the display name for a given
+     * region code is not found.
+     *
+     * See the [Rust documentation for `of`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.RegionDisplayNames.html#method.of) for more information.
+     */
     fun of(region: String): Result<String> {
         val regionSliceMemory = PrimitiveArrayTools.borrowUtf8(region)
         val write = DW.lib.diplomat_buffer_write_create(0)

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/RegionDisplayNames.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/RegionDisplayNames.kt
@@ -12,9 +12,9 @@ internal interface RegionDisplayNamesLib: Library {
     fun icu4x_RegionDisplayNames_of_mv1(handle: Pointer, region: Slice, write: Pointer): ResultUnitInt
 }
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `RegionDisplayNames`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.RegionDisplayNames.html) for more information.
+ *
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
  */
 class RegionDisplayNames internal constructor (
     internal val handle: Pointer,
@@ -45,11 +45,11 @@ class RegionDisplayNames internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * Creates a new `RegionDisplayNames` from locale data and an options bag using compiled data.
          *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.RegionDisplayNames.html#method.try_new) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun create(locale: Locale, options: DisplayNamesOptions): Result<RegionDisplayNames> {
             
@@ -67,11 +67,11 @@ class RegionDisplayNames internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * Creates a new `RegionDisplayNames` from locale data and an options bag using a particular data source.
          *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.RegionDisplayNames.html#method.try_new) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun create_with_provider(provider: DataProvider, locale: Locale, options: DisplayNamesOptions): Result<RegionDisplayNames> {
             
@@ -89,13 +89,13 @@ class RegionDisplayNames internal constructor (
     }
     
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * Returns the locale specific display name of a region.
      * Note that the function returns an empty string in case the display name for a given
      * region code is not found.
      *
      * See the [Rust documentation for `of`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.RegionDisplayNames.html#method.of) for more information.
+     *
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
      */
     fun of(region: String): Result<String> {
         val regionSliceMemory = PrimitiveArrayTools.borrowUtf8(region)

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/ReorderedIndexMap.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/ReorderedIndexMap.kt
@@ -12,12 +12,13 @@ internal interface ReorderedIndexMapLib: Library {
     fun icu4x_ReorderedIndexMap_is_empty_mv1(handle: Pointer): Byte
     fun icu4x_ReorderedIndexMap_get_mv1(handle: Pointer, index: FFISizet): FFISizet
 }
-/** Thin wrapper around a vector that maps visual indices to source indices
-*
-*`map[visualIndex] = sourceIndex`
-*
-*Produced by `reorder_visual()` on [Bidi].
-*/
+/**
+ * Thin wrapper around a vector that maps visual indices to source indices
+ *
+ * `map[visualIndex] = sourceIndex`
+ *
+ * Produced by `reorder_visual()` on [Bidi].
+ */
 class ReorderedIndexMap internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -46,8 +47,9 @@ class ReorderedIndexMap internal constructor (
         internal val lib: ReorderedIndexMapLib = Native.load("icu4x", libClass)
     }
     
-    /** Get this as a slice/array of indices
-    */
+    /**
+     * Get this as a slice/array of indices
+     */
     fun asSlice(): ULongArray {
         // This lifetime edge depends on lifetimes: 'a
         val aEdges: MutableList<Any> = mutableListOf(this);
@@ -56,26 +58,29 @@ class ReorderedIndexMap internal constructor (
             return PrimitiveArrayTools.getULongArray(returnVal)
     }
     
-    /** The length of this map
-    */
+    /**
+     * The length of this map
+     */
     fun len(): ULong {
         
         val returnVal = lib.icu4x_ReorderedIndexMap_len_mv1(handle);
         return (returnVal.toULong())
     }
     
-    /** Whether this map is empty
-    */
+    /**
+     * Whether this map is empty
+     */
     fun isEmpty(): Boolean {
         
         val returnVal = lib.icu4x_ReorderedIndexMap_is_empty_mv1(handle);
         return (returnVal > 0)
     }
     
-    /** Get element at `index`. Returns 0 when out of bounds
-    *(note that 0 is also a valid in-bounds value, please use `len()`
-    *to avoid out-of-bounds)
-    */
+    /**
+     * Get element at `index`. Returns 0 when out of bounds
+     * (note that 0 is also a valid in-bounds value, please use `len()`
+     * to avoid out-of-bounds)
+     */
     internal fun getInternal(index: ULong): ULong {
         
         val returnVal = lib.icu4x_ReorderedIndexMap_get_mv1(handle, FFISizet(index));

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/Rfc9557ParseError.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/Rfc9557ParseError.kt
@@ -8,7 +8,8 @@ import com.sun.jna.Structure
 
 internal interface Rfc9557ParseErrorLib: Library {
 }
-/** Additional information: [1](https://docs.rs/icu/2.3.1/icu/calendar/enum.ParseError.html), [2](https://docs.rs/icu/2.3.1/icu/time/enum.ParseError.html)
+/**
+ * Additional information: [1](https://docs.rs/icu/2.3.1/icu/calendar/enum.ParseError.html), [2](https://docs.rs/icu/2.3.1/icu/time/enum.ParseError.html)
 */
 enum class Rfc9557ParseError {
     Unknown,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/Script.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/Script.kt
@@ -14,7 +14,8 @@ internal interface ScriptLib: Library {
     fun icu4x_Script_from_integer_value_mv1(other: FFIUint16): OptionInt
     fun icu4x_Script_try_from_str_mv1(s: Slice): OptionInt
 }
-/** See the [Rust documentation for `Script`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Script.html) for more information.
+/**
+ * See the [Rust documentation for `Script`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Script.html) for more information.
 */
 enum class Script(val inner: Int) {
     Common(0),
@@ -469,8 +470,9 @@ enum class Script(val inner: Int) {
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.EnumeratedProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.EnumeratedProperty.html#tymethod.for_char) for more information.
+         */
         fun forChar(ch: Int): Script {
             
             val returnVal = lib.icu4x_Script_for_char_mv1(ch);
@@ -478,10 +480,11 @@ enum class Script(val inner: Int) {
         }
         @JvmStatic
         
-        /** Convert from an integer value from ICU4C or `CodePointMapData`
-        *
-        *See the [Rust documentation for `from_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Script.html#method.from_icu4c_value) for more information.
-        */
+        /**
+         * Convert from an integer value from ICU4C or `CodePointMapData`
+         *
+         * See the [Rust documentation for `from_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Script.html#method.from_icu4c_value) for more information.
+         */
         fun fromIntegerValue(other: UShort): Script? {
             
             val returnVal = lib.icu4x_Script_from_integer_value_mv1(FFIUint16(other));
@@ -491,10 +494,11 @@ enum class Script(val inner: Int) {
         }
         @JvmStatic
         
-        /** Creates a `Script` from a string.
-        *
-        *Short names, long names, and aliases are supported, and matching is case-insensitive.
-        */
+        /**
+         * Creates a `Script` from a string.
+         *
+         * Short names, long names, and aliases are supported, and matching is case-insensitive.
+         */
         fun tryFromStr(s: String): Script? {
             val sSliceMemory = PrimitiveArrayTools.borrowUtf8(s)
             
@@ -509,10 +513,11 @@ enum class Script(val inner: Int) {
         }
     }
     
-    /** Get the "long" name of this property value (returns empty if property value is unknown)
-    *
-    *See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesLongBorrowed.html#method.get) for more information.
-    */
+    /**
+     * Get the "long" name of this property value (returns empty if property value is unknown)
+     *
+     * See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesLongBorrowed.html#method.get) for more information.
+     */
     fun longName(): String? {
         
         val returnVal = lib.icu4x_Script_long_name_mv1(this.toNative());
@@ -522,10 +527,11 @@ enum class Script(val inner: Int) {
                                 
     }
     
-    /** Get the "short" name of this property value (returns empty if property value is unknown)
-    *
-    *See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesShortBorrowed.html#method.get) for more information.
-    */
+    /**
+     * Get the "short" name of this property value (returns empty if property value is unknown)
+     *
+     * See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesShortBorrowed.html#method.get) for more information.
+     */
     fun shortName(): String? {
         
         val returnVal = lib.icu4x_Script_short_name_mv1(this.toNative());
@@ -535,10 +541,11 @@ enum class Script(val inner: Int) {
                                 
     }
     
-    /** Convert to an integer value usable with ICU4C and `CodePointMapData`
-    *
-    *See the [Rust documentation for `to_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Script.html#method.to_icu4c_value) for more information.
-    */
+    /**
+     * Convert to an integer value usable with ICU4C and `CodePointMapData`
+     *
+     * See the [Rust documentation for `to_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.Script.html#method.to_icu4c_value) for more information.
+     */
     fun toIntegerValue(): UShort {
         
         val returnVal = lib.icu4x_Script_to_integer_value_mv1(this.toNative());

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/ScriptExtensionsSet.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/ScriptExtensionsSet.kt
@@ -11,10 +11,11 @@ internal interface ScriptExtensionsSetLib: Library {
     fun icu4x_ScriptExtensionsSet_count_mv1(handle: Pointer): FFISizet
     fun icu4x_ScriptExtensionsSet_script_at_mv2(handle: Pointer, index: FFISizet): OptionInt
 }
-/** An object that represents the `Script_Extensions` property for a single character
-*
-*See the [Rust documentation for `ScriptExtensionsSet`](https://docs.rs/icu/2.3.1/icu/properties/script/struct.ScriptExtensionsSet.html) for more information.
-*/
+/**
+ * An object that represents the `Script_Extensions` property for a single character
+ *
+ * See the [Rust documentation for `ScriptExtensionsSet`](https://docs.rs/icu/2.3.1/icu/properties/script/struct.ScriptExtensionsSet.html) for more information.
+ */
 class ScriptExtensionsSet internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -44,30 +45,33 @@ class ScriptExtensionsSet internal constructor (
         internal val lib: ScriptExtensionsSetLib = Native.load("icu4x", libClass)
     }
     
-    /** Check if the `Script_Extensions` property of the given code point covers the given script
-    *
-    *See the [Rust documentation for `contains`](https://docs.rs/icu/2.3.1/icu/properties/script/struct.ScriptExtensionsSet.html#method.contains) for more information.
-    */
+    /**
+     * Check if the `Script_Extensions` property of the given code point covers the given script
+     *
+     * See the [Rust documentation for `contains`](https://docs.rs/icu/2.3.1/icu/properties/script/struct.ScriptExtensionsSet.html#method.contains) for more information.
+     */
     fun contains(script: Script): Boolean {
         
         val returnVal = lib.icu4x_ScriptExtensionsSet_contains_mv2(handle, script.toNative());
         return (returnVal > 0)
     }
     
-    /** Get the number of scripts contained in here
-    *
-    *See the [Rust documentation for `iter`](https://docs.rs/icu/2.3.1/icu/properties/script/struct.ScriptExtensionsSet.html#method.iter) for more information.
-    */
+    /**
+     * Get the number of scripts contained in here
+     *
+     * See the [Rust documentation for `iter`](https://docs.rs/icu/2.3.1/icu/properties/script/struct.ScriptExtensionsSet.html#method.iter) for more information.
+     */
     fun count(): ULong {
         
         val returnVal = lib.icu4x_ScriptExtensionsSet_count_mv1(handle);
         return (returnVal.toULong())
     }
     
-    /** Get script at index
-    *
-    *See the [Rust documentation for `iter`](https://docs.rs/icu/2.3.1/icu/properties/script/struct.ScriptExtensionsSet.html#method.iter) for more information.
-    */
+    /**
+     * Get script at index
+     *
+     * See the [Rust documentation for `iter`](https://docs.rs/icu/2.3.1/icu/properties/script/struct.ScriptExtensionsSet.html#method.iter) for more information.
+     */
     fun scriptAt(index: ULong): Script? {
         
         val returnVal = lib.icu4x_ScriptExtensionsSet_script_at_mv2(handle, FFISizet(index));

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/ScriptWithExtensions.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/ScriptWithExtensions.kt
@@ -14,10 +14,11 @@ internal interface ScriptWithExtensionsLib: Library {
     fun icu4x_ScriptWithExtensions_as_borrowed_mv1(handle: Pointer): Pointer
     fun icu4x_ScriptWithExtensions_iter_ranges_for_script_mv2(handle: Pointer, script: Int): Pointer
 }
-/** An ICU4X `ScriptWithExtensions` map object, capable of holding a map of codepoints to scriptextensions values
-*
-*See the [Rust documentation for `ScriptWithExtensions`](https://docs.rs/icu/2.3.1/icu/properties/script/struct.ScriptWithExtensions.html) for more information.
-*/
+/**
+ * An ICU4X `ScriptWithExtensions` map object, capable of holding a map of codepoints to scriptextensions values
+ *
+ * See the [Rust documentation for `ScriptWithExtensions`](https://docs.rs/icu/2.3.1/icu/properties/script/struct.ScriptWithExtensions.html) for more information.
+ */
 class ScriptWithExtensions internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -46,10 +47,11 @@ class ScriptWithExtensions internal constructor (
         internal val lib: ScriptWithExtensionsLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Create a map for the `Script`/`Script_Extensions` properties, using compiled data.
-        *
-        *See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/properties/script/struct.ScriptWithExtensions.html#method.new) for more information.
-        */
+        /**
+         * Create a map for the `Script`/`Script_Extensions` properties, using compiled data.
+         *
+         * See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/properties/script/struct.ScriptWithExtensions.html#method.new) for more information.
+         */
         fun create(): ScriptWithExtensions {
             
             val returnVal = lib.icu4x_ScriptWithExtensions_create_mv1();
@@ -60,10 +62,11 @@ class ScriptWithExtensions internal constructor (
         }
         @JvmStatic
         
-        /** Create a map for the `Script`/`Script_Extensions` properties, using compiled data.
-        *
-        *See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/properties/script/struct.ScriptWithExtensions.html#method.new) for more information.
-        */
+        /**
+         * Create a map for the `Script`/`Script_Extensions` properties, using compiled data.
+         *
+         * See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/properties/script/struct.ScriptWithExtensions.html#method.new) for more information.
+         */
         fun createWithProvider(provider: DataProvider): Result<ScriptWithExtensions> {
             
             val returnVal = lib.icu4x_ScriptWithExtensions_create_with_provider_mv1(provider.handle);
@@ -79,30 +82,33 @@ class ScriptWithExtensions internal constructor (
         }
     }
     
-    /** Get the Script property value for a code point
-    *
-    *See the [Rust documentation for `get_script_val`](https://docs.rs/icu/2.3.1/icu/properties/script/struct.ScriptWithExtensionsBorrowed.html#method.get_script_val) for more information.
-    */
+    /**
+     * Get the Script property value for a code point
+     *
+     * See the [Rust documentation for `get_script_val`](https://docs.rs/icu/2.3.1/icu/properties/script/struct.ScriptWithExtensionsBorrowed.html#method.get_script_val) for more information.
+     */
     fun getScriptVal(ch: Int): Script {
         
         val returnVal = lib.icu4x_ScriptWithExtensions_get_script_val_mv2(handle, ch);
         return (Script.fromNative(returnVal))
     }
     
-    /** Check if the `Script_Extensions` property of the given code point covers the given script
-    *
-    *See the [Rust documentation for `has_script`](https://docs.rs/icu/2.3.1/icu/properties/script/struct.ScriptWithExtensionsBorrowed.html#method.has_script) for more information.
-    */
+    /**
+     * Check if the `Script_Extensions` property of the given code point covers the given script
+     *
+     * See the [Rust documentation for `has_script`](https://docs.rs/icu/2.3.1/icu/properties/script/struct.ScriptWithExtensionsBorrowed.html#method.has_script) for more information.
+     */
     fun hasScript(ch: Int, script: Script): Boolean {
         
         val returnVal = lib.icu4x_ScriptWithExtensions_has_script_mv2(handle, ch, script.toNative());
         return (returnVal > 0)
     }
     
-    /** Borrow this object for a slightly faster variant with more operations
-    *
-    *See the [Rust documentation for `as_borrowed`](https://docs.rs/icu/2.3.1/icu/properties/script/struct.ScriptWithExtensions.html#method.as_borrowed) for more information.
-    */
+    /**
+     * Borrow this object for a slightly faster variant with more operations
+     *
+     * See the [Rust documentation for `as_borrowed`](https://docs.rs/icu/2.3.1/icu/properties/script/struct.ScriptWithExtensions.html#method.as_borrowed) for more information.
+     */
     fun asBorrowed(): ScriptWithExtensionsBorrowed {
         // This lifetime edge depends on lifetimes: 'a
         val aEdges: MutableList<Any> = mutableListOf(this);
@@ -114,10 +120,11 @@ class ScriptWithExtensions internal constructor (
         return returnOpaque
     }
     
-    /** Get a list of ranges of code points that contain this script in their `Script_Extensions` values
-    *
-    *See the [Rust documentation for `get_script_extensions_ranges`](https://docs.rs/icu/2.3.1/icu/properties/script/struct.ScriptWithExtensionsBorrowed.html#method.get_script_extensions_ranges) for more information.
-    */
+    /**
+     * Get a list of ranges of code points that contain this script in their `Script_Extensions` values
+     *
+     * See the [Rust documentation for `get_script_extensions_ranges`](https://docs.rs/icu/2.3.1/icu/properties/script/struct.ScriptWithExtensionsBorrowed.html#method.get_script_extensions_ranges) for more information.
+     */
     fun iterRangesForScript(script: Script): CodePointRangeIterator {
         // This lifetime edge depends on lifetimes: 'a
         val aEdges: MutableList<Any> = mutableListOf(this);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/ScriptWithExtensionsBorrowed.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/ScriptWithExtensionsBorrowed.kt
@@ -12,10 +12,11 @@ internal interface ScriptWithExtensionsBorrowedLib: Library {
     fun icu4x_ScriptWithExtensionsBorrowed_has_script_mv2(handle: Pointer, ch: Int, script: Int): Byte
     fun icu4x_ScriptWithExtensionsBorrowed_get_script_extensions_set_mv2(handle: Pointer, script: Int): Pointer
 }
-/** A slightly faster `ScriptWithExtensions` object
-*
-*See the [Rust documentation for `ScriptWithExtensionsBorrowed`](https://docs.rs/icu/2.3.1/icu/properties/script/struct.ScriptWithExtensionsBorrowed.html) for more information.
-*/
+/**
+ * A slightly faster `ScriptWithExtensions` object
+ *
+ * See the [Rust documentation for `ScriptWithExtensionsBorrowed`](https://docs.rs/icu/2.3.1/icu/properties/script/struct.ScriptWithExtensionsBorrowed.html) for more information.
+ */
 class ScriptWithExtensionsBorrowed internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -45,20 +46,22 @@ class ScriptWithExtensionsBorrowed internal constructor (
         internal val lib: ScriptWithExtensionsBorrowedLib = Native.load("icu4x", libClass)
     }
     
-    /** Get the Script property value for a code point
-    *
-    *See the [Rust documentation for `get_script_val`](https://docs.rs/icu/2.3.1/icu/properties/script/struct.ScriptWithExtensionsBorrowed.html#method.get_script_val) for more information.
-    */
+    /**
+     * Get the Script property value for a code point
+     *
+     * See the [Rust documentation for `get_script_val`](https://docs.rs/icu/2.3.1/icu/properties/script/struct.ScriptWithExtensionsBorrowed.html#method.get_script_val) for more information.
+     */
     fun getScriptVal(ch: Int): Script {
         
         val returnVal = lib.icu4x_ScriptWithExtensionsBorrowed_get_script_val_mv2(handle, ch);
         return (Script.fromNative(returnVal))
     }
     
-    /** Get the Script property value for a code point
-    *
-    *See the [Rust documentation for `get_script_extensions_val`](https://docs.rs/icu/2.3.1/icu/properties/script/struct.ScriptWithExtensionsBorrowed.html#method.get_script_extensions_val) for more information.
-    */
+    /**
+     * Get the Script property value for a code point
+     *
+     * See the [Rust documentation for `get_script_extensions_val`](https://docs.rs/icu/2.3.1/icu/properties/script/struct.ScriptWithExtensionsBorrowed.html#method.get_script_extensions_val) for more information.
+     */
     fun getScriptExtensionsVal(ch: Int): ScriptExtensionsSet {
         // This lifetime edge depends on lifetimes: 'a
         val aEdges: MutableList<Any> = mutableListOf(this);
@@ -70,21 +73,23 @@ class ScriptWithExtensionsBorrowed internal constructor (
         return returnOpaque
     }
     
-    /** Check if the `Script_Extensions` property of the given code point covers the given script
-    *
-    *See the [Rust documentation for `has_script`](https://docs.rs/icu/2.3.1/icu/properties/script/struct.ScriptWithExtensionsBorrowed.html#method.has_script) for more information.
-    */
+    /**
+     * Check if the `Script_Extensions` property of the given code point covers the given script
+     *
+     * See the [Rust documentation for `has_script`](https://docs.rs/icu/2.3.1/icu/properties/script/struct.ScriptWithExtensionsBorrowed.html#method.has_script) for more information.
+     */
     fun hasScript(ch: Int, script: Script): Boolean {
         
         val returnVal = lib.icu4x_ScriptWithExtensionsBorrowed_has_script_mv2(handle, ch, script.toNative());
         return (returnVal > 0)
     }
     
-    /** Build the `CodePointSetData` corresponding to a codepoints matching a particular script
-    *in their `Script_Extensions`
-    *
-    *See the [Rust documentation for `get_script_extensions_set`](https://docs.rs/icu/2.3.1/icu/properties/script/struct.ScriptWithExtensionsBorrowed.html#method.get_script_extensions_set) for more information.
-    */
+    /**
+     * Build the `CodePointSetData` corresponding to a codepoints matching a particular script
+     * in their `Script_Extensions`
+     *
+     * See the [Rust documentation for `get_script_extensions_set`](https://docs.rs/icu/2.3.1/icu/properties/script/struct.ScriptWithExtensionsBorrowed.html#method.get_script_extensions_set) for more information.
+     */
     fun getScriptExtensionsSet(script: Script): CodePointSetData {
         
         val returnVal = lib.icu4x_ScriptWithExtensionsBorrowed_get_script_extensions_set_mv2(handle, script.toNative());

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/SegmenterWordType.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/SegmenterWordType.kt
@@ -9,7 +9,8 @@ import com.sun.jna.Structure
 internal interface SegmenterWordTypeLib: Library {
     fun icu4x_SegmenterWordType_is_word_like_mv1(inner: Int): Byte
 }
-/** See the [Rust documentation for `WordType`](https://docs.rs/icu/2.3.1/icu/segmenter/options/enum.WordType.html) for more information.
+/**
+ * See the [Rust documentation for `WordType`](https://docs.rs/icu/2.3.1/icu/segmenter/options/enum.WordType.html) for more information.
 */
 enum class SegmenterWordType {
     None,
@@ -33,8 +34,9 @@ enum class SegmenterWordType {
         }
     }
     
-    /** See the [Rust documentation for `is_word_like`](https://docs.rs/icu/2.3.1/icu/segmenter/options/enum.WordType.html#method.is_word_like) for more information.
-    */
+    /**
+     * See the [Rust documentation for `is_word_like`](https://docs.rs/icu/2.3.1/icu/segmenter/options/enum.WordType.html#method.is_word_like) for more information.
+     */
     fun isWordLike(): Boolean {
         
         val returnVal = lib.icu4x_SegmenterWordType_is_word_like_mv1(this.toNative());

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/SentenceBreak.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/SentenceBreak.kt
@@ -14,7 +14,8 @@ internal interface SentenceBreakLib: Library {
     fun icu4x_SentenceBreak_from_integer_value_mv1(other: FFIUint8): OptionInt
     fun icu4x_SentenceBreak_try_from_str_mv1(s: Slice): OptionInt
 }
-/** See the [Rust documentation for `SentenceBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.SentenceBreak.html) for more information.
+/**
+ * See the [Rust documentation for `SentenceBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.SentenceBreak.html) for more information.
 */
 enum class SentenceBreak {
     Other,
@@ -50,8 +51,9 @@ enum class SentenceBreak {
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.EnumeratedProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.EnumeratedProperty.html#tymethod.for_char) for more information.
+         */
         fun forChar(ch: Int): SentenceBreak {
             
             val returnVal = lib.icu4x_SentenceBreak_for_char_mv1(ch);
@@ -59,10 +61,11 @@ enum class SentenceBreak {
         }
         @JvmStatic
         
-        /** Convert from an integer value from ICU4C or `CodePointMapData`
-        *
-        *See the [Rust documentation for `from_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.SentenceBreak.html#method.from_icu4c_value) for more information.
-        */
+        /**
+         * Convert from an integer value from ICU4C or `CodePointMapData`
+         *
+         * See the [Rust documentation for `from_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.SentenceBreak.html#method.from_icu4c_value) for more information.
+         */
         fun fromIntegerValue(other: UByte): SentenceBreak? {
             
             val returnVal = lib.icu4x_SentenceBreak_from_integer_value_mv1(FFIUint8(other));
@@ -72,10 +75,11 @@ enum class SentenceBreak {
         }
         @JvmStatic
         
-        /** Creates a `SentenceBreak` from a string.
-        *
-        *Short names, long names, and aliases are supported, and matching is case-insensitive.
-        */
+        /**
+         * Creates a `SentenceBreak` from a string.
+         *
+         * Short names, long names, and aliases are supported, and matching is case-insensitive.
+         */
         fun tryFromStr(s: String): SentenceBreak? {
             val sSliceMemory = PrimitiveArrayTools.borrowUtf8(s)
             
@@ -90,10 +94,11 @@ enum class SentenceBreak {
         }
     }
     
-    /** Get the "long" name of this property value (returns empty if property value is unknown)
-    *
-    *See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesLongBorrowed.html#method.get) for more information.
-    */
+    /**
+     * Get the "long" name of this property value (returns empty if property value is unknown)
+     *
+     * See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesLongBorrowed.html#method.get) for more information.
+     */
     fun longName(): String? {
         
         val returnVal = lib.icu4x_SentenceBreak_long_name_mv1(this.toNative());
@@ -103,10 +108,11 @@ enum class SentenceBreak {
                                 
     }
     
-    /** Get the "short" name of this property value (returns empty if property value is unknown)
-    *
-    *See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesShortBorrowed.html#method.get) for more information.
-    */
+    /**
+     * Get the "short" name of this property value (returns empty if property value is unknown)
+     *
+     * See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesShortBorrowed.html#method.get) for more information.
+     */
     fun shortName(): String? {
         
         val returnVal = lib.icu4x_SentenceBreak_short_name_mv1(this.toNative());
@@ -116,10 +122,11 @@ enum class SentenceBreak {
                                 
     }
     
-    /** Convert to an integer value usable with ICU4C and `CodePointMapData`
-    *
-    *See the [Rust documentation for `to_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.SentenceBreak.html#method.to_icu4c_value) for more information.
-    */
+    /**
+     * Convert to an integer value usable with ICU4C and `CodePointMapData`
+     *
+     * See the [Rust documentation for `to_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.SentenceBreak.html#method.to_icu4c_value) for more information.
+     */
     fun toIntegerValue(): UByte {
         
         val returnVal = lib.icu4x_SentenceBreak_to_integer_value_mv1(this.toNative());

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/SentenceBreakIteratorLatin1.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/SentenceBreakIteratorLatin1.kt
@@ -9,8 +9,9 @@ internal interface SentenceBreakIteratorLatin1Lib: Library {
     fun icu4x_SentenceBreakIteratorLatin1_destroy_mv1(handle: Pointer)
     fun icu4x_SentenceBreakIteratorLatin1_next_mv1(handle: Pointer): Int
 }
-/** See the [Rust documentation for `SentenceBreakIterator`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.SentenceBreakIterator.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `SentenceBreakIterator`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.SentenceBreakIterator.html) for more information.
+ */
 class SentenceBreakIteratorLatin1 internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -40,11 +41,12 @@ class SentenceBreakIteratorLatin1 internal constructor (
         internal val lib: SentenceBreakIteratorLatin1Lib = Native.load("icu4x", libClass)
     }
     
-    /** Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
-    *out of range of a 32-bit signed integer.
-    *
-    *See the [Rust documentation for `next`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.SentenceBreakIterator.html#method.next) for more information.
-    */
+    /**
+     * Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
+     * out of range of a 32-bit signed integer.
+     *
+     * See the [Rust documentation for `next`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.SentenceBreakIterator.html#method.next) for more information.
+     */
     fun next(): Int {
         
         val returnVal = lib.icu4x_SentenceBreakIteratorLatin1_next_mv1(handle);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/SentenceBreakIteratorUtf16.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/SentenceBreakIteratorUtf16.kt
@@ -9,8 +9,9 @@ internal interface SentenceBreakIteratorUtf16Lib: Library {
     fun icu4x_SentenceBreakIteratorUtf16_destroy_mv1(handle: Pointer)
     fun icu4x_SentenceBreakIteratorUtf16_next_mv1(handle: Pointer): Int
 }
-/** See the [Rust documentation for `SentenceBreakIterator`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.SentenceBreakIterator.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `SentenceBreakIterator`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.SentenceBreakIterator.html) for more information.
+ */
 class SentenceBreakIteratorUtf16 internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -40,11 +41,12 @@ class SentenceBreakIteratorUtf16 internal constructor (
         internal val lib: SentenceBreakIteratorUtf16Lib = Native.load("icu4x", libClass)
     }
     
-    /** Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
-    *out of range of a 32-bit signed integer.
-    *
-    *See the [Rust documentation for `next`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.SentenceBreakIterator.html#method.next) for more information.
-    */
+    /**
+     * Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
+     * out of range of a 32-bit signed integer.
+     *
+     * See the [Rust documentation for `next`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.SentenceBreakIterator.html#method.next) for more information.
+     */
     fun next(): Int {
         
         val returnVal = lib.icu4x_SentenceBreakIteratorUtf16_next_mv1(handle);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/SentenceBreakIteratorUtf8.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/SentenceBreakIteratorUtf8.kt
@@ -9,8 +9,9 @@ internal interface SentenceBreakIteratorUtf8Lib: Library {
     fun icu4x_SentenceBreakIteratorUtf8_destroy_mv1(handle: Pointer)
     fun icu4x_SentenceBreakIteratorUtf8_next_mv1(handle: Pointer): Int
 }
-/** See the [Rust documentation for `SentenceBreakIterator`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.SentenceBreakIterator.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `SentenceBreakIterator`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.SentenceBreakIterator.html) for more information.
+ */
 class SentenceBreakIteratorUtf8 internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -40,11 +41,12 @@ class SentenceBreakIteratorUtf8 internal constructor (
         internal val lib: SentenceBreakIteratorUtf8Lib = Native.load("icu4x", libClass)
     }
     
-    /** Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
-    *out of range of a 32-bit signed integer.
-    *
-    *See the [Rust documentation for `next`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.SentenceBreakIterator.html#method.next) for more information.
-    */
+    /**
+     * Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
+     * out of range of a 32-bit signed integer.
+     *
+     * See the [Rust documentation for `next`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.SentenceBreakIterator.html#method.next) for more information.
+     */
     fun next(): Int {
         
         val returnVal = lib.icu4x_SentenceBreakIteratorUtf8_next_mv1(handle);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/SentenceSegmenter.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/SentenceSegmenter.kt
@@ -12,10 +12,11 @@ internal interface SentenceSegmenterLib: Library {
     fun icu4x_SentenceSegmenter_create_with_content_locale_and_provider_mv1(provider: Pointer, locale: Pointer): ResultPointerInt
     fun icu4x_SentenceSegmenter_segment_utf16_mv1(handle: Pointer, input: Slice): Pointer
 }
-/** An ICU4X sentence-break segmenter, capable of finding sentence breakpoints in strings.
-*
-*See the [Rust documentation for `SentenceSegmenter`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.SentenceSegmenter.html) for more information.
-*/
+/**
+ * An ICU4X sentence-break segmenter, capable of finding sentence breakpoints in strings.
+ *
+ * See the [Rust documentation for `SentenceSegmenter`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.SentenceSegmenter.html) for more information.
+ */
 class SentenceSegmenter internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -44,10 +45,11 @@ class SentenceSegmenter internal constructor (
         internal val lib: SentenceSegmenterLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Construct a [SentenceSegmenter] using compiled data. This does not assume any content locale.
-        *
-        *See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.SentenceSegmenter.html#method.new) for more information.
-        */
+        /**
+         * Construct a [SentenceSegmenter] using compiled data. This does not assume any content locale.
+         *
+         * See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.SentenceSegmenter.html#method.new) for more information.
+         */
         fun create(): SentenceSegmenter {
             
             val returnVal = lib.icu4x_SentenceSegmenter_create_mv1();
@@ -58,8 +60,9 @@ class SentenceSegmenter internal constructor (
         }
         @JvmStatic
         
-        /** Construct a [SentenceSegmenter] for content known to be of a given locale, using compiled data.
-        */
+        /**
+         * Construct a [SentenceSegmenter] for content known to be of a given locale, using compiled data.
+         */
         fun createWithContentLocale(locale: Locale): Result<SentenceSegmenter> {
             
             val returnVal = lib.icu4x_SentenceSegmenter_create_with_content_locale_mv1(locale.handle);
@@ -75,8 +78,9 @@ class SentenceSegmenter internal constructor (
         }
         @JvmStatic
         
-        /** Construct a [SentenceSegmenter]  for content known to be of a given locale, using a particular data source.
-        */
+        /**
+         * Construct a [SentenceSegmenter]  for content known to be of a given locale, using a particular data source.
+         */
         fun createWithContentLocaleAndProvider(provider: DataProvider, locale: Locale): Result<SentenceSegmenter> {
             
             val returnVal = lib.icu4x_SentenceSegmenter_create_with_content_locale_and_provider_mv1(provider.handle, locale.handle);
@@ -92,13 +96,14 @@ class SentenceSegmenter internal constructor (
         }
     }
     
-    /** Segments a string.
-    *
-    *Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
-    *to the WHATWG Encoding Standard.
-    *
-    *See the [Rust documentation for `segment_utf16`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.SentenceSegmenterBorrowed.html#method.segment_utf16) for more information.
-    */
+    /**
+     * Segments a string.
+     *
+     * Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
+     * to the WHATWG Encoding Standard.
+     *
+     * See the [Rust documentation for `segment_utf16`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.SentenceSegmenterBorrowed.html#method.segment_utf16) for more information.
+     */
     fun segment(input: String): SentenceBreakIteratorUtf16 {
         // This lifetime edge depends on lifetimes: 'a
         val aEdges: MutableList<Any> = mutableListOf(this);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/Time.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/Time.kt
@@ -16,10 +16,11 @@ internal interface TimeLib: Library {
     fun icu4x_Time_second_mv1(handle: Pointer): FFIUint8
     fun icu4x_Time_subsecond_mv1(handle: Pointer): FFIUint32
 }
-/** An ICU4X Time object representing a time in terms of hour, minute, second, nanosecond
-*
-*See the [Rust documentation for `Time`](https://docs.rs/icu/2.3.1/icu/time/struct.Time.html) for more information.
-*/
+/**
+ * An ICU4X Time object representing a time in terms of hour, minute, second, nanosecond
+ *
+ * See the [Rust documentation for `Time`](https://docs.rs/icu/2.3.1/icu/time/struct.Time.html) for more information.
+ */
 class Time internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -48,10 +49,11 @@ class Time internal constructor (
         internal val lib: TimeLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Creates a new [Time] given field values
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/time/struct.Time.html#method.try_new) for more information.
-        */
+        /**
+         * Creates a new [Time] given field values
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/time/struct.Time.html#method.try_new) for more information.
+         */
         fun create(hour: UByte, minute: UByte, second: UByte, subsecond: UInt): Result<Time> {
             
             val returnVal = lib.icu4x_Time_create_mv1(FFIUint8(hour), FFIUint8(minute), FFIUint8(second), FFIUint32(subsecond));
@@ -67,10 +69,11 @@ class Time internal constructor (
         }
         @JvmStatic
         
-        /** Creates a new [Time] from an IXDTF string.
-        *
-        *See the [Rust documentation for `try_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.Time.html#method.try_from_str) for more information.
-        */
+        /**
+         * Creates a new [Time] from an IXDTF string.
+         *
+         * See the [Rust documentation for `try_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.Time.html#method.try_from_str) for more information.
+         */
         fun fromString(v: String): Result<Time> {
             val vSliceMemory = PrimitiveArrayTools.borrowUtf8(v)
             
@@ -91,10 +94,11 @@ class Time internal constructor (
         }
         @JvmStatic
         
-        /** Creates a new [Time] representing the start of the day (00:00:00.000).
-        *
-        *See the [Rust documentation for `start_of_day`](https://docs.rs/icu/2.3.1/icu/time/struct.Time.html#method.start_of_day) for more information.
-        */
+        /**
+         * Creates a new [Time] representing the start of the day (00:00:00.000).
+         *
+         * See the [Rust documentation for `start_of_day`](https://docs.rs/icu/2.3.1/icu/time/struct.Time.html#method.start_of_day) for more information.
+         */
         fun startOfDay(): Result<Time> {
             
             val returnVal = lib.icu4x_Time_start_of_day_mv1();
@@ -110,10 +114,11 @@ class Time internal constructor (
         }
         @JvmStatic
         
-        /** Creates a new [Time] representing noon (12:00:00.000).
-        *
-        *See the [Rust documentation for `noon`](https://docs.rs/icu/2.3.1/icu/time/struct.Time.html#method.noon) for more information.
-        */
+        /**
+         * Creates a new [Time] representing noon (12:00:00.000).
+         *
+         * See the [Rust documentation for `noon`](https://docs.rs/icu/2.3.1/icu/time/struct.Time.html#method.noon) for more information.
+         */
         fun noon(): Result<Time> {
             
             val returnVal = lib.icu4x_Time_noon_mv1();
@@ -129,40 +134,44 @@ class Time internal constructor (
         }
     }
     
-    /** Returns the hour in this time
-    *
-    *See the [Rust documentation for `hour`](https://docs.rs/icu/2.3.1/icu/time/struct.Time.html#structfield.hour) for more information.
-    */
+    /**
+     * Returns the hour in this time
+     *
+     * See the [Rust documentation for `hour`](https://docs.rs/icu/2.3.1/icu/time/struct.Time.html#structfield.hour) for more information.
+     */
     fun hour(): UByte {
         
         val returnVal = lib.icu4x_Time_hour_mv1(handle);
         return (returnVal.toUByte())
     }
     
-    /** Returns the minute in this time
-    *
-    *See the [Rust documentation for `minute`](https://docs.rs/icu/2.3.1/icu/time/struct.Time.html#structfield.minute) for more information.
-    */
+    /**
+     * Returns the minute in this time
+     *
+     * See the [Rust documentation for `minute`](https://docs.rs/icu/2.3.1/icu/time/struct.Time.html#structfield.minute) for more information.
+     */
     fun minute(): UByte {
         
         val returnVal = lib.icu4x_Time_minute_mv1(handle);
         return (returnVal.toUByte())
     }
     
-    /** Returns the second in this time
-    *
-    *See the [Rust documentation for `second`](https://docs.rs/icu/2.3.1/icu/time/struct.Time.html#structfield.second) for more information.
-    */
+    /**
+     * Returns the second in this time
+     *
+     * See the [Rust documentation for `second`](https://docs.rs/icu/2.3.1/icu/time/struct.Time.html#structfield.second) for more information.
+     */
     fun second(): UByte {
         
         val returnVal = lib.icu4x_Time_second_mv1(handle);
         return (returnVal.toUByte())
     }
     
-    /** Returns the subsecond in this time as nanoseconds
-    *
-    *See the [Rust documentation for `subsecond`](https://docs.rs/icu/2.3.1/icu/time/struct.Time.html#structfield.subsecond) for more information.
-    */
+    /**
+     * Returns the subsecond in this time as nanoseconds
+     *
+     * See the [Rust documentation for `subsecond`](https://docs.rs/icu/2.3.1/icu/time/struct.Time.html#structfield.subsecond) for more information.
+     */
     fun subsecond(): UInt {
         
         val returnVal = lib.icu4x_Time_subsecond_mv1(handle);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/TimeFormatter.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/TimeFormatter.kt
@@ -11,8 +11,9 @@ internal interface TimeFormatterLib: Library {
     fun icu4x_TimeFormatter_create_with_provider_mv1(provider: Pointer, locale: Pointer, length: OptionInt, timePrecision: OptionInt, alignment: OptionInt): ResultPointerInt
     fun icu4x_TimeFormatter_format_mv1(handle: Pointer, time: Pointer, write: Pointer): Unit
 }
-/** See the [Rust documentation for `NoCalendarFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/type.NoCalendarFormatter.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `NoCalendarFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/type.NoCalendarFormatter.html) for more information.
+ */
 class TimeFormatter internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -41,12 +42,13 @@ class TimeFormatter internal constructor (
         internal val lib: TimeFormatterLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/type.NoCalendarFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `T`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/type.NoCalendarFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `T`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.for_length)
+         */
         fun create(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<TimeFormatter> {
             
             val returnVal = lib.icu4x_TimeFormatter_create_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -62,12 +64,13 @@ class TimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/type.NoCalendarFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `T`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.for_length)
-        */
+        /**
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/type.NoCalendarFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `T`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.for_length)
+         */
         fun createWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<TimeFormatter> {
             
             val returnVal = lib.icu4x_TimeFormatter_create_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -83,8 +86,9 @@ class TimeFormatter internal constructor (
         }
     }
     
-    /** See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/type.NoCalendarFormatter.html#method.format) for more information.
-    */
+    /**
+     * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/type.NoCalendarFormatter.html#method.format) for more information.
+     */
     fun format(time: Time): String {
         val write = DW.lib.diplomat_buffer_write_create(0)
         val returnVal = lib.icu4x_TimeFormatter_format_mv1(handle, time.handle, write);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/TimePrecision.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/TimePrecision.kt
@@ -9,9 +9,10 @@ import com.sun.jna.Structure
 internal interface TimePrecisionLib: Library {
     fun icu4x_TimePrecision_from_subsecond_digits_mv1(digits: FFIUint8): OptionInt
 }
-/** See the [Rust documentation for `TimePrecision`](https://docs.rs/icu/2.3.1/icu/datetime/options/enum.TimePrecision.html) for more information.
-*
-*See the [Rust documentation for `SubsecondDigits`](https://docs.rs/icu/2.3.1/icu/datetime/options/enum.SubsecondDigits.html) for more information.
+/**
+ * See the [Rust documentation for `TimePrecision`](https://docs.rs/icu/2.3.1/icu/datetime/options/enum.TimePrecision.html) for more information.
+ *
+ * See the [Rust documentation for `SubsecondDigits`](https://docs.rs/icu/2.3.1/icu/datetime/options/enum.SubsecondDigits.html) for more information.
 */
 enum class TimePrecision {
     Hour,
@@ -45,8 +46,9 @@ enum class TimePrecision {
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `try_from_int`](https://docs.rs/icu/2.3.1/icu/datetime/options/enum.SubsecondDigits.html#method.try_from_int) for more information.
-        */
+        /**
+         * See the [Rust documentation for `try_from_int`](https://docs.rs/icu/2.3.1/icu/datetime/options/enum.SubsecondDigits.html#method.try_from_int) for more information.
+         */
         fun fromSubsecondDigits(digits: UByte): TimePrecision? {
             
             val returnVal = lib.icu4x_TimePrecision_from_subsecond_digits_mv1(FFIUint8(digits));

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/TimeRangeFormatter.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/TimeRangeFormatter.kt
@@ -12,9 +12,9 @@ internal interface TimeRangeFormatterLib: Library {
     fun icu4x_TimeRangeFormatter_format_mv1(handle: Pointer, startTime: Pointer, endTime: Pointer, write: Pointer): Unit
 }
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `NoCalendarRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html) for more information.
+ *
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
  */
 class TimeRangeFormatter internal constructor (
     internal val handle: Pointer,
@@ -45,13 +45,13 @@ class TimeRangeFormatter internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `T`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun create(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<TimeRangeFormatter> {
             
@@ -69,13 +69,13 @@ class TimeRangeFormatter internal constructor (
         @JvmStatic
         
         /**
-         * 🚧 This API is unstable and may experience breaking changes outside major releases.
-         *
          * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html#method.try_new) for more information.
          *
          * See the [Rust documentation for `T`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html) for more information.
          *
          * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.for_length)
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun createWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<TimeRangeFormatter> {
             
@@ -93,9 +93,9 @@ class TimeRangeFormatter internal constructor (
     }
     
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html#method.format) for more information.
+     *
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
      */
     fun format(startTime: Time, endTime: Time): String {
         val write = DW.lib.diplomat_buffer_write_create(0)

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/TimeRangeFormatter.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/TimeRangeFormatter.kt
@@ -11,10 +11,11 @@ internal interface TimeRangeFormatterLib: Library {
     fun icu4x_TimeRangeFormatter_create_with_provider_mv1(provider: Pointer, locale: Pointer, length: OptionInt, timePrecision: OptionInt, alignment: OptionInt): ResultPointerInt
     fun icu4x_TimeRangeFormatter_format_mv1(handle: Pointer, startTime: Pointer, endTime: Pointer, write: Pointer): Unit
 }
-/** 🚧 This API is unstable and may experience breaking changes outside major releases.
-*
-*See the [Rust documentation for `NoCalendarRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html) for more information.
-*/
+/**
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
+ *
+ * See the [Rust documentation for `NoCalendarRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html) for more information.
+ */
 class TimeRangeFormatter internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -43,14 +44,15 @@ class TimeRangeFormatter internal constructor (
         internal val lib: TimeRangeFormatterLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `T`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `T`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.for_length)
+         */
         fun create(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<TimeRangeFormatter> {
             
             val returnVal = lib.icu4x_TimeRangeFormatter_create_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -66,14 +68,15 @@ class TimeRangeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html#method.try_new) for more information.
-        *
-        *See the [Rust documentation for `T`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.for_length)
-        */
+        /**
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html#method.try_new) for more information.
+         *
+         * See the [Rust documentation for `T`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.for_length)
+         */
         fun createWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<TimeRangeFormatter> {
             
             val returnVal = lib.icu4x_TimeRangeFormatter_create_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -89,10 +92,11 @@ class TimeRangeFormatter internal constructor (
         }
     }
     
-    /** 🚧 This API is unstable and may experience breaking changes outside major releases.
-    *
-    *See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html#method.format) for more information.
-    */
+    /**
+     * 🚧 This API is unstable and may experience breaking changes outside major releases.
+     *
+     * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html#method.format) for more information.
+     */
     fun format(startTime: Time, endTime: Time): String {
         val write = DW.lib.diplomat_buffer_write_create(0)
         val returnVal = lib.icu4x_TimeRangeFormatter_format_mv1(handle, startTime.handle, endTime.handle, write);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/TimeZone.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/TimeZone.kt
@@ -16,8 +16,9 @@ internal interface TimeZoneLib: Library {
     fun icu4x_TimeZone_with_offset_mv1(handle: Pointer, offset: Pointer): Pointer
     fun icu4x_TimeZone_without_offset_mv1(handle: Pointer): Pointer
 }
-/** See the [Rust documentation for `TimeZone`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZone.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `TimeZone`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZone.html) for more information.
+ */
 class TimeZone internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -46,10 +47,11 @@ class TimeZone internal constructor (
         internal val lib: TimeZoneLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** The unknown time zone.
-        *
-        *See the [Rust documentation for `unknown`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZoneInfo.html#method.unknown) for more information.
-        */
+        /**
+         * The unknown time zone.
+         *
+         * See the [Rust documentation for `unknown`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZoneInfo.html#method.unknown) for more information.
+         */
         fun unknown(): TimeZone {
             
             val returnVal = lib.icu4x_TimeZone_unknown_mv1();
@@ -60,10 +62,11 @@ class TimeZone internal constructor (
         }
         @JvmStatic
         
-        /** Construct a [TimeZone] from an IANA time zone ID.
-        *
-        *See the [Rust documentation for `from_iana_id`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZone.html#method.from_iana_id) for more information.
-        */
+        /**
+         * Construct a [TimeZone] from an IANA time zone ID.
+         *
+         * See the [Rust documentation for `from_iana_id`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZone.html#method.from_iana_id) for more information.
+         */
         fun createFromIanaId(ianaId: String): TimeZone {
             val ianaIdSliceMemory = PrimitiveArrayTools.borrowUtf8(ianaId)
             
@@ -79,10 +82,11 @@ class TimeZone internal constructor (
         }
         @JvmStatic
         
-        /** Construct a [TimeZone] from a Windows time zone ID and region.
-        *
-        *See the [Rust documentation for `from_windows_id`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZone.html#method.from_windows_id) for more information.
-        */
+        /**
+         * Construct a [TimeZone] from a Windows time zone ID and region.
+         *
+         * See the [Rust documentation for `from_windows_id`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZone.html#method.from_windows_id) for more information.
+         */
         fun createFromWindowsId(windowsId: String, region: String): TimeZone {
             val windowsIdSliceMemory = PrimitiveArrayTools.borrowUtf8(windowsId)
             val regionSliceMemory = PrimitiveArrayTools.borrowUtf8(region)
@@ -100,10 +104,11 @@ class TimeZone internal constructor (
         }
         @JvmStatic
         
-        /** Construct a [TimeZone] from the platform-specific ID.
-        *
-        *See the [Rust documentation for `from_system_id`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZone.html#method.from_system_id) for more information.
-        */
+        /**
+         * Construct a [TimeZone] from the platform-specific ID.
+         *
+         * See the [Rust documentation for `from_system_id`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZone.html#method.from_system_id) for more information.
+         */
         fun createFromSystemId(id: String, region: String): TimeZone {
             val idSliceMemory = PrimitiveArrayTools.borrowUtf8(id)
             val regionSliceMemory = PrimitiveArrayTools.borrowUtf8(region)
@@ -121,12 +126,13 @@ class TimeZone internal constructor (
         }
         @JvmStatic
         
-        /** Creates a time zone from a BCP-47 string.
-        *
-        *Returns the unknown time zone if the string is not a valid BCP-47 subtag.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZone.html)
-        */
+        /**
+         * Creates a time zone from a BCP-47 string.
+         *
+         * Returns the unknown time zone if the string is not a valid BCP-47 subtag.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZone.html)
+         */
         fun createFromBcp47(id: String): TimeZone {
             val idSliceMemory = PrimitiveArrayTools.borrowUtf8(id)
             
@@ -142,18 +148,20 @@ class TimeZone internal constructor (
         }
     }
     
-    /** Whether the time zone is the unknown zone.
-    *
-    *See the [Rust documentation for `is_unknown`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZone.html#method.is_unknown) for more information.
-    */
+    /**
+     * Whether the time zone is the unknown zone.
+     *
+     * See the [Rust documentation for `is_unknown`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZone.html#method.is_unknown) for more information.
+     */
     fun isUnknown(): Boolean {
         
         val returnVal = lib.icu4x_TimeZone_is_unknown_mv1(handle);
         return (returnVal > 0)
     }
     
-    /** See the [Rust documentation for `with_offset`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZone.html#method.with_offset) for more information.
-    */
+    /**
+     * See the [Rust documentation for `with_offset`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZone.html#method.with_offset) for more information.
+     */
     fun withOffset(offset: UtcOffset): TimeZoneInfo {
         
         val returnVal = lib.icu4x_TimeZone_with_offset_mv1(handle, offset.handle);
@@ -163,8 +171,9 @@ class TimeZone internal constructor (
         return returnOpaque
     }
     
-    /** See the [Rust documentation for `without_offset`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZone.html#method.without_offset) for more information.
-    */
+    /**
+     * See the [Rust documentation for `without_offset`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZone.html#method.without_offset) for more information.
+     */
     fun withoutOffset(): TimeZoneInfo {
         
         val returnVal = lib.icu4x_TimeZone_without_offset_mv1(handle);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/TimeZoneAndCanonical.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/TimeZoneAndCanonical.kt
@@ -62,8 +62,9 @@ internal class OptionTimeZoneAndCanonicalNative constructor(): Structure(), Stru
 
 }
 
-/** See the [Rust documentation for `TimeZoneAndCanonical`](https://docs.rs/icu/2.3.1/icu/time/zone/iana/struct.TimeZoneAndCanonical.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `TimeZoneAndCanonical`](https://docs.rs/icu/2.3.1/icu/time/zone/iana/struct.TimeZoneAndCanonical.html) for more information.
+ */
 class TimeZoneAndCanonical (var timeZone: TimeZone, var canonical: String) {
     companion object {
 

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/TimeZoneAndCanonicalAndNormalized.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/TimeZoneAndCanonicalAndNormalized.kt
@@ -64,8 +64,9 @@ internal class OptionTimeZoneAndCanonicalAndNormalizedNative constructor(): Stru
 
 }
 
-/** See the [Rust documentation for `TimeZoneAndCanonicalAndNormalized`](https://docs.rs/icu/2.3.1/icu/time/zone/iana/struct.TimeZoneAndCanonicalAndNormalized.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `TimeZoneAndCanonicalAndNormalized`](https://docs.rs/icu/2.3.1/icu/time/zone/iana/struct.TimeZoneAndCanonicalAndNormalized.html) for more information.
+ */
 class TimeZoneAndCanonicalAndNormalized (var timeZone: TimeZone, var canonical: String, var normalized: String) {
     companion object {
 

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/TimeZoneAndCanonicalAndNormalizedIterator.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/TimeZoneAndCanonicalAndNormalizedIterator.kt
@@ -10,8 +10,9 @@ internal interface TimeZoneAndCanonicalAndNormalizedIteratorLib: Library {
     fun icu4x_TimeZoneAndCanonicalAndNormalizedIterator_next_mv1(handle: Pointer): OptionTimeZoneAndCanonicalAndNormalizedNative
 }
 typealias TimeZoneAndCanonicalAndNormalizedIteratorIteratorItem = TimeZoneAndCanonicalAndNormalized
-/** See the [Rust documentation for `TimeZoneAndCanonicalAndNormalizedIter`](https://docs.rs/icu/2.3.1/icu/time/zone/iana/struct.TimeZoneAndCanonicalAndNormalizedIter.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `TimeZoneAndCanonicalAndNormalizedIter`](https://docs.rs/icu/2.3.1/icu/time/zone/iana/struct.TimeZoneAndCanonicalAndNormalizedIter.html) for more information.
+ */
 class TimeZoneAndCanonicalAndNormalizedIterator internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -41,8 +42,9 @@ class TimeZoneAndCanonicalAndNormalizedIterator internal constructor (
         internal val lib: TimeZoneAndCanonicalAndNormalizedIteratorLib = Native.load("icu4x", libClass)
     }
     
-    /** See the [Rust documentation for `next`](https://docs.rs/icu/2.3.1/icu/time/zone/iana/struct.TimeZoneAndCanonicalAndNormalizedIter.html#method.next) for more information.
-    */
+    /**
+     * See the [Rust documentation for `next`](https://docs.rs/icu/2.3.1/icu/time/zone/iana/struct.TimeZoneAndCanonicalAndNormalizedIter.html#method.next) for more information.
+     */
     internal fun nextInternal(): TimeZoneAndCanonicalAndNormalized? {
         // This lifetime edge depends on lifetimes: 'a
         val aEdges: MutableList<Any> = mutableListOf(this);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/TimeZoneAndCanonicalIterator.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/TimeZoneAndCanonicalIterator.kt
@@ -10,8 +10,9 @@ internal interface TimeZoneAndCanonicalIteratorLib: Library {
     fun icu4x_TimeZoneAndCanonicalIterator_next_mv1(handle: Pointer): OptionTimeZoneAndCanonicalNative
 }
 typealias TimeZoneAndCanonicalIteratorIteratorItem = TimeZoneAndCanonical
-/** See the [Rust documentation for `TimeZoneAndCanonicalIter`](https://docs.rs/icu/2.3.1/icu/time/zone/iana/struct.TimeZoneAndCanonicalIter.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `TimeZoneAndCanonicalIter`](https://docs.rs/icu/2.3.1/icu/time/zone/iana/struct.TimeZoneAndCanonicalIter.html) for more information.
+ */
 class TimeZoneAndCanonicalIterator internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -41,8 +42,9 @@ class TimeZoneAndCanonicalIterator internal constructor (
         internal val lib: TimeZoneAndCanonicalIteratorLib = Native.load("icu4x", libClass)
     }
     
-    /** See the [Rust documentation for `next`](https://docs.rs/icu/2.3.1/icu/time/zone/iana/struct.TimeZoneAndCanonicalIter.html#method.next) for more information.
-    */
+    /**
+     * See the [Rust documentation for `next`](https://docs.rs/icu/2.3.1/icu/time/zone/iana/struct.TimeZoneAndCanonicalIter.html#method.next) for more information.
+     */
     internal fun nextInternal(): TimeZoneAndCanonical? {
         // This lifetime edge depends on lifetimes: 'a
         val aEdges: MutableList<Any> = mutableListOf(this);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/TimeZoneFormatter.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/TimeZoneFormatter.kt
@@ -25,8 +25,9 @@ internal interface TimeZoneFormatterLib: Library {
     fun icu4x_TimeZoneFormatter_create_exemplar_city_with_provider_mv1(provider: Pointer, locale: Pointer): ResultPointerInt
     fun icu4x_TimeZoneFormatter_format_mv1(handle: Pointer, zone: Pointer, write: Pointer): ResultUnitInt
 }
-/** See the [Rust documentation for `NoCalendarFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/type.NoCalendarFormatter.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `NoCalendarFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/type.NoCalendarFormatter.html) for more information.
+ */
 class TimeZoneFormatter internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -55,13 +56,14 @@ class TimeZoneFormatter internal constructor (
         internal val lib: TimeZoneFormatterLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
+         */
         fun createSpecificLong(locale: Locale): Result<TimeZoneFormatter> {
             
             val returnVal = lib.icu4x_TimeZoneFormatter_create_specific_long_mv1(locale.handle);
@@ -77,13 +79,14 @@ class TimeZoneFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
+         */
         fun createSpecificLongWithProvider(provider: DataProvider, locale: Locale): Result<TimeZoneFormatter> {
             
             val returnVal = lib.icu4x_TimeZoneFormatter_create_specific_long_with_provider_mv1(provider.handle, locale.handle);
@@ -99,13 +102,14 @@ class TimeZoneFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
+         */
         fun createSpecificShort(locale: Locale): Result<TimeZoneFormatter> {
             
             val returnVal = lib.icu4x_TimeZoneFormatter_create_specific_short_mv1(locale.handle);
@@ -121,13 +125,14 @@ class TimeZoneFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
+         */
         fun createSpecificShortWithProvider(provider: DataProvider, locale: Locale): Result<TimeZoneFormatter> {
             
             val returnVal = lib.icu4x_TimeZoneFormatter_create_specific_short_with_provider_mv1(provider.handle, locale.handle);
@@ -143,13 +148,14 @@ class TimeZoneFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
+         */
         fun createLocalizedOffsetLong(locale: Locale): Result<TimeZoneFormatter> {
             
             val returnVal = lib.icu4x_TimeZoneFormatter_create_localized_offset_long_mv1(locale.handle);
@@ -165,13 +171,14 @@ class TimeZoneFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
+         */
         fun createLocalizedOffsetLongWithProvider(provider: DataProvider, locale: Locale): Result<TimeZoneFormatter> {
             
             val returnVal = lib.icu4x_TimeZoneFormatter_create_localized_offset_long_with_provider_mv1(provider.handle, locale.handle);
@@ -187,13 +194,14 @@ class TimeZoneFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
+         */
         fun createLocalizedOffsetShort(locale: Locale): Result<TimeZoneFormatter> {
             
             val returnVal = lib.icu4x_TimeZoneFormatter_create_localized_offset_short_mv1(locale.handle);
@@ -209,13 +217,14 @@ class TimeZoneFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
+         */
         fun createLocalizedOffsetShortWithProvider(provider: DataProvider, locale: Locale): Result<TimeZoneFormatter> {
             
             val returnVal = lib.icu4x_TimeZoneFormatter_create_localized_offset_short_with_provider_mv1(provider.handle, locale.handle);
@@ -231,13 +240,14 @@ class TimeZoneFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `GenericLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
+         */
         fun createGenericLong(locale: Locale): Result<TimeZoneFormatter> {
             
             val returnVal = lib.icu4x_TimeZoneFormatter_create_generic_long_mv1(locale.handle);
@@ -253,13 +263,14 @@ class TimeZoneFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `GenericLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
+         */
         fun createGenericLongWithProvider(provider: DataProvider, locale: Locale): Result<TimeZoneFormatter> {
             
             val returnVal = lib.icu4x_TimeZoneFormatter_create_generic_long_with_provider_mv1(provider.handle, locale.handle);
@@ -275,13 +286,14 @@ class TimeZoneFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `GenericShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
+         */
         fun createGenericShort(locale: Locale): Result<TimeZoneFormatter> {
             
             val returnVal = lib.icu4x_TimeZoneFormatter_create_generic_short_mv1(locale.handle);
@@ -297,13 +309,14 @@ class TimeZoneFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `GenericShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
+         */
         fun createGenericShortWithProvider(provider: DataProvider, locale: Locale): Result<TimeZoneFormatter> {
             
             val returnVal = lib.icu4x_TimeZoneFormatter_create_generic_short_with_provider_mv1(provider.handle, locale.handle);
@@ -319,13 +332,14 @@ class TimeZoneFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `Location`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `Location`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
+         */
         fun createLocation(locale: Locale): Result<TimeZoneFormatter> {
             
             val returnVal = lib.icu4x_TimeZoneFormatter_create_location_mv1(locale.handle);
@@ -341,13 +355,14 @@ class TimeZoneFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `Location`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `Location`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
+         */
         fun createLocationWithProvider(provider: DataProvider, locale: Locale): Result<TimeZoneFormatter> {
             
             val returnVal = lib.icu4x_TimeZoneFormatter_create_location_with_provider_mv1(provider.handle, locale.handle);
@@ -363,13 +378,14 @@ class TimeZoneFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
+         */
         fun createExemplarCity(locale: Locale): Result<TimeZoneFormatter> {
             
             val returnVal = lib.icu4x_TimeZoneFormatter_create_exemplar_city_mv1(locale.handle);
@@ -385,13 +401,14 @@ class TimeZoneFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
+         */
         fun createExemplarCityWithProvider(provider: DataProvider, locale: Locale): Result<TimeZoneFormatter> {
             
             val returnVal = lib.icu4x_TimeZoneFormatter_create_exemplar_city_with_provider_mv1(provider.handle, locale.handle);
@@ -407,8 +424,9 @@ class TimeZoneFormatter internal constructor (
         }
     }
     
-    /** See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.format) for more information.
-    */
+    /**
+     * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.format) for more information.
+     */
     fun format(zone: TimeZoneInfo): Result<String> {
         val write = DW.lib.diplomat_buffer_write_create(0)
         val returnVal = lib.icu4x_TimeZoneFormatter_format_mv1(handle, zone.handle, write);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/TimeZoneInfo.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/TimeZoneInfo.kt
@@ -19,8 +19,9 @@ internal interface TimeZoneInfoLib: Library {
     fun icu4x_TimeZoneInfo_infer_variant_mv1(handle: Pointer, offsetCalculator: Pointer): OptionUnit
     fun icu4x_TimeZoneInfo_variant_mv1(handle: Pointer): OptionInt
 }
-/** See the [Rust documentation for `TimeZoneInfo`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZoneInfo.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `TimeZoneInfo`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZoneInfo.html) for more information.
+ */
 class TimeZoneInfo internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -49,10 +50,11 @@ class TimeZoneInfo internal constructor (
         internal val lib: TimeZoneInfoLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Creates a time zone for UTC (Coordinated Universal Time).
-        *
-        *See the [Rust documentation for `utc`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZoneInfo.html#method.utc) for more information.
-        */
+        /**
+         * Creates a time zone for UTC (Coordinated Universal Time).
+         *
+         * See the [Rust documentation for `utc`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZoneInfo.html#method.utc) for more information.
+         */
         fun utc(): TimeZoneInfo {
             
             val returnVal = lib.icu4x_TimeZoneInfo_utc_mv1();
@@ -63,10 +65,11 @@ class TimeZoneInfo internal constructor (
         }
         @JvmStatic
         
-        /** Creates a time zone info from parts.
-        *
-        *`variant` is ignored.
-        */
+        /**
+         * Creates a time zone info from parts.
+         *
+         * `variant` is ignored.
+         */
         fun fromParts(id: TimeZone, offset: UtcOffset?, variant: TimeZoneVariant?): TimeZoneInfo {
             
             val returnVal = lib.icu4x_TimeZoneInfo_from_parts_mv1(id.handle, offset?.handle, variant?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -77,8 +80,9 @@ class TimeZoneInfo internal constructor (
         }
     }
     
-    /** See the [Rust documentation for `id`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZoneInfo.html#method.id) for more information.
-    */
+    /**
+     * See the [Rust documentation for `id`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZoneInfo.html#method.id) for more information.
+     */
     fun id(): TimeZone {
         
         val returnVal = lib.icu4x_TimeZoneInfo_id_mv1(handle);
@@ -88,20 +92,21 @@ class TimeZoneInfo internal constructor (
         return returnOpaque
     }
     
-    /** Sets the datetime at which to interpret the time zone
-    *for display name lookup.
-    *
-    *Notes:
-    *
-    *- If not set, the formatting datetime is used if possible.
-    *- If the offset is not set, the datetime is interpreted as UTC.
-    *- The constraints are the same as with `ZoneNameTimestamp` in Rust.
-    *- Set to year 1000 or 9999 for a reference far in the past or future.
-    *
-    *See the [Rust documentation for `at_date_time`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZoneInfo.html#method.at_date_time) for more information.
-    *
-    *Additional information: [1](https://docs.rs/icu/2.3.1/icu/time/zone/struct.ZoneNameTimestamp.html)
-    */
+    /**
+     * Sets the datetime at which to interpret the time zone
+     * for display name lookup.
+     *
+     * Notes:
+     *
+     * - If not set, the formatting datetime is used if possible.
+     * - If the offset is not set, the datetime is interpreted as UTC.
+     * - The constraints are the same as with `ZoneNameTimestamp` in Rust.
+     * - Set to year 1000 or 9999 for a reference far in the past or future.
+     *
+     * See the [Rust documentation for `at_date_time`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZoneInfo.html#method.at_date_time) for more information.
+     *
+     * Additional information: [1](https://docs.rs/icu/2.3.1/icu/time/zone/struct.ZoneNameTimestamp.html)
+     */
     fun atDateTimeIso(date: IsoDate, time: Time): TimeZoneInfo {
         
         val returnVal = lib.icu4x_TimeZoneInfo_at_date_time_iso_mv1(handle, date.handle, time.handle);
@@ -111,20 +116,21 @@ class TimeZoneInfo internal constructor (
         return returnOpaque
     }
     
-    /** Sets the datetime at which to interpret the time zone
-    *for display name lookup.
-    *
-    *Notes:
-    *
-    *- If not set, the formatting datetime is used if possible.
-    *- If the offset is not set, the datetime is interpreted as UTC.
-    *- The constraints are the same as with `ZoneNameTimestamp` in Rust.
-    *- Set to year 1000 or 9999 for a reference far in the past or future.
-    *
-    *See the [Rust documentation for `at_date_time`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZoneInfo.html#method.at_date_time) for more information.
-    *
-    *Additional information: [1](https://docs.rs/icu/2.3.1/icu/time/zone/struct.ZoneNameTimestamp.html)
-    */
+    /**
+     * Sets the datetime at which to interpret the time zone
+     * for display name lookup.
+     *
+     * Notes:
+     *
+     * - If not set, the formatting datetime is used if possible.
+     * - If the offset is not set, the datetime is interpreted as UTC.
+     * - The constraints are the same as with `ZoneNameTimestamp` in Rust.
+     * - Set to year 1000 or 9999 for a reference far in the past or future.
+     *
+     * See the [Rust documentation for `at_date_time`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZoneInfo.html#method.at_date_time) for more information.
+     *
+     * Additional information: [1](https://docs.rs/icu/2.3.1/icu/time/zone/struct.ZoneNameTimestamp.html)
+     */
     fun atDateTime(date: Date, time: Time): TimeZoneInfo {
         
         val returnVal = lib.icu4x_TimeZoneInfo_at_date_time_mv1(handle, date.handle, time.handle);
@@ -134,18 +140,19 @@ class TimeZoneInfo internal constructor (
         return returnOpaque
     }
     
-    /** Sets the timestamp, in milliseconds since Unix epoch, at which to interpret the time zone
-    *for display name lookup.
-    *
-    *Notes:
-    *
-    *- If not set, the formatting datetime is used if possible.
-    *- The constraints are the same as with `ZoneNameTimestamp` in Rust.
-    *
-    *See the [Rust documentation for `with_zone_name_timestamp`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZoneInfo.html#method.with_zone_name_timestamp) for more information.
-    *
-    *Additional information: [1](https://docs.rs/icu/2.3.1/icu/time/zone/struct.ZoneNameTimestamp.html#method.from_epoch_seconds)
-    */
+    /**
+     * Sets the timestamp, in milliseconds since Unix epoch, at which to interpret the time zone
+     * for display name lookup.
+     *
+     * Notes:
+     *
+     * - If not set, the formatting datetime is used if possible.
+     * - The constraints are the same as with `ZoneNameTimestamp` in Rust.
+     *
+     * See the [Rust documentation for `with_zone_name_timestamp`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZoneInfo.html#method.with_zone_name_timestamp) for more information.
+     *
+     * Additional information: [1](https://docs.rs/icu/2.3.1/icu/time/zone/struct.ZoneNameTimestamp.html#method.from_epoch_seconds)
+     */
     fun atTimestamp(timestamp: Long): TimeZoneInfo {
         
         val returnVal = lib.icu4x_TimeZoneInfo_at_timestamp_mv1(handle, timestamp);
@@ -155,10 +162,11 @@ class TimeZoneInfo internal constructor (
         return returnOpaque
     }
     
-    /** Returns the `DateTime` for the UTC zone name reference time
-    *
-    *See the [Rust documentation for `zone_name_timestamp`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZoneInfo.html#method.zone_name_timestamp) for more information.
-    */
+    /**
+     * Returns the `DateTime` for the UTC zone name reference time
+     *
+     * See the [Rust documentation for `zone_name_timestamp`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZoneInfo.html#method.zone_name_timestamp) for more information.
+     */
     fun zoneNameDateTime(): IsoDateTime? {
         
         val returnVal = lib.icu4x_TimeZoneInfo_zone_name_date_time_mv1(handle);
@@ -169,8 +177,9 @@ class TimeZoneInfo internal constructor (
                                 
     }
     
-    /** See the [Rust documentation for `with_variant`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZoneInfo.html#method.with_variant) for more information.
-    */
+    /**
+     * See the [Rust documentation for `with_variant`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZoneInfo.html#method.with_variant) for more information.
+     */
     fun withVariant(timeVariant: TimeZoneVariant): TimeZoneInfo {
         
         val returnVal = lib.icu4x_TimeZoneInfo_with_variant_mv1(handle, timeVariant.toNative());
@@ -180,8 +189,9 @@ class TimeZoneInfo internal constructor (
         return returnOpaque
     }
     
-    /** See the [Rust documentation for `offset`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZoneInfo.html#method.offset) for more information.
-    */
+    /**
+     * See the [Rust documentation for `offset`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZoneInfo.html#method.offset) for more information.
+     */
     fun offset(): UtcOffset? {
         
         val returnVal = lib.icu4x_TimeZoneInfo_offset_mv1(handle);
@@ -191,18 +201,20 @@ class TimeZoneInfo internal constructor (
         return returnOpaque
     }
     
-    /** See the [Rust documentation for `infer_variant`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZoneInfo.html#method.infer_variant) for more information.
-    *
-    *Additional information: [1](https://docs.rs/icu/2.3.1/icu/time/zone/enum.TimeZoneVariant.html)
-    */
+    /**
+     * See the [Rust documentation for `infer_variant`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZoneInfo.html#method.infer_variant) for more information.
+     *
+     * Additional information: [1](https://docs.rs/icu/2.3.1/icu/time/zone/enum.TimeZoneVariant.html)
+     */
     fun inferVariant(offsetCalculator: VariantOffsetsCalculator): Unit? {
         
         val returnVal = lib.icu4x_TimeZoneInfo_infer_variant_mv1(handle, offsetCalculator.handle);
         return returnVal.option()
     }
     
-    /** See the [Rust documentation for `variant`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZoneInfo.html#method.variant) for more information.
-    */
+    /**
+     * See the [Rust documentation for `variant`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZoneInfo.html#method.variant) for more information.
+     */
     fun variant(): TimeZoneVariant? {
         
         val returnVal = lib.icu4x_TimeZoneInfo_variant_mv1(handle);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/TimeZoneInvalidOffsetError.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/TimeZoneInvalidOffsetError.kt
@@ -6,8 +6,9 @@ import com.sun.jna.Native
 import com.sun.jna.Pointer
 import com.sun.jna.Structure
 
-/** Additional information: [1](https://docs.rs/icu/2.3.1/icu/time/zone/struct.InvalidOffsetError.html)
-*/
+/**
+ * Additional information: [1](https://docs.rs/icu/2.3.1/icu/time/zone/struct.InvalidOffsetError.html)
+ */
 class TimeZoneInvalidOffsetError (): Exception("Rust error result for TimeZoneInvalidOffsetError") {
     companion object {
 

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/TimeZoneIterator.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/TimeZoneIterator.kt
@@ -10,8 +10,9 @@ internal interface TimeZoneIteratorLib: Library {
     fun icu4x_TimeZoneIterator_next_mv1(handle: Pointer): Pointer?
 }
 typealias TimeZoneIteratorIteratorItem = TimeZone?
-/** See the [Rust documentation for `TimeZoneIter`](https://docs.rs/icu/2.3.1/icu/time/zone/iana/struct.TimeZoneIter.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `TimeZoneIter`](https://docs.rs/icu/2.3.1/icu/time/zone/iana/struct.TimeZoneIter.html) for more information.
+ */
 class TimeZoneIterator internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -41,8 +42,9 @@ class TimeZoneIterator internal constructor (
         internal val lib: TimeZoneIteratorLib = Native.load("icu4x", libClass)
     }
     
-    /** See the [Rust documentation for `next`](https://docs.rs/icu/2.3.1/icu/time/zone/iana/struct.TimeZoneIter.html#method.next) for more information.
-    */
+    /**
+     * See the [Rust documentation for `next`](https://docs.rs/icu/2.3.1/icu/time/zone/iana/struct.TimeZoneIter.html#method.next) for more information.
+     */
     internal fun nextInternal(): TimeZone? {
         
         val returnVal = lib.icu4x_TimeZoneIterator_next_mv1(handle);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/TimeZoneVariant.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/TimeZoneVariant.kt
@@ -9,7 +9,8 @@ import com.sun.jna.Structure
 internal interface TimeZoneVariantLib: Library {
     fun icu4x_TimeZoneVariant_from_rearguard_isdst_mv1(isdst: Boolean): Int
 }
-/** See the [Rust documentation for `TimeZoneVariant`](https://docs.rs/icu/2.3.1/icu/time/zone/enum.TimeZoneVariant.html) for more information.
+/**
+ * See the [Rust documentation for `TimeZoneVariant`](https://docs.rs/icu/2.3.1/icu/time/zone/enum.TimeZoneVariant.html) for more information.
 */
 enum class TimeZoneVariant {
     Standard,
@@ -32,10 +33,11 @@ enum class TimeZoneVariant {
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `from_rearguard_isdst`](https://docs.rs/icu/2.3.1/icu/time/zone/enum.TimeZoneVariant.html#method.from_rearguard_isdst) for more information.
-        *
-        *See the [Rust documentation for `with_variant`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZoneInfo.html#method.with_variant) for more information.
-        */
+        /**
+         * See the [Rust documentation for `from_rearguard_isdst`](https://docs.rs/icu/2.3.1/icu/time/zone/enum.TimeZoneVariant.html#method.from_rearguard_isdst) for more information.
+         *
+         * See the [Rust documentation for `with_variant`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZoneInfo.html#method.with_variant) for more information.
+         */
         fun fromRearguardIsdst(isdst: Boolean): TimeZoneVariant {
             
             val returnVal = lib.icu4x_TimeZoneVariant_from_rearguard_isdst_mv1(isdst);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/TitlecaseMapper.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/TitlecaseMapper.kt
@@ -12,8 +12,9 @@ internal interface TitlecaseMapperLib: Library {
     fun icu4x_TitlecaseMapper_titlecase_segment_v1_mv1(handle: Pointer, s: Slice, locale: Pointer, options: TitlecaseOptionsNative, write: Pointer): Unit
     fun icu4x_TitlecaseMapper_titlecase_segment_with_compiled_data_v1_mv1(s: Slice, locale: Pointer, options: TitlecaseOptionsNative, write: Pointer): Unit
 }
-/** See the [Rust documentation for `TitlecaseMapper`](https://docs.rs/icu/2.3.1/icu/casemap/struct.TitlecaseMapper.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `TitlecaseMapper`](https://docs.rs/icu/2.3.1/icu/casemap/struct.TitlecaseMapper.html) for more information.
+ */
 class TitlecaseMapper internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -42,10 +43,11 @@ class TitlecaseMapper internal constructor (
         internal val lib: TitlecaseMapperLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Construct a new `TitlecaseMapper` instance using compiled data.
-        *
-        *See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/casemap/struct.TitlecaseMapper.html#method.new) for more information.
-        */
+        /**
+         * Construct a new `TitlecaseMapper` instance using compiled data.
+         *
+         * See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/casemap/struct.TitlecaseMapper.html#method.new) for more information.
+         */
         fun create(): Result<TitlecaseMapper> {
             
             val returnVal = lib.icu4x_TitlecaseMapper_create_mv1();
@@ -61,10 +63,11 @@ class TitlecaseMapper internal constructor (
         }
         @JvmStatic
         
-        /** Construct a new `TitlecaseMapper` instance using a particular data source.
-        *
-        *See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/casemap/struct.TitlecaseMapper.html#method.new) for more information.
-        */
+        /**
+         * Construct a new `TitlecaseMapper` instance using a particular data source.
+         *
+         * See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/casemap/struct.TitlecaseMapper.html#method.new) for more information.
+         */
         fun createWithProvider(provider: DataProvider): Result<TitlecaseMapper> {
             
             val returnVal = lib.icu4x_TitlecaseMapper_create_with_provider_mv1(provider.handle);
@@ -80,12 +83,13 @@ class TitlecaseMapper internal constructor (
         }
         @JvmStatic
         
-        /** Returns the full titlecase mapping of the given string, using compiled data (avoids having to allocate a `TitlecaseMapper` object)
-        *
-        *The `v1` refers to the version of the options struct, which may change as we add more options
-        *
-        *See the [Rust documentation for `titlecase_segment`](https://docs.rs/icu/2.3.1/icu/casemap/struct.TitlecaseMapperBorrowed.html#method.titlecase_segment) for more information.
-        */
+        /**
+         * Returns the full titlecase mapping of the given string, using compiled data (avoids having to allocate a `TitlecaseMapper` object)
+         *
+         * The `v1` refers to the version of the options struct, which may change as we add more options
+         *
+         * See the [Rust documentation for `titlecase_segment`](https://docs.rs/icu/2.3.1/icu/casemap/struct.TitlecaseMapperBorrowed.html#method.titlecase_segment) for more information.
+         */
         fun titlecase_segment_with_compiled_data(s: String, locale: Locale, options: TitlecaseOptions): String {
             val sSliceMemory = PrimitiveArrayTools.borrowUtf8(s)
             val write = DW.lib.diplomat_buffer_write_create(0)
@@ -100,12 +104,13 @@ class TitlecaseMapper internal constructor (
         }
     }
     
-    /** Returns the full titlecase mapping of the given string
-    *
-    *The `v1` refers to the version of the options struct, which may change as we add more options
-    *
-    *See the [Rust documentation for `titlecase_segment`](https://docs.rs/icu/2.3.1/icu/casemap/struct.TitlecaseMapperBorrowed.html#method.titlecase_segment) for more information.
-    */
+    /**
+     * Returns the full titlecase mapping of the given string
+     *
+     * The `v1` refers to the version of the options struct, which may change as we add more options
+     *
+     * See the [Rust documentation for `titlecase_segment`](https://docs.rs/icu/2.3.1/icu/casemap/struct.TitlecaseMapperBorrowed.html#method.titlecase_segment) for more information.
+     */
     fun titlecase_segment(s: String, locale: Locale, options: TitlecaseOptions): String {
         val sSliceMemory = PrimitiveArrayTools.borrowUtf8(s)
         val write = DW.lib.diplomat_buffer_write_create(0)

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/TitlecaseOptions.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/TitlecaseOptions.kt
@@ -63,8 +63,9 @@ internal class OptionTitlecaseOptionsNative constructor(): Structure(), Structur
 
 }
 
-/** See the [Rust documentation for `TitlecaseOptions`](https://docs.rs/icu/2.3.1/icu/casemap/options/struct.TitlecaseOptions.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `TitlecaseOptions`](https://docs.rs/icu/2.3.1/icu/casemap/options/struct.TitlecaseOptions.html) for more information.
+ */
 class TitlecaseOptions (var leadingAdjustment: LeadingAdjustment?, var trailingCase: TrailingCase?) {
     companion object {
 
@@ -81,8 +82,9 @@ class TitlecaseOptions (var leadingAdjustment: LeadingAdjustment?, var trailingC
 
         @JvmStatic
         
-        /** See the [Rust documentation for `default`](https://docs.rs/icu/2.3.1/icu/casemap/options/struct.TitlecaseOptions.html#method.default) for more information.
-        */
+        /**
+         * See the [Rust documentation for `default`](https://docs.rs/icu/2.3.1/icu/casemap/options/struct.TitlecaseOptions.html#method.default) for more information.
+         */
         fun default_(): TitlecaseOptions {
             
             val returnVal = lib.icu4x_TitlecaseOptionsV1_default_mv1();

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/TrailingCase.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/TrailingCase.kt
@@ -8,7 +8,8 @@ import com.sun.jna.Structure
 
 internal interface TrailingCaseLib: Library {
 }
-/** See the [Rust documentation for `TrailingCase`](https://docs.rs/icu/2.3.1/icu/casemap/options/enum.TrailingCase.html) for more information.
+/**
+ * See the [Rust documentation for `TrailingCase`](https://docs.rs/icu/2.3.1/icu/casemap/options/enum.TrailingCase.html) for more information.
 */
 enum class TrailingCase {
     Lower,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/TransformResult.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/TransformResult.kt
@@ -8,7 +8,8 @@ import com.sun.jna.Structure
 
 internal interface TransformResultLib: Library {
 }
-/** See the [Rust documentation for `TransformResult`](https://docs.rs/icu/2.3.1/icu/locale/enum.TransformResult.html) for more information.
+/**
+ * See the [Rust documentation for `TransformResult`](https://docs.rs/icu/2.3.1/icu/locale/enum.TransformResult.html) for more information.
 */
 enum class TransformResult {
     Modified,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/UtcOffset.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/UtcOffset.kt
@@ -16,8 +16,9 @@ internal interface UtcOffsetLib: Library {
     fun icu4x_UtcOffset_minutes_part_mv1(handle: Pointer): FFIUint32
     fun icu4x_UtcOffset_seconds_part_mv1(handle: Pointer): FFIUint32
 }
-/** See the [Rust documentation for `UtcOffset`](https://docs.rs/icu/2.3.1/icu/time/zone/struct.UtcOffset.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `UtcOffset`](https://docs.rs/icu/2.3.1/icu/time/zone/struct.UtcOffset.html) for more information.
+ */
 class UtcOffset internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -46,12 +47,13 @@ class UtcOffset internal constructor (
         internal val lib: UtcOffsetLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Creates an offset from seconds.
-        *
-        *Errors if the offset seconds are out of range.
-        *
-        *See the [Rust documentation for `try_from_seconds`](https://docs.rs/icu/2.3.1/icu/time/zone/struct.UtcOffset.html#method.try_from_seconds) for more information.
-        */
+        /**
+         * Creates an offset from seconds.
+         *
+         * Errors if the offset seconds are out of range.
+         *
+         * See the [Rust documentation for `try_from_seconds`](https://docs.rs/icu/2.3.1/icu/time/zone/struct.UtcOffset.html#method.try_from_seconds) for more information.
+         */
         fun fromSeconds(seconds: Int): Result<UtcOffset> {
             
             val returnVal = lib.icu4x_UtcOffset_from_seconds_mv1(seconds);
@@ -67,12 +69,13 @@ class UtcOffset internal constructor (
         }
         @JvmStatic
         
-        /** Creates an offset from a string.
-        *
-        *See the [Rust documentation for `try_from_str`](https://docs.rs/icu/2.3.1/icu/time/zone/struct.UtcOffset.html#method.try_from_str) for more information.
-        *
-        *Additional information: [1](https://docs.rs/icu/2.3.1/icu/time/zone/struct.UtcOffset.html)
-        */
+        /**
+         * Creates an offset from a string.
+         *
+         * See the [Rust documentation for `try_from_str`](https://docs.rs/icu/2.3.1/icu/time/zone/struct.UtcOffset.html#method.try_from_str) for more information.
+         *
+         * Additional information: [1](https://docs.rs/icu/2.3.1/icu/time/zone/struct.UtcOffset.html)
+         */
         fun fromString(offset: String): Result<UtcOffset> {
             val offsetSliceMemory = PrimitiveArrayTools.borrowUtf8(offset)
             
@@ -93,74 +96,80 @@ class UtcOffset internal constructor (
         }
     }
     
-    /** Returns the value as offset seconds.
-    *
-    *See the [Rust documentation for `offset`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZoneInfo.html#method.offset) for more information.
-    *
-    *See the [Rust documentation for `to_seconds`](https://docs.rs/icu/2.3.1/icu/time/zone/struct.UtcOffset.html#method.to_seconds) for more information.
-    *
-    *Additional information: [1](https://docs.rs/icu/2.3.1/icu/time/zone/struct.UtcOffset.html)
-    */
+    /**
+     * Returns the value as offset seconds.
+     *
+     * See the [Rust documentation for `offset`](https://docs.rs/icu/2.3.1/icu/time/struct.TimeZoneInfo.html#method.offset) for more information.
+     *
+     * See the [Rust documentation for `to_seconds`](https://docs.rs/icu/2.3.1/icu/time/zone/struct.UtcOffset.html#method.to_seconds) for more information.
+     *
+     * Additional information: [1](https://docs.rs/icu/2.3.1/icu/time/zone/struct.UtcOffset.html)
+     */
     fun seconds(): Int {
         
         val returnVal = lib.icu4x_UtcOffset_seconds_mv1(handle);
         return (returnVal)
     }
     
-    /** Returns whether the offset is positive.
-    *
-    *See the [Rust documentation for `is_non_negative`](https://docs.rs/icu/2.3.1/icu/time/zone/struct.UtcOffset.html#method.is_non_negative) for more information.
-    *
-    *Additional information: [1](https://docs.rs/icu/2.3.1/icu/time/zone/struct.UtcOffset.html)
-    */
+    /**
+     * Returns whether the offset is positive.
+     *
+     * See the [Rust documentation for `is_non_negative`](https://docs.rs/icu/2.3.1/icu/time/zone/struct.UtcOffset.html#method.is_non_negative) for more information.
+     *
+     * Additional information: [1](https://docs.rs/icu/2.3.1/icu/time/zone/struct.UtcOffset.html)
+     */
     fun isNonNegative(): Boolean {
         
         val returnVal = lib.icu4x_UtcOffset_is_non_negative_mv1(handle);
         return (returnVal > 0)
     }
     
-    /** Returns whether the offset is zero.
-    *
-    *See the [Rust documentation for `is_zero`](https://docs.rs/icu/2.3.1/icu/time/zone/struct.UtcOffset.html#method.is_zero) for more information.
-    *
-    *Additional information: [1](https://docs.rs/icu/2.3.1/icu/time/zone/struct.UtcOffset.html)
-    */
+    /**
+     * Returns whether the offset is zero.
+     *
+     * See the [Rust documentation for `is_zero`](https://docs.rs/icu/2.3.1/icu/time/zone/struct.UtcOffset.html#method.is_zero) for more information.
+     *
+     * Additional information: [1](https://docs.rs/icu/2.3.1/icu/time/zone/struct.UtcOffset.html)
+     */
     fun isZero(): Boolean {
         
         val returnVal = lib.icu4x_UtcOffset_is_zero_mv1(handle);
         return (returnVal > 0)
     }
     
-    /** Returns the hours part of the offset.
-    *
-    *See the [Rust documentation for `hours_part`](https://docs.rs/icu/2.3.1/icu/time/zone/struct.UtcOffset.html#method.hours_part) for more information.
-    *
-    *Additional information: [1](https://docs.rs/icu/2.3.1/icu/time/zone/struct.UtcOffset.html)
-    */
+    /**
+     * Returns the hours part of the offset.
+     *
+     * See the [Rust documentation for `hours_part`](https://docs.rs/icu/2.3.1/icu/time/zone/struct.UtcOffset.html#method.hours_part) for more information.
+     *
+     * Additional information: [1](https://docs.rs/icu/2.3.1/icu/time/zone/struct.UtcOffset.html)
+     */
     fun hoursPart(): Int {
         
         val returnVal = lib.icu4x_UtcOffset_hours_part_mv1(handle);
         return (returnVal)
     }
     
-    /** Returns the minutes part of the offset.
-    *
-    *See the [Rust documentation for `minutes_part`](https://docs.rs/icu/2.3.1/icu/time/zone/struct.UtcOffset.html#method.minutes_part) for more information.
-    *
-    *Additional information: [1](https://docs.rs/icu/2.3.1/icu/time/zone/struct.UtcOffset.html)
-    */
+    /**
+     * Returns the minutes part of the offset.
+     *
+     * See the [Rust documentation for `minutes_part`](https://docs.rs/icu/2.3.1/icu/time/zone/struct.UtcOffset.html#method.minutes_part) for more information.
+     *
+     * Additional information: [1](https://docs.rs/icu/2.3.1/icu/time/zone/struct.UtcOffset.html)
+     */
     fun minutesPart(): UInt {
         
         val returnVal = lib.icu4x_UtcOffset_minutes_part_mv1(handle);
         return (returnVal.toUInt())
     }
     
-    /** Returns the seconds part of the offset.
-    *
-    *See the [Rust documentation for `seconds_part`](https://docs.rs/icu/2.3.1/icu/time/zone/struct.UtcOffset.html#method.seconds_part) for more information.
-    *
-    *Additional information: [1](https://docs.rs/icu/2.3.1/icu/time/zone/struct.UtcOffset.html)
-    */
+    /**
+     * Returns the seconds part of the offset.
+     *
+     * See the [Rust documentation for `seconds_part`](https://docs.rs/icu/2.3.1/icu/time/zone/struct.UtcOffset.html#method.seconds_part) for more information.
+     *
+     * Additional information: [1](https://docs.rs/icu/2.3.1/icu/time/zone/struct.UtcOffset.html)
+     */
     fun secondsPart(): UInt {
         
         val returnVal = lib.icu4x_UtcOffset_seconds_part_mv1(handle);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/VariantOffsets.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/VariantOffsets.kt
@@ -62,8 +62,9 @@ internal class OptionVariantOffsetsNative constructor(): Structure(), Structure.
 
 }
 
-/** See the [Rust documentation for `VariantOffsets`](https://docs.rs/icu/2.3.1/icu/time/zone/struct.VariantOffsets.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `VariantOffsets`](https://docs.rs/icu/2.3.1/icu/time/zone/struct.VariantOffsets.html) for more information.
+ */
 class VariantOffsets (var standard: UtcOffset, var daylight: UtcOffset?) {
     companion object {
 

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/VariantOffsetsCalculator.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/VariantOffsetsCalculator.kt
@@ -12,8 +12,9 @@ internal interface VariantOffsetsCalculatorLib: Library {
     fun icu4x_VariantOffsetsCalculator_compute_offsets_from_time_zone_and_date_time_mv1(handle: Pointer, timeZone: Pointer, utcDate: Pointer, utcTime: Pointer): OptionVariantOffsetsNative
     fun icu4x_VariantOffsetsCalculator_compute_offsets_from_time_zone_and_timestamp_mv1(handle: Pointer, timeZone: Pointer, timestamp: Long): OptionVariantOffsetsNative
 }
-/** See the [Rust documentation for `VariantOffsetsCalculator`](https://docs.rs/icu/2.3.1/icu/time/zone/struct.VariantOffsetsCalculator.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `VariantOffsetsCalculator`](https://docs.rs/icu/2.3.1/icu/time/zone/struct.VariantOffsetsCalculator.html) for more information.
+ */
 class VariantOffsetsCalculator internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -42,10 +43,11 @@ class VariantOffsetsCalculator internal constructor (
         internal val lib: VariantOffsetsCalculatorLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Construct a new [VariantOffsetsCalculator] instance using compiled data.
-        *
-        *See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/time/zone/struct.VariantOffsetsCalculator.html#method.new) for more information.
-        */
+        /**
+         * Construct a new [VariantOffsetsCalculator] instance using compiled data.
+         *
+         * See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/time/zone/struct.VariantOffsetsCalculator.html#method.new) for more information.
+         */
         fun create(): VariantOffsetsCalculator {
             
             val returnVal = lib.icu4x_VariantOffsetsCalculator_create_mv1();
@@ -56,10 +58,11 @@ class VariantOffsetsCalculator internal constructor (
         }
         @JvmStatic
         
-        /** Construct a new [VariantOffsetsCalculator] instance using a particular data source.
-        *
-        *See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/time/zone/struct.VariantOffsetsCalculator.html#method.new) for more information.
-        */
+        /**
+         * Construct a new [VariantOffsetsCalculator] instance using a particular data source.
+         *
+         * See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/time/zone/struct.VariantOffsetsCalculator.html#method.new) for more information.
+         */
         fun createWithProvider(provider: DataProvider): Result<VariantOffsetsCalculator> {
             
             val returnVal = lib.icu4x_VariantOffsetsCalculator_create_with_provider_mv1(provider.handle);
@@ -75,8 +78,9 @@ class VariantOffsetsCalculator internal constructor (
         }
     }
     
-    /** See the [Rust documentation for `compute_offsets_from_time_zone_and_name_timestamp`](https://docs.rs/icu/2.3.1/icu/time/zone/struct.VariantOffsetsCalculatorBorrowed.html#method.compute_offsets_from_time_zone_and_name_timestamp) for more information.
-    */
+    /**
+     * See the [Rust documentation for `compute_offsets_from_time_zone_and_name_timestamp`](https://docs.rs/icu/2.3.1/icu/time/zone/struct.VariantOffsetsCalculatorBorrowed.html#method.compute_offsets_from_time_zone_and_name_timestamp) for more information.
+     */
     fun computeOffsetsFromTimeZoneAndDateTime(timeZone: TimeZone, utcDate: IsoDate, utcTime: Time): VariantOffsets? {
         
         val returnVal = lib.icu4x_VariantOffsetsCalculator_compute_offsets_from_time_zone_and_date_time_mv1(handle, timeZone.handle, utcDate.handle, utcTime.handle);
@@ -87,8 +91,9 @@ class VariantOffsetsCalculator internal constructor (
                                 
     }
     
-    /** See the [Rust documentation for `compute_offsets_from_time_zone_and_name_timestamp`](https://docs.rs/icu/2.3.1/icu/time/zone/struct.VariantOffsetsCalculatorBorrowed.html#method.compute_offsets_from_time_zone_and_name_timestamp) for more information.
-    */
+    /**
+     * See the [Rust documentation for `compute_offsets_from_time_zone_and_name_timestamp`](https://docs.rs/icu/2.3.1/icu/time/zone/struct.VariantOffsetsCalculatorBorrowed.html#method.compute_offsets_from_time_zone_and_name_timestamp) for more information.
+     */
     fun computeOffsetsFromTimeZoneAndTimestamp(timeZone: TimeZone, timestamp: Long): VariantOffsets? {
         
         val returnVal = lib.icu4x_VariantOffsetsCalculator_compute_offsets_from_time_zone_and_timestamp_mv1(handle, timeZone.handle, timestamp);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/VerticalOrientation.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/VerticalOrientation.kt
@@ -14,7 +14,8 @@ internal interface VerticalOrientationLib: Library {
     fun icu4x_VerticalOrientation_from_integer_value_mv1(other: FFIUint8): OptionInt
     fun icu4x_VerticalOrientation_try_from_str_mv1(s: Slice): OptionInt
 }
-/** See the [Rust documentation for `VerticalOrientation`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.VerticalOrientation.html) for more information.
+/**
+ * See the [Rust documentation for `VerticalOrientation`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.VerticalOrientation.html) for more information.
 */
 enum class VerticalOrientation {
     Rotated,
@@ -39,8 +40,9 @@ enum class VerticalOrientation {
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.EnumeratedProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.EnumeratedProperty.html#tymethod.for_char) for more information.
+         */
         fun forChar(ch: Int): VerticalOrientation {
             
             val returnVal = lib.icu4x_VerticalOrientation_for_char_mv1(ch);
@@ -48,10 +50,11 @@ enum class VerticalOrientation {
         }
         @JvmStatic
         
-        /** Convert from an integer value from ICU4C or `CodePointMapData`
-        *
-        *See the [Rust documentation for `from_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.VerticalOrientation.html#method.from_icu4c_value) for more information.
-        */
+        /**
+         * Convert from an integer value from ICU4C or `CodePointMapData`
+         *
+         * See the [Rust documentation for `from_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.VerticalOrientation.html#method.from_icu4c_value) for more information.
+         */
         fun fromIntegerValue(other: UByte): VerticalOrientation? {
             
             val returnVal = lib.icu4x_VerticalOrientation_from_integer_value_mv1(FFIUint8(other));
@@ -61,10 +64,11 @@ enum class VerticalOrientation {
         }
         @JvmStatic
         
-        /** Creates a `VerticalOrientation` from a string.
-        *
-        *Short names, long names, and aliases are supported, and matching is case-insensitive.
-        */
+        /**
+         * Creates a `VerticalOrientation` from a string.
+         *
+         * Short names, long names, and aliases are supported, and matching is case-insensitive.
+         */
         fun tryFromStr(s: String): VerticalOrientation? {
             val sSliceMemory = PrimitiveArrayTools.borrowUtf8(s)
             
@@ -79,10 +83,11 @@ enum class VerticalOrientation {
         }
     }
     
-    /** Get the "long" name of this property value (returns empty if property value is unknown)
-    *
-    *See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesLongBorrowed.html#method.get) for more information.
-    */
+    /**
+     * Get the "long" name of this property value (returns empty if property value is unknown)
+     *
+     * See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesLongBorrowed.html#method.get) for more information.
+     */
     fun longName(): String? {
         
         val returnVal = lib.icu4x_VerticalOrientation_long_name_mv1(this.toNative());
@@ -92,10 +97,11 @@ enum class VerticalOrientation {
                                 
     }
     
-    /** Get the "short" name of this property value (returns empty if property value is unknown)
-    *
-    *See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesShortBorrowed.html#method.get) for more information.
-    */
+    /**
+     * Get the "short" name of this property value (returns empty if property value is unknown)
+     *
+     * See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesShortBorrowed.html#method.get) for more information.
+     */
     fun shortName(): String? {
         
         val returnVal = lib.icu4x_VerticalOrientation_short_name_mv1(this.toNative());
@@ -105,10 +111,11 @@ enum class VerticalOrientation {
                                 
     }
     
-    /** Convert to an integer value usable with ICU4C and `CodePointMapData`
-    *
-    *See the [Rust documentation for `to_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.VerticalOrientation.html#method.to_icu4c_value) for more information.
-    */
+    /**
+     * Convert to an integer value usable with ICU4C and `CodePointMapData`
+     *
+     * See the [Rust documentation for `to_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.VerticalOrientation.html#method.to_icu4c_value) for more information.
+     */
     fun toIntegerValue(): UByte {
         
         val returnVal = lib.icu4x_VerticalOrientation_to_integer_value_mv1(this.toNative());

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/WeekInformation.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/WeekInformation.kt
@@ -13,10 +13,11 @@ internal interface WeekInformationLib: Library {
     fun icu4x_WeekInformation_is_weekend_mv1(handle: Pointer, day: Int): Byte
     fun icu4x_WeekInformation_weekend_mv1(handle: Pointer): Pointer
 }
-/** A Week calculator, useful to be passed in to `week_of_year()` on Date and `DateTime` types
-*
-*See the [Rust documentation for `WeekInformation`](https://docs.rs/icu/2.3.1/icu/calendar/week/struct.WeekInformation.html) for more information.
-*/
+/**
+ * A Week calculator, useful to be passed in to `week_of_year()` on Date and `DateTime` types
+ *
+ * See the [Rust documentation for `WeekInformation`](https://docs.rs/icu/2.3.1/icu/calendar/week/struct.WeekInformation.html) for more information.
+ */
 class WeekInformation internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -45,10 +46,11 @@ class WeekInformation internal constructor (
         internal val lib: WeekInformationLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Creates a new [WeekInformation] from locale data using compiled data.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/calendar/week/struct.WeekInformation.html#method.try_new) for more information.
-        */
+        /**
+         * Creates a new [WeekInformation] from locale data using compiled data.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/calendar/week/struct.WeekInformation.html#method.try_new) for more information.
+         */
         fun create(locale: Locale): Result<WeekInformation> {
             
             val returnVal = lib.icu4x_WeekInformation_create_mv1(locale.handle);
@@ -64,10 +66,11 @@ class WeekInformation internal constructor (
         }
         @JvmStatic
         
-        /** Creates a new [WeekInformation] from locale data using a particular data source.
-        *
-        *See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/calendar/week/struct.WeekInformation.html#method.try_new) for more information.
-        */
+        /**
+         * Creates a new [WeekInformation] from locale data using a particular data source.
+         *
+         * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/calendar/week/struct.WeekInformation.html#method.try_new) for more information.
+         */
         fun createWithProvider(provider: DataProvider, locale: Locale): Result<WeekInformation> {
             
             val returnVal = lib.icu4x_WeekInformation_create_with_provider_mv1(provider.handle, locale.handle);
@@ -83,28 +86,31 @@ class WeekInformation internal constructor (
         }
     }
     
-    /** Returns the weekday that starts the week for this object's locale
-    *
-    *See the [Rust documentation for `first_weekday`](https://docs.rs/icu/2.3.1/icu/calendar/week/struct.WeekInformation.html#structfield.first_weekday) for more information.
-    */
+    /**
+     * Returns the weekday that starts the week for this object's locale
+     *
+     * See the [Rust documentation for `first_weekday`](https://docs.rs/icu/2.3.1/icu/calendar/week/struct.WeekInformation.html#structfield.first_weekday) for more information.
+     */
     fun firstWeekday(): Weekday {
         
         val returnVal = lib.icu4x_WeekInformation_first_weekday_mv1(handle);
         return (Weekday.fromNative(returnVal))
     }
     
-    /** See the [Rust documentation for `weekend`](https://docs.rs/icu/2.3.1/icu/calendar/week/struct.WeekInformation.html#structfield.weekend) for more information.
-    *
-    *See the [Rust documentation for `contains`](https://docs.rs/icu/2.3.1/icu/calendar/provider/struct.WeekdaySet.html#method.contains) for more information.
-    */
+    /**
+     * See the [Rust documentation for `weekend`](https://docs.rs/icu/2.3.1/icu/calendar/week/struct.WeekInformation.html#structfield.weekend) for more information.
+     *
+     * See the [Rust documentation for `contains`](https://docs.rs/icu/2.3.1/icu/calendar/provider/struct.WeekdaySet.html#method.contains) for more information.
+     */
     fun isWeekend(day: Weekday): Boolean {
         
         val returnVal = lib.icu4x_WeekInformation_is_weekend_mv1(handle, day.toNative());
         return (returnVal > 0)
     }
     
-    /** See the [Rust documentation for `weekend`](https://docs.rs/icu/2.3.1/icu/calendar/week/struct.WeekInformation.html#method.weekend) for more information.
-    */
+    /**
+     * See the [Rust documentation for `weekend`](https://docs.rs/icu/2.3.1/icu/calendar/week/struct.WeekInformation.html#method.weekend) for more information.
+     */
     fun weekend(): WeekdaySetIterator {
         
         val returnVal = lib.icu4x_WeekInformation_weekend_mv1(handle);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/Weekday.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/Weekday.kt
@@ -8,7 +8,8 @@ import com.sun.jna.Structure
 
 internal interface WeekdayLib: Library {
 }
-/** See the [Rust documentation for `Weekday`](https://docs.rs/icu/2.3.1/icu/calendar/types/enum.Weekday.html) for more information.
+/**
+ * See the [Rust documentation for `Weekday`](https://docs.rs/icu/2.3.1/icu/calendar/types/enum.Weekday.html) for more information.
 */
 enum class Weekday(val inner: Int) {
     Monday(1),

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/WeekdaySetIterator.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/WeekdaySetIterator.kt
@@ -10,10 +10,11 @@ internal interface WeekdaySetIteratorLib: Library {
     fun icu4x_WeekdaySetIterator_next_mv1(handle: Pointer): OptionInt
 }
 typealias WeekdaySetIteratorIteratorItem = Weekday
-/** Documents which days of the week are considered to be a part of the weekend
-*
-*See the [Rust documentation for `WeekdaySetIterator`](https://docs.rs/icu/2.3.1/icu/calendar/week/struct.WeekdaySetIterator.html) for more information.
-*/
+/**
+ * Documents which days of the week are considered to be a part of the weekend
+ *
+ * See the [Rust documentation for `WeekdaySetIterator`](https://docs.rs/icu/2.3.1/icu/calendar/week/struct.WeekdaySetIterator.html) for more information.
+ */
 class WeekdaySetIterator internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -42,8 +43,9 @@ class WeekdaySetIterator internal constructor (
         internal val lib: WeekdaySetIteratorLib = Native.load("icu4x", libClass)
     }
     
-    /** See the [Rust documentation for `next`](https://docs.rs/icu/2.3.1/icu/calendar/week/struct.WeekdaySetIterator.html#method.next) for more information.
-    */
+    /**
+     * See the [Rust documentation for `next`](https://docs.rs/icu/2.3.1/icu/calendar/week/struct.WeekdaySetIterator.html#method.next) for more information.
+     */
     internal fun nextInternal(): Weekday? {
         
         val returnVal = lib.icu4x_WeekdaySetIterator_next_mv1(handle);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/WindowsParser.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/WindowsParser.kt
@@ -11,13 +11,14 @@ internal interface WindowsParserLib: Library {
     fun icu4x_WindowsParser_create_with_provider_mv1(provider: Pointer): ResultPointerInt
     fun icu4x_WindowsParser_parse_mv1(handle: Pointer, value: Slice, region: Slice): Pointer?
 }
-/** A mapper between Windows time zone identifiers and BCP-47 time zone identifiers.
-*
-*This mapper supports two-way mapping, but it is optimized for the case of Windows to BCP-47.
-*It also supports normalizing and canonicalizing the Windows strings.
-*
-*See the [Rust documentation for `WindowsParser`](https://docs.rs/icu/2.3.1/icu/time/zone/windows/struct.WindowsParser.html) for more information.
-*/
+/**
+ * A mapper between Windows time zone identifiers and BCP-47 time zone identifiers.
+ *
+ * This mapper supports two-way mapping, but it is optimized for the case of Windows to BCP-47.
+ * It also supports normalizing and canonicalizing the Windows strings.
+ *
+ * See the [Rust documentation for `WindowsParser`](https://docs.rs/icu/2.3.1/icu/time/zone/windows/struct.WindowsParser.html) for more information.
+ */
 class WindowsParser internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -46,10 +47,11 @@ class WindowsParser internal constructor (
         internal val lib: WindowsParserLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Create a new [WindowsParser] using compiled data
-        *
-        *See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/time/zone/windows/struct.WindowsParser.html#method.new) for more information.
-        */
+        /**
+         * Create a new [WindowsParser] using compiled data
+         *
+         * See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/time/zone/windows/struct.WindowsParser.html#method.new) for more information.
+         */
         fun create(): WindowsParser {
             
             val returnVal = lib.icu4x_WindowsParser_create_mv1();
@@ -60,10 +62,11 @@ class WindowsParser internal constructor (
         }
         @JvmStatic
         
-        /** Create a new [WindowsParser] using a particular data source
-        *
-        *See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/time/zone/windows/struct.WindowsParser.html#method.new) for more information.
-        */
+        /**
+         * Create a new [WindowsParser] using a particular data source
+         *
+         * See the [Rust documentation for `new`](https://docs.rs/icu/2.3.1/icu/time/zone/windows/struct.WindowsParser.html#method.new) for more information.
+         */
         fun createWithProvider(provider: DataProvider): Result<WindowsParser> {
             
             val returnVal = lib.icu4x_WindowsParser_create_with_provider_mv1(provider.handle);
@@ -79,8 +82,9 @@ class WindowsParser internal constructor (
         }
     }
     
-    /** See the [Rust documentation for `parse`](https://docs.rs/icu/2.3.1/icu/time/zone/windows/struct.WindowsParserBorrowed.html#method.parse) for more information.
-    */
+    /**
+     * See the [Rust documentation for `parse`](https://docs.rs/icu/2.3.1/icu/time/zone/windows/struct.WindowsParserBorrowed.html#method.parse) for more information.
+     */
     fun parse(value: String, region: String): TimeZone? {
         val valueSliceMemory = PrimitiveArrayTools.borrowUtf8(value)
         val regionSliceMemory = PrimitiveArrayTools.borrowUtf8(region)

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/WordBreak.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/WordBreak.kt
@@ -14,7 +14,8 @@ internal interface WordBreakLib: Library {
     fun icu4x_WordBreak_from_integer_value_mv1(other: FFIUint8): OptionInt
     fun icu4x_WordBreak_try_from_str_mv1(s: Slice): OptionInt
 }
-/** See the [Rust documentation for `WordBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.WordBreak.html) for more information.
+/**
+ * See the [Rust documentation for `WordBreak`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.WordBreak.html) for more information.
 */
 enum class WordBreak {
     Other,
@@ -58,8 +59,9 @@ enum class WordBreak {
         }
         @JvmStatic
         
-        /** See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.EnumeratedProperty.html#tymethod.for_char) for more information.
-        */
+        /**
+         * See the [Rust documentation for `for_char`](https://docs.rs/icu/2.3.1/icu/properties/props/trait.EnumeratedProperty.html#tymethod.for_char) for more information.
+         */
         fun forChar(ch: Int): WordBreak {
             
             val returnVal = lib.icu4x_WordBreak_for_char_mv1(ch);
@@ -67,10 +69,11 @@ enum class WordBreak {
         }
         @JvmStatic
         
-        /** Convert from an integer value from ICU4C or `CodePointMapData`
-        *
-        *See the [Rust documentation for `from_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.WordBreak.html#method.from_icu4c_value) for more information.
-        */
+        /**
+         * Convert from an integer value from ICU4C or `CodePointMapData`
+         *
+         * See the [Rust documentation for `from_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.WordBreak.html#method.from_icu4c_value) for more information.
+         */
         fun fromIntegerValue(other: UByte): WordBreak? {
             
             val returnVal = lib.icu4x_WordBreak_from_integer_value_mv1(FFIUint8(other));
@@ -80,10 +83,11 @@ enum class WordBreak {
         }
         @JvmStatic
         
-        /** Creates a `WordBreak` from a string.
-        *
-        *Short names, long names, and aliases are supported, and matching is case-insensitive.
-        */
+        /**
+         * Creates a `WordBreak` from a string.
+         *
+         * Short names, long names, and aliases are supported, and matching is case-insensitive.
+         */
         fun tryFromStr(s: String): WordBreak? {
             val sSliceMemory = PrimitiveArrayTools.borrowUtf8(s)
             
@@ -98,10 +102,11 @@ enum class WordBreak {
         }
     }
     
-    /** Get the "long" name of this property value (returns empty if property value is unknown)
-    *
-    *See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesLongBorrowed.html#method.get) for more information.
-    */
+    /**
+     * Get the "long" name of this property value (returns empty if property value is unknown)
+     *
+     * See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesLongBorrowed.html#method.get) for more information.
+     */
     fun longName(): String? {
         
         val returnVal = lib.icu4x_WordBreak_long_name_mv1(this.toNative());
@@ -111,10 +116,11 @@ enum class WordBreak {
                                 
     }
     
-    /** Get the "short" name of this property value (returns empty if property value is unknown)
-    *
-    *See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesShortBorrowed.html#method.get) for more information.
-    */
+    /**
+     * Get the "short" name of this property value (returns empty if property value is unknown)
+     *
+     * See the [Rust documentation for `get`](https://docs.rs/icu/2.3.1/icu/properties/struct.PropertyNamesShortBorrowed.html#method.get) for more information.
+     */
     fun shortName(): String? {
         
         val returnVal = lib.icu4x_WordBreak_short_name_mv1(this.toNative());
@@ -124,10 +130,11 @@ enum class WordBreak {
                                 
     }
     
-    /** Convert to an integer value usable with ICU4C and `CodePointMapData`
-    *
-    *See the [Rust documentation for `to_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.WordBreak.html#method.to_icu4c_value) for more information.
-    */
+    /**
+     * Convert to an integer value usable with ICU4C and `CodePointMapData`
+     *
+     * See the [Rust documentation for `to_icu4c_value`](https://docs.rs/icu/2.3.1/icu/properties/props/struct.WordBreak.html#method.to_icu4c_value) for more information.
+     */
     fun toIntegerValue(): UByte {
         
         val returnVal = lib.icu4x_WordBreak_to_integer_value_mv1(this.toNative());

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/WordBreakIteratorLatin1.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/WordBreakIteratorLatin1.kt
@@ -11,8 +11,9 @@ internal interface WordBreakIteratorLatin1Lib: Library {
     fun icu4x_WordBreakIteratorLatin1_word_type_mv1(handle: Pointer): Int
     fun icu4x_WordBreakIteratorLatin1_is_word_like_mv1(handle: Pointer): Byte
 }
-/** See the [Rust documentation for `WordBreakIterator`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.WordBreakIterator.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `WordBreakIterator`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.WordBreakIterator.html) for more information.
+ */
 class WordBreakIteratorLatin1 internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -42,31 +43,34 @@ class WordBreakIteratorLatin1 internal constructor (
         internal val lib: WordBreakIteratorLatin1Lib = Native.load("icu4x", libClass)
     }
     
-    /** Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
-    *out of range of a 32-bit signed integer.
-    *
-    *See the [Rust documentation for `next`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.WordBreakIterator.html#method.next) for more information.
-    */
+    /**
+     * Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
+     * out of range of a 32-bit signed integer.
+     *
+     * See the [Rust documentation for `next`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.WordBreakIterator.html#method.next) for more information.
+     */
     fun next(): Int {
         
         val returnVal = lib.icu4x_WordBreakIteratorLatin1_next_mv1(handle);
         return (returnVal)
     }
     
-    /** Return the status value of break boundary.
-    *
-    *See the [Rust documentation for `word_type`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.WordBreakIterator.html#method.word_type) for more information.
-    */
+    /**
+     * Return the status value of break boundary.
+     *
+     * See the [Rust documentation for `word_type`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.WordBreakIterator.html#method.word_type) for more information.
+     */
     fun wordType(): SegmenterWordType {
         
         val returnVal = lib.icu4x_WordBreakIteratorLatin1_word_type_mv1(handle);
         return (SegmenterWordType.fromNative(returnVal))
     }
     
-    /** Return true when break boundary is word-like such as letter/number/CJK
-    *
-    *See the [Rust documentation for `is_word_like`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.WordBreakIterator.html#method.is_word_like) for more information.
-    */
+    /**
+     * Return true when break boundary is word-like such as letter/number/CJK
+     *
+     * See the [Rust documentation for `is_word_like`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.WordBreakIterator.html#method.is_word_like) for more information.
+     */
     fun isWordLike(): Boolean {
         
         val returnVal = lib.icu4x_WordBreakIteratorLatin1_is_word_like_mv1(handle);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/WordBreakIteratorUtf16.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/WordBreakIteratorUtf16.kt
@@ -11,8 +11,9 @@ internal interface WordBreakIteratorUtf16Lib: Library {
     fun icu4x_WordBreakIteratorUtf16_word_type_mv1(handle: Pointer): Int
     fun icu4x_WordBreakIteratorUtf16_is_word_like_mv1(handle: Pointer): Byte
 }
-/** See the [Rust documentation for `WordBreakIterator`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.WordBreakIterator.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `WordBreakIterator`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.WordBreakIterator.html) for more information.
+ */
 class WordBreakIteratorUtf16 internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -42,31 +43,34 @@ class WordBreakIteratorUtf16 internal constructor (
         internal val lib: WordBreakIteratorUtf16Lib = Native.load("icu4x", libClass)
     }
     
-    /** Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
-    *out of range of a 32-bit signed integer.
-    *
-    *See the [Rust documentation for `next`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.WordBreakIterator.html#method.next) for more information.
-    */
+    /**
+     * Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
+     * out of range of a 32-bit signed integer.
+     *
+     * See the [Rust documentation for `next`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.WordBreakIterator.html#method.next) for more information.
+     */
     fun next(): Int {
         
         val returnVal = lib.icu4x_WordBreakIteratorUtf16_next_mv1(handle);
         return (returnVal)
     }
     
-    /** Return the status value of break boundary.
-    *
-    *See the [Rust documentation for `word_type`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.WordBreakIterator.html#method.word_type) for more information.
-    */
+    /**
+     * Return the status value of break boundary.
+     *
+     * See the [Rust documentation for `word_type`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.WordBreakIterator.html#method.word_type) for more information.
+     */
     fun wordType(): SegmenterWordType {
         
         val returnVal = lib.icu4x_WordBreakIteratorUtf16_word_type_mv1(handle);
         return (SegmenterWordType.fromNative(returnVal))
     }
     
-    /** Return true when break boundary is word-like such as letter/number/CJK
-    *
-    *See the [Rust documentation for `is_word_like`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.WordBreakIterator.html#method.is_word_like) for more information.
-    */
+    /**
+     * Return true when break boundary is word-like such as letter/number/CJK
+     *
+     * See the [Rust documentation for `is_word_like`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.WordBreakIterator.html#method.is_word_like) for more information.
+     */
     fun isWordLike(): Boolean {
         
         val returnVal = lib.icu4x_WordBreakIteratorUtf16_is_word_like_mv1(handle);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/WordBreakIteratorUtf8.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/WordBreakIteratorUtf8.kt
@@ -11,8 +11,9 @@ internal interface WordBreakIteratorUtf8Lib: Library {
     fun icu4x_WordBreakIteratorUtf8_word_type_mv1(handle: Pointer): Int
     fun icu4x_WordBreakIteratorUtf8_is_word_like_mv1(handle: Pointer): Byte
 }
-/** See the [Rust documentation for `WordBreakIterator`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.WordBreakIterator.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `WordBreakIterator`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.WordBreakIterator.html) for more information.
+ */
 class WordBreakIteratorUtf8 internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -42,31 +43,34 @@ class WordBreakIteratorUtf8 internal constructor (
         internal val lib: WordBreakIteratorUtf8Lib = Native.load("icu4x", libClass)
     }
     
-    /** Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
-    *out of range of a 32-bit signed integer.
-    *
-    *See the [Rust documentation for `next`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.WordBreakIterator.html#method.next) for more information.
-    */
+    /**
+     * Finds the next breakpoint. Returns -1 if at the end of the string or if the index is
+     * out of range of a 32-bit signed integer.
+     *
+     * See the [Rust documentation for `next`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.WordBreakIterator.html#method.next) for more information.
+     */
     fun next(): Int {
         
         val returnVal = lib.icu4x_WordBreakIteratorUtf8_next_mv1(handle);
         return (returnVal)
     }
     
-    /** Return the status value of break boundary.
-    *
-    *See the [Rust documentation for `word_type`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.WordBreakIterator.html#method.word_type) for more information.
-    */
+    /**
+     * Return the status value of break boundary.
+     *
+     * See the [Rust documentation for `word_type`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.WordBreakIterator.html#method.word_type) for more information.
+     */
     fun wordType(): SegmenterWordType {
         
         val returnVal = lib.icu4x_WordBreakIteratorUtf8_word_type_mv1(handle);
         return (SegmenterWordType.fromNative(returnVal))
     }
     
-    /** Return true when break boundary is word-like such as letter/number/CJK
-    *
-    *See the [Rust documentation for `is_word_like`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.WordBreakIterator.html#method.is_word_like) for more information.
-    */
+    /**
+     * Return true when break boundary is word-like such as letter/number/CJK
+     *
+     * See the [Rust documentation for `is_word_like`](https://docs.rs/icu/2.3.1/icu/segmenter/iterators/struct.WordBreakIterator.html#method.is_word_like) for more information.
+     */
     fun isWordLike(): Boolean {
         
         val returnVal = lib.icu4x_WordBreakIteratorUtf8_is_word_like_mv1(handle);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/WordSegmenter.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/WordSegmenter.kt
@@ -21,10 +21,11 @@ internal interface WordSegmenterLib: Library {
     fun icu4x_WordSegmenter_create_for_non_complex_scripts_with_content_locale_and_provider_mv1(provider: Pointer, locale: Pointer): ResultPointerInt
     fun icu4x_WordSegmenter_segment_utf16_mv1(handle: Pointer, input: Slice): Pointer
 }
-/** An ICU4X word-break segmenter, capable of finding word breakpoints in strings.
-*
-*See the [Rust documentation for `WordSegmenter`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.WordSegmenter.html) for more information.
-*/
+/**
+ * An ICU4X word-break segmenter, capable of finding word breakpoints in strings.
+ *
+ * See the [Rust documentation for `WordSegmenter`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.WordSegmenter.html) for more information.
+ */
 class WordSegmenter internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -53,14 +54,15 @@ class WordSegmenter internal constructor (
         internal val lib: WordSegmenterLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Construct a [WordSegmenter] with automatically selecting the best available LSTM
-        *or dictionary payload data, using compiled data. This does not assume any content locale.
-        *
-        *Note: currently, it uses dictionary for Chinese and Japanese, and LSTM for Burmese,
-        *Khmer, Lao, and Thai.
-        *
-        *See the [Rust documentation for `new_auto`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.WordSegmenter.html#method.new_auto) for more information.
-        */
+        /**
+         * Construct a [WordSegmenter] with automatically selecting the best available LSTM
+         * or dictionary payload data, using compiled data. This does not assume any content locale.
+         *
+         * Note: currently, it uses dictionary for Chinese and Japanese, and LSTM for Burmese,
+         * Khmer, Lao, and Thai.
+         *
+         * See the [Rust documentation for `new_auto`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.WordSegmenter.html#method.new_auto) for more information.
+         */
         fun createAuto(): WordSegmenter {
             
             val returnVal = lib.icu4x_WordSegmenter_create_auto_mv1();
@@ -71,14 +73,15 @@ class WordSegmenter internal constructor (
         }
         @JvmStatic
         
-        /** Construct a [WordSegmenter] with automatically selecting the best available LSTM
-        *or dictionary payload data, using compiled data.
-        *
-        *Note: currently, it uses dictionary for Chinese and Japanese, and LSTM for Burmese,
-        *Khmer, Lao, and Thai.
-        *
-        *See the [Rust documentation for `try_new_auto`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.WordSegmenter.html#method.try_new_auto) for more information.
-        */
+        /**
+         * Construct a [WordSegmenter] with automatically selecting the best available LSTM
+         * or dictionary payload data, using compiled data.
+         *
+         * Note: currently, it uses dictionary for Chinese and Japanese, and LSTM for Burmese,
+         * Khmer, Lao, and Thai.
+         *
+         * See the [Rust documentation for `try_new_auto`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.WordSegmenter.html#method.try_new_auto) for more information.
+         */
         fun createAutoWithContentLocale(locale: Locale): Result<WordSegmenter> {
             
             val returnVal = lib.icu4x_WordSegmenter_create_auto_with_content_locale_mv1(locale.handle);
@@ -94,14 +97,15 @@ class WordSegmenter internal constructor (
         }
         @JvmStatic
         
-        /** Construct a [WordSegmenter] with automatically selecting the best available LSTM
-        *or dictionary payload data, using a particular data source.
-        *
-        *Note: currently, it uses dictionary for Chinese and Japanese, and LSTM for Burmese,
-        *Khmer, Lao, and Thai.
-        *
-        *See the [Rust documentation for `try_new_auto`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.WordSegmenter.html#method.try_new_auto) for more information.
-        */
+        /**
+         * Construct a [WordSegmenter] with automatically selecting the best available LSTM
+         * or dictionary payload data, using a particular data source.
+         *
+         * Note: currently, it uses dictionary for Chinese and Japanese, and LSTM for Burmese,
+         * Khmer, Lao, and Thai.
+         *
+         * See the [Rust documentation for `try_new_auto`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.WordSegmenter.html#method.try_new_auto) for more information.
+         */
         fun createAutoWithContentLocaleAndProvider(provider: DataProvider, locale: Locale): Result<WordSegmenter> {
             
             val returnVal = lib.icu4x_WordSegmenter_create_auto_with_content_locale_and_provider_mv1(provider.handle, locale.handle);
@@ -117,14 +121,15 @@ class WordSegmenter internal constructor (
         }
         @JvmStatic
         
-        /** Construct a [WordSegmenter] with LSTM payload data for Burmese, Khmer, Lao, and
-        *Thai, using compiled data. This does not assume any content locale.
-        *
-        *Note: currently, it uses dictionary for Chinese and Japanese, and LSTM for Burmese,
-        *Khmer, Lao, and Thai.
-        *
-        *See the [Rust documentation for `new_lstm`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.WordSegmenter.html#method.new_lstm) for more information.
-        */
+        /**
+         * Construct a [WordSegmenter] with LSTM payload data for Burmese, Khmer, Lao, and
+         * Thai, using compiled data. This does not assume any content locale.
+         *
+         * Note: currently, it uses dictionary for Chinese and Japanese, and LSTM for Burmese,
+         * Khmer, Lao, and Thai.
+         *
+         * See the [Rust documentation for `new_lstm`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.WordSegmenter.html#method.new_lstm) for more information.
+         */
         fun createLstm(): WordSegmenter {
             
             val returnVal = lib.icu4x_WordSegmenter_create_lstm_mv1();
@@ -135,14 +140,15 @@ class WordSegmenter internal constructor (
         }
         @JvmStatic
         
-        /** Construct a [WordSegmenter] with LSTM payload data for Burmese, Khmer, Lao, and
-        *Thai, using compiled data.
-        *
-        *Note: currently, it uses dictionary for Chinese and Japanese, and LSTM for Burmese,
-        *Khmer, Lao, and Thai.
-        *
-        *See the [Rust documentation for `try_new_lstm`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.WordSegmenter.html#method.try_new_lstm) for more information.
-        */
+        /**
+         * Construct a [WordSegmenter] with LSTM payload data for Burmese, Khmer, Lao, and
+         * Thai, using compiled data.
+         *
+         * Note: currently, it uses dictionary for Chinese and Japanese, and LSTM for Burmese,
+         * Khmer, Lao, and Thai.
+         *
+         * See the [Rust documentation for `try_new_lstm`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.WordSegmenter.html#method.try_new_lstm) for more information.
+         */
         fun createLstmWithContentLocale(locale: Locale): Result<WordSegmenter> {
             
             val returnVal = lib.icu4x_WordSegmenter_create_lstm_with_content_locale_mv1(locale.handle);
@@ -158,14 +164,15 @@ class WordSegmenter internal constructor (
         }
         @JvmStatic
         
-        /** Construct a [WordSegmenter] with LSTM payload data for Burmese, Khmer, Lao, and
-        *Thai, using a particular data source.
-        *
-        *Note: currently, it uses dictionary for Chinese and Japanese, and LSTM for Burmese,
-        *Khmer, Lao, and Thai.
-        *
-        *See the [Rust documentation for `try_new_lstm`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.WordSegmenter.html#method.try_new_lstm) for more information.
-        */
+        /**
+         * Construct a [WordSegmenter] with LSTM payload data for Burmese, Khmer, Lao, and
+         * Thai, using a particular data source.
+         *
+         * Note: currently, it uses dictionary for Chinese and Japanese, and LSTM for Burmese,
+         * Khmer, Lao, and Thai.
+         *
+         * See the [Rust documentation for `try_new_lstm`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.WordSegmenter.html#method.try_new_lstm) for more information.
+         */
         fun createLstmWithContentLocaleAndProvider(provider: DataProvider, locale: Locale): Result<WordSegmenter> {
             
             val returnVal = lib.icu4x_WordSegmenter_create_lstm_with_content_locale_and_provider_mv1(provider.handle, locale.handle);
@@ -181,14 +188,15 @@ class WordSegmenter internal constructor (
         }
         @JvmStatic
         
-        /** Construct a [WordSegmenter] with dictionary payload data for Chinese, Japanese,
-        *Burmese, Khmer, Lao, and Thai, using compiled data. This does not assume any content locale.
-        *
-        *Note: currently, it uses dictionary for Chinese and Japanese, and dictionary for Burmese,
-        *Khmer, Lao, and Thai.
-        *
-        *See the [Rust documentation for `new_dictionary`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.WordSegmenter.html#method.new_dictionary) for more information.
-        */
+        /**
+         * Construct a [WordSegmenter] with dictionary payload data for Chinese, Japanese,
+         * Burmese, Khmer, Lao, and Thai, using compiled data. This does not assume any content locale.
+         *
+         * Note: currently, it uses dictionary for Chinese and Japanese, and dictionary for Burmese,
+         * Khmer, Lao, and Thai.
+         *
+         * See the [Rust documentation for `new_dictionary`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.WordSegmenter.html#method.new_dictionary) for more information.
+         */
         fun createDictionary(): WordSegmenter {
             
             val returnVal = lib.icu4x_WordSegmenter_create_dictionary_mv1();
@@ -199,14 +207,15 @@ class WordSegmenter internal constructor (
         }
         @JvmStatic
         
-        /** Construct a [WordSegmenter] with dictionary payload data for Chinese, Japanese,
-        *Burmese, Khmer, Lao, and Thai, using compiled data.
-        *
-        *Note: currently, it uses dictionary for Chinese and Japanese, and dictionary for Burmese,
-        *Khmer, Lao, and Thai.
-        *
-        *See the [Rust documentation for `try_new_dictionary`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.WordSegmenter.html#method.try_new_dictionary) for more information.
-        */
+        /**
+         * Construct a [WordSegmenter] with dictionary payload data for Chinese, Japanese,
+         * Burmese, Khmer, Lao, and Thai, using compiled data.
+         *
+         * Note: currently, it uses dictionary for Chinese and Japanese, and dictionary for Burmese,
+         * Khmer, Lao, and Thai.
+         *
+         * See the [Rust documentation for `try_new_dictionary`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.WordSegmenter.html#method.try_new_dictionary) for more information.
+         */
         fun createDictionaryWithContentLocale(locale: Locale): Result<WordSegmenter> {
             
             val returnVal = lib.icu4x_WordSegmenter_create_dictionary_with_content_locale_mv1(locale.handle);
@@ -222,14 +231,15 @@ class WordSegmenter internal constructor (
         }
         @JvmStatic
         
-        /** Construct a [WordSegmenter] with dictionary payload data for Chinese, Japanese,
-        *Burmese, Khmer, Lao, and Thai, using a particular data source.
-        *
-        *Note: currently, it uses dictionary for Chinese and Japanese, and dictionary for Burmese,
-        *Khmer, Lao, and Thai.
-        *
-        *See the [Rust documentation for `try_new_dictionary`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.WordSegmenter.html#method.try_new_dictionary) for more information.
-        */
+        /**
+         * Construct a [WordSegmenter] with dictionary payload data for Chinese, Japanese,
+         * Burmese, Khmer, Lao, and Thai, using a particular data source.
+         *
+         * Note: currently, it uses dictionary for Chinese and Japanese, and dictionary for Burmese,
+         * Khmer, Lao, and Thai.
+         *
+         * See the [Rust documentation for `try_new_dictionary`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.WordSegmenter.html#method.try_new_dictionary) for more information.
+         */
         fun createDictionaryWithContentLocaleAndProvider(provider: DataProvider, locale: Locale): Result<WordSegmenter> {
             
             val returnVal = lib.icu4x_WordSegmenter_create_dictionary_with_content_locale_and_provider_mv1(provider.handle, locale.handle);
@@ -245,11 +255,12 @@ class WordSegmenter internal constructor (
         }
         @JvmStatic
         
-        /** Construct a [WordSegmenter] with no support for scripts requiring complex context dependent word breaks (Chinese, Japanese,
-        *Burmese, Khmer, Lao, and Thai), using compiled data. This does not assume any content locale.
-        *
-        *See the [Rust documentation for `new_for_non_complex_scripts`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.WordSegmenter.html#method.new_for_non_complex_scripts) for more information.
-        */
+        /**
+         * Construct a [WordSegmenter] with no support for scripts requiring complex context dependent word breaks (Chinese, Japanese,
+         * Burmese, Khmer, Lao, and Thai), using compiled data. This does not assume any content locale.
+         *
+         * See the [Rust documentation for `new_for_non_complex_scripts`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.WordSegmenter.html#method.new_for_non_complex_scripts) for more information.
+         */
         fun createForNonComplexScripts(): WordSegmenter {
             
             val returnVal = lib.icu4x_WordSegmenter_create_for_non_complex_scripts_mv1();
@@ -260,11 +271,12 @@ class WordSegmenter internal constructor (
         }
         @JvmStatic
         
-        /** Construct a [WordSegmenter] with no support for scripts requiring complex context dependent word breaks (Chinese, Japanese,
-        *Burmese, Khmer, Lao, and Thai), using compiled data.
-        *
-        *See the [Rust documentation for `try_new_for_non_complex_scripts`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.WordSegmenter.html#method.try_new_for_non_complex_scripts) for more information.
-        */
+        /**
+         * Construct a [WordSegmenter] with no support for scripts requiring complex context dependent word breaks (Chinese, Japanese,
+         * Burmese, Khmer, Lao, and Thai), using compiled data.
+         *
+         * See the [Rust documentation for `try_new_for_non_complex_scripts`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.WordSegmenter.html#method.try_new_for_non_complex_scripts) for more information.
+         */
         fun createForNonComplexScriptsWithContentLocale(locale: Locale): Result<WordSegmenter> {
             
             val returnVal = lib.icu4x_WordSegmenter_create_for_non_complex_scripts_with_content_locale_mv1(locale.handle);
@@ -280,11 +292,12 @@ class WordSegmenter internal constructor (
         }
         @JvmStatic
         
-        /** Construct a [WordSegmenter] with no support for scripts requiring complex context dependent word breaks (Chinese, Japanese,
-        *Burmese, Khmer, Lao, and Thai), using a particular data source.
-        *
-        *See the [Rust documentation for `try_new_for_non_complex_scripts`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.WordSegmenter.html#method.try_new_for_non_complex_scripts) for more information.
-        */
+        /**
+         * Construct a [WordSegmenter] with no support for scripts requiring complex context dependent word breaks (Chinese, Japanese,
+         * Burmese, Khmer, Lao, and Thai), using a particular data source.
+         *
+         * See the [Rust documentation for `try_new_for_non_complex_scripts`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.WordSegmenter.html#method.try_new_for_non_complex_scripts) for more information.
+         */
         fun createForNonComplexScriptsWithContentLocaleAndProvider(provider: DataProvider, locale: Locale): Result<WordSegmenter> {
             
             val returnVal = lib.icu4x_WordSegmenter_create_for_non_complex_scripts_with_content_locale_and_provider_mv1(provider.handle, locale.handle);
@@ -300,13 +313,14 @@ class WordSegmenter internal constructor (
         }
     }
     
-    /** Segments a string.
-    *
-    *Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
-    *to the WHATWG Encoding Standard.
-    *
-    *See the [Rust documentation for `segment_utf16`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.WordSegmenterBorrowed.html#method.segment_utf16) for more information.
-    */
+    /**
+     * Segments a string.
+     *
+     * Ill-formed input is treated as if errors had been replaced with REPLACEMENT CHARACTERs according
+     * to the WHATWG Encoding Standard.
+     *
+     * See the [Rust documentation for `segment_utf16`](https://docs.rs/icu/2.3.1/icu/segmenter/struct.WordSegmenterBorrowed.html#method.segment_utf16) for more information.
+     */
     fun segment(input: String): WordBreakIteratorUtf16 {
         // This lifetime edge depends on lifetimes: 'a
         val aEdges: MutableList<Any> = mutableListOf(this);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/YearStyle.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/YearStyle.kt
@@ -8,7 +8,8 @@ import com.sun.jna.Structure
 
 internal interface YearStyleLib: Library {
 }
-/** See the [Rust documentation for `YearStyle`](https://docs.rs/icu/2.3.1/icu/datetime/options/enum.YearStyle.html) for more information.
+/**
+ * See the [Rust documentation for `YearStyle`](https://docs.rs/icu/2.3.1/icu/datetime/options/enum.YearStyle.html) for more information.
 */
 enum class YearStyle {
     Auto,

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/ZonedDateFormatter.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/ZonedDateFormatter.kt
@@ -26,8 +26,9 @@ internal interface ZonedDateFormatterLib: Library {
     fun icu4x_ZonedDateFormatter_format_iso_mv1(handle: Pointer, isoDate: Pointer, zone: Pointer, write: Pointer): ResultUnitInt
     fun icu4x_ZonedDateFormatter_format_same_calendar_mv1(handle: Pointer, date: Pointer, zone: Pointer, write: Pointer): ResultUnitDateTimeMismatchedCalendarErrorNative
 }
-/** See the [Rust documentation for `DateTimeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `DateTimeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html) for more information.
+ */
 class ZonedDateFormatter internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -56,13 +57,14 @@ class ZonedDateFormatter internal constructor (
         internal val lib: ZonedDateFormatterLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
+         */
         fun createSpecificLong(locale: Locale, formatter: DateFormatter): Result<ZonedDateFormatter> {
             
             val returnVal = lib.icu4x_ZonedDateFormatter_create_specific_long_mv1(locale.handle, formatter.handle);
@@ -78,13 +80,14 @@ class ZonedDateFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
+         */
         fun createSpecificLongWithProvider(provider: DataProvider, locale: Locale, formatter: DateFormatter): Result<ZonedDateFormatter> {
             
             val returnVal = lib.icu4x_ZonedDateFormatter_create_specific_long_with_provider_mv1(provider.handle, locale.handle, formatter.handle);
@@ -100,13 +103,14 @@ class ZonedDateFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
+         */
         fun createSpecificShort(locale: Locale, formatter: DateFormatter): Result<ZonedDateFormatter> {
             
             val returnVal = lib.icu4x_ZonedDateFormatter_create_specific_short_mv1(locale.handle, formatter.handle);
@@ -122,13 +126,14 @@ class ZonedDateFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
+         */
         fun createSpecificShortWithProvider(provider: DataProvider, locale: Locale, formatter: DateFormatter): Result<ZonedDateFormatter> {
             
             val returnVal = lib.icu4x_ZonedDateFormatter_create_specific_short_with_provider_mv1(provider.handle, locale.handle, formatter.handle);
@@ -144,13 +149,14 @@ class ZonedDateFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
+         */
         fun createLocalizedOffsetLong(locale: Locale, formatter: DateFormatter): Result<ZonedDateFormatter> {
             
             val returnVal = lib.icu4x_ZonedDateFormatter_create_localized_offset_long_mv1(locale.handle, formatter.handle);
@@ -166,13 +172,14 @@ class ZonedDateFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
+         */
         fun createLocalizedOffsetLongWithProvider(provider: DataProvider, locale: Locale, formatter: DateFormatter): Result<ZonedDateFormatter> {
             
             val returnVal = lib.icu4x_ZonedDateFormatter_create_localized_offset_long_with_provider_mv1(provider.handle, locale.handle, formatter.handle);
@@ -188,13 +195,14 @@ class ZonedDateFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
+         */
         fun createLocalizedOffsetShort(locale: Locale, formatter: DateFormatter): Result<ZonedDateFormatter> {
             
             val returnVal = lib.icu4x_ZonedDateFormatter_create_localized_offset_short_mv1(locale.handle, formatter.handle);
@@ -210,13 +218,14 @@ class ZonedDateFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
+         */
         fun createLocalizedOffsetShortWithProvider(provider: DataProvider, locale: Locale, formatter: DateFormatter): Result<ZonedDateFormatter> {
             
             val returnVal = lib.icu4x_ZonedDateFormatter_create_localized_offset_short_with_provider_mv1(provider.handle, locale.handle, formatter.handle);
@@ -232,13 +241,14 @@ class ZonedDateFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `GenericLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
+         */
         fun createGenericLong(locale: Locale, formatter: DateFormatter): Result<ZonedDateFormatter> {
             
             val returnVal = lib.icu4x_ZonedDateFormatter_create_generic_long_mv1(locale.handle, formatter.handle);
@@ -254,13 +264,14 @@ class ZonedDateFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `GenericLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
+         */
         fun createGenericLongWithProvider(provider: DataProvider, locale: Locale, formatter: DateFormatter): Result<ZonedDateFormatter> {
             
             val returnVal = lib.icu4x_ZonedDateFormatter_create_generic_long_with_provider_mv1(provider.handle, locale.handle, formatter.handle);
@@ -276,13 +287,14 @@ class ZonedDateFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `GenericShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
+         */
         fun createGenericShort(locale: Locale, formatter: DateFormatter): Result<ZonedDateFormatter> {
             
             val returnVal = lib.icu4x_ZonedDateFormatter_create_generic_short_mv1(locale.handle, formatter.handle);
@@ -298,13 +310,14 @@ class ZonedDateFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `GenericShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
+         */
         fun createGenericShortWithProvider(provider: DataProvider, locale: Locale, formatter: DateFormatter): Result<ZonedDateFormatter> {
             
             val returnVal = lib.icu4x_ZonedDateFormatter_create_generic_short_with_provider_mv1(provider.handle, locale.handle, formatter.handle);
@@ -320,13 +333,14 @@ class ZonedDateFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `Location`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `Location`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
+         */
         fun createLocation(locale: Locale, formatter: DateFormatter): Result<ZonedDateFormatter> {
             
             val returnVal = lib.icu4x_ZonedDateFormatter_create_location_mv1(locale.handle, formatter.handle);
@@ -342,13 +356,14 @@ class ZonedDateFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `Location`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `Location`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
+         */
         fun createLocationWithProvider(provider: DataProvider, locale: Locale, formatter: DateFormatter): Result<ZonedDateFormatter> {
             
             val returnVal = lib.icu4x_ZonedDateFormatter_create_location_with_provider_mv1(provider.handle, locale.handle, formatter.handle);
@@ -364,13 +379,14 @@ class ZonedDateFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
+         */
         fun createExemplarCity(locale: Locale, formatter: DateFormatter): Result<ZonedDateFormatter> {
             
             val returnVal = lib.icu4x_ZonedDateFormatter_create_exemplar_city_mv1(locale.handle, formatter.handle);
@@ -386,13 +402,14 @@ class ZonedDateFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
+         */
         fun createExemplarCityWithProvider(provider: DataProvider, locale: Locale, formatter: DateFormatter): Result<ZonedDateFormatter> {
             
             val returnVal = lib.icu4x_ZonedDateFormatter_create_exemplar_city_with_provider_mv1(provider.handle, locale.handle, formatter.handle);
@@ -408,8 +425,9 @@ class ZonedDateFormatter internal constructor (
         }
     }
     
-    /** See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.format) for more information.
-    */
+    /**
+     * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.format) for more information.
+     */
     fun formatIso(isoDate: IsoDate, zone: TimeZoneInfo): Result<String> {
         val write = DW.lib.diplomat_buffer_write_create(0)
         val returnVal = lib.icu4x_ZonedDateFormatter_format_iso_mv1(handle, isoDate.handle, zone.handle, write);
@@ -423,8 +441,9 @@ class ZonedDateFormatter internal constructor (
         }
     }
     
-    /** See the [Rust documentation for `format_same_calendar`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.format_same_calendar) for more information.
-    */
+    /**
+     * See the [Rust documentation for `format_same_calendar`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.format_same_calendar) for more information.
+     */
     fun formatSameCalendar(date: Date, zone: TimeZoneInfo): Result<String> {
         val write = DW.lib.diplomat_buffer_write_create(0)
         val returnVal = lib.icu4x_ZonedDateFormatter_format_same_calendar_mv1(handle, date.handle, zone.handle, write);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/ZonedDateFormatterGregorian.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/ZonedDateFormatterGregorian.kt
@@ -26,8 +26,9 @@ internal interface ZonedDateFormatterGregorianLib: Library {
     fun icu4x_ZonedDateFormatterGregorian_format_iso_mv1(handle: Pointer, isoDate: Pointer, zone: Pointer, write: Pointer): ResultUnitInt
     fun icu4x_ZonedDateFormatterGregorian_format_same_calendar_mv1(handle: Pointer, date: Pointer, zone: Pointer, write: Pointer): ResultUnitDateTimeMismatchedCalendarErrorNative
 }
-/** See the [Rust documentation for `FixedCalendarDateTimeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `FixedCalendarDateTimeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html) for more information.
+ */
 class ZonedDateFormatterGregorian internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -56,13 +57,14 @@ class ZonedDateFormatterGregorian internal constructor (
         internal val lib: ZonedDateFormatterGregorianLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
+         */
         fun createSpecificLong(locale: Locale, formatter: DateFormatterGregorian): Result<ZonedDateFormatterGregorian> {
             
             val returnVal = lib.icu4x_ZonedDateFormatterGregorian_create_specific_long_mv1(locale.handle, formatter.handle);
@@ -78,13 +80,14 @@ class ZonedDateFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
+         */
         fun createSpecificLongWithProvider(provider: DataProvider, locale: Locale, formatter: DateFormatterGregorian): Result<ZonedDateFormatterGregorian> {
             
             val returnVal = lib.icu4x_ZonedDateFormatterGregorian_create_specific_long_with_provider_mv1(provider.handle, locale.handle, formatter.handle);
@@ -100,13 +103,14 @@ class ZonedDateFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
+         */
         fun createSpecificShort(locale: Locale, formatter: DateFormatterGregorian): Result<ZonedDateFormatterGregorian> {
             
             val returnVal = lib.icu4x_ZonedDateFormatterGregorian_create_specific_short_mv1(locale.handle, formatter.handle);
@@ -122,13 +126,14 @@ class ZonedDateFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
+         */
         fun createSpecificShortWithProvider(provider: DataProvider, locale: Locale, formatter: DateFormatterGregorian): Result<ZonedDateFormatterGregorian> {
             
             val returnVal = lib.icu4x_ZonedDateFormatterGregorian_create_specific_short_with_provider_mv1(provider.handle, locale.handle, formatter.handle);
@@ -144,13 +149,14 @@ class ZonedDateFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
+         */
         fun createLocalizedOffsetLong(locale: Locale, formatter: DateFormatterGregorian): Result<ZonedDateFormatterGregorian> {
             
             val returnVal = lib.icu4x_ZonedDateFormatterGregorian_create_localized_offset_long_mv1(locale.handle, formatter.handle);
@@ -166,13 +172,14 @@ class ZonedDateFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
+         */
         fun createLocalizedOffsetLongWithProvider(provider: DataProvider, locale: Locale, formatter: DateFormatterGregorian): Result<ZonedDateFormatterGregorian> {
             
             val returnVal = lib.icu4x_ZonedDateFormatterGregorian_create_localized_offset_long_with_provider_mv1(provider.handle, locale.handle, formatter.handle);
@@ -188,13 +195,14 @@ class ZonedDateFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
+         */
         fun createLocalizedOffsetShort(locale: Locale, formatter: DateFormatterGregorian): Result<ZonedDateFormatterGregorian> {
             
             val returnVal = lib.icu4x_ZonedDateFormatterGregorian_create_localized_offset_short_mv1(locale.handle, formatter.handle);
@@ -210,13 +218,14 @@ class ZonedDateFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
+         */
         fun createLocalizedOffsetShortWithProvider(provider: DataProvider, locale: Locale, formatter: DateFormatterGregorian): Result<ZonedDateFormatterGregorian> {
             
             val returnVal = lib.icu4x_ZonedDateFormatterGregorian_create_localized_offset_short_with_provider_mv1(provider.handle, locale.handle, formatter.handle);
@@ -232,13 +241,14 @@ class ZonedDateFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `GenericLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
+         */
         fun createGenericLong(locale: Locale, formatter: DateFormatterGregorian): Result<ZonedDateFormatterGregorian> {
             
             val returnVal = lib.icu4x_ZonedDateFormatterGregorian_create_generic_long_mv1(locale.handle, formatter.handle);
@@ -254,13 +264,14 @@ class ZonedDateFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `GenericLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
+         */
         fun createGenericLongWithProvider(provider: DataProvider, locale: Locale, formatter: DateFormatterGregorian): Result<ZonedDateFormatterGregorian> {
             
             val returnVal = lib.icu4x_ZonedDateFormatterGregorian_create_generic_long_with_provider_mv1(provider.handle, locale.handle, formatter.handle);
@@ -276,13 +287,14 @@ class ZonedDateFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `GenericShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
+         */
         fun createGenericShort(locale: Locale, formatter: DateFormatterGregorian): Result<ZonedDateFormatterGregorian> {
             
             val returnVal = lib.icu4x_ZonedDateFormatterGregorian_create_generic_short_mv1(locale.handle, formatter.handle);
@@ -298,13 +310,14 @@ class ZonedDateFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `GenericShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
+         */
         fun createGenericShortWithProvider(provider: DataProvider, locale: Locale, formatter: DateFormatterGregorian): Result<ZonedDateFormatterGregorian> {
             
             val returnVal = lib.icu4x_ZonedDateFormatterGregorian_create_generic_short_with_provider_mv1(provider.handle, locale.handle, formatter.handle);
@@ -320,13 +333,14 @@ class ZonedDateFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `Location`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `Location`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
+         */
         fun createLocation(locale: Locale, formatter: DateFormatterGregorian): Result<ZonedDateFormatterGregorian> {
             
             val returnVal = lib.icu4x_ZonedDateFormatterGregorian_create_location_mv1(locale.handle, formatter.handle);
@@ -342,13 +356,14 @@ class ZonedDateFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `Location`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `Location`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
+         */
         fun createLocationWithProvider(provider: DataProvider, locale: Locale, formatter: DateFormatterGregorian): Result<ZonedDateFormatterGregorian> {
             
             val returnVal = lib.icu4x_ZonedDateFormatterGregorian_create_location_with_provider_mv1(provider.handle, locale.handle, formatter.handle);
@@ -364,13 +379,14 @@ class ZonedDateFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
+         */
         fun createExemplarCity(locale: Locale, formatter: DateFormatterGregorian): Result<ZonedDateFormatterGregorian> {
             
             val returnVal = lib.icu4x_ZonedDateFormatterGregorian_create_exemplar_city_mv1(locale.handle, formatter.handle);
@@ -386,13 +402,14 @@ class ZonedDateFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
+         */
         fun createExemplarCityWithProvider(provider: DataProvider, locale: Locale, formatter: DateFormatterGregorian): Result<ZonedDateFormatterGregorian> {
             
             val returnVal = lib.icu4x_ZonedDateFormatterGregorian_create_exemplar_city_with_provider_mv1(provider.handle, locale.handle, formatter.handle);
@@ -408,8 +425,9 @@ class ZonedDateFormatterGregorian internal constructor (
         }
     }
     
-    /** See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.format) for more information.
-    */
+    /**
+     * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.format) for more information.
+     */
     fun formatIso(isoDate: IsoDate, zone: TimeZoneInfo): Result<String> {
         val write = DW.lib.diplomat_buffer_write_create(0)
         val returnVal = lib.icu4x_ZonedDateFormatterGregorian_format_iso_mv1(handle, isoDate.handle, zone.handle, write);
@@ -423,8 +441,9 @@ class ZonedDateFormatterGregorian internal constructor (
         }
     }
     
-    /** See the [Rust documentation for `format_same_calendar`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.format_same_calendar) for more information.
-    */
+    /**
+     * See the [Rust documentation for `format_same_calendar`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.format_same_calendar) for more information.
+     */
     fun formatSameCalendar(date: Date, zone: TimeZoneInfo): Result<String> {
         val write = DW.lib.diplomat_buffer_write_create(0)
         val returnVal = lib.icu4x_ZonedDateFormatterGregorian_format_same_calendar_mv1(handle, date.handle, zone.handle, write);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/ZonedDateTime.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/ZonedDateTime.kt
@@ -69,10 +69,11 @@ internal class OptionZonedDateTimeNative constructor(): Structure(), Structure.B
 
 }
 
-/** An ICU4X `DateTime` object capable of containing a date, time, and zone for any calendar.
-*
-*See the [Rust documentation for `ZonedDateTime`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedDateTime.html) for more information.
-*/
+/**
+ * An ICU4X `DateTime` object capable of containing a date, time, and zone for any calendar.
+ *
+ * See the [Rust documentation for `ZonedDateTime`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedDateTime.html) for more information.
+ */
 class ZonedDateTime (var date: Date, var time: Time, var zone: TimeZoneInfo) {
     companion object {
 
@@ -90,10 +91,11 @@ class ZonedDateTime (var date: Date, var time: Time, var zone: TimeZoneInfo) {
 
         @JvmStatic
         
-        /** Creates a new [ZonedIsoDateTime] from an IXDTF string.
-        *
-        *See the [Rust documentation for `try_strict_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedDateTime.html#method.try_strict_from_str) for more information.
-        */
+        /**
+         * Creates a new [ZonedIsoDateTime] from an IXDTF string.
+         *
+         * See the [Rust documentation for `try_strict_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedDateTime.html#method.try_strict_from_str) for more information.
+         */
         fun strictFromString(v: String, calendar: Calendar, ianaParser: IanaParser): Result<ZonedDateTime> {
             val vSliceMemory = PrimitiveArrayTools.borrowUtf8(v)
             
@@ -112,10 +114,11 @@ class ZonedDateTime (var date: Date, var time: Time, var zone: TimeZoneInfo) {
         }
         @JvmStatic
         
-        /** Creates a new [ZonedDateTime] from an IXDTF string.
-        *
-        *See the [Rust documentation for `try_full_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedDateTime.html#method.try_full_from_str) for more information.
-        */
+        /**
+         * Creates a new [ZonedDateTime] from an IXDTF string.
+         *
+         * See the [Rust documentation for `try_full_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedDateTime.html#method.try_full_from_str) for more information.
+         */
         fun fullFromString(v: String, calendar: Calendar, ianaParser: IanaParser, offsetCalculator: VariantOffsetsCalculator): Result<ZonedDateTime> {
             val vSliceMemory = PrimitiveArrayTools.borrowUtf8(v)
             
@@ -134,10 +137,11 @@ class ZonedDateTime (var date: Date, var time: Time, var zone: TimeZoneInfo) {
         }
         @JvmStatic
         
-        /** Creates a new [ZonedDateTime] from a location-only IXDTF string.
-        *
-        *See the [Rust documentation for `try_location_only_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedDateTime.html#method.try_location_only_from_str) for more information.
-        */
+        /**
+         * Creates a new [ZonedDateTime] from a location-only IXDTF string.
+         *
+         * See the [Rust documentation for `try_location_only_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedDateTime.html#method.try_location_only_from_str) for more information.
+         */
         fun locationOnlyFromString(v: String, calendar: Calendar, ianaParser: IanaParser): Result<ZonedDateTime> {
             val vSliceMemory = PrimitiveArrayTools.borrowUtf8(v)
             
@@ -156,10 +160,11 @@ class ZonedDateTime (var date: Date, var time: Time, var zone: TimeZoneInfo) {
         }
         @JvmStatic
         
-        /** Creates a new [ZonedDateTime] from an offset-only IXDTF string.
-        *
-        *See the [Rust documentation for `try_offset_only_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedDateTime.html#method.try_offset_only_from_str) for more information.
-        */
+        /**
+         * Creates a new [ZonedDateTime] from an offset-only IXDTF string.
+         *
+         * See the [Rust documentation for `try_offset_only_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedDateTime.html#method.try_offset_only_from_str) for more information.
+         */
         fun offsetOnlyFromString(v: String, calendar: Calendar): Result<ZonedDateTime> {
             val vSliceMemory = PrimitiveArrayTools.borrowUtf8(v)
             
@@ -178,10 +183,11 @@ class ZonedDateTime (var date: Date, var time: Time, var zone: TimeZoneInfo) {
         }
         @JvmStatic
         
-        /** Creates a new [ZonedDateTime] from an IXDTF string, without requiring the offset.
-        *
-        *See the [Rust documentation for `try_lenient_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedDateTime.html#method.try_lenient_from_str) for more information.
-        */
+        /**
+         * Creates a new [ZonedDateTime] from an IXDTF string, without requiring the offset.
+         *
+         * See the [Rust documentation for `try_lenient_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedDateTime.html#method.try_lenient_from_str) for more information.
+         */
         fun lenientFromString(v: String, calendar: Calendar, ianaParser: IanaParser): Result<ZonedDateTime> {
             val vSliceMemory = PrimitiveArrayTools.borrowUtf8(v)
             

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/ZonedDateTimeFormatter.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/ZonedDateTimeFormatter.kt
@@ -26,8 +26,9 @@ internal interface ZonedDateTimeFormatterLib: Library {
     fun icu4x_ZonedDateTimeFormatter_format_iso_mv1(handle: Pointer, isoDate: Pointer, time: Pointer, zone: Pointer, write: Pointer): ResultUnitInt
     fun icu4x_ZonedDateTimeFormatter_format_same_calendar_mv1(handle: Pointer, date: Pointer, time: Pointer, zone: Pointer, write: Pointer): ResultUnitDateTimeMismatchedCalendarErrorNative
 }
-/** See the [Rust documentation for `DateTimeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `DateTimeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html) for more information.
+ */
 class ZonedDateTimeFormatter internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -56,13 +57,14 @@ class ZonedDateTimeFormatter internal constructor (
         internal val lib: ZonedDateTimeFormatterLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
+         */
         fun createSpecificLong(locale: Locale, formatter: DateTimeFormatter): Result<ZonedDateTimeFormatter> {
             
             val returnVal = lib.icu4x_ZonedDateTimeFormatter_create_specific_long_mv1(locale.handle, formatter.handle);
@@ -78,13 +80,14 @@ class ZonedDateTimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
+         */
         fun createSpecificLongWithProvider(provider: DataProvider, locale: Locale, formatter: DateTimeFormatter): Result<ZonedDateTimeFormatter> {
             
             val returnVal = lib.icu4x_ZonedDateTimeFormatter_create_specific_long_with_provider_mv1(provider.handle, locale.handle, formatter.handle);
@@ -100,13 +103,14 @@ class ZonedDateTimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
+         */
         fun createSpecificShort(locale: Locale, formatter: DateTimeFormatter): Result<ZonedDateTimeFormatter> {
             
             val returnVal = lib.icu4x_ZonedDateTimeFormatter_create_specific_short_mv1(locale.handle, formatter.handle);
@@ -122,13 +126,14 @@ class ZonedDateTimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
+         */
         fun createSpecificShortWithProvider(provider: DataProvider, locale: Locale, formatter: DateTimeFormatter): Result<ZonedDateTimeFormatter> {
             
             val returnVal = lib.icu4x_ZonedDateTimeFormatter_create_specific_short_with_provider_mv1(provider.handle, locale.handle, formatter.handle);
@@ -144,13 +149,14 @@ class ZonedDateTimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
+         */
         fun createLocalizedOffsetLong(locale: Locale, formatter: DateTimeFormatter): Result<ZonedDateTimeFormatter> {
             
             val returnVal = lib.icu4x_ZonedDateTimeFormatter_create_localized_offset_long_mv1(locale.handle, formatter.handle);
@@ -166,13 +172,14 @@ class ZonedDateTimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
+         */
         fun createLocalizedOffsetLongWithProvider(provider: DataProvider, locale: Locale, formatter: DateTimeFormatter): Result<ZonedDateTimeFormatter> {
             
             val returnVal = lib.icu4x_ZonedDateTimeFormatter_create_localized_offset_long_with_provider_mv1(provider.handle, locale.handle, formatter.handle);
@@ -188,13 +195,14 @@ class ZonedDateTimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
+         */
         fun createLocalizedOffsetShort(locale: Locale, formatter: DateTimeFormatter): Result<ZonedDateTimeFormatter> {
             
             val returnVal = lib.icu4x_ZonedDateTimeFormatter_create_localized_offset_short_mv1(locale.handle, formatter.handle);
@@ -210,13 +218,14 @@ class ZonedDateTimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
+         */
         fun createLocalizedOffsetShortWithProvider(provider: DataProvider, locale: Locale, formatter: DateTimeFormatter): Result<ZonedDateTimeFormatter> {
             
             val returnVal = lib.icu4x_ZonedDateTimeFormatter_create_localized_offset_short_with_provider_mv1(provider.handle, locale.handle, formatter.handle);
@@ -232,13 +241,14 @@ class ZonedDateTimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `GenericLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
+         */
         fun createGenericLong(locale: Locale, formatter: DateTimeFormatter): Result<ZonedDateTimeFormatter> {
             
             val returnVal = lib.icu4x_ZonedDateTimeFormatter_create_generic_long_mv1(locale.handle, formatter.handle);
@@ -254,13 +264,14 @@ class ZonedDateTimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `GenericLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
+         */
         fun createGenericLongWithProvider(provider: DataProvider, locale: Locale, formatter: DateTimeFormatter): Result<ZonedDateTimeFormatter> {
             
             val returnVal = lib.icu4x_ZonedDateTimeFormatter_create_generic_long_with_provider_mv1(provider.handle, locale.handle, formatter.handle);
@@ -276,13 +287,14 @@ class ZonedDateTimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `GenericShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
+         */
         fun createGenericShort(locale: Locale, formatter: DateTimeFormatter): Result<ZonedDateTimeFormatter> {
             
             val returnVal = lib.icu4x_ZonedDateTimeFormatter_create_generic_short_mv1(locale.handle, formatter.handle);
@@ -298,13 +310,14 @@ class ZonedDateTimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `GenericShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
+         */
         fun createGenericShortWithProvider(provider: DataProvider, locale: Locale, formatter: DateTimeFormatter): Result<ZonedDateTimeFormatter> {
             
             val returnVal = lib.icu4x_ZonedDateTimeFormatter_create_generic_short_with_provider_mv1(provider.handle, locale.handle, formatter.handle);
@@ -320,13 +333,14 @@ class ZonedDateTimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `Location`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `Location`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
+         */
         fun createLocation(locale: Locale, formatter: DateTimeFormatter): Result<ZonedDateTimeFormatter> {
             
             val returnVal = lib.icu4x_ZonedDateTimeFormatter_create_location_mv1(locale.handle, formatter.handle);
@@ -342,13 +356,14 @@ class ZonedDateTimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `Location`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `Location`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
+         */
         fun createLocationWithProvider(provider: DataProvider, locale: Locale, formatter: DateTimeFormatter): Result<ZonedDateTimeFormatter> {
             
             val returnVal = lib.icu4x_ZonedDateTimeFormatter_create_location_with_provider_mv1(provider.handle, locale.handle, formatter.handle);
@@ -364,13 +379,14 @@ class ZonedDateTimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
+         */
         fun createExemplarCity(locale: Locale, formatter: DateTimeFormatter): Result<ZonedDateTimeFormatter> {
             
             val returnVal = lib.icu4x_ZonedDateTimeFormatter_create_exemplar_city_mv1(locale.handle, formatter.handle);
@@ -386,13 +402,14 @@ class ZonedDateTimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
+         */
         fun createExemplarCityWithProvider(provider: DataProvider, locale: Locale, formatter: DateTimeFormatter): Result<ZonedDateTimeFormatter> {
             
             val returnVal = lib.icu4x_ZonedDateTimeFormatter_create_exemplar_city_with_provider_mv1(provider.handle, locale.handle, formatter.handle);
@@ -408,8 +425,9 @@ class ZonedDateTimeFormatter internal constructor (
         }
     }
     
-    /** See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.format) for more information.
-    */
+    /**
+     * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.format) for more information.
+     */
     fun formatIso(isoDate: IsoDate, time: Time, zone: TimeZoneInfo): Result<String> {
         val write = DW.lib.diplomat_buffer_write_create(0)
         val returnVal = lib.icu4x_ZonedDateTimeFormatter_format_iso_mv1(handle, isoDate.handle, time.handle, zone.handle, write);
@@ -423,8 +441,9 @@ class ZonedDateTimeFormatter internal constructor (
         }
     }
     
-    /** See the [Rust documentation for `format_same_calendar`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.format_same_calendar) for more information.
-    */
+    /**
+     * See the [Rust documentation for `format_same_calendar`](https://docs.rs/icu/2.3.1/icu/datetime/struct.DateTimeFormatter.html#method.format_same_calendar) for more information.
+     */
     fun formatSameCalendar(date: Date, time: Time, zone: TimeZoneInfo): Result<String> {
         val write = DW.lib.diplomat_buffer_write_create(0)
         val returnVal = lib.icu4x_ZonedDateTimeFormatter_format_same_calendar_mv1(handle, date.handle, time.handle, zone.handle, write);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/ZonedDateTimeFormatterGregorian.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/ZonedDateTimeFormatterGregorian.kt
@@ -26,8 +26,9 @@ internal interface ZonedDateTimeFormatterGregorianLib: Library {
     fun icu4x_ZonedDateTimeFormatterGregorian_format_iso_mv1(handle: Pointer, isoDate: Pointer, time: Pointer, zone: Pointer, write: Pointer): ResultUnitInt
     fun icu4x_ZonedDateTimeFormatterGregorian_format_same_calendar_mv1(handle: Pointer, date: Pointer, time: Pointer, zone: Pointer, write: Pointer): ResultUnitDateTimeMismatchedCalendarErrorNative
 }
-/** See the [Rust documentation for `FixedCalendarDateTimeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `FixedCalendarDateTimeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html) for more information.
+ */
 class ZonedDateTimeFormatterGregorian internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -56,13 +57,14 @@ class ZonedDateTimeFormatterGregorian internal constructor (
         internal val lib: ZonedDateTimeFormatterGregorianLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
+         */
         fun createSpecificLong(locale: Locale, formatter: DateTimeFormatterGregorian): Result<ZonedDateTimeFormatterGregorian> {
             
             val returnVal = lib.icu4x_ZonedDateTimeFormatterGregorian_create_specific_long_mv1(locale.handle, formatter.handle);
@@ -78,13 +80,14 @@ class ZonedDateTimeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
+         */
         fun createSpecificLongWithProvider(provider: DataProvider, locale: Locale, formatter: DateTimeFormatterGregorian): Result<ZonedDateTimeFormatterGregorian> {
             
             val returnVal = lib.icu4x_ZonedDateTimeFormatterGregorian_create_specific_long_with_provider_mv1(provider.handle, locale.handle, formatter.handle);
@@ -100,13 +103,14 @@ class ZonedDateTimeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
+         */
         fun createSpecificShort(locale: Locale, formatter: DateTimeFormatterGregorian): Result<ZonedDateTimeFormatterGregorian> {
             
             val returnVal = lib.icu4x_ZonedDateTimeFormatterGregorian_create_specific_short_mv1(locale.handle, formatter.handle);
@@ -122,13 +126,14 @@ class ZonedDateTimeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
+         */
         fun createSpecificShortWithProvider(provider: DataProvider, locale: Locale, formatter: DateTimeFormatterGregorian): Result<ZonedDateTimeFormatterGregorian> {
             
             val returnVal = lib.icu4x_ZonedDateTimeFormatterGregorian_create_specific_short_with_provider_mv1(provider.handle, locale.handle, formatter.handle);
@@ -144,13 +149,14 @@ class ZonedDateTimeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
+         */
         fun createLocalizedOffsetLong(locale: Locale, formatter: DateTimeFormatterGregorian): Result<ZonedDateTimeFormatterGregorian> {
             
             val returnVal = lib.icu4x_ZonedDateTimeFormatterGregorian_create_localized_offset_long_mv1(locale.handle, formatter.handle);
@@ -166,13 +172,14 @@ class ZonedDateTimeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
+         */
         fun createLocalizedOffsetLongWithProvider(provider: DataProvider, locale: Locale, formatter: DateTimeFormatterGregorian): Result<ZonedDateTimeFormatterGregorian> {
             
             val returnVal = lib.icu4x_ZonedDateTimeFormatterGregorian_create_localized_offset_long_with_provider_mv1(provider.handle, locale.handle, formatter.handle);
@@ -188,13 +195,14 @@ class ZonedDateTimeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
+         */
         fun createLocalizedOffsetShort(locale: Locale, formatter: DateTimeFormatterGregorian): Result<ZonedDateTimeFormatterGregorian> {
             
             val returnVal = lib.icu4x_ZonedDateTimeFormatterGregorian_create_localized_offset_short_mv1(locale.handle, formatter.handle);
@@ -210,13 +218,14 @@ class ZonedDateTimeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
+         */
         fun createLocalizedOffsetShortWithProvider(provider: DataProvider, locale: Locale, formatter: DateTimeFormatterGregorian): Result<ZonedDateTimeFormatterGregorian> {
             
             val returnVal = lib.icu4x_ZonedDateTimeFormatterGregorian_create_localized_offset_short_with_provider_mv1(provider.handle, locale.handle, formatter.handle);
@@ -232,13 +241,14 @@ class ZonedDateTimeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `GenericLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
+         */
         fun createGenericLong(locale: Locale, formatter: DateTimeFormatterGregorian): Result<ZonedDateTimeFormatterGregorian> {
             
             val returnVal = lib.icu4x_ZonedDateTimeFormatterGregorian_create_generic_long_mv1(locale.handle, formatter.handle);
@@ -254,13 +264,14 @@ class ZonedDateTimeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `GenericLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
+         */
         fun createGenericLongWithProvider(provider: DataProvider, locale: Locale, formatter: DateTimeFormatterGregorian): Result<ZonedDateTimeFormatterGregorian> {
             
             val returnVal = lib.icu4x_ZonedDateTimeFormatterGregorian_create_generic_long_with_provider_mv1(provider.handle, locale.handle, formatter.handle);
@@ -276,13 +287,14 @@ class ZonedDateTimeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `GenericShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
+         */
         fun createGenericShort(locale: Locale, formatter: DateTimeFormatterGregorian): Result<ZonedDateTimeFormatterGregorian> {
             
             val returnVal = lib.icu4x_ZonedDateTimeFormatterGregorian_create_generic_short_mv1(locale.handle, formatter.handle);
@@ -298,13 +310,14 @@ class ZonedDateTimeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `GenericShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
+         */
         fun createGenericShortWithProvider(provider: DataProvider, locale: Locale, formatter: DateTimeFormatterGregorian): Result<ZonedDateTimeFormatterGregorian> {
             
             val returnVal = lib.icu4x_ZonedDateTimeFormatterGregorian_create_generic_short_with_provider_mv1(provider.handle, locale.handle, formatter.handle);
@@ -320,13 +333,14 @@ class ZonedDateTimeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `Location`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `Location`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
+         */
         fun createLocation(locale: Locale, formatter: DateTimeFormatterGregorian): Result<ZonedDateTimeFormatterGregorian> {
             
             val returnVal = lib.icu4x_ZonedDateTimeFormatterGregorian_create_location_mv1(locale.handle, formatter.handle);
@@ -342,13 +356,14 @@ class ZonedDateTimeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `Location`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `Location`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
+         */
         fun createLocationWithProvider(provider: DataProvider, locale: Locale, formatter: DateTimeFormatterGregorian): Result<ZonedDateTimeFormatterGregorian> {
             
             val returnVal = lib.icu4x_ZonedDateTimeFormatterGregorian_create_location_with_provider_mv1(provider.handle, locale.handle, formatter.handle);
@@ -364,13 +379,14 @@ class ZonedDateTimeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
+         */
         fun createExemplarCity(locale: Locale, formatter: DateTimeFormatterGregorian): Result<ZonedDateTimeFormatterGregorian> {
             
             val returnVal = lib.icu4x_ZonedDateTimeFormatterGregorian_create_exemplar_city_mv1(locale.handle, formatter.handle);
@@ -386,13 +402,14 @@ class ZonedDateTimeFormatterGregorian internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
+         */
         fun createExemplarCityWithProvider(provider: DataProvider, locale: Locale, formatter: DateTimeFormatterGregorian): Result<ZonedDateTimeFormatterGregorian> {
             
             val returnVal = lib.icu4x_ZonedDateTimeFormatterGregorian_create_exemplar_city_with_provider_mv1(provider.handle, locale.handle, formatter.handle);
@@ -408,8 +425,9 @@ class ZonedDateTimeFormatterGregorian internal constructor (
         }
     }
     
-    /** See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.format) for more information.
-    */
+    /**
+     * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.format) for more information.
+     */
     fun formatIso(isoDate: IsoDate, time: Time, zone: TimeZoneInfo): Result<String> {
         val write = DW.lib.diplomat_buffer_write_create(0)
         val returnVal = lib.icu4x_ZonedDateTimeFormatterGregorian_format_iso_mv1(handle, isoDate.handle, time.handle, zone.handle, write);
@@ -423,8 +441,9 @@ class ZonedDateTimeFormatterGregorian internal constructor (
         }
     }
     
-    /** See the [Rust documentation for `format_same_calendar`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.format_same_calendar) for more information.
-    */
+    /**
+     * See the [Rust documentation for `format_same_calendar`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.format_same_calendar) for more information.
+     */
     fun formatSameCalendar(date: Date, time: Time, zone: TimeZoneInfo): Result<String> {
         val write = DW.lib.diplomat_buffer_write_create(0)
         val returnVal = lib.icu4x_ZonedDateTimeFormatterGregorian_format_same_calendar_mv1(handle, date.handle, time.handle, zone.handle, write);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/ZonedIsoDateTime.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/ZonedIsoDateTime.kt
@@ -67,10 +67,11 @@ internal class OptionZonedIsoDateTimeNative constructor(): Structure(), Structur
 
 }
 
-/** An ICU4X `ZonedDateTime` object capable of containing a ISO-8601 date, time, and zone.
-*
-*See the [Rust documentation for `ZonedDateTime`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedDateTime.html) for more information.
-*/
+/**
+ * An ICU4X `ZonedDateTime` object capable of containing a ISO-8601 date, time, and zone.
+ *
+ * See the [Rust documentation for `ZonedDateTime`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedDateTime.html) for more information.
+ */
 class ZonedIsoDateTime (var date: IsoDate, var time: Time, var zone: TimeZoneInfo) {
     companion object {
 
@@ -88,10 +89,11 @@ class ZonedIsoDateTime (var date: IsoDate, var time: Time, var zone: TimeZoneInf
 
         @JvmStatic
         
-        /** Creates a new [ZonedIsoDateTime] from an IXDTF string.
-        *
-        *See the [Rust documentation for `try_strict_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedDateTime.html#method.try_strict_from_str) for more information.
-        */
+        /**
+         * Creates a new [ZonedIsoDateTime] from an IXDTF string.
+         *
+         * See the [Rust documentation for `try_strict_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedDateTime.html#method.try_strict_from_str) for more information.
+         */
         fun strictFromString(v: String, ianaParser: IanaParser): Result<ZonedIsoDateTime> {
             val vSliceMemory = PrimitiveArrayTools.borrowUtf8(v)
             
@@ -110,10 +112,11 @@ class ZonedIsoDateTime (var date: IsoDate, var time: Time, var zone: TimeZoneInf
         }
         @JvmStatic
         
-        /** Creates a new [ZonedIsoDateTime] from an IXDTF string.
-        *
-        *See the [Rust documentation for `try_full_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedDateTime.html#method.try_full_from_str) for more information.
-        */
+        /**
+         * Creates a new [ZonedIsoDateTime] from an IXDTF string.
+         *
+         * See the [Rust documentation for `try_full_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedDateTime.html#method.try_full_from_str) for more information.
+         */
         fun fullFromString(v: String, ianaParser: IanaParser, offsetCalculator: VariantOffsetsCalculator): Result<ZonedIsoDateTime> {
             val vSliceMemory = PrimitiveArrayTools.borrowUtf8(v)
             
@@ -132,12 +135,13 @@ class ZonedIsoDateTime (var date: IsoDate, var time: Time, var zone: TimeZoneInf
         }
         @JvmStatic
         
-        /** Creates a new [ZonedIsoDateTime] from milliseconds since epoch (timestamp) and a UTC offset.
-        *
-        *Note: [ZonedIsoDateTime]s created with this constructor can only be formatted using localized offset zone styles.
-        *
-        *See the [Rust documentation for `from_epoch_milliseconds_and_utc_offset`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedDateTime.html#method.from_epoch_milliseconds_and_utc_offset) for more information.
-        */
+        /**
+         * Creates a new [ZonedIsoDateTime] from milliseconds since epoch (timestamp) and a UTC offset.
+         *
+         * Note: [ZonedIsoDateTime]s created with this constructor can only be formatted using localized offset zone styles.
+         *
+         * See the [Rust documentation for `from_epoch_milliseconds_and_utc_offset`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedDateTime.html#method.from_epoch_milliseconds_and_utc_offset) for more information.
+         */
         fun fromEpochMillisecondsAndUtcOffset(epochMilliseconds: Long, utcOffset: UtcOffset): ZonedIsoDateTime {
             
             val returnVal = lib.icu4x_ZonedIsoDateTime_from_epoch_milliseconds_and_utc_offset_mv1(epochMilliseconds, utcOffset.handle);

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/ZonedTime.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/ZonedTime.kt
@@ -70,6 +70,8 @@ internal class OptionZonedTimeNative constructor(): Structure(), Structure.ByVal
  * An ICU4X `ZonedTime` object capable of containing a ISO-8601 time, and zone.
  *
  * See the [Rust documentation for `ZonedTime`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedTime.html) for more information.
+ *
+ * 🚧 This API is unstable and may experience breaking changes outside major releases.
  */
 class ZonedTime (var time: Time, var zone: TimeZoneInfo) {
     companion object {
@@ -91,6 +93,8 @@ class ZonedTime (var time: Time, var zone: TimeZoneInfo) {
          * Creates a new [ZonedTime] from an IXDTF string.
          *
          * See the [Rust documentation for `try_strict_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedTime.html#method.try_strict_from_str) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun strictFromString(v: String, ianaParser: IanaParser): Result<ZonedTime> {
             val vSliceMemory = PrimitiveArrayTools.borrowUtf8(v)
@@ -114,6 +118,8 @@ class ZonedTime (var time: Time, var zone: TimeZoneInfo) {
          * Creates a new [ZonedTime] from a location-only IXDTF string.
          *
          * See the [Rust documentation for `try_location_only_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedTime.html#method.try_location_only_from_str) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun locationOnlyFromString(v: String, ianaParser: IanaParser): Result<ZonedTime> {
             val vSliceMemory = PrimitiveArrayTools.borrowUtf8(v)
@@ -137,6 +143,8 @@ class ZonedTime (var time: Time, var zone: TimeZoneInfo) {
          * Creates a new [ZonedTime] from an offset-only IXDTF string.
          *
          * See the [Rust documentation for `try_offset_only_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedTime.html#method.try_offset_only_from_str) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun offsetOnlyFromString(v: String): Result<ZonedTime> {
             val vSliceMemory = PrimitiveArrayTools.borrowUtf8(v)
@@ -160,6 +168,8 @@ class ZonedTime (var time: Time, var zone: TimeZoneInfo) {
          * Creates a new [ZonedTime] from an IXDTF string, without requiring the offset.
          *
          * See the [Rust documentation for `try_lenient_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedTime.html#method.try_lenient_from_str) for more information.
+         *
+         * 🚧 This API is unstable and may experience breaking changes outside major releases.
          */
         fun lenientFromString(v: String, ianaParser: IanaParser): Result<ZonedTime> {
             val vSliceMemory = PrimitiveArrayTools.borrowUtf8(v)

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/ZonedTime.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/ZonedTime.kt
@@ -66,10 +66,11 @@ internal class OptionZonedTimeNative constructor(): Structure(), Structure.ByVal
 
 }
 
-/** An ICU4X `ZonedTime` object capable of containing a ISO-8601 time, and zone.
-*
-*See the [Rust documentation for `ZonedTime`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedTime.html) for more information.
-*/
+/**
+ * An ICU4X `ZonedTime` object capable of containing a ISO-8601 time, and zone.
+ *
+ * See the [Rust documentation for `ZonedTime`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedTime.html) for more information.
+ */
 class ZonedTime (var time: Time, var zone: TimeZoneInfo) {
     companion object {
 
@@ -86,10 +87,11 @@ class ZonedTime (var time: Time, var zone: TimeZoneInfo) {
 
         @JvmStatic
         
-        /** Creates a new [ZonedTime] from an IXDTF string.
-        *
-        *See the [Rust documentation for `try_strict_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedTime.html#method.try_strict_from_str) for more information.
-        */
+        /**
+         * Creates a new [ZonedTime] from an IXDTF string.
+         *
+         * See the [Rust documentation for `try_strict_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedTime.html#method.try_strict_from_str) for more information.
+         */
         fun strictFromString(v: String, ianaParser: IanaParser): Result<ZonedTime> {
             val vSliceMemory = PrimitiveArrayTools.borrowUtf8(v)
             
@@ -108,10 +110,11 @@ class ZonedTime (var time: Time, var zone: TimeZoneInfo) {
         }
         @JvmStatic
         
-        /** Creates a new [ZonedTime] from a location-only IXDTF string.
-        *
-        *See the [Rust documentation for `try_location_only_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedTime.html#method.try_location_only_from_str) for more information.
-        */
+        /**
+         * Creates a new [ZonedTime] from a location-only IXDTF string.
+         *
+         * See the [Rust documentation for `try_location_only_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedTime.html#method.try_location_only_from_str) for more information.
+         */
         fun locationOnlyFromString(v: String, ianaParser: IanaParser): Result<ZonedTime> {
             val vSliceMemory = PrimitiveArrayTools.borrowUtf8(v)
             
@@ -130,10 +133,11 @@ class ZonedTime (var time: Time, var zone: TimeZoneInfo) {
         }
         @JvmStatic
         
-        /** Creates a new [ZonedTime] from an offset-only IXDTF string.
-        *
-        *See the [Rust documentation for `try_offset_only_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedTime.html#method.try_offset_only_from_str) for more information.
-        */
+        /**
+         * Creates a new [ZonedTime] from an offset-only IXDTF string.
+         *
+         * See the [Rust documentation for `try_offset_only_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedTime.html#method.try_offset_only_from_str) for more information.
+         */
         fun offsetOnlyFromString(v: String): Result<ZonedTime> {
             val vSliceMemory = PrimitiveArrayTools.borrowUtf8(v)
             
@@ -152,10 +156,11 @@ class ZonedTime (var time: Time, var zone: TimeZoneInfo) {
         }
         @JvmStatic
         
-        /** Creates a new [ZonedTime] from an IXDTF string, without requiring the offset.
-        *
-        *See the [Rust documentation for `try_lenient_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedTime.html#method.try_lenient_from_str) for more information.
-        */
+        /**
+         * Creates a new [ZonedTime] from an IXDTF string, without requiring the offset.
+         *
+         * See the [Rust documentation for `try_lenient_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedTime.html#method.try_lenient_from_str) for more information.
+         */
         fun lenientFromString(v: String, ianaParser: IanaParser): Result<ZonedTime> {
             val vSliceMemory = PrimitiveArrayTools.borrowUtf8(v)
             

--- a/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/ZonedTimeFormatter.kt
+++ b/ffi/mvn/src/main/kotlin/src/main/kotlin/org/unicode/icu4x/ZonedTimeFormatter.kt
@@ -25,8 +25,9 @@ internal interface ZonedTimeFormatterLib: Library {
     fun icu4x_ZonedTimeFormatter_create_exemplar_city_with_provider_mv1(provider: Pointer, locale: Pointer, length: OptionInt, timePrecision: OptionInt, alignment: OptionInt): ResultPointerInt
     fun icu4x_ZonedTimeFormatter_format_mv1(handle: Pointer, time: Pointer, zone: Pointer, write: Pointer): ResultUnitInt
 }
-/** See the [Rust documentation for `NoCalendarFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/type.NoCalendarFormatter.html) for more information.
-*/
+/**
+ * See the [Rust documentation for `NoCalendarFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/type.NoCalendarFormatter.html) for more information.
+ */
 class ZonedTimeFormatter internal constructor (
     internal val handle: Pointer,
     // These ensure that anything that is borrowed is kept alive and not cleaned
@@ -55,13 +56,14 @@ class ZonedTimeFormatter internal constructor (
         internal val lib: ZonedTimeFormatterLib = Native.load("icu4x", libClass)
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
+         */
         fun createSpecificLong(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<ZonedTimeFormatter> {
             
             val returnVal = lib.icu4x_ZonedTimeFormatter_create_specific_long_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -77,13 +79,14 @@ class ZonedTimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `SpecificLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificLong.html) for more information.
+         */
         fun createSpecificLongWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<ZonedTimeFormatter> {
             
             val returnVal = lib.icu4x_ZonedTimeFormatter_create_specific_long_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -99,13 +102,14 @@ class ZonedTimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
+         */
         fun createSpecificShort(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<ZonedTimeFormatter> {
             
             val returnVal = lib.icu4x_ZonedTimeFormatter_create_specific_short_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -121,13 +125,14 @@ class ZonedTimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `SpecificShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.SpecificShort.html) for more information.
+         */
         fun createSpecificShortWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<ZonedTimeFormatter> {
             
             val returnVal = lib.icu4x_ZonedTimeFormatter_create_specific_short_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -143,13 +148,14 @@ class ZonedTimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
+         */
         fun createLocalizedOffsetLong(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<ZonedTimeFormatter> {
             
             val returnVal = lib.icu4x_ZonedTimeFormatter_create_localized_offset_long_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -165,13 +171,14 @@ class ZonedTimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `LocalizedOffsetLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetLong.html) for more information.
+         */
         fun createLocalizedOffsetLongWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<ZonedTimeFormatter> {
             
             val returnVal = lib.icu4x_ZonedTimeFormatter_create_localized_offset_long_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -187,13 +194,14 @@ class ZonedTimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
+         */
         fun createLocalizedOffsetShort(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<ZonedTimeFormatter> {
             
             val returnVal = lib.icu4x_ZonedTimeFormatter_create_localized_offset_short_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -209,13 +217,14 @@ class ZonedTimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `LocalizedOffsetShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.LocalizedOffsetShort.html) for more information.
+         */
         fun createLocalizedOffsetShortWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<ZonedTimeFormatter> {
             
             val returnVal = lib.icu4x_ZonedTimeFormatter_create_localized_offset_short_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -231,13 +240,14 @@ class ZonedTimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `GenericLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
+         */
         fun createGenericLong(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<ZonedTimeFormatter> {
             
             val returnVal = lib.icu4x_ZonedTimeFormatter_create_generic_long_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -253,13 +263,14 @@ class ZonedTimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `GenericLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `GenericLong`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericLong.html) for more information.
+         */
         fun createGenericLongWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<ZonedTimeFormatter> {
             
             val returnVal = lib.icu4x_ZonedTimeFormatter_create_generic_long_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -275,13 +286,14 @@ class ZonedTimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `GenericShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
+         */
         fun createGenericShort(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<ZonedTimeFormatter> {
             
             val returnVal = lib.icu4x_ZonedTimeFormatter_create_generic_short_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -297,13 +309,14 @@ class ZonedTimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `GenericShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `GenericShort`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.GenericShort.html) for more information.
+         */
         fun createGenericShortWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<ZonedTimeFormatter> {
             
             val returnVal = lib.icu4x_ZonedTimeFormatter_create_generic_short_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -319,13 +332,14 @@ class ZonedTimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `Location`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `Location`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
+         */
         fun createLocation(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<ZonedTimeFormatter> {
             
             val returnVal = lib.icu4x_ZonedTimeFormatter_create_location_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -341,13 +355,14 @@ class ZonedTimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `Location`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `Location`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.Location.html) for more information.
+         */
         fun createLocationWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<ZonedTimeFormatter> {
             
             val returnVal = lib.icu4x_ZonedTimeFormatter_create_location_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -363,13 +378,14 @@ class ZonedTimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
+         */
         fun createExemplarCity(locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<ZonedTimeFormatter> {
             
             val returnVal = lib.icu4x_ZonedTimeFormatter_create_exemplar_city_mv1(locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -385,13 +401,14 @@ class ZonedTimeFormatter internal constructor (
         }
         @JvmStatic
         
-        /** Creates a zoned formatter based on a non-zoned formatter.
-        *
-        *Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
-        *or else unexpected behavior may occur!
-        *
-        *See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
-        */
+        /**
+         * Creates a zoned formatter based on a non-zoned formatter.
+         *
+         * Caution: The locale provided here must match the locale used to construct the non-zoned formatter,
+         * or else unexpected behavior may occur!
+         *
+         * See the [Rust documentation for `ExemplarCity`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/zone/struct.ExemplarCity.html) for more information.
+         */
         fun createExemplarCityWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength?, timePrecision: TimePrecision?, alignment: DateTimeAlignment?): Result<ZonedTimeFormatter> {
             
             val returnVal = lib.icu4x_ZonedTimeFormatter_create_exemplar_city_with_provider_mv1(provider.handle, locale.handle, length?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), timePrecision?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none(), alignment?.let { OptionInt.some(it.toNative()) } ?: OptionInt.none());
@@ -407,8 +424,9 @@ class ZonedTimeFormatter internal constructor (
         }
     }
     
-    /** See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.format) for more information.
-    */
+    /**
+     * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/struct.FixedCalendarDateTimeFormatter.html#method.format) for more information.
+     */
     fun format(time: Time, zone: TimeZoneInfo): Result<String> {
         val write = DW.lib.diplomat_buffer_write_create(0)
         val returnVal = lib.icu4x_ZonedTimeFormatter_format_mv1(handle, time.handle, zone.handle, write);

--- a/ffi/npm/lib/DateRangeFormatter.d.ts
+++ b/ffi/npm/lib/DateRangeFormatter.d.ts
@@ -12,9 +12,9 @@ import type { pointer, codepoint } from "./diplomat-runtime.d.ts";
 
 
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `DateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html) for more information.
+ *
+ * @experimental
  */
 export class DateRangeFormatter {
     /** @internal */
@@ -24,236 +24,236 @@ export class DateRangeFormatter {
 
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.for_length)
+     *
+     * @experimental
      */
     static createD(locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null): DateRangeFormatter;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.for_length)
+     *
+     * @experimental
      */
     static createDWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null): DateRangeFormatter;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.for_length)
+     *
+     * @experimental
      */
     static createMd(locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null): DateRangeFormatter;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.for_length)
+     *
+     * @experimental
      */
     static createMdWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null): DateRangeFormatter;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.for_length)
+     *
+     * @experimental
      */
     static createYmd(locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateRangeFormatter;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.for_length)
+     *
+     * @experimental
      */
     static createYmdWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateRangeFormatter;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.for_length)
+     *
+     * @experimental
      */
     static createDe(locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null): DateRangeFormatter;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.for_length)
+     *
+     * @experimental
      */
     static createDeWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null): DateRangeFormatter;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.for_length)
+     *
+     * @experimental
      */
     static createMde(locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null): DateRangeFormatter;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.for_length)
+     *
+     * @experimental
      */
     static createMdeWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null): DateRangeFormatter;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.for_length)
+     *
+     * @experimental
      */
     static createYmde(locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateRangeFormatter;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.for_length)
+     *
+     * @experimental
      */
     static createYmdeWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateRangeFormatter;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html#method.for_length)
+     *
+     * @experimental
      */
     static createE(locale: Locale, length: DateTimeLength | null): DateRangeFormatter;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html#method.for_length)
+     *
+     * @experimental
      */
     static createEWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null): DateRangeFormatter;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.for_length)
+     *
+     * @experimental
      */
     static createM(locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null): DateRangeFormatter;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.for_length)
+     *
+     * @experimental
      */
     static createMWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null): DateRangeFormatter;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.for_length)
+     *
+     * @experimental
      */
     static createYm(locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateRangeFormatter;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.for_length)
+     *
+     * @experimental
      */
     static createYmWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateRangeFormatter;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.for_length)
+     *
+     * @experimental
      */
     static createY(locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateRangeFormatter;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.for_length)
+     *
+     * @experimental
      */
     static createYWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateRangeFormatter;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
+     *
+     * @experimental
      */
     formatIso(startIsoDate: IsoDate, endIsoDate: IsoDate): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
+     *
+     * @experimental
      */
     formatSameCalendar(startDate: Date, endDate: Date): string;
 }

--- a/ffi/npm/lib/DateRangeFormatter.mjs
+++ b/ffi/npm/lib/DateRangeFormatter.mjs
@@ -15,9 +15,9 @@ const DateRangeFormatter_box_destroy_registry = new FinalizationRegistry((ptr) =
 });
 
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `DateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html) for more information.
+ *
+ * @experimental
  */
 export class DateRangeFormatter {
     // Internal ptr reference:
@@ -49,13 +49,13 @@ export class DateRangeFormatter {
 
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.for_length)
+     *
+     * @experimental
      */
     static createD(locale, length, alignment) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -82,13 +82,13 @@ export class DateRangeFormatter {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.for_length)
+     *
+     * @experimental
      */
     static createDWithProvider(provider, locale, length, alignment) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -115,13 +115,13 @@ export class DateRangeFormatter {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.for_length)
+     *
+     * @experimental
      */
     static createMd(locale, length, alignment) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -148,13 +148,13 @@ export class DateRangeFormatter {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.for_length)
+     *
+     * @experimental
      */
     static createMdWithProvider(provider, locale, length, alignment) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -181,13 +181,13 @@ export class DateRangeFormatter {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.for_length)
+     *
+     * @experimental
      */
     static createYmd(locale, length, alignment, yearStyle) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -214,13 +214,13 @@ export class DateRangeFormatter {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.for_length)
+     *
+     * @experimental
      */
     static createYmdWithProvider(provider, locale, length, alignment, yearStyle) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -247,13 +247,13 @@ export class DateRangeFormatter {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.for_length)
+     *
+     * @experimental
      */
     static createDe(locale, length, alignment) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -280,13 +280,13 @@ export class DateRangeFormatter {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.for_length)
+     *
+     * @experimental
      */
     static createDeWithProvider(provider, locale, length, alignment) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -313,13 +313,13 @@ export class DateRangeFormatter {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.for_length)
+     *
+     * @experimental
      */
     static createMde(locale, length, alignment) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -346,13 +346,13 @@ export class DateRangeFormatter {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.for_length)
+     *
+     * @experimental
      */
     static createMdeWithProvider(provider, locale, length, alignment) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -379,13 +379,13 @@ export class DateRangeFormatter {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.for_length)
+     *
+     * @experimental
      */
     static createYmde(locale, length, alignment, yearStyle) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -412,13 +412,13 @@ export class DateRangeFormatter {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.for_length)
+     *
+     * @experimental
      */
     static createYmdeWithProvider(provider, locale, length, alignment, yearStyle) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -445,13 +445,13 @@ export class DateRangeFormatter {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html#method.for_length)
+     *
+     * @experimental
      */
     static createE(locale, length) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -478,13 +478,13 @@ export class DateRangeFormatter {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html#method.for_length)
+     *
+     * @experimental
      */
     static createEWithProvider(provider, locale, length) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -511,13 +511,13 @@ export class DateRangeFormatter {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.for_length)
+     *
+     * @experimental
      */
     static createM(locale, length, alignment) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -544,13 +544,13 @@ export class DateRangeFormatter {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.for_length)
+     *
+     * @experimental
      */
     static createMWithProvider(provider, locale, length, alignment) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -577,13 +577,13 @@ export class DateRangeFormatter {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.for_length)
+     *
+     * @experimental
      */
     static createYm(locale, length, alignment, yearStyle) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -610,13 +610,13 @@ export class DateRangeFormatter {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.for_length)
+     *
+     * @experimental
      */
     static createYmWithProvider(provider, locale, length, alignment, yearStyle) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -643,13 +643,13 @@ export class DateRangeFormatter {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.for_length)
+     *
+     * @experimental
      */
     static createY(locale, length, alignment, yearStyle) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -676,13 +676,13 @@ export class DateRangeFormatter {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.for_length)
+     *
+     * @experimental
      */
     static createYWithProvider(provider, locale, length, alignment, yearStyle) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -709,9 +709,9 @@ export class DateRangeFormatter {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
+     *
+     * @experimental
      */
     formatIso(startIsoDate, endIsoDate) {
         const write = new diplomatRuntime.DiplomatWriteBuf(wasm);
@@ -729,9 +729,9 @@ export class DateRangeFormatter {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
+     *
+     * @experimental
      */
     formatSameCalendar(startDate, endDate) {
         const write = new diplomatRuntime.DiplomatWriteBuf(wasm);

--- a/ffi/npm/lib/DateRangeFormatterGregorian.d.ts
+++ b/ffi/npm/lib/DateRangeFormatterGregorian.d.ts
@@ -11,9 +11,9 @@ import type { pointer, codepoint } from "./diplomat-runtime.d.ts";
 
 
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `FixedCalendarDateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html) for more information.
+ *
+ * @experimental
  */
 export class DateRangeFormatterGregorian {
     /** @internal */
@@ -23,229 +23,229 @@ export class DateRangeFormatterGregorian {
 
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.for_length)
+     *
+     * @experimental
      */
     static createD(locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null): DateRangeFormatterGregorian;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.for_length)
+     *
+     * @experimental
      */
     static createDWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null): DateRangeFormatterGregorian;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.for_length)
+     *
+     * @experimental
      */
     static createMd(locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null): DateRangeFormatterGregorian;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.for_length)
+     *
+     * @experimental
      */
     static createMdWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null): DateRangeFormatterGregorian;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.for_length)
+     *
+     * @experimental
      */
     static createYmd(locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateRangeFormatterGregorian;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.for_length)
+     *
+     * @experimental
      */
     static createYmdWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateRangeFormatterGregorian;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.for_length)
+     *
+     * @experimental
      */
     static createDe(locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null): DateRangeFormatterGregorian;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.for_length)
+     *
+     * @experimental
      */
     static createDeWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null): DateRangeFormatterGregorian;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.for_length)
+     *
+     * @experimental
      */
     static createMde(locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null): DateRangeFormatterGregorian;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.for_length)
+     *
+     * @experimental
      */
     static createMdeWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null): DateRangeFormatterGregorian;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.for_length)
+     *
+     * @experimental
      */
     static createYmde(locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateRangeFormatterGregorian;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.for_length)
+     *
+     * @experimental
      */
     static createYmdeWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateRangeFormatterGregorian;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html#method.for_length)
+     *
+     * @experimental
      */
     static createE(locale: Locale, length: DateTimeLength | null): DateRangeFormatterGregorian;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html#method.for_length)
+     *
+     * @experimental
      */
     static createEWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null): DateRangeFormatterGregorian;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.for_length)
+     *
+     * @experimental
      */
     static createM(locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null): DateRangeFormatterGregorian;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.for_length)
+     *
+     * @experimental
      */
     static createMWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null): DateRangeFormatterGregorian;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.for_length)
+     *
+     * @experimental
      */
     static createYm(locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateRangeFormatterGregorian;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.for_length)
+     *
+     * @experimental
      */
     static createYmWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateRangeFormatterGregorian;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.for_length)
+     *
+     * @experimental
      */
     static createY(locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateRangeFormatterGregorian;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.for_length)
+     *
+     * @experimental
      */
     static createYWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateRangeFormatterGregorian;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.format) for more information.
+     *
+     * @experimental
      */
     formatIso(startIsoDate: IsoDate, endIsoDate: IsoDate): string;
 }

--- a/ffi/npm/lib/DateRangeFormatterGregorian.mjs
+++ b/ffi/npm/lib/DateRangeFormatterGregorian.mjs
@@ -14,9 +14,9 @@ const DateRangeFormatterGregorian_box_destroy_registry = new FinalizationRegistr
 });
 
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `FixedCalendarDateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html) for more information.
+ *
+ * @experimental
  */
 export class DateRangeFormatterGregorian {
     // Internal ptr reference:
@@ -48,13 +48,13 @@ export class DateRangeFormatterGregorian {
 
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.for_length)
+     *
+     * @experimental
      */
     static createD(locale, length, alignment) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -81,13 +81,13 @@ export class DateRangeFormatterGregorian {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `D`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.D.html#method.for_length)
+     *
+     * @experimental
      */
     static createDWithProvider(provider, locale, length, alignment) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -114,13 +114,13 @@ export class DateRangeFormatterGregorian {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.for_length)
+     *
+     * @experimental
      */
     static createMd(locale, length, alignment) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -147,13 +147,13 @@ export class DateRangeFormatterGregorian {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MD.html#method.for_length)
+     *
+     * @experimental
      */
     static createMdWithProvider(provider, locale, length, alignment) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -180,13 +180,13 @@ export class DateRangeFormatterGregorian {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.for_length)
+     *
+     * @experimental
      */
     static createYmd(locale, length, alignment, yearStyle) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -213,13 +213,13 @@ export class DateRangeFormatterGregorian {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMD`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMD.html#method.for_length)
+     *
+     * @experimental
      */
     static createYmdWithProvider(provider, locale, length, alignment, yearStyle) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -246,13 +246,13 @@ export class DateRangeFormatterGregorian {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.for_length)
+     *
+     * @experimental
      */
     static createDe(locale, length, alignment) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -279,13 +279,13 @@ export class DateRangeFormatterGregorian {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DE.html#method.for_length)
+     *
+     * @experimental
      */
     static createDeWithProvider(provider, locale, length, alignment) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -312,13 +312,13 @@ export class DateRangeFormatterGregorian {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.for_length)
+     *
+     * @experimental
      */
     static createMde(locale, length, alignment) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -345,13 +345,13 @@ export class DateRangeFormatterGregorian {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDE.html#method.for_length)
+     *
+     * @experimental
      */
     static createMdeWithProvider(provider, locale, length, alignment) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -378,13 +378,13 @@ export class DateRangeFormatterGregorian {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.for_length)
+     *
+     * @experimental
      */
     static createYmde(locale, length, alignment, yearStyle) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -411,13 +411,13 @@ export class DateRangeFormatterGregorian {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDE`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDE.html#method.for_length)
+     *
+     * @experimental
      */
     static createYmdeWithProvider(provider, locale, length, alignment, yearStyle) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -444,13 +444,13 @@ export class DateRangeFormatterGregorian {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html#method.for_length)
+     *
+     * @experimental
      */
     static createE(locale, length) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -477,13 +477,13 @@ export class DateRangeFormatterGregorian {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `E`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.E.html#method.for_length)
+     *
+     * @experimental
      */
     static createEWithProvider(provider, locale, length) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -510,13 +510,13 @@ export class DateRangeFormatterGregorian {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.for_length)
+     *
+     * @experimental
      */
     static createM(locale, length, alignment) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -543,13 +543,13 @@ export class DateRangeFormatterGregorian {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `M`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.M.html#method.for_length)
+     *
+     * @experimental
      */
     static createMWithProvider(provider, locale, length, alignment) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -576,13 +576,13 @@ export class DateRangeFormatterGregorian {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.for_length)
+     *
+     * @experimental
      */
     static createYm(locale, length, alignment, yearStyle) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -609,13 +609,13 @@ export class DateRangeFormatterGregorian {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YM`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YM.html#method.for_length)
+     *
+     * @experimental
      */
     static createYmWithProvider(provider, locale, length, alignment, yearStyle) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -642,13 +642,13 @@ export class DateRangeFormatterGregorian {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.for_length)
+     *
+     * @experimental
      */
     static createY(locale, length, alignment, yearStyle) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -675,13 +675,13 @@ export class DateRangeFormatterGregorian {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `Y`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_alignment), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.with_year_style), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.Y.html#method.for_length)
+     *
+     * @experimental
      */
     static createYWithProvider(provider, locale, length, alignment, yearStyle) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -708,9 +708,9 @@ export class DateRangeFormatterGregorian {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.format) for more information.
+     *
+     * @experimental
      */
     formatIso(startIsoDate, endIsoDate) {
         const write = new diplomatRuntime.DiplomatWriteBuf(wasm);

--- a/ffi/npm/lib/DateTimeRangeFormatter.d.ts
+++ b/ffi/npm/lib/DateTimeRangeFormatter.d.ts
@@ -14,9 +14,9 @@ import type { pointer, codepoint } from "./diplomat-runtime.d.ts";
 
 
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `DateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html) for more information.
+ *
+ * @experimental
  */
 export class DateTimeRangeFormatter {
     /** @internal */
@@ -26,170 +26,170 @@ export class DateTimeRangeFormatter {
 
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.for_length)
+     *
+     * @experimental
      */
     static createDt(locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): DateTimeRangeFormatter;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.for_length)
+     *
+     * @experimental
      */
     static createDtWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): DateTimeRangeFormatter;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.for_length)
+     *
+     * @experimental
      */
     static createMdt(locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): DateTimeRangeFormatter;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.for_length)
+     *
+     * @experimental
      */
     static createMdtWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): DateTimeRangeFormatter;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.for_length)
+     *
+     * @experimental
      */
     static createYmdt(locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateTimeRangeFormatter;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.for_length)
+     *
+     * @experimental
      */
     static createYmdtWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateTimeRangeFormatter;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.for_length)
+     *
+     * @experimental
      */
     static createDet(locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): DateTimeRangeFormatter;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.for_length)
+     *
+     * @experimental
      */
     static createDetWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): DateTimeRangeFormatter;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.for_length)
+     *
+     * @experimental
      */
     static createMdet(locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): DateTimeRangeFormatter;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.for_length)
+     *
+     * @experimental
      */
     static createMdetWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): DateTimeRangeFormatter;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.for_length)
+     *
+     * @experimental
      */
     static createYmdet(locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateTimeRangeFormatter;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.for_length)
+     *
+     * @experimental
      */
     static createYmdetWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateTimeRangeFormatter;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.for_length)
+     *
+     * @experimental
      */
     static createEt(locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): DateTimeRangeFormatter;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.for_length)
+     *
+     * @experimental
      */
     static createEtWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): DateTimeRangeFormatter;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
+     *
+     * @experimental
      */
     formatIso(startIsoDate: IsoDate, startTime: Time, endIsoDate: IsoDate, endTime: Time): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
+     *
+     * @experimental
      */
     formatSameCalendar(startDate: Date, startTime: Time, endDate: Date, endTime: Time): string;
 }

--- a/ffi/npm/lib/DateTimeRangeFormatter.mjs
+++ b/ffi/npm/lib/DateTimeRangeFormatter.mjs
@@ -17,9 +17,9 @@ const DateTimeRangeFormatter_box_destroy_registry = new FinalizationRegistry((pt
 });
 
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `DateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html) for more information.
+ *
+ * @experimental
  */
 export class DateTimeRangeFormatter {
     // Internal ptr reference:
@@ -51,13 +51,13 @@ export class DateTimeRangeFormatter {
 
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.for_length)
+     *
+     * @experimental
      */
     static createDt(locale, length, timePrecision, alignment) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -84,13 +84,13 @@ export class DateTimeRangeFormatter {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.for_length)
+     *
+     * @experimental
      */
     static createDtWithProvider(provider, locale, length, timePrecision, alignment) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -117,13 +117,13 @@ export class DateTimeRangeFormatter {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.for_length)
+     *
+     * @experimental
      */
     static createMdt(locale, length, timePrecision, alignment) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -150,13 +150,13 @@ export class DateTimeRangeFormatter {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.for_length)
+     *
+     * @experimental
      */
     static createMdtWithProvider(provider, locale, length, timePrecision, alignment) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -183,13 +183,13 @@ export class DateTimeRangeFormatter {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.for_length)
+     *
+     * @experimental
      */
     static createYmdt(locale, length, timePrecision, alignment, yearStyle) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -216,13 +216,13 @@ export class DateTimeRangeFormatter {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.for_length)
+     *
+     * @experimental
      */
     static createYmdtWithProvider(provider, locale, length, timePrecision, alignment, yearStyle) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -249,13 +249,13 @@ export class DateTimeRangeFormatter {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.for_length)
+     *
+     * @experimental
      */
     static createDet(locale, length, timePrecision, alignment) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -282,13 +282,13 @@ export class DateTimeRangeFormatter {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.for_length)
+     *
+     * @experimental
      */
     static createDetWithProvider(provider, locale, length, timePrecision, alignment) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -315,13 +315,13 @@ export class DateTimeRangeFormatter {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.for_length)
+     *
+     * @experimental
      */
     static createMdet(locale, length, timePrecision, alignment) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -348,13 +348,13 @@ export class DateTimeRangeFormatter {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.for_length)
+     *
+     * @experimental
      */
     static createMdetWithProvider(provider, locale, length, timePrecision, alignment) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -381,13 +381,13 @@ export class DateTimeRangeFormatter {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.for_length)
+     *
+     * @experimental
      */
     static createYmdet(locale, length, timePrecision, alignment, yearStyle) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -414,13 +414,13 @@ export class DateTimeRangeFormatter {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.for_length)
+     *
+     * @experimental
      */
     static createYmdetWithProvider(provider, locale, length, timePrecision, alignment, yearStyle) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -447,13 +447,13 @@ export class DateTimeRangeFormatter {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.for_length)
+     *
+     * @experimental
      */
     static createEt(locale, length, timePrecision, alignment) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -480,13 +480,13 @@ export class DateTimeRangeFormatter {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.for_length)
+     *
+     * @experimental
      */
     static createEtWithProvider(provider, locale, length, timePrecision, alignment) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -513,9 +513,9 @@ export class DateTimeRangeFormatter {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
+     *
+     * @experimental
      */
     formatIso(startIsoDate, startTime, endIsoDate, endTime) {
         const write = new diplomatRuntime.DiplomatWriteBuf(wasm);
@@ -533,9 +533,9 @@ export class DateTimeRangeFormatter {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.DateRangeFormatter.html#method.format) for more information.
+     *
+     * @experimental
      */
     formatSameCalendar(startDate, startTime, endDate, endTime) {
         const write = new diplomatRuntime.DiplomatWriteBuf(wasm);

--- a/ffi/npm/lib/DateTimeRangeFormatterGregorian.d.ts
+++ b/ffi/npm/lib/DateTimeRangeFormatterGregorian.d.ts
@@ -13,9 +13,9 @@ import type { pointer, codepoint } from "./diplomat-runtime.d.ts";
 
 
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `FixedCalendarDateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html) for more information.
+ *
+ * @experimental
  */
 export class DateTimeRangeFormatterGregorian {
     /** @internal */
@@ -25,163 +25,163 @@ export class DateTimeRangeFormatterGregorian {
 
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.for_length)
+     *
+     * @experimental
      */
     static createDt(locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): DateTimeRangeFormatterGregorian;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.for_length)
+     *
+     * @experimental
      */
     static createDtWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): DateTimeRangeFormatterGregorian;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.for_length)
+     *
+     * @experimental
      */
     static createMdt(locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): DateTimeRangeFormatterGregorian;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.for_length)
+     *
+     * @experimental
      */
     static createMdtWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): DateTimeRangeFormatterGregorian;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.for_length)
+     *
+     * @experimental
      */
     static createYmdt(locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateTimeRangeFormatterGregorian;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.for_length)
+     *
+     * @experimental
      */
     static createYmdtWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateTimeRangeFormatterGregorian;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.for_length)
+     *
+     * @experimental
      */
     static createDet(locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): DateTimeRangeFormatterGregorian;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.for_length)
+     *
+     * @experimental
      */
     static createDetWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): DateTimeRangeFormatterGregorian;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.for_length)
+     *
+     * @experimental
      */
     static createMdet(locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): DateTimeRangeFormatterGregorian;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.for_length)
+     *
+     * @experimental
      */
     static createMdetWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): DateTimeRangeFormatterGregorian;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.for_length)
+     *
+     * @experimental
      */
     static createYmdet(locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateTimeRangeFormatterGregorian;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.for_length)
+     *
+     * @experimental
      */
     static createYmdetWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null, yearStyle: YearStyle | null): DateTimeRangeFormatterGregorian;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.for_length)
+     *
+     * @experimental
      */
     static createEt(locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): DateTimeRangeFormatterGregorian;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.for_length)
+     *
+     * @experimental
      */
     static createEtWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): DateTimeRangeFormatterGregorian;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.format) for more information.
+     *
+     * @experimental
      */
     formatIso(startIsoDate: IsoDate, startTime: Time, endIsoDate: IsoDate, endTime: Time): string;
 }

--- a/ffi/npm/lib/DateTimeRangeFormatterGregorian.mjs
+++ b/ffi/npm/lib/DateTimeRangeFormatterGregorian.mjs
@@ -16,9 +16,9 @@ const DateTimeRangeFormatterGregorian_box_destroy_registry = new FinalizationReg
 });
 
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `FixedCalendarDateRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html) for more information.
+ *
+ * @experimental
  */
 export class DateTimeRangeFormatterGregorian {
     // Internal ptr reference:
@@ -50,13 +50,13 @@ export class DateTimeRangeFormatterGregorian {
 
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.for_length)
+     *
+     * @experimental
      */
     static createDt(locale, length, timePrecision, alignment) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -83,13 +83,13 @@ export class DateTimeRangeFormatterGregorian {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DT.html#method.for_length)
+     *
+     * @experimental
      */
     static createDtWithProvider(provider, locale, length, timePrecision, alignment) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -116,13 +116,13 @@ export class DateTimeRangeFormatterGregorian {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.for_length)
+     *
+     * @experimental
      */
     static createMdt(locale, length, timePrecision, alignment) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -149,13 +149,13 @@ export class DateTimeRangeFormatterGregorian {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDT.html#method.for_length)
+     *
+     * @experimental
      */
     static createMdtWithProvider(provider, locale, length, timePrecision, alignment) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -182,13 +182,13 @@ export class DateTimeRangeFormatterGregorian {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.for_length)
+     *
+     * @experimental
      */
     static createYmdt(locale, length, timePrecision, alignment, yearStyle) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -215,13 +215,13 @@ export class DateTimeRangeFormatterGregorian {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDT`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDT.html#method.for_length)
+     *
+     * @experimental
      */
     static createYmdtWithProvider(provider, locale, length, timePrecision, alignment, yearStyle) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -248,13 +248,13 @@ export class DateTimeRangeFormatterGregorian {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.for_length)
+     *
+     * @experimental
      */
     static createDet(locale, length, timePrecision, alignment) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -281,13 +281,13 @@ export class DateTimeRangeFormatterGregorian {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `DET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.DET.html#method.for_length)
+     *
+     * @experimental
      */
     static createDetWithProvider(provider, locale, length, timePrecision, alignment) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -314,13 +314,13 @@ export class DateTimeRangeFormatterGregorian {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.for_length)
+     *
+     * @experimental
      */
     static createMdet(locale, length, timePrecision, alignment) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -347,13 +347,13 @@ export class DateTimeRangeFormatterGregorian {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `MDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.MDET.html#method.for_length)
+     *
+     * @experimental
      */
     static createMdetWithProvider(provider, locale, length, timePrecision, alignment) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -380,13 +380,13 @@ export class DateTimeRangeFormatterGregorian {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.for_length)
+     *
+     * @experimental
      */
     static createYmdet(locale, length, timePrecision, alignment, yearStyle) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -413,13 +413,13 @@ export class DateTimeRangeFormatterGregorian {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `YMDET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.with_year_style), [4](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.YMDET.html#method.for_length)
+     *
+     * @experimental
      */
     static createYmdetWithProvider(provider, locale, length, timePrecision, alignment, yearStyle) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -446,13 +446,13 @@ export class DateTimeRangeFormatterGregorian {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.for_length)
+     *
+     * @experimental
      */
     static createEt(locale, length, timePrecision, alignment) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -479,13 +479,13 @@ export class DateTimeRangeFormatterGregorian {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `ET`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.ET.html#method.for_length)
+     *
+     * @experimental
      */
     static createEtWithProvider(provider, locale, length, timePrecision, alignment) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -512,9 +512,9 @@ export class DateTimeRangeFormatterGregorian {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/struct.FixedCalendarDateRangeFormatter.html#method.format) for more information.
+     *
+     * @experimental
      */
     formatIso(startIsoDate, startTime, endIsoDate, endTime) {
         const write = new diplomatRuntime.DiplomatWriteBuf(wasm);

--- a/ffi/npm/lib/DisplayNamesFallback.d.ts
+++ b/ffi/npm/lib/DisplayNamesFallback.d.ts
@@ -4,9 +4,9 @@ import type { pointer, codepoint } from "./diplomat-runtime.d.ts";
 
 
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `Fallback`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/enum.Fallback.html) for more information.
+ *
+ * @experimental
  */
 export class DisplayNamesFallback {
 

--- a/ffi/npm/lib/DisplayNamesFallback.mjs
+++ b/ffi/npm/lib/DisplayNamesFallback.mjs
@@ -5,9 +5,9 @@ import * as diplomatRuntime from "./diplomat-runtime.mjs";
 
 
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `Fallback`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/enum.Fallback.html) for more information.
+ *
+ * @experimental
  */
 export class DisplayNamesFallback {
     #value = undefined;

--- a/ffi/npm/lib/DisplayNamesOptions.d.ts
+++ b/ffi/npm/lib/DisplayNamesOptions.d.ts
@@ -13,9 +13,9 @@ export type DisplayNamesOptions_obj = {
 
 
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `DisplayNamesOptions`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/struct.DisplayNamesOptions.html) for more information.
+ *
+ * @experimental
  */
 export class DisplayNamesOptions {
     get style(): DisplayNamesStyle | null;

--- a/ffi/npm/lib/DisplayNamesOptions.mjs
+++ b/ffi/npm/lib/DisplayNamesOptions.mjs
@@ -8,9 +8,9 @@ import * as diplomatRuntime from "./diplomat-runtime.mjs";
 
 
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `DisplayNamesOptions`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/struct.DisplayNamesOptions.html) for more information.
+ *
+ * @experimental
  */
 export class DisplayNamesOptions {
     #style;

--- a/ffi/npm/lib/DisplayNamesStyle.d.ts
+++ b/ffi/npm/lib/DisplayNamesStyle.d.ts
@@ -4,9 +4,9 @@ import type { pointer, codepoint } from "./diplomat-runtime.d.ts";
 
 
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `Style`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/enum.Style.html) for more information.
+ *
+ * @experimental
  */
 export class DisplayNamesStyle {
 

--- a/ffi/npm/lib/DisplayNamesStyle.mjs
+++ b/ffi/npm/lib/DisplayNamesStyle.mjs
@@ -5,9 +5,9 @@ import * as diplomatRuntime from "./diplomat-runtime.mjs";
 
 
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `Style`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/enum.Style.html) for more information.
+ *
+ * @experimental
  */
 export class DisplayNamesStyle {
     #value = undefined;

--- a/ffi/npm/lib/LanguageDisplay.d.ts
+++ b/ffi/npm/lib/LanguageDisplay.d.ts
@@ -4,9 +4,9 @@ import type { pointer, codepoint } from "./diplomat-runtime.d.ts";
 
 
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `LanguageDisplay`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/enum.LanguageDisplay.html) for more information.
+ *
+ * @experimental
  */
 export class LanguageDisplay {
 

--- a/ffi/npm/lib/LanguageDisplay.mjs
+++ b/ffi/npm/lib/LanguageDisplay.mjs
@@ -5,9 +5,9 @@ import * as diplomatRuntime from "./diplomat-runtime.mjs";
 
 
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `LanguageDisplay`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/enum.LanguageDisplay.html) for more information.
+ *
+ * @experimental
  */
 export class LanguageDisplay {
     #value = undefined;

--- a/ffi/npm/lib/LanguageDisplayUnstable.d.ts
+++ b/ffi/npm/lib/LanguageDisplayUnstable.d.ts
@@ -4,9 +4,9 @@ import type { pointer, codepoint } from "./diplomat-runtime.d.ts";
 
 
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `LanguageDisplay`](https://docs.rs/icu/2.3.1/icu/locale/names/enum.LanguageDisplay.html) for more information.
+ *
+ * @experimental
  */
 export class LanguageDisplayUnstable {
 

--- a/ffi/npm/lib/LanguageDisplayUnstable.mjs
+++ b/ffi/npm/lib/LanguageDisplayUnstable.mjs
@@ -5,9 +5,9 @@ import * as diplomatRuntime from "./diplomat-runtime.mjs";
 
 
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `LanguageDisplay`](https://docs.rs/icu/2.3.1/icu/locale/names/enum.LanguageDisplay.html) for more information.
+ *
+ * @experimental
  */
 export class LanguageDisplayUnstable {
     #value = undefined;

--- a/ffi/npm/lib/LocaleDisplayNamesFormatter.d.ts
+++ b/ffi/npm/lib/LocaleDisplayNamesFormatter.d.ts
@@ -9,9 +9,9 @@ import type { pointer, codepoint } from "./diplomat-runtime.d.ts";
 
 
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `LocaleDisplayNamesFormatter`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.LocaleDisplayNamesFormatter.html) for more information.
+ *
+ * @experimental
  */
 export class LocaleDisplayNamesFormatter {
     /** @internal */
@@ -19,30 +19,29 @@ export class LocaleDisplayNamesFormatter {
 
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * Creates a new `LocaleDisplayNamesFormatter` from locale data and an options bag using a particular data source.
      *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/struct.LocaleDisplayNamesFormatter.html#method.try_new) for more information.
+     *
+     * @experimental
      */
     static createWithProvider(provider: DataProvider, locale: Locale, options: DisplayNamesOptions_obj): LocaleDisplayNamesFormatter;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * Returns the locale-specific display name of a locale.
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
      * See the [Rust documentation for `of`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.LocaleDisplayNamesFormatter.html#method.of) for more information.
+     *
+     * @experimental
      */
     of(locale: Locale): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * Creates a new `LocaleDisplayNamesFormatter` from locale data and an options bag using compiled data.
      *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.LocaleDisplayNamesFormatter.html#method.try_new) for more information.
+     *
+     * @experimental
      */
     constructor(locale: Locale, options: DisplayNamesOptions_obj);
 }

--- a/ffi/npm/lib/LocaleDisplayNamesFormatter.mjs
+++ b/ffi/npm/lib/LocaleDisplayNamesFormatter.mjs
@@ -11,9 +11,9 @@ const LocaleDisplayNamesFormatter_box_destroy_registry = new FinalizationRegistr
 });
 
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `LocaleDisplayNamesFormatter`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.LocaleDisplayNamesFormatter.html) for more information.
+ *
+ * @experimental
  */
 export class LocaleDisplayNamesFormatter {
     // Internal ptr reference:
@@ -45,11 +45,11 @@ export class LocaleDisplayNamesFormatter {
 
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * Creates a new `LocaleDisplayNamesFormatter` from locale data and an options bag using compiled data.
      *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.LocaleDisplayNamesFormatter.html#method.try_new) for more information.
+     *
+     * @experimental
      */
     #defaultConstructor(locale, options) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -76,11 +76,11 @@ export class LocaleDisplayNamesFormatter {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * Creates a new `LocaleDisplayNamesFormatter` from locale data and an options bag using a particular data source.
      *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/struct.LocaleDisplayNamesFormatter.html#method.try_new) for more information.
+     *
+     * @experimental
      */
     static createWithProvider(provider, locale, options) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -107,12 +107,11 @@ export class LocaleDisplayNamesFormatter {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * Returns the locale-specific display name of a locale.
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
      *
      * See the [Rust documentation for `of`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.LocaleDisplayNamesFormatter.html#method.of) for more information.
+     *
+     * @experimental
      */
     of(locale) {
         const write = new diplomatRuntime.DiplomatWriteBuf(wasm);
@@ -130,11 +129,11 @@ export class LocaleDisplayNamesFormatter {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * Creates a new `LocaleDisplayNamesFormatter` from locale data and an options bag using compiled data.
      *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.LocaleDisplayNamesFormatter.html#method.try_new) for more information.
+     *
+     * @experimental
      */
     constructor(locale, options) {
         if (arguments[0] === diplomatRuntime.exposeConstructor) {

--- a/ffi/npm/lib/LocaleNamesUnstable.d.ts
+++ b/ffi/npm/lib/LocaleNamesUnstable.d.ts
@@ -8,8 +8,6 @@ import type { pointer, codepoint } from "./diplomat-runtime.d.ts";
 
 
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * This struct holds free functions for loading display names for languages, scripts,
  * regions, and language identifiers.
  *
@@ -20,6 +18,8 @@ import type { pointer, codepoint } from "./diplomat-runtime.d.ts";
  * See the [Rust documentation for `VariantDisplayName`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.VariantDisplayName.html) for more information.
  *
  * See the [Rust documentation for `LanguageIdentifierDisplayName`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html) for more information.
+ *
+ * @experimental
  */
 export class LocaleNamesUnstable {
     /** @internal */
@@ -29,282 +29,282 @@ export class LocaleNamesUnstable {
 
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_light_with_fallback) for more information.
+     *
+     * @experimental
      */
     static forRegionLight(locale: Locale, region: string): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_light_with_fallback) for more information.
+     *
+     * @experimental
      */
     static forRegionLightWithProvider(provider: DataProvider, locale: Locale, region: string): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_tiny_with_fallback) for more information.
+     *
+     * @experimental
      */
     static forRegionTiny(locale: Locale, region: string): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_tiny_with_fallback) for more information.
+     *
+     * @experimental
      */
     static forRegionTinyWithProvider(provider: DataProvider, locale: Locale, region: string): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `new_short_tiny_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_short_tiny_with_fallback) for more information.
+     *
+     * @experimental
      */
     static forRegionShortTiny(locale: Locale, region: string): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `new_short_tiny_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_short_tiny_with_fallback) for more information.
+     *
+     * @experimental
      */
     static forRegionShortTinyWithProvider(provider: DataProvider, locale: Locale, region: string): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `new_short_light_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_short_light_with_fallback) for more information.
+     *
+     * @experimental
      */
     static forRegionShortLight(locale: Locale, region: string): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `new_short_light_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_short_light_with_fallback) for more information.
+     *
+     * @experimental
      */
     static forRegionShortLightWithProvider(provider: DataProvider, locale: Locale, region: string): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_light_with_fallback) for more information.
+     *
+     * @experimental
      */
     static forScriptLight(locale: Locale, script: string): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_light_with_fallback) for more information.
+     *
+     * @experimental
      */
     static forScriptLightWithProvider(provider: DataProvider, locale: Locale, script: string): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_tiny_with_fallback) for more information.
+     *
+     * @experimental
      */
     static forScriptTiny(locale: Locale, script: string): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_tiny_with_fallback) for more information.
+     *
+     * @experimental
      */
     static forScriptTinyWithProvider(provider: DataProvider, locale: Locale, script: string): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_heavy_with_fallback) for more information.
+     *
+     * @experimental
      */
     static forScriptHeavy(locale: Locale, script: string): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_heavy_with_fallback) for more information.
+     *
+     * @experimental
      */
     static forScriptHeavyWithProvider(provider: DataProvider, locale: Locale, script: string): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `new_short_heavy_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_short_heavy_with_fallback) for more information.
+     *
+     * @experimental
      */
     static forScriptShortHeavy(locale: Locale, script: string): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `new_short_heavy_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_short_heavy_with_fallback) for more information.
+     *
+     * @experimental
      */
     static forScriptShortHeavyWithProvider(provider: DataProvider, locale: Locale, script: string): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.VariantDisplayName.html#method.new_heavy_with_fallback) for more information.
+     *
+     * @experimental
      */
     static forVariantHeavy(locale: Locale, variant: string): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.VariantDisplayName.html#method.new_heavy_with_fallback) for more information.
+     *
+     * @experimental
      */
     static forVariantHeavyWithProvider(provider: DataProvider, locale: Locale, variant: string): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_light) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierLight(locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_light) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierLightWithProvider(provider: DataProvider, locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_tiny`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_tiny) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierTiny(locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_tiny`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_tiny) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierTinyWithProvider(provider: DataProvider, locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_short_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_light) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierShortLight(locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_short_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_light) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierShortLightWithProvider(provider: DataProvider, locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_long_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_long_light) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierLongLight(locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_long_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_long_light) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierLongLightWithProvider(provider: DataProvider, locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_menu_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_menu_light) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierMenuLight(locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_menu_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_menu_light) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierMenuLightWithProvider(provider: DataProvider, locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_short_menu_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_menu_light) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierShortMenuLight(locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_short_menu_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_menu_light) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierShortMenuLightWithProvider(provider: DataProvider, locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_heavy) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierHeavy(locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_heavy) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierHeavyWithProvider(provider: DataProvider, locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_short_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_heavy) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierShortHeavy(locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_short_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_heavy) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierShortHeavyWithProvider(provider: DataProvider, locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_long_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_long_heavy) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierLongHeavy(locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_long_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_long_heavy) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierLongHeavyWithProvider(provider: DataProvider, locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_menu_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_menu_heavy) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierMenuHeavy(locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_menu_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_menu_heavy) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierMenuHeavyWithProvider(provider: DataProvider, locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_short_menu_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_menu_heavy) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierShortMenuHeavy(locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_short_menu_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_menu_heavy) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierShortMenuHeavyWithProvider(provider: DataProvider, locale: Locale, langid: Locale, languageDisplay: LanguageDisplayUnstable): string;
 }

--- a/ffi/npm/lib/LocaleNamesUnstable.mjs
+++ b/ffi/npm/lib/LocaleNamesUnstable.mjs
@@ -11,8 +11,6 @@ const LocaleNamesUnstable_box_destroy_registry = new FinalizationRegistry((ptr) 
 });
 
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * This struct holds free functions for loading display names for languages, scripts,
  * regions, and language identifiers.
  *
@@ -23,6 +21,8 @@ const LocaleNamesUnstable_box_destroy_registry = new FinalizationRegistry((ptr) 
  * See the [Rust documentation for `VariantDisplayName`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.VariantDisplayName.html) for more information.
  *
  * See the [Rust documentation for `LanguageIdentifierDisplayName`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html) for more information.
+ *
+ * @experimental
  */
 export class LocaleNamesUnstable {
     // Internal ptr reference:
@@ -54,9 +54,9 @@ export class LocaleNamesUnstable {
 
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_light_with_fallback) for more information.
+     *
+     * @experimental
      */
     static forRegionLight(locale, region) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -79,9 +79,9 @@ export class LocaleNamesUnstable {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_light_with_fallback) for more information.
+     *
+     * @experimental
      */
     static forRegionLightWithProvider(provider, locale, region) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -112,9 +112,9 @@ export class LocaleNamesUnstable {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_tiny_with_fallback) for more information.
+     *
+     * @experimental
      */
     static forRegionTiny(locale, region) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -137,9 +137,9 @@ export class LocaleNamesUnstable {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_tiny_with_fallback) for more information.
+     *
+     * @experimental
      */
     static forRegionTinyWithProvider(provider, locale, region) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -170,9 +170,9 @@ export class LocaleNamesUnstable {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `new_short_tiny_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_short_tiny_with_fallback) for more information.
+     *
+     * @experimental
      */
     static forRegionShortTiny(locale, region) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -195,9 +195,9 @@ export class LocaleNamesUnstable {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `new_short_tiny_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_short_tiny_with_fallback) for more information.
+     *
+     * @experimental
      */
     static forRegionShortTinyWithProvider(provider, locale, region) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -228,9 +228,9 @@ export class LocaleNamesUnstable {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `new_short_light_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_short_light_with_fallback) for more information.
+     *
+     * @experimental
      */
     static forRegionShortLight(locale, region) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -253,9 +253,9 @@ export class LocaleNamesUnstable {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `new_short_light_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.RegionDisplayName.html#method.new_short_light_with_fallback) for more information.
+     *
+     * @experimental
      */
     static forRegionShortLightWithProvider(provider, locale, region) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -286,9 +286,9 @@ export class LocaleNamesUnstable {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_light_with_fallback) for more information.
+     *
+     * @experimental
      */
     static forScriptLight(locale, script) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -311,9 +311,9 @@ export class LocaleNamesUnstable {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `new_light_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_light_with_fallback) for more information.
+     *
+     * @experimental
      */
     static forScriptLightWithProvider(provider, locale, script) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -344,9 +344,9 @@ export class LocaleNamesUnstable {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_tiny_with_fallback) for more information.
+     *
+     * @experimental
      */
     static forScriptTiny(locale, script) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -369,9 +369,9 @@ export class LocaleNamesUnstable {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `new_tiny_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_tiny_with_fallback) for more information.
+     *
+     * @experimental
      */
     static forScriptTinyWithProvider(provider, locale, script) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -402,9 +402,9 @@ export class LocaleNamesUnstable {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_heavy_with_fallback) for more information.
+     *
+     * @experimental
      */
     static forScriptHeavy(locale, script) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -427,9 +427,9 @@ export class LocaleNamesUnstable {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_heavy_with_fallback) for more information.
+     *
+     * @experimental
      */
     static forScriptHeavyWithProvider(provider, locale, script) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -460,9 +460,9 @@ export class LocaleNamesUnstable {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `new_short_heavy_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_short_heavy_with_fallback) for more information.
+     *
+     * @experimental
      */
     static forScriptShortHeavy(locale, script) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -485,9 +485,9 @@ export class LocaleNamesUnstable {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `new_short_heavy_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.ScriptDisplayName.html#method.new_short_heavy_with_fallback) for more information.
+     *
+     * @experimental
      */
     static forScriptShortHeavyWithProvider(provider, locale, script) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -518,9 +518,9 @@ export class LocaleNamesUnstable {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.VariantDisplayName.html#method.new_heavy_with_fallback) for more information.
+     *
+     * @experimental
      */
     static forVariantHeavy(locale, variant) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -543,9 +543,9 @@ export class LocaleNamesUnstable {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `new_heavy_with_fallback`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.VariantDisplayName.html#method.new_heavy_with_fallback) for more information.
+     *
+     * @experimental
      */
     static forVariantHeavyWithProvider(provider, locale, variant) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -576,9 +576,9 @@ export class LocaleNamesUnstable {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_light) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierLight(locale, langid, languageDisplay) {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
@@ -604,9 +604,9 @@ export class LocaleNamesUnstable {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_light) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierLightWithProvider(provider, locale, langid, languageDisplay) {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
@@ -632,9 +632,9 @@ export class LocaleNamesUnstable {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_tiny`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_tiny) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierTiny(locale, langid, languageDisplay) {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
@@ -660,9 +660,9 @@ export class LocaleNamesUnstable {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_tiny`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_tiny) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierTinyWithProvider(provider, locale, langid, languageDisplay) {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
@@ -688,9 +688,9 @@ export class LocaleNamesUnstable {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_short_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_light) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierShortLight(locale, langid, languageDisplay) {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
@@ -716,9 +716,9 @@ export class LocaleNamesUnstable {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_short_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_light) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierShortLightWithProvider(provider, locale, langid, languageDisplay) {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
@@ -744,9 +744,9 @@ export class LocaleNamesUnstable {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_long_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_long_light) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierLongLight(locale, langid, languageDisplay) {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
@@ -772,9 +772,9 @@ export class LocaleNamesUnstable {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_long_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_long_light) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierLongLightWithProvider(provider, locale, langid, languageDisplay) {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
@@ -800,9 +800,9 @@ export class LocaleNamesUnstable {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_menu_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_menu_light) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierMenuLight(locale, langid, languageDisplay) {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
@@ -828,9 +828,9 @@ export class LocaleNamesUnstable {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_menu_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_menu_light) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierMenuLightWithProvider(provider, locale, langid, languageDisplay) {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
@@ -856,9 +856,9 @@ export class LocaleNamesUnstable {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_short_menu_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_menu_light) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierShortMenuLight(locale, langid, languageDisplay) {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
@@ -884,9 +884,9 @@ export class LocaleNamesUnstable {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_short_menu_light`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_menu_light) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierShortMenuLightWithProvider(provider, locale, langid, languageDisplay) {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
@@ -912,9 +912,9 @@ export class LocaleNamesUnstable {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_heavy) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierHeavy(locale, langid, languageDisplay) {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
@@ -940,9 +940,9 @@ export class LocaleNamesUnstable {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_heavy) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierHeavyWithProvider(provider, locale, langid, languageDisplay) {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
@@ -968,9 +968,9 @@ export class LocaleNamesUnstable {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_short_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_heavy) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierShortHeavy(locale, langid, languageDisplay) {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
@@ -996,9 +996,9 @@ export class LocaleNamesUnstable {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_short_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_heavy) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierShortHeavyWithProvider(provider, locale, langid, languageDisplay) {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
@@ -1024,9 +1024,9 @@ export class LocaleNamesUnstable {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_long_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_long_heavy) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierLongHeavy(locale, langid, languageDisplay) {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
@@ -1052,9 +1052,9 @@ export class LocaleNamesUnstable {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_long_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_long_heavy) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierLongHeavyWithProvider(provider, locale, langid, languageDisplay) {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
@@ -1080,9 +1080,9 @@ export class LocaleNamesUnstable {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_menu_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_menu_heavy) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierMenuHeavy(locale, langid, languageDisplay) {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
@@ -1108,9 +1108,9 @@ export class LocaleNamesUnstable {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_menu_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_menu_heavy) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierMenuHeavyWithProvider(provider, locale, langid, languageDisplay) {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
@@ -1136,9 +1136,9 @@ export class LocaleNamesUnstable {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_short_menu_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_menu_heavy) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierShortMenuHeavy(locale, langid, languageDisplay) {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
@@ -1164,9 +1164,9 @@ export class LocaleNamesUnstable {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new_short_menu_heavy`](https://docs.rs/icu/2.3.1/icu/locale/names/struct.LanguageIdentifierDisplayName.html#method.try_new_short_menu_heavy) for more information.
+     *
+     * @experimental
      */
     static forLanguageIdentifierShortMenuHeavyWithProvider(provider, locale, langid, languageDisplay) {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);

--- a/ffi/npm/lib/PluralRulesWithRanges.d.ts
+++ b/ffi/npm/lib/PluralRulesWithRanges.d.ts
@@ -10,6 +10,8 @@ import type { pointer, codepoint } from "./diplomat-runtime.d.ts";
 
 /**
  * See the [Rust documentation for `PluralRulesWithRanges`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRulesWithRanges.html) for more information.
+ *
+ * @experimental
  */
 export class PluralRulesWithRanges {
     /** @internal */
@@ -22,6 +24,8 @@ export class PluralRulesWithRanges {
      * construct a {@link PluralRulesWithRanges} for the given locale, for cardinal numbers, using compiled data.
      *
      * See the [Rust documentation for `try_new_cardinal`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRulesWithRanges.html#method.try_new_cardinal) for more information.
+     *
+     * @experimental
      */
     static createCardinal(locale: Locale): PluralRulesWithRanges;
 
@@ -29,6 +33,8 @@ export class PluralRulesWithRanges {
      * construct a {@link PluralRulesWithRanges} for the given locale, for cardinal numbers, using a particular data source.
      *
      * See the [Rust documentation for `try_new_cardinal`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRulesWithRanges.html#method.try_new_cardinal) for more information.
+     *
+     * @experimental
      */
     static createCardinalWithProvider(provider: DataProvider, locale: Locale): PluralRulesWithRanges;
 
@@ -36,6 +42,8 @@ export class PluralRulesWithRanges {
      * Construct a {@link PluralRulesWithRanges} for the given locale, for ordinal numbers, using compiled data.
      *
      * See the [Rust documentation for `try_new_ordinal`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRulesWithRanges.html#method.try_new_ordinal) for more information.
+     *
+     * @experimental
      */
     static createOrdinal(locale: Locale): PluralRulesWithRanges;
 
@@ -43,6 +51,8 @@ export class PluralRulesWithRanges {
      * Construct a {@link PluralRulesWithRanges} for the given locale, for ordinal numbers, using a particular data source.
      *
      * See the [Rust documentation for `try_new_ordinal`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRulesWithRanges.html#method.try_new_ordinal) for more information.
+     *
+     * @experimental
      */
     static createOrdinalWithProvider(provider: DataProvider, locale: Locale): PluralRulesWithRanges;
 
@@ -50,6 +60,8 @@ export class PluralRulesWithRanges {
      * Get the category for a given number represented as operands
      *
      * See the [Rust documentation for `category_for_range`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRulesWithRanges.html#method.category_for_range) for more information.
+     *
+     * @experimental
      */
     categoryForRange(start: PluralOperands, end: PluralOperands): PluralCategory;
 }

--- a/ffi/npm/lib/PluralRulesWithRanges.mjs
+++ b/ffi/npm/lib/PluralRulesWithRanges.mjs
@@ -13,6 +13,8 @@ const PluralRulesWithRanges_box_destroy_registry = new FinalizationRegistry((ptr
 
 /**
  * See the [Rust documentation for `PluralRulesWithRanges`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRulesWithRanges.html) for more information.
+ *
+ * @experimental
  */
 export class PluralRulesWithRanges {
     // Internal ptr reference:
@@ -47,6 +49,8 @@ export class PluralRulesWithRanges {
      * construct a {@link PluralRulesWithRanges} for the given locale, for cardinal numbers, using compiled data.
      *
      * See the [Rust documentation for `try_new_cardinal`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRulesWithRanges.html#method.try_new_cardinal) for more information.
+     *
+     * @experimental
      */
     static createCardinal(locale) {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
@@ -72,6 +76,8 @@ export class PluralRulesWithRanges {
      * construct a {@link PluralRulesWithRanges} for the given locale, for cardinal numbers, using a particular data source.
      *
      * See the [Rust documentation for `try_new_cardinal`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRulesWithRanges.html#method.try_new_cardinal) for more information.
+     *
+     * @experimental
      */
     static createCardinalWithProvider(provider, locale) {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
@@ -97,6 +103,8 @@ export class PluralRulesWithRanges {
      * Construct a {@link PluralRulesWithRanges} for the given locale, for ordinal numbers, using compiled data.
      *
      * See the [Rust documentation for `try_new_ordinal`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRulesWithRanges.html#method.try_new_ordinal) for more information.
+     *
+     * @experimental
      */
     static createOrdinal(locale) {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
@@ -122,6 +130,8 @@ export class PluralRulesWithRanges {
      * Construct a {@link PluralRulesWithRanges} for the given locale, for ordinal numbers, using a particular data source.
      *
      * See the [Rust documentation for `try_new_ordinal`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRulesWithRanges.html#method.try_new_ordinal) for more information.
+     *
+     * @experimental
      */
     static createOrdinalWithProvider(provider, locale) {
         const diplomatReceive = new diplomatRuntime.DiplomatReceiveBuf(wasm, 5, 4, true);
@@ -147,6 +157,8 @@ export class PluralRulesWithRanges {
      * Get the category for a given number represented as operands
      *
      * See the [Rust documentation for `category_for_range`](https://docs.rs/icu/2.3.1/icu/plurals/struct.PluralRulesWithRanges.html#method.category_for_range) for more information.
+     *
+     * @experimental
      */
     categoryForRange(start, end) {
 

--- a/ffi/npm/lib/RegionDisplayNames.d.ts
+++ b/ffi/npm/lib/RegionDisplayNames.d.ts
@@ -10,9 +10,9 @@ import type { pointer, codepoint } from "./diplomat-runtime.d.ts";
 
 
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `RegionDisplayNames`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.RegionDisplayNames.html) for more information.
+ *
+ * @experimental
  */
 export class RegionDisplayNames {
     /** @internal */
@@ -20,31 +20,31 @@ export class RegionDisplayNames {
 
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * Creates a new `RegionDisplayNames` from locale data and an options bag using a particular data source.
      *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.RegionDisplayNames.html#method.try_new) for more information.
+     *
+     * @experimental
      */
     static createWithProvider(provider: DataProvider, locale: Locale, options: DisplayNamesOptions_obj): RegionDisplayNames;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * Returns the locale specific display name of a region.
      * Note that the function returns an empty string in case the display name for a given
      * region code is not found.
      *
      * See the [Rust documentation for `of`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.RegionDisplayNames.html#method.of) for more information.
+     *
+     * @experimental
      */
     of(region: string): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * Creates a new `RegionDisplayNames` from locale data and an options bag using compiled data.
      *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.RegionDisplayNames.html#method.try_new) for more information.
+     *
+     * @experimental
      */
     constructor(locale: Locale, options: DisplayNamesOptions_obj);
 }

--- a/ffi/npm/lib/RegionDisplayNames.mjs
+++ b/ffi/npm/lib/RegionDisplayNames.mjs
@@ -12,9 +12,9 @@ const RegionDisplayNames_box_destroy_registry = new FinalizationRegistry((ptr) =
 });
 
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `RegionDisplayNames`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.RegionDisplayNames.html) for more information.
+ *
+ * @experimental
  */
 export class RegionDisplayNames {
     // Internal ptr reference:
@@ -46,11 +46,11 @@ export class RegionDisplayNames {
 
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * Creates a new `RegionDisplayNames` from locale data and an options bag using compiled data.
      *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.RegionDisplayNames.html#method.try_new) for more information.
+     *
+     * @experimental
      */
     #defaultConstructor(locale, options) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -77,11 +77,11 @@ export class RegionDisplayNames {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * Creates a new `RegionDisplayNames` from locale data and an options bag using a particular data source.
      *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.RegionDisplayNames.html#method.try_new) for more information.
+     *
+     * @experimental
      */
     static createWithProvider(provider, locale, options) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -108,13 +108,13 @@ export class RegionDisplayNames {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * Returns the locale specific display name of a region.
      * Note that the function returns an empty string in case the display name for a given
      * region code is not found.
      *
      * See the [Rust documentation for `of`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.RegionDisplayNames.html#method.of) for more information.
+     *
+     * @experimental
      */
     of(region) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -145,11 +145,11 @@ export class RegionDisplayNames {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * Creates a new `RegionDisplayNames` from locale data and an options bag using compiled data.
      *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/experimental/displaynames/multi/struct.RegionDisplayNames.html#method.try_new) for more information.
+     *
+     * @experimental
      */
     constructor(locale, options) {
         if (arguments[0] === diplomatRuntime.exposeConstructor) {

--- a/ffi/npm/lib/TimeRangeFormatter.d.ts
+++ b/ffi/npm/lib/TimeRangeFormatter.d.ts
@@ -11,9 +11,9 @@ import type { pointer, codepoint } from "./diplomat-runtime.d.ts";
 
 
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `NoCalendarRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html) for more information.
+ *
+ * @experimental
  */
 export class TimeRangeFormatter {
     /** @internal */
@@ -21,31 +21,31 @@ export class TimeRangeFormatter {
 
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `T`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.for_length)
+     *
+     * @experimental
      */
     static createWithProvider(provider: DataProvider, locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null): TimeRangeFormatter;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html#method.format) for more information.
+     *
+     * @experimental
      */
     format(startTime: Time, endTime: Time): string;
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `T`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.for_length)
+     *
+     * @experimental
      */
     constructor(locale: Locale, length: DateTimeLength | null, timePrecision: TimePrecision | null, alignment: DateTimeAlignment | null);
 }

--- a/ffi/npm/lib/TimeRangeFormatter.mjs
+++ b/ffi/npm/lib/TimeRangeFormatter.mjs
@@ -14,9 +14,9 @@ const TimeRangeFormatter_box_destroy_registry = new FinalizationRegistry((ptr) =
 });
 
 /**
- * 🚧 This API is unstable and may experience breaking changes outside major releases.
- *
  * See the [Rust documentation for `NoCalendarRangeFormatter`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html) for more information.
+ *
+ * @experimental
  */
 export class TimeRangeFormatter {
     // Internal ptr reference:
@@ -48,13 +48,13 @@ export class TimeRangeFormatter {
 
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `T`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.for_length)
+     *
+     * @experimental
      */
     #defaultConstructor(locale, length, timePrecision, alignment) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -81,13 +81,13 @@ export class TimeRangeFormatter {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `T`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.for_length)
+     *
+     * @experimental
      */
     static createWithProvider(provider, locale, length, timePrecision, alignment) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -114,9 +114,9 @@ export class TimeRangeFormatter {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `format`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html#method.format) for more information.
+     *
+     * @experimental
      */
     format(startTime, endTime) {
         const write = new diplomatRuntime.DiplomatWriteBuf(wasm);
@@ -134,13 +134,13 @@ export class TimeRangeFormatter {
     }
 
     /**
-     * 🚧 This API is unstable and may experience breaking changes outside major releases.
-     *
      * See the [Rust documentation for `try_new`](https://docs.rs/icu/2.3.1/icu/datetime/range/type.NoCalendarRangeFormatter.html#method.try_new) for more information.
      *
      * See the [Rust documentation for `T`](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html) for more information.
      *
      * Additional information: [1](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.with_time_precision), [2](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.with_alignment), [3](https://docs.rs/icu/2.3.1/icu/datetime/fieldsets/struct.T.html#method.for_length)
+     *
+     * @experimental
      */
     constructor(locale, length, timePrecision, alignment) {
         if (arguments[0] === diplomatRuntime.exposeConstructor) {

--- a/ffi/npm/lib/ZonedTime.d.ts
+++ b/ffi/npm/lib/ZonedTime.d.ts
@@ -11,6 +11,8 @@ import type { pointer, codepoint } from "./diplomat-runtime.d.ts";
  * An ICU4X `ZonedTime` object capable of containing a ISO-8601 time, and zone.
  *
  * See the [Rust documentation for `ZonedTime`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedTime.html) for more information.
+ *
+ * @experimental
  */
 export class ZonedTime {
     get time(): Time;
@@ -23,6 +25,8 @@ export class ZonedTime {
      * Creates a new {@link ZonedTime} from an IXDTF string.
      *
      * See the [Rust documentation for `try_strict_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedTime.html#method.try_strict_from_str) for more information.
+     *
+     * @experimental
      */
     static strictFromString(v: string, ianaParser: IanaParser): ZonedTime;
 
@@ -30,6 +34,8 @@ export class ZonedTime {
      * Creates a new {@link ZonedTime} from a location-only IXDTF string.
      *
      * See the [Rust documentation for `try_location_only_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedTime.html#method.try_location_only_from_str) for more information.
+     *
+     * @experimental
      */
     static locationOnlyFromString(v: string, ianaParser: IanaParser): ZonedTime;
 
@@ -37,6 +43,8 @@ export class ZonedTime {
      * Creates a new {@link ZonedTime} from an offset-only IXDTF string.
      *
      * See the [Rust documentation for `try_offset_only_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedTime.html#method.try_offset_only_from_str) for more information.
+     *
+     * @experimental
      */
     static offsetOnlyFromString(v: string): ZonedTime;
 
@@ -44,6 +52,8 @@ export class ZonedTime {
      * Creates a new {@link ZonedTime} from an IXDTF string, without requiring the offset.
      *
      * See the [Rust documentation for `try_lenient_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedTime.html#method.try_lenient_from_str) for more information.
+     *
+     * @experimental
      */
     static lenientFromString(v: string, ianaParser: IanaParser): ZonedTime;
 }

--- a/ffi/npm/lib/ZonedTime.mjs
+++ b/ffi/npm/lib/ZonedTime.mjs
@@ -12,6 +12,8 @@ import * as diplomatRuntime from "./diplomat-runtime.mjs";
  * An ICU4X `ZonedTime` object capable of containing a ISO-8601 time, and zone.
  *
  * See the [Rust documentation for `ZonedTime`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedTime.html) for more information.
+ *
+ * @experimental
  */
 export class ZonedTime {
     #time;
@@ -112,6 +114,8 @@ export class ZonedTime {
      * Creates a new {@link ZonedTime} from an IXDTF string.
      *
      * See the [Rust documentation for `try_strict_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedTime.html#method.try_strict_from_str) for more information.
+     *
+     * @experimental
      */
     static strictFromString(v, ianaParser) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -142,6 +146,8 @@ export class ZonedTime {
      * Creates a new {@link ZonedTime} from a location-only IXDTF string.
      *
      * See the [Rust documentation for `try_location_only_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedTime.html#method.try_location_only_from_str) for more information.
+     *
+     * @experimental
      */
     static locationOnlyFromString(v, ianaParser) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -172,6 +178,8 @@ export class ZonedTime {
      * Creates a new {@link ZonedTime} from an offset-only IXDTF string.
      *
      * See the [Rust documentation for `try_offset_only_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedTime.html#method.try_offset_only_from_str) for more information.
+     *
+     * @experimental
      */
     static offsetOnlyFromString(v) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();
@@ -202,6 +210,8 @@ export class ZonedTime {
      * Creates a new {@link ZonedTime} from an IXDTF string, without requiring the offset.
      *
      * See the [Rust documentation for `try_lenient_from_str`](https://docs.rs/icu/2.3.1/icu/time/struct.ZonedTime.html#method.try_lenient_from_str) for more information.
+     *
+     * @experimental
      */
     static lenientFromString(v, ianaParser) {
         let functionCleanupArena = new diplomatRuntime.CleanupArena();

--- a/ffi/npm/package.json
+++ b/ffi/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "icu",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "ICU4X JavaScript bindings via WebAssembly",
   "main": "lib/index.mjs",
   "exports": {

--- a/ffi/npm/package.json
+++ b/ffi/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "icu",
-  "version": "2.3.3",
+  "version": "2.3.2",
   "description": "ICU4X JavaScript bindings via WebAssembly",
   "main": "lib/index.mjs",
   "exports": {

--- a/tools/make/codegen/templates/range_formatter.rs.jinja
+++ b/tools/make/codegen/templates/range_formatter.rs.jinja
@@ -40,7 +40,6 @@ pub mod ffi {
         {%- let ffi_type = format!("{}RangeFormatter", {{ flavor.camel() }}) %}
     {%- endif %}
 
-    /// 🚧 This API is unstable and may experience breaking changes outside major releases.
     #[diplomat::opaque]
     #[diplomat::rust_link(icu::datetime::range::{{ formatter_kind.rustlink_range() }}, {{ formatter_kind.rustlink_doctype() }})]
     pub struct {{ ffi_type }}(
@@ -64,7 +63,6 @@ pub mod ffi {
     impl {{ ffi_type }} {
         {%- for variant in variants %}
         {%- for ctor in ConstructorType::VALUES %}
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         {%- decl named_constructor %}
         {%- decl named_constructor_full %}
         {%- if ctor.is_with_provider() %}
@@ -169,7 +167,6 @@ pub mod ffi {
         }
         {% endfor %}
         {%- endfor %}
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::rust_link(icu::datetime::range::{{ formatter_kind.rustlink_range() }}::format, {{ formatter_kind.rustlink_doctype_fn() }})]
         #[diplomat::rust_link(icu::datetime::range::FormattedDateRange, Struct, hidden)]
         #[diplomat::rust_link(icu::datetime::range::FormattedDateRange::to_string, FnInStruct, hidden)]
@@ -212,7 +209,6 @@ pub mod ffi {
             let _infallible = self.0.format(&start_value, &end_value).write_to(write);
         }
         {% if !formatter_kind.is_fixed_calendar %}
-        /// 🚧 This API is unstable and may experience breaking changes outside major releases.
         #[diplomat::rust_link(icu::datetime::range::{{ formatter_kind.rustlink_range() }}::format, {{ formatter_kind.rustlink_doctype_fn() }})]
         #[diplomat::rust_link(icu::datetime::range::FormattedDateRange, Struct, hidden)]
         #[diplomat::rust_link(icu::datetime::range::FormattedDateRange::to_string, FnInStruct, hidden)]


### PR DESCRIPTION
This contains https://github.com/rust-diplomat/diplomat/pull/1272 which adds missing unstable annotations.

Dart doc [before](https://unicode-org.github.io/icu4x/dartdoc/icu4x/PluralRulesWithRanges-class.html) [after](https://icu4x-pr-artifacts.storage.googleapis.com/gha/5e6940bce0a3bae435baaa8df7ee2cdee8cc2c59/dartdoc/icu4x/PluralRulesWithRanges-class.html)

TsDoc [before](https://unicode-org.github.io/icu4x/tsdoc/classes/PluralRulesWithRanges.html) [after](https://icu4x-pr-artifacts.storage.googleapis.com/gha/5e6940bce0a3bae435baaa8df7ee2cdee8cc2c59/tsdoc/classes/PluralRulesWithRanges.html)

CPP [before](https://unicode-org.github.io/icu4x/cppdoc/classicu4x_1_1PluralRulesWithRanges.html) [after](https://icu4x-pr-artifacts.storage.googleapis.com/gha/5e6940bce0a3bae435baaa8df7ee2cdee8cc2c59/cppdoc/classicu4x_1_1PluralRulesWithRanges.html)

Kdoc [before](https://unicode-org.github.io/icu4x/kdoc/icu4x/org.unicode.icu4x/-plural-rules-with-ranges/index.html) [after](https://icu4x-pr-artifacts.storage.googleapis.com/gha/5e6940bce0a3bae435baaa8df7ee2cdee8cc2c59/kdoc/icu4x/org.unicode.icu4x/-plural-rules-with-ranges/index.html)

## Changelog

N/A