### PR TITLE
Add edit mappings to `icu_casemap`

### DIFF
--- a/components/casemap/src/casemapper.rs
+++ b/components/casemap/src/casemapper.rs
@@ -2,6 +2,7 @@
 // called LICENSE at the top level of the ICU4X source tree
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
+use crate::CaseMapWriteable;
 use crate::internals::{CaseMapLocale, FoldOptions, FullCaseWriteable, StringAndWriteable};
 use crate::provider::CaseMap;
 use crate::provider::CaseMapV1;
@@ -11,7 +12,6 @@ use crate::titlecase::{LeadingAdjustment, TitlecaseOptions, TrailingCase};
 use alloc::borrow::Cow;
 use icu_locale_core::LanguageIdentifier;
 use icu_provider::prelude::*;
-use writeable::Writeable;
 
 /// A struct with the ability to convert characters and strings to uppercase or lowercase,
 /// or fold them to a normalized form for case-insensitive comparison.
@@ -101,7 +101,7 @@ impl Default for CaseMapperBorrowed<'static> {
 }
 
 impl<'a> CaseMapperBorrowed<'a> {
-    /// Returns the full lowercase mapping of the given string as a [`Writeable`].
+    /// Returns the full lowercase mapping of the given string as a [`CaseMapWriteable`].
     /// This function is context and language sensitive. Callers should pass the text's language
     /// as a `LanguageIdentifier` (usually the `id` field of the `Locale`) if available, or
     /// `Default::default()` for the root locale.
@@ -112,7 +112,7 @@ impl<'a> CaseMapperBorrowed<'a> {
         self,
         src: &'a str,
         langid: &LanguageIdentifier,
-    ) -> impl Writeable + 'a + use<'a> {
+    ) -> impl CaseMapWriteable + 'a + use<'a> {
         self.data.full_helper_writeable::<false>(
             src,
             CaseMapLocale::from_langid(langid),
@@ -121,7 +121,7 @@ impl<'a> CaseMapperBorrowed<'a> {
         )
     }
 
-    /// Returns the full uppercase mapping of the given string as a [`Writeable`].
+    /// Returns the full uppercase mapping of the given string as a [`CaseMapWriteable`].
     /// This function is context and language sensitive. Callers should pass the text's language
     /// as a `LanguageIdentifier` (usually the `id` field of the `Locale`) if available, or
     /// `Default::default()` for the root locale.
@@ -132,7 +132,7 @@ impl<'a> CaseMapperBorrowed<'a> {
         self,
         src: &'a str,
         langid: &LanguageIdentifier,
-    ) -> impl Writeable + 'a + use<'a> {
+    ) -> impl CaseMapWriteable + 'a + use<'a> {
         self.data.full_helper_writeable::<false>(
             src,
             CaseMapLocale::from_langid(langid),
@@ -141,7 +141,7 @@ impl<'a> CaseMapperBorrowed<'a> {
         )
     }
 
-    /// Returns the full titlecase mapping of the given string as a [`Writeable`], treating
+    /// Returns the full titlecase mapping of the given string as a [`CaseMapWriteable`], treating
     /// the string as a single segment (and thus only titlecasing the beginning of it). Performs
     /// the specified leading adjustment behavior from the options without loading additional data.
     ///
@@ -169,7 +169,7 @@ impl<'a> CaseMapperBorrowed<'a> {
         src: &'a str,
         langid: &LanguageIdentifier,
         options: TitlecaseOptions,
-    ) -> impl Writeable + 'a + use<'a> {
+    ) -> impl CaseMapWriteable + 'a + use<'a> {
         self.titlecase_segment_with_adjustment(src, langid, options, |data, ch| data.is_cased(ch))
     }
 
@@ -213,14 +213,14 @@ impl<'a> CaseMapperBorrowed<'a> {
             writeable,
         }
     }
-    /// Case-folds the characters in the given string as a [`Writeable`].
+    /// Case-folds the characters in the given string as a [`CaseMapWriteable`].
     /// This function is locale-independent and context-insensitive.
     ///
     /// Can be used to test if two strings are case-insensitively equivalent.
     ///
     /// See [`Self::fold_string()`] for the equivalent convenience function that returns a string,
     /// as well as for an example.
-    pub fn fold(self, src: &'a str) -> impl Writeable + 'a {
+    pub fn fold(self, src: &'a str) -> impl CaseMapWriteable + 'a {
         self.data.full_helper_writeable::<false>(
             src,
             CaseMapLocale::Root,
@@ -229,7 +229,7 @@ impl<'a> CaseMapperBorrowed<'a> {
         )
     }
 
-    /// Case-folds the characters in the given string as a [`Writeable`],
+    /// Case-folds the characters in the given string as a [`CaseMapWriteable`],
     /// using Turkic (T) mappings for dotted/dotless I.
     /// This function is locale-independent and context-insensitive.
     ///
@@ -237,7 +237,7 @@ impl<'a> CaseMapperBorrowed<'a> {
     ///
     /// See [`Self::fold_turkic_string()`] for the equivalent convenience function that returns a string,
     /// as well as for an example.
-    pub fn fold_turkic(self, src: &'a str) -> impl Writeable + 'a {
+    pub fn fold_turkic(self, src: &'a str) -> impl CaseMapWriteable + 'a {
         self.data.full_helper_writeable::<false>(
             src,
             CaseMapLocale::Turkish,
@@ -252,7 +252,7 @@ impl<'a> CaseMapperBorrowed<'a> {
     /// as a `LanguageIdentifier` (usually the `id` field of the `Locale`) if available, or
     /// `Default::default()` for the root locale.
     ///
-    /// See [`Self::lowercase()`] for the equivalent lower-level function that returns a [`Writeable`]
+    /// See [`Self::lowercase()`] for the equivalent lower-level function that returns a [`CaseMapWriteable`]
     ///
     /// # Examples
     ///
@@ -286,7 +286,7 @@ impl<'a> CaseMapperBorrowed<'a> {
     /// as a `LanguageIdentifier` (usually the `id` field of the `Locale`) if available, or
     /// `Default::default()` for the root locale.
     ///
-    /// See [`Self::uppercase()`] for the equivalent lower-level function that returns a [`Writeable`]
+    /// See [`Self::uppercase()`] for the equivalent lower-level function that returns a [`CaseMapWriteable`]
     ///
     /// # Examples
     ///
@@ -317,7 +317,7 @@ impl<'a> CaseMapperBorrowed<'a> {
         writeable::to_string_or_borrow(&self.uppercase(src, langid), src.as_bytes())
     }
 
-    /// Returns the full titlecase mapping of the given string as a [`Writeable`], treating
+    /// Returns the full titlecase mapping of the given string as a [`CaseMapWriteable`], treating
     /// the string as a single segment (and thus only titlecasing the beginning of it). Performs
     /// the specified leading adjustment behavior from the options without loading additional data.
     ///
@@ -339,7 +339,7 @@ impl<'a> CaseMapperBorrowed<'a> {
     /// the behavior of this function and the equivalent ones on [`TitlecaseMapper`] when the head adjustment mode
     /// is [`LeadingAdjustment::None`].
     ///
-    /// See [`Self::titlecase_segment_with_only_case_data()`] for the equivalent lower-level function that returns a [`Writeable`]
+    /// See [`Self::titlecase_segment_with_only_case_data()`] for the equivalent lower-level function that returns a [`CaseMapWriteable`]
     ///
     /// # Examples
     ///
@@ -388,7 +388,7 @@ impl<'a> CaseMapperBorrowed<'a> {
     ///
     /// Can be used to test if two strings are case-insensitively equivalent.
     ///
-    /// See [`Self::fold()`] for the equivalent lower-level function that returns a [`Writeable`]
+    /// See [`Self::fold()`] for the equivalent lower-level function that returns a [`CaseMapWriteable`]
     ///s s
     /// # Examples
     ///
@@ -415,7 +415,7 @@ impl<'a> CaseMapperBorrowed<'a> {
     ///
     /// Can be used to test if two strings are case-insensitively equivalent.
     ///
-    /// See [`Self::fold_turkic()`] for the equivalent lower-level function that returns a [`Writeable`]
+    /// See [`Self::fold_turkic()`] for the equivalent lower-level function that returns a [`CaseMapWriteable`]
     ///
     /// # Examples
     ///

--- a/components/casemap/src/edits.rs
+++ b/components/casemap/src/edits.rs
@@ -1,0 +1,71 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::fmt;
+use core::ops::Range;
+use writeable::Writeable;
+
+/// A changed source range and its replacement in the case mapped output.
+///
+/// Characteristics:
+/// - Both ranges use UTF-8 byte offsets, relative to the beginning of the input and
+///   output.
+/// - Endpoints are character boundaries.
+/// - An empty destination range represents a deletion.
+/// - Equal length ranges can still represent a change, for example `a` to `A`.
+/// - Edits are ordered, non-overlapping, and reported separately for each changed
+///   source character.
+/// - Gaps between edits are unchanged text.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct CaseMapEdit {
+    /// The range replaced in the source string.
+    pub source: Range<usize>,
+    /// The replacement range in the output string.
+    pub destination: Range<usize>,
+}
+
+/// A case mapping result that can also report how the source text changed.
+///
+/// # Examples
+///
+/// ```
+/// use icu::casemap::{CaseMapper, CaseMapWriteable};
+/// use icu::locale::langid;
+///
+/// let (output, edits) = CaseMapper::new()
+///     .uppercase("cß!", &langid!("und"))
+///     .to_string_with_edits();
+/// assert_eq!(output, "CSS!");
+/// assert_eq!(edits.len(), 2);
+/// assert_eq!(edits[0].source, 0..1);
+/// assert_eq!(edits[0].destination, 0..1);
+/// assert_eq!(edits[1].source, 1..3);
+/// assert_eq!(edits[1].destination, 1..3);
+/// ```
+pub trait CaseMapWriteable: Writeable {
+    /// Writes the mapped text and calls `record_edit` for each change.
+    ///
+    /// Errors from `sink` are propagated immediately. On error, the sink and
+    /// callback may have received partial output.
+    ///
+    /// See [`CaseMapEdit`].
+    fn write_to_with_edits<W: fmt::Write + ?Sized>(
+        &self,
+        sink: &mut W,
+        record_edit: impl FnMut(CaseMapEdit),
+    ) -> fmt::Result;
+
+    /// Returns the mapped string together with its changes.
+    ///
+    /// Prefer `write_to_with_edits` to avoid allocations.
+    fn to_string_with_edits(&self) -> (String, Vec<CaseMapEdit>) {
+        let mut output = String::new();
+        let mut edits = Vec::new();
+        let _ = self.write_to_with_edits(&mut output, |edit| edits.push(edit));
+        (output, edits)
+    }
+}

--- a/components/casemap/src/internals.rs
+++ b/components/casemap/src/internals.rs
@@ -15,6 +15,7 @@ use crate::provider::exception_helpers::ExceptionSlot;
 use crate::provider::{CaseMap, CaseMapUnfold};
 use crate::set::ClosureSink;
 use crate::titlecase::TrailingCase;
+use crate::{CaseMapEdit, CaseMapWriteable};
 use core::fmt;
 use icu_locale_core::LanguageIdentifier;
 use writeable::Writeable;
@@ -52,6 +53,23 @@ impl<Wr: Writeable> Writeable for StringAndWriteable<'_, Wr> {
     }
 }
 
+impl<Wr: CaseMapWriteable> CaseMapWriteable for StringAndWriteable<'_, Wr> {
+    fn write_to_with_edits<W: fmt::Write + ?Sized>(
+        &self,
+        sink: &mut W,
+        mut record_edit: impl FnMut(CaseMapEdit),
+    ) -> fmt::Result {
+        sink.write_str(self.string)?;
+        let offset = self.string.len();
+        self.writeable.write_to_with_edits(sink, |edit| {
+            record_edit(CaseMapEdit {
+                source: edit.source.start + offset..edit.source.end + offset,
+                destination: edit.destination.start + offset..edit.destination.end + offset,
+            });
+        })
+    }
+}
+
 pub(crate) struct FullCaseWriteable<'a, 'data, const IS_TITLE_CONTEXT: bool> {
     data: &'data CaseMap<'data>,
     src: &'a str,
@@ -60,8 +78,12 @@ pub(crate) struct FullCaseWriteable<'a, 'data, const IS_TITLE_CONTEXT: bool> {
     titlecase_tail_casing: TrailingCase,
 }
 
-impl<'a, const IS_TITLE_CONTEXT: bool> Writeable for FullCaseWriteable<'a, '_, IS_TITLE_CONTEXT> {
-    fn write_to<W: fmt::Write + ?Sized>(&self, sink: &mut W) -> fmt::Result {
+impl<const IS_TITLE_CONTEXT: bool> FullCaseWriteable<'_, '_, IS_TITLE_CONTEXT> {
+    fn write_mappings<W: fmt::Write + ?Sized>(
+        &self,
+        sink: &mut W,
+        mut on_mapping: impl FnMut(usize, char, &FullMappingResult<'_>),
+    ) -> fmt::Result {
         let src = self.src;
         let mut mapping = self.mapping;
         let mut iter = src.char_indices();
@@ -78,8 +100,11 @@ impl<'a, const IS_TITLE_CONTEXT: bool> Writeable for FullCaseWriteable<'a, '_, I
         };
         for (i, c) in &mut iter {
             let context = ContextIterator::new(&src[..i], &src[i..]);
-            self.data
-                .full_helper::<IS_TITLE_CONTEXT, W>(c, context, self.locale, mapping, sink)?;
+            let result =
+                self.data
+                    .full_helper::<IS_TITLE_CONTEXT>(c, context, self.locale, mapping);
+            result.write_to(sink)?;
+            on_mapping(i, c, &result);
             if IS_TITLE_CONTEXT {
                 // Check if we're uppercasing a dutch IJ
                 if let Some(count) = dutch_titlecase_count {
@@ -110,6 +135,35 @@ impl<'a, const IS_TITLE_CONTEXT: bool> Writeable for FullCaseWriteable<'a, '_, I
         }
         Ok(())
     }
+}
+
+impl<const IS_TITLE_CONTEXT: bool> CaseMapWriteable
+    for FullCaseWriteable<'_, '_, IS_TITLE_CONTEXT>
+{
+    fn write_to_with_edits<W: fmt::Write + ?Sized>(
+        &self,
+        sink: &mut W,
+        mut record_edit: impl FnMut(CaseMapEdit),
+    ) -> fmt::Result {
+        let mut destination_offset = 0;
+        self.write_mappings(sink, |source_offset, source, result| {
+            let destination_end = destination_offset + result.len_utf8();
+            if !result.is_unchanged(source) {
+                record_edit(CaseMapEdit {
+                    source: source_offset..source_offset + source.len_utf8(),
+                    destination: destination_offset..destination_end,
+                });
+            }
+            destination_offset = destination_end;
+        })
+    }
+}
+
+impl<'a, const IS_TITLE_CONTEXT: bool> Writeable for FullCaseWriteable<'a, '_, IS_TITLE_CONTEXT> {
+    fn write_to<W: fmt::Write + ?Sized>(&self, sink: &mut W) -> fmt::Result {
+        self.write_mappings(sink, |_, _, _| {})
+    }
+
     fn writeable_length_hint(&self) -> writeable::LengthHint {
         writeable::LengthHint::at_least(self.src.len())
     }
@@ -223,14 +277,13 @@ impl<'data> CaseMap<'data> {
     // IS_TITLE_CONTEXT must be true if kind is MappingKind::Title
     // The kind may be a different kind with IS_TITLE_CONTEXT still true because
     // titlecasing a segment involves switching to lowercase later
-    fn full_helper<const IS_TITLE_CONTEXT: bool, W: fmt::Write + ?Sized>(
+    fn full_helper<const IS_TITLE_CONTEXT: bool>(
         &self,
         c: char,
         context: ContextIterator,
         locale: CaseMapLocale,
         kind: MappingKind,
-        sink: &mut W,
-    ) -> fmt::Result {
+    ) -> FullMappingResult<'_> {
         // If using a title mapping IS_TITLE_CONTEXT must be true
         debug_assert!(kind != MappingKind::Title || IS_TITLE_CONTEXT);
         // In a title context, kind MUST be Title or Lower
@@ -251,7 +304,7 @@ impl<'data> CaseMap<'data> {
             if greek_to_me::is_greek_diacritic_except_ypogegrammeni(c)
                 && context.preceded_by_greek_letter()
             {
-                return Ok(());
+                return FullMappingResult::Remove;
             }
             let data = greek_to_me::get_data(c);
             // Check if the character is a Greek vowel
@@ -277,11 +330,12 @@ impl<'data> CaseMap<'data> {
                             precomposed_diacritics.dialytika = preceding_vowel.precomposed.accented;
                         }
                     }
-                    // Write the base of the uppercased combining character sequence.
+                    // Compute the base of the uppercased combining character sequence.
                     // In most branches this is [`upper_base`], i.e., the uppercase letter with all accents removed.
                     // In some branches the base has a precomposed diacritic.
                     // In the case of the Greek disjunctive "or", a combining tonos may also be written.
-                    match vowel {
+                    let mut tonos = None;
+                    let base = match vowel {
                         GreekVowel::Η => {
                             // The letter η (eta) is allowed to retain a tonos when it is form a single-letter word to distinguish
                             // the feminine definite article ἡ (monotonic η) from the disjunctive "or" ἤ (monotonic ή).
@@ -297,43 +351,46 @@ impl<'data> CaseMap<'data> {
                                 && !diacritics.ypogegrammeni
                             {
                                 if precomposed_diacritics.accented {
-                                    sink.write_char('Ή')?;
+                                    'Ή'
                                 } else {
-                                    sink.write_char('Η')?;
-                                    sink.write_char(greek_to_me::TONOS)?;
+                                    tonos = Some(greek_to_me::TONOS);
+                                    'Η'
                                 }
                             } else {
-                                sink.write_char('Η')?;
+                                'Η'
                             }
                         }
-                        GreekVowel::Ι => sink.write_char(if precomposed_diacritics.dialytika {
-                            diacritics.dialytika = false;
-                            'Ϊ'
-                        } else {
-                            vowel.into()
-                        })?,
-                        GreekVowel::Υ => sink.write_char(if precomposed_diacritics.dialytika {
-                            diacritics.dialytika = false;
-                            'Ϋ'
-                        } else {
-                            vowel.into()
-                        })?,
-                        _ => sink.write_char(vowel.into())?,
+                        GreekVowel::Ι => {
+                            if precomposed_diacritics.dialytika {
+                                diacritics.dialytika = false;
+                                'Ϊ'
+                            } else {
+                                vowel.into()
+                            }
+                        }
+                        GreekVowel::Υ => {
+                            if precomposed_diacritics.dialytika {
+                                diacritics.dialytika = false;
+                                'Ϋ'
+                            } else {
+                                vowel.into()
+                            }
+                        }
+                        _ => vowel.into(),
                     };
-                    if diacritics.dialytika {
-                        sink.write_char(greek_to_me::DIALYTIKA)?;
-                    }
-                    if precomposed_diacritics.ypogegrammeni {
-                        sink.write_char('Ι')?;
-                    }
-
-                    return Ok(());
+                    return FullMappingResult::CodePoints {
+                        first: base,
+                        rest: [
+                            tonos,
+                            diacritics.dialytika.then_some(greek_to_me::DIALYTIKA),
+                            precomposed_diacritics.ypogegrammeni.then_some('Ι'),
+                        ],
+                    };
                 }
                 // Rho might have breathing marks, we handle it specially
                 // to remove them
                 Some(GreekPrecomposedLetterData::Consonant(true)) => {
-                    sink.write_char(greek_to_me::CAPITAL_RHO)?;
-                    return Ok(());
+                    return FullMappingResult::CodePoint(greek_to_me::CAPITAL_RHO);
                 }
                 _ => (),
             }
@@ -345,9 +402,9 @@ impl<'data> CaseMap<'data> {
                 let mapped = c as i32 + data.delta() as i32;
                 // GIGO: delta should be valid
                 let mapped = char::from_u32(mapped as u32).unwrap_or(c);
-                sink.write_char(mapped)
+                FullMappingResult::CodePoint(mapped)
             } else {
-                sink.write_char(c)
+                FullMappingResult::CodePoint(c)
             }
         } else {
             let idx = data.exception_index();
@@ -362,28 +419,28 @@ impl<'data> CaseMap<'data> {
                         .full_upper_or_title_special_case::<IS_TITLE_CONTEXT>(c, context, locale),
                 }
             {
-                return special.write_to(sink);
+                return special;
             }
             if let Some(mapped_string) = exception.get_fullmappings_slot_for_kind(kind)
                 && !mapped_string.is_empty()
             {
-                return sink.write_str(mapped_string);
+                return FullMappingResult::String(mapped_string);
             }
 
             if kind == MappingKind::Fold && exception.bits.no_simple_case_folding() {
-                return sink.write_char(c);
+                return FullMappingResult::CodePoint(c);
             }
 
             if data.is_relevant_to(kind)
                 && let Some(simple) = exception.get_simple_case_slot_for(c)
             {
-                return sink.write_char(simple);
+                return FullMappingResult::CodePoint(simple);
             }
 
             if let Some(slot_char) = exception.slot_char_for_kind(kind) {
-                sink.write_char(slot_char)
+                FullMappingResult::CodePoint(slot_char)
             } else {
-                sink.write_char(c)
+                FullMappingResult::CodePoint(c)
             }
         }
     }
@@ -696,15 +753,35 @@ pub enum FullMappingResult<'a> {
     Remove,
     CodePoint(char),
     String(&'a str),
+    CodePoints {
+        first: char,
+        rest: [Option<char>; 3],
+    },
 }
 
 impl FullMappingResult<'_> {
-    #[allow(dead_code)]
-    fn add_to_set<S: ClosureSink>(&self, set: &mut S) {
+    fn len_utf8(&self) -> usize {
         match *self {
-            FullMappingResult::CodePoint(c) => set.add_char(c),
-            FullMappingResult::String(s) => set.add_string(s),
-            FullMappingResult::Remove => {}
+            Self::Remove => 0,
+            Self::CodePoint(c) => c.len_utf8(),
+            Self::String(s) => s.len(),
+            Self::CodePoints { first, rest } => {
+                first.len_utf8()
+                    + rest
+                        .into_iter()
+                        .flatten()
+                        .map(char::len_utf8)
+                        .sum::<usize>()
+            }
+        }
+    }
+
+    fn is_unchanged(&self, source: char) -> bool {
+        match *self {
+            Self::Remove => false,
+            Self::CodePoint(c) => c == source,
+            Self::String(s) => s == source.encode_utf8(&mut [0; 4]),
+            Self::CodePoints { first, rest } => first == source && rest.iter().all(Option::is_none),
         }
     }
 }
@@ -715,7 +792,18 @@ impl Writeable for FullMappingResult<'_> {
             FullMappingResult::CodePoint(c) => sink.write_char(c),
             FullMappingResult::String(s) => sink.write_str(s),
             FullMappingResult::Remove => Ok(()),
+            FullMappingResult::CodePoints { first, rest } => {
+                sink.write_char(first)?;
+                for c in rest.into_iter().flatten() {
+                    sink.write_char(c)?;
+                }
+                Ok(())
+            }
         }
+    }
+
+    fn writeable_length_hint(&self) -> writeable::LengthHint {
+        writeable::LengthHint::exact(self.len_utf8())
     }
 }
 

--- a/components/casemap/src/lib.rs
+++ b/components/casemap/src/lib.rs
@@ -46,6 +46,7 @@ extern crate alloc;
 
 mod casemapper;
 mod closer;
+mod edits;
 pub mod provider;
 mod set;
 pub(crate) mod titlecase;
@@ -57,6 +58,7 @@ mod internals;
 
 pub use casemapper::{CaseMapper, CaseMapperBorrowed};
 pub use closer::{CaseMapCloser, CaseMapCloserBorrowed};
+pub use edits::{CaseMapEdit, CaseMapWriteable};
 pub use set::ClosureSink;
 pub use titlecase::{TitlecaseMapper, TitlecaseMapperBorrowed};
 

--- a/components/casemap/src/titlecase.rs
+++ b/components/casemap/src/titlecase.rs
@@ -3,6 +3,7 @@
 // (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
 
 //! Titlecasing-specific
+use crate::CaseMapWriteable;
 use crate::provider::CaseMapV1;
 use crate::{CaseMapper, CaseMapperBorrowed};
 use alloc::borrow::Cow;
@@ -11,7 +12,6 @@ use icu_properties::props::{GeneralCategory, GeneralCategoryGroup};
 use icu_properties::provider::PropertyEnumGeneralCategoryV1;
 use icu_properties::{CodePointMapData, CodePointMapDataBorrowed};
 use icu_provider::prelude::*;
-use writeable::Writeable;
 
 /// How to handle the rest of the string once the beginning of the
 /// string has been titlecased.
@@ -328,7 +328,7 @@ impl Default for TitlecaseMapperBorrowed<'static> {
 }
 
 impl<'a> TitlecaseMapperBorrowed<'a> {
-    /// Returns the full titlecase mapping of the given string as a [`Writeable`], treating
+    /// Returns the full titlecase mapping of the given string as a [`CaseMapWriteable`], treating
     /// the string as a single segment (and thus only titlecasing the beginning of it).
     ///
     /// This should typically be used as a lower-level helper to construct the titlecasing operation desired
@@ -346,7 +346,7 @@ impl<'a> TitlecaseMapperBorrowed<'a> {
         src: &'a str,
         langid: &LanguageIdentifier,
         options: TitlecaseOptions,
-    ) -> impl Writeable + 'a + use<'a> {
+    ) -> impl CaseMapWriteable + 'a + use<'a> {
         if options.leading_adjustment.unwrap_or_default() == LeadingAdjustment::Auto {
             // letter, number, symbol, or private use code point
             const HEAD_GROUPS: GeneralCategoryGroup = GeneralCategoryGroup::Letter
@@ -376,7 +376,7 @@ impl<'a> TitlecaseMapperBorrowed<'a> {
     /// as a `LanguageIdentifier` (usually the `id` field of the `Locale`) if available, or
     /// `Default::default()` for the root locale.
     ///
-    /// See [`TitlecaseMapperBorrowed::titlecase_segment()`] for the equivalent lower-level function that returns a [`Writeable`]
+    /// See [`TitlecaseMapperBorrowed::titlecase_segment()`] for the equivalent lower-level function that returns a [`CaseMapWriteable`]
     ///
     /// # Examples
     ///

--- a/components/casemap/tests/edits.rs
+++ b/components/casemap/tests/edits.rs
@@ -1,0 +1,230 @@
+// This file is part of ICU4X. For terms of use, please see the file
+// called LICENSE at the top level of the ICU4X source tree
+// (online at: https://github.com/unicode-org/icu4x/blob/main/LICENSE ).
+
+#![cfg(feature = "compiled_data")]
+
+use core::ops::Range;
+use icu_casemap::options::{LeadingAdjustment, TitlecaseOptions, TrailingCase};
+use icu_casemap::{CaseMapWriteable, CaseMapper, TitlecaseMapper};
+use icu_locale_core::langid;
+
+type EditRanges = (Range<usize>, Range<usize>);
+
+fn check(mapping: impl CaseMapWriteable, expected: &str, ranges: &[EditRanges]) {
+    let (output, edits) = mapping.to_string_with_edits();
+    assert_eq!(output, expected);
+    assert_eq!(output, mapping.write_to_string());
+    let actual: Vec<_> = edits
+        .into_iter()
+        .map(|e| (e.source, e.destination))
+        .collect();
+    assert_eq!(actual, ranges);
+}
+
+#[test]
+fn changed_ranges() {
+    let cm = CaseMapper::new();
+    let root = langid!("und");
+    check(cm.uppercase("", &root), "", &[]);
+    check(cm.uppercase("A😀!", &root), "A😀!", &[]);
+    check(
+        cm.uppercase("cß!ﬃz", &root),
+        "CSS!FFIZ",
+        &[(0..1, 0..1), (1..3, 1..3), (4..7, 4..7), (7..8, 7..8)],
+    );
+    check(
+        cm.lowercase("İ Ⱥ𐐀!", &root),
+        "i\u{307} ⱥ𐐨!",
+        &[(0..2, 0..3), (3..5, 4..7), (5..9, 7..11)],
+    );
+    check(cm.fold("ẞİ!"), "ssi\u{307}!", &[(0..3, 0..2), (3..5, 2..5)]);
+    check(cm.fold_turkic("Iİ!"), "ıi!", &[(0..1, 0..2), (1..3, 2..3)]);
+}
+
+#[test]
+fn contextual_changes_and_deletions() {
+    let cm = CaseMapper::new();
+    check(
+        cm.lowercase("I\u{307}X", &langid!("tr")),
+        "ix",
+        &[(0..1, 0..1), (1..3, 1..1), (3..4, 1..2)],
+    );
+    check(
+        cm.lowercase("I\u{301}", &langid!("lt")),
+        "i\u{307}\u{301}",
+        &[(0..1, 0..3)],
+    );
+    check(
+        cm.lowercase("ΟΣ ΟΣΑ", &langid!("und")),
+        "ος οσα",
+        &[
+            (0..2, 0..2),
+            (2..4, 2..4),
+            (5..7, 5..7),
+            (7..9, 7..9),
+            (9..11, 9..11),
+        ],
+    );
+    check(
+        cm.uppercase("α\u{301}ι!", &langid!("el")),
+        "ΑΙ\u{308}!",
+        &[(0..2, 0..2), (2..4, 2..2), (4..6, 2..6)],
+    );
+    // The eta writes two characters; the following tonos is deleted.
+    check(
+        cm.uppercase("η\u{301}", &langid!("el")),
+        "Η\u{301}",
+        &[(0..2, 0..4), (2..4, 4..4)],
+    );
+}
+
+#[test]
+fn greek_computed_replacements() {
+    let cm = CaseMapper::new();
+    let el = langid!("el");
+    // Taking the Greek special-case path does not necessarily change the text.
+    for source in ["Α", "Η", "Ι", "Ϊ", "Υ", "Ϋ", "Ρ", "Ή"] {
+        check(cm.uppercase(source, &el), source, &[]);
+    }
+    // The replacement begins with the original uppercase base, but expands it.
+    // The whole string is unchanged even though the individual mappings change.
+    check(
+        cm.uppercase("Η\u{301}", &el),
+        "Η\u{301}",
+        &[(0..2, 0..4), (2..4, 4..4)],
+    );
+    // Preserve the order of the base, combining dialytika, and capital iota.
+    check(
+        cm.uppercase("ᾳ\u{308}z", &el),
+        "Α\u{308}ΙZ",
+        &[(0..3, 0..6), (3..5, 6..6), (5..6, 6..7)],
+    );
+    check(
+        cm.uppercase("η\u{301}\u{308}", &el),
+        "Η\u{301}\u{308}",
+        &[(0..2, 0..6), (2..4, 6..6), (4..6, 6..6)],
+    );
+}
+
+#[test]
+fn titlecase_prefix_tail_and_dutch_ij() {
+    let cm = CaseMapper::new();
+    let tm = TitlecaseMapper::new();
+    let root = langid!("und");
+    let options = TitlecaseOptions::default();
+    check(
+        tm.titlecase_segment("«ßABC»,", &root, options),
+        "«Ssabc»,",
+        &[(2..4, 2..4), (4..5, 4..5), (5..6, 5..6), (6..7, 6..7)],
+    );
+    check(
+        cm.titlecase_segment_with_only_case_data("«ßABC»,", &root, options),
+        "«Ssabc»,",
+        &[(2..4, 2..4), (4..5, 4..5), (5..6, 5..6), (6..7, 6..7)],
+    );
+    check(
+        tm.titlecase_segment("«😀!»,", &root, options),
+        "«😀!»,",
+        &[],
+    );
+    let mut preserve = options;
+    preserve.trailing_case = Some(TrailingCase::Unchanged);
+    check(
+        tm.titlecase_segment("«iJkD»,", &langid!("nl"), preserve),
+        "«IJkD»,",
+        &[(2..3, 2..3)],
+    );
+    check(
+        tm.titlecase_segment("«ijKD»,", &langid!("nl"), options),
+        "«IJkd»,",
+        &[(2..3, 2..3), (3..4, 3..4), (4..5, 4..5), (5..6, 5..6)],
+    );
+    check(
+        tm.titlecase_segment("«iABC", &langid!("tr"), preserve),
+        "«İABC",
+        &[(2..3, 2..4)],
+    );
+    let mut no_adjust = options;
+    no_adjust.leading_adjustment = Some(LeadingAdjustment::None);
+    check(
+        tm.titlecase_segment("«ABC»,", &root, no_adjust),
+        "«abc»,",
+        &[(2..3, 2..3), (3..4, 3..4), (4..5, 4..5)],
+    );
+}
+
+// Validate the edit contract independently of the mapping: unchanged gaps must
+// match and replacing the source ranges must reconstruct the entire output.
+fn check_reconstruction(source: &str, mapping: impl CaseMapWriteable) {
+    let (output, edits) = mapping.to_string_with_edits();
+    assert_eq!(output, mapping.write_to_string());
+    let mut reconstructed = String::new();
+    let (mut source_end, mut destination_end) = (0, 0);
+    for edit in edits {
+        assert!(edit.source.start >= source_end);
+        assert!(edit.destination.start >= destination_end);
+        assert_eq!(
+            &source[source_end..edit.source.start],
+            &output[destination_end..edit.destination.start]
+        );
+        assert_eq!(source[edit.source.clone()].chars().count(), 1);
+        assert_ne!(
+            &source[edit.source.clone()],
+            &output[edit.destination.clone()]
+        );
+        reconstructed.push_str(&source[source_end..edit.source.start]);
+        reconstructed.push_str(&output[edit.destination.clone()]);
+        source_end = edit.source.end;
+        destination_end = edit.destination.end;
+    }
+    assert_eq!(&source[source_end..], &output[destination_end..]);
+    reconstructed.push_str(&source[source_end..]);
+    assert_eq!(reconstructed, output);
+}
+
+#[test]
+fn reconstruct_all_mapping_modes() {
+    let cm = CaseMapper::new();
+    let tm = TitlecaseMapper::new();
+    let inputs = [
+        "",
+        "abc",
+        "«123 ijkD»,",
+        "«i\u{301}j\u{301}ssel»,",
+        "Aß ﬃİẞȺ𐐀😀",
+        "I\u{307} I\u{301} ΟΣ ΟΣΑ α\u{301}ι η\u{301}",
+        "և Երևանի",
+    ];
+    for source in inputs {
+        check_reconstruction(source, cm.fold(source));
+        check_reconstruction(source, cm.fold_turkic(source));
+        for locale in [
+            langid!("und"),
+            langid!("tr"),
+            langid!("lt"),
+            langid!("el"),
+            langid!("nl"),
+            langid!("hy"),
+        ] {
+            check_reconstruction(source, cm.lowercase(source, &locale));
+            check_reconstruction(source, cm.uppercase(source, &locale));
+            for leading in [
+                LeadingAdjustment::Auto,
+                LeadingAdjustment::None,
+                LeadingAdjustment::ToCased,
+            ] {
+                for trailing in [TrailingCase::Lower, TrailingCase::Unchanged] {
+                    let mut options = TitlecaseOptions::default();
+                    options.leading_adjustment = Some(leading);
+                    options.trailing_case = Some(trailing);
+                    check_reconstruction(source, tm.titlecase_segment(source, &locale, options));
+                    check_reconstruction(
+                        source,
+                        cm.titlecase_segment_with_only_case_data(source, &locale, options),
+                    );
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Intent

This is a draft PR that tries to address https://github.com/unicode-org/icu4x/issues/8467. I haven't contributed to ICU4X before, so I thought this should remain a draft. I'm happy to either have this taken over by a domain expert or reviewed and I address comments.

## Note

I let AI drive writing the tests because I don't know enough languages to understand when case transforms occur 😅 .

## Changelog

icu_casemap: Add mapping from source to transformed string
  * New traits: `CaseMapWriteable`
  * New types: `CaseMapEdit`
