### PR TITLE
Move some segmenter tests around

### DIFF
--- a/components/segmenter/src/complex/dictionary.rs
+++ b/components/segmenter/src/complex/dictionary.rs
@@ -149,91 +149,62 @@ impl<'data> DictionarySegmenter<'data> {
 #[cfg(feature = "serde")]
 mod tests {
     use super::*;
-    use crate::{GraphemeClusterSegmenter, LineSegmenter, WordSegmenter};
+    use crate::GraphemeClusterSegmenter;
+    use crate::complex::ComplexPayloadsBorrowed;
     use icu_provider::prelude::*;
+
+    use super::super::check_complex;
 
     #[test]
     fn burmese_dictionary_test() {
-        let segmenter = LineSegmenter::new_dictionary(Default::default());
-        // From css/css-text/word-break/word-break-normal-my-000.html
-        let s = "မြန်မာစာမြန်မာစာမြန်မာစာ";
-        let result: Vec<usize> = segmenter.segment_str(s).collect();
-        assert_eq!(result, vec![0, 18, 24, 42, 48, 66, 72]);
+        let mut segmenter = ComplexPayloadsBorrowed::new();
+        segmenter.with_southeast_asian_dictionaries();
+        let segmenter = segmenter.select(ComplexScript::Myanmar).unwrap();
 
-        let s_utf16: Vec<u16> = s.encode_utf16().collect();
-        let result: Vec<usize> = segmenter.segment_utf16(&s_utf16).collect();
-        assert_eq!(result, vec![0, 6, 8, 14, 16, 22, 24]);
+        // From css/css-text/word-break/word-break-normal-my-000.html
+        check_complex(
+            "မြန်မာစာမြန်မာစာမြန်မာစာ",
+            &["မြန်မာ", "စာ", "မြန်မာ", "စာ", "မြန်မာ", "စာ"],
+            segmenter,
+        );
     }
 
     #[test]
     fn cj_dictionary_test() {
-        let response: DataResponse<SegmenterDictionaryAutoV1> = Baked
-            .load(DataRequest {
-                id: DataIdentifierBorrowed::for_marker_attributes(
-                    DataMarkerAttributes::from_str_or_panic("cjdict"),
-                ),
-                ..Default::default()
-            })
-            .unwrap();
-        let word_segmenter = WordSegmenter::new_dictionary(Default::default());
-        let dict_segmenter =
-            DictionarySegmenter::new(response.payload.get(), GraphemeClusterSegmenter::new());
+        let mut segmenter = ComplexPayloadsBorrowed::new();
+        segmenter.with_japanese_dictionary();
+        let segmenter = segmenter.select(ComplexScript::ChineseOrJapanese).unwrap();
 
         // Match case
-        let s = "龟山岛龟山岛";
-        let result: Vec<usize> = dict_segmenter.segment_str(s).collect();
-        assert_eq!(result, vec![9, 18]);
-
-        let result: Vec<usize> = word_segmenter.segment_str(s).collect();
-        assert_eq!(result, vec![0, 9, 18]);
-
-        let s_utf16: Vec<u16> = s.encode_utf16().collect();
-        let result: Vec<usize> = dict_segmenter.segment_utf16(&s_utf16).collect();
-        assert_eq!(result, vec![3, 6]);
-
-        let result: Vec<usize> = word_segmenter.segment_utf16(&s_utf16).collect();
-        assert_eq!(result, vec![0, 3, 6]);
+        check_complex("龟山岛龟山岛", &["龟山岛", "龟山岛"], segmenter);
 
         // Match case, then no match case
-        let s = "エディターエディ";
-        let result: Vec<usize> = dict_segmenter.segment_str(s).collect();
-        assert_eq!(result, vec![15, 24]);
-
-        // TODO(#3236): Why is WordSegmenter not returning the middle segment?
-        let result: Vec<usize> = word_segmenter.segment_str(s).collect();
-        assert_eq!(result, vec![0, 24]);
-
-        let s_utf16: Vec<u16> = s.encode_utf16().collect();
-        let result: Vec<usize> = dict_segmenter.segment_utf16(&s_utf16).collect();
-        assert_eq!(result, vec![5, 8]);
-
-        // TODO(#3236): Why is WordSegmenter not returning the middle segment?
-        let result: Vec<usize> = word_segmenter.segment_utf16(&s_utf16).collect();
-        assert_eq!(result, vec![0, 8]);
+        check_complex("エディターエディ", &["エディター", "エディ"], segmenter);
     }
 
     #[test]
     fn khmer_dictionary_test() {
-        let segmenter = LineSegmenter::new_dictionary(Default::default());
-        let s = "ភាសាខ្មែរភាសាខ្មែរភាសាខ្មែរ";
-        let result: Vec<usize> = segmenter.segment_str(s).collect();
-        assert_eq!(result, vec![0, 27, 54, 81]);
+        let mut segmenter = ComplexPayloadsBorrowed::new();
+        segmenter.with_southeast_asian_dictionaries();
+        let segmenter = segmenter.select(ComplexScript::Khmer).unwrap();
 
-        let s_utf16: Vec<u16> = s.encode_utf16().collect();
-        let result: Vec<usize> = segmenter.segment_utf16(&s_utf16).collect();
-        assert_eq!(result, vec![0, 9, 18, 27]);
+        check_complex(
+            "ភាសាខ្មែរភាសាខ្មែរភាសាខ្មែរ",
+            &["ភាសាខ្មែរ", "ភាសាខ្មែរ", "ភាសាខ្មែរ"],
+            segmenter,
+        );
     }
 
     #[test]
     fn lao_dictionary_test() {
-        let segmenter = LineSegmenter::new_dictionary(Default::default());
-        let s = "ພາສາລາວພາສາລາວພາສາລາວ";
-        let r: Vec<usize> = segmenter.segment_str(s).collect();
-        assert_eq!(r, vec![0, 12, 21, 33, 42, 54, 63]);
-
-        let s_utf16: Vec<u16> = s.encode_utf16().collect();
-        let r: Vec<usize> = segmenter.segment_utf16(&s_utf16).collect();
-        assert_eq!(r, vec![0, 4, 7, 11, 14, 18, 21]);
+        let mut segmenter = ComplexPayloadsBorrowed::new();
+        segmenter.with_southeast_asian_dictionaries();
+        let segmenter = segmenter.select(ComplexScript::Lao).unwrap();
+        check_complex(
+            "ພາສາລາວພາສາລາວພາສາລາວ",
+            &["ພາສາ", "ລາວ", "ພາສາ", "ລາວ", "ພາສາ", "ລາວ"],
+            segmenter,
+        );
     }
 
     #[test]

--- a/components/segmenter/src/complex/mod.rs
+++ b/components/segmenter/src/complex/mod.rs
@@ -497,64 +497,45 @@ fn try_load_static<M: DataMarker, P: DataProvider<M> + ?Sized>(
 }
 
 #[cfg(test)]
-#[cfg(feature = "compiled_data")]
-mod utf8_tests {
-    use super::*;
+#[track_caller]
+fn check_complex(s: &str, expected: &[&str], segmenter: ComplexPayloadBorrowed<'_>) {
+    use itertools::Itertools;
 
-    #[test]
-    fn no_model_utf8_fallback() {
-        let segmenter = ComplexPayloadsBorrowed::new();
-        let thai = "ภาษาไทย".as_bytes();
-        assert_eq!(segmenter.segment_utf8(thai), [thai.len()]);
+    let segments = [0]
+        .into_iter()
+        .chain(segmenter.segment_str(s, GraphemeClusterSegmenter::new(), 0))
+        .tuple_windows()
+        .map(|(a, b)| &s[a..b])
+        .collect::<Vec<_>>();
+    assert_eq!(segments, expected, "{s}");
 
-        let mut malformed = thai.to_vec();
-        malformed.push(0xFF);
-        malformed.extend_from_slice(thai);
-        assert_eq!(
-            segmenter.segment_utf8(&malformed),
-            [thai.len(), thai.len() + 1, malformed.len()]
-        );
-    }
+    let segments = [0]
+        .into_iter()
+        .chain(segmenter.segment_utf8(s.as_bytes(), GraphemeClusterSegmenter::new(), 0))
+        .tuple_windows()
+        .map(|(a, b)| &s[a..b])
+        .collect::<Vec<_>>();
+    assert_eq!(segments, expected, "{s}");
+
+    let utf16: Vec<u16> = s.encode_utf16().collect();
+    let expected = expected
+        .iter()
+        .copied()
+        .map(|s| s.encode_utf16().collect::<Vec<_>>())
+        .collect::<Vec<_>>();
+    let iter = [0]
+        .into_iter()
+        .chain(segmenter.segment_utf16(&utf16, GraphemeClusterSegmenter::new(), 0))
+        .tuple_windows()
+        .map(|(a, b)| &utf16[a..b])
+        .collect::<Vec<_>>();
+    assert_eq!(iter, expected, "{s}");
 }
 
 #[cfg(test)]
 #[cfg(feature = "serde")]
 mod tests {
     use super::*;
-
-    #[track_caller]
-    fn check_complex(s: &str, expected: &[&str], segmenter: ComplexPayloadsBorrowed<'_>) {
-        use itertools::Itertools;
-
-        let segments = [0]
-            .into_iter()
-            .chain(segmenter.segment_str(s))
-            .tuple_windows()
-            .map(|(a, b)| &s[a..b])
-            .collect::<Vec<_>>();
-        assert_eq!(segments, expected, "{s}");
-
-        // let segments = segmenter
-        //     .segment_utf8(s.as_bytes())
-        //     .tuple_windows()
-        //     .map(|(a, b)| &s[a..b])
-        //     .collect::<Vec<_>>();
-        // assert_eq!(segments, expected, "{s}");
-
-        let utf16: Vec<u16> = s.encode_utf16().collect();
-        let expected = expected
-            .iter()
-            .copied()
-            .map(|s| s.encode_utf16().collect::<Vec<_>>())
-            .collect::<Vec<_>>();
-        let iter = [0]
-            .into_iter()
-            .chain(segmenter.segment_utf16(&utf16))
-            .tuple_windows()
-            .map(|(a, b)| &utf16[a..b])
-            .collect::<Vec<_>>();
-        assert_eq!(iter, expected, "{s}");
-    }
 
     #[test]
     fn thai() {
@@ -563,32 +544,15 @@ mod tests {
         let mut dict = ComplexPayloadsBorrowed::new();
         dict.with_southeast_asian_dictionaries();
 
-        check_complex("ภาษาไทยภาษาไทย", &["ภาษา", "ไทย", "ภาษา", "ไทย"], lstm);
-        check_complex("ภาษาไทยภาษาไทย", &["ภาษา", "ไทย", "ภาษา", "ไทย"], dict);
-    }
-
-    #[test]
-    fn mixed() {
-        let mut lstm = ComplexPayloadsBorrowed::new();
-        lstm.with_southeast_asian_lstms();
-        lstm.with_japanese_dictionary();
-
-        let mut dict = ComplexPayloadsBorrowed::new();
-        dict.with_southeast_asian_dictionaries();
-        dict.with_japanese_dictionary();
-
-        check_complex("ภาษาไทย龟山岛", &["ภาษา", "ไทย", "龟山岛"], lstm);
-        check_complex("ภาษาไทย龟山岛", &["ภาษา", "ไทย", "龟山岛"], dict);
-
         check_complex(
-            "こんにちは世界ภาษาไทย",
-            &["こんにちは", "世界", "ภาษา", "ไทย"],
-            lstm,
+            "ภาษาไทยภาษาไทย",
+            &["ภาษา", "ไทย", "ภาษา", "ไทย"],
+            lstm.select(ComplexScript::Thai).unwrap(),
         );
         check_complex(
-            "こんにちは世界ภาษาไทย",
-            &["こんにちは", "世界", "ภาษา", "ไทย"],
-            dict,
+            "ภาษาไทยภาษาไทย",
+            &["ภาษา", "ไทย", "ภาษา", "ไทย"],
+            dict.select(ComplexScript::Thai).unwrap(),
         );
     }
 }

--- a/components/segmenter/src/complex/mod.rs
+++ b/components/segmenter/src/complex/mod.rs
@@ -5,13 +5,10 @@
 use crate::provider::*;
 use crate::scaffold::{PotentiallyIllFormedUtf8, RuleBreakType, Utf8, Utf16};
 use crate::{GraphemeClusterSegmenter, GraphemeClusterSegmenterBorrowed};
-use alloc::vec::Vec;
 use icu_provider::prelude::*;
 
 mod dictionary;
 use dictionary::*;
-mod script;
-use script::*;
 #[cfg(feature = "lstm")]
 mod lstm;
 #[cfg(feature = "lstm")]
@@ -206,44 +203,6 @@ impl<'data> ComplexPayloadsBorrowed<'data> {
             }),
             ComplexScript::None => None,
         }
-    }
-
-    pub(crate) fn segment_str(&self, input: &str) -> Vec<usize> {
-        let mut result = Vec::new();
-        let mut offset = 0;
-        for (slice, complex_script) in ComplexScriptIterator::new(input) {
-            match self.select(complex_script) {
-                Some(d) => result.extend(d.segment_str(slice, self.grapheme, offset)),
-                None => result.push(offset + slice.len()),
-            }
-            offset += slice.len();
-        }
-        result
-    }
-    pub(crate) fn segment_utf8(&self, input: &[u8]) -> Vec<usize> {
-        let mut result = Vec::new();
-        let mut offset = 0;
-        for (slice, complex_script) in ComplexScriptIteratorUtf8::new(input) {
-            match self.select(complex_script) {
-                Some(d) => result.extend(d.segment_utf8(slice, self.grapheme, offset)),
-                None => result.push(offset + slice.len()),
-            }
-            offset += slice.len();
-        }
-        result
-    }
-    /// Return UTF-16 segment offset array using dictionary or lstm segmenter.
-    pub(crate) fn segment_utf16(&self, input: &[u16]) -> Vec<usize> {
-        let mut result = Vec::new();
-        let mut offset = 0;
-        for (slice, complex_script) in ComplexScriptIteratorUtf16::new(input) {
-            match self.select(complex_script) {
-                Some(d) => result.extend(d.segment_utf16(slice, self.grapheme, offset)),
-                None => result.push(offset + slice.len()),
-            }
-            offset += slice.len();
-        }
-        result
     }
 }
 

--- a/components/segmenter/src/complex/script.rs
+++ b/components/segmenter/src/complex/script.rs
@@ -151,77 +151,50 @@ impl<'s> Iterator for ComplexScriptIteratorUtf16<'s> {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_thai_only() {
-        let s = "ภาษาไทยภาษาไทย";
-        let utf16: Vec<u16> = s.encode_utf16().collect();
-        let mut iter = ComplexScriptIteratorUtf16::new(&utf16);
+    #[track_caller]
+    fn test_iter(s: &str, expected: &[(&str, ComplexScript)]) {
         assert_eq!(
-            iter.next(),
-            Some((utf16.as_slice(), ComplexScript::Thai)),
-            "Thai script only with UTF-16"
+            ComplexScriptIterator::new(s).collect::<Vec<_>>(),
+            expected,
+            "UTF-8 iteration"
         );
-        let mut iter = ComplexScriptIterator::new(s);
+
         assert_eq!(
-            iter.next(),
-            Some((s, ComplexScript::Thai)),
-            "Thai script only with UTF-8"
+            ComplexScriptIteratorUtf8::new(s.as_bytes()).collect::<Vec<_>>(),
+            expected
+                .iter()
+                .map(|(s, script)| (s.as_bytes(), *script))
+                .collect::<Vec<_>>(),
+            "UTF-8 iteration"
         );
-        assert_eq!(iter.next(), None, "Iterator for UTF-8 is finished");
+
+        assert_eq!(
+            ComplexScriptIteratorUtf16::new(&s.encode_utf16().collect::<Vec<_>>())
+                .collect::<Vec<_>>(),
+            expected
+                .iter()
+                .copied()
+                .map(|(s, script)| (&*s.encode_utf16().collect::<Vec<_>>().leak(), script))
+                .collect::<Vec<_>>(),
+            "UTF-16 iteration"
+        );
     }
 
     #[test]
-    fn test_myanmar_only() {
-        let s = "မြန်မာစာမြန်မာစာမြန်မာစာ";
-        let utf16: Vec<u16> = s.encode_utf16().collect();
-        let mut iter = ComplexScriptIteratorUtf16::new(&utf16);
-        assert_eq!(
-            iter.next(),
-            Some((utf16.as_slice(), ComplexScript::Myanmar)),
-            "Myanmar script only with UTF-16"
-        );
-        let mut iter = ComplexScriptIterator::new(s);
-        assert_eq!(
-            iter.next(),
-            Some((s, ComplexScript::Myanmar)),
-            "Myanmar script only with UTF-8"
-        );
-        assert_eq!(iter.next(), None, "Iterator for UTF-8 is finished");
-    }
+    fn test_script_iter() {
+        test_iter("ภาษาไทยภาษาไทย", &[("ภาษาไทยภาษาไทย", ComplexScript::Thai)]);
 
-    #[test]
-    fn test_combine() {
-        const TEST_STR_THAI: &str = "ภาษาไทยภาษาไทย";
-        const TEST_STR_MYANMAR: &str = "ဗမာနွယ်ဘာသာစကားမျာ";
-        let s = format!("{TEST_STR_THAI}{TEST_STR_MYANMAR}");
-        let utf16: Vec<u16> = s.encode_utf16().collect();
-        let thai_utf16: Vec<u16> = TEST_STR_THAI.encode_utf16().collect();
-        let myanmar_utf16: Vec<u16> = TEST_STR_MYANMAR.encode_utf16().collect();
+        test_iter(
+            "မြန်မာစာမြန်မာစာမြန်မာစာ",
+            &[("မြန်မာစာမြန်မာစာမြန်မာစာ", ComplexScript::Myanmar)],
+        );
 
-        let mut iter = ComplexScriptIteratorUtf16::new(&utf16);
-        assert_eq!(
-            iter.next(),
-            Some((thai_utf16.as_slice(), ComplexScript::Thai)),
-            "Thai script with UTF-16 at first"
+        test_iter(
+            "ภาษาไทยภาษาไทยဗမာနွယ်ဘာသာစကားမျာ",
+            &[
+                ("ภาษาไทยภาษาไทย", ComplexScript::Thai),
+                ("ဗမာနွယ်ဘာသာစကားမျာ", ComplexScript::Myanmar),
+            ],
         );
-        assert_eq!(
-            iter.next(),
-            Some((myanmar_utf16.as_slice(), ComplexScript::Myanmar)),
-            "Myanmar script with UTF-16 at second"
-        );
-        assert_eq!(iter.next(), None, "Iterator for UTF-16 is finished");
-
-        let mut iter = ComplexScriptIterator::new(&s);
-        assert_eq!(
-            iter.next(),
-            Some((TEST_STR_THAI, ComplexScript::Thai)),
-            "Thai script with UTF-8 at first"
-        );
-        assert_eq!(
-            iter.next(),
-            Some((TEST_STR_MYANMAR, ComplexScript::Myanmar)),
-            "Myanmar script with UTF-8 at second"
-        );
-        assert_eq!(iter.next(), None, "Iterator for UTF-8 is finished");
     }
 }

--- a/components/segmenter/src/line.rs
+++ b/components/segmenter/src/line.rs
@@ -1525,6 +1525,12 @@ mod tests {
             &["မြန်မာဘာသာ", "စကား"],
             LineSegmenter::new_dictionary(Default::default()),
         );
+
+        check_line(
+            "မြန်မာစာမြန်မာစာမြန်မာစာ",
+            &["မြန်မာ", "စာ", "မြန်မာ", "စာ", "မြန်မာ", "စာ"],
+            LineSegmenter::new_dictionary(Default::default()),
+        );
     }
 
     #[test]
@@ -1544,6 +1550,16 @@ mod tests {
         check_line(
             "မြန်မာဘာသာစကား",
             &["မြန်မာဘာသာ", "စကား"],
+            {
+                let mut s = LineSegmenter::new_17_for_non_complex_scripts(Default::default());
+                s.load_dictionary();
+                s
+            },
+        );
+
+        check_line(
+            "မြန်မာစာမြန်မာစာမြန်မာစာ",
+            &["မြန်မာ", "စာ", "မြန်မာ", "စာ", "မြန်မာ", "စာ"],
             {
                 let mut s = LineSegmenter::new_17_for_non_complex_scripts(Default::default());
                 s.load_dictionary();
@@ -1575,6 +1591,16 @@ mod tests {
                 s
             },
         );
+
+        check_line(
+            "မြန်မာစာမြန်မာစာမြန်မာစာ",
+            &["မြန်မာ", "စာ", "မြန်မာ", "စာ", "မြန်မာ", "စာ"],
+            {
+                let mut s = LineSegmenter::new_neo_for_non_complex_scripts(Default::default());
+                s.load_dictionary();
+                s
+            },
+        );
     }
 
     #[test]
@@ -1588,6 +1614,12 @@ mod tests {
         check_line(
             "សេចក្ដីប្រកាសជាសកលស្ដីពីសិទ្ធិមនុស្ស",
             &["សេចក្ដីប្រកាស", "ជាស", "កល", "ស្ដីពី", "សិទ្ធិមនុស្ស"],
+            LineSegmenter::new_dictionary(Default::default()),
+        );
+
+        check_line(
+            "ភាសាខ្មែរភាសាខ្មែរភាសាខ្មែរ",
+            &["ភាសាខ្មែរ", "ភាសាខ្មែរ", "ភាសាខ្មែរ"],
             LineSegmenter::new_dictionary(Default::default()),
         );
     }
@@ -1607,6 +1639,16 @@ mod tests {
         check_line(
             "សេចក្ដីប្រកាសជាសកលស្ដីពីសិទ្ធិមនុស្ស",
             &["សេចក្ដីប្រកាស", "ជាស", "កល", "ស្ដីពី", "សិទ្ធិមនុស្ស"],
+            {
+                let mut s = LineSegmenter::new_17_for_non_complex_scripts(Default::default());
+                s.load_dictionary();
+                s
+            },
+        );
+
+        check_line(
+            "ភាសាខ្មែរភាសាខ្មែរភាសាខ្មែរ",
+            &["ភាសាខ្មែរ", "ភាសាខ្មែរ", "ភាសាខ្មែរ"],
             {
                 let mut s = LineSegmenter::new_17_for_non_complex_scripts(Default::default());
                 s.load_dictionary();
@@ -1647,6 +1689,16 @@ mod tests {
                 s
             },
         );
+
+        check_line(
+            "ភាសាខ្មែរភាសាខ្មែរភាសាខ្មែរ",
+            &["ភាសាខ្មែរ", "ភាសាខ្មែរ", "ភាសាខ្មែរ"],
+            {
+                let mut s = LineSegmenter::new_neo_for_non_complex_scripts(Default::default());
+                s.load_dictionary();
+                s
+            },
+        );
     }
 
     #[test]
@@ -1660,6 +1712,12 @@ mod tests {
         check_line(
             "ກ່ຽວກັບສິດຂອງມະນຸດ",
             &["ກ່ຽວກັບ", "ສິດ", "ຂອງ", "ມະນຸດ"],
+            LineSegmenter::new_dictionary(Default::default()),
+        );
+
+        check_line(
+            "ພາສາລາວພາສາລາວພາສາລາວ",
+            &["ພາສາ", "ລາວ", "ພາສາ", "ລາວ", "ພາສາ", "ລາວ"],
             LineSegmenter::new_dictionary(Default::default()),
         );
     }
@@ -1679,6 +1737,16 @@ mod tests {
         check_line(
             "ກ່ຽວກັບສິດຂອງມະນຸດ",
             &["ກ່ຽວກັບ", "ສິດ", "ຂອງ", "ມະນຸດ"],
+            {
+                let mut s = LineSegmenter::new_17_for_non_complex_scripts(Default::default());
+                s.load_dictionary();
+                s
+            },
+        );
+
+        check_line(
+            "ພາສາລາວພາສາລາວພາສາລາວ",
+            &["ພາສາ", "ລາວ", "ພາສາ", "ລາວ", "ພາສາ", "ລາວ"],
             {
                 let mut s = LineSegmenter::new_17_for_non_complex_scripts(Default::default());
                 s.load_dictionary();
@@ -1707,6 +1775,85 @@ mod tests {
                 s.load_dictionary();
                 s
             },
+        );
+
+        check_line(
+            "ພາສາລາວພາສາລາວພາສາລາວ",
+            &["ພາສາ", "ລາວ", "ພາສາ", "ລາວ", "ພາສາ", "ລາວ"],
+            {
+                let mut s = LineSegmenter::new_neo_for_non_complex_scripts(Default::default());
+                s.load_dictionary();
+                s
+            },
+        );
+    }
+
+    #[test]
+    fn mixed_line_break() {
+        let mut lstm = LineSegmenter::new_for_non_complex_scripts(Default::default());
+        lstm.load_lstm();
+
+        let mut dict = LineSegmenter::new_for_non_complex_scripts(Default::default());
+        dict.load_dictionary();
+
+        check_line("ภาษาไทย龟山岛", &["ภาษา", "ไทย", "龟", "山", "岛"], lstm);
+        check_line("ภาษาไทย龟山岛", &["ภาษา", "ไทย", "龟", "山", "岛"], dict);
+
+        check_line(
+            "こんにちは世界ภาษาไทย",
+            &["こ", "ん", "に", "ち", "は", "世", "界", "ภาษา", "ไทย"],
+            lstm,
+        );
+        check_line(
+            "こんにちは世界ภาษาไทย",
+            &["こ", "ん", "に", "ち", "は", "世", "界", "ภาษา", "ไทย"],
+            dict,
+        );
+    }
+
+    #[test]
+    fn mixed_line_break_neo() {
+        let mut lstm = LineSegmenter::new_neo_for_non_complex_scripts(Default::default());
+        lstm.load_lstm();
+
+        let mut dict = LineSegmenter::new_neo_for_non_complex_scripts(Default::default());
+        dict.load_dictionary();
+
+        check_line("ภาษาไทย龟山岛", &["ภาษา", "ไทย", "龟", "山", "岛"], lstm);
+        check_line("ภาษาไทย龟山岛", &["ภาษา", "ไทย", "龟", "山", "岛"], dict);
+
+        check_line(
+            "こんにちは世界ภาษาไทย",
+            &["こ", "ん", "に", "ち", "は", "世", "界", "ภาษา", "ไทย"],
+            lstm,
+        );
+        check_line(
+            "こんにちは世界ภาษาไทย",
+            &["こ", "ん", "に", "ち", "は", "世", "界", "ภาษา", "ไทย"],
+            dict,
+        );
+    }
+
+    #[test]
+    fn mixed_line_break_17() {
+        let mut lstm = LineSegmenter::new_17_for_non_complex_scripts(Default::default());
+        lstm.load_lstm();
+
+        let mut dict = LineSegmenter::new_17_for_non_complex_scripts(Default::default());
+        dict.load_dictionary();
+
+        check_line("ภาษาไทย龟山岛", &["ภาษา", "ไทย", "龟", "山", "岛"], lstm);
+        check_line("ภาษาไทย龟山岛", &["ภาษา", "ไทย", "龟", "山", "岛"], dict);
+
+        check_line(
+            "こんにちは世界ภาษาไทย",
+            &["こ", "ん", "に", "ち", "は", "世", "界", "ภาษา", "ไทย"],
+            lstm,
+        );
+        check_line(
+            "こんにちは世界ภาษาไทย",
+            &["こ", "ん", "に", "ち", "は", "世", "界", "ภาษา", "ไทย"],
+            dict,
         );
     }
 

--- a/components/segmenter/src/rule_segmenter_v1.rs
+++ b/components/segmenter/src/rule_segmenter_v1.rs
@@ -9,6 +9,9 @@ use alloc::vec::{self, Vec};
 
 pub(crate) type ResultCache = vec::IntoIter<usize>;
 
+mod script_iter;
+use script_iter::*;
+
 /// Converts complex-run-relative break offsets into distances in consumption order.
 ///
 /// The first distance starts at `previous_offset`; later distances start at the
@@ -49,7 +52,16 @@ impl ComplexRunSegmenter for Utf8 {
     ) -> Vec<usize> {
         #[allow(clippy::indexing_slicing)] // valid offsets from CharIndices
         let input = &input.as_str()[start..end];
-        complex.segment_str(input)
+        let mut result = Vec::new();
+        let mut offset = 0;
+        for (slice, complex_script) in ComplexScriptIterator(input) {
+            match complex.select(complex_script) {
+                Some(d) => result.extend(d.segment_str(slice, complex.grapheme, offset)),
+                None => result.push(offset + slice.len()),
+            }
+            offset += slice.len();
+        }
+        result
     }
 }
 
@@ -62,7 +74,16 @@ impl ComplexRunSegmenter for PotentiallyIllFormedUtf8 {
     ) -> Vec<usize> {
         #[allow(clippy::indexing_slicing)] // valid offsets from Utf8CharIndices
         let input = &input.as_slice()[start..end];
-        complex.segment_utf8(input)
+        let mut result = Vec::new();
+        let mut offset = 0;
+        for (slice, complex_script) in ComplexScriptIteratorUtf8(input) {
+            match complex.select(complex_script) {
+                Some(d) => result.extend(d.segment_utf8(slice, complex.grapheme, offset)),
+                None => result.push(offset + slice.len()),
+            }
+            offset += slice.len();
+        }
+        result
     }
 }
 
@@ -75,7 +96,16 @@ impl ComplexRunSegmenter for Utf16 {
     ) -> Vec<usize> {
         #[allow(clippy::indexing_slicing)] // valid offsets from Utf16Indices
         let input = &input.as_slice()[start..end];
-        complex.segment_utf16(input)
+        let mut result = Vec::new();
+        let mut offset = 0;
+        for (slice, complex_script) in ComplexScriptIteratorUtf16(input) {
+            match complex.select(complex_script) {
+                Some(d) => result.extend(d.segment_utf16(slice, complex.grapheme, offset)),
+                None => result.push(offset + slice.len()),
+            }
+            offset += slice.len();
+        }
+        result
     }
 }
 

--- a/components/segmenter/src/rule_segmenter_v1.rs
+++ b/components/segmenter/src/rule_segmenter_v1.rs
@@ -313,6 +313,8 @@ impl<Y: RuleBreakType> RuleBreakIterator<'_, '_, Y> {
 
 #[cfg(test)]
 mod tests {
+    use utf8_iter::Utf8CharIndices;
+
     use super::*;
 
     #[test]
@@ -334,5 +336,32 @@ mod tests {
     #[should_panic(expected = "complex break offsets must be monotonically non-decreasing")]
     fn result_cache_rejects_offsets_before_current_position() {
         let _ = result_cache_from_offsets(vec![2], 3);
+    }
+
+    #[test]
+    fn no_model_utf8_fallback() {
+        let thai = "ภาษาไทย".as_bytes();
+        assert_eq!(
+            PotentiallyIllFormedUtf8::segment_complex_run(
+                ComplexPayloadsBorrowed::new(),
+                &Utf8CharIndices::new(thai),
+                0,
+                thai.len()
+            ),
+            [thai.len()]
+        );
+
+        let mut malformed = thai.to_vec();
+        malformed.push(0xFF);
+        malformed.extend_from_slice(thai);
+        assert_eq!(
+            PotentiallyIllFormedUtf8::segment_complex_run(
+                ComplexPayloadsBorrowed::new(),
+                &Utf8CharIndices::new(&malformed),
+                0,
+                malformed.len()
+            ),
+            [thai.len(), thai.len() + 1, malformed.len()]
+        );
     }
 }

--- a/components/segmenter/src/rule_segmenter_v1/script_iter.rs
+++ b/components/segmenter/src/rule_segmenter_v1/script_iter.rs
@@ -6,7 +6,7 @@ use crate::provider::ComplexScript;
 use utf8_iter::Utf8CharIndices;
 
 // TODO: Use data provider
-pub(crate) fn get_complex_script(codepoint: u32) -> ComplexScript {
+fn get_complex_script(codepoint: u32) -> ComplexScript {
     // For Thai, Burmese, Lao and Khmer, these are the intersections
     // of lb=SA with the respective Script
     match codepoint {
@@ -63,86 +63,62 @@ pub(crate) fn get_complex_script(codepoint: u32) -> ComplexScript {
 
 /// This struct is an iterator that returns the string per complex script from the
 /// given string.
-pub(super) struct ComplexScriptIterator<'s> {
-    rest: &'s str,
-}
-
-impl<'s> ComplexScriptIterator<'s> {
-    pub(super) fn new(input: &'s str) -> Self {
-        Self { rest: input }
-    }
-}
+pub(super) struct ComplexScriptIterator<'s>(pub(super) &'s str);
 
 impl<'s> Iterator for ComplexScriptIterator<'s> {
     type Item = (&'s str, ComplexScript);
 
     fn next(&mut self) -> Option<Self::Item> {
-        let mut indices = self.rest.char_indices();
+        let mut indices = self.0.char_indices();
         let lang = get_complex_script(indices.next()?.1 as u32);
         match indices.find(|&(_, ch)| get_complex_script(ch as u32) != lang) {
             Some((i, _)) => {
-                let (result, rest) = self.rest.split_at(i);
-                self.rest = rest;
+                let (result, rest) = self.0.split_at(i);
+                self.0 = rest;
                 Some((result, lang))
             }
-            None => Some((core::mem::take(&mut self.rest), lang)),
+            None => Some((core::mem::take(&mut self.0), lang)),
         }
     }
 }
 
-pub(super) struct ComplexScriptIteratorUtf8<'s> {
-    rest: &'s [u8],
-}
-
-impl<'s> ComplexScriptIteratorUtf8<'s> {
-    pub(super) fn new(input: &'s [u8]) -> Self {
-        Self { rest: input }
-    }
-}
+pub(super) struct ComplexScriptIteratorUtf8<'s>(pub(super) &'s [u8]);
 
 impl<'s> Iterator for ComplexScriptIteratorUtf8<'s> {
     type Item = (&'s [u8], ComplexScript);
 
     fn next(&mut self) -> Option<Self::Item> {
-        let mut indices = Utf8CharIndices::new(self.rest);
+        let mut indices = Utf8CharIndices::new(self.0);
         let script = get_complex_script(indices.next()?.1 as u32);
         match indices.find(|&(_, ch)| get_complex_script(ch as u32) != script) {
             Some((i, _)) => {
-                let (result, rest) = self.rest.split_at(i);
-                self.rest = rest;
+                let (result, rest) = self.0.split_at(i);
+                self.0 = rest;
                 Some((result, script))
             }
-            None => Some((core::mem::take(&mut self.rest), script)),
+            None => Some((core::mem::take(&mut self.0), script)),
         }
     }
 }
 
-pub(super) struct ComplexScriptIteratorUtf16<'s> {
-    rest: &'s [u16],
-}
-
-impl<'s> ComplexScriptIteratorUtf16<'s> {
-    pub(super) fn new(input: &'s [u16]) -> Self {
-        Self { rest: input }
-    }
-}
+pub(super) struct ComplexScriptIteratorUtf16<'s>(pub(super) &'s [u16]);
 
 impl<'s> Iterator for ComplexScriptIteratorUtf16<'s> {
     type Item = (&'s [u16], ComplexScript);
 
     fn next(&mut self) -> Option<Self::Item> {
-        let lang = get_complex_script(*self.rest.first()? as u32);
+        let lang = get_complex_script(*self.0.first()? as u32);
         match self
-            .rest
+            .0
             .iter()
             .position(|&ch| get_complex_script(ch as u32) != lang)
         {
             Some(i) => {
-                let (result, rest) = self.rest.split_at(i);
-                self.rest = rest;
+                let (result, rest) = self.0.split_at(i);
+                self.0 = rest;
                 Some((result, lang))
             }
-            None => Some((core::mem::take(&mut self.rest), lang)),
+            None => Some((core::mem::take(&mut self.0), lang)),
         }
     }
 }
@@ -154,13 +130,13 @@ mod tests {
     #[track_caller]
     fn test_iter(s: &str, expected: &[(&str, ComplexScript)]) {
         assert_eq!(
-            ComplexScriptIterator::new(s).collect::<Vec<_>>(),
+            ComplexScriptIterator(s).collect::<Vec<_>>(),
             expected,
             "UTF-8 iteration"
         );
 
         assert_eq!(
-            ComplexScriptIteratorUtf8::new(s.as_bytes()).collect::<Vec<_>>(),
+            ComplexScriptIteratorUtf8(s.as_bytes()).collect::<Vec<_>>(),
             expected
                 .iter()
                 .map(|(s, script)| (s.as_bytes(), *script))
@@ -169,8 +145,7 @@ mod tests {
         );
 
         assert_eq!(
-            ComplexScriptIteratorUtf16::new(&s.encode_utf16().collect::<Vec<_>>())
-                .collect::<Vec<_>>(),
+            ComplexScriptIteratorUtf16(&s.encode_utf16().collect::<Vec<_>>()).collect::<Vec<_>>(),
             expected
                 .iter()
                 .copied()

--- a/components/segmenter/src/word.rs
+++ b/components/segmenter/src/word.rs
@@ -1009,6 +1009,12 @@ impl<Y: RuleBreakType> crate::rule_segmenter_v2::ComplexHandler<Y> for ComplexWo
     }
 }
 
+#[cfg(test)]
+use crate::{GraphemeClusterSegmenterBorrowed, LineSegmenterBorrowed, SentenceSegmenterBorrowed};
+
+#[cfg(test)]
+include!("../tests/helpers.rs.raw");
+
 #[test]
 fn empty_string() {
     let segmenter =
@@ -1026,37 +1032,76 @@ fn empty_string_neo() {
 }
 
 #[test]
+fn cj_dictionary_test() {
+    let segmenter = WordSegmenter::new_auto(WordBreakInvariantOptions::default());
+
+    // Match case
+    check_word("龟山岛龟山岛", &["龟山岛", "龟山岛"], segmenter);
+
+    // Match case, then no match case
+    check_word("エディターエディ", &["エディターエディ"], segmenter);
+}
+
+#[test]
+fn cj_dictionary_test_neo() {
+    let mut segmenter =
+        WordSegmenter::new_neo_for_non_complex_scripts(WordBreakInvariantOptions::default());
+    segmenter.load_auto();
+
+    // Match case
+    check_word("龟山岛龟山岛", &["龟山岛", "龟山岛"], segmenter);
+
+    // Match case, then no match case
+    check_word("エディターエディ", &["エディター", "エディ"], segmenter);
+}
+
+#[test]
 fn complex_mixed_thai_cj_word_break() {
-    let segmenter = WordSegmenter::new_dictionary(WordBreakInvariantOptions::default());
-    let input = "ภาษาไทย龟山岛";
+    check_word(
+        "ภาษาไทย龟山岛",
+        &["ภาษา", "ไทย", "龟山岛"],
+        WordSegmenter::new_auto(WordBreakInvariantOptions::default()),
+    );
+    check_word(
+        "ภาษาไทย龟山岛",
+        &["ภาษา", "ไทย", "龟山岛"],
+        WordSegmenter::new_dictionary(WordBreakInvariantOptions::default()),
+    );
 
-    let breaks: Vec<usize> = segmenter.segment_str(input).collect();
-    assert_eq!(breaks, [0, 12, 21, 30]);
-
-    let breaks: Vec<usize> = segmenter.segment_utf8(input.as_bytes()).collect();
-    assert_eq!(breaks, [0, 12, 21, 30]);
-
-    let utf16 = input.encode_utf16().collect::<Vec<_>>();
-    let breaks: Vec<usize> = segmenter.segment_utf16(&utf16).collect();
-    assert_eq!(breaks, [0, 4, 7, 10]);
+    check_word(
+        "こんにちは世界ภาษาไทย",
+        &["こんにちは", "世界", "ภาษา", "ไทย"],
+        WordSegmenter::new_auto(WordBreakInvariantOptions::default()),
+    );
+    check_word(
+        "こんにちは世界ภาษาไทย",
+        &["こんにちは", "世界", "ภาษา", "ไทย"],
+        WordSegmenter::new_dictionary(WordBreakInvariantOptions::default()),
+    );
 }
 
 #[test]
 fn complex_mixed_thai_cj_word_break_neo() {
-    let mut segmenter =
+    let mut auto =
         WordSegmenter::new_neo_for_non_complex_scripts(WordBreakInvariantOptions::default());
-    segmenter.load_dictionary();
-    let input = "ภาษาไทย龟山岛";
+    auto.load_auto();
+    let mut dictionary =
+        WordSegmenter::new_neo_for_non_complex_scripts(WordBreakInvariantOptions::default());
+    dictionary.load_dictionary();
 
-    let breaks: Vec<usize> = segmenter.segment_str(input).collect();
-    assert_eq!(breaks, [0, 12, 21, 30]);
+    check_word("ภาษาไทย龟山岛", &["ภาษา", "ไทย", "龟山岛"], auto);
+    check_word("ภาษาไทย龟山岛", &["ภาษา", "ไทย", "龟山岛"], dictionary);
 
-    let breaks: Vec<usize> = segmenter.segment_utf8(input.as_bytes()).collect();
-    assert_eq!(breaks, [0, 12, 21, 30]);
-
-    let utf16 = input.encode_utf16().collect::<Vec<_>>();
-    let breaks: Vec<usize> = segmenter.segment_utf16(&utf16).collect();
-    assert_eq!(breaks, [0, 4, 7, 10]);
+    check_word(
+        "こんにちは世界ภาษาไทย",
+        &["こんにちは", "世界", "ภาษา", "ไทย"],
+        auto,
+    );
+    check_word(
+        "こんにちは世界ภาษาไทย",
+        &["こんにちは", "世界", "ภาษา", "ไทย"],
+        dictionary,
+    );
 }
 
 #[test]


### PR DESCRIPTION
There are tests for the dictionary that change behaviour between neo and legacy, that just shouldn't be the case.

## Changelog

N/A