### PR TITLE
refactor(currency): replace TinyAsciiStr<1> with CurrencySymbolWidth enum

### DIFF
--- a/components/experimental/src/dimension/currency/formatter.rs
+++ b/components/experimental/src/dimension/currency/formatter.rs
@@ -10,7 +10,7 @@ use super::super::provider::currency::{
     fractions::{CurrencyFractionsV1, FractionInfo, Rounding},
     no_currency::{CurrencyPatternsNoCurrency, CurrencyPatternsNoCurrencyV1},
     patterns::CurrencyPatternsDataV1,
-    symbols::CurrencySymbolsV1,
+    symbols::{CurrencySymbolWidth, CurrencySymbolsV1},
 };
 use super::CurrencyType;
 use fixed_decimal::{
@@ -99,7 +99,7 @@ impl<V: AbstractFormatter> CurrencyFormatter<V> {
         value_formatter: V,
         prefs: CurrencyFormatterPreferences,
         currency: CurrencyType,
-        width: TinyAsciiStr<1>,
+        width: CurrencySymbolWidth,
         options: CurrencyFormatterOptions,
     ) -> Result<Self, DataError> {
         let locale = CurrencyEssentialsV1::make_locale(prefs.locale_preferences);
@@ -150,7 +150,7 @@ impl<V: AbstractFormatter> CurrencyFormatter<V> {
         value_formatter: V,
         prefs: CurrencyFormatterPreferences,
         currency: CurrencyType,
-        width: TinyAsciiStr<1>,
+        width: CurrencySymbolWidth,
         options: CurrencyFormatterOptions,
     ) -> Result<Self, DataError>
     where

--- a/components/experimental/src/dimension/provider/currency/symbols.rs
+++ b/components/experimental/src/dimension/provider/currency/symbols.rs
@@ -64,16 +64,48 @@ impl CurrencySymbol<'_> {
     }
 }
 
+/// The width of a currency symbol.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "datagen", derive(databake::Bake))]
+#[cfg_attr(feature = "datagen", databake(path = icu_experimental::dimension::provider::currency::symbols))]
+#[non_exhaustive]
+pub enum CurrencySymbolWidth {
+    /// Standard or short currency symbol (e.g. `"$"` or `"CA$"`).
+    Short,
+    /// Narrow currency symbol (e.g. `"$"`).
+    Narrow,
+}
+
+impl CurrencySymbolWidth {
+    /// Returns the 1-byte ASCII character code used in data marker attributes.
+    pub const fn as_tinystr(self) -> TinyAsciiStr<1> {
+        match self {
+            Self::Short => tinystr!(1, "s"),
+            Self::Narrow => tinystr!(1, "n"),
+        }
+    }
+
+    /// Returns the character code as a string slice.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Short => "s",
+            Self::Narrow => "n",
+        }
+    }
+}
+
 impl CurrencySymbolsV1 {
-    pub const SHORT: TinyAsciiStr<1> = tinystr!(1, "s");
-    pub const NARROW: TinyAsciiStr<1> = tinystr!(1, "n");
+    pub const SHORT: CurrencySymbolWidth = CurrencySymbolWidth::Short;
+    pub const NARROW: CurrencySymbolWidth = CurrencySymbolWidth::Narrow;
 
     pub fn make_attributes(
         currency: CurrencyType,
-        width: TinyAsciiStr<1>,
+        width: CurrencySymbolWidth,
         buffer: &mut TinyAsciiStr<5>,
     ) -> &DataMarkerAttributes {
         *buffer = width
+            .as_tinystr()
             .concat::<1, 2>(tinystr!(1, "/"))
             .concat::<3, 5>(currency.iso_code());
         // All valid

--- a/provider/source/src/currency/symbols.rs
+++ b/provider/source/src/currency/symbols.rs
@@ -115,7 +115,7 @@ fn test_symbols() {
     let provider = SourceDataProvider::new_testing();
 
     #[allow(const_item_mutation)]
-    let load = |locale: DataLocale, currency: CurrencyType, width: TinyAsciiStr<1>| {
+    let load = |locale: DataLocale, currency: CurrencyType, width: CurrencySymbolWidth| {
         DataProvider::<CurrencySymbolsV1>::load(
             &provider,
             DataRequest {


### PR DESCRIPTION
### Stack

1. #8488 (👈 This PR)
2. #8487

```mermaid
graph TD
    main["unicode-org:main"]
    pr1["PR 1 (#8488): Refactor TinyAsciiStr<1> to CurrencySymbolWidth enum (This PR)"]
    pr2["PR 2 (#8487): Fall back narrow symbol to standard symbol"]
    main --> pr1
    pr1 --> pr2
    style pr1 stroke:#2ea043,stroke-width:3px
```

---

## Description

Refactors the representation of currency symbol width in `components/experimental` from a stringly-typed `TinyAsciiStr<1>` (`"s"` and `"n"`) to a dedicated, type-safe enum `CurrencySymbolWidth`:

- Defines `pub enum CurrencySymbolWidth { Short, Narrow }` with `as_tinystr()` and `as_str()` helper methods.
- Updates `CurrencySymbolsV1::make_attributes` to accept `CurrencySymbolWidth`.
- Updates `CurrencySymbolsV1::SHORT` and `NARROW` constants to be `CurrencySymbolWidth::Short` and `CurrencySymbolWidth::Narrow`.
- Updates internal constructors in `formatter.rs` (`try_new_essential` and `try_new_essential_unstable`) to take `CurrencySymbolWidth`.

## Memory / Performance Notes

Zero runtime overhead. The enum is `Copy` and compiles to a 1-byte integer representation, maintaining zero-allocation properties across data requests.

## Changelog

N/A
