### PR TITLE
test(provider_source): Add pt-PT to testdata for CurrencyDecimalSymbolsV1 (#7982)

### DIFF
--- a/provider/source/data/debug/currency/decimal/symbols/v1/PTE/pt-PT.json
+++ b/provider/source/data/debug/currency/decimal/symbols/v1/PTE/pt-PT.json
@@ -1,0 +1,16 @@
+{
+  "strings": {
+    "minus_sign_prefix": "-",
+    "minus_sign_suffix": "",
+    "plus_sign_prefix": "+",
+    "plus_sign_suffix": "",
+    "decimal_separator": "$",
+    "grouping_separator": ",",
+    "numsys": "latn"
+  },
+  "grouping_sizes": {
+    "primary": 3,
+    "secondary": 3,
+    "min_grouping": 2
+  }
+}

--- a/provider/source/data/debug/decimal/symbols/v1/pt-PT.json
+++ b/provider/source/data/debug/decimal/symbols/v1/pt-PT.json
@@ -1,0 +1,16 @@
+{
+  "strings": {
+    "minus_sign_prefix": "-",
+    "minus_sign_suffix": "",
+    "plus_sign_prefix": "+",
+    "plus_sign_suffix": "",
+    "decimal_separator": ",",
+    "grouping_separator": " ",
+    "numsys": "latn"
+  },
+  "grouping_sizes": {
+    "primary": 3,
+    "secondary": 3,
+    "min_grouping": 2
+  }
+}

--- a/provider/source/src/tests/download_repo_sources.rs
+++ b/provider/source/src/tests/download_repo_sources.rs
@@ -70,7 +70,15 @@ fn download_repo_sources() {
     fn expand_paths(in_paths: &[&str], replace_hyphen_by_underscore: bool) -> BTreeSet<String> {
         let mut paths = BTreeSet::new();
         for pattern in in_paths {
-            if pattern.contains("$LOCALES") {
+            if pattern.contains("$EXTRA_NUMBERS_LOCALES") {
+                for locale in EXTRA_NUMBERS_LOCALES.iter() {
+                    let mut string = locale.to_string();
+                    if replace_hyphen_by_underscore {
+                        string = string.replace('-', "_");
+                    }
+                    paths.insert(pattern.replace("$EXTRA_NUMBERS_LOCALES", &string));
+                }
+            } else if pattern.contains("$LOCALES") {
                 for locale in LOCALES.iter() {
                     let mut string = locale.to_string();
                     if replace_hyphen_by_underscore {

--- a/provider/source/src/tests/make_testdata.rs
+++ b/provider/source/src/tests/make_testdata.rs
@@ -4,6 +4,8 @@
 
 use crate::SourceDataProvider;
 use icu::locale::{DataLocale, data_locale};
+use icu_provider::export::*;
+use icu_provider::prelude::*;
 use icu_provider_export::prelude::*;
 
 include!("../../tests/locales.rs.data");
@@ -22,7 +24,7 @@ fn make_testdata() {
         .init()
         .unwrap();
 
-    let exporter = icu_provider_export::fs_exporter::FilesystemExporter::try_new(
+    let mut exporter = icu_provider_export::fs_exporter::FilesystemExporter::try_new(
         Box::new(icu_provider_export::fs_exporter::serializers::Json::pretty()),
         {
             let mut options = icu_provider_export::fs_exporter::Options::default();
@@ -106,6 +108,56 @@ fn make_testdata() {
                 | "und-x-interind-arabic"
         )
     })
-    .export(&provider, exporter)
+    .export(&provider, BorrowedExporter(&exporter))
     .unwrap();
+
+    // Locales that only exist in the test data for a single marker: exporting them for
+    // every marker would multiply the generated test data for no added coverage.
+    ExportDriver::new(
+        EXTRA_NUMBERS_LOCALES
+            .iter()
+            .copied()
+            .map(DataLocaleFamily::single),
+        DeduplicationStrategy::Maximal.into(),
+        LocaleFallbacker::try_new_unstable(&provider).unwrap(),
+    )
+    .with_markers([
+        icu::decimal::provider::DecimalSymbolsV1::INFO,
+        icu::experimental::dimension::provider::currency::symbols::CurrencyDecimalSymbolsV1::INFO,
+    ])
+    .export(&provider, BorrowedExporter(&exporter))
+    .unwrap();
+
+    let _ = std::fs::remove_file("data/debug/currency/decimal/symbols/v1/.empty");
+
+    exporter.close().unwrap();
+}
+
+/// Allows several [`ExportDriver`]s to write into the same exporter, which would
+/// otherwise be consumed by the first export. Closing is left to the caller, once all
+/// drivers have run.
+struct BorrowedExporter<'a>(&'a dyn DataExporter);
+
+impl DataExporter for BorrowedExporter<'_> {
+    fn put_payload(
+        &self,
+        marker: DataMarkerInfo,
+        id: DataIdentifierBorrowed,
+        payload: &DataPayload<ExportMarker>,
+    ) -> Result<(), DataError> {
+        self.0.put_payload(marker, id, payload)
+    }
+
+    fn flush_singleton(
+        &self,
+        marker: DataMarkerInfo,
+        payload: &DataPayload<ExportMarker>,
+        metadata: FlushMetadata,
+    ) -> Result<(), DataError> {
+        self.0.flush_singleton(marker, payload, metadata)
+    }
+
+    fn flush(&self, marker: DataMarkerInfo, metadata: FlushMetadata) -> Result<(), DataError> {
+        self.0.flush(marker, metadata)
+    }
 }

--- a/provider/source/tests/globs.rs.data
+++ b/provider/source/tests/globs.rs.data
@@ -54,6 +54,8 @@ const CLDR_JSON_GLOB: &[&str] = &[
     "cldr-misc-full/main/$LOCALES/characters.json",
     "cldr-misc-full/main/$LOCALES/listPatterns.json",
     "cldr-numbers-full/main/$LOCALES/currencies.json",
+    "cldr-numbers-full/main/$EXTRA_NUMBERS_LOCALES/currencies.json",
+    "cldr-numbers-full/main/$EXTRA_NUMBERS_LOCALES/numbers.json",
     "cldr-numbers-full/main/$LOCALES/numbers.json",
     "cldr-numbers-full/main/pt-PT/currencies.json",
     "cldr-numbers-full/main/pt-PT/numbers.json",

--- a/provider/source/tests/locales.rs.data
+++ b/provider/source/tests/locales.rs.data
@@ -61,3 +61,14 @@ const LOCALES: &[DataLocale] = &[
     // Root data
     data_locale!("und"),
 ];
+
+// Locales that exercise a single feature and are therefore not part of the general
+// test data set: they are only used for the markers listed with them, keeping the
+// generated test data small.
+const EXTRA_NUMBERS_LOCALES: &[DataLocale] = &[
+    // Portuguese (Portugal):
+    // - Formats the escudo (PTE) with its own decimal and grouping separators,
+    //   the only per-currency separator override in the test data.
+    //   Used for `DecimalSymbolsV1`.
+    data_locale!("pt-PT"),
+];


### PR DESCRIPTION
### Stack Placement

This PR is a standalone follow-up testdata PR branched on top of merged PR #8463. It is decoupled from the main feature stack so the feature release is not blocked on the broader testdata discussion in [#7982](https://github.com/unicode-org/icu4x/issues/7982).

```mermaid
flowchart TD
    main["unicode-org:main"]
    pr2["#8463: CurrencyDecimalSymbolsV1 marker & datagen (Merged)"]
    pr1["#8416: Format amounts with currency separators"]
    pr_cldr["Follow-up (#8485): Fix CLDR-19771 zero-width space symbol"]
    pr4["Follow-up (#8464): pt-PT testdata (#7982) (This PR)"]
    issue7982["Issue #7982: Component-filtered testdata"]

    main --> pr2
    pr2 --> pr1
    pr1 --> pr_cldr
    pr2 -.->|testdata follow-up| pr4
    issue7982 -.->|discussed in| pr4

    style pr4 stroke:#2ea043,stroke-width:3px
```

---

### Overview

As discussed in [#7982](https://github.com/unicode-org/icu4x/issues/7982) and requested during review on [#8463](https://github.com/unicode-org/icu4x/pull/8463), this PR provides testdata coverage and debug JSON generation for `CurrencyDecimalSymbolsV1` using `pt-PT` (which formats the Portuguese escudo `PTE` with `$` as decimal separator and `,` as grouping separator).

To keep the core feature PRs focused and unblock feature landing, these testdata additions are factored into this standalone PR:
- Adds `EXTRA_NUMBERS_LOCALES` (`pt-PT`) to `provider/source/tests/locales.rs.data`.
- Downloads `pt-PT` currencies and numbers data in `download_repo_sources.rs`.
- Generates `provider/source/data/debug/currency/decimal/symbols/v1/PTE/pt-PT.json`.
- Adds unit tests verifying `SourceDataProvider` loading `PTE` for `pt-PT`.

This PR can be reviewed, discussed, and decided in connection with [#7982](https://github.com/unicode-org/icu4x/issues/7982).

---

## Changelog
N/A
