### PR TITLE
Move zero-copy check to `make bakeddata`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,8 +215,10 @@ dependencies = [
  "icu",
  "icu_provider",
  "icu_provider_export",
+ "icu_provider_registry",
  "icu_provider_source",
  "log",
+ "postcard",
  "simple_logger",
 ]
 
@@ -2002,7 +2004,6 @@ dependencies = [
  "num-rational",
  "num-traits",
  "parse-zoneinfo",
- "postcard",
  "potential_utf",
  "serde",
  "serde-aux",

--- a/provider/source/Cargo.toml
+++ b/provider/source/Cargo.toml
@@ -71,10 +71,8 @@ ureq = { workspace = true, optional = true}
 num-traits = { workspace = true, optional = true }
 
 [dev-dependencies]
-postcard = { workspace = true, features = ["alloc"] }
 icu_provider_adapters = { workspace = true }
-icu_provider_export = { workspace = true, features = ["fs_exporter", "baked_exporter", "rayon", "blob_exporter"] }
-icu_provider = { workspace = true, features = ["deserialize_postcard_1"] }
+icu_provider_export = { workspace = true, features = ["fs_exporter", "rayon", "blob_exporter"] }
 icu_segmenter = { path = "../../components/segmenter", features = ["lstm"] }
 simple_logger = { workspace = true }
 icu = { path = "../../components/icu", default-features = false, features = ["unstable"] }

--- a/provider/source/src/tests/make_testdata.rs
+++ b/provider/source/src/tests/make_testdata.rs
@@ -4,15 +4,7 @@
 
 use crate::SourceDataProvider;
 use icu::locale::{DataLocale, data_locale};
-use icu_provider::dynutil::UpcastDataPayload;
-use icu_provider::export::*;
-use icu_provider::prelude::*;
 use icu_provider_export::prelude::*;
-use std::alloc::{GlobalAlloc, Layout, System};
-use std::cell::Cell;
-use std::collections::BTreeMap;
-use std::collections::BTreeSet;
-use std::sync::Mutex;
 
 include!("../../tests/locales.rs.data");
 
@@ -20,40 +12,26 @@ include!("../../tests/locales.rs.data");
 #[cfg(feature = "use_wasm")]
 fn make_testdata() {
     // Only produce output if the variable is set. Test is hermetic otherwise.
-    let exporter: Box<dyn DataExporter> = if std::option_env!("ICU4X_WRITE_TESTDATA").is_none() {
-        Box::new(ZeroCopyCheckExporter {
-            zero_copy_violations: Default::default(),
-            zero_copy_transient_violations: Default::default(),
-            rountrip_errors: Default::default(),
-        })
-    } else {
-        simple_logger::SimpleLogger::new()
-            .env()
-            .with_level(log::LevelFilter::Info)
-            .init()
-            .unwrap();
+    if std::option_env!("ICU4X_WRITE_TESTDATA").is_none() {
+        return;
+    }
 
-        Box::new(MultiExporter::new(vec![
-            Box::new(
-                icu_provider_export::fs_exporter::FilesystemExporter::try_new(
-                    Box::new(icu_provider_export::fs_exporter::serializers::Json::pretty()),
-                    {
-                        let mut options = icu_provider_export::fs_exporter::Options::default();
-                        options.root = "data/debug".into();
-                        options.overwrite =
-                            icu_provider_export::fs_exporter::OverwriteOption::RemoveAndReplace;
-                        options
-                    },
-                )
-                .unwrap(),
-            ),
-            Box::new(ZeroCopyCheckExporter {
-                zero_copy_violations: Default::default(),
-                zero_copy_transient_violations: Default::default(),
-                rountrip_errors: Default::default(),
-            }),
-        ]))
-    };
+    simple_logger::SimpleLogger::new()
+        .env()
+        .with_level(log::LevelFilter::Info)
+        .init()
+        .unwrap();
+
+    let exporter = icu_provider_export::fs_exporter::FilesystemExporter::try_new(
+        Box::new(icu_provider_export::fs_exporter::serializers::Json::pretty()),
+        {
+            let mut options = icu_provider_export::fs_exporter::Options::default();
+            options.root = "data/debug".into();
+            options.overwrite = icu_provider_export::fs_exporter::OverwriteOption::RemoveAndReplace;
+            options
+        },
+    )
+    .unwrap();
 
     let provider = SourceDataProvider::new_testing();
 
@@ -130,210 +108,4 @@ fn make_testdata() {
     })
     .export(&provider, exporter)
     .unwrap();
-}
-
-struct ZeroCopyCheckExporter {
-    zero_copy_violations: Mutex<BTreeSet<DataMarkerInfo>>,
-    zero_copy_transient_violations: Mutex<BTreeSet<DataMarkerInfo>>,
-    rountrip_errors: Mutex<BTreeMap<DataMarkerInfo, BTreeSet<String>>>,
-}
-
-// Types in this list cannot be zero-copy deserialized.
-//
-// Such types contain some data that was allocated during deserializations
-//
-// Every entry in this list is a bug that needs to be addressed before stabilization.
-const EXPECTED_VIOLATIONS: &[DataMarkerInfo] = &[];
-
-// Types in this list can be zero-copy deserialized (and do not contain allocated data),
-// however there is some allocation that occurs during deserialization for validation.
-//
-// Entries in this list represent a less-than-ideal state of things, however ICU4X is shippable with violations
-// in this list since it does not affect databake.
-const EXPECTED_TRANSIENT_VIOLATIONS: &[DataMarkerInfo] = &[
-    // Regex DFAs need to be validated, which involved creating a BTreeMap.
-    // If required we could avoid this using one of the approaches in
-    // https://github.com/unicode-org/icu4x/pulls/3697.
-    icu::list::provider::ListOrV1::INFO,
-    icu::list::provider::ListAndV1::INFO,
-    icu::list::provider::ListUnitV1::INFO,
-];
-
-impl DataExporter for ZeroCopyCheckExporter {
-    fn put_payload(
-        &self,
-        marker: DataMarkerInfo,
-        id: DataIdentifierBorrowed,
-        payload_before: &DataPayload<ExportMarker>,
-    ) -> Result<(), DataError> {
-        use postcard::{
-            Serializer,
-            ser_flavors::{AllocVec, Flavor},
-        };
-        let mut serializer = Serializer {
-            output: AllocVec::new(),
-        };
-        payload_before.serialize(&mut serializer).unwrap();
-        let serialized = serializer.output.finalize().unwrap();
-
-        let buffer_payload = DataPayload::from_owned_buffer(serialized.into_boxed_slice());
-
-        MeasuringAllocator::start_measure();
-
-        let allocated;
-        let deallocated;
-        let payload_after;
-
-        macro_rules! cb {
-            ($($marker_ty:ty:$marker:ident,)+ #[unstable] $($emarker_ty:ty:$emarker:ident,)+) => {
-                ((allocated, deallocated), payload_after) = match marker {
-                    k if k == icu_provider::hello_world::HelloWorldV1::INFO => {
-                        let deserialized: DataPayload<icu_provider::hello_world::HelloWorldV1> = buffer_payload.into_deserialized(icu_provider::buf::BufferFormat::Postcard1).unwrap();
-                        (MeasuringAllocator::end_measure(), UpcastDataPayload::upcast(deserialized))
-                    }
-                    $(
-                        k if k == <$marker_ty>::INFO => {
-                            let deserialized: DataPayload<$marker_ty> = buffer_payload.into_deserialized(icu_provider::buf::BufferFormat::Postcard1).unwrap();
-                            (MeasuringAllocator::end_measure(), UpcastDataPayload::upcast(deserialized))
-                        }
-                    )+
-                    $(
-                        k if k == <$emarker_ty>::INFO => {
-                            let deserialized: DataPayload<$emarker_ty> = buffer_payload.into_deserialized(icu_provider::buf::BufferFormat::Postcard1).unwrap();
-                            (MeasuringAllocator::end_measure(), UpcastDataPayload::upcast(deserialized))
-                        }
-                    )+
-                    _ => unreachable!("unregistered marker {marker:?}")
-                };
-            }
-        }
-        icu_provider_registry::registry!(cb);
-
-        if payload_before != &payload_after {
-            self.rountrip_errors
-                .lock()
-                .expect("poison")
-                .entry(marker)
-                .or_default()
-                .insert(
-                    id.locale.to_string()
-                        + if id.marker_attributes.is_empty() {
-                            ""
-                        } else {
-                            "-x"
-                        }
-                        + id.marker_attributes.as_str(),
-                );
-        }
-
-        if deallocated != allocated {
-            if !EXPECTED_VIOLATIONS.contains(&marker) {
-                eprintln!(
-                    "Zerocopy violation {marker:?} {id:?}: {allocated}B allocated, {deallocated}B deallocated"
-                );
-            }
-            self.zero_copy_violations
-                .lock()
-                .expect("poison")
-                .insert(marker);
-        } else if allocated > 0 {
-            if !EXPECTED_TRANSIENT_VIOLATIONS.contains(&marker) {
-                eprintln!(
-                    "Transient zerocopy violation {marker:?} {id:?}: {allocated}B allocated/deallocated"
-                );
-            }
-            self.zero_copy_transient_violations
-                .lock()
-                .expect("poison")
-                .insert(marker);
-        }
-
-        Ok(())
-    }
-
-    fn close(&mut self) -> Result<ExporterCloseMetadata, DataError> {
-        let rountrip_errors = self.rountrip_errors.get_mut().expect("poison");
-        // These serialize to a different variant for stability
-        rountrip_errors.remove(&icu::datetime::provider::names::DatetimeNamesMonthChineseV1::INFO);
-        rountrip_errors.remove(&icu::datetime::provider::names::DatetimeNamesMonthDangiV1::INFO);
-        rountrip_errors.remove(&icu::datetime::provider::names::DatetimeNamesMonthHebrewV1::INFO);
-        rountrip_errors.remove(&icu::datetime::provider::names::DatetimeNamesYearJapaneseV1::INFO);
-        assert_eq!(rountrip_errors, &mut BTreeMap::default());
-
-        let violations = self
-            .zero_copy_violations
-            .get_mut()
-            .expect("poison")
-            .iter()
-            .copied()
-            .collect::<Vec<_>>();
-
-        let transient_violations = self
-            .zero_copy_transient_violations
-            .get_mut()
-            .expect("poison")
-            .iter()
-            .copied()
-            .collect::<Vec<_>>();
-
-        assert!(
-            transient_violations == EXPECTED_TRANSIENT_VIOLATIONS
-                && violations == EXPECTED_VIOLATIONS,
-            "Expected violations list does not match found violations!\n\
-            If the new list is smaller, please update EXPECTED_VIOLATIONS in make-testdata.rs\n\
-            If it is bigger and that was unexpected, please make sure the marker remains zero-copy, or ask ICU4X team members if it is okay \
-            to temporarily allow for this marker to be allowlisted.\n\
-            Common cause: did you forget to add `serde(borrow)` to all of the fields in your data struct?\n\
-            Expected:\n{EXPECTED_VIOLATIONS:?}\nFound:\n{violations:?}\nExpected (transient):\n{EXPECTED_TRANSIENT_VIOLATIONS:?}\nFound (transient):\n{transient_violations:?}"
-        );
-
-        Ok(Default::default())
-    }
-}
-
-#[global_allocator]
-static ALLOCATOR: MeasuringAllocator = MeasuringAllocator;
-
-// Inspired by the assert_no_alloc crate
-struct MeasuringAllocator;
-
-impl MeasuringAllocator {
-    // We need to track allocations on each thread independently
-    thread_local! {
-        static ACTIVE: Cell<bool> = const { Cell::new(false) };
-        static TOTAL_ALLOCATED: Cell<u64> = const { Cell::new(0) };
-        static TOTAL_DEALLOCATED: Cell<u64> = const { Cell::new(0) };
-    }
-
-    pub fn start_measure() {
-        Self::ACTIVE.with(|c| c.set(true));
-    }
-
-    pub fn end_measure() -> (u64, u64) {
-        Self::ACTIVE.with(|c| c.set(false));
-        (
-            Self::TOTAL_ALLOCATED.with(|c| c.take()),
-            Self::TOTAL_DEALLOCATED.with(|c| c.take()),
-        )
-    }
-}
-
-unsafe impl GlobalAlloc for MeasuringAllocator {
-    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        if Self::ACTIVE.with(|f| f.get()) {
-            Self::TOTAL_ALLOCATED.with(|c| c.set(c.get() + layout.size() as u64));
-        }
-
-        // Safety: By our safety invariant.
-        unsafe { System.alloc(layout) }
-    }
-
-    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        if Self::ACTIVE.with(|f| f.get()) {
-            Self::TOTAL_DEALLOCATED.with(|c| c.set(c.get() + layout.size() as u64));
-        }
-
-        // Safety: By our safety invariant.
-        unsafe { System.dealloc(ptr, layout) }
-    }
 }

--- a/tools/make/bakeddata/Cargo.toml
+++ b/tools/make/bakeddata/Cargo.toml
@@ -10,13 +10,15 @@ edition.workspace = true
 
 [dependencies]
 icu = { workspace = true, features = ["unstable"] }
-icu_provider = { workspace = true }
+icu_provider = { workspace = true, features = ["deserialize_postcard_1"] }
 icu_provider_export = { workspace = true, features = ["baked_exporter", "rayon"] }
 icu_provider_source = { workspace = true, features = ["networking", "unstable", "use_wasm"] }
+icu_provider_registry = { workspace = true }
 
 log = { workspace = true }
 simple_logger = { workspace = true }
 crlify = { workspace = true }
+postcard = { workspace = true, features = ["alloc"] }
 
 [package.metadata.cargo-all-features]
 # Unpublished internal tool; skip

--- a/tools/make/bakeddata/src/main.rs
+++ b/tools/make/bakeddata/src/main.rs
@@ -4,13 +4,15 @@
 
 extern crate icu_provider_export;
 
+use icu_provider::dynutil::UpcastDataPayload;
 use icu_provider::export::*;
 use icu_provider::prelude::*;
 use icu_provider_export::baked_exporter;
 use icu_provider_export::prelude::*;
 use icu_provider_source::{CoverageLevel, SourceDataProvider};
-use std::collections::BTreeMap;
-use std::collections::{HashMap, HashSet};
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::cell::Cell;
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;
@@ -103,6 +105,12 @@ fn main() {
     options.overwrite = true;
     options.pretty = true;
 
+    let zero_copy_check_exporter = Box::leak(Box::new(ZeroCopyCheckExporter {
+        zero_copy_violations: Default::default(),
+        zero_copy_transient_violations: Default::default(),
+        rountrip_errors: Default::default(),
+    }));
+
     for (component, markers, version) in &components {
         let path = Path::new("provider/data").join(component);
 
@@ -143,6 +151,7 @@ fn main() {
         let stub_exporter = StubExporter(
             baked_exporter::BakedExporter::new(path.join("stubdata"), options).unwrap(),
         );
+
         let fingerprinter = StatisticsExporter::default();
 
         let export_metdata = driver
@@ -154,6 +163,7 @@ fn main() {
                     Box::new(baked_exporter),
                     Box::new(stub_exporter),
                     Box::new(fingerprinter),
+                    Box::new(&*zero_copy_check_exporter),
                 ]),
             )
             .unwrap();
@@ -263,17 +273,6 @@ fn main() {
 
     if components.len() == COMPONENTS.len() {
         // On full datagen runs (as in CI) validate that `--markers all --locales full` works
-        struct SinkExporter;
-        impl DataExporter for SinkExporter {
-            fn put_payload(
-                &self,
-                _marker: DataMarkerInfo,
-                _id: DataIdentifierBorrowed,
-                _payload: &DataPayload<ExportMarker>,
-            ) -> Result<(), DataError> {
-                Ok(())
-            }
-        }
         ExportDriver::new(
             [DataLocaleFamily::FULL],
             DeduplicationStrategy::Maximal.into(),
@@ -281,9 +280,11 @@ fn main() {
         )
         // These are all supported models
         .with_recommended_segmenter_models()
-        .export(&source, SinkExporter)
+        .export(&source, &*zero_copy_check_exporter)
         .unwrap();
     }
+
+    zero_copy_check_exporter.check();
 }
 
 struct StubExporter<E>(E);
@@ -367,5 +368,223 @@ impl DataExporter for StatisticsExporter {
         Ok(ExporterCloseMetadata(Some(Box::new(core::mem::take(
             self.data.get_mut().expect("poison"),
         )))))
+    }
+}
+
+struct ZeroCopyCheckExporter {
+    zero_copy_violations: Mutex<BTreeSet<DataMarkerInfo>>,
+    zero_copy_transient_violations: Mutex<BTreeSet<DataMarkerInfo>>,
+    rountrip_errors: Mutex<BTreeMap<DataMarkerInfo, BTreeSet<String>>>,
+}
+
+impl DataExporter for &'_ ZeroCopyCheckExporter {
+    fn put_payload(
+        &self,
+        marker: DataMarkerInfo,
+        id: DataIdentifierBorrowed,
+        payload_before: &DataPayload<ExportMarker>,
+    ) -> Result<(), DataError> {
+        use postcard::{
+            Serializer,
+            ser_flavors::{AllocVec, Flavor},
+        };
+        let mut serializer = Serializer {
+            output: AllocVec::new(),
+        };
+        payload_before.serialize(&mut serializer).unwrap();
+        let serialized = serializer.output.finalize().unwrap();
+
+        let buffer_payload = DataPayload::from_owned_buffer(serialized.into_boxed_slice());
+
+        MeasuringAllocator::start_measure();
+
+        let allocated;
+        let deallocated;
+        let payload_after;
+
+        macro_rules! cb {
+            ($($marker_ty:ty:$marker:ident,)+ #[unstable] $($emarker_ty:ty:$emarker:ident,)+) => {
+                ((allocated, deallocated), payload_after) = match marker {
+                    k if k == icu_provider::hello_world::HelloWorldV1::INFO => {
+                        let deserialized: DataPayload<icu_provider::hello_world::HelloWorldV1> = buffer_payload.into_deserialized(icu_provider::buf::BufferFormat::Postcard1).unwrap();
+                        (MeasuringAllocator::end_measure(), UpcastDataPayload::upcast(deserialized))
+                    }
+                    $(
+                        k if k == <$marker_ty>::INFO => {
+                            let deserialized: DataPayload<$marker_ty> = buffer_payload.into_deserialized(icu_provider::buf::BufferFormat::Postcard1).unwrap();
+                            (MeasuringAllocator::end_measure(), UpcastDataPayload::upcast(deserialized))
+                        }
+                    )+
+                    $(
+                        k if k == <$emarker_ty>::INFO => {
+                            let deserialized: DataPayload<$emarker_ty> = buffer_payload.into_deserialized(icu_provider::buf::BufferFormat::Postcard1).unwrap();
+                            (MeasuringAllocator::end_measure(), UpcastDataPayload::upcast(deserialized))
+                        }
+                    )+
+                    _ => unreachable!("unregistered marker {marker:?}")
+                };
+            }
+        }
+        icu_provider_registry::registry!(cb);
+
+        if payload_before != &payload_after {
+            self.rountrip_errors
+                .lock()
+                .expect("poison")
+                .entry(marker)
+                .or_default()
+                .insert(
+                    id.locale.to_string()
+                        + if id.marker_attributes.is_empty() {
+                            ""
+                        } else {
+                            "-x"
+                        }
+                        + id.marker_attributes.as_str(),
+                );
+        }
+
+        if deallocated != allocated {
+            if !ZeroCopyCheckExporter::EXPECTED_VIOLATIONS.contains(&marker) {
+                eprintln!(
+                    "Zerocopy violation {marker:?} {id:?}: {allocated}B allocated, {deallocated}B deallocated"
+                );
+            }
+            self.zero_copy_violations
+                .lock()
+                .expect("poison")
+                .insert(marker);
+        } else if allocated > 0 {
+            if !ZeroCopyCheckExporter::EXPECTED_TRANSIENT_VIOLATIONS.contains(&marker) {
+                eprintln!(
+                    "Transient zerocopy violation {marker:?} {id:?}: {allocated}B allocated/deallocated"
+                );
+            }
+            self.zero_copy_transient_violations
+                .lock()
+                .expect("poison")
+                .insert(marker);
+        }
+
+        Ok(())
+    }
+}
+
+impl ZeroCopyCheckExporter {
+    // Types in this list cannot be zero-copy deserialized.
+    //
+    // Such types contain some data that was allocated during deserializations
+    //
+    // Every entry in this list is a bug that needs to be addressed before stabilization.
+    const EXPECTED_VIOLATIONS: &[DataMarkerInfo] = &[];
+
+    // Types in this list can be zero-copy deserialized (and do not contain allocated data),
+    // however there is some allocation that occurs during deserialization for validation.
+    //
+    // Entries in this list represent a less-than-ideal state of things, however ICU4X is shippable with violations
+    // in this list since it does not affect databake.
+    const EXPECTED_TRANSIENT_VIOLATIONS: &[DataMarkerInfo] = &[
+        // Regex DFAs need to be validated, which involved creating a BTreeMap.
+        // If required we could avoid this using one of the approaches in
+        // https://github.com/unicode-org/icu4x/pulls/3697.
+        icu::list::provider::ListOrV1::INFO,
+        icu::list::provider::ListAndV1::INFO,
+        icu::list::provider::ListUnitV1::INFO,
+    ];
+
+    const EXPECTED_ROUNDTRIP_VIOLATIONS: &[DataMarkerInfo] = &[
+        // These serialize to a different variant for stability
+        icu::datetime::provider::names::DatetimeNamesMonthDangiV1::INFO,
+        icu::datetime::provider::names::DatetimeNamesMonthHebrewV1::INFO,
+        icu::datetime::provider::names::DatetimeNamesMonthChineseV1::INFO,
+        icu::datetime::provider::names::DatetimeNamesYearJapaneseV1::INFO,
+    ];
+
+    fn check(&self) {
+        let rountrip_errors = self
+            .rountrip_errors
+            .lock()
+            .expect("poison")
+            .keys()
+            .copied()
+            .collect::<Vec<_>>();
+
+        assert_eq!(rountrip_errors, Self::EXPECTED_ROUNDTRIP_VIOLATIONS);
+
+        let violations = self
+            .zero_copy_violations
+            .lock()
+            .expect("poison")
+            .iter()
+            .copied()
+            .collect::<Vec<_>>();
+
+        let transient_violations = self
+            .zero_copy_transient_violations
+            .lock()
+            .expect("poison")
+            .iter()
+            .copied()
+            .collect::<Vec<_>>();
+
+        assert!(
+            transient_violations == Self::EXPECTED_TRANSIENT_VIOLATIONS
+                && violations == Self::EXPECTED_VIOLATIONS,
+            "Expected violations list does not match found violations!\n\
+            If the new list is smaller, please update EXPECTED_VIOLATIONS in make-testdata.rs\n\
+            If it is bigger and that was unexpected, please make sure the marker remains zero-copy, or ask ICU4X team members if it is okay \
+            to temporarily allow for this marker to be allowlisted.\n\
+            Common cause: did you forget to add `serde(borrow)` to all of the fields in your data struct?\n\
+            Expected:\n{:?}\nFound:\n{violations:?}\nExpected (transient):\n{:?}\nFound (transient):\n{transient_violations:?}",
+            Self::EXPECTED_VIOLATIONS,
+            Self::EXPECTED_TRANSIENT_VIOLATIONS,
+        );
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: MeasuringAllocator = MeasuringAllocator;
+
+// Inspired by the assert_no_alloc crate
+struct MeasuringAllocator;
+
+impl MeasuringAllocator {
+    // We need to track allocations on each thread independently
+    thread_local! {
+        static ACTIVE: Cell<bool> = const { Cell::new(false) };
+        static TOTAL_ALLOCATED: Cell<u64> = const { Cell::new(0) };
+        static TOTAL_DEALLOCATED: Cell<u64> = const { Cell::new(0) };
+    }
+
+    pub fn start_measure() {
+        Self::ACTIVE.with(|c| c.set(true));
+    }
+
+    pub fn end_measure() -> (u64, u64) {
+        Self::ACTIVE.with(|c| c.set(false));
+        (
+            Self::TOTAL_ALLOCATED.with(|c| c.take()),
+            Self::TOTAL_DEALLOCATED.with(|c| c.take()),
+        )
+    }
+}
+
+unsafe impl GlobalAlloc for MeasuringAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if Self::ACTIVE.with(|f| f.get()) {
+            Self::TOTAL_ALLOCATED.with(|c| c.set(c.get() + layout.size() as u64));
+        }
+
+        // Safety: By our safety invariant.
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        if Self::ACTIVE.with(|f| f.get()) {
+            Self::TOTAL_DEALLOCATED.with(|c| c.set(c.get() + layout.size() as u64));
+        }
+
+        // Safety: By our safety invariant.
+        unsafe { System.dealloc(ptr, layout) }
     }
 }


### PR DESCRIPTION
Currently we only test that the testdata locale structs zero-copy-deserialize. This might miss allocations, e.g. the Hebrew regex in list formatting.

Instead, do this in `make bakeddata` which tests the structs for all CLDR locales.

This does not have a measurable performance impact:
```
main: 197.20s user 19.72s system 326% cpu 1:06.37 total
PR: 158.19s user 17.43s system 285% cpu 1:01.43 total
```

## Changelog

N/A