### PR TITLE
feat(currency): Add CurrencyDecimalSymbolsV1 marker and generate per-currency decimal symbols

### DIFF
--- a/components/experimental/src/dimension/provider/currency/symbols.rs
+++ b/components/experimental/src/dimension/provider/currency/symbols.rs
@@ -21,6 +21,15 @@ icu_provider::data_marker!(
     attributes_domain = "currency",
 );
 
+icu_provider::data_marker!(
+    /// Currency-specific decimal symbols override data.
+    CurrencyDecimalSymbolsV1,
+    "currency/decimal/symbols/v1",
+    icu_decimal::provider::DecimalSymbols<'static>,
+    #[cfg(feature = "datagen")]
+    attributes_domain = "currency",
+);
+
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[cfg_attr(feature = "datagen", derive(serde::Serialize, databake::Bake))]
 #[cfg_attr(feature = "datagen", databake(path = icu_experimental::dimension::provider::currency::symbols))]

--- a/components/experimental/src/lib.rs
+++ b/components/experimental/src/lib.rs
@@ -59,6 +59,7 @@ pub mod provider {
 
         impl_currency_essentials_v1!(Baked);
         impl_currency_symbols_v1!(Baked);
+        impl_currency_decimal_symbols_v1!(Baked);
         impl_currency_displayname_v1!(Baked);
         impl_currency_patterns_data_v1!(Baked);
         impl_currency_extended_data_v1!(Baked);
@@ -126,6 +127,7 @@ pub mod provider {
         super::dimension::provider::currency::displayname::CurrencyDisplaynameV1::INFO,
         super::dimension::provider::currency::essentials::CurrencyEssentialsV1::INFO,
         super::dimension::provider::currency::symbols::CurrencySymbolsV1::INFO,
+        super::dimension::provider::currency::symbols::CurrencyDecimalSymbolsV1::INFO,
         super::dimension::provider::currency::patterns::CurrencyPatternsDataV1::INFO,
         super::dimension::provider::currency::extended::CurrencyExtendedDataV1::INFO,
         super::dimension::provider::currency::fractions::CurrencyFractionsV1::INFO,

--- a/provider/data/experimental/data/currency_decimal_symbols_v1.rs.data
+++ b/provider/data/experimental/data/currency_decimal_symbols_v1.rs.data
@@ -1,0 +1,70 @@
+// @generated
+/// Implement `DataProvider<CurrencyDecimalSymbolsV1>` on the given struct using the data
+/// hardcoded in this file. This allows the struct to be used with
+/// `icu`'s `_unstable` constructors.
+///
+/// Using this implementation will embed the following data in the binary's data segment:
+/// * 127B for the lookup data structure (11 data identifiers)
+/// * 469B[^1] for the actual data (10 unique structs)
+///
+/// [^1]: these numbers can be smaller in practice due to linker deduplication
+///
+/// This macro requires the following crates:
+/// * `icu`
+/// * `icu_provider`
+/// * `icu_provider/baked`
+/// * `zerovec`
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __impl_currency_decimal_symbols_v1 {
+    ($ provider : ty) => {
+        #[clippy::msrv = "1.88"]
+        const _: () = <$provider>::MUST_USE_MAKE_PROVIDER_MACRO;
+        #[clippy::msrv = "1.88"]
+        impl $provider {
+            const DATA_CURRENCY_DECIMAL_SYMBOLS_V1: icu_provider::baked::zerotrie::Data<icu::experimental::dimension::provider::currency::symbols::CurrencyDecimalSymbolsV1> = {
+                const TRIE: icu_provider::baked::zerotrie::ZeroTrieSimpleAscii<&'static [u8]> = icu_provider::baked::zerotrie::ZeroTrieSimpleAscii { store: b"\xC7cdegikp\x06\x0F$*07a\x1EESP\x83e-LU\x1ELUF\x87\xC3ltu\x05\n\x1EGRD\x83\x1EEEK\x82\x1EESP\x84l\x1EESP\x85t\x1EITL\x86ea\x1ECVE\x80t-\xC3ACP\x06\x0CO\x1EPTE\x88V\x1ECVE\x81T\x1EPTE\x89" };
+                const VALUES: &'static [<icu::experimental::dimension::provider::currency::symbols::CurrencyDecimalSymbolsV1 as icu_provider::baked::zerotrie::DynamicDataMarker>::DataStruct] = &[icu::decimal::provider::DecimalSymbols { strings: unsafe { zerovec::VarZeroCow::from_bytes_unchecked(b"\x01\x01\x02\x02\x03\x05-+$\xC2\xA0latn") }, grouping_sizes: icu::decimal::provider::GroupingSizes { primary: 3u8, secondary: 3u8, min_grouping: 1u8 } }, icu::decimal::provider::DecimalSymbols { strings: unsafe { zerovec::VarZeroCow::from_bytes_unchecked(b"\x01\x01\x02\x02\x03\x05-+$\xC2\xA0latn") }, grouping_sizes: icu::decimal::provider::GroupingSizes { primary: 3u8, secondary: 3u8, min_grouping: 2u8 } }, icu::decimal::provider::DecimalSymbols { strings: unsafe { zerovec::VarZeroCow::from_bytes_unchecked(b"\x03\x03\x04\x04\x05\x07\xE2\x88\x92+.\xC2\xA0latn") }, grouping_sizes: icu::decimal::provider::GroupingSizes { primary: 3u8, secondary: 3u8, min_grouping: 2u8 } }, icu::decimal::provider::DecimalSymbols { strings: unsafe { zerovec::VarZeroCow::from_bytes_unchecked(b"\x01\x01\x02\x02\x03\x04-+,.latn") }, grouping_sizes: icu::decimal::provider::GroupingSizes { primary: 3u8, secondary: 3u8, min_grouping: 1u8 } }, icu::decimal::provider::DecimalSymbols { strings: unsafe { zerovec::VarZeroCow::from_bytes_unchecked(b"\x03\x03\x04\x04\x05\x06\xE2\x88\x92+,.latn") }, grouping_sizes: icu::decimal::provider::GroupingSizes { primary: 3u8, secondary: 3u8, min_grouping: 1u8 } }, icu::decimal::provider::DecimalSymbols { strings: unsafe { zerovec::VarZeroCow::from_bytes_unchecked(b"\x01\x01\x02\x02\x03\x06-+,\xE2\x80\xAFlatn") }, grouping_sizes: icu::decimal::provider::GroupingSizes { primary: 3u8, secondary: 3u8, min_grouping: 1u8 } }, icu::decimal::provider::DecimalSymbols { strings: unsafe { zerovec::VarZeroCow::from_bytes_unchecked(b"\x01\x01\x02\x02\x03\x04-+,.latn") }, grouping_sizes: icu::decimal::provider::GroupingSizes { primary: 3u8, secondary: 3u8, min_grouping: 2u8 } }, icu::decimal::provider::DecimalSymbols { strings: unsafe { zerovec::VarZeroCow::from_bytes_unchecked(b"\x01\x01\x02\x02\x03\x04-+.,latn") }, grouping_sizes: icu::decimal::provider::GroupingSizes { primary: 3u8, secondary: 3u8, min_grouping: 1u8 } }, icu::decimal::provider::DecimalSymbols { strings: unsafe { zerovec::VarZeroCow::from_bytes_unchecked(b"\x01\x01\x02\x02\x03\x04-+$,latn") }, grouping_sizes: icu::decimal::provider::GroupingSizes { primary: 3u8, secondary: 3u8, min_grouping: 1u8 } }, icu::decimal::provider::DecimalSymbols { strings: unsafe { zerovec::VarZeroCow::from_bytes_unchecked(b"\x01\x01\x02\x02\x03\x04-+$,latn") }, grouping_sizes: icu::decimal::provider::GroupingSizes { primary: 3u8, secondary: 3u8, min_grouping: 2u8 } }];
+                unsafe { icu_provider::baked::zerotrie::Data::from_trie_and_values_unchecked(TRIE, VALUES) }
+            };
+        }
+        #[clippy::msrv = "1.88"]
+        impl icu_provider::DataProvider<icu::experimental::dimension::provider::currency::symbols::CurrencyDecimalSymbolsV1> for $provider {
+            fn load(&self, req: icu_provider::DataRequest) -> Result<icu_provider::DataResponse<icu::experimental::dimension::provider::currency::symbols::CurrencyDecimalSymbolsV1>, icu_provider::DataError> {
+                let mut metadata = icu_provider::DataResponseMetadata::default();
+                let payload = if let Some(payload) = icu_provider::baked::DataStore::get(&Self::DATA_CURRENCY_DECIMAL_SYMBOLS_V1, req.id, req.metadata.attributes_prefix_match) {
+                    payload
+                } else {
+                    const FALLBACKER: icu_locale_fallback::LocaleFallbackerWithConfig<'static> = icu_locale_fallback::LocaleFallbacker::new().for_config(<icu::experimental::dimension::provider::currency::symbols::CurrencyDecimalSymbolsV1 as icu_provider::DataMarker>::INFO.fallback_config);
+                    let mut fallback_iterator = FALLBACKER.fallback_for(req.id.locale.clone());
+                    loop {
+                        if let Some(payload) = icu_provider::baked::DataStore::get(&Self::DATA_CURRENCY_DECIMAL_SYMBOLS_V1, icu_provider::DataIdentifierBorrowed::for_marker_attributes_and_locale(req.id.marker_attributes, fallback_iterator.get()), req.metadata.attributes_prefix_match) {
+                            metadata.locale = Some(fallback_iterator.take());
+                            break payload;
+                        }
+                        if fallback_iterator.get().is_unknown() {
+                            return Err(icu_provider::DataErrorKind::IdentifierNotFound.with_req(<icu::experimental::dimension::provider::currency::symbols::CurrencyDecimalSymbolsV1 as icu_provider::DataMarker>::INFO, req));
+                        }
+                        fallback_iterator.step();
+                    }
+                };
+                Ok(icu_provider::DataResponse { payload, metadata })
+            }
+        }
+    };
+    ($ provider : ty , ITER) => {
+        __impl_currency_decimal_symbols_v1!($provider);
+        #[clippy::msrv = "1.88"]
+        impl icu_provider::IterableDataProvider<icu::experimental::dimension::provider::currency::symbols::CurrencyDecimalSymbolsV1> for $provider {
+            fn iter_ids(&self) -> Result<std::collections::BTreeSet<icu_provider::DataIdentifierCow<'static>>, icu_provider::DataError> {
+                Ok(icu_provider::baked::DataStore::iter(&Self::DATA_CURRENCY_DECIMAL_SYMBOLS_V1).collect())
+            }
+        }
+    };
+    ($ provider : ty , DRY) => {};
+    ($ provider : ty , DRY , ITER) => {
+        __impl_currency_decimal_symbols_v1!($provider, ITER);
+    };
+}
+#[doc(inline)]
+pub use __impl_currency_decimal_symbols_v1 as impl_currency_decimal_symbols_v1;

--- a/provider/data/experimental/data/mod.rs
+++ b/provider/data/experimental/data/mod.rs
@@ -41,6 +41,7 @@ include!("units_names_length_extended_v1.rs.data");
 include!("locale_names_language_v0.rs.data");
 include!("currency_essentials_v1.rs.data");
 include!("locale_names_script_v0.rs.data");
+include!("currency_decimal_symbols_v1.rs.data");
 include!("units_names_length_outlier_v1.rs.data");
 include!("datetime_relative_month_short_v1.rs.data");
 include!("locale_names_locale_v0.rs.data");
@@ -134,6 +135,7 @@ macro_rules! impl_data_provider {
         impl_locale_names_language_v0!($provider);
         impl_currency_essentials_v1!($provider);
         impl_locale_names_script_v0!($provider);
+        impl_currency_decimal_symbols_v1!($provider);
         impl_units_names_length_outlier_v1!($provider);
         impl_datetime_relative_month_short_v1!($provider);
         impl_locale_names_locale_v0!($provider);

--- a/provider/data/experimental/fingerprints.csv
+++ b/provider/data/experimental/fingerprints.csv
@@ -1,3 +1,16 @@
+currency/decimal/symbols/v1, <lookup>, 127B, 11 identifiers
+currency/decimal/symbols/v1, <total>, 469B, 189B, 10 unique payloads
+currency/decimal/symbols/v1, ca/ESP, 46B, 18B, a1c6d58e8b50443f
+currency/decimal/symbols/v1, de-LU/LUF, 46B, 18B, 3fb007994296856a
+currency/decimal/symbols/v1, el/GRD, -> ca/ESP
+currency/decimal/symbols/v1, et/EEK, 49B, 21B, 1e7bda97fc47a75b
+currency/decimal/symbols/v1, eu/ESP, 48B, 20B, ad715ee6fa0d32be
+currency/decimal/symbols/v1, gl/ESP, 48B, 20B, 1bf992c0a6d711d8
+currency/decimal/symbols/v1, it/ITL, 46B, 18B, 28dd4136886d5f01
+currency/decimal/symbols/v1, kea/CVE, 47B, 19B, 7f4fc75dad04de0d
+currency/decimal/symbols/v1, pt-AO/PTE, 46B, 18B, 5a368e82989e526
+currency/decimal/symbols/v1, pt-CV/CVE, 47B, 19B, 5807166997b686f4
+currency/decimal/symbols/v1, pt-PT/PTE, 46B, 18B, b777d39d046db9a9
 currency/displayname/v1, <lookup>, 199888B, 32067 identifiers
 currency/displayname/v1, <total>, 1479025B, 817648B, 28756 unique payloads
 currency/displayname/v1, af/AED, 57B, 34B, 15625d9aef7c43a7

--- a/provider/data/experimental/stubdata/currency_decimal_symbols_v1.rs.data
+++ b/provider/data/experimental/stubdata/currency_decimal_symbols_v1.rs.data
@@ -1,0 +1,57 @@
+// @generated
+/// Implement `DataProvider<CurrencyDecimalSymbolsV1>` on the given struct using the data
+/// hardcoded in this file. This allows the struct to be used with
+/// `icu`'s `_unstable` constructors.
+///
+/// This macro requires the following crates:
+/// * `icu`
+/// * `icu_provider`
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __impl_currency_decimal_symbols_v1 {
+    ($ provider : ty) => {
+        #[clippy::msrv = "1.88"]
+        const _: () = <$provider>::MUST_USE_MAKE_PROVIDER_MACRO;
+        #[clippy::msrv = "1.88"]
+        impl icu_provider::DataProvider<icu::experimental::dimension::provider::currency::symbols::CurrencyDecimalSymbolsV1> for $provider {
+            fn load(&self, req: icu_provider::DataRequest) -> Result<icu_provider::DataResponse<icu::experimental::dimension::provider::currency::symbols::CurrencyDecimalSymbolsV1>, icu_provider::DataError> {
+                Err(icu_provider::DataErrorKind::IdentifierNotFound.with_req(<icu::experimental::dimension::provider::currency::symbols::CurrencyDecimalSymbolsV1 as icu_provider::DataMarker>::INFO, req))
+            }
+        }
+    };
+    ($ provider : ty , ITER) => {
+        __impl_currency_decimal_symbols_v1!($provider);
+        #[clippy::msrv = "1.88"]
+        impl icu_provider::IterableDataProvider<icu::experimental::dimension::provider::currency::symbols::CurrencyDecimalSymbolsV1> for $provider {
+            fn iter_ids(&self) -> Result<std::collections::BTreeSet<icu_provider::DataIdentifierCow<'static>>, icu_provider::DataError> {
+                Ok(Default::default())
+            }
+        }
+    };
+    ($ provider : ty , DRY) => {
+        __impl_currency_decimal_symbols_v1!($provider);
+        #[clippy::msrv = "1.88"]
+        impl icu_provider::DryDataProvider<icu::experimental::dimension::provider::currency::symbols::CurrencyDecimalSymbolsV1> for $provider {
+            fn dry_load(&self, req: icu_provider::DataRequest) -> Result<icu_provider::DataResponseMetadata, icu_provider::DataError> {
+                Err(icu_provider::DataErrorKind::IdentifierNotFound.with_req(<icu::experimental::dimension::provider::currency::symbols::CurrencyDecimalSymbolsV1 as icu_provider::DataMarker>::INFO, req))
+            }
+        }
+    };
+    ($ provider : ty , DRY , ITER) => {
+        __impl_currency_decimal_symbols_v1!($provider);
+        #[clippy::msrv = "1.88"]
+        impl icu_provider::DryDataProvider<icu::experimental::dimension::provider::currency::symbols::CurrencyDecimalSymbolsV1> for $provider {
+            fn dry_load(&self, req: icu_provider::DataRequest) -> Result<icu_provider::DataResponseMetadata, icu_provider::DataError> {
+                Err(icu_provider::DataErrorKind::IdentifierNotFound.with_req(<icu::experimental::dimension::provider::currency::symbols::CurrencyDecimalSymbolsV1 as icu_provider::DataMarker>::INFO, req))
+            }
+        }
+        #[clippy::msrv = "1.88"]
+        impl icu_provider::IterableDataProvider<icu::experimental::dimension::provider::currency::symbols::CurrencyDecimalSymbolsV1> for $provider {
+            fn iter_ids(&self) -> Result<std::collections::BTreeSet<icu_provider::DataIdentifierCow<'static>>, icu_provider::DataError> {
+                Ok(Default::default())
+            }
+        }
+    };
+}
+#[doc(inline)]
+pub use __impl_currency_decimal_symbols_v1 as impl_currency_decimal_symbols_v1;

--- a/provider/data/experimental/stubdata/mod.rs
+++ b/provider/data/experimental/stubdata/mod.rs
@@ -41,6 +41,7 @@ include!("units_names_length_extended_v1.rs.data");
 include!("locale_names_language_v0.rs.data");
 include!("currency_essentials_v1.rs.data");
 include!("locale_names_script_v0.rs.data");
+include!("currency_decimal_symbols_v1.rs.data");
 include!("units_names_length_outlier_v1.rs.data");
 include!("datetime_relative_month_short_v1.rs.data");
 include!("locale_names_locale_v0.rs.data");
@@ -133,6 +134,7 @@ macro_rules! impl_data_provider {
         impl_locale_names_language_v0!($provider);
         impl_currency_essentials_v1!($provider);
         impl_locale_names_script_v0!($provider);
+        impl_currency_decimal_symbols_v1!($provider);
         impl_units_names_length_outlier_v1!($provider);
         impl_datetime_relative_month_short_v1!($provider);
         impl_locale_names_locale_v0!($provider);

--- a/provider/registry/src/lib.rs
+++ b/provider/registry/src/lib.rs
@@ -295,6 +295,7 @@ macro_rules! registry(
             icu::experimental::dimension::provider::currency::displayname::CurrencyDisplaynameV1: CurrencyDisplaynameV1,
             icu::experimental::dimension::provider::currency::essentials::CurrencyEssentialsV1: CurrencyEssentialsV1,
             icu::experimental::dimension::provider::currency::symbols::CurrencySymbolsV1: CurrencySymbolsV1,
+            icu::experimental::dimension::provider::currency::symbols::CurrencyDecimalSymbolsV1: CurrencyDecimalSymbolsV1,
             icu::experimental::dimension::provider::currency::patterns::CurrencyPatternsDataV1: CurrencyPatternsDataV1,
             icu::experimental::dimension::provider::currency::extended::CurrencyExtendedDataV1: CurrencyExtendedDataV1,
             icu::experimental::dimension::provider::currency::fractions::CurrencyFractionsV1: CurrencyFractionsV1,

--- a/provider/source/src/cldr_serde/currencies/data.rs
+++ b/provider/source/src/cldr_serde/currencies/data.rs
@@ -44,6 +44,12 @@ pub(crate) struct CurrencyPatterns {
 
     #[serde(rename = "displayName-count-other")]
     pub(crate) other: Option<String>,
+
+    /// Decimal separator override for this currency (UTS 35 `<currency><decimal>`).
+    pub(crate) decimal: Option<String>,
+
+    /// Grouping separator override for this currency (UTS 35 `<currency><group>`).
+    pub(crate) group: Option<String>,
 }
 
 #[derive(PartialEq, Debug, Deserialize)]

--- a/provider/source/src/currency/decimal_symbols.rs
+++ b/provider/source/src/currency/decimal_symbols.rs
@@ -1,0 +1,319 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use crate::IterableDataProviderCached;
+use crate::SourceDataProvider;
+use crate::cldr_serde;
+use crate::decimal::decimal_pattern::DecimalSubPattern;
+use icu::decimal::provider::*;
+use icu::experimental::dimension::provider::currency::symbols::CurrencyDecimalSymbolsV1;
+use icu_provider::prelude::*;
+use std::collections::HashSet;
+use zerovec::VarZeroCow;
+
+/// Splits marker attributes into an optional numbering system and the currency code.
+///
+/// Returns `Err(IdentifierNotFound)` if the currency is missing or empty.
+///
+/// Attribute format:
+/// - `<currency>` (e.g. `"PTE"`): `Ok((None, "PTE"))`
+/// - `<numsys>/<currency>` (e.g. `"arab/PTE"`): `Ok((Some("arab"), "PTE"))`
+fn split_currency_attributes(
+    attrs: &DataMarkerAttributes,
+) -> Result<(Option<&str>, &str), DataError> {
+    let (nu, currency) = match attrs.as_str().split_once('/') {
+        Some((nu, curr)) => (Some(nu), curr),
+        None => (None, attrs.as_str()),
+    };
+    if currency.is_empty() {
+        return Err(DataErrorKind::IdentifierNotFound.into_error());
+    }
+    Ok((nu, currency))
+}
+
+/// Formats marker attributes from an optional numbering system and currency code.
+///
+/// Returns an error if `currency` is not 3 uppercase ASCII letters (ISO-4217),
+/// or if `nu` is not 3-8 lowercase ASCII letters (BCP-47 numbering system subtag).
+fn currency_attributes(
+    nu: Option<&str>,
+    currency: &str,
+) -> Result<Box<DataMarkerAttributes>, DataError> {
+    if currency.len() != 3 || !currency.bytes().all(|b| b.is_ascii_uppercase()) {
+        log::error!(
+            "currency attribute must be 3 uppercase ASCII letters as an ISO-4217 currency code: {currency}"
+        );
+        return Err(DataError::custom(
+            "currency attribute must be 3 uppercase ASCII letters as an ISO-4217 currency code",
+        )
+        .with_debug_context(&currency));
+    }
+    if let Some(nu) = nu
+        && (!(3..=8).contains(&nu.len()) || !nu.bytes().all(|b| b.is_ascii_lowercase()))
+    {
+        return Err(DataError::custom(
+            "numbering system attribute must be 3-8 lowercase ASCII letters",
+        )
+        .with_debug_context(&nu));
+    }
+    Ok(match nu {
+        Some(nu) => DataMarkerAttributes::try_from_string(format!("{nu}/{currency}")),
+        None => DataMarkerAttributes::try_from_string(currency.to_owned()),
+    }
+    .expect("valid marker attributes"))
+}
+
+impl DataProvider<CurrencyDecimalSymbolsV1> for SourceDataProvider {
+    fn load(&self, req: DataRequest) -> Result<DataResponse<CurrencyDecimalSymbolsV1>, DataError> {
+        self.check_req::<CurrencyDecimalSymbolsV1>(req)?;
+
+        let (nsattr, currency) = split_currency_attributes(req.id.marker_attributes)
+            .map_err(|e| e.with_req(CurrencyDecimalSymbolsV1::INFO, req))?;
+
+        let resource: &cldr_serde::numbers::Resource = self
+            .cldr()?
+            .numbers()
+            .read_and_parse(req.id.locale, "numbers.json")?;
+
+        let numbers = &resource.main.value.numbers;
+
+        let nsname = nsattr.unwrap_or(&numbers.default_numbering_system);
+
+        let Some(symbols) = &numbers.numsys_data.symbols.get(nsname) else {
+            return Err(
+                DataErrorKind::IdentifierNotFound.with_req(CurrencyDecimalSymbolsV1::INFO, req)
+            );
+        };
+        let Some(formats) = &numbers.numsys_data.formats.get(nsname) else {
+            return Err(
+                DataErrorKind::IdentifierNotFound.with_req(CurrencyDecimalSymbolsV1::INFO, req)
+            );
+        };
+
+        let positive = DecimalSubPattern::try_from_items(&formats.standard.positive)?;
+        let negative = formats
+            .standard
+            .negative
+            .as_ref()
+            .map(|s| DecimalSubPattern::try_from_items(s))
+            .transpose()?;
+
+        let affixes = negative
+            .as_ref()
+            .map(|n| (n.prefix.as_str(), n.suffix.as_str()))
+            .unwrap_or_else(|| ("-", ""));
+
+        let currencies: &cldr_serde::currencies::data::Resource = self
+            .cldr()?
+            .numbers()
+            .read_and_parse(req.id.locale, "currencies.json")?;
+
+        let overrides = currencies
+            .main
+            .value
+            .numbers
+            .currencies
+            .get(currency)
+            .ok_or_else(|| {
+                DataErrorKind::IdentifierNotFound.with_req(CurrencyDecimalSymbolsV1::INFO, req)
+            })?;
+
+        let decimal = overrides.decimal.as_deref();
+        let group = overrides.group.as_deref();
+
+        if decimal.is_none() && group.is_none() {
+            return Err(
+                DataErrorKind::IdentifierNotFound.with_req(CurrencyDecimalSymbolsV1::INFO, req)
+            );
+        }
+
+        let decimal_separator = decimal.unwrap_or(&symbols.decimal);
+        let grouping_separator = group.unwrap_or(&symbols.group);
+
+        let strings = DecimalSymbolStrsBuilder {
+            minus_sign_prefix: VarZeroCow::new_owned(
+                affixes.0.replace('-', &symbols.minus_sign).into_boxed_str(),
+            ),
+            minus_sign_suffix: VarZeroCow::new_owned(
+                affixes.1.replace('-', &symbols.minus_sign).into_boxed_str(),
+            ),
+            plus_sign_prefix: VarZeroCow::new_owned(
+                affixes.0.replace('-', &symbols.plus_sign).into_boxed_str(),
+            ),
+            plus_sign_suffix: VarZeroCow::new_owned(
+                affixes.1.replace('-', &symbols.plus_sign).into_boxed_str(),
+            ),
+            decimal_separator: VarZeroCow::new_owned(decimal_separator.to_owned().into_boxed_str()),
+            grouping_separator: VarZeroCow::new_owned(
+                grouping_separator.to_owned().into_boxed_str(),
+            ),
+            numsys: VarZeroCow::new_owned(nsname.to_owned().into_boxed_str()),
+        }
+        .build();
+
+        if let Some(n) = negative.as_ref()
+            && (
+                positive.max_fraction_digits,
+                positive.min_fraction_digits,
+                positive.primary_grouping,
+                positive.secondary_grouping,
+            ) != (
+                n.max_fraction_digits,
+                n.min_fraction_digits,
+                n.primary_grouping,
+                n.secondary_grouping,
+            )
+        {
+            return Err(DataError::custom("positive/negative groupings don't match")
+                .with_req(CurrencyDecimalSymbolsV1::INFO, req));
+        }
+
+        let grouping_sizes = GroupingSizes {
+            primary: positive.primary_grouping,
+            secondary: positive.secondary_grouping,
+            min_grouping: numbers.minimum_grouping_digits,
+        };
+
+        Ok(DataResponse {
+            metadata: Default::default(),
+            payload: DataPayload::from_owned(DecimalSymbols {
+                strings,
+                grouping_sizes,
+            }),
+        })
+    }
+}
+
+impl IterableDataProviderCached<CurrencyDecimalSymbolsV1> for SourceDataProvider {
+    fn iter_ids_cached(&self) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
+        let mut ids = HashSet::new();
+
+        for locale in self.cldr()?.numbers().list_locales()? {
+            let currencies: &cldr_serde::currencies::data::Resource = self
+                .cldr()?
+                .numbers()
+                .read_and_parse(&locale, "currencies.json")?;
+
+            let overriding = currencies
+                .main
+                .value
+                .numbers
+                .currencies
+                .iter()
+                .filter(|(_, patterns)| patterns.decimal.is_some() || patterns.group.is_some())
+                .map(|(currency, _)| currency.as_str())
+                .collect::<Vec<_>>();
+
+            if overriding.is_empty() {
+                continue;
+            }
+
+            // The overrides are not scoped to a numbering system, but the rest of the
+            // symbols are, so each numbering system needs its own identifier.
+            let numsys = self.get_supported_numsys_for_langid(&locale, true)?;
+
+            for currency in overriding {
+                if currency.len() != 3 || !currency.bytes().all(|b| b.is_ascii_uppercase()) {
+                    log::error!(
+                        "Skipping non-ISO-4217 currency override for '{currency}' in locale {locale}"
+                    );
+                    continue;
+                }
+                let default_attr = currency_attributes(None, currency)?;
+                ids.insert(
+                    DataIdentifierBorrowed::for_marker_attributes_and_locale(
+                        &default_attr,
+                        &locale,
+                    )
+                    .into_owned(),
+                );
+                for nsname in &numsys {
+                    let attr = currency_attributes(Some(nsname.as_str()), currency)?;
+                    ids.insert(
+                        DataIdentifierBorrowed::for_marker_attributes_and_locale(&attr, &locale)
+                            .into_owned(),
+                    );
+                }
+            }
+        }
+
+        Ok(ids)
+    }
+}
+
+#[test]
+fn test_currency_attributes_roundtrip() {
+    let pte = DataMarkerAttributes::from_str_or_panic("PTE");
+    let arab_pte = DataMarkerAttributes::from_str_or_panic("arab/PTE");
+    assert_eq!(split_currency_attributes(pte).unwrap(), (None, "PTE"));
+    assert_eq!(
+        split_currency_attributes(arab_pte).unwrap(),
+        (Some("arab"), "PTE")
+    );
+    let empty = DataMarkerAttributes::from_str_or_panic("");
+    assert!(split_currency_attributes(empty).is_err());
+
+    assert_eq!(currency_attributes(None, "PTE").unwrap().as_str(), "PTE");
+    assert_eq!(
+        currency_attributes(Some("arab"), "PTE").unwrap().as_str(),
+        "arab/PTE"
+    );
+}
+
+#[test]
+fn test_currency_attributes_validation() {
+    // Valid attributes:
+    assert!(currency_attributes(None, "USD").is_ok());
+    assert!(currency_attributes(Some("latn"), "PTE").is_ok());
+    assert!(currency_attributes(Some("arabext"), "PTE").is_ok());
+
+    // Invalid currency (must be 3 uppercase ASCII letters as an ISO-4217 currency code):
+    assert!(currency_attributes(None, "usd").is_err());
+    assert!(currency_attributes(None, "US").is_err());
+    assert!(currency_attributes(None, "USDD").is_err());
+    assert!(currency_attributes(None, "").is_err());
+    assert!(currency_attributes(None, "123").is_err());
+
+    // Invalid numbering system (must be 3-8 lowercase ASCII letters):
+    assert!(currency_attributes(Some(""), "USD").is_err());
+    assert!(currency_attributes(Some("la"), "USD").is_err());
+    assert!(currency_attributes(Some("latn/"), "USD").is_err());
+    assert!(currency_attributes(Some("LATN"), "USD").is_err());
+    assert!(currency_attributes(Some("123"), "USD").is_err());
+    assert!(currency_attributes(Some("toolongsystem"), "USD").is_err());
+}
+
+#[test]
+fn test_currency_symbols() {
+    use icu::locale::langid;
+
+    let provider = SourceDataProvider::new_testing();
+
+    let load = |currency| {
+        DataProvider::<CurrencyDecimalSymbolsV1>::load(
+            &provider,
+            DataRequest {
+                id: DataIdentifierBorrowed::for_marker_attributes_and_locale(
+                    DataMarkerAttributes::from_str_or_panic(currency),
+                    &langid!("pt-PT").into(),
+                ),
+                ..Default::default()
+            },
+        )
+    };
+
+    // `pt-PT` formats the Portuguese escudo with `$` as its decimal separator and `,`
+    // as its grouping separator, instead of the standard `,` and U+00A0.
+    let escudo = load("PTE").unwrap().payload;
+    assert_eq!(escudo.get().decimal_separator(), "$");
+    assert_eq!(escudo.get().grouping_separator(), ",");
+    assert_eq!(escudo.get().numsys(), "latn");
+
+    // Currencies without overrides have no identifier of their own; consumers fall back
+    // to the locale's standard symbols.
+    assert_eq!(
+        load("EUR").map(|_| ()).unwrap_err().kind,
+        DataErrorKind::IdentifierNotFound
+    );
+}

--- a/provider/source/src/currency/mod.rs
+++ b/provider/source/src/currency/mod.rs
@@ -2,6 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+pub(crate) mod decimal_symbols;
 pub(crate) mod displayname;
 pub(crate) mod essentials;
 pub(crate) mod extended;

--- a/provider/source/src/decimal/mod.rs
+++ b/provider/source/src/decimal/mod.rs
@@ -51,7 +51,7 @@ impl SourceDataProvider {
     }
 
     /// Get all numbering systems supported by a langid, potentially excluding the default one
-    fn get_supported_numsys_for_langid(
+    pub(crate) fn get_supported_numsys_for_langid(
         &self,
         locale: &DataLocale,
         exclude_default: bool,

--- a/provider/source/src/segmenter/mod.rs
+++ b/provider/source/src/segmenter/mod.rs
@@ -1985,6 +1985,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "unstable")]
     fn load_line_data() {
         let provider = SourceDataProvider::new_testing();
         let response: DataResponse<SegmenterBreakLineV3> = provider

--- a/provider/source/src/tests/data.rs
+++ b/provider/source/src/tests/data.rs
@@ -536,6 +536,8 @@ pub fn cldr_data() -> AbstractFs {
         "cldr-numbers-full/main/fr/numbers.json",
         "cldr-numbers-full/main/ja/currencies.json",
         "cldr-numbers-full/main/ja/numbers.json",
+        "cldr-numbers-full/main/pt-PT/currencies.json",
+        "cldr-numbers-full/main/pt-PT/numbers.json",
         "cldr-numbers-full/main/ru/currencies.json",
         "cldr-numbers-full/main/ru/numbers.json",
         "cldr-numbers-full/main/sr-Latn/currencies.json",

--- a/provider/source/src/units/categorized_display_name.rs
+++ b/provider/source/src/units/categorized_display_name.rs
@@ -66,8 +66,8 @@ impl SourceDataProvider {
         category: &str,
     ) -> Result<HashSet<DataIdentifierCow<'static>>, DataError> {
         let mut data_locales = HashSet::new();
-        let numbers = self.cldr()?.numbers();
-        let locales = numbers.list_locales()?;
+        let units = self.cldr()?.units();
+        let locales = units.list_locales()?;
         for locale in locales {
             // Load and parse the unit constants from the supplemental data file.
             let preferences: &cldr_serde::units::preferences::Resource = self

--- a/provider/source/tests/data/cldr/cldr-numbers-full/main/pt-PT/currencies.json
+++ b/provider/source/tests/data/cldr/cldr-numbers-full/main/pt-PT/currencies.json
@@ -1,0 +1,1649 @@
+{
+  "main": {
+    "pt-PT": {
+      "identity": {
+        "language": "pt",
+        "territory": "PT"
+      },
+      "numbers": {
+        "currencies": {
+          "ADP": {
+            "displayName": "Peseta de Andorra",
+            "displayName-count-one": "Peseta de Andorra",
+            "displayName-count-other": "Pesetas de Andorra"
+          },
+          "AED": {
+            "displayName": "dirham dos Emirados Árabes Unidos",
+            "displayName-count-one": "dirham dos Emirados Árabes Unidos",
+            "displayName-count-other": "sdirham dos Emirados Árabes Unidos"
+          },
+          "AFA": {
+            "displayName": "Afeghani (1927–2002)",
+            "displayName-count-one": "Afegane do Afeganistão (AFA)",
+            "displayName-count-other": "Afeganes do Afeganistão (AFA)"
+          },
+          "AFN": {
+            "displayName": "afegâni afegão",
+            "displayName-count-one": "afegâni afegão",
+            "displayName-count-other": "afegânis afegãos",
+            "symbol-alt-narrow": "؋"
+          },
+          "ALK": {
+            "displayName": "Lek Albanês (1946–1965)",
+            "displayName-count-one": "Lek Albanês (1946–1965)",
+            "displayName-count-other": "Leks Albaneses (1946–1965)"
+          },
+          "ALL": {
+            "displayName": "lek albanês",
+            "displayName-count-one": "lek albanês",
+            "displayName-count-other": "leks albaneses"
+          },
+          "AMD": {
+            "displayName": "dram arménio",
+            "displayName-count-one": "dram arménio",
+            "displayName-count-other": "drams arménios",
+            "symbol-alt-narrow": "֏"
+          },
+          "ANG": {
+            "displayName": "florim das Antilhas Holandesas",
+            "displayName-count-one": "florim das Antilhas Holandesas",
+            "displayName-count-other": "florins das Antilhas Holandesas"
+          },
+          "AOA": {
+            "displayName": "kwanza angolano",
+            "displayName-count-one": "kwanza angolano",
+            "displayName-count-other": "kwanzas angolanos",
+            "symbol-alt-narrow": "Kz"
+          },
+          "AOK": {
+            "displayName": "Cuanza angolano (1977–1990)",
+            "displayName-count-one": "Kwanza angolano (AOK)",
+            "displayName-count-other": "Kwanzas angolanos (AOK)"
+          },
+          "AON": {
+            "displayName": "Novo cuanza angolano (1990–2000)",
+            "displayName-count-one": "Novo kwanza angolano (AON)",
+            "displayName-count-other": "Novos kwanzas angolanos (AON)"
+          },
+          "AOR": {
+            "displayName": "Cuanza angolano reajustado (1995–1999)",
+            "displayName-count-one": "Kwanza angolano reajustado (AOR)",
+            "displayName-count-other": "Kwanzas angolanos reajustados (AOR)"
+          },
+          "ARA": {
+            "displayName": "Austral argentino",
+            "displayName-count-one": "Austral argentino",
+            "displayName-count-other": "Austrais argentinos"
+          },
+          "ARL": {
+            "displayName": "Peso lei argentino (1970–1983)",
+            "displayName-count-one": "Peso lei argentino (1970–1983)",
+            "displayName-count-other": "Pesos lei argentinos (1970–1983)"
+          },
+          "ARM": {
+            "displayName": "Peso argentino (1881–1970)",
+            "displayName-count-one": "Peso argentino (1881–1970)",
+            "displayName-count-other": "Pesos argentinos (1881–1970)"
+          },
+          "ARP": {
+            "displayName": "Peso argentino (1983–1985)",
+            "displayName-count-one": "Peso argentino (1983–1985)",
+            "displayName-count-other": "Pesos argentinos (1983–1985)"
+          },
+          "ARS": {
+            "displayName": "peso argentino",
+            "displayName-count-one": "peso argentino",
+            "displayName-count-other": "pesos argentinos",
+            "symbol-alt-narrow": "$"
+          },
+          "ATS": {
+            "displayName": "Xelim austríaco",
+            "displayName-count-one": "Schilling australiano",
+            "displayName-count-other": "Schillings australianos"
+          },
+          "AUD": {
+            "displayName": "dólar australiano",
+            "displayName-count-one": "dólar australiano",
+            "displayName-count-other": "dólares australianos",
+            "symbol": "AU$",
+            "symbol-alt-narrow": "$"
+          },
+          "AWG": {
+            "displayName": "florim de Aruba",
+            "displayName-count-one": "florim de Aruba",
+            "displayName-count-other": "florins de Aruba"
+          },
+          "AZM": {
+            "displayName": "Manat azerbaijano (1993–2006)",
+            "displayName-count-one": "Manat do Azeibaijão (1993–2006)",
+            "displayName-count-other": "Manats do Azeibaijão (1993–2006)"
+          },
+          "AZN": {
+            "displayName": "manat azeri",
+            "displayName-count-one": "manat azeri",
+            "displayName-count-other": "manats azeris",
+            "symbol-alt-narrow": "₼"
+          },
+          "BAD": {
+            "displayName": "Dinar da Bósnia-Herzegóvina",
+            "displayName-count-one": "Dinar da Bósnia Herzegovina",
+            "displayName-count-other": "Dinares da Bósnia Herzegovina"
+          },
+          "BAM": {
+            "displayName": "marco bósnio-herzegóvino conversível",
+            "displayName-count-one": "marco bósnio-herzegóvino conversível",
+            "displayName-count-other": "marcos bósnio-herzegóvinos conversíveis",
+            "symbol-alt-narrow": "KM"
+          },
+          "BAN": {
+            "displayName": "Novo dinar da Bósnia-Herzegovina (1994–1997)",
+            "displayName-count-one": "Novo dinar da Bósnia-Herzegovina",
+            "displayName-count-other": "Novos dinares da Bósnia-Herzegovina"
+          },
+          "BBD": {
+            "displayName": "dólar barbadense",
+            "displayName-count-one": "dólar barbadense",
+            "displayName-count-other": "dólares barbadenses",
+            "symbol-alt-narrow": "$"
+          },
+          "BDT": {
+            "displayName": "taka bengali",
+            "displayName-count-one": "taka bengali",
+            "displayName-count-other": "takas bengalis",
+            "symbol-alt-narrow": "৳"
+          },
+          "BEC": {
+            "displayName": "Franco belga (convertível)",
+            "displayName-count-one": "Franco belga (conversível)",
+            "displayName-count-other": "Francos belgas (conversíveis)"
+          },
+          "BEF": {
+            "displayName": "Franco belga",
+            "displayName-count-one": "Franco belga",
+            "displayName-count-other": "Francos belgas"
+          },
+          "BEL": {
+            "displayName": "Franco belga (financeiro)",
+            "displayName-count-one": "Franco belga (financeiro)",
+            "displayName-count-other": "Francos belgas (financeiros)"
+          },
+          "BGL": {
+            "displayName": "Lev forte búlgaro",
+            "displayName-count-one": "Lev forte búlgaro",
+            "displayName-count-other": "Levs fortes búlgaros"
+          },
+          "BGM": {
+            "displayName": "Lev socialista búlgaro",
+            "displayName-count-one": "Lev socialista búlgaro",
+            "displayName-count-other": "Levs socialistas búlgaros"
+          },
+          "BGN": {
+            "displayName": "lev búlgaro",
+            "displayName-count-one": "lev búlgaro",
+            "displayName-count-other": "levs búlgaros"
+          },
+          "BGO": {
+            "displayName": "Lev búlgaro (1879–1952)",
+            "displayName-count-one": "Lev búlgaro (1879–1952)",
+            "displayName-count-other": "Levs búlgaros (1879–1952)"
+          },
+          "BHD": {
+            "displayName": "dinar baremita",
+            "displayName-count-one": "dinar baremita",
+            "displayName-count-other": "dinares baremitas"
+          },
+          "BIF": {
+            "displayName": "franco burundiano",
+            "displayName-count-one": "franco burundiano",
+            "displayName-count-other": "francos burundianos"
+          },
+          "BMD": {
+            "displayName": "dólar bermudense",
+            "displayName-count-one": "dólar bermudense",
+            "displayName-count-other": "dólares bermudense",
+            "symbol-alt-narrow": "$"
+          },
+          "BND": {
+            "displayName": "dólar bruneano",
+            "displayName-count-one": "dólar bruneano",
+            "displayName-count-other": "dólares bruneanos",
+            "symbol-alt-narrow": "$"
+          },
+          "BOB": {
+            "displayName": "boliviano",
+            "displayName-count-one": "boliviano",
+            "displayName-count-other": "bolivianos",
+            "symbol-alt-narrow": "Bs"
+          },
+          "BOL": {
+            "displayName": "Boliviano (1863–1963)",
+            "displayName-count-one": "Boliviano (1863–1963)",
+            "displayName-count-other": "Bolivianos (1863–1963)"
+          },
+          "BOP": {
+            "displayName": "Peso boliviano",
+            "displayName-count-one": "Peso boliviano",
+            "displayName-count-other": "Pesos bolivianos"
+          },
+          "BOV": {
+            "displayName": "Mvdol boliviano",
+            "displayName-count-one": "Mvdol boliviano",
+            "displayName-count-other": "Mvdols bolivianos"
+          },
+          "BRB": {
+            "displayName": "Cruzeiro novo brasileiro (1967–1986)",
+            "displayName-count-one": "Cruzeiro novo brasileiro (BRB)",
+            "displayName-count-other": "Cruzeiros novos brasileiros (BRB)"
+          },
+          "BRC": {
+            "displayName": "Cruzado brasileiro (1986–1989)",
+            "displayName-count-one": "Cruzado brasileiro",
+            "displayName-count-other": "Cruzados brasileiros"
+          },
+          "BRE": {
+            "displayName": "Cruzeiro brasileiro (1990–1993)",
+            "displayName-count-one": "Cruzeiro brasileiro (BRE)",
+            "displayName-count-other": "Cruzeiros brasileiros (BRE)"
+          },
+          "BRL": {
+            "displayName": "real brasileiro",
+            "displayName-count-one": "real brasileiro",
+            "displayName-count-other": "reais brasileiros",
+            "symbol": "R$",
+            "symbol-alt-narrow": "R$"
+          },
+          "BRN": {
+            "displayName": "Cruzado novo brasileiro (1989–1990)",
+            "displayName-count-one": "Cruzado novo brasileiro",
+            "displayName-count-other": "Cruzados novos brasileiros"
+          },
+          "BRR": {
+            "displayName": "Cruzeiro brasileiro (1993–1994)",
+            "displayName-count-one": "Cruzeiro brasileiro",
+            "displayName-count-other": "Cruzeiros brasileiros"
+          },
+          "BRZ": {
+            "displayName": "Cruzeiro brasileiro (1942–1967)",
+            "displayName-count-one": "Cruzeiro brasileiro antigo",
+            "displayName-count-other": "Cruzeiros brasileiros antigos"
+          },
+          "BSD": {
+            "displayName": "dólar das Bahamas",
+            "displayName-count-one": "dólar das Bahamas",
+            "displayName-count-other": "dólares das Bahamas",
+            "symbol-alt-narrow": "$"
+          },
+          "BTN": {
+            "displayName": "ngultrum butanês",
+            "displayName-count-one": "ngultrum butanês",
+            "displayName-count-other": "ngultrumes butaneses"
+          },
+          "BUK": {
+            "displayName": "Kyat birmanês",
+            "displayName-count-one": "Kyat burmês",
+            "displayName-count-other": "Kyats burmeses"
+          },
+          "BWP": {
+            "displayName": "pula de Botswana",
+            "displayName-count-one": "pula de Botswana",
+            "displayName-count-other": "pulas de Botswana",
+            "symbol-alt-narrow": "P"
+          },
+          "BYB": {
+            "displayName": "Rublo novo bielorusso (1994–1999)",
+            "displayName-count-one": "Novo rublo bielorusso (BYB)",
+            "displayName-count-other": "Novos rublos bielorussos (BYB)"
+          },
+          "BYN": {
+            "displayName": "rublo bielorrusso",
+            "displayName-count-one": "rublo bielorrusso",
+            "displayName-count-other": "rublos bielorrussos",
+            "symbol-alt-narrow": "р."
+          },
+          "BYR": {
+            "displayName": "Rublo bielorrusso (2000–2016)",
+            "displayName-count-one": "Rublo bielorrusso (2000–2016)",
+            "displayName-count-other": "Rublos bielorrussos (2000–2016)"
+          },
+          "BZD": {
+            "displayName": "dólar belizense",
+            "displayName-count-one": "dólar belizense",
+            "displayName-count-other": "dólares belizense",
+            "symbol-alt-narrow": "$"
+          },
+          "CAD": {
+            "displayName": "dólar canadiano",
+            "displayName-count-one": "dólar canadiano",
+            "displayName-count-other": "dólares canadianos",
+            "symbol": "CA$",
+            "symbol-alt-narrow": "$"
+          },
+          "CDF": {
+            "displayName": "franco congolês",
+            "displayName-count-one": "franco congolês",
+            "displayName-count-other": "francos congoleses"
+          },
+          "CHE": {
+            "displayName": "Euro WIR",
+            "displayName-count-one": "Euro WIR",
+            "displayName-count-other": "Euros WIR"
+          },
+          "CHF": {
+            "displayName": "franco suíço",
+            "displayName-count-one": "franco suíço",
+            "displayName-count-other": "francos suíços",
+            "symbol": "CHF",
+            "symbol-alt-narrow": "Fr."
+          },
+          "CHW": {
+            "displayName": "Franco WIR",
+            "displayName-count-one": "Franco WIR",
+            "displayName-count-other": "Francos WIR"
+          },
+          "CLE": {
+            "displayName": "Escudo chileno",
+            "displayName-count-one": "Escudo chileno",
+            "displayName-count-other": "Escudos chilenos"
+          },
+          "CLF": {
+            "displayName": "Unidades de Fomento chilenas",
+            "displayName-count-one": "Unidade de fomento chilena",
+            "displayName-count-other": "Unidades de fomento chilenas"
+          },
+          "CLP": {
+            "displayName": "peso chileno",
+            "displayName-count-one": "peso chileno",
+            "displayName-count-other": "pesos chilenos",
+            "symbol-alt-narrow": "$"
+          },
+          "CNH": {
+            "displayName": "yuan offshore",
+            "displayName-count-one": "yuan offshore",
+            "displayName-count-other": "yuans offshore"
+          },
+          "CNY": {
+            "displayName": "yuan",
+            "displayName-count-one": "yuan",
+            "displayName-count-other": "yuans",
+            "symbol": "CN¥",
+            "symbol-alt-narrow": "¥"
+          },
+          "COP": {
+            "displayName": "peso colombiano",
+            "displayName-count-one": "peso colombiano",
+            "displayName-count-other": "pesos colombianos",
+            "symbol-alt-narrow": "$"
+          },
+          "COU": {
+            "displayName": "Unidade de Valor Real",
+            "displayName-count-one": "Unidade de valor real",
+            "displayName-count-other": "Unidades de valor real"
+          },
+          "CRC": {
+            "displayName": "colon costa-riquenho",
+            "displayName-count-one": "colon costa-riquenho",
+            "displayName-count-other": "colons costa-riquenho",
+            "symbol-alt-narrow": "₡"
+          },
+          "CSD": {
+            "displayName": "Dinar sérvio (2002–2006)",
+            "displayName-count-one": "Dinar antigo da Sérvia",
+            "displayName-count-other": "Dinares antigos da Sérvia"
+          },
+          "CSK": {
+            "displayName": "Coroa Forte checoslovaca",
+            "displayName-count-one": "Coroa forte tchecoslovaca",
+            "displayName-count-other": "Coroas fortes tchecoslovacas"
+          },
+          "CUC": {
+            "displayName": "peso cubano conversível",
+            "displayName-count-one": "peso cubano conversível",
+            "displayName-count-other": "pesos cubanos conversíveis",
+            "symbol-alt-narrow": "$"
+          },
+          "CUP": {
+            "displayName": "peso cubano",
+            "displayName-count-one": "peso cubano",
+            "displayName-count-other": "pesos cubanos",
+            "symbol-alt-narrow": "$"
+          },
+          "CVE": {
+            "displayName": "escudo cabo-verdiano",
+            "displayName-count-one": "escudo cabo-verdiano",
+            "displayName-count-other": "escudos cabo-verdianos"
+          },
+          "CYP": {
+            "displayName": "Libra de Chipre",
+            "displayName-count-one": "Libra cipriota",
+            "displayName-count-other": "Libras cipriotas"
+          },
+          "CZK": {
+            "displayName": "coroa checa",
+            "displayName-count-one": "coroa checa",
+            "displayName-count-other": "coroas checas",
+            "symbol-alt-narrow": "Kč"
+          },
+          "DDM": {
+            "displayName": "Ostmark da Alemanha Oriental",
+            "displayName-count-one": "Marco da Alemanha Oriental",
+            "displayName-count-other": "Marcos da Alemanha Oriental"
+          },
+          "DEM": {
+            "displayName": "Marco alemão",
+            "displayName-count-one": "Marco alemão",
+            "displayName-count-other": "Marcos alemães"
+          },
+          "DJF": {
+            "displayName": "franco jibutiano",
+            "displayName-count-one": "franco jibutiano",
+            "displayName-count-other": "francos jibutianos"
+          },
+          "DKK": {
+            "displayName": "coroa dinamarquesa",
+            "displayName-count-one": "coroa dinamarquesa",
+            "displayName-count-other": "coroas dinamarquesas",
+            "symbol-alt-narrow": "kr"
+          },
+          "DOP": {
+            "displayName": "peso dominicano",
+            "displayName-count-one": "peso dominicano",
+            "displayName-count-other": "pesos dominicanos",
+            "symbol-alt-narrow": "$"
+          },
+          "DZD": {
+            "displayName": "dinar argelino",
+            "displayName-count-one": "dinar argelino",
+            "displayName-count-other": "dinares argelinos"
+          },
+          "ECS": {
+            "displayName": "Sucre equatoriano",
+            "displayName-count-one": "Sucre equatoriano",
+            "displayName-count-other": "Sucres equatorianos"
+          },
+          "ECV": {
+            "displayName": "Unidad de Valor Constante (UVC) do Equador",
+            "displayName-count-one": "Unidade de valor constante equatoriana (UVC)",
+            "displayName-count-other": "Unidades de valor constante equatorianas (UVC)"
+          },
+          "EEK": {
+            "displayName": "Coroa estoniana",
+            "displayName-count-one": "Coroa estoniana",
+            "displayName-count-other": "Coroas estonianas"
+          },
+          "EGP": {
+            "displayName": "libra egípcia",
+            "displayName-count-one": "libra egípcia",
+            "displayName-count-other": "libras egípcias",
+            "symbol-alt-narrow": "E£"
+          },
+          "ERN": {
+            "displayName": "nakfa eritreia",
+            "displayName-count-one": "nakfa eritreia",
+            "displayName-count-other": "nakfas eritreias"
+          },
+          "ESA": {
+            "displayName": "Peseta espanhola (conta A)",
+            "displayName-count-one": "Peseta espanhola (conta A)",
+            "displayName-count-other": "Pesetas espanholas (conta A)"
+          },
+          "ESB": {
+            "displayName": "Peseta espanhola (conta conversível)",
+            "displayName-count-one": "Peseta espanhola (conta conversível)",
+            "displayName-count-other": "Pesetas espanholas (conta conversível)"
+          },
+          "ESP": {
+            "displayName": "Peseta espanhola",
+            "displayName-count-one": "Peseta espanhola",
+            "displayName-count-other": "Pesetas espanholas",
+            "symbol-alt-narrow": "₧"
+          },
+          "ETB": {
+            "displayName": "birr etíope",
+            "displayName-count-one": "birr etíope",
+            "displayName-count-other": "birres etíopes"
+          },
+          "EUR": {
+            "displayName": "euro",
+            "displayName-count-one": "euro",
+            "displayName-count-other": "euros",
+            "symbol": "€",
+            "symbol-alt-narrow": "€"
+          },
+          "FIM": {
+            "displayName": "Marca finlandesa",
+            "displayName-count-one": "Marco finlandês",
+            "displayName-count-other": "Marcos finlandeses"
+          },
+          "FJD": {
+            "displayName": "dólar fijiano",
+            "displayName-count-one": "dólar fijiano",
+            "displayName-count-other": "dólares fijianos",
+            "symbol-alt-narrow": "$"
+          },
+          "FKP": {
+            "displayName": "libra das Ilhas Falkland",
+            "displayName-count-one": "libra das Ilhas Falkland",
+            "displayName-count-other": "libras das Ilhas Falkland",
+            "symbol-alt-narrow": "£"
+          },
+          "FRF": {
+            "displayName": "Franco francês",
+            "displayName-count-one": "Franco francês",
+            "displayName-count-other": "Francos franceses"
+          },
+          "GBP": {
+            "displayName": "libra esterlina britânica",
+            "displayName-count-one": "libra esterlina britânica",
+            "displayName-count-other": "libras esterlinas britânicas",
+            "symbol": "£",
+            "symbol-alt-narrow": "£"
+          },
+          "GEK": {
+            "displayName": "Cupom Lari georgiano",
+            "displayName-count-one": "Kupon larit da Geórgia",
+            "displayName-count-other": "Kupon larits da Geórgia"
+          },
+          "GEL": {
+            "displayName": "lari georgiano",
+            "displayName-count-one": "lari georgiano",
+            "displayName-count-other": "laris georgianos",
+            "symbol-alt-narrow": "₾"
+          },
+          "GHC": {
+            "displayName": "Cedi de Gana (1979–2007)",
+            "displayName-count-one": "Cedi de Gana (1979–2007)",
+            "displayName-count-other": "Cedis de Gana (1979–2007)"
+          },
+          "GHS": {
+            "displayName": "cedi ganês",
+            "displayName-count-one": "cedi ganês",
+            "displayName-count-other": "cedis ganeses",
+            "symbol-alt-narrow": "GH₵"
+          },
+          "GIP": {
+            "displayName": "libra de Gibraltar",
+            "displayName-count-one": "libra de Gibraltar",
+            "displayName-count-other": "libras de Gibraltar",
+            "symbol-alt-narrow": "£"
+          },
+          "GMD": {
+            "displayName": "dalasi gambiano",
+            "displayName-count-one": "dalasi gambiano",
+            "displayName-count-other": "dalasis gambianos"
+          },
+          "GNF": {
+            "displayName": "franco guineense",
+            "displayName-count-one": "franco guineense",
+            "displayName-count-other": "francos guineenses",
+            "symbol-alt-narrow": "FG"
+          },
+          "GNS": {
+            "displayName": "Syli da Guiné",
+            "displayName-count-one": "Syli guineano",
+            "displayName-count-other": "Sylis guineanos"
+          },
+          "GQE": {
+            "displayName": "Ekwele da Guiné Equatorial",
+            "displayName-count-one": "Ekwele da Guiné Equatorial",
+            "displayName-count-other": "Ekweles da Guiné Equatorial"
+          },
+          "GRD": {
+            "displayName": "Dracma grego",
+            "displayName-count-one": "Dracma grego",
+            "displayName-count-other": "Dracmas gregos"
+          },
+          "GTQ": {
+            "displayName": "quetzal da Guatemala",
+            "displayName-count-one": "quetzal da Guatemala",
+            "displayName-count-other": "quetzales da Guatemala",
+            "symbol-alt-narrow": "Q"
+          },
+          "GWE": {
+            "displayName": "Escudo da Guiné Portuguesa",
+            "displayName-count-one": "Escudo da Guiné Portuguesa",
+            "displayName-count-other": "Escudos da Guinéa Portuguesa"
+          },
+          "GWP": {
+            "displayName": "Peso da Guiné-Bissau",
+            "displayName-count-one": "Peso de Guiné-Bissau",
+            "displayName-count-other": "Pesos de Guiné-Bissau"
+          },
+          "GYD": {
+            "displayName": "dólar da Guiana",
+            "displayName-count-one": "dólar da Guiana",
+            "displayName-count-other": "dólares da Guiana",
+            "symbol-alt-narrow": "$"
+          },
+          "HKD": {
+            "displayName": "dólar de Hong Kong",
+            "displayName-count-one": "dólar de Hong Kong",
+            "displayName-count-other": "dólares de Hong Kong",
+            "symbol": "HK$",
+            "symbol-alt-narrow": "$"
+          },
+          "HNL": {
+            "displayName": "lempira das Honduras",
+            "displayName-count-one": "lempira das Honduras",
+            "displayName-count-other": "lempiras das Honduras",
+            "symbol-alt-narrow": "L"
+          },
+          "HRD": {
+            "displayName": "Dinar croata",
+            "displayName-count-one": "Dinar croata",
+            "displayName-count-other": "Dinares croatas"
+          },
+          "HRK": {
+            "displayName": "kuna croata",
+            "displayName-count-one": "kuna croata",
+            "displayName-count-other": "kunas croatas",
+            "symbol-alt-narrow": "kn"
+          },
+          "HTG": {
+            "displayName": "gourde haitiano",
+            "displayName-count-one": "gourde haitiano",
+            "displayName-count-other": "gourdes haitianos"
+          },
+          "HUF": {
+            "displayName": "forint húngaro",
+            "displayName-count-one": "forint húngaro",
+            "displayName-count-other": "forints húngaros",
+            "symbol-alt-narrow": "Ft"
+          },
+          "IDR": {
+            "displayName": "rupia indonésia",
+            "displayName-count-one": "rupia indonésia",
+            "displayName-count-other": "rupias indonésias",
+            "symbol-alt-narrow": "Rp"
+          },
+          "IEP": {
+            "displayName": "Libra irlandesa",
+            "displayName-count-one": "Libra irlandesa",
+            "displayName-count-other": "Libras irlandesas"
+          },
+          "ILP": {
+            "displayName": "Libra israelita",
+            "displayName-count-one": "Libra israelita",
+            "displayName-count-other": "Libras israelitas"
+          },
+          "ILR": {
+            "displayName": "Sheqel antigo israelita",
+            "displayName-count-one": "Sheqel antigo israelita",
+            "displayName-count-other": "Sheqels antigos israelitas"
+          },
+          "ILS": {
+            "displayName": "sheqel novo israelita",
+            "displayName-count-one": "sheqel novo israelita",
+            "displayName-count-other": "sheqels novos israelitas",
+            "symbol": "₪",
+            "symbol-alt-narrow": "₪"
+          },
+          "INR": {
+            "displayName": "rupia indiana",
+            "displayName-count-one": "rupia indiana",
+            "displayName-count-other": "rupias indianas",
+            "symbol": "₹",
+            "symbol-alt-narrow": "₹"
+          },
+          "IQD": {
+            "displayName": "dinar iraquiano",
+            "displayName-count-one": "dinar iraquiano",
+            "displayName-count-other": "dinares iraquianos"
+          },
+          "IRR": {
+            "displayName": "rial iraniano",
+            "displayName-count-one": "rial iraniano",
+            "displayName-count-other": "riais iranianos"
+          },
+          "ISJ": {
+            "displayName": "Coroa antiga islandesa",
+            "displayName-count-one": "Coroa antiga islandesa",
+            "displayName-count-other": "Coroas antigas islandesas"
+          },
+          "ISK": {
+            "displayName": "coroa islandesa",
+            "displayName-count-one": "coroa islandesa",
+            "displayName-count-other": "coroas islandesas",
+            "symbol-alt-narrow": "kr"
+          },
+          "ITL": {
+            "displayName": "Lira italiana",
+            "displayName-count-one": "Lira italiana",
+            "displayName-count-other": "Liras italianas"
+          },
+          "JMD": {
+            "displayName": "dólar jamaicano",
+            "displayName-count-one": "dólar jamaicano",
+            "displayName-count-other": "dólares jamaicanos",
+            "symbol-alt-narrow": "$"
+          },
+          "JOD": {
+            "displayName": "dinar jordaniano",
+            "displayName-count-one": "dinar jordaniano",
+            "displayName-count-other": "dinares jordanianos"
+          },
+          "JPY": {
+            "displayName": "iene japonês",
+            "displayName-count-one": "iene japonês",
+            "displayName-count-other": "ienes japoneses",
+            "symbol": "JP¥",
+            "symbol-alt-narrow": "¥"
+          },
+          "KES": {
+            "displayName": "xelim queniano",
+            "displayName-count-one": "xelim queniano",
+            "displayName-count-other": "xelins quenianos"
+          },
+          "KGS": {
+            "displayName": "som quirguiz",
+            "displayName-count-one": "som quirguiz",
+            "displayName-count-other": "somes quirguizes",
+            "symbol-alt-narrow": "⃀"
+          },
+          "KHR": {
+            "displayName": "riel cambojano",
+            "displayName-count-one": "riel cambojano",
+            "displayName-count-other": "rieles cambojanos",
+            "symbol-alt-narrow": "៛"
+          },
+          "KMF": {
+            "displayName": "franco comoriano",
+            "displayName-count-one": "franco comoriano",
+            "displayName-count-other": "francos comorianos",
+            "symbol-alt-narrow": "CF"
+          },
+          "KPW": {
+            "displayName": "won norte-coreano",
+            "displayName-count-one": "won norte-coreano",
+            "displayName-count-other": "wons norte-coreanos",
+            "symbol-alt-narrow": "₩"
+          },
+          "KRH": {
+            "displayName": "Hwan da Coreia do Sul (1953–1962)",
+            "displayName-count-one": "Hwan da Coreia do Sul",
+            "displayName-count-other": "Hwans da Coreia do Sul"
+          },
+          "KRO": {
+            "displayName": "Won da Coreia do Sul (1945–1953)",
+            "displayName-count-one": "Won antigo da Coreia do Sul",
+            "displayName-count-other": "Wons antigos da Coreia do Sul"
+          },
+          "KRW": {
+            "displayName": "won sul-coreano",
+            "displayName-count-one": "won sul-coreano",
+            "displayName-count-other": "wons sul-coreano",
+            "symbol": "₩",
+            "symbol-alt-narrow": "₩"
+          },
+          "KWD": {
+            "displayName": "dinar kuwaitiano",
+            "displayName-count-one": "dinar kuwaitiano",
+            "displayName-count-other": "dinares kuwaitianos"
+          },
+          "KYD": {
+            "displayName": "dólar das Ilhas Caimão",
+            "displayName-count-one": "dólar das Ilhas Caimão",
+            "displayName-count-other": "dólares das Ilhas Caimão",
+            "symbol-alt-narrow": "$"
+          },
+          "KZT": {
+            "displayName": "tenge cazaque",
+            "displayName-count-one": "tenge cazaque",
+            "displayName-count-other": "tenges cazaques",
+            "symbol-alt-narrow": "₸"
+          },
+          "LAK": {
+            "displayName": "kip laosiano",
+            "displayName-count-one": "kip laosiano",
+            "displayName-count-other": "kips laosianos",
+            "symbol-alt-narrow": "₭"
+          },
+          "LBP": {
+            "displayName": "libra libanesa",
+            "displayName-count-one": "libra libanesa",
+            "displayName-count-other": "libras libanesas",
+            "symbol-alt-narrow": "L£"
+          },
+          "LKR": {
+            "displayName": "rupia do Sri Lanka",
+            "displayName-count-one": "rupia do Sri Lanka",
+            "displayName-count-other": "rupias do Sri Lanka",
+            "symbol-alt-narrow": "Rs"
+          },
+          "LRD": {
+            "displayName": "dólar liberiano",
+            "displayName-count-one": "dólar liberiano",
+            "displayName-count-other": "dólares liberianos",
+            "symbol-alt-narrow": "$"
+          },
+          "LSL": {
+            "displayName": "loti lesotiano",
+            "displayName-count-one": "loti lesotiano",
+            "displayName-count-other": "lotis lesotianos"
+          },
+          "LTL": {
+            "displayName": "Litas da Lituânia",
+            "displayName-count-one": "Litas da Lituânia",
+            "displayName-count-other": "Litas da Lituânia",
+            "symbol-alt-narrow": "Lt"
+          },
+          "LTT": {
+            "displayName": "Talonas lituano",
+            "displayName-count-one": "Talonas lituanas",
+            "displayName-count-other": "Talonases lituanas"
+          },
+          "LUC": {
+            "displayName": "Franco conversível de Luxemburgo",
+            "displayName-count-one": "Franco conversível de Luxemburgo",
+            "displayName-count-other": "Francos conversíveis de Luxemburgo"
+          },
+          "LUF": {
+            "displayName": "Franco luxemburguês",
+            "displayName-count-one": "Franco de Luxemburgo",
+            "displayName-count-other": "Francos de Luxemburgo"
+          },
+          "LUL": {
+            "displayName": "Franco financeiro de Luxemburgo",
+            "displayName-count-one": "Franco financeiro de Luxemburgo",
+            "displayName-count-other": "Francos financeiros de Luxemburgo"
+          },
+          "LVL": {
+            "displayName": "Lats da Letónia",
+            "displayName-count-one": "Lats da Letónia",
+            "displayName-count-other": "Lats da Letónia",
+            "symbol-alt-narrow": "Ls"
+          },
+          "LVR": {
+            "displayName": "Rublo letão",
+            "displayName-count-one": "Rublo da Letônia",
+            "displayName-count-other": "Rublos da Letônia"
+          },
+          "LYD": {
+            "displayName": "dinar líbio",
+            "displayName-count-one": "dinar líbio",
+            "displayName-count-other": "dinares líbios"
+          },
+          "MAD": {
+            "displayName": "dirham marroquino",
+            "displayName-count-one": "dirham marroquino",
+            "displayName-count-other": "dirhams marroquinos"
+          },
+          "MAF": {
+            "displayName": "Franco marroquino",
+            "displayName-count-one": "Franco marroquino",
+            "displayName-count-other": "Francos marroquinos"
+          },
+          "MCF": {
+            "displayName": "Franco monegasco",
+            "displayName-count-one": "Franco monegasco",
+            "displayName-count-other": "Francos monegascos"
+          },
+          "MDC": {
+            "displayName": "Cupon moldávio",
+            "displayName-count-other": "Cupon moldávio"
+          },
+          "MDL": {
+            "displayName": "leu moldavo",
+            "displayName-count-one": "leu moldavo",
+            "displayName-count-other": "leus moldavos"
+          },
+          "MGA": {
+            "displayName": "ariari malgaxe",
+            "displayName-count-one": "ariari malgaxe",
+            "displayName-count-other": "ariaris malgaxes",
+            "symbol-alt-narrow": "Ar"
+          },
+          "MGF": {
+            "displayName": "Franco de Madagascar",
+            "displayName-count-one": "Franco de Madagascar",
+            "displayName-count-other": "Francos de Madagascar"
+          },
+          "MKD": {
+            "displayName": "dinar macedónio",
+            "displayName-count-one": "dinar macedónio",
+            "displayName-count-other": "dinares macedónios"
+          },
+          "MKN": {
+            "displayName": "Dinar macedônio (1992–1993)",
+            "displayName-count-one": "Dinar macedônio (1992–1993)",
+            "displayName-count-other": "Dinares macedônios (1992–1993)"
+          },
+          "MLF": {
+            "displayName": "Franco de Mali",
+            "displayName-count-one": "Franco de Mali",
+            "displayName-count-other": "Francos de Mali"
+          },
+          "MMK": {
+            "displayName": "kyat de Mianmar",
+            "displayName-count-one": "kyat de Mianmar",
+            "displayName-count-other": "kyats de Mianmar",
+            "symbol-alt-narrow": "K"
+          },
+          "MNT": {
+            "displayName": "tugrik mongol",
+            "displayName-count-one": "tugrik mongol",
+            "displayName-count-other": "tugriks mongóis",
+            "symbol-alt-narrow": "₮"
+          },
+          "MOP": {
+            "displayName": "pataca macaense",
+            "displayName-count-one": "pataca macaense",
+            "displayName-count-other": "patacas macaenses"
+          },
+          "MRO": {
+            "displayName": "ouguiya mauritana (1973–2017)",
+            "displayName-count-one": "ouguiya mauritana (1973–2017)",
+            "displayName-count-other": "ouguiyas mauritanas (1973–2017)"
+          },
+          "MRU": {
+            "displayName": "ouguiya mauritana",
+            "displayName-count-one": "ouguiya mauritana",
+            "displayName-count-other": "ouguiyas mauritanas"
+          },
+          "MTL": {
+            "displayName": "Lira maltesa",
+            "displayName-count-one": "Lira Maltesa",
+            "displayName-count-other": "Liras maltesas"
+          },
+          "MTP": {
+            "displayName": "Libra maltesa",
+            "displayName-count-one": "Libra maltesa",
+            "displayName-count-other": "Libras maltesas"
+          },
+          "MUR": {
+            "displayName": "rupia mauriciana",
+            "displayName-count-one": "rupia mauriciana",
+            "displayName-count-other": "rupias mauricianas",
+            "symbol-alt-narrow": "Rs"
+          },
+          "MVR": {
+            "displayName": "rupia maldivana",
+            "displayName-count-one": "rupia maldivana",
+            "displayName-count-other": "rupias maldivanas"
+          },
+          "MWK": {
+            "displayName": "kwacha malauiano",
+            "displayName-count-one": "kwacha malauiano",
+            "displayName-count-other": "kwachas malauianos"
+          },
+          "MXN": {
+            "displayName": "peso mexicano",
+            "displayName-count-one": "peso mexicano",
+            "displayName-count-other": "pesos mexicanos",
+            "symbol": "MX$",
+            "symbol-alt-narrow": "$"
+          },
+          "MXP": {
+            "displayName": "Peso Plata mexicano (1861–1992)",
+            "displayName-count-one": "Peso de prata mexicano (1861–1992)",
+            "displayName-count-other": "Pesos de prata mexicanos (1861–1992)"
+          },
+          "MXV": {
+            "displayName": "Unidad de Inversion (UDI) mexicana",
+            "displayName-count-one": "Unidade de investimento mexicana (UDI)",
+            "displayName-count-other": "Unidades de investimento mexicanas (UDI)"
+          },
+          "MYR": {
+            "displayName": "ringgit malaio",
+            "displayName-count-one": "ringgit malaio",
+            "displayName-count-other": "ringgits malaios",
+            "symbol-alt-narrow": "RM"
+          },
+          "MZE": {
+            "displayName": "Escudo de Moçambique",
+            "displayName-count-one": "Escudo de Moçambique",
+            "displayName-count-other": "Escudos de Moçambique"
+          },
+          "MZM": {
+            "displayName": "Metical de Moçambique (1980–2006)",
+            "displayName-count-one": "Metical antigo de Moçambique",
+            "displayName-count-other": "Meticales antigos de Moçambique"
+          },
+          "MZN": {
+            "displayName": "metical moçambicano",
+            "displayName-count-one": "metical moçambicano",
+            "displayName-count-other": "meticais moçambicanos"
+          },
+          "NAD": {
+            "displayName": "dólar namibiano",
+            "displayName-count-one": "dólar namibiano",
+            "displayName-count-other": "dólares namibianos",
+            "symbol-alt-narrow": "$"
+          },
+          "NGN": {
+            "displayName": "naira nigeriana",
+            "displayName-count-one": "naira nigeriana",
+            "displayName-count-other": "nairas nigerianas",
+            "symbol-alt-narrow": "₦"
+          },
+          "NIC": {
+            "displayName": "Córdoba nicaraguano (1988–1991)",
+            "displayName-count-one": "Córdoba nicaraguano (1988–1991)",
+            "displayName-count-other": "Córdobas nicaraguano (1988–1991)"
+          },
+          "NIO": {
+            "displayName": "córdoba nicaraguano",
+            "displayName-count-one": "córdoba nicaraguano",
+            "displayName-count-other": "córdobas nicaraguanos",
+            "symbol-alt-narrow": "C$"
+          },
+          "NLG": {
+            "displayName": "Florim holandês",
+            "displayName-count-one": "Florim holandês",
+            "displayName-count-other": "Florins holandeses"
+          },
+          "NOK": {
+            "displayName": "coroa norueguesa",
+            "displayName-count-one": "coroa norueguesa",
+            "displayName-count-other": "coroas norueguesas",
+            "symbol-alt-narrow": "kr"
+          },
+          "NPR": {
+            "displayName": "rupia nepalesa",
+            "displayName-count-one": "rupia nepalesa",
+            "displayName-count-other": "rupias nepalesas",
+            "symbol-alt-narrow": "Rs"
+          },
+          "NZD": {
+            "displayName": "dólar neozelandês",
+            "displayName-count-one": "dólar neozelandês",
+            "displayName-count-other": "dólares neozelandeses",
+            "symbol": "NZ$",
+            "symbol-alt-narrow": "$"
+          },
+          "OMR": {
+            "displayName": "rial omanense",
+            "displayName-count-one": "rial omanense",
+            "displayName-count-other": "riais omanenses"
+          },
+          "PAB": {
+            "displayName": "balboa do Panamá",
+            "displayName-count-one": "balboa do Panamá",
+            "displayName-count-other": "balboas do Panamá"
+          },
+          "PEI": {
+            "displayName": "Inti peruano",
+            "displayName-count-one": "Inti peruano",
+            "displayName-count-other": "Intis peruanos"
+          },
+          "PEN": {
+            "displayName": "sol peruano",
+            "displayName-count-one": "sol peruano",
+            "displayName-count-other": "sóis peruanos"
+          },
+          "PES": {
+            "displayName": "Sol peruano (1863–1965)",
+            "displayName-count-one": "Sol peruano (1863–1965)",
+            "displayName-count-other": "Soles peruanos (1863–1965)"
+          },
+          "PGK": {
+            "displayName": "kina papuásia",
+            "displayName-count-one": "kina papuásia",
+            "displayName-count-other": "kinas papuásias"
+          },
+          "PHP": {
+            "displayName": "peso filipino",
+            "displayName-count-one": "peso filipino",
+            "displayName-count-other": "pesos filipinos",
+            "symbol": "PHP",
+            "symbol-alt-narrow": "₱"
+          },
+          "PKR": {
+            "displayName": "rupia paquistanesa",
+            "displayName-count-one": "rupia paquistanesa",
+            "displayName-count-other": "rupias paquistanesas",
+            "symbol-alt-narrow": "Rs"
+          },
+          "PLN": {
+            "displayName": "zloti polaco",
+            "displayName-count-one": "zloti polaco",
+            "displayName-count-other": "zlotis polacos",
+            "symbol-alt-narrow": "zł"
+          },
+          "PLZ": {
+            "displayName": "Zloti polonês (1950–1995)",
+            "displayName-count-one": "Zloti polonês (1950–1995)",
+            "displayName-count-other": "Zlotis poloneses (1950–1995)"
+          },
+          "PTE": {
+            "displayName": "escudo português",
+            "displayName-count-one": "escudo português",
+            "displayName-count-other": "escudos portugueses",
+            "symbol": "​",
+            "decimal": "$",
+            "group": ","
+          },
+          "PYG": {
+            "displayName": "guarani paraguaio",
+            "displayName-count-one": "guarani paraguaio",
+            "displayName-count-other": "guaranis paraguaios",
+            "symbol-alt-narrow": "₲"
+          },
+          "QAR": {
+            "displayName": "rial catarense",
+            "displayName-count-one": "rial catarense",
+            "displayName-count-other": "riais catarenses"
+          },
+          "RHD": {
+            "displayName": "Dólar rodesiano",
+            "displayName-count-one": "Dólar da Rodésia",
+            "displayName-count-other": "Dólares da Rodésia"
+          },
+          "ROL": {
+            "displayName": "Leu romeno (1952–2006)",
+            "displayName-count-one": "Leu antigo da Romênia",
+            "displayName-count-other": "Leus antigos da Romênia"
+          },
+          "RON": {
+            "displayName": "leu romeno",
+            "displayName-count-one": "leu romeno",
+            "displayName-count-other": "leus romenos",
+            "symbol-alt-narrow": "L"
+          },
+          "RSD": {
+            "displayName": "dinar sérvio",
+            "displayName-count-one": "dinar sérvio",
+            "displayName-count-other": "dinares sérvios"
+          },
+          "RUB": {
+            "displayName": "rublo russo",
+            "displayName-count-one": "rublo russo",
+            "displayName-count-other": "rublos russos",
+            "symbol-alt-narrow": "₽"
+          },
+          "RUR": {
+            "displayName": "Rublo russo (1991–1998)",
+            "displayName-count-one": "Rublo russo (1991–1998)",
+            "displayName-count-other": "Rublos russos (1991–1998)"
+          },
+          "RWF": {
+            "displayName": "franco ruandês",
+            "displayName-count-one": "franco ruandês",
+            "displayName-count-other": "francos ruandeses",
+            "symbol-alt-narrow": "RF"
+          },
+          "SAR": {
+            "displayName": "rial saudita",
+            "displayName-count-one": "rial saudita",
+            "displayName-count-other": "riais sauditas",
+            "symbol-alt-variant": "⃁"
+          },
+          "SBD": {
+            "displayName": "dólar das Ilhas Salomão",
+            "displayName-count-one": "dólar das Ilhas Salomão",
+            "displayName-count-other": "dólares das Ilhas Salomão",
+            "symbol-alt-narrow": "$"
+          },
+          "SCR": {
+            "displayName": "rupia seichelense",
+            "displayName-count-one": "rupia seichelense",
+            "displayName-count-other": "rupias seichelenses"
+          },
+          "SDD": {
+            "displayName": "Dinar sudanês (1992–2007)",
+            "displayName-count-one": "Dinar antigo do Sudão",
+            "displayName-count-other": "Dinares antigos do Sudão"
+          },
+          "SDG": {
+            "displayName": "libra sudanesa",
+            "displayName-count-one": "libra sudanesa",
+            "displayName-count-other": "libras sudanesas"
+          },
+          "SDP": {
+            "displayName": "Libra sudanesa (1957–1998)",
+            "displayName-count-one": "Libra antiga sudanesa",
+            "displayName-count-other": "Libras antigas sudanesas"
+          },
+          "SEK": {
+            "displayName": "coroa sueca",
+            "displayName-count-one": "coroa sueca",
+            "displayName-count-other": "coroas suecas",
+            "symbol-alt-narrow": "kr"
+          },
+          "SGD": {
+            "displayName": "dólar singapuriano",
+            "displayName-count-one": "dólar singapuriano",
+            "displayName-count-other": "dólares singapurianos",
+            "symbol-alt-narrow": "$"
+          },
+          "SHP": {
+            "displayName": "libra santa-helenense",
+            "displayName-count-one": "libra santa-helenense",
+            "displayName-count-other": "libras santa-helenenses",
+            "symbol-alt-narrow": "£"
+          },
+          "SIT": {
+            "displayName": "Tolar Bons esloveno",
+            "displayName-count-one": "Tolar da Eslovênia",
+            "displayName-count-other": "Tolares da Eslovênia"
+          },
+          "SKK": {
+            "displayName": "Coroa eslovaca",
+            "displayName-count-one": "Coroa eslovaca",
+            "displayName-count-other": "Coroas eslovacas"
+          },
+          "SLE": {
+            "displayName": "leone de Serra Leoa",
+            "displayName-count-one": "leone de Serra Leoa",
+            "displayName-count-other": "leones de Serra Leoa"
+          },
+          "SLL": {
+            "displayName": "leone de Serra Leoa (1964—2022)",
+            "displayName-count-one": "leone de Serra Leoa (1964—2022)",
+            "displayName-count-other": "leones de Serra Leoa (1964—2022)"
+          },
+          "SOS": {
+            "displayName": "xelim somali",
+            "displayName-count-one": "xelim somali",
+            "displayName-count-other": "xelins somalis"
+          },
+          "SRD": {
+            "displayName": "dólar do Suriname",
+            "displayName-count-one": "dólar do Suriname",
+            "displayName-count-other": "dólares do Suriname",
+            "symbol-alt-narrow": "$"
+          },
+          "SRG": {
+            "displayName": "Florim do Suriname",
+            "displayName-count-one": "Florim do Suriname",
+            "displayName-count-other": "Florins do Suriname"
+          },
+          "SSP": {
+            "displayName": "libra sul-sudanesa",
+            "displayName-count-one": "libra sul-sudanesa",
+            "displayName-count-other": "libras sul-sudanesas",
+            "symbol-alt-narrow": "£"
+          },
+          "STD": {
+            "displayName": "Dobra de São Tomé e Príncipe (1977–2017)",
+            "displayName-count-one": "Dobra de São Tomé e Príncipe (1977–2017)",
+            "displayName-count-other": "Dobras de São Tomé e Príncipe (1977–2017)"
+          },
+          "STN": {
+            "displayName": "dobra de São Tomé e Príncipe",
+            "displayName-count-one": "dobra de São Tomé e Príncipe",
+            "displayName-count-other": "dobras de São Tomé e Príncipe",
+            "symbol-alt-narrow": "Db"
+          },
+          "SUR": {
+            "displayName": "Rublo soviético",
+            "displayName-count-one": "Rublo soviético",
+            "displayName-count-other": "Rublos soviéticos"
+          },
+          "SVC": {
+            "displayName": "Colom salvadorenho",
+            "displayName-count-one": "Colon de El Salvador",
+            "displayName-count-other": "Colons de El Salvador"
+          },
+          "SYP": {
+            "displayName": "libra síria",
+            "displayName-count-one": "libra síria",
+            "displayName-count-other": "libras sírias",
+            "symbol-alt-narrow": "£"
+          },
+          "SZL": {
+            "displayName": "lilangeni suázi",
+            "displayName-count-one": "lilangeni suázi",
+            "displayName-count-other": "lilangenis suázis"
+          },
+          "THB": {
+            "displayName": "baht tailandês",
+            "displayName-count-one": "baht tailandês",
+            "displayName-count-other": "bahts tailandeses",
+            "symbol": "฿",
+            "symbol-alt-narrow": "฿"
+          },
+          "TJR": {
+            "displayName": "Rublo do Tadjiquistão",
+            "displayName-count-one": "Rublo do Tajaquistão",
+            "displayName-count-other": "Rublos do Tajaquistão"
+          },
+          "TJS": {
+            "displayName": "somoni tajique",
+            "displayName-count-one": "somoni tajique",
+            "displayName-count-other": "somonis tajiques"
+          },
+          "TMM": {
+            "displayName": "Manat do Turcomenistão (1993–2009)",
+            "displayName-count-one": "Manat do Turcomenistão (1993–2009)",
+            "displayName-count-other": "Manats do Turcomenistão (1993–2009)"
+          },
+          "TMT": {
+            "displayName": "manat turcomeno",
+            "displayName-count-one": "manat turcomeno",
+            "displayName-count-other": "manats turcomenos"
+          },
+          "TND": {
+            "displayName": "dinar tunisino",
+            "displayName-count-one": "dinar tunisino",
+            "displayName-count-other": "dinares tunisinos"
+          },
+          "TOP": {
+            "displayName": "paʻanga tonganesa",
+            "displayName-count-one": "paʻanga tonganesa",
+            "displayName-count-other": "paʻangas tonganesas",
+            "symbol-alt-narrow": "T$"
+          },
+          "TPE": {
+            "displayName": "Escudo timorense",
+            "displayName-count-one": "Escudo do Timor",
+            "displayName-count-other": "Escudos do Timor"
+          },
+          "TRL": {
+            "displayName": "Lira turca (1922–2005)",
+            "displayName-count-one": "Lira turca antiga",
+            "displayName-count-other": "Liras turcas antigas"
+          },
+          "TRY": {
+            "displayName": "lira turca",
+            "displayName-count-one": "lira turca",
+            "displayName-count-other": "liras turcas",
+            "symbol-alt-narrow": "₺",
+            "symbol-alt-variant": "TL"
+          },
+          "TTD": {
+            "displayName": "dólar de Trindade e Tobago",
+            "displayName-count-one": "dólar de Trindade e Tobago",
+            "displayName-count-other": "dólares de Trindade e Tobago",
+            "symbol-alt-narrow": "$"
+          },
+          "TWD": {
+            "displayName": "novo dólar taiwanês",
+            "displayName-count-one": "novo dólar taiwanês",
+            "displayName-count-other": "novos dólares taiwaneses",
+            "symbol": "NT$",
+            "symbol-alt-narrow": "NT$"
+          },
+          "TZS": {
+            "displayName": "xelim tanzaniano",
+            "displayName-count-one": "xelim tanzaniano",
+            "displayName-count-other": "xelins tanzanianos"
+          },
+          "UAH": {
+            "displayName": "hryvnia ucraniano",
+            "displayName-count-one": "hryvnia ucraniano",
+            "displayName-count-other": "hryvnias ucranianos",
+            "symbol-alt-narrow": "₴"
+          },
+          "UAK": {
+            "displayName": "Karbovanetz ucraniano",
+            "displayName-count-one": "Karbovanetz da Ucrânia",
+            "displayName-count-other": "Karbovanetzs da Ucrânia"
+          },
+          "UGS": {
+            "displayName": "Xelim ugandense (1966–1987)",
+            "displayName-count-one": "Shilling de Uganda (1966–1987)",
+            "displayName-count-other": "Shillings de Uganda (1966–1987)"
+          },
+          "UGX": {
+            "displayName": "xelim ugandense",
+            "displayName-count-one": "xelim ugandense",
+            "displayName-count-other": "xelins ugandenses"
+          },
+          "USD": {
+            "displayName": "dólar dos Estados Unidos",
+            "displayName-count-one": "dólar dos Estados Unidos",
+            "displayName-count-other": "dólares dos Estados Unidos",
+            "symbol": "US$",
+            "symbol-alt-narrow": "$"
+          },
+          "USN": {
+            "displayName": "Dólar norte-americano (Dia seguinte)",
+            "displayName-count-one": "Dólar americano (dia seguinte)",
+            "displayName-count-other": "Dólares americanos (dia seguinte)"
+          },
+          "USS": {
+            "displayName": "Dólar norte-americano (Mesmo dia)",
+            "displayName-count-one": "Dólar americano (mesmo dia)",
+            "displayName-count-other": "Dólares americanos (mesmo dia)"
+          },
+          "UYI": {
+            "displayName": "Peso uruguaio en unidades indexadas",
+            "displayName-count-one": "Peso uruguaio em unidades indexadas",
+            "displayName-count-other": "Pesos uruguaios em unidades indexadas"
+          },
+          "UYP": {
+            "displayName": "Peso uruguaio (1975–1993)",
+            "displayName-count-one": "Peso uruguaio (1975–1993)",
+            "displayName-count-other": "Pesos uruguaios (1975–1993)"
+          },
+          "UYU": {
+            "displayName": "peso uruguaio",
+            "displayName-count-one": "peso uruguaio",
+            "displayName-count-other": "pesos uruguaios",
+            "symbol-alt-narrow": "$"
+          },
+          "UZS": {
+            "displayName": "som uzbeque",
+            "displayName-count-one": "som uzbeque",
+            "displayName-count-other": "somes uzbeques"
+          },
+          "VEB": {
+            "displayName": "Bolívar venezuelano (1871–2008)",
+            "displayName-count-one": "Bolívar venezuelano (1871–2008)",
+            "displayName-count-other": "Bolívares venezuelanos (1871–2008)"
+          },
+          "VEF": {
+            "displayName": "bolívar (2008–2018)",
+            "displayName-count-one": "bolívar (2008–2018)",
+            "displayName-count-other": "bolívares (2008–2018)",
+            "symbol-alt-narrow": "Bs"
+          },
+          "VES": {
+            "displayName": "bolívar",
+            "displayName-count-one": "bolívar",
+            "displayName-count-other": "bolívares"
+          },
+          "VND": {
+            "displayName": "dong vietnamita",
+            "displayName-count-one": "dong vietnamita",
+            "displayName-count-other": "dongs vietnamitas",
+            "symbol": "₫",
+            "symbol-alt-narrow": "₫"
+          },
+          "VNN": {
+            "displayName": "Dong vietnamita (1978–1985)",
+            "displayName-count-other": "Dong vietnamita (1978–1985)"
+          },
+          "VUV": {
+            "displayName": "vatu de Vanuatu",
+            "displayName-count-one": "vatu de Vanuatu",
+            "displayName-count-other": "vatus de Vanuatu"
+          },
+          "WST": {
+            "displayName": "tala samoano",
+            "displayName-count-one": "tala samoano",
+            "displayName-count-other": "talas samoanos"
+          },
+          "XAF": {
+            "displayName": "franco CFA (BEAC)",
+            "displayName-count-one": "franco CFA (BEAC)",
+            "displayName-count-other": "francos CFA (BEAC)",
+            "symbol": "FCFA"
+          },
+          "XAG": {
+            "displayName": "Prata",
+            "displayName-count-one": "Prata",
+            "displayName-count-other": "Pratas"
+          },
+          "XAU": {
+            "displayName": "Ouro",
+            "displayName-count-one": "Ouro",
+            "displayName-count-other": "Ouros"
+          },
+          "XBA": {
+            "displayName": "Unidade Composta Europeia",
+            "displayName-count-one": "Unidade de composição europeia",
+            "displayName-count-other": "Unidades de composição europeias"
+          },
+          "XBB": {
+            "displayName": "Unidade Monetária Europeia",
+            "displayName-count-one": "Unidade monetária europeia",
+            "displayName-count-other": "Unidades monetárias europeias"
+          },
+          "XBC": {
+            "displayName": "Unidade de Conta Europeia (XBC)",
+            "displayName-count-one": "Unidade europeia de conta (XBC)",
+            "displayName-count-other": "Unidades europeias de conta (XBC)"
+          },
+          "XBD": {
+            "displayName": "Unidade de Conta Europeia (XBD)",
+            "displayName-count-one": "Unidade europeia de conta (XBD)",
+            "displayName-count-other": "Unidades europeias de conta (XBD)"
+          },
+          "XCD": {
+            "displayName": "dólar das Caraíbas Orientais",
+            "displayName-count-one": "dólar das Caraíbas Orientais",
+            "displayName-count-other": "dólares das Caraíbas Orientais",
+            "symbol": "EC$",
+            "symbol-alt-narrow": "$"
+          },
+          "XCG": {
+            "displayName": "florim caribenho",
+            "displayName-count-one": "florim caribenho",
+            "displayName-count-other": "florins caribenhos",
+            "symbol": "Cg."
+          },
+          "XDR": {
+            "displayName": "Direitos Especiais de Giro",
+            "displayName-count-one": "Direitos de desenho especiais",
+            "displayName-count-other": "Direitos de desenho especiais"
+          },
+          "XEU": {
+            "displayName": "Unidade de Moeda Europeia",
+            "displayName-count-one": "Unidade de moeda europeia",
+            "displayName-count-other": "Unidades de moedas europeias"
+          },
+          "XFO": {
+            "displayName": "Franco-ouro francês",
+            "displayName-count-one": "Franco de ouro francês",
+            "displayName-count-other": "Francos de ouro franceses"
+          },
+          "XFU": {
+            "displayName": "Franco UIC francês",
+            "displayName-count-one": "Franco UIC francês",
+            "displayName-count-other": "Francos UIC franceses"
+          },
+          "XOF": {
+            "displayName": "franco CFA (BCEAO)",
+            "displayName-count-one": "franco CFA (BCEAO)",
+            "displayName-count-other": "francos CFA (BCEAO)",
+            "symbol": "F CFA"
+          },
+          "XPD": {
+            "displayName": "Paládio",
+            "displayName-count-one": "Paládio",
+            "displayName-count-other": "Paládios"
+          },
+          "XPF": {
+            "displayName": "franco CFP",
+            "displayName-count-one": "franco CFP",
+            "displayName-count-other": "francos CFP",
+            "symbol": "CFPF"
+          },
+          "XPT": {
+            "displayName": "Platina",
+            "displayName-count-one": "Platina",
+            "displayName-count-other": "Platinas"
+          },
+          "XRE": {
+            "displayName": "Fundos RINET",
+            "displayName-count-other": "Fundos RINET"
+          },
+          "XTS": {
+            "displayName": "Código de Moeda de Teste",
+            "displayName-count-one": "Código de moeda de teste",
+            "displayName-count-other": "Códigos de moeda de teste"
+          },
+          "XXX": {
+            "displayName": "moeda desconhecida",
+            "displayName-count-one": "(moeda desconhecida)",
+            "displayName-count-other": "(moedas desconhecidas)",
+            "symbol": "¤"
+          },
+          "YDD": {
+            "displayName": "Dinar iemenita",
+            "displayName-count-one": "Dinar do Iêmen",
+            "displayName-count-other": "Dinares do Iêmen"
+          },
+          "YER": {
+            "displayName": "rial iemenita",
+            "displayName-count-one": "rial iemenita",
+            "displayName-count-other": "riais iemenitas"
+          },
+          "YUD": {
+            "displayName": "Dinar forte iugoslavo (1966–1990)",
+            "displayName-count-one": "Dinar forte iugoslavo",
+            "displayName-count-other": "Dinares fortes iugoslavos"
+          },
+          "YUM": {
+            "displayName": "Dinar noviy iugoslavo (1994–2002)",
+            "displayName-count-one": "Dinar noviy da Iugoslávia",
+            "displayName-count-other": "Dinares noviy da Iugoslávia"
+          },
+          "YUN": {
+            "displayName": "Dinar conversível iugoslavo (1990–1992)",
+            "displayName-count-one": "Dinar conversível da Iugoslávia",
+            "displayName-count-other": "Dinares conversíveis da Iugoslávia"
+          },
+          "YUR": {
+            "displayName": "Dinar reformado iugoslavo (1992–1993)",
+            "displayName-count-one": "Dinar iugoslavo reformado",
+            "displayName-count-other": "Dinares iugoslavos reformados"
+          },
+          "ZAL": {
+            "displayName": "Rand sul-africano (financeiro)",
+            "displayName-count-one": "Rand da África do Sul (financeiro)",
+            "displayName-count-other": "Rands da África do Sul (financeiro)"
+          },
+          "ZAR": {
+            "displayName": "rand sul-africano",
+            "displayName-count-one": "rand sul-africano",
+            "displayName-count-other": "rands sul-africanos",
+            "symbol-alt-narrow": "R"
+          },
+          "ZMK": {
+            "displayName": "Kwacha zambiano (1968–2012)",
+            "displayName-count-one": "Kwacha zambiano (1968–2012)",
+            "displayName-count-other": "Kwachas zambianos (1968–2012)"
+          },
+          "ZMW": {
+            "displayName": "kwacha zambiano",
+            "displayName-count-one": "kwacha zambiano",
+            "displayName-count-other": "kwachas zambianos",
+            "symbol-alt-narrow": "ZK"
+          },
+          "ZRN": {
+            "displayName": "Zaire Novo zairense (1993–1998)",
+            "displayName-count-one": "Novo zaire do Zaire",
+            "displayName-count-other": "Novos zaires do Zaire"
+          },
+          "ZRZ": {
+            "displayName": "Zaire zairense (1971–1993)",
+            "displayName-count-one": "Zaire do Zaire",
+            "displayName-count-other": "Zaires do Zaire"
+          },
+          "ZWD": {
+            "displayName": "Dólar do Zimbábue (1980–2008)",
+            "displayName-count-one": "Dólar do Zimbábue",
+            "displayName-count-other": "Dólares do Zimbábue"
+          },
+          "ZWG": {
+            "displayName": "ouro zimbabuense",
+            "displayName-count-one": "ouro zimbabuense",
+            "displayName-count-other": "ouros zimbabuenses"
+          },
+          "ZWL": {
+            "displayName": "Dólar do Zimbábue (2009)",
+            "displayName-count-one": "Dólar do Zimbábue (2009)",
+            "displayName-count-other": "Dólares do Zimbábue (2009)"
+          },
+          "ZWR": {
+            "displayName": "Dólar do Zimbábue (2008)",
+            "displayName-count-one": "Dólar do Zimbábue (2008)",
+            "displayName-count-other": "Dólares do Zimbábue (2008)"
+          }
+        }
+      }
+    }
+  }
+}

--- a/provider/source/tests/data/cldr/cldr-numbers-full/main/pt-PT/numbers.json
+++ b/provider/source/tests/data/cldr/cldr-numbers-full/main/pt-PT/numbers.json
@@ -1,0 +1,167 @@
+{
+  "main": {
+    "pt-PT": {
+      "identity": {
+        "language": "pt",
+        "territory": "PT"
+      },
+      "numbers": {
+        "defaultNumberingSystem": "latn",
+        "otherNumberingSystems": {
+          "native": "latn"
+        },
+        "minimumGroupingDigits": "2",
+        "symbols-numberSystem-latn": {
+          "decimal": ",",
+          "group": " ",
+          "list": ";",
+          "percentSign": "%",
+          "plusSign": "+",
+          "minusSign": "-",
+          "approximatelySign": "~",
+          "exponential": "E",
+          "superscriptingExponent": "×",
+          "perMille": "‰",
+          "infinity": "∞",
+          "nan": "NaN",
+          "timeSeparator": ":"
+        },
+        "decimalFormats-numberSystem-latn": {
+          "standard": "#,##0.###",
+          "long": {
+            "decimalFormat": {
+              "1000-count-one": "0 mil",
+              "1000-count-other": "0 mil",
+              "10000-count-one": "00 mil",
+              "10000-count-other": "00 mil",
+              "100000-count-one": "000 mil",
+              "100000-count-other": "000 mil",
+              "1000000-count-one": "0 milhão",
+              "1000000-count-other": "0 milhões",
+              "10000000-count-one": "00 milhões",
+              "10000000-count-other": "00 milhões",
+              "100000000-count-one": "000 milhões",
+              "100000000-count-other": "000 milhões",
+              "1000000000-count-one": "0 mil milhões",
+              "1000000000-count-other": "0 mil milhões",
+              "10000000000-count-one": "00 mil milhões",
+              "10000000000-count-other": "00 mil milhões",
+              "100000000000-count-one": "000 mil milhões",
+              "100000000000-count-other": "000 mil milhões",
+              "1000000000000-count-one": "0 bilião",
+              "1000000000000-count-other": "0 biliões",
+              "10000000000000-count-one": "00 biliões",
+              "10000000000000-count-other": "00 biliões",
+              "100000000000000-count-one": "000 biliões",
+              "100000000000000-count-other": "000 biliões"
+            }
+          },
+          "short": {
+            "decimalFormat": {
+              "1000-count-one": "0 mil",
+              "1000-count-other": "0 mil",
+              "10000-count-one": "00 mil",
+              "10000-count-other": "00 mil",
+              "100000-count-one": "000 mil",
+              "100000-count-other": "000 mil",
+              "1000000-count-one": "0 M",
+              "1000000-count-other": "0 M",
+              "10000000-count-one": "00 M",
+              "10000000-count-other": "00 M",
+              "100000000-count-one": "000 M",
+              "100000000-count-other": "000 M",
+              "1000000000-count-one": "0 mM",
+              "1000000000-count-other": "0 mM",
+              "10000000000-count-one": "00 mM",
+              "10000000000-count-other": "00 mM",
+              "100000000000-count-one": "000 mM",
+              "100000000000-count-other": "000 mM",
+              "1000000000000-count-one": "0 Bi",
+              "1000000000000-count-other": "0 Bi",
+              "10000000000000-count-one": "00 Bi",
+              "10000000000000-count-other": "00 Bi",
+              "100000000000000-count-one": "000 Bi",
+              "100000000000000-count-other": "000 Bi"
+            }
+          }
+        },
+        "rationalFormats-numberSystem-latn": {
+          "rationalPattern": "{0}⁄{1}",
+          "integerAndRationalPattern": "{0} {1}",
+          "integerAndRationalPattern-alt-superSub": "{0}⁠{1}",
+          "rationalUsage": "sometimes"
+        },
+        "scientificFormats-numberSystem-latn": {
+          "standard": "#E0"
+        },
+        "percentFormats-numberSystem-latn": {
+          "standard": "#,##0%"
+        },
+        "currencyFormats-numberSystem-latn": {
+          "currencySpacing": {
+            "beforeCurrency": {
+              "currencyMatch": "[[:^S:]&[:^Z:]]",
+              "surroundingMatch": "[:digit:]",
+              "insertBetween": " "
+            },
+            "afterCurrency": {
+              "currencyMatch": "[[:^S:]&[:^Z:]]",
+              "surroundingMatch": "[:digit:]",
+              "insertBetween": " "
+            }
+          },
+          "standard": "#,##0.00 ¤",
+          "standard-alphaNextToNumber": "#,##0.00 ¤",
+          "standard-noCurrency": "#,##0.00",
+          "accounting": "#,##0.00 ¤;(#,##0.00 ¤)",
+          "accounting-alphaNextToNumber": "#,##0.00 ¤;(#,##0.00 ¤)",
+          "accounting-noCurrency": "#,##0.00;(#,##0.00)",
+          "short": {
+            "standard": {
+              "1000-count-one": "0 mil ¤",
+              "1000-count-other": "0 mil ¤",
+              "10000-count-one": "00 mil ¤",
+              "10000-count-other": "00 mil ¤",
+              "100000-count-one": "000 mil ¤",
+              "100000-count-other": "000 mil ¤",
+              "1000000-count-one": "0 M ¤",
+              "1000000-count-other": "0 M ¤",
+              "10000000-count-one": "00 M ¤",
+              "10000000-count-other": "00 M ¤",
+              "100000000-count-one": "000 M ¤",
+              "100000000-count-other": "000 M ¤",
+              "1000000000-count-one": "0 mM ¤",
+              "1000000000-count-other": "0 mM ¤",
+              "10000000000-count-one": "00 mM ¤",
+              "10000000000-count-other": "00 mM ¤",
+              "100000000000-count-one": "000 mM ¤",
+              "100000000000-count-other": "000 mM ¤",
+              "1000000000000-count-one": "0 Bi ¤",
+              "1000000000000-count-other": "0 Bi ¤",
+              "10000000000000-count-one": "00 Bi ¤",
+              "10000000000000-count-other": "00 Bi ¤",
+              "100000000000000-count-one": "000 Bi ¤",
+              "100000000000000-count-other": "000 Bi ¤"
+            }
+          },
+          "currencyPatternAppendISO": "{0} ¤¤",
+          "unitPattern-count-other": "{0} {1}"
+        },
+        "miscPatterns-numberSystem-latn": {
+          "approximately": "~{0}",
+          "atLeast": "+{0}",
+          "atMost": "≤{0}",
+          "range": "{0} - {1}"
+        },
+        "minimalPairs": {
+          "pluralMinimalPairs-count-one": "{0} dia",
+          "pluralMinimalPairs-count-many": "{0} de dias",
+          "pluralMinimalPairs-count-other": "{0} dias",
+          "other": "{0}.º lugar",
+          "feminine": "a {0}",
+          "masculine": "o {0}"
+        }
+      }
+    }
+  }
+}

--- a/provider/source/tests/globs.rs.data
+++ b/provider/source/tests/globs.rs.data
@@ -55,6 +55,8 @@ const CLDR_JSON_GLOB: &[&str] = &[
     "cldr-misc-full/main/$LOCALES/listPatterns.json",
     "cldr-numbers-full/main/$LOCALES/currencies.json",
     "cldr-numbers-full/main/$LOCALES/numbers.json",
+    "cldr-numbers-full/main/pt-PT/currencies.json",
+    "cldr-numbers-full/main/pt-PT/numbers.json",
     "cldr-person-names-full/main/$LOCALES/personNames.json",
     "cldr-transforms/transforms/Any-Publishing.json",
     "cldr-transforms/transforms/Any-Publishing.txt",


### PR DESCRIPTION
### Stack Overview

- **#8463 (This PR - Merged)**: `feat(currency): Add CurrencyDecimalSymbolsV1 marker and generate per-currency decimal symbols`
- **#8416 (Open)**: `feat(currency): Format amounts with the separators of their currency` (replaces #8441 via provider wrapper)
- **Follow-up (#8464 - Open)**: `test(provider_source): Add pt-PT to testdata for CurrencyDecimalSymbolsV1 (#7982)`

```mermaid
flowchart TD
    main["unicode-org:main"]
    pr2["#8463: CurrencyDecimalSymbolsV1 marker & datagen (Merged - This PR)"]
    pr1["#8416: Format amounts with currency separators"]
    pr4["Follow-up (#8464): pt-PT testdata (#7982)"]

    main --> pr2
    pr2 --> pr1
    pr2 -.-> pr4
    style pr2 stroke:#8957e5,stroke-width:3px
```

---

### Overview

Following the architectural discussion on #8416, we implement **Option 2B**: isolating currency-specific decimal and grouping separator overrides into a dedicated data marker (`CurrencyDecimalSymbolsV1`) inside `icu_experimental` rather than placing currency entries inside `icu_decimal_data` (`DecimalSymbolsV1`).

- **Zero currency awareness in `icu_decimal`**: `components/decimal` and `provider/data/decimal` remain completely untouched.
- **Zero-cost `DecimalSymbols<'static>` reuse**: `CurrencyDecimalSymbolsV1` uses `icu_decimal::provider::DecimalSymbols<'static>` as its `Yokeable` data struct, allowing `DataPayload<CurrencyDecimalSymbolsV1>` to be converted into `DataPayload<DecimalSymbolsV1>` at zero cost via `.cast()`.
- **Datagen (`provider/source/src/currency/decimal_symbols.rs`)**: Reads CLDR `currencies.json` for currencies with single-character `decimal` or `group` overrides (e.g. `PTE` in `pt-PT`, which uses `$` as its decimal separator and `,` as its grouping separator) and generates attributes `<currency>` (default numbering system) and `<numsys>/<currency>`.
- **Compact baked footprint**: Across all of CLDR, only 11 data identifiers exist, compiling into a 127-byte lookup table in `icu_experimental_data`.

---

### Architecture / Data Flow

```mermaid
flowchart LR
    CLDR["CLDR currencies.json + numbers.json"] --> Datagen["SourceDataProvider (CurrencyDecimalSymbolsV1)"]
    Datagen --> Baked["icu_experimental_data (CurrencyDecimalSymbolsV1)"]
    Baked --> Payload["DataPayload&lt;CurrencyDecimalSymbolsV1&gt;"]
    Payload -->|".cast::&lt;DecimalSymbolsV1&gt;()"| Decimal["DataPayload&lt;DecimalSymbolsV1&gt;"]
```

---

## Changelog

* [icu_experimental] Added `CurrencyDecimalSymbolsV1` data marker for per-currency decimal symbol overrides.
